### PR TITLE
LibWeb: Remap logical properties after writing mode changes

### DIFF
--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -396,6 +396,15 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
         }
     }
 
+    // https://drafts.csswg.org/css-logical-1/#intro
+    // This mapping, which depends on the used values of writing-mode, direction, and text-orientation, controls the
+    // interpretation of flow-relative keywords and properties.
+    // NB: Since writing-mode and direction are inherited, changing either on an ancestor requires recascading its
+    //     descendants.
+    // FIXME: Include text-orientation once it is implemented.
+    if (AK::first_is_one_of(property_id, CSS::PropertyID::Direction, CSS::PropertyID::WritingMode))
+        invalidation.recompute_descendant_styles = true;
+
     // OPTIMIZATION: Special handling for CSS `visibility`:
     if (property_id == CSS::PropertyID::Visibility) {
         // We don't need to relayout if the visibility changes from visible to hidden or vice versa. Only collapse requires relayout.

--- a/Tests/LibWeb/Text/expected/css/dynamic-writing-mode-remaps-logical-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/dynamic-writing-mode-remaps-logical-properties.txt
@@ -1,0 +1,1 @@
+margin-top: 10px; margin-left: 0px

--- a/Tests/LibWeb/Text/input/css/dynamic-writing-mode-remaps-logical-properties.html
+++ b/Tests/LibWeb/Text/input/css/dynamic-writing-mode-remaps-logical-properties.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#parent {
+    position: relative;
+    width: 100px;
+    height: 100px;
+}
+#child {
+    width: 20px;
+    height: 20px;
+    margin-inline-start: 10px;
+}
+</style>
+<div id="parent"><div id="child"></div></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const container = document.querySelector('#parent');
+        const target = document.querySelector('#child');
+        target.offsetTop;
+        container.style.writingMode = 'vertical-rl';
+        const style = getComputedStyle(target);
+        println(`margin-top: ${style.marginTop}; margin-left: ${style.marginLeft}`);
+    });
+</script>


### PR DESCRIPTION
Descendant mappings stayed stale because they occur during the cascade.