### PR TITLE
LibWeb: Store uncommon node and element state lazily

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -31,11 +31,6 @@ static void for_each_ascii_whitespace_separated_token(Utf16View input, Function<
     }
 }
 
-void ARIAMixin::visit_edges(GC::Cell::Visitor& visitor)
-{
-    (void)visitor;
-}
-
 // https://www.w3.org/TR/wai-aria-1.2/#introroles
 Optional<Role> ARIAMixin::role_from_role_attribute_value() const
 {
@@ -282,31 +277,39 @@ Vector<Utf16String> ARIAMixin::parse_id_reference_list(Optional<Utf16String> con
 #define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
     GC::Ptr<DOM::Element> ARIAMixin::attribute() const               \
     {                                                                \
-        return m_##attribute.ptr();                                  \
+        auto const* rare_data = aria_rare_data();                    \
+        return rare_data ? rare_data->attribute.ptr() : nullptr;     \
     }                                                                \
                                                                      \
     void ARIAMixin::set_##attribute(GC::Ptr<DOM::Element> value)     \
     {                                                                \
-        m_##attribute = value.ptr();                                 \
+        if (!value) {                                                \
+            if (auto* rare_data = aria_rare_data())                  \
+                rare_data->attribute = nullptr;                      \
+            return;                                                  \
+        }                                                            \
+        ensure_aria_rare_data().attribute = value.ptr();             \
     }
 ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 
-#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute)                 \
-    Optional<Vector<GC::Weak<DOM::Element>> const&> ARIAMixin::attribute() const     \
-    {                                                                                \
-        if (!m_##attribute)                                                          \
-            return {};                                                               \
-        return *m_##attribute;                                                       \
-    }                                                                                \
-                                                                                     \
-    void ARIAMixin::set_##attribute(Optional<Vector<GC::Weak<DOM::Element>>> value)  \
-    {                                                                                \
-        if (!value.has_value()) {                                                    \
-            m_##attribute.clear();                                                   \
-            return;                                                                  \
-        }                                                                            \
-        m_##attribute = make<Vector<GC::Weak<DOM::Element>>>(value.release_value()); \
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute)                                     \
+    Optional<Vector<GC::Weak<DOM::Element>> const&> ARIAMixin::attribute() const                         \
+    {                                                                                                    \
+        auto const* rare_data = aria_rare_data();                                                        \
+        if (!rare_data || !rare_data->attribute)                                                         \
+            return {};                                                                                   \
+        return *rare_data->attribute;                                                                    \
+    }                                                                                                    \
+                                                                                                         \
+    void ARIAMixin::set_##attribute(Optional<Vector<GC::Weak<DOM::Element>>> value)                      \
+    {                                                                                                    \
+        if (!value.has_value()) {                                                                        \
+            if (auto* rare_data = aria_rare_data())                                                      \
+                rare_data->attribute.clear();                                                            \
+            return;                                                                                      \
+        }                                                                                                \
+        ensure_aria_rare_data().attribute = make<Vector<GC::Weak<DOM::Element>>>(value.release_value()); \
     }
 ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE

--- a/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -78,22 +78,24 @@ public:
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 
 protected:
+    struct RareData {
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
+    GC::Weak<DOM::Element> attribute;
+        ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
+
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
+    OwnPtr<Vector<GC::Weak<DOM::Element>>> attribute;
+        ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
+    };
+
     ARIAMixin();
 
-    void visit_edges(GC::Cell::Visitor&);
-
     virtual bool id_reference_exists(Utf16View) const = 0;
-
-private:
-#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
-    GC::Weak<DOM::Element> m_##attribute;
-    ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
-#undef __ENUMERATE_ARIA_ATTRIBUTE
-
-#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
-    OwnPtr<Vector<GC::Weak<DOM::Element>>> m_##attribute;
-    ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
-#undef __ENUMERATE_ARIA_ATTRIBUTE
+    virtual RareData* aria_rare_data() = 0;
+    virtual RareData const* aria_rare_data() const = 0;
+    virtual RareData& ensure_aria_rare_data() = 0;
 };
 
 }

--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -23,6 +23,28 @@
 
 namespace Web::DOM {
 
+CharacterData::RareData::~RareData() = default;
+
+OwnPtr<Node::RareData> CharacterData::create_rare_data() const
+{
+    return make<RareData>();
+}
+
+CharacterData::RareData& CharacterData::ensure_character_data_rare_data() const
+{
+    return static_cast<RareData&>(ensure_rare_data());
+}
+
+CharacterData::RareData* CharacterData::character_data_rare_data()
+{
+    return static_cast<RareData*>(rare_data());
+}
+
+CharacterData::RareData const* CharacterData::character_data_rare_data() const
+{
+    return static_cast<RareData const*>(rare_data());
+}
+
 GC_DEFINE_ALLOCATOR(CharacterData);
 
 CharacterData::CharacterData(Document& document, NodeType type, Utf16String data)
@@ -182,13 +204,15 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     document().bump_character_data_version();
 
-    if (m_grapheme_segmenter)
-        m_grapheme_segmenter->set_segmented_text(m_data);
-    // The line segmenter may be the ASCII fast-path variant, which only accepts a subset of inputs; let the
-    // lazy getter re-pick the implementation against the new data.
-    m_line_segmenter = nullptr;
-    if (m_word_segmenter)
-        m_word_segmenter->set_segmented_text(m_data);
+    if (auto* rare_data = character_data_rare_data()) {
+        if (rare_data->grapheme_segmenter)
+            rare_data->grapheme_segmenter->set_segmented_text(m_data);
+        // The line segmenter may be the ASCII fast-path variant, which only accepts a subset of inputs; let the
+        // lazy getter re-pick the implementation against the new data.
+        rare_data->line_segmenter = nullptr;
+        if (rare_data->word_segmenter)
+            rare_data->word_segmenter->set_segmented_text(m_data);
+    }
 
     if (is<Text>(*this)) {
         if (auto parent = parent_element())
@@ -221,36 +245,39 @@ WebIDL::ExceptionOr<void> CharacterData::delete_data(size_t offset, size_t count
 
 Unicode::Segmenter& CharacterData::grapheme_segmenter() const
 {
-    if (!m_grapheme_segmenter) {
-        m_grapheme_segmenter = document().grapheme_segmenter().clone();
-        m_grapheme_segmenter->set_segmented_text(m_data);
+    auto& segmenter = ensure_character_data_rare_data().grapheme_segmenter;
+    if (!segmenter) {
+        segmenter = document().grapheme_segmenter().clone();
+        segmenter->set_segmented_text(m_data);
     }
 
-    return *m_grapheme_segmenter;
+    return *segmenter;
 }
 
 Unicode::Segmenter& CharacterData::line_segmenter() const
 {
-    if (!m_line_segmenter) {
+    auto& segmenter = ensure_character_data_rare_data().line_segmenter;
+    if (!segmenter) {
         if (auto ascii = Unicode::Segmenter::try_create_for_ascii_line(m_data.utf16_view())) {
-            m_line_segmenter = ascii.release_nonnull();
+            segmenter = ascii.release_nonnull();
         } else {
-            m_line_segmenter = document().line_segmenter().clone();
-            m_line_segmenter->set_segmented_text(m_data);
+            segmenter = document().line_segmenter().clone();
+            segmenter->set_segmented_text(m_data);
         }
     }
 
-    return *m_line_segmenter;
+    return *segmenter;
 }
 
 Unicode::Segmenter& CharacterData::word_segmenter() const
 {
-    if (!m_word_segmenter) {
-        m_word_segmenter = document().word_segmenter().clone();
-        m_word_segmenter->set_segmented_text(m_data);
+    auto& segmenter = ensure_character_data_rare_data().word_segmenter;
+    if (!segmenter) {
+        segmenter = document().word_segmenter().clone();
+        segmenter->set_segmented_text(m_data);
     }
 
-    return *m_word_segmenter;
+    return *segmenter;
 }
 
 }

--- a/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Libraries/LibWeb/DOM/CharacterData.h
@@ -43,16 +43,25 @@ public:
     Unicode::Segmenter& word_segmenter() const;
 
 protected:
+    struct RareData : Node::RareData {
+        virtual ~RareData() override;
+
+        OwnPtr<Unicode::Segmenter> grapheme_segmenter;
+        OwnPtr<Unicode::Segmenter> line_segmenter;
+        OwnPtr<Unicode::Segmenter> word_segmenter;
+    };
+
     CharacterData(Document&, NodeType, Utf16String);
+
+    virtual OwnPtr<Node::RareData> create_rare_data() const override;
+    RareData& ensure_character_data_rare_data() const;
+    RareData* character_data_rare_data();
+    RareData const* character_data_rare_data() const;
 
 private:
     virtual size_t external_memory_size() const override;
 
     Utf16String m_data;
-
-    mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
-    mutable OwnPtr<Unicode::Segmenter> m_line_segmenter;
-    mutable OwnPtr<Unicode::Segmenter> m_word_segmenter;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -197,6 +197,9 @@ struct Element::RareData final
     // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
     GC::Ptr<HTML::CustomElementDefinition> custom_element_definition;
 
+    // https://dom.spec.whatwg.org/#element-custom-element-registry
+    GC::Ptr<HTML::CustomElementRegistry> custom_element_registry;
+
     Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
 
     // https://w3c.github.io/webappsec-csp/#is-element-nonceable
@@ -249,6 +252,7 @@ void Element::RareData::visit_edges(Cell::Visitor& visitor)
     visitor.visit(computed_style_map_cache);
     visitor.visit(attribute_style_map);
     visitor.visit(custom_element_definition);
+    visitor.visit(custom_element_registry);
     if (pseudo_element_data) {
         for (auto& pseudo_element : *pseudo_element_data)
             visitor.visit(pseudo_element.value);
@@ -368,7 +372,6 @@ void Element::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_attributes);
     visitor.visit(m_inline_style);
     visitor.visit(m_shadow_root);
-    visitor.visit(m_custom_element_registry);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute
@@ -4289,6 +4292,32 @@ void Element::set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinitio
         return;
     }
     ensure_element_rare_data().custom_element_definition = definition;
+}
+
+GC::Ptr<HTML::CustomElementRegistry> Element::custom_element_registry() const
+{
+    if (m_uses_document_global_custom_element_registry)
+        return document().effective_global_custom_element_registry();
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->custom_element_registry : nullptr;
+}
+
+void Element::set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> registry)
+{
+    if (HTML::is_a_global_custom_element_registry(registry) && registry == document().custom_element_registry()) {
+        m_uses_document_global_custom_element_registry = true;
+        if (auto* rare_data = element_rare_data())
+            rare_data->custom_element_registry = nullptr;
+        return;
+    }
+
+    m_uses_document_global_custom_element_registry = false;
+    if (!registry) {
+        if (auto* rare_data = element_rare_data())
+            rare_data->custom_element_registry = nullptr;
+        return;
+    }
+    ensure_element_rare_data().custom_element_registry = registry;
 }
 
 void Element::enqueue_a_custom_element_callback_reaction(Utf16FlyString const& callback_name, CustomElementCallbackReactionArguments arguments)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -195,6 +195,7 @@ void Element::RareData::visit_edges(Cell::Visitor& visitor)
     visitor.visit(attribute_style_map);
     visitor.visit(custom_element_definition);
     visitor.visit(custom_element_registry);
+    visitor.visit(dataset);
     if (pseudo_element_data) {
         for (auto& pseudo_element : *pseudo_element_data)
             visitor.visit(pseudo_element.value);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -64,6 +64,7 @@
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ElementFactory.h>
+#include <LibWeb/DOM/ElementRareData.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/SelectorQuery.h>
@@ -155,68 +156,7 @@
 
 namespace Web::DOM {
 
-struct Element::RareData final
-    : Node::RareData
-    , SlottableMixin::RareData
-    , ARIA::ARIAMixin::RareData {
-    virtual void visit_edges(Cell::Visitor&) override;
-
-    mutable Optional<Utf16FlyString> html_uppercased_qualified_name;
-    GC::Ptr<CSS::StylePropertyMap> attribute_style_map;
-    GC::Ptr<DOMTokenList> class_list;
-    GC::Ptr<DOMTokenList> part_list;
-    mutable OwnPtr<PseudoElementData> pseudo_element_data;
-    Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element;
-    Vector<Utf16FlyString> parts;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
-    // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:
-    // NOTE: See the structs at the top of Element.h.
-    OwnPtr<CustomElementReactionQueue> custom_element_reaction_queue;
-
-    // https://dom.spec.whatwg.org/#concept-element-is-value
-    Optional<Utf16FlyString> is_value;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#states-set
-    GC::Ptr<HTML::CustomStateSet> custom_state_set;
-
-    // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
-    // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
-    OwnPtr<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>> registered_intersection_observers;
-
-    // https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemapcache-slot
-    // Every Element has a [[computedStyleMapCache]] internal slot, initially set to null, which caches the result of
-    // the computedStyleMap() method when it is first called.
-    GC::Ptr<CSS::StylePropertyMapReadOnly> computed_style_map_cache;
-
-    OwnPtr<CSS::CountersSet> counters_set;
-
-    // https://drafts.csswg.org/css-values-5/#random-caching
-    HashMap<CSS::RandomCachingKey, double> element_specific_css_random_base_value_cache;
-
-    // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
-    GC::Ptr<HTML::CustomElementDefinition> custom_element_definition;
-
-    // https://dom.spec.whatwg.org/#element-custom-element-registry
-    GC::Ptr<HTML::CustomElementRegistry> custom_element_registry;
-
-    Optional<Utf16FlyString> name;
-
-    Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
-
-    // https://w3c.github.io/webappsec-csp/#is-element-nonceable
-    // AD-HOC: We need to know the element had a duplicate attribute when it was created from the HTML parser.
-    //         However, there currently isn't any specified way to do this, so we store a flag on the token, which is
-    //         then passed down to here. This is used by Content Security Policy to disable the nonce attribute if this
-    //         flag is set.
-    bool had_duplicate_attribute_during_tokenization { false };
-
-    // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
-    ProximityToTheViewport proximity_to_the_viewport { ProximityToTheViewport::NotDetermined };
-
-    // https://drafts.csswg.org/css-view-transitions-1/#captured-in-a-view-transition
-    bool captured_in_a_view_transition { false };
-};
+Element::RareData::~RareData() = default;
 
 void Element::RareData::visit_edges(Cell::Visitor& visitor)
 {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -155,7 +155,10 @@
 
 namespace Web::DOM {
 
-struct Element::RareData final : Node::RareData {
+struct Element::RareData final
+    : Node::RareData
+    , SlottableMixin::RareData
+    , ARIA::ARIAMixin::RareData {
     virtual void visit_edges(Cell::Visitor&) override;
 
     mutable Optional<Utf16FlyString> html_uppercased_qualified_name;
@@ -195,6 +198,7 @@ struct Element::RareData final : Node::RareData {
 void Element::RareData::visit_edges(Cell::Visitor& visitor)
 {
     Node::RareData::visit_edges(visitor);
+    SlottableMixin::RareData::visit_edges(visitor);
     visitor.visit(class_list);
     visitor.visit(part_list);
     if (custom_element_reaction_queue) {
@@ -241,6 +245,36 @@ void Element::RareData::visit_edges(Cell::Visitor& visitor)
 OwnPtr<Node::RareData> Element::create_rare_data() const
 {
     return make<RareData>();
+}
+
+SlottableMixin::RareData* Element::slottable_rare_data()
+{
+    return element_rare_data();
+}
+
+SlottableMixin::RareData const* Element::slottable_rare_data() const
+{
+    return element_rare_data();
+}
+
+SlottableMixin::RareData& Element::ensure_slottable_rare_data()
+{
+    return ensure_element_rare_data();
+}
+
+ARIA::ARIAMixin::RareData* Element::aria_rare_data()
+{
+    return element_rare_data();
+}
+
+ARIA::ARIAMixin::RareData const* Element::aria_rare_data() const
+{
+    return element_rare_data();
+}
+
+ARIA::ARIAMixin::RareData& Element::ensure_aria_rare_data()
+{
+    return ensure_element_rare_data();
 }
 
 Element::RareData& Element::ensure_element_rare_data() const
@@ -310,9 +344,7 @@ Element::~Element() = default;
 void Element::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    SlottableMixin::visit_edges(visitor);
     Animatable::visit_edges(visitor);
-    ARIAMixin::visit_edges(visitor);
 
     visitor.visit(m_attributes);
     visitor.visit(m_inline_style);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -155,6 +155,121 @@
 
 namespace Web::DOM {
 
+struct Element::RareData final : Node::RareData {
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    mutable Optional<Utf16FlyString> html_uppercased_qualified_name;
+    GC::Ptr<CSS::StylePropertyMap> attribute_style_map;
+    GC::Ptr<DOMTokenList> class_list;
+    GC::Ptr<DOMTokenList> part_list;
+    mutable OwnPtr<PseudoElementData> pseudo_element_data;
+    Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element;
+    Vector<Utf16FlyString> parts;
+
+    // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
+    // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:
+    // NOTE: See the structs at the top of Element.h.
+    OwnPtr<CustomElementReactionQueue> custom_element_reaction_queue;
+
+    // https://dom.spec.whatwg.org/#concept-element-is-value
+    Optional<Utf16FlyString> is_value;
+
+    // https://html.spec.whatwg.org/multipage/custom-elements.html#states-set
+    GC::Ptr<HTML::CustomStateSet> custom_state_set;
+
+    // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
+    // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
+    OwnPtr<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>> registered_intersection_observers;
+
+    // https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemapcache-slot
+    // Every Element has a [[computedStyleMapCache]] internal slot, initially set to null, which caches the result of
+    // the computedStyleMap() method when it is first called.
+    GC::Ptr<CSS::StylePropertyMapReadOnly> computed_style_map_cache;
+
+    OwnPtr<CSS::CountersSet> counters_set;
+
+    // https://drafts.csswg.org/css-values-5/#random-caching
+    HashMap<CSS::RandomCachingKey, double> element_specific_css_random_base_value_cache;
+};
+
+void Element::RareData::visit_edges(Cell::Visitor& visitor)
+{
+    Node::RareData::visit_edges(visitor);
+    visitor.visit(class_list);
+    visitor.visit(part_list);
+    if (custom_element_reaction_queue) {
+        for (auto const& reaction : *custom_element_reaction_queue) {
+            reaction.visit(
+                [&](CustomElementUpgradeReaction const& upgrade_reaction) {
+                    visitor.visit(upgrade_reaction.custom_element_definition);
+                },
+                [&](CustomElementCallbackReaction const& callback_reaction) {
+                    visitor.visit(callback_reaction.callback);
+                    callback_reaction.arguments.visit(
+                        [](Empty) {},
+                        [&](CustomElementAdoptedCallbackReactionArguments const& adopted_arguments) {
+                            visitor.visit(adopted_arguments.old_document);
+                            visitor.visit(adopted_arguments.new_document);
+                        },
+                        [&](CustomElementAttributeChangedCallbackReactionArguments const&) {},
+                        [&](CustomElementFormAssociatedCallbackReactionArguments const& form_associated_arguments) {
+                            visitor.visit(form_associated_arguments.form);
+                        },
+                        [&](CustomElementFormDisabledCallbackReactionArguments const&) {});
+                },
+                [&](CustomElementConnectedMoveCallbackReaction const& connected_move_reaction) {
+                    visitor.visit(connected_move_reaction.disconnected_callback);
+                    visitor.visit(connected_move_reaction.connected_callback);
+                });
+        }
+    }
+    visitor.visit(custom_state_set);
+    visitor.visit(computed_style_map_cache);
+    visitor.visit(attribute_style_map);
+    if (pseudo_element_data) {
+        for (auto& pseudo_element : *pseudo_element_data)
+            visitor.visit(pseudo_element.value);
+    }
+    if (registered_intersection_observers) {
+        for (auto& observer : *registered_intersection_observers)
+            visitor.visit(observer);
+    }
+    if (counters_set)
+        counters_set->visit_edges(visitor);
+}
+
+OwnPtr<Node::RareData> Element::create_rare_data() const
+{
+    return make<RareData>();
+}
+
+Element::RareData& Element::ensure_element_rare_data() const
+{
+    return static_cast<RareData&>(ensure_rare_data());
+}
+
+Element::RareData* Element::element_rare_data()
+{
+    return static_cast<RareData*>(rare_data());
+}
+
+Element::RareData const* Element::element_rare_data() const
+{
+    return static_cast<RareData const*>(rare_data());
+}
+
+Element::PseudoElementData* Element::pseudo_element_data()
+{
+    auto* rare_data = element_rare_data();
+    return rare_data ? rare_data->pseudo_element_data.ptr() : nullptr;
+}
+
+Element::PseudoElementData const* Element::pseudo_element_data() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->pseudo_element_data.ptr() : nullptr;
+}
+
 GC_DEFINE_ALLOCATOR(Element);
 
 static void invalidate_content_blocker_style_if_needed(Element& element)
@@ -201,51 +316,9 @@ void Element::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_attributes);
     visitor.visit(m_inline_style);
-    visitor.visit(m_class_list);
     visitor.visit(m_shadow_root);
-    visitor.visit(m_part_list);
     visitor.visit(m_custom_element_registry);
     visitor.visit(m_custom_element_definition);
-    if (m_custom_element_reaction_queue) {
-        for (auto const& reaction : *m_custom_element_reaction_queue) {
-            reaction.visit(
-                [&](CustomElementUpgradeReaction const& upgrade_reaction) {
-                    visitor.visit(upgrade_reaction.custom_element_definition);
-                },
-                [&](CustomElementCallbackReaction const& callback_reaction) {
-                    visitor.visit(callback_reaction.callback);
-                    callback_reaction.arguments.visit(
-                        [](Empty) {},
-                        [&](CustomElementAdoptedCallbackReactionArguments const& adopted_arguments) {
-                            visitor.visit(adopted_arguments.old_document);
-                            visitor.visit(adopted_arguments.new_document);
-                        },
-                        [&](CustomElementAttributeChangedCallbackReactionArguments const&) {},
-                        [&](CustomElementFormAssociatedCallbackReactionArguments const& form_associated_arguments) {
-                            visitor.visit(form_associated_arguments.form);
-                        },
-                        [&](CustomElementFormDisabledCallbackReactionArguments const&) {});
-                },
-                [&](CustomElementConnectedMoveCallbackReaction const& connected_move_reaction) {
-                    visitor.visit(connected_move_reaction.disconnected_callback);
-                    visitor.visit(connected_move_reaction.connected_callback);
-                });
-        }
-    }
-    visitor.visit(m_custom_state_set);
-    visitor.visit(m_computed_style_map_cache);
-    visitor.visit(m_attribute_style_map);
-    if (m_pseudo_element_data) {
-        for (auto& pseudo_element : *m_pseudo_element_data) {
-            visitor.visit(pseudo_element.value);
-        }
-    }
-    if (m_registered_intersection_observers) {
-        for (auto& observer : *m_registered_intersection_observers)
-            visitor.visit(observer);
-    }
-    if (m_counters_set)
-        m_counters_set->visit_edges(visitor);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute
@@ -1944,9 +2017,10 @@ void Element::invalidate_descendant_styles_depending_on_style_container_query()
 
 GC::Ref<DOMTokenList> Element::class_list()
 {
-    if (!m_class_list)
-        m_class_list = DOMTokenList::create(*this, HTML::AttributeNames::class_);
-    return *m_class_list;
+    auto& rare_data = ensure_element_rare_data();
+    if (!rare_data.class_list)
+        rare_data.class_list = DOMTokenList::create(*this, HTML::AttributeNames::class_);
+    return *rare_data.class_list;
 }
 
 // https://drafts.csswg.org/css-shadow-1/#dom-element-part
@@ -1954,9 +2028,18 @@ GC::Ref<DOMTokenList> Element::part_list()
 {
     // The part attribute’s getter must return a DOMTokenList object whose associated element is the context object and
     // whose associated attribute’s local name is part.
-    if (!m_part_list)
-        m_part_list = DOMTokenList::create(*this, HTML::AttributeNames::part);
-    return *m_part_list;
+    auto& rare_data = ensure_element_rare_data();
+    if (!rare_data.part_list)
+        rare_data.part_list = DOMTokenList::create(*this, HTML::AttributeNames::part);
+    return *rare_data.part_list;
+}
+
+ReadonlySpan<Utf16FlyString> Element::part_names() const
+{
+    auto const* rare_data = element_rare_data();
+    if (!rare_data)
+        return {};
+    return rare_data->parts;
 }
 
 // https://dom.spec.whatwg.org/#valid-shadow-host-name
@@ -1984,10 +2067,10 @@ WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(ShadowRootMode mode, boo
         return WebIDL::NotSupportedError::create("Element's local name is not a valid shadow host name"_utf16);
 
     // 3. If element’s local name is a valid custom element name, or element’s is value is not null:
-    if (HTML::is_valid_custom_element_name(local_name()) || m_is_value.has_value()) {
+    if (HTML::is_valid_custom_element_name(local_name()) || is_value().has_value()) {
         // 1. Let definition be the result of looking up a custom element definition given element’s custom element
         //    registry, its namespace, its local name, and its is value.
-        auto definition = HTML::look_up_a_custom_element_definition(custom_element_registry(), namespace_uri(), local_name(), m_is_value);
+        auto definition = HTML::look_up_a_custom_element_definition(custom_element_registry(), namespace_uri(), local_name(), is_value());
 
         // 2. If definition is non-null and definition’s disable shadow is true, then throw a "NotSupportedError"
         //    DOMException.
@@ -2241,9 +2324,10 @@ GC::Ref<CSS::CSSStyleProperties> Element::style()
 
 GC::Ref<CSS::StylePropertyMap> Element::attribute_style_map()
 {
-    if (!m_attribute_style_map)
-        m_attribute_style_map = CSS::StylePropertyMap::create(style());
-    return *m_attribute_style_map;
+    auto& rare_data = ensure_element_rare_data();
+    if (!rare_data.attribute_style_map)
+        rare_data.attribute_style_map = CSS::StylePropertyMap::create(style());
+    return *rare_data.attribute_style_map;
 }
 
 void Element::set_inline_style(GC::Ptr<CSS::CSSStyleProperties> style)
@@ -2252,8 +2336,8 @@ void Element::set_inline_style(GC::Ptr<CSS::CSSStyleProperties> style)
         return;
     auto had_declarations = m_inline_style && !m_inline_style->properties().is_empty();
     m_inline_style = style;
-    if (m_attribute_style_map)
-        m_attribute_style_map = nullptr;
+    if (auto* rare_data = element_rare_data())
+        rare_data->attribute_style_map = nullptr;
 
     // The element's own declarations moved without an attribute moving: a user-agent shadow tree
     // hands its inner elements a style object directly, and an `<input>`'s placeholder swaps
@@ -2773,7 +2857,7 @@ bool Element::matches_focus_within_pseudo_class() const
 
 bool Element::has_synthetic_pseudo_elements() const
 {
-    if (m_pseudo_element_data) {
+    if (pseudo_element_data()) {
         bool has_any_synthetic_pseudo_elements = false;
 
         for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement const& pseudo_element) {
@@ -2828,13 +2912,14 @@ void Element::serialize_children_as_json(JsonObjectSerializer<Utf16StringBuilder
     };
 
     if (has_pseudo_elements) {
-        if (auto backdrop = m_pseudo_element_data->get(CSS::PseudoElement::Backdrop); backdrop.has_value()) {
+        auto const& pseudo_elements = *pseudo_element_data();
+        if (auto backdrop = pseudo_elements.get(CSS::PseudoElement::Backdrop); backdrop.has_value()) {
             serialize_pseudo_element(CSS::PseudoElement::Backdrop, backdrop.value());
         }
-        if (auto marker = m_pseudo_element_data->get(CSS::PseudoElement::Marker); marker.has_value()) {
+        if (auto marker = pseudo_elements.get(CSS::PseudoElement::Marker); marker.has_value()) {
             serialize_pseudo_element(CSS::PseudoElement::Marker, marker.value());
         }
-        if (auto before = m_pseudo_element_data->get(CSS::PseudoElement::Before); before.has_value()) {
+        if (auto before = pseudo_elements.get(CSS::PseudoElement::Before); before.has_value()) {
             serialize_pseudo_element(CSS::PseudoElement::Before, before.value());
         }
     }
@@ -2848,7 +2933,7 @@ void Element::serialize_children_as_json(JsonObjectSerializer<Utf16StringBuilder
     for_each_child(add_child);
 
     if (has_pseudo_elements) {
-        if (auto after = m_pseudo_element_data->get(CSS::PseudoElement::After); after.has_value()) {
+        if (auto after = pseudo_element_data()->get(CSS::PseudoElement::After); after.has_value()) {
             serialize_pseudo_element(CSS::PseudoElement::After, after.value());
         }
 
@@ -4240,8 +4325,8 @@ void Element::set_custom_element_state(CustomElementState state)
 
 void Element::clear_custom_element_reaction_queue()
 {
-    if (m_custom_element_reaction_queue)
-        m_custom_element_reaction_queue->clear();
+    if (auto* rare_data = element_rare_data(); rare_data && rare_data->custom_element_reaction_queue)
+        rare_data->custom_element_reaction_queue->clear();
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors
@@ -4254,13 +4339,14 @@ void Element::setup_custom_element_from_constructor(HTML::CustomElementDefinitio
     m_custom_element_definition = custom_element_definition;
 
     // 7.8. Set element's is value to is value.
-    m_is_value = is_value;
+    set_is_value(is_value);
 }
 
 void Element::set_prefix(Optional<Utf16FlyString> value)
 {
     m_qualified_name.set_prefix(move(value));
-    m_html_uppercased_qualified_name.clear();
+    if (auto* rare_data = element_rare_data())
+        rare_data->html_uppercased_qualified_name.clear();
 }
 
 // https://dom.spec.whatwg.org/#locate-a-namespace-prefix
@@ -4436,7 +4522,15 @@ void Element::set_associated_shadow_host_pseudo_element(CSS::PseudoElement type)
 
     shadow_root.host()->register_element_reference_pseudo_element(type, *this);
 
-    m_associated_shadow_host_pseudo_element = type;
+    ensure_element_rare_data().associated_shadow_host_pseudo_element = type;
+}
+
+Optional<CSS::PseudoElement> Element::associated_shadow_host_pseudo_element() const
+{
+    auto const* rare_data = element_rare_data();
+    if (!rare_data)
+        return {};
+    return rare_data->associated_shadow_host_pseudo_element;
 }
 
 Optional<SyntheticPseudoElement&> Element::get_synthetic_pseudo_element(CSS::PseudoElement type) const
@@ -4453,14 +4547,15 @@ Optional<SyntheticPseudoElement&> Element::get_synthetic_pseudo_element(CSS::Pse
 
 Optional<PseudoElement&> Element::get_pseudo_element(CSS::PseudoElement type) const
 {
-    if (!m_pseudo_element_data)
+    auto const* pseudo_element_data = this->pseudo_element_data();
+    if (!pseudo_element_data)
         return {};
 
     if (!CSS::Selector::PseudoElementSelector::is_known_pseudo_element_type(type)) {
         return {};
     }
 
-    auto pseudo_element = m_pseudo_element_data->get(type);
+    auto pseudo_element = pseudo_element_data->get(type);
     if (!pseudo_element.has_value())
         return {};
 
@@ -4471,36 +4566,39 @@ void Element::register_element_reference_pseudo_element(CSS::PseudoElement type,
 {
     VERIFY(CSS::is_element_reference_pseudo_element(type));
 
-    if (!m_pseudo_element_data)
-        m_pseudo_element_data = make<PseudoElementData>();
+    auto& pseudo_element_data = ensure_element_rare_data().pseudo_element_data;
+    if (!pseudo_element_data)
+        pseudo_element_data = make<PseudoElementData>();
 
-    m_pseudo_element_data->set(type, GC::Heap::the().allocate<ElementReferencePseudoElement>(element));
+    pseudo_element_data->set(type, GC::Heap::the().allocate<ElementReferencePseudoElement>(element));
 }
 
 void Element::clear_element_reference_pseudo_elements()
 {
-    if (!m_pseudo_element_data)
+    auto* pseudo_element_data = this->pseudo_element_data();
+    if (!pseudo_element_data)
         return;
 
     for (auto i = to_underlying(CSS::first_element_reference_pseudo_element); i <= to_underlying(CSS::last_element_reference_pseudo_element); ++i)
-        m_pseudo_element_data->remove(static_cast<CSS::PseudoElement>(i));
+        pseudo_element_data->remove(static_cast<CSS::PseudoElement>(i));
 }
 
 SyntheticPseudoElement& Element::ensure_synthetic_pseudo_element(CSS::PseudoElement type) const
 {
-    if (!m_pseudo_element_data)
-        m_pseudo_element_data = make<PseudoElementData>();
+    auto& pseudo_element_data = ensure_element_rare_data().pseudo_element_data;
+    if (!pseudo_element_data)
+        pseudo_element_data = make<PseudoElementData>();
 
     VERIFY(CSS::is_synthetic_pseudo_element(type));
 
-    if (!m_pseudo_element_data->get(type).has_value()) {
+    if (!pseudo_element_data->get(type).has_value()) {
         if (is_pseudo_element_root(type))
-            m_pseudo_element_data->set(type, heap().allocate<SyntheticPseudoElementTreeNode>(const_cast<Element&>(*this)));
+            pseudo_element_data->set(type, heap().allocate<SyntheticPseudoElementTreeNode>(const_cast<Element&>(*this)));
         else
-            m_pseudo_element_data->set(type, heap().allocate<SyntheticPseudoElement>(const_cast<Element&>(*this)));
+            pseudo_element_data->set(type, heap().allocate<SyntheticPseudoElement>(const_cast<Element&>(*this)));
     }
 
-    return as<SyntheticPseudoElement>(*m_pseudo_element_data->get(type).value());
+    return as<SyntheticPseudoElement>(*pseudo_element_data->get(type).value());
 }
 
 void Element::set_custom_property_data(Optional<CSS::PseudoElement> pseudo_element, RefPtr<CSS::CustomPropertyData const> data)
@@ -4865,16 +4963,18 @@ bool Element::id_reference_exists(Utf16View id_reference) const
 
 void Element::register_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, GC::Ref<IntersectionObserver::IntersectionObserver> observer)
 {
-    if (!m_registered_intersection_observers)
-        m_registered_intersection_observers = make<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>>();
-    m_registered_intersection_observers->append(observer);
+    auto& registered_intersection_observers = ensure_element_rare_data().registered_intersection_observers;
+    if (!registered_intersection_observers)
+        registered_intersection_observers = make<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>>();
+    registered_intersection_observers->append(observer);
 }
 
 void Element::unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, GC::Ref<IntersectionObserver::IntersectionObserver> observer)
 {
-    if (!m_registered_intersection_observers)
+    auto* rare_data = element_rare_data();
+    if (!rare_data || !rare_data->registered_intersection_observers)
         return;
-    m_registered_intersection_observers->remove_first_matching([&observer](GC::Ref<IntersectionObserver::IntersectionObserver> const& entry) {
+    rare_data->registered_intersection_observers->remove_first_matching([&observer](GC::Ref<IntersectionObserver::IntersectionObserver> const& entry) {
         return entry == observer;
     });
 }
@@ -5243,8 +5343,8 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
                 return IterationDecision::Continue;
             });
         }
-        if (m_class_list)
-            m_class_list->associated_attribute_changed(value_or_empty);
+        if (auto* rare_data = element_rare_data(); rare_data && rare_data->class_list)
+            rare_data->class_list->associated_attribute_changed(value_or_empty);
     } else if (local_name == HTML::AttributeNames::style) {
         // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
         if (m_inline_style && m_inline_style->is_updating())
@@ -5271,12 +5371,14 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         else
             CSS::Invalidation::invalidate_style_after_language_change(*this);
     } else if (local_name == HTML::AttributeNames::part) {
-        m_parts.clear();
+        if (auto* rare_data = element_rare_data())
+            rare_data->parts.clear();
         if (!value_or_empty.is_empty()) {
+            auto& parts = ensure_element_rare_data().parts;
             auto new_parts = value_or_empty;
             auto append_part = [&](Utf16View new_part) {
-                if (!m_parts.contains_slow(new_part))
-                    m_parts.append(Utf16FlyString::from_utf16(new_part));
+                if (!parts.contains_slow(new_part))
+                    parts.append(Utf16FlyString::from_utf16(new_part));
             };
             size_t start = 0;
             for (size_t i = 0; i <= new_parts.length_in_code_units(); ++i) {
@@ -5287,8 +5389,8 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
                 start = i + 1;
             }
         }
-        if (m_part_list)
-            m_part_list->associated_attribute_changed(value_or_empty);
+        if (auto* rare_data = element_rare_data(); rare_data && rare_data->part_list)
+            rare_data->part_list->associated_attribute_changed(value_or_empty);
         CSS::record_element_parts_changed(*this);
     } else if (local_name == HTML::AttributeNames::exportparts) {
         CSS::Invalidation::invalidate_style_after_exportparts_attribute_change(*this);
@@ -5327,16 +5429,51 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
 
 auto Element::ensure_custom_element_reaction_queue() -> CustomElementReactionQueue&
 {
-    if (!m_custom_element_reaction_queue)
-        m_custom_element_reaction_queue = make<CustomElementReactionQueue>();
-    return *m_custom_element_reaction_queue;
+    auto& custom_element_reaction_queue = ensure_element_rare_data().custom_element_reaction_queue;
+    if (!custom_element_reaction_queue)
+        custom_element_reaction_queue = make<CustomElementReactionQueue>();
+    return *custom_element_reaction_queue;
+}
+
+auto Element::custom_element_reaction_queue() -> CustomElementReactionQueue*
+{
+    auto* rare_data = element_rare_data();
+    return rare_data ? rare_data->custom_element_reaction_queue.ptr() : nullptr;
+}
+
+auto Element::custom_element_reaction_queue() const -> CustomElementReactionQueue const*
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->custom_element_reaction_queue.ptr() : nullptr;
 }
 
 HTML::CustomStateSet& Element::ensure_custom_state_set()
 {
-    if (!m_custom_state_set)
-        m_custom_state_set = HTML::CustomStateSet::create(*this);
-    return *m_custom_state_set;
+    auto& custom_state_set = ensure_element_rare_data().custom_state_set;
+    if (!custom_state_set)
+        custom_state_set = HTML::CustomStateSet::create(*this);
+    return *custom_state_set;
+}
+
+GC::Ptr<HTML::CustomStateSet const> Element::custom_state_set() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->custom_state_set : nullptr;
+}
+
+Optional<Utf16FlyString> const& Element::is_value() const
+{
+    static NeverDestroyed<Optional<Utf16FlyString>> empty_is_value;
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->is_value : *empty_is_value;
+}
+
+void Element::set_is_value(Optional<Utf16FlyString> const& is)
+{
+    if (is.has_value())
+        ensure_element_rare_data().is_value = is;
+    else if (auto* rare_data = element_rare_data())
+        rare_data->is_value.clear();
 }
 
 CSS::StyleSheetList& Element::document_or_shadow_root_style_sheets()
@@ -5385,21 +5522,32 @@ WebIDL::ExceptionOr<void> Element::set_html_unsafe(StringView html)
 
 Optional<CSS::CountersSet const&> Element::counters_set() const
 {
-    if (!m_counters_set)
+    auto const* rare_data = element_rare_data();
+    if (!rare_data || !rare_data->counters_set)
         return {};
-    return *m_counters_set;
+    return *rare_data->counters_set;
 }
 
 CSS::CountersSet& Element::ensure_counters_set()
 {
-    if (!m_counters_set)
-        m_counters_set = make<CSS::CountersSet>();
-    return *m_counters_set;
+    auto& counters_set = ensure_element_rare_data().counters_set;
+    if (!counters_set)
+        counters_set = make<CSS::CountersSet>();
+    return *counters_set;
 }
 
 void Element::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
 {
-    m_counters_set = move(counters_set);
+    if (counters_set)
+        ensure_element_rare_data().counters_set = move(counters_set);
+    else if (auto* rare_data = element_rare_data())
+        rare_data->counters_set = nullptr;
+}
+
+bool Element::has_non_empty_counters_set() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data && rare_data->counters_set;
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes
@@ -5562,7 +5710,7 @@ GC::Ptr<NamedNodeMap const> Element::attributes() const
 
 Utf16FlyString const& Element::html_uppercased_qualified_name() const
 {
-    return m_html_uppercased_qualified_name.ensure([&] { return make_html_uppercased_qualified_name(); });
+    return ensure_element_rare_data().html_uppercased_qualified_name.ensure([&] { return make_html_uppercased_qualified_name(); });
 }
 
 void Element::play_or_cancel_animations_after_display_property_change()
@@ -5681,12 +5829,13 @@ GC::Ref<CSS::StylePropertyMapReadOnly> Element::computed_style_map()
     //
     // NOTE: In practice, since the values are "hidden" behind a .get() method call, UAs can delay computing anything
     //    until a given property is actually requested.
-    if (m_computed_style_map_cache == nullptr) {
-        m_computed_style_map_cache = CSS::StylePropertyMapReadOnly::create_computed_style(AbstractElement { *this });
+    auto& computed_style_map_cache = ensure_element_rare_data().computed_style_map_cache;
+    if (computed_style_map_cache == nullptr) {
+        computed_style_map_cache = CSS::StylePropertyMapReadOnly::create_computed_style(AbstractElement { *this });
     }
 
     // 2. Return this’s [[computedStyleMapCache]] internal slot.
-    return *m_computed_style_map_cache;
+    return *computed_style_map_cache;
 }
 
 double Element::ensure_css_random_base_value(CSS::RandomCachingKey const& random_caching_key)
@@ -5696,7 +5845,7 @@ double Element::ensure_css_random_base_value(CSS::RandomCachingKey const& random
     if (!random_caching_key.element_id.has_value())
         return document().ensure_element_shared_css_random_base_value(random_caching_key);
 
-    return m_element_specific_css_random_base_value_cache.ensure(random_caching_key, []() {
+    return ensure_element_rare_data().element_specific_css_random_base_value_cache.ensure(random_caching_key, []() {
         static XorShift128PlusRNG random_number_generator;
         return random_number_generator.get();
     });

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -193,6 +193,24 @@ struct Element::RareData final
 
     // https://drafts.csswg.org/css-values-5/#random-caching
     HashMap<CSS::RandomCachingKey, double> element_specific_css_random_base_value_cache;
+
+    // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
+    GC::Ptr<HTML::CustomElementDefinition> custom_element_definition;
+
+    Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
+
+    // https://w3c.github.io/webappsec-csp/#is-element-nonceable
+    // AD-HOC: We need to know the element had a duplicate attribute when it was created from the HTML parser.
+    //         However, there currently isn't any specified way to do this, so we store a flag on the token, which is
+    //         then passed down to here. This is used by Content Security Policy to disable the nonce attribute if this
+    //         flag is set.
+    bool had_duplicate_attribute_during_tokenization { false };
+
+    // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
+    ProximityToTheViewport proximity_to_the_viewport { ProximityToTheViewport::NotDetermined };
+
+    // https://drafts.csswg.org/css-view-transitions-1/#captured-in-a-view-transition
+    bool captured_in_a_view_transition { false };
 };
 
 void Element::RareData::visit_edges(Cell::Visitor& visitor)
@@ -230,6 +248,7 @@ void Element::RareData::visit_edges(Cell::Visitor& visitor)
     visitor.visit(custom_state_set);
     visitor.visit(computed_style_map_cache);
     visitor.visit(attribute_style_map);
+    visitor.visit(custom_element_definition);
     if (pseudo_element_data) {
         for (auto& pseudo_element : *pseudo_element_data)
             visitor.visit(pseudo_element.value);
@@ -350,7 +369,6 @@ void Element::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_inline_style);
     visitor.visit(m_shadow_root);
     visitor.visit(m_custom_element_registry);
-    visitor.visit(m_custom_element_definition);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute
@@ -4257,10 +4275,27 @@ void Element::enqueue_a_form_disabled_callback_reaction(bool is_disabled)
                                                                                                        });
 }
 
+GC::Ptr<HTML::CustomElementDefinition> Element::custom_element_definition() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->custom_element_definition : nullptr;
+}
+
+void Element::set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinition> definition)
+{
+    if (!definition) {
+        if (auto* rare_data = element_rare_data())
+            rare_data->custom_element_definition = nullptr;
+        return;
+    }
+    ensure_element_rare_data().custom_element_definition = definition;
+}
+
 void Element::enqueue_a_custom_element_callback_reaction(Utf16FlyString const& callback_name, CustomElementCallbackReactionArguments arguments)
 {
     // 1. Let definition be element's custom element definition.
-    auto& definition = m_custom_element_definition;
+    auto definition = custom_element_definition();
+    VERIFY(definition);
 
     // 2. Let callback be the value of the entry in definition's lifecycle callbacks with key callbackName.
     GC::Ptr<Web::WebIDL::CallbackType> callback;
@@ -4368,7 +4403,7 @@ void Element::setup_custom_element_from_constructor(HTML::CustomElementDefinitio
     set_custom_element_state(CustomElementState::Custom);
 
     // 7.7. Set element's custom element definition to definition.
-    m_custom_element_definition = custom_element_definition;
+    set_custom_element_definition(custom_element_definition);
 
     // 7.8. Set element's is value to is value.
     set_is_value(is_value);
@@ -4886,6 +4921,12 @@ bool Element::check_visibility(CheckVisibilityOptions const& options)
     return true;
 }
 
+ProximityToTheViewport Element::proximity_to_the_viewport() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->proximity_to_the_viewport : ProximityToTheViewport::NotDetermined;
+}
+
 // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
 void Element::determine_proximity_to_the_viewport()
 {
@@ -4899,8 +4940,10 @@ void Element::determine_proximity_to_the_viewport()
     // viewport soon. A margin of 50% is suggested as a reasonable default.
     viewport_rect.inflate(viewport_rect.width(), viewport_rect.height());
     // FIXME: We don't have paint containment or the overflow clip edge yet, so this is just using the absolute rect for now.
-    if (paintable_box()->absolute_rect().intersects(viewport_rect))
-        m_proximity_to_the_viewport = ProximityToTheViewport::CloseToTheViewport;
+    if (paintable_box()->absolute_rect().intersects(viewport_rect)) {
+        ensure_element_rare_data().proximity_to_the_viewport = ProximityToTheViewport::CloseToTheViewport;
+        return;
+    }
 
     // FIXME: If a filter (see [FILTER-EFFECTS-1]) with non local effects includes the element as part of its input, the user
     //        agent should also treat the element as relevant to the user when the filter’s output can affect the rendering
@@ -4909,7 +4952,7 @@ void Element::determine_proximity_to_the_viewport()
 
     // - The element is far away from the viewport: In this state, the element’s proximity to the viewport has been
     //   computed and is not close to the viewport.
-    m_proximity_to_the_viewport = ProximityToTheViewport::FarAwayFromTheViewport;
+    ensure_element_rare_data().proximity_to_the_viewport = ProximityToTheViewport::FarAwayFromTheViewport;
 
     // - The element’s proximity to the viewport is not determined: In this state, the computation to determine the
     //   element’s proximity to the viewport has not been done since the last time the element was connected.
@@ -4922,7 +4965,7 @@ bool Element::is_relevant_to_the_user()
     // An element is relevant to the user if any of the following conditions are true:
 
     // The element is close to the viewport.
-    if (m_proximity_to_the_viewport == ProximityToTheViewport::CloseToTheViewport)
+    if (proximity_to_the_viewport() == ProximityToTheViewport::CloseToTheViewport)
         return true;
 
     // Either the element or its contents are focused, as described in the focus section of the HTML spec.
@@ -4956,6 +4999,22 @@ bool Element::is_relevant_to_the_user()
 
     // NOTE: none of the above conditions are true, so the element is not relevant to the user.
     return false;
+}
+
+bool Element::captured_in_a_view_transition() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data && rare_data->captured_in_a_view_transition;
+}
+
+void Element::set_captured_in_a_view_transition(bool value)
+{
+    if (!value) {
+        if (auto* rare_data = element_rare_data())
+            rare_data->captured_in_a_view_transition = false;
+        return;
+    }
+    ensure_element_rare_data().captured_in_a_view_transition = true;
 }
 
 // https://drafts.csswg.org/css-contain-2/#skips-its-contents
@@ -5843,7 +5902,13 @@ bool Element::is_focusable() const
 
 void Element::set_had_duplicate_attribute_during_tokenization(Badge<HTML::HTMLParser>)
 {
-    m_had_duplicate_attribute_during_tokenization = true;
+    ensure_element_rare_data().had_duplicate_attribute_during_tokenization = true;
+}
+
+bool Element::had_duplicate_attribute_during_tokenization() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data && rare_data->had_duplicate_attribute_during_tokenization;
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap
@@ -5905,6 +5970,22 @@ void Element::set_fullscreen_flag(bool is_fullscreen)
         return;
     m_fullscreen_flag = is_fullscreen;
     CSS::record_element_state_changed(*this, CSS::PseudoClass::Fullscreen, is_fullscreen);
+}
+
+void Element::set_fullscreen_request_type(Fullscreen::RequestType request_type)
+{
+    if (request_type == Fullscreen::RequestType::Standard) {
+        if (auto* rare_data = element_rare_data())
+            rare_data->fullscreen_request_type = request_type;
+        return;
+    }
+    ensure_element_rare_data().fullscreen_request_type = request_type;
+}
+
+Fullscreen::RequestType Element::fullscreen_request_type() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->fullscreen_request_type : Fullscreen::RequestType::Standard;
 }
 
 GC::Ptr<Element const> Element::element_to_inherit_style_from(Optional<CSS::PseudoElement> pseudo_element) const

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5049,7 +5049,8 @@ CSSPixelPoint Element::scroll_offset(Optional<CSS::PseudoElement> pseudo_element
             return pseudo_element->scroll_offset();
         return {};
     }
-    return m_scroll_offset;
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->scroll_offset : CSSPixelPoint {};
 }
 
 void Element::set_scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type, CSSPixelPoint offset)
@@ -5058,8 +5059,17 @@ void Element::set_scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type
         if (auto pseudo_element = get_synthetic_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
             pseudo_element->set_scroll_offset(offset);
     } else {
-        m_scroll_offset = offset;
+        if (!offset.is_zero())
+            ensure_element_rare_data().scroll_offset = offset;
+        else if (auto* rare_data = element_rare_data())
+            rare_data->scroll_offset = {};
     }
+}
+
+Optional<Element::Dir> Element::dir() const
+{
+    auto const* rare_data = element_rare_data();
+    return rare_data ? rare_data->dir : Optional<Dir> {};
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#translation-mode
@@ -5422,14 +5432,18 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         bool const is_dir = local_name == HTML::AttributeNames::dir;
         if (is_dir) {
             // https://html.spec.whatwg.org/multipage/dom.html#attr-dir
+            Optional<Dir> dir;
             if (value_or_empty.equals_ignoring_ascii_case(u"ltr"sv))
-                m_dir = Dir::Ltr;
+                dir = Dir::Ltr;
             else if (value_or_empty.equals_ignoring_ascii_case(u"rtl"sv))
-                m_dir = Dir::Rtl;
+                dir = Dir::Rtl;
             else if (value_or_empty.equals_ignoring_ascii_case(u"auto"sv))
-                m_dir = Dir::Auto;
-            else
-                m_dir = {};
+                dir = Dir::Auto;
+
+            if (dir.has_value())
+                ensure_element_rare_data().dir = dir;
+            else if (auto* rare_data = element_rare_data())
+                rare_data->dir = {};
         }
         if (is_dir)
             CSS::Invalidation::invalidate_style_after_directionality_change(*this);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -200,6 +200,8 @@ struct Element::RareData final
     // https://dom.spec.whatwg.org/#element-custom-element-registry
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry;
 
+    Optional<Utf16FlyString> name;
+
     Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
 
     // https://w3c.github.io/webappsec-csp/#is-element-nonceable
@@ -2666,7 +2668,7 @@ void Element::inserted()
             document().set_needs_mathml_and_svg_user_agent_style_sheets();
         if (m_id.has_value())
             document().element_with_id_was_added({}, *this);
-        if (m_name.has_value())
+        if (m_has_name)
             document().element_with_name_was_added({}, *this);
         if (m_id.has_value() || !m_classes.is_empty())
             invalidate_content_blocker_style_if_needed(*this);
@@ -2691,7 +2693,7 @@ void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, No
     if (old_root.is_connected()) {
         if (m_id.has_value())
             document().element_with_id_was_removed({}, *this);
-        if (m_name.has_value())
+        if (m_has_name)
             document().element_with_name_was_removed({}, *this);
         if (anchor_values) {
             auto& anchor_names = is<ShadowRoot>(old_root)
@@ -5446,10 +5448,12 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
             document().element_id_changed({}, *this, old_id);
         }
     } else if (local_name == HTML::AttributeNames::name) {
-        if (value_or_empty.is_empty())
-            m_name = {};
-        else
-            m_name = Utf16FlyString::from_utf16(value_or_empty);
+        m_has_name = !value_or_empty.is_empty();
+        if (m_has_name) {
+            ensure_element_rare_data().name = Utf16FlyString::from_utf16(value_or_empty);
+        } else if (auto* rare_data = element_rare_data()) {
+            rare_data->name = {};
+        }
 
         if (is_connected())
             document().element_name_changed({}, *this);
@@ -5545,6 +5549,16 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         CSS::record_element_id_changed(*this, old_style_engine_id, m_id);
     else if (local_name == HTML::AttributeNames::class_)
         CSS::record_element_class_list_changed(*this, old_style_engine_classes, m_classes);
+}
+
+Optional<Utf16FlyString> Element::name() const
+{
+    if (!m_has_name)
+        return {};
+    auto const* rare_data = element_rare_data();
+    VERIFY(rare_data);
+    VERIFY(rare_data->name.has_value());
+    return rare_data->name;
 }
 
 auto Element::ensure_custom_element_reaction_queue() -> CustomElementReactionQueue&

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -774,8 +774,8 @@ public:
 
     WebIDL::ExceptionOr<void> request_pointer_lock(PointerLockOptions const&);
 
-    GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const { return m_custom_element_registry; }
-    void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> registry) { m_custom_element_registry = registry; }
+    GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const;
+    void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry>);
 
     virtual void initialize_element() { }
 
@@ -868,9 +868,6 @@ private:
     Optional<Utf16FlyString> m_id;
     Optional<Utf16FlyString> m_name;
 
-    // https://dom.spec.whatwg.org/#element-custom-element-registry
-    GC::Ptr<HTML::CustomElementRegistry> m_custom_element_registry;
-
     CSSPixelPoint m_scroll_offset;
 
     bool m_is_being_activated : 1 { false };
@@ -888,6 +885,7 @@ private:
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_style_uses_tree_counting_function : 1 { false };
     bool m_fullscreen_flag : 1 { false };
+    bool m_uses_document_global_custom_element_registry : 1 { false };
 
     mutable Optional<Utf16String> m_lang_value;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -815,6 +815,12 @@ private:
 
     struct RareData;
     virtual OwnPtr<Node::RareData> create_rare_data() const override;
+    virtual SlottableMixin::RareData* slottable_rare_data() override;
+    virtual SlottableMixin::RareData const* slottable_rare_data() const override;
+    virtual SlottableMixin::RareData& ensure_slottable_rare_data() override;
+    virtual ARIA::ARIAMixin::RareData* aria_rare_data() override;
+    virtual ARIA::ARIAMixin::RareData const* aria_rare_data() const override;
+    virtual ARIA::ARIAMixin::RareData& ensure_aria_rare_data() override;
     RareData& ensure_element_rare_data() const;
     RareData* element_rare_data();
     RareData const* element_rare_data() const;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -809,11 +809,12 @@ protected:
     void play_or_cancel_animations_after_display_property_change();
     void clear_element_reference_pseudo_elements();
 
+    struct RareData;
+
 private:
     using PreservedPseudoElementStyles = Array<RefPtr<CSS::ComputedValues const>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)>;
     using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
 
-    struct RareData;
     virtual OwnPtr<Node::RareData> create_rare_data() const override;
     virtual SlottableMixin::RareData* slottable_rare_data() override;
     virtual SlottableMixin::RareData const* slottable_rare_data() const override;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -687,7 +687,7 @@ public:
         Rtl,
         Auto,
     };
-    Optional<Dir> dir() const { return m_dir; }
+    Optional<Dir> dir() const;
     bool has_auto_directionality() const;
 
     enum class Directionality {
@@ -873,10 +873,8 @@ private:
 
     Vector<Utf16FlyString> m_classes;
     CSS::StyleNodeID m_style_node_id;
-    Optional<Dir> m_dir;
 
     Optional<Utf16FlyString> m_id;
-    CSSPixelPoint m_scroll_offset;
 
     bool m_is_being_activated : 1 { false };
     bool m_in_top_layer : 1 { false };

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -440,8 +440,8 @@ public:
 
     void set_fullscreen_flag(bool is_fullscreen);
     bool is_fullscreen_element() const { return m_fullscreen_flag; }
-    void set_fullscreen_request_type(Fullscreen::RequestType request_type) { m_fullscreen_request_type = request_type; }
-    Fullscreen::RequestType fullscreen_request_type() const { return m_fullscreen_request_type; }
+    void set_fullscreen_request_type(Fullscreen::RequestType);
+    Fullscreen::RequestType fullscreen_request_type() const;
 
     GC::Ptr<WebIDL::CallbackType> onfullscreenchange();
     void set_onfullscreenchange(GC::Ptr<WebIDL::CallbackType>);
@@ -648,7 +648,7 @@ public:
     void set_is_value(Optional<Utf16FlyString> const& is);
 
     void set_custom_element_state(CustomElementState);
-    void set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinition> definition) { m_custom_element_definition = definition; }
+    void set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinition>);
     void clear_custom_element_reaction_queue();
     void setup_custom_element_from_constructor(HTML::CustomElementDefinition& custom_element_definition, Optional<Utf16FlyString> const& is_value);
 
@@ -713,7 +713,7 @@ public:
     CSS::CountersSet& ensure_counters_set();
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
-    ProximityToTheViewport proximity_to_the_viewport() const { return m_proximity_to_the_viewport; }
+    ProximityToTheViewport proximity_to_the_viewport() const;
     void determine_proximity_to_the_viewport();
     bool is_relevant_to_the_user();
 
@@ -732,8 +732,8 @@ public:
 
     void invalidate_list_item_counters_for_list_owner();
 
-    bool captured_in_a_view_transition() const { return m_captured_in_a_view_transition; }
-    void set_captured_in_a_view_transition(bool value) { m_captured_in_a_view_transition = value; }
+    bool captured_in_a_view_transition() const;
+    void set_captured_in_a_view_transition(bool);
 
     // https://drafts.csswg.org/css-images-4/#element-not-rendered
     bool not_rendered() const;
@@ -753,7 +753,7 @@ public:
     virtual bool contributes_a_script_blocking_style_sheet() const { return false; }
 
     void set_had_duplicate_attribute_during_tokenization(Badge<HTML::HTMLParser>);
-    bool had_duplicate_attribute_during_tokenization() const { return m_had_duplicate_attribute_during_tokenization; }
+    bool had_duplicate_attribute_during_tokenization() const;
 
     GC::Ref<CSS::StylePropertyMapReadOnly> computed_style_map();
 
@@ -802,7 +802,7 @@ protected:
     virtual bool id_reference_exists(Utf16View) const override;
 
     CustomElementState custom_element_state() const { return m_custom_element_state; }
-    GC::Ptr<HTML::CustomElementDefinition> custom_element_definition() const { return m_custom_element_definition; }
+    GC::Ptr<HTML::CustomElementDefinition> custom_element_definition() const;
 
     friend void Bindings::set_prototype_from_custom_element_definition_if_needed(Element&, Bindings::PlatformObject&);
 
@@ -871,9 +871,6 @@ private:
     // https://dom.spec.whatwg.org/#element-custom-element-registry
     GC::Ptr<HTML::CustomElementRegistry> m_custom_element_registry;
 
-    // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
-    GC::Ptr<HTML::CustomElementDefinition> m_custom_element_definition;
-
     CSSPixelPoint m_scroll_offset;
 
     bool m_is_being_activated : 1 { false };
@@ -892,25 +889,10 @@ private:
     bool m_style_uses_tree_counting_function : 1 { false };
     bool m_fullscreen_flag : 1 { false };
 
-    Fullscreen::RequestType m_fullscreen_request_type { Fullscreen::RequestType::Standard };
-
     mutable Optional<Utf16String> m_lang_value;
-
-    // https://w3c.github.io/webappsec-csp/#is-element-nonceable
-    // AD-HOC: We need to know the element had a duplicate attribute when it was created from the HTML parser.
-    //         However, there currently isn't any specified way to do this, so we store a flag on the token, which is
-    //         then passed down to here. This is used by Content Security Policy to disable the nonce attribute if this
-    //         flag is set.
-    bool m_had_duplicate_attribute_during_tokenization { false };
 
     // https://dom.spec.whatwg.org/#concept-element-custom-element-state
     CustomElementState m_custom_element_state { CustomElementState::Undefined };
-
-    // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
-    ProximityToTheViewport m_proximity_to_the_viewport { ProximityToTheViewport::NotDetermined };
-
-    // https://drafts.csswg.org/css-view-transitions-1/#captured-in-a-view-transition
-    bool m_captured_in_a_view_transition { false };
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -248,7 +248,7 @@ public:
 
     GC::Ref<DOMTokenList> class_list();
     GC::Ref<DOMTokenList> part_list();
-    ReadonlySpan<Utf16FlyString> part_names() const { return m_parts; }
+    ReadonlySpan<Utf16FlyString> part_names() const;
 
     using ShadowRootOptions = Bindings::ShadowRootInit;
 
@@ -326,7 +326,7 @@ public:
 
     void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason, CSS::LayoutTreeRebuildRoot);
 
-    Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element() const { return m_associated_shadow_host_pseudo_element; }
+    Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element() const;
     void set_associated_shadow_host_pseudo_element(CSS::PseudoElement pseudo_element);
 
     Layout::NodeWithStyle* layout_node();
@@ -360,12 +360,13 @@ public:
     template<typename Callback>
     void for_each_synthetic_pseudo_element(Callback const& callback)
     {
-        if (!m_pseudo_element_data)
+        auto* pseudo_element_data = this->pseudo_element_data();
+        if (!pseudo_element_data)
             return;
 
         for (auto i = to_underlying(CSS::first_synthetic_pseudo_element); i <= to_underlying(CSS::last_synthetic_pseudo_element); ++i) {
             auto type = static_cast<CSS::PseudoElement>(i);
-            auto pseudo_element = m_pseudo_element_data->get(type);
+            auto pseudo_element = pseudo_element_data->get(type);
             if (!pseudo_element.has_value())
                 continue;
 
@@ -383,12 +384,13 @@ public:
     template<typename Callback>
     void for_each_synthetic_pseudo_element(Callback const& callback) const
     {
-        if (!m_pseudo_element_data)
+        auto const* pseudo_element_data = this->pseudo_element_data();
+        if (!pseudo_element_data)
             return;
 
         for (auto i = to_underlying(CSS::first_synthetic_pseudo_element); i <= to_underlying(CSS::last_synthetic_pseudo_element); ++i) {
             auto type = static_cast<CSS::PseudoElement>(i);
-            auto pseudo_element = m_pseudo_element_data->get(type);
+            auto pseudo_element = pseudo_element_data->get(type);
             if (!pseudo_element.has_value())
                 continue;
 
@@ -629,11 +631,11 @@ public:
     void enqueue_a_custom_element_callback_reaction(Utf16FlyString const& callback_name, CustomElementCallbackReactionArguments arguments);
 
     using CustomElementReactionQueue = Vector<Variant<CustomElementUpgradeReaction, CustomElementCallbackReaction, CustomElementConnectedMoveCallbackReaction>>;
-    CustomElementReactionQueue* custom_element_reaction_queue() { return m_custom_element_reaction_queue; }
-    CustomElementReactionQueue const* custom_element_reaction_queue() const { return m_custom_element_reaction_queue; }
+    CustomElementReactionQueue* custom_element_reaction_queue();
+    CustomElementReactionQueue const* custom_element_reaction_queue() const;
     CustomElementReactionQueue& ensure_custom_element_reaction_queue();
 
-    GC::Ptr<HTML::CustomStateSet const> custom_state_set() const { return m_custom_state_set; }
+    GC::Ptr<HTML::CustomStateSet const> custom_state_set() const;
     HTML::CustomStateSet& ensure_custom_state_set();
 
     bool can_upgrade_custom_element() const { return m_custom_element_state == CustomElementState::Undefined || m_custom_element_state == CustomElementState::Uncustomized; }
@@ -642,8 +644,8 @@ public:
     bool is_defined() const;
     bool is_custom() const;
 
-    Optional<Utf16FlyString> const& is_value() const { return m_is_value; }
-    void set_is_value(Optional<Utf16FlyString> const& is) { m_is_value = is; }
+    Optional<Utf16FlyString> const& is_value() const;
+    void set_is_value(Optional<Utf16FlyString> const& is);
 
     void set_custom_element_state(CustomElementState);
     void set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinition> definition) { m_custom_element_definition = definition; }
@@ -706,7 +708,7 @@ public:
     void set_rendered_in_top_layer(bool rendered_in_top_layer) { m_rendered_in_top_layer = rendered_in_top_layer; }
     bool rendered_in_top_layer() const { return m_rendered_in_top_layer; }
 
-    bool has_non_empty_counters_set() const { return m_counters_set; }
+    bool has_non_empty_counters_set() const;
     Optional<CSS::CountersSet const&> counters_set() const;
     CSS::CountersSet& ensure_counters_set();
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
@@ -809,6 +811,15 @@ protected:
 
 private:
     using PreservedPseudoElementStyles = Array<RefPtr<CSS::ComputedValues const>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)>;
+    using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
+
+    struct RareData;
+    virtual OwnPtr<Node::RareData> create_rare_data() const override;
+    RareData& ensure_element_rare_data() const;
+    RareData* element_rare_data();
+    RareData const* element_rare_data() const;
+    PseudoElementData* pseudo_element_data();
+    PseudoElementData const* pseudo_element_data() const;
 
     Utf16FlyString make_html_uppercased_qualified_name() const;
 
@@ -828,14 +839,10 @@ private:
     Directionality parent_directionality() const;
 
     QualifiedName m_qualified_name;
-    mutable Optional<Utf16FlyString> m_html_uppercased_qualified_name;
 
     GC::Ptr<NamedNodeMap> m_attributes;
     GC::Ptr<CSS::CSSStyleProperties> m_inline_style;
-    GC::Ptr<CSS::StylePropertyMap> m_attribute_style_map;
-    GC::Ptr<DOMTokenList> m_class_list;
     GC::Ptr<ShadowRoot> m_shadow_root;
-    GC::Ptr<DOMTokenList> m_part_list;
 
     // The authoritative StyleEngine record. C++ compatibility consumers borrow the record-owned
     // computed-values view rather than retaining one complete style per element.
@@ -844,47 +851,22 @@ private:
     OwnPtr<CSS::StyleInputRecord> m_style_input_record;
     PublishedCustomPropertyNames m_published_custom_property_names;
 
-    using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
-    mutable OwnPtr<PseudoElementData> m_pseudo_element_data;
     void register_element_reference_pseudo_element(CSS::PseudoElement type, GC::Ref<Element> element);
     SyntheticPseudoElement& ensure_synthetic_pseudo_element(CSS::PseudoElement) const;
     void clear_synthetic_pseudo_element_layout_nodes();
 
-    Optional<CSS::PseudoElement> m_associated_shadow_host_pseudo_element;
-
     Vector<Utf16FlyString> m_classes;
     CSS::StyleNodeID m_style_node_id;
-    Vector<Utf16FlyString> m_parts;
     Optional<Dir> m_dir;
 
     Optional<Utf16FlyString> m_id;
     Optional<Utf16FlyString> m_name;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
-    // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:
-    // NOTE: See the structs at the top of this header.
-    OwnPtr<CustomElementReactionQueue> m_custom_element_reaction_queue;
 
     // https://dom.spec.whatwg.org/#element-custom-element-registry
     GC::Ptr<HTML::CustomElementRegistry> m_custom_element_registry;
 
     // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
     GC::Ptr<HTML::CustomElementDefinition> m_custom_element_definition;
-
-    // https://dom.spec.whatwg.org/#concept-element-is-value
-    Optional<Utf16FlyString> m_is_value;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#states-set
-    GC::Ptr<HTML::CustomStateSet> m_custom_state_set;
-
-    // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
-    // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
-    OwnPtr<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>> m_registered_intersection_observers;
-
-    // https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemapcache-slot
-    // Every Element has a [[computedStyleMapCache]] internal slot, initially set to null, which caches the result of
-    // the computedStyleMap() method when it is first called.
-    GC::Ptr<CSS::StylePropertyMapReadOnly> m_computed_style_map_cache;
 
     CSSPixelPoint m_scroll_offset;
 
@@ -908,8 +890,6 @@ private:
 
     size_t m_sibling_invalidation_distance { 0 };
 
-    OwnPtr<CSS::CountersSet> m_counters_set;
-
     mutable Optional<Utf16String> m_lang_value;
 
     // https://w3c.github.io/webappsec-csp/#is-element-nonceable
@@ -927,9 +907,6 @@ private:
 
     // https://drafts.csswg.org/css-view-transitions-1/#captured-in-a-view-transition
     bool m_captured_in_a_view_transition { false };
-
-    // https://drafts.csswg.org/css-values-5/#random-caching
-    HashMap<CSS::RandomCachingKey, double> m_element_specific_css_random_base_value_cache;
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -691,7 +691,7 @@ public:
     bool is_auto_directionality_form_associated_element() const;
 
     Optional<Utf16FlyString> const& id() const { return m_id; }
-    Optional<Utf16FlyString> const& name() const { return m_name; }
+    Optional<Utf16FlyString> name() const;
 
     virtual GC::Ptr<GC::Function<void()>> take_lazy_load_resumption_steps(Badge<DOM::Document>)
     {
@@ -866,8 +866,6 @@ private:
     Optional<Dir> m_dir;
 
     Optional<Utf16FlyString> m_id;
-    Optional<Utf16FlyString> m_name;
-
     CSSPixelPoint m_scroll_offset;
 
     bool m_is_being_activated : 1 { false };
@@ -886,6 +884,7 @@ private:
     bool m_style_uses_tree_counting_function : 1 { false };
     bool m_fullscreen_flag : 1 { false };
     bool m_uses_document_global_custom_element_registry : 1 { false };
+    bool m_has_name : 1 { false };
 
     mutable Optional<Utf16String> m_lang_value;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -894,8 +894,6 @@ private:
 
     Fullscreen::RequestType m_fullscreen_request_type { Fullscreen::RequestType::Standard };
 
-    size_t m_sibling_invalidation_distance { 0 };
-
     mutable Optional<Utf16String> m_lang_value;
 
     // https://w3c.github.io/webappsec-csp/#is-element-nonceable

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -62,6 +62,13 @@ class Element;
 
 }
 
+namespace Web::HTML {
+
+template<typename>
+class HTMLOrSVGOrMathMLElement;
+
+}
+
 namespace Web::Bindings {
 
 class PlatformObject;
@@ -805,6 +812,8 @@ protected:
     GC::Ptr<HTML::CustomElementDefinition> custom_element_definition() const;
 
     friend void Bindings::set_prototype_from_custom_element_definition_if_needed(Element&, Bindings::PlatformObject&);
+    template<typename>
+    friend class HTML::HTMLOrSVGOrMathMLElement;
 
     void play_or_cancel_animations_after_display_property_change();
     void clear_element_reference_pseudo_elements();

--- a/Libraries/LibWeb/DOM/ElementRareData.h
+++ b/Libraries/LibWeb/DOM/ElementRareData.h
@@ -60,6 +60,13 @@ struct Element::RareData
 
     // https://dom.spec.whatwg.org/#element-custom-element-registry
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry;
+
+    // https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev
+    GC::Ptr<HTML::DOMStringMap> dataset;
+
+    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cryptographicnonce
+    Utf16String cryptographic_nonce;
+
     Optional<Utf16FlyString> name;
     Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
 

--- a/Libraries/LibWeb/DOM/ElementRareData.h
+++ b/Libraries/LibWeb/DOM/ElementRareData.h
@@ -68,6 +68,8 @@ struct Element::RareData
     Utf16String cryptographic_nonce;
 
     Optional<Utf16FlyString> name;
+    Optional<Dir> dir;
+    CSSPixelPoint scroll_offset;
     Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
 
     // https://w3c.github.io/webappsec-csp/#is-element-nonceable

--- a/Libraries/LibWeb/DOM/ElementRareData.h
+++ b/Libraries/LibWeb/DOM/ElementRareData.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/CountersSet.h>
+#include <LibWeb/CSS/StylePropertyMap.h>
+#include <LibWeb/CSS/StyleValues/RandomValueSharingStyleValue.h>
+#include <LibWeb/DOM/DOMTokenList.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/HTML/CustomElements/CustomStateSet.h>
+#include <LibWeb/IntersectionObserver/IntersectionObserver.h>
+
+namespace Web::DOM {
+
+struct Element::RareData
+    : Node::RareData
+    , SlottableMixin::RareData
+    , ARIA::ARIAMixin::RareData {
+    virtual ~RareData() override;
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    mutable Optional<Utf16FlyString> html_uppercased_qualified_name;
+    GC::Ptr<CSS::StylePropertyMap> attribute_style_map;
+    GC::Ptr<DOMTokenList> class_list;
+    GC::Ptr<DOMTokenList> part_list;
+    mutable OwnPtr<PseudoElementData> pseudo_element_data;
+    Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element;
+    Vector<Utf16FlyString> parts;
+
+    // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
+    // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:
+    // NOTE: See the structs at the top of Element.h.
+    OwnPtr<CustomElementReactionQueue> custom_element_reaction_queue;
+
+    // https://dom.spec.whatwg.org/#concept-element-is-value
+    Optional<Utf16FlyString> is_value;
+
+    // https://html.spec.whatwg.org/multipage/custom-elements.html#states-set
+    GC::Ptr<HTML::CustomStateSet> custom_state_set;
+
+    // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
+    // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
+    OwnPtr<Vector<GC::Ref<IntersectionObserver::IntersectionObserver>>> registered_intersection_observers;
+
+    // https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemapcache-slot
+    // Every Element has a [[computedStyleMapCache]] internal slot, initially set to null, which caches the result of
+    // the computedStyleMap() method when it is first called.
+    GC::Ptr<CSS::StylePropertyMapReadOnly> computed_style_map_cache;
+    OwnPtr<CSS::CountersSet> counters_set;
+
+    // https://drafts.csswg.org/css-values-5/#random-caching
+    HashMap<CSS::RandomCachingKey, double> element_specific_css_random_base_value_cache;
+
+    // https://dom.spec.whatwg.org/#concept-element-custom-element-definition
+    GC::Ptr<HTML::CustomElementDefinition> custom_element_definition;
+
+    // https://dom.spec.whatwg.org/#element-custom-element-registry
+    GC::Ptr<HTML::CustomElementRegistry> custom_element_registry;
+    Optional<Utf16FlyString> name;
+    Fullscreen::RequestType fullscreen_request_type { Fullscreen::RequestType::Standard };
+
+    // https://w3c.github.io/webappsec-csp/#is-element-nonceable
+    // AD-HOC: We need to know the element had a duplicate attribute when it was created from the HTML parser.
+    //         However, there currently isn't any specified way to do this, so we store a flag on the token, which is
+    //         then passed down to here. This is used by Content Security Policy to disable the nonce attribute if this
+    //         flag is set.
+    bool had_duplicate_attribute_during_tokenization { false };
+
+    // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
+    ProximityToTheViewport proximity_to_the_viewport { ProximityToTheViewport::NotDetermined };
+
+    // https://drafts.csswg.org/css-view-transitions-1/#captured-in-a-view-transition
+    bool captured_in_a_view_transition { false };
+};
+
+}

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -168,6 +168,7 @@ Node::RareData::~RareData() = default;
 void Node::RareData::visit_edges(Cell::Visitor& visitor)
 {
     visitor.visit(child_nodes);
+    visitor.visit(children);
     if (registered_observer_list)
         visitor.visit(*registered_observer_list);
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -163,18 +163,47 @@ CSS::UserSelect Node::user_select_used_value() const
     return CSS::UserSelect::Text;
 }
 
+Node::RareData::~RareData() = default;
+
+void Node::RareData::visit_edges(Cell::Visitor& visitor)
+{
+    visitor.visit(child_nodes);
+    if (registered_observer_list)
+        visitor.visit(*registered_observer_list);
+}
+
+size_t Node::RareData::external_memory_size() const
+{
+    if (!registered_observer_list)
+        return 0;
+    return JS::vector_external_memory_size(*registered_observer_list);
+}
+
+OwnPtr<Node::RareData> Node::create_rare_data() const
+{
+    return make<RareData>();
+}
+
+Node::RareData& Node::ensure_rare_data() const
+{
+    if (!m_rare_data)
+        m_rare_data = create_rare_data();
+    return *m_rare_data;
+}
+
 void Node::finalize()
 {
     Base::finalize();
-    if (m_unique_id.has_value())
-        deallocate_unique_id(*m_unique_id);
+    if (m_rare_data && m_rare_data->unique_id.has_value())
+        deallocate_unique_id(*m_rare_data->unique_id);
 }
 
 UniqueNodeID Node::unique_id() const
 {
-    if (!m_unique_id.has_value())
-        m_unique_id = allocate_unique_id(const_cast<Node&>(*this));
-    return *m_unique_id;
+    auto& unique_id = ensure_rare_data().unique_id;
+    if (!unique_id.has_value())
+        unique_id = allocate_unique_id(const_cast<Node&>(*this));
+    return *unique_id;
 }
 
 void Node::visit_edges(Cell::Visitor& visitor)
@@ -182,18 +211,15 @@ void Node::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     TreeNode::visit_edges(visitor);
     visitor.visit(m_document);
-    visitor.visit(m_child_nodes);
-
-    if (m_registered_observer_list) {
-        visitor.visit(*m_registered_observer_list);
-    }
+    if (m_rare_data)
+        m_rare_data->visit_edges(visitor);
 }
 
 size_t Node::external_memory_size() const
 {
     auto size = Base::external_memory_size();
-    if (m_registered_observer_list)
-        size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(*m_registered_observer_list));
+    if (m_rare_data)
+        size = JS::saturating_add_external_memory_size(size, m_rare_data->external_memory_size());
     return size;
 }
 
@@ -1191,9 +1217,10 @@ void Node::remove(bool suppress_observers)
     //     observer whose observer is registered’s observer, options is registered’s options, and source is registered
     //     to node’s registered observer list.
     for (auto* inclusive_ancestor = parent; inclusive_ancestor; inclusive_ancestor = inclusive_ancestor->parent()) {
-        if (!inclusive_ancestor->m_registered_observer_list)
+        auto* registered_observer_list = inclusive_ancestor->registered_observer_list();
+        if (!registered_observer_list)
             continue;
-        for (auto& registered : *inclusive_ancestor->m_registered_observer_list) {
+        for (auto& registered : *registered_observer_list) {
             if (registered->options().subtree) {
                 auto transient_observer = TransientRegisteredObserver::create(registered->observer(), registered->options(), registered);
                 add_registered_observer(move(transient_observer));
@@ -2254,12 +2281,13 @@ Slottable Node::as_slottable()
 
 GC::Ref<NodeList> Node::child_nodes()
 {
-    if (!m_child_nodes) {
-        m_child_nodes = LiveNodeList::create(*this, LiveNodeList::Scope::Children, [](auto&) {
+    auto& child_nodes = ensure_rare_data().child_nodes;
+    if (!child_nodes) {
+        child_nodes = LiveNodeList::create(*this, LiveNodeList::Scope::Children, [](auto&) {
             return true;
         });
     }
-    return *m_child_nodes;
+    return *child_nodes;
 }
 
 Vector<GC::Root<Node>> Node::children_as_vector() const
@@ -3178,9 +3206,10 @@ void Node::queue_mutation_record(Utf16FlyString const& type, Optional<Utf16FlySt
     // 2. Let nodes be the inclusive ancestors of target.
     // 3. For each node of nodes, and then for each registered of node’s registered observer list:
     for (auto* node = this; node; node = node->parent()) {
-        if (!node->m_registered_observer_list)
+        auto* registered_observer_list = node->registered_observer_list();
+        if (!registered_observer_list)
             continue;
-        for (auto& registered_observer : *node->m_registered_observer_list) {
+        for (auto& registered_observer : *registered_observer_list) {
             // 1. Let options be registered’s options.
             auto& options = registered_observer->options();
 
@@ -3842,9 +3871,20 @@ Optional<Utf16View> Node::first_valid_id(Utf16View value, Document const& docume
 
 void Node::add_registered_observer(RegisteredObserver& registered_observer)
 {
-    if (!m_registered_observer_list)
-        m_registered_observer_list = make<Vector<GC::Ref<RegisteredObserver>>>();
-    m_registered_observer_list->append(registered_observer);
+    auto& registered_observer_list = ensure_rare_data().registered_observer_list;
+    if (!registered_observer_list)
+        registered_observer_list = make<Vector<GC::Ref<RegisteredObserver>>>();
+    registered_observer_list->append(registered_observer);
+}
+
+Vector<GC::Ref<RegisteredObserver>>* Node::registered_observer_list()
+{
+    return m_rare_data ? m_rare_data->registered_observer_list.ptr() : nullptr;
+}
+
+Vector<GC::Ref<RegisteredObserver>> const* Node::registered_observer_list() const
+{
+    return m_rare_data ? m_rare_data->registered_observer_list.ptr() : nullptr;
 }
 
 Element const* Node::first_letter_owner_for_layout_subtree_from(Node const& inclusive_ancestor) const

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -548,6 +548,7 @@ protected:
         OwnPtr<Vector<GC::Ref<RegisteredObserver>>> registered_observer_list;
 
         GC::Ptr<NodeList> child_nodes;
+        GC::Ptr<HTMLCollection> children;
     };
 
     Node(Document&, NodeType);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -464,8 +464,8 @@ public:
 
     size_t length() const;
 
-    auto& registered_observer_list() { return m_registered_observer_list; }
-    auto const& registered_observer_list() const { return m_registered_observer_list; }
+    Vector<GC::Ref<RegisteredObserver>>* registered_observer_list();
+    Vector<GC::Ref<RegisteredObserver>> const* registered_observer_list() const;
 
     void add_registered_observer(RegisteredObserver&);
 
@@ -536,9 +536,28 @@ public:
     }
 
 protected:
+    struct RareData {
+        virtual ~RareData();
+        virtual void visit_edges(Cell::Visitor&);
+        virtual size_t external_memory_size() const;
+
+        mutable Optional<UniqueNodeID> unique_id;
+
+        // https://dom.spec.whatwg.org/#registered-observer-list
+        // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
+        OwnPtr<Vector<GC::Ref<RegisteredObserver>>> registered_observer_list;
+
+        GC::Ptr<NodeList> child_nodes;
+    };
+
     Node(Document&, NodeType);
 
     void set_document(Document&);
+
+    virtual OwnPtr<RareData> create_rare_data() const;
+    RareData& ensure_rare_data() const;
+    RareData* rare_data() { return m_rare_data; }
+    RareData const* rare_data() const { return m_rare_data; }
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
@@ -557,12 +576,6 @@ protected:
     bool m_is_connected { false };
     bool m_inside_blocking_wheel_event_handler { false };
 
-    mutable Optional<UniqueNodeID> m_unique_id;
-
-    // https://dom.spec.whatwg.org/#registered-observer-list
-    // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
-    OwnPtr<Vector<GC::Ref<RegisteredObserver>>> m_registered_observer_list;
-
     void build_accessibility_tree(AccessibilityTreeNode& parent);
 
     ErrorOr<Utf16String> name_or_description(NameOrDescription, Document const&, HashTable<UniqueNodeID>&, IsDescendant = IsDescendant::No, ShouldComputeRole = ShouldComputeRole::Yes) const;
@@ -579,7 +592,7 @@ private:
 
     static Optional<Utf16View> first_valid_id(Utf16View, Document const&);
 
-    GC::Ptr<NodeList> m_child_nodes;
+    mutable OwnPtr<RareData> m_rare_data;
 };
 
 }

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -77,22 +77,17 @@ u32 ParentNode::child_element_count() const
     return count;
 }
 
-void ParentNode::visit_edges(Cell::Visitor& visitor)
-{
-    Base::visit_edges(visitor);
-    visitor.visit(m_children);
-}
-
 // https://dom.spec.whatwg.org/#dom-parentnode-children
 GC::Ref<HTMLCollection> ParentNode::children()
 {
     // The children getter steps are to return an HTMLCollection collection rooted at this matching only element children.
-    if (!m_children) {
-        m_children = HTMLCollection::create(*this, HTMLCollection::Scope::Children, [](Element const&) {
+    auto& children = ensure_rare_data().children;
+    if (!children) {
+        children = HTMLCollection::create(*this, HTMLCollection::Scope::Children, [](Element const&) {
             return true;
         });
     }
-    return *m_children;
+    return *children;
 }
 
 // https://dom.spec.whatwg.org/#concept-getelementsbytagname

--- a/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Libraries/LibWeb/DOM/ParentNode.h
@@ -47,11 +47,6 @@ protected:
         : Node(document, type)
     {
     }
-
-    virtual void visit_edges(Cell::Visitor&) override;
-
-private:
-    GC::Ptr<HTMLCollection> m_children;
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/Slottable.cpp
+++ b/Libraries/LibWeb/DOM/Slottable.cpp
@@ -21,10 +21,59 @@ namespace Web::DOM {
 
 SlottableMixin::~SlottableMixin() = default;
 
-void SlottableMixin::visit_edges(JS::Cell::Visitor& visitor)
+void SlottableMixin::RareData::visit_edges(JS::Cell::Visitor& visitor)
 {
-    visitor.visit(m_assigned_slot);
-    visitor.visit(m_manual_slot_assignment);
+    visitor.visit(assigned_slot);
+    visitor.visit(manual_slot_assignment);
+}
+
+Utf16FlyString const& SlottableMixin::slottable_name() const
+{
+    static Utf16FlyString const empty_name;
+    auto const* rare_data = slottable_rare_data();
+    return rare_data ? rare_data->name : empty_name;
+}
+
+void SlottableMixin::set_slottable_name(Utf16FlyString name)
+{
+    if (name.is_empty()) {
+        if (auto* rare_data = slottable_rare_data())
+            rare_data->name = Utf16FlyString {};
+        return;
+    }
+    ensure_slottable_rare_data().name = move(name);
+}
+
+GC::Ptr<HTML::HTMLSlotElement> SlottableMixin::assigned_slot_internal() const
+{
+    auto const* rare_data = slottable_rare_data();
+    return rare_data ? rare_data->assigned_slot : nullptr;
+}
+
+void SlottableMixin::set_assigned_slot(GC::Ptr<HTML::HTMLSlotElement> assigned_slot)
+{
+    if (!assigned_slot) {
+        if (auto* rare_data = slottable_rare_data())
+            rare_data->assigned_slot = nullptr;
+        return;
+    }
+    ensure_slottable_rare_data().assigned_slot = assigned_slot;
+}
+
+GC::Ptr<HTML::HTMLSlotElement> SlottableMixin::manual_slot_assignment()
+{
+    auto const* rare_data = slottable_rare_data();
+    return rare_data ? rare_data->manual_slot_assignment : nullptr;
+}
+
+void SlottableMixin::set_manual_slot_assignment(GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment)
+{
+    if (!manual_slot_assignment) {
+        if (auto* rare_data = slottable_rare_data())
+            rare_data->manual_slot_assignment = nullptr;
+        return;
+    }
+    ensure_slottable_rare_data().manual_slot_assignment = manual_slot_assignment;
 }
 
 // https://dom.spec.whatwg.org/#dom-slotable-assignedslot

--- a/Libraries/LibWeb/DOM/Slottable.h
+++ b/Libraries/LibWeb/DOM/Slottable.h
@@ -25,29 +25,34 @@ public:
 
     virtual Node& slottable_as_node() = 0;
 
-    Utf16FlyString const& slottable_name() const { return m_name; } // Not called `name` to distinguish from `Element::name`.
-    void set_slottable_name(Utf16FlyString name) { m_name = move(name); }
+    Utf16FlyString const& slottable_name() const; // Not called `name` to distinguish from `Element::name`.
+    void set_slottable_name(Utf16FlyString name);
 
     GC::Ptr<HTML::HTMLSlotElement> assigned_slot();
 
-    GC::Ptr<HTML::HTMLSlotElement> assigned_slot_internal() const { return m_assigned_slot; }
-    void set_assigned_slot(GC::Ptr<HTML::HTMLSlotElement> assigned_slot) { m_assigned_slot = assigned_slot; }
+    GC::Ptr<HTML::HTMLSlotElement> assigned_slot_internal() const;
+    void set_assigned_slot(GC::Ptr<HTML::HTMLSlotElement> assigned_slot);
 
-    GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment() { return m_manual_slot_assignment; }
-    void set_manual_slot_assignment(GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment) { m_manual_slot_assignment = manual_slot_assignment; }
+    GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment();
+    void set_manual_slot_assignment(GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment);
 
 protected:
-    void visit_edges(JS::Cell::Visitor&);
+    struct RareData {
+        void visit_edges(JS::Cell::Visitor&);
 
-private:
-    // https://dom.spec.whatwg.org/#slotable-name
-    Utf16FlyString m_name;
+        // https://dom.spec.whatwg.org/#slotable-name
+        Utf16FlyString name;
 
-    // https://dom.spec.whatwg.org/#slotable-assigned-slot
-    GC::Ptr<HTML::HTMLSlotElement> m_assigned_slot;
+        // https://dom.spec.whatwg.org/#slotable-assigned-slot
+        GC::Ptr<HTML::HTMLSlotElement> assigned_slot;
 
-    // https://dom.spec.whatwg.org/#slottable-manual-slot-assignment
-    GC::Ptr<HTML::HTMLSlotElement> m_manual_slot_assignment;
+        // https://dom.spec.whatwg.org/#slottable-manual-slot-assignment
+        GC::Ptr<HTML::HTMLSlotElement> manual_slot_assignment;
+    };
+
+    virtual RareData* slottable_rare_data() = 0;
+    virtual RareData const* slottable_rare_data() const = 0;
+    virtual RareData& ensure_slottable_rare_data() = 0;
 };
 
 enum class OpenFlag {

--- a/Libraries/LibWeb/DOM/Text.cpp
+++ b/Libraries/LibWeb/DOM/Text.cpp
@@ -16,11 +16,11 @@
 namespace Web::DOM {
 
 struct Text::RareData final
-    : Node::RareData
+    : CharacterData::RareData
     , SlottableMixin::RareData {
     virtual void visit_edges(Cell::Visitor& visitor) override
     {
-        Node::RareData::visit_edges(visitor);
+        CharacterData::RareData::visit_edges(visitor);
         SlottableMixin::RareData::visit_edges(visitor);
     }
 };

--- a/Libraries/LibWeb/DOM/Text.cpp
+++ b/Libraries/LibWeb/DOM/Text.cpp
@@ -15,6 +15,36 @@
 
 namespace Web::DOM {
 
+struct Text::RareData final
+    : Node::RareData
+    , SlottableMixin::RareData {
+    virtual void visit_edges(Cell::Visitor& visitor) override
+    {
+        Node::RareData::visit_edges(visitor);
+        SlottableMixin::RareData::visit_edges(visitor);
+    }
+};
+
+OwnPtr<Node::RareData> Text::create_rare_data() const
+{
+    return make<RareData>();
+}
+
+SlottableMixin::RareData* Text::slottable_rare_data()
+{
+    return static_cast<RareData*>(rare_data());
+}
+
+SlottableMixin::RareData const* Text::slottable_rare_data() const
+{
+    return static_cast<RareData const*>(rare_data());
+}
+
+SlottableMixin::RareData& Text::ensure_slottable_rare_data()
+{
+    return static_cast<RareData&>(ensure_rare_data());
+}
+
 GC_DEFINE_ALLOCATOR(Text);
 
 Text::Text(Document& document, Utf16String data)
@@ -40,7 +70,6 @@ GC::Ref<Text> Text::create_for_constructor(JS::Object& relevant_global_object, U
 void Text::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    SlottableMixin::visit_edges(visitor);
 }
 
 // https://dom.spec.whatwg.org/#dom-text-splittext

--- a/Libraries/LibWeb/DOM/Text.h
+++ b/Libraries/LibWeb/DOM/Text.h
@@ -51,6 +51,12 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
+    struct RareData;
+    virtual OwnPtr<Node::RareData> create_rare_data() const override;
+    virtual SlottableMixin::RareData* slottable_rare_data() override;
+    virtual SlottableMixin::RareData const* slottable_rare_data() const override;
+    virtual SlottableMixin::RareData& ensure_slottable_rare_data() override;
+
     Optional<size_t> m_max_length {};
     bool m_is_password_input { false };
 };

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NeverDestroyed.h>
 #include <AK/Utf16StringBuilder.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
@@ -42,6 +43,39 @@
 #include <LibWeb/VisualLines.h>
 
 namespace Web::HTML {
+
+FormAssociatedElement::FACERareData& FormAssociatedElement::ensure_face_rare_data()
+{
+    if (!m_face_rare_data)
+        m_face_rare_data = make<FACERareData>();
+    return *m_face_rare_data;
+}
+
+FormAssociatedElement::FACERareData const& FormAssociatedElement::face_rare_data() const
+{
+    static NeverDestroyed<FACERareData> empty_data;
+    return m_face_rare_data ? *m_face_rare_data : *empty_data;
+}
+
+ValidityStateFlags const& FormAssociatedElement::face_validity_flags() const
+{
+    return face_rare_data().validity_flags;
+}
+
+Utf16String const& FormAssociatedElement::face_validation_message() const
+{
+    return face_rare_data().validation_message;
+}
+
+FormAssociatedElement::FACESubmissionValue const& FormAssociatedElement::face_submission_value() const
+{
+    return face_rare_data().submission_value;
+}
+
+FormAssociatedElement::FACESubmissionValue const& FormAssociatedElement::face_state() const
+{
+    return face_rare_data().state;
+}
 
 static SelectionDirection string_to_selection_direction(Utf16View value)
 {
@@ -333,10 +367,10 @@ void FormAssociatedElement::update_face_disabled_state()
         return;
 
     bool is_disabled = !enabled();
-    if (is_disabled == m_face_disabled_state)
+    if (is_disabled == face_rare_data().disabled_state)
         return;
 
-    m_face_disabled_state = is_disabled;
+    ensure_face_rare_data().disabled_state = is_disabled;
 
     html_element.enqueue_a_form_disabled_callback_reaction(is_disabled);
 }
@@ -566,21 +600,21 @@ bool FormAssociatedElement::novalidate_state() const
 bool FormAssociatedElement::suffering_from_being_missing() const
 {
     // When the setValidity() method sets valueMissing flag to true for a form-associated custom element.
-    return m_face_validity_flags.value_missing;
+    return face_validity_flags().value_missing;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-type-mismatch
 bool FormAssociatedElement::suffering_from_a_type_mismatch() const
 {
     // When the setValidity() method sets typeMismatch flag to true for a form-associated custom element.
-    return m_face_validity_flags.type_mismatch;
+    return face_validity_flags().type_mismatch;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-pattern-mismatch
 bool FormAssociatedElement::suffering_from_a_pattern_mismatch() const
 {
     // When the setValidity() method sets patternMismatch flag to true for a form-associated custom element.
-    return m_face_validity_flags.pattern_mismatch;
+    return face_validity_flags().pattern_mismatch;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-too-long
@@ -588,7 +622,7 @@ bool FormAssociatedElement::suffering_from_being_too_long() const
 {
     // When the setValidity() method sets tooLong flag to true for a form-associated custom element.
     // FIXME: Implement this for non-FACEs.
-    return m_face_validity_flags.too_long;
+    return face_validity_flags().too_long;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-too-short
@@ -596,35 +630,35 @@ bool FormAssociatedElement::suffering_from_being_too_short() const
 {
     // When the setValidity() method sets tooShort flag to true for a form-associated custom element.
     // FIXME: Implement this for non-FACEs.
-    return m_face_validity_flags.too_short;
+    return face_validity_flags().too_short;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-an-overflow
 bool FormAssociatedElement::suffering_from_an_underflow() const
 {
     // When the setValidity() method sets rangeUnderflow flag to true for a form-associated custom element.
-    return m_face_validity_flags.range_underflow;
+    return face_validity_flags().range_underflow;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-an-overflow
 bool FormAssociatedElement::suffering_from_an_overflow() const
 {
     // When the setValidity() method sets rangeOverflow flag to true for a form-associated custom element.
-    return m_face_validity_flags.range_overflow;
+    return face_validity_flags().range_overflow;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-step-mismatch
 bool FormAssociatedElement::suffering_from_a_step_mismatch() const
 {
     // When the setValidity() method sets stepMismatch flag to true for a form-associated custom element.
-    return m_face_validity_flags.step_mismatch;
+    return face_validity_flags().step_mismatch;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-bad-input
 bool FormAssociatedElement::suffering_from_bad_input() const
 {
     // When the setValidity() method sets badInput flag to true for a form-associated custom element.
-    return m_face_validity_flags.bad_input;
+    return face_validity_flags().bad_input;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-custom-error
@@ -637,38 +671,41 @@ bool FormAssociatedElement::suffering_from_a_custom_error() const
 
 void FormAssociatedElement::set_face_validity_flags(Badge<ElementInternals>, ValidityStateFlags const& value)
 {
-    m_face_validity_flags = value;
+    ensure_face_rare_data().validity_flags = value;
 }
 
 void FormAssociatedElement::set_face_validation_message(Badge<ElementInternals>, Utf16View value)
 {
-    m_face_validation_message = Utf16String::from_utf16(value);
+    ensure_face_rare_data().validation_message = Utf16String::from_utf16(value);
 }
 
 void FormAssociatedElement::set_face_validation_anchor(Badge<ElementInternals>, GC::Ptr<HTMLElement> value)
 {
-    m_face_validation_anchor = value;
+    ensure_face_rare_data().validation_anchor = value;
 }
 
 void FormAssociatedElement::set_face_submission_value(Badge<ElementInternals>, FACESubmissionValue const& value)
 {
-    m_face_submission_value = value;
+    ensure_face_rare_data().submission_value = value;
 }
 
 void FormAssociatedElement::set_face_state(Badge<ElementInternals>, FACESubmissionValue const& value)
 {
-    m_face_state = value;
+    ensure_face_rare_data().state = value;
 }
 
 void FormAssociatedElement::visit_edges(JS::Cell::Visitor& visitor)
 {
-    m_face_submission_value.visit(
+    if (!m_face_rare_data)
+        return;
+
+    m_face_rare_data->submission_value.visit(
         [&visitor](GC::Ref<FileAPI::File> file) {
             visitor.visit(file);
         },
         [](auto&) {});
 
-    m_face_state.visit(
+    m_face_rare_data->state.visit(
         [&visitor](GC::Ref<FileAPI::File> file) {
             visitor.visit(file);
         },

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -46,15 +46,39 @@ namespace Web::HTML {
 
 FormAssociatedElement::FACERareData& FormAssociatedElement::ensure_face_rare_data()
 {
-    if (!m_face_rare_data)
-        m_face_rare_data = make<FACERareData>();
-    return *m_face_rare_data;
+    auto& face_rare_data = ensure_form_associated_rare_data().face_rare_data;
+    if (!face_rare_data)
+        face_rare_data = make<FACERareData>();
+    return *face_rare_data;
 }
 
 FormAssociatedElement::FACERareData const& FormAssociatedElement::face_rare_data() const
 {
     static NeverDestroyed<FACERareData> empty_data;
-    return m_face_rare_data ? *m_face_rare_data : *empty_data;
+    auto const* rare_data = form_associated_rare_data();
+    return rare_data && rare_data->face_rare_data ? *rare_data->face_rare_data : *empty_data;
+}
+
+HTMLFormElement* FormAssociatedElement::form()
+{
+    auto* rare_data = form_associated_rare_data();
+    return rare_data ? rare_data->form.ptr().ptr() : nullptr;
+}
+
+HTMLFormElement const* FormAssociatedElement::form() const
+{
+    auto const* rare_data = form_associated_rare_data();
+    return rare_data ? rare_data->form.ptr().ptr() : nullptr;
+}
+
+void FormAssociatedElement::set_custom_validity_error_message(Badge<ElementInternals>, Utf16View value)
+{
+    if (value.is_empty()) {
+        if (auto* rare_data = form_associated_rare_data())
+            rare_data->custom_validity_error_message = {};
+        return;
+    }
+    ensure_form_associated_rare_data().custom_validity_error_message = Utf16String::from_utf16(value);
 }
 
 ValidityStateFlags const& FormAssociatedElement::face_validity_flags() const
@@ -149,11 +173,14 @@ void FormAssociatedElement::reset_algorithm()
 
 void FormAssociatedElement::set_form(HTMLFormElement* form)
 {
-    if (m_form)
-        m_form->remove_associated_element({}, form_associated_element_to_html_element());
-    m_form = form;
-    if (m_form)
-        m_form->add_associated_element({}, form_associated_element_to_html_element());
+    if (auto* old_form = this->form())
+        old_form->remove_associated_element({}, form_associated_element_to_html_element());
+    if (form)
+        ensure_form_associated_rare_data().form = form;
+    else if (auto* rare_data = form_associated_rare_data())
+        rare_data->form = nullptr;
+    if (form)
+        form->add_associated_element({}, form_associated_element_to_html_element());
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
@@ -171,7 +198,12 @@ void FormAssociatedElement::set_custom_validity(Utf16String& error)
     error = Infra::normalize_newlines(error);
 
     // 2. Set the custom validity error message to error.
-    m_custom_validity_error_message = error;
+    if (error.is_empty()) {
+        if (auto* rare_data = form_associated_rare_data())
+            rare_data->custom_validity_error_message = {};
+    } else {
+        ensure_form_associated_rare_data().custom_validity_error_message = error;
+    }
 
     // AD-HOC: Setting a custom validity error changes which validity pseudo-classes match.
     CSS::Invalidation::invalidate_style_after_validity_change(form_associated_element_to_html_element());
@@ -201,16 +233,17 @@ bool FormAssociatedElement::enabled() const
 
 void FormAssociatedElement::set_parser_inserted(Badge<HTMLParser>)
 {
-    m_parser_inserted = true;
+    ensure_form_associated_rare_data().parser_inserted = true;
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:nodes-are-inserted
 void FormAssociatedElement::form_node_was_inserted()
 {
     // 1. If the form-associated element's parser inserted flag is set, then return.
-    if (m_parser_inserted) {
-        if (m_form)
-            m_form->default_button_state_maybe_changed();
+    auto const* rare_data = form_associated_rare_data();
+    if (rare_data && rare_data->parser_inserted) {
+        if (auto* form = this->form())
+            form->default_button_state_maybe_changed();
         return;
     }
 
@@ -222,20 +255,22 @@ void FormAssociatedElement::form_node_was_inserted()
 void FormAssociatedElement::form_node_was_removed()
 {
     // 1. If the form-associated element has a form owner and the form-associated element and its form owner are no longer in the same tree, then reset the form owner of the form-associated element.
-    if (m_form && &form_associated_element_to_html_element().root() != &m_form->root())
+    auto* form = this->form();
+    if (form && &form_associated_element_to_html_element().root() != &form->root())
         reset_form_owner();
-    else if (m_form)
-        m_form->default_button_state_maybe_changed();
+    else if (form)
+        form->default_button_state_maybe_changed();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:attr-fae-form-2
 void FormAssociatedElement::form_node_was_moved()
 {
     // When a listed form-associated element's form attribute is set, changed, or removed, then the user agent must reset the form owner of that element.
-    if (m_form && &form_associated_element_to_html_element().root() != &m_form->root())
+    auto* form = this->form();
+    if (form && &form_associated_element_to_html_element().root() != &form->root())
         reset_form_owner();
-    else if (m_form)
-        m_form->default_button_state_maybe_changed();
+    else if (form)
+        form->default_button_state_maybe_changed();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:category-listed-3
@@ -277,20 +312,21 @@ void FormAssociatedElement::element_with_id_was_added_or_removed(Badge<DOM::Docu
 void FormAssociatedElement::reset_form_owner()
 {
     auto& html_element = form_associated_element_to_html_element();
-    GC::Ptr<HTMLFormElement> old_form { m_form.ptr() };
+    GC::Ptr<HTMLFormElement> old_form { form() };
 
     // 1. Unset element's parser inserted flag.
-    m_parser_inserted = false;
+    if (auto* rare_data = form_associated_rare_data())
+        rare_data->parser_inserted = false;
 
     // 2. If all of the following conditions are true
     //    - element's form owner is not null
     //    - element is not listed or its form content attribute is not present
     //    - element's form owner is its nearest form element ancestor after the change to the ancestor chain
     //    then do nothing, and return.
-    if (m_form
+    if (auto* form = this->form(); form
         && (!is_listed() || !html_element.has_attribute(HTML::AttributeNames::form))
-        && html_element.first_ancestor_of_type<HTMLFormElement>() == m_form.ptr().ptr()) {
-        m_form->default_button_state_maybe_changed();
+        && html_element.first_ancestor_of_type<HTMLFormElement>() == form) {
+        form->default_button_state_maybe_changed();
         return;
     }
 
@@ -326,13 +362,14 @@ void FormAssociatedElement::reset_form_owner()
     }
 
     // See the AD-HOC comment above.
-    if (m_form != old_form && html_element.is_form_associated_custom_element())
-        html_element.enqueue_a_form_associated_callback_reaction(m_form.ptr());
+    auto* new_form = form();
+    if (new_form != old_form.ptr() && html_element.is_form_associated_custom_element())
+        html_element.enqueue_a_form_associated_callback_reaction(new_form);
 
     if (old_form)
         old_form->default_button_state_maybe_changed();
-    if (m_form && m_form != old_form)
-        m_form->default_button_state_maybe_changed();
+    if (new_form && new_form != old_form.ptr())
+        new_form->default_button_state_maybe_changed();
 }
 
 void FormAssociatedElement::form_associated_element_was_inserted()
@@ -442,8 +479,11 @@ Utf16String FormAssociatedElement::validation_message() const
 
     // If the element is a candidate for constraint validation and is suffering from a custom error, then
     // the custom validity error message should be present in the return value.
-    if (suffering_from_a_custom_error())
-        return m_custom_validity_error_message;
+    if (suffering_from_a_custom_error()) {
+        auto const* rare_data = form_associated_rare_data();
+        VERIFY(rare_data);
+        return rare_data->custom_validity_error_message;
+    }
 
     // FIXME: Return more specific localized messages
     return "Invalid form"_utf16;
@@ -666,7 +706,8 @@ bool FormAssociatedElement::suffering_from_a_custom_error() const
 {
     // When a control's custom validity error message (as set by the element's setCustomValidity() method or ElementInternals's setValidity() method) is not the empty
     // string.
-    return !m_custom_validity_error_message.is_empty();
+    auto const* rare_data = form_associated_rare_data();
+    return rare_data && !rare_data->custom_validity_error_message.is_empty();
 }
 
 void FormAssociatedElement::set_face_validity_flags(Badge<ElementInternals>, ValidityStateFlags const& value)
@@ -694,18 +735,18 @@ void FormAssociatedElement::set_face_state(Badge<ElementInternals>, FACESubmissi
     ensure_face_rare_data().state = value;
 }
 
-void FormAssociatedElement::visit_edges(JS::Cell::Visitor& visitor)
+void FormAssociatedElement::RareData::visit_edges(JS::Cell::Visitor& visitor)
 {
-    if (!m_face_rare_data)
+    if (!face_rare_data)
         return;
 
-    m_face_rare_data->submission_value.visit(
+    face_rare_data->submission_value.visit(
         [&visitor](GC::Ref<FileAPI::File> file) {
             visitor.visit(file);
         },
         [](auto&) {});
 
-    m_face_rare_data->state.visit(
+    face_rare_data->state.visit(
         [&visitor](GC::Ref<FileAPI::File> file) {
             visitor.visit(file);
         },

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/OwnPtr.h>
 #include <AK/Utf16FlyString.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
@@ -137,18 +138,18 @@ public:
 
     void update_face_disabled_state();
 
-    ValidityStateFlags const& face_validity_flags() const { return m_face_validity_flags; }
+    ValidityStateFlags const& face_validity_flags() const;
     void set_face_validity_flags(Badge<ElementInternals>, ValidityStateFlags const& value);
 
-    Utf16String const& face_validation_message() const { return m_face_validation_message; }
+    Utf16String const& face_validation_message() const;
     void set_face_validation_message(Badge<ElementInternals>, Utf16View value);
 
     void set_face_validation_anchor(Badge<ElementInternals>, GC::Ptr<HTMLElement> value);
 
-    FACESubmissionValue const& face_submission_value() const { return m_face_submission_value; }
+    FACESubmissionValue const& face_submission_value() const;
     void set_face_submission_value(Badge<ElementInternals>, FACESubmissionValue const& value);
 
-    FACESubmissionValue const& face_state() const { return m_face_state; }
+    FACESubmissionValue const& face_state() const;
     void set_face_state(Badge<ElementInternals>, FACESubmissionValue const& value);
 
     void set_custom_validity_error_message(Badge<ElementInternals>, Utf16View value) { m_custom_validity_error_message = Utf16String::from_utf16(value); }
@@ -170,34 +171,41 @@ protected:
     void visit_edges(JS::Cell::Visitor&);
 
 private:
+    struct FACERareData {
+        ValidityStateFlags validity_flags {};
+
+        // https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-message
+        // Each form-associated custom element has a validation message string. It is the empty string initially.
+        Utf16String validation_message;
+
+        // https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-anchor
+        // Each form-associated custom element has a validation anchor element. It is null initially.
+        GC::Weak<HTMLElement> validation_anchor;
+
+        // https://html.spec.whatwg.org/multipage/custom-elements.html#face-submission-value
+        // Each form-associated custom element has submission value. It is used to provide one or more entries on form
+        // submission. The initial value is null, and it can be null, a string, a File, or a list of entries.
+        FACESubmissionValue submission_value;
+
+        // https://html.spec.whatwg.org/multipage/custom-elements.html#face-state
+        // Each form-associated custom element has state. The initial value is null, and it can be null, a string, a File,
+        // or a list of entries.
+        FACESubmissionValue state;
+
+        // AD-HOC: Cache the disabled state to detect changes and enqueue formDisabledCallback.
+        bool disabled_state { false };
+    };
+
+    FACERareData const& face_rare_data() const;
+    FACERareData& ensure_face_rare_data();
+
     GC::Weak<HTMLFormElement> m_form;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#parser-inserted-flag
     bool m_parser_inserted { false };
 
-    ValidityStateFlags m_face_validity_flags {};
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-message
-    // Each form-associated custom element has a validation message string. It is the empty string initially.
-    Utf16String m_face_validation_message;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#face-validation-anchor
-    // Each form-associated custom element has a validation anchor element. It is null initially.
-    GC::Weak<HTMLElement> m_face_validation_anchor;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#face-submission-value
-    // Each form-associated custom element has submission value. It is used to provide one or more entries on form submission.
-    // The initial value of submission value is null, and submission value can be null, a string, a File, or a list of entries.
-    FACESubmissionValue m_face_submission_value;
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#face-state
-    // Each form-associated custom element has state. It is information with which the user agent can restore a user's input
-    // for the element. The initial value of state is null, and state can be null, a string, a File, or a list of entries.
-    FACESubmissionValue m_face_state;
-
-    // AD-HOC: Cached disabled state for form-associated custom elements, used to detect changes
-    //         and enqueue formDisabledCallback. Only meaningful for FACEs.
-    bool m_face_disabled_state { false };
+    // State used only by form-associated custom elements.
+    OwnPtr<FACERareData> m_face_rare_data;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#custom-validity-error-message
     Utf16String m_custom_validity_error_message;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -42,8 +42,8 @@ public:
 
     virtual bool is_form_associated_element() const;
 
-    HTMLFormElement* form() { return m_form; }
-    HTMLFormElement const* form() const { return m_form; }
+    HTMLFormElement* form();
+    HTMLFormElement const* form() const;
 
     void set_form(HTMLFormElement*);
 
@@ -152,7 +152,7 @@ public:
     FACESubmissionValue const& face_state() const;
     void set_face_state(Badge<ElementInternals>, FACESubmissionValue const& value);
 
-    void set_custom_validity_error_message(Badge<ElementInternals>, Utf16View value) { m_custom_validity_error_message = Utf16String::from_utf16(value); }
+    void set_custom_validity_error_message(Badge<ElementInternals>, Utf16View value);
 
 protected:
     FormAssociatedElement() = default;
@@ -168,9 +168,6 @@ protected:
     void form_node_was_moved();
     void form_node_attribute_changed(Utf16FlyString const&, Optional<Utf16String> const&);
 
-    void visit_edges(JS::Cell::Visitor&);
-
-private:
     struct FACERareData {
         ValidityStateFlags validity_flags {};
 
@@ -196,19 +193,28 @@ private:
         bool disabled_state { false };
     };
 
+    struct RareData {
+        void visit_edges(JS::Cell::Visitor&);
+
+        GC::Weak<HTMLFormElement> form;
+
+        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#parser-inserted-flag
+        bool parser_inserted { false };
+
+        // State used only by form-associated custom elements.
+        OwnPtr<FACERareData> face_rare_data;
+
+        // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#custom-validity-error-message
+        Utf16String custom_validity_error_message;
+    };
+
+    virtual RareData* form_associated_rare_data() = 0;
+    virtual RareData const* form_associated_rare_data() const = 0;
+    virtual RareData& ensure_form_associated_rare_data() = 0;
+
+private:
     FACERareData const& face_rare_data() const;
     FACERareData& ensure_face_rare_data();
-
-    GC::Weak<HTMLFormElement> m_form;
-
-    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#parser-inserted-flag
-    bool m_parser_inserted { false };
-
-    // State used only by form-associated custom elements.
-    OwnPtr<FACERareData> m_face_rare_data;
-
-    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#custom-validity-error-message
-    Utf16String m_custom_validity_error_message;
 };
 
 enum class SelectionSource {

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -166,7 +166,6 @@ void HTMLElement::set_popover_visibility_state(PopoverVisibilityState state)
 void HTMLElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    HTMLOrSVGOrMathMLElement::visit_edges(visitor);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-translate

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/EditingHostManager.h>
 #include <LibWeb/DOM/ElementFactory.h>
+#include <LibWeb/DOM/ElementRareData.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/LiveNodeList.h>
 #include <LibWeb/DOM/Position.h>
@@ -62,6 +63,61 @@
 
 namespace Web::HTML {
 
+struct HTMLElement::RareData final : DOM::Element::RareData {
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    GC::Ptr<DOM::NodeList> labels;
+
+    // https://html.spec.whatwg.org/multipage/custom-elements.html#attached-internals
+    GC::Ptr<ElementInternals> attached_internals;
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-trigger
+    GC::Ptr<HTMLElement> popover_trigger;
+
+    // https://html.spec.whatwg.org/multipage/popover.html#the-popover-attribute:toggle-task-tracker
+    Optional<ToggleTaskTracker> popover_toggle_task_tracker;
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-close-watcher
+    GC::Ptr<CloseWatcher> popover_close_watcher;
+
+    Optional<Utf16FlyString> opened_in_popover_mode;
+};
+
+void HTMLElement::RareData::visit_edges(Cell::Visitor& visitor)
+{
+    DOM::Element::RareData::visit_edges(visitor);
+    visitor.visit(labels);
+    visitor.visit(attached_internals);
+    visitor.visit(popover_trigger);
+    visitor.visit(popover_close_watcher);
+}
+
+OwnPtr<DOM::Node::RareData> HTMLElement::create_rare_data() const
+{
+    return make<RareData>();
+}
+
+HTMLElement::RareData& HTMLElement::ensure_html_element_rare_data() const
+{
+    return static_cast<RareData&>(ensure_rare_data());
+}
+
+HTMLElement::RareData* HTMLElement::html_element_rare_data()
+{
+    return static_cast<RareData*>(rare_data());
+}
+
+HTMLElement::RareData const* HTMLElement::html_element_rare_data() const
+{
+    return static_cast<RareData const*>(rare_data());
+}
+
+Optional<Utf16FlyString> HTMLElement::opened_in_popover_mode() const
+{
+    auto const* rare_data = html_element_rare_data();
+    return rare_data ? rare_data->opened_in_popover_mode : Optional<Utf16FlyString> {};
+}
+
 GC_DEFINE_ALLOCATOR(HTMLElement);
 
 static Optional<Utf16View> optional_utf16_view(Optional<Utf16String> const& string)
@@ -94,10 +150,6 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     HTMLOrSVGOrMathMLElement::visit_edges(visitor);
     FormAssociatedElement::visit_edges(visitor);
-    visitor.visit(m_labels);
-    visitor.visit(m_attached_internals);
-    visitor.visit(m_popover_trigger);
-    visitor.visit(m_popover_close_watcher);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-translate
@@ -944,14 +996,15 @@ GC::Ptr<DOM::NodeList> HTMLElement::labels()
     if (!is_labelable())
         return {};
 
-    if (!m_labels) {
-        m_labels = DOM::LiveNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, [&](DOM::Node const& node) {
+    auto& labels = ensure_html_element_rare_data().labels;
+    if (!labels) {
+        labels = DOM::LiveNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, [&](DOM::Node const& node) {
             auto const* label_element = as_if<HTMLLabelElement>(node);
             return label_element && label_element->control().ptr() == this;
         });
     }
 
-    return m_labels;
+    return labels;
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-hidden
@@ -1186,7 +1239,7 @@ WebIDL::ExceptionOr<GC::Ref<ElementInternals>> HTMLElement::attach_internals()
         return WebIDL::NotSupportedError::create("ElementInternals are disabled for this custom element"_utf16);
 
     // 5. If this's attached internals is non-null, then throw an "NotSupportedError" DOMException.
-    if (m_attached_internals)
+    if (auto* rare_data = html_element_rare_data(); rare_data && rare_data->attached_internals)
         return WebIDL::NotSupportedError::create("ElementInternals already attached"_utf16);
 
     // 6. If this's custom element state is not "precustomized" or "custom", then throw a "NotSupportedError" DOMException.
@@ -1196,7 +1249,7 @@ WebIDL::ExceptionOr<GC::Ref<ElementInternals>> HTMLElement::attach_internals()
     // 7. Set this's attached internals to a new ElementInternals instance whose target element is this.
     auto internals = ElementInternals::create(*this);
 
-    m_attached_internals = internals;
+    ensure_html_element_rare_data().attached_internals = internals;
 
     // 8. Return this's attached internals.
     return { internals };
@@ -1297,11 +1350,13 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
     if (!TRY(check_popover_validity(ExpectedToBeShowing::No, throw_exceptions, nullptr, IgnoreDomState::No)))
         return {};
 
+    auto& rare_data = ensure_html_element_rare_data();
+
     // 2. Let document be element's node document.
     auto& document = this->document();
 
     // 3. Assert: element's popover trigger is null.
-    VERIFY(!m_popover_trigger);
+    VERIFY(!rare_data.popover_trigger);
 
     // 4. Assert: element is not in document's top layer.
     VERIFY(!in_top_layer());
@@ -1449,7 +1504,7 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
             document.showing_auto_popover_list().append(*this);
 
             // 2. Set element's opened in popover mode to "auto".
-            m_opened_in_popover_mode = "auto"_utf16_fly_string;
+            rare_data.opened_in_popover_mode = "auto"_utf16_fly_string;
         }
         // Otherwise:
         else {
@@ -1464,7 +1519,7 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
             document.showing_hint_popover_list().append(*this);
 
             // 3. Set element's opened in popover mode to "hint".
-            m_opened_in_popover_mode = "hint"_utf16_fly_string;
+            rare_data.opened_in_popover_mode = "hint"_utf16_fly_string;
         }
 
         // 6. Set element's popover close watcher to the result of establishing a close watcher given element's relevant global object, with:
@@ -1482,8 +1537,8 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
         // - getEnabledState being to return true.
         auto get_enabled_state = GC::create_function(GC::Heap::the(), [] { return true; });
 
-        m_popover_close_watcher = CloseWatcher::establish(*document.window(), move(get_enabled_state));
-        m_popover_close_watcher->add_event_listener_without_options(HTML::EventNames::close, DOM::IDLEventListener::create(close_callback));
+        rare_data.popover_close_watcher = CloseWatcher::establish(*document.window(), move(get_enabled_state));
+        rare_data.popover_close_watcher->add_event_listener_without_options(HTML::EventNames::close, DOM::IDLEventListener::create(close_callback));
     }
     // FIXME: 19. Set element's previously focused element to null.
     // FIXME: 20. Let originallyFocusedElement be document's focused area of the document's DOM anchor.
@@ -1492,7 +1547,7 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
     // 22. Set element's popover visibility state to showing.
     set_popover_visibility_state(PopoverVisibilityState::Showing);
     // 23. Set element's popover trigger to source.
-    m_popover_trigger = source;
+    rare_data.popover_trigger = source;
     // FIXME: 24. Set element's implicit anchor element to source.
     // FIXME: 25. Run the popover focusing steps given element.
     // FIXME: 26. If shouldRestoreFocus is true and element's popover attribute is not in the No Popover state, then set element's previously focused element to originallyFocusedElement.
@@ -1520,6 +1575,8 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement focus_p
     if (!TRY(check_popover_validity(ExpectedToBeShowing::Yes, throw_exceptions, nullptr, ignore_dom_state)))
         return {};
 
+    auto& rare_data = ensure_html_element_rare_data();
+
     // 2. Let document be element's node document.
     auto& document = this->document();
 
@@ -1534,21 +1591,21 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement focus_p
         fire_events = FireEvents::No;
 
     // 6. Let cleanupSteps be the following steps:
-    auto cleanup_steps = [&nested_hide, this] {
+    auto cleanup_steps = [&nested_hide, &rare_data, this] {
         // 6.1. If nestedHide is false, then set element's popover showing or hiding to false.
-        if (nested_hide)
+        if (!nested_hide)
             m_popover_showing_or_hiding = false;
         // 6.2. If element's popover close watcher is not null, then:
-        if (m_popover_close_watcher) {
+        if (rare_data.popover_close_watcher) {
             // 6.2.1. Destroy element's popover close watcher.
-            m_popover_close_watcher->destroy();
+            rare_data.popover_close_watcher->destroy();
             // 6.2.2. Set element's popover close watcher to null.
-            m_popover_close_watcher = nullptr;
+            rare_data.popover_close_watcher = nullptr;
         }
     };
 
     // 7. If element's opened in popover mode is "auto" or "hint", then:
-    if (m_opened_in_popover_mode.has_value() && m_opened_in_popover_mode->is_one_of(u"auto"sv, u"hint"sv)) {
+    if (rare_data.opened_in_popover_mode.has_value() && rare_data.opened_in_popover_mode->is_one_of(u"auto"sv, u"hint"sv)) {
         // 7.1. Run hide all popovers until given element, focusPreviousElement, and fireEvents.
         hide_all_popovers_until(GC::Ptr(this), focus_previous_element, fire_events);
 
@@ -1595,12 +1652,12 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement focus_p
     // Spec issue: https://github.com/whatwg/html/issues/11007
 
     // If element's opened in popover mode is "auto" or "hint":
-    if (m_opened_in_popover_mode.has_value() && m_opened_in_popover_mode->is_one_of(u"auto"sv, u"hint"sv)) {
+    if (rare_data.opened_in_popover_mode.has_value() && rare_data.opened_in_popover_mode->is_one_of(u"auto"sv, u"hint"sv)) {
         // If document's showing hint popover list's last item is element:
         auto& hint_popovers = document.showing_hint_popover_list();
         if (!hint_popovers.is_empty() && hint_popovers.last().ptr() == this) {
             // Assert: element's opened in popover mode is "hint".
-            VERIFY(m_opened_in_popover_mode == u"hint"sv);
+            VERIFY(rare_data.opened_in_popover_mode == u"hint"sv);
 
             // Remove the last item from document's showing hint popover list.
             hint_popovers.remove(hint_popovers.size() - 1);
@@ -1617,10 +1674,10 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement focus_p
     }
 
     // 11. Set element's popover trigger to null.
-    m_popover_trigger = nullptr;
+    rare_data.popover_trigger = nullptr;
 
     // 12. Set element's opened in popover mode to null.
-    m_opened_in_popover_mode = {};
+    rare_data.opened_in_popover_mode = {};
 
     // 13. Set element's popover visibility state to hidden.
     set_popover_visibility_state(PopoverVisibilityState::Hidden);
@@ -1696,7 +1753,7 @@ void HTMLElement::hide_all_popovers_until(Variant<GC::Ptr<HTMLElement>, GC::Ptr<
     VERIFY(endpoint.has<GC::Ptr<DOM::Document>>() || endpoint.get<GC::Ptr<HTMLElement>>()->popover_visibility_state() == PopoverVisibilityState::Showing);
 
     // 4. Assert: endpoint is a Document or endpoint's popover attribute is in the auto state or endpoint's popover attribute is in the hint state.
-    VERIFY(endpoint.has<GC::Ptr<DOM::Document>>() || endpoint.get<GC::Ptr<HTMLElement>>()->m_opened_in_popover_mode->is_one_of(u"auto"sv, u"hint"sv));
+    VERIFY(endpoint.has<GC::Ptr<DOM::Document>>() || endpoint.get<GC::Ptr<HTMLElement>>()->opened_in_popover_mode()->is_one_of(u"auto"sv, u"hint"sv));
 
     // 5. If endpoint is a Document:
     if (endpoint.has<GC::Ptr<DOM::Document>>()) {
@@ -1714,7 +1771,7 @@ void HTMLElement::hide_all_popovers_until(Variant<GC::Ptr<HTMLElement>, GC::Ptr<
     auto endpoint_element = endpoint.get<GC::Ptr<HTMLElement>>();
     if (document->showing_hint_popover_list().contains_slow(GC::Ref(*endpoint_element))) {
         // 1. Assert: endpoint's popover attribute is in the hint state.
-        VERIFY(endpoint_element->m_opened_in_popover_mode == u"hint"sv);
+        VERIFY(endpoint_element->opened_in_popover_mode() == u"hint"sv);
 
         // 2. Run hide popover stack until given endpoint, document's showing hint popover list, focusPreviousElement, and fireEvents.
         endpoint_element->hide_popover_stack_until(document->showing_hint_popover_list(), focus_previous_element, fire_events);
@@ -1949,18 +2006,20 @@ GC::Ptr<HTMLElement> HTMLElement::nearest_inclusive_target_popover()
 // https://html.spec.whatwg.org/multipage/popover.html#queue-a-popover-toggle-event-task
 void HTMLElement::queue_a_popover_toggle_event_task(Utf16FlyString old_state, Utf16FlyString new_state, GC::Ptr<HTMLElement> source)
 {
+    auto& popover_toggle_task_tracker = ensure_html_element_rare_data().popover_toggle_task_tracker;
+
     // 1. If element's popover toggle task tracker is not null, then:
-    if (m_popover_toggle_task_tracker.has_value()) {
+    if (popover_toggle_task_tracker.has_value()) {
         // 1. Set oldState to element's popover toggle task tracker's old state.
-        old_state = move(m_popover_toggle_task_tracker->old_state);
+        old_state = move(popover_toggle_task_tracker->old_state);
 
         // 2. Remove element's popover toggle task tracker's task from its task queue.
         HTML::main_thread_event_loop().task_queue().remove_tasks_matching([&](auto const& task) {
-            return task.id() == m_popover_toggle_task_tracker->task_id;
+            return task.id() == popover_toggle_task_tracker->task_id;
         });
 
         // 3. Set element's popover toggle task tracker to null.
-        m_popover_toggle_task_tracker->task_id = {};
+        popover_toggle_task_tracker.clear();
     }
 
     // 2. Queue an element task given the DOM manipulation task source and element to run the following steps:
@@ -1975,11 +2034,11 @@ void HTMLElement::queue_a_popover_toggle_event_task(Utf16FlyString old_state, Ut
         dispatch_event(ToggleEvent::create(HTML::EventNames::toggle, move(event_init), HighResolutionTime::current_high_resolution_time(relevant_global_object(*this))));
 
         // 2. Set element's popover toggle task tracker to null.
-        m_popover_toggle_task_tracker = {};
+        ensure_html_element_rare_data().popover_toggle_task_tracker = {};
     });
 
     // 3. Set element's popover toggle task tracker to a struct with task set to the just-queued task and old state set to oldState.
-    m_popover_toggle_task_tracker = ToggleTaskTracker {
+    popover_toggle_task_tracker = ToggleTaskTracker {
         .task_id = task_id,
         .old_state = move(old_state),
     };

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -63,7 +63,9 @@
 
 namespace Web::HTML {
 
-struct HTMLElement::RareData final : DOM::Element::RareData {
+struct HTMLElement::RareData final
+    : DOM::Element::RareData
+    , FormAssociatedElement::RareData {
     virtual void visit_edges(Cell::Visitor&) override;
 
     GC::Ptr<DOM::NodeList> labels;
@@ -86,6 +88,7 @@ struct HTMLElement::RareData final : DOM::Element::RareData {
 void HTMLElement::RareData::visit_edges(Cell::Visitor& visitor)
 {
     DOM::Element::RareData::visit_edges(visitor);
+    FormAssociatedElement::RareData::visit_edges(visitor);
     visitor.visit(labels);
     visitor.visit(attached_internals);
     visitor.visit(popover_trigger);
@@ -110,6 +113,21 @@ HTMLElement::RareData* HTMLElement::html_element_rare_data()
 HTMLElement::RareData const* HTMLElement::html_element_rare_data() const
 {
     return static_cast<RareData const*>(rare_data());
+}
+
+FormAssociatedElement::RareData* HTMLElement::form_associated_rare_data()
+{
+    return html_element_rare_data();
+}
+
+FormAssociatedElement::RareData const* HTMLElement::form_associated_rare_data() const
+{
+    return html_element_rare_data();
+}
+
+FormAssociatedElement::RareData& HTMLElement::ensure_form_associated_rare_data()
+{
+    return ensure_html_element_rare_data();
 }
 
 Optional<Utf16FlyString> HTMLElement::opened_in_popover_mode() const
@@ -149,7 +167,6 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     HTMLOrSVGOrMathMLElement::visit_edges(visitor);
-    FormAssociatedElement::visit_edges(visitor);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-translate

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -149,7 +149,7 @@ public:
 
     void set_popover(Optional<Utf16String> value);
     Optional<Utf16FlyString> popover() const;
-    Optional<Utf16FlyString> opened_in_popover_mode() const { return m_opened_in_popover_mode; }
+    Optional<Utf16FlyString> opened_in_popover_mode() const;
 
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void moved_from(IsSubtreeRoot, GC::Ptr<DOM::Node> old_ancestor) override;
@@ -205,6 +205,12 @@ protected:
     [[nodiscard]] Utf16String get_the_text_steps();
 
 private:
+    struct RareData;
+    virtual OwnPtr<DOM::Node::RareData> create_rare_data() const override;
+    RareData& ensure_html_element_rare_data() const;
+    RareData* html_element_rare_data();
+    RareData const* html_element_rare_data() const;
+
     virtual bool is_html_element() const final { return true; }
 
     // ^FormAssociatedElement
@@ -217,8 +223,6 @@ private:
 
     GC::Ref<DOM::DocumentFragment> rendered_text_fragment(Utf16View const& input);
 
-    GC::Ptr<DOM::NodeList> m_labels;
-
     void queue_a_popover_toggle_event_task(Utf16FlyString old_state, Utf16FlyString new_state, GC::Ptr<HTMLElement> source);
 
     static Optional<Utf16FlyString> popover_value_to_state(Optional<Utf16View> value);
@@ -228,9 +232,6 @@ private:
     static void close_entire_popover_list(Vector<GC::Ref<HTMLElement>> const& popover_list, FocusPreviousElement focus_previous_element, FireEvents fire_events);
     static GC::Ptr<HTMLElement> topmost_clicked_popover(GC::Ptr<DOM::Node> node);
     size_t popover_stack_position();
-
-    // https://html.spec.whatwg.org/multipage/custom-elements.html#attached-internals
-    GC::Ptr<ElementInternals> m_attached_internals;
 
     // https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable
     ContentEditableState m_content_editable_state { ContentEditableState::Inherit };
@@ -247,17 +248,6 @@ private:
 
     // https://html.spec.whatwg.org/multipage/popover.html#popover-showing-or-hiding
     bool m_popover_showing_or_hiding { false };
-
-    // https://html.spec.whatwg.org/multipage/popover.html#popover-trigger
-    GC::Ptr<HTMLElement> m_popover_trigger;
-
-    // https://html.spec.whatwg.org/multipage/popover.html#the-popover-attribute:toggle-task-tracker
-    Optional<ToggleTaskTracker> m_popover_toggle_task_tracker;
-
-    // https://html.spec.whatwg.org/multipage/popover.html#popover-close-watcher
-    GC::Ptr<CloseWatcher> m_popover_close_watcher;
-
-    Optional<Utf16FlyString> m_opened_in_popover_mode;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -211,6 +211,10 @@ private:
     RareData* html_element_rare_data();
     RareData const* html_element_rare_data() const;
 
+    virtual FormAssociatedElement::RareData* form_associated_rare_data() override;
+    virtual FormAssociatedElement::RareData const* form_associated_rare_data() const override;
+    virtual FormAssociatedElement::RareData& ensure_form_associated_rare_data() override;
+
     virtual bool is_html_element() const final { return true; }
 
     // ^FormAssociatedElement

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -365,7 +365,7 @@ GC::Ref<HTMLLinkElement::LinkProcessingOptions> HTMLLinkElement::create_link_opt
 
         // cryptographic nonce metadata
         //     the current value of el's [[CryptographicNonce]] internal slot
-        m_cryptographic_nonce,
+        nonce(),
 
         // fetch priority
         //     the state of el's fetchpriority content attribute

--- a/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.cpp
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NeverDestroyed.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/ElementRareData.h>
 #include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLOrSVGOrMathMLElement.h>
@@ -18,13 +20,59 @@
 
 namespace Web::HTML {
 
+template<typename ElementBase>
+GC::Ptr<DOMStringMap>& HTMLOrSVGOrMathMLElement<ElementBase>::dataset_storage()
+{
+    return static_cast<ElementBase*>(this)->ensure_element_rare_data().dataset;
+}
+
+template<typename ElementBase>
+Utf16String* HTMLOrSVGOrMathMLElement<ElementBase>::cryptographic_nonce_storage()
+{
+    auto* rare_data = static_cast<ElementBase*>(this)->element_rare_data();
+    return rare_data ? &rare_data->cryptographic_nonce : nullptr;
+}
+
+template<typename ElementBase>
+Utf16String const* HTMLOrSVGOrMathMLElement<ElementBase>::cryptographic_nonce_storage() const
+{
+    auto const* rare_data = static_cast<ElementBase const*>(this)->element_rare_data();
+    return rare_data ? &rare_data->cryptographic_nonce : nullptr;
+}
+
+template<typename ElementBase>
+Utf16String& HTMLOrSVGOrMathMLElement<ElementBase>::ensure_cryptographic_nonce_storage()
+{
+    return static_cast<ElementBase*>(this)->ensure_element_rare_data().cryptographic_nonce;
+}
+
 // https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev
 template<typename ElementBase>
 GC::Ref<DOMStringMap> HTMLOrSVGOrMathMLElement<ElementBase>::dataset()
 {
-    if (!m_dataset)
-        m_dataset = DOMStringMap::create(*static_cast<ElementBase*>(this));
-    return *m_dataset;
+    auto& dataset = dataset_storage();
+    if (!dataset)
+        dataset = DOMStringMap::create(*static_cast<ElementBase*>(this));
+    return *dataset;
+}
+
+template<typename ElementBase>
+Utf16String const& HTMLOrSVGOrMathMLElement<ElementBase>::nonce() const
+{
+    static NeverDestroyed<Utf16String> empty_nonce;
+    auto const* nonce = cryptographic_nonce_storage();
+    return nonce ? *nonce : *empty_nonce;
+}
+
+template<typename ElementBase>
+void HTMLOrSVGOrMathMLElement<ElementBase>::set_nonce(Utf16View nonce)
+{
+    if (nonce.is_empty()) {
+        if (auto* storage = cryptographic_nonce_storage())
+            *storage = {};
+        return;
+    }
+    ensure_cryptographic_nonce_storage() = Utf16String::from_utf16(nonce);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-focus
@@ -75,12 +123,12 @@ void HTMLOrSVGOrMathMLElement<ElementBase>::attribute_changed(Utf16FlyString con
 
     // 3. If value is null, then set element's [[CryptographicNonce]] to the empty string.
     if (!value.has_value()) {
-        m_cryptographic_nonce = {};
+        set_nonce({});
     }
 
     // 4. Otherwise, set element's [[CryptographicNonce]] to value.
     else {
-        m_cryptographic_nonce = *value;
+        set_nonce(*value);
     }
 }
 
@@ -90,7 +138,7 @@ WebIDL::ExceptionOr<void> HTMLOrSVGOrMathMLElement<ElementBase>::cloned(DOM::Nod
 {
     // The cloning steps for elements that include HTMLOrSVGOrMathMLElement given node, copy, and subtree
     // are to set copy's [[CryptographicNonce]] to node's [[CryptographicNonce]].
-    static_cast<ElementBase&>(copy).m_cryptographic_nonce = m_cryptographic_nonce;
+    static_cast<ElementBase&>(copy).set_nonce(nonce());
     return {};
 }
 
@@ -115,13 +163,13 @@ void HTMLOrSVGOrMathMLElement<ElementBase>::inserted()
     //    nonce content attribute whose value is not the empty string, then:
     if (csp_list->contains_header_delivered_policy() && element.has_attribute(HTML::AttributeNames::nonce)) {
         // 2.1. Let nonce be element's [[CryptographicNonce]].
-        auto nonce = m_cryptographic_nonce;
+        auto nonce = this->nonce();
 
         // 2.2. Set an attribute value for element using "nonce" and the empty string.
         element.set_attribute_value(HTML::AttributeNames::nonce, Utf16String {});
 
         // 2.3. Set element's [[CryptographicNonce]] to nonce.
-        m_cryptographic_nonce = nonce;
+        set_nonce(nonce);
     }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute
@@ -158,12 +206,6 @@ void HTMLOrSVGOrMathMLElement<ElementBase>::inserted()
             candidates.append(GC::Ref { element });
         }
     }
-}
-
-template<typename ElementBase>
-void HTMLOrSVGOrMathMLElement<ElementBase>::visit_edges(JS::Cell::Visitor& visitor)
-{
-    visitor.visit(m_dataset);
 }
 
 template class HTMLOrSVGOrMathMLElement<HTMLElement>;

--- a/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGOrMathMLElement.h
@@ -9,7 +9,6 @@
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <LibGC/Ptr.h>
-#include <LibJS/Heap/Cell.h>
 #include <LibWeb/Bindings/HTMLElement.h>
 #include <LibWeb/HTML/DOMStringMap.h>
 
@@ -21,8 +20,8 @@ public:
     [[nodiscard]] GC::Ref<DOMStringMap> dataset();
 
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
-    Utf16String const& nonce() const { return m_cryptographic_nonce; }
-    void set_nonce(Utf16View nonce) { m_cryptographic_nonce = Utf16String::from_utf16(nonce); }
+    Utf16String const& nonce() const;
+    void set_nonce(Utf16View nonce);
 
     void focus(Bindings::FocusOptions const& = {});
     void blur();
@@ -31,13 +30,12 @@ protected:
     void attribute_changed(Utf16FlyString const&, Optional<Utf16String> const&, Optional<Utf16String> const&, Optional<Utf16FlyString> const&);
     WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const;
     void inserted();
-    void visit_edges(JS::Cell::Visitor&);
 
-    // https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev
-    GC::Ptr<DOMStringMap> m_dataset;
-
-    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cryptographicnonce
-    Utf16String m_cryptographic_nonce;
+private:
+    GC::Ptr<DOMStringMap>& dataset_storage();
+    Utf16String* cryptographic_nonce_storage();
+    Utf16String const* cryptographic_nonce_storage() const;
+    Utf16String& ensure_cryptographic_nonce_storage();
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -374,7 +374,7 @@ void HTMLScriptElement::prepare_script()
     auto module_script_credential_mode = cors_settings_attribute_credentials_mode(m_crossorigin);
 
     // 27. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
-    auto cryptographic_nonce = m_cryptographic_nonce;
+    auto cryptographic_nonce = nonce();
 
     // 28. If el has an integrity attribute, then let integrity metadata be that attribute's value.
     //     Otherwise, let integrity metadata be the empty string.

--- a/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -56,7 +56,6 @@ Optional<ARIA::Role> MathMLElement::default_role() const
 void MathMLElement::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    HTMLOrSVGOrMathMLElement::visit_edges(visitor);
 }
 
 bool MathMLElement::is_presentational_hint(Utf16FlyString const& name) const

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -246,7 +246,6 @@ Optional<ARIA::Role> SVGElement::default_role() const
 void SVGElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    HTMLOrSVGOrMathMLElement::visit_edges(visitor);
     visitor.visit(m_class_name_animated_string);
     visitor.visit(m_reflected_attribute_cache);
 }


### PR DESCRIPTION
Move infrequently used `Node`, `Element`, `HTMLElement`, `ParentNode`, `CharacterData`, ARIA, slottable, and form-associated state behind lazily allocated rare-data records. Reuse a single inherited GC-managed pointer across the element hierarchy while preserving default values, ownership, and GC edge visitation.

Also remove unused element state and avoid storing the document-wide custom element registry on every element.

The measured object sizes change as follows:

| Type | Before | After | Reduction |
|---|---:|---:|---:|
| `Node` | 152 bytes | 128 bytes | 24 bytes (15.8%) |
| `Element` | 608 bytes | 296 bytes | 312 bytes (51.3%) |
| `HTMLElement` | 920 bytes | 320 bytes | 600 bytes (65.2%) |
| `HTMLDivElement` | 920 bytes | 320 bytes | 600 bytes (65.2%) |
| `SVGElement` | 688 bytes | 360 bytes | 328 bytes (47.7%) |

Benchmarks look friendly:

| Benchmark | Old score | New score | Score ratio | Old time | New time | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| Speedometer2 | 52.65 ± 26.93 | 53.74 ± 1.09 | 1.021× | 9.66 ± 6.34 ms | 9.27 ± 0.46 ms | 1.042× |
| Speedometer3 | 2.89 ± 0.41 | 2.94 ± 0.46 | 1.018× | 9.54 ± 3.63 ms | 9.31 ± 1.21 ms | 1.024× |