### PR TITLE
LibWeb: Instantiate attribute wrappers lazily

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -32,7 +32,6 @@
 #include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/CSS/StyleValues/ColorFunctionStyleValue.h>
-#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -321,8 +320,8 @@ static void publish_element_selector_features(StyleEngine& style_engine, DOM::El
         publish_feature(StyleEngineFFI::FfiFeatureKind::Id, StyleAtomID {}, StyleEngineFFI::FfiFeatureValueKind::Atom, intern_id_or_class_atom(style_engine, element, *id));
     for (auto const& class_name : element.class_names())
         publish_feature(StyleEngineFFI::FfiFeatureKind::Class, intern_id_or_class_atom(style_engine, element, class_name), StyleEngineFFI::FfiFeatureValueKind::Present, StyleAtomID {});
-    element.for_each_attribute([&](DOM::Attr const& attribute) {
-        publish_feature(StyleEngineFFI::FfiFeatureKind::Attribute, attribute_name_atom(style_engine, attribute.local_name(), attribute.namespace_uri()), StyleEngineFFI::FfiFeatureValueKind::Atom, style_engine.intern_attribute_value(attribute.value()));
+    element.for_each_attribute([&](DOM::QualifiedName const& name, Utf16View value) {
+        publish_feature(StyleEngineFFI::FfiFeatureKind::Attribute, attribute_name_atom(style_engine, name.local_name(), name.namespace_()), StyleEngineFFI::FfiFeatureValueKind::Atom, style_engine.intern_attribute_value(value));
     });
 
     bool has_nonempty_text_child = false;

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
@@ -949,7 +949,7 @@ enum class NonceableResult {
     // FIXME: File spec issue to ask if this should include SVGScriptElement.
     if (is<HTML::HTMLScriptElement>(element.ptr())) {
         for (size_t attribute_index = 0; attribute_index < element->attributes()->length(); ++attribute_index) {
-            auto const* attribute = element->attributes()->item(attribute_index);
+            auto attribute = element->attributes()->item(attribute_index);
             VERIFY(attribute);
 
             // 1. If attribute’s name contains an ASCII case-insensitive match for "<script" or "<style", return

--- a/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Libraries/LibWeb/DOM/Attr.cpp
@@ -10,10 +10,6 @@
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/DOM/MutationType.h>
-#include <LibWeb/DOM/StaticNodeList.h>
-#include <LibWeb/Editing/EditingHistory.h>
-#include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
 #include <LibWeb/TrustedTypes/TrustedTypePolicy.h>
 
 namespace Web::DOM {
@@ -32,7 +28,7 @@ GC::Ref<Attr> Attr::create(Document& document, QualifiedName qualified_name, Utf
 
 GC::Ref<Attr> Attr::clone(Document& document) const
 {
-    return GC::Heap::the().allocate<Attr>(document, m_qualified_name, m_value, nullptr);
+    return GC::Heap::the().allocate<Attr>(document, m_qualified_name, value(), nullptr);
 }
 
 Attr::Attr(Document& document, QualifiedName qualified_name, Utf16String value, GC::Ptr<Element> owner_element)
@@ -62,6 +58,22 @@ Element const* Attr::owner_element() const
 void Attr::set_owner_element(Element* owner_element)
 {
     m_owner_element = owner_element;
+}
+
+Utf16String Attr::value() const
+{
+    if (auto* element = owner_element()) {
+        auto index = element->find_attribute_index_ns(namespace_uri(), local_name());
+        VERIFY(index.has_value());
+        return element->m_attributes->at(*index).value;
+    }
+    return m_value;
+}
+
+void Attr::detach_from_element(Utf16String value)
+{
+    m_value = move(value);
+    m_owner_element = nullptr;
 }
 
 // https://dom.spec.whatwg.org/#set-an-existing-attribute-value
@@ -99,33 +111,11 @@ WebIDL::ExceptionOr<void> Attr::set_value(Utf16String value)
 // https://dom.spec.whatwg.org/#concept-element-attributes-change
 void Attr::change_attribute(Utf16String value)
 {
-    // 1. Let oldValue be attribute’s value.
-    auto old_value = move(m_value);
-
-    // 2. Set attribute’s value to value.
+    if (auto* element = owner_element()) {
+        element->change_attribute_value(*this, move(value));
+        return;
+    }
     m_value = move(value);
-
-    // 3. Handle attribute changes for attribute with attribute’s element, oldValue, and value.
-    handle_attribute_changes(*owner_element(), old_value, m_value);
-}
-
-// https://dom.spec.whatwg.org/#handle-attribute-changes
-void Attr::handle_attribute_changes(Element& element, Optional<Utf16String> const& old_value, Optional<Utf16String> const& new_value)
-{
-    // NB: Mutations during a recorded editing command must go through the Editing proxy functions.
-    if (auto history = element.document().editing_history_if_exists())
-        history->notify_dom_mutation();
-
-    // 1. Queue a mutation record of "attributes" for element with attribute’s local name, attribute’s namespace, oldValue, « », « », null, and null.
-    element.queue_mutation_record(MutationType::attributes, local_name(), namespace_uri(), old_value, {}, {}, nullptr, nullptr);
-
-    // 2. If element is custom, then enqueue a custom element callback reaction with element, callback name "attributeChangedCallback",
-    //    and « attribute’s local name, oldValue, newValue, attribute’s namespace ».
-    if (element.is_custom())
-        element.enqueue_an_attribute_changed_callback_reaction(local_name(), old_value, new_value, namespace_uri());
-
-    // 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
-    element.run_attribute_change_steps(local_name(), old_value, new_value, namespace_uri());
 }
 
 }

--- a/Libraries/LibWeb/DOM/Attr.h
+++ b/Libraries/LibWeb/DOM/Attr.h
@@ -34,7 +34,7 @@ public:
     Utf16FlyString const& local_name() const { return m_qualified_name.local_name(); }
     Utf16FlyString const& name() const { return m_qualified_name.as_string(); }
 
-    Utf16String const& value() const { return m_value; }
+    Utf16String value() const;
     WebIDL::ExceptionOr<void> set_value(Utf16String value);
     WebIDL::ExceptionOr<void> set_value(Utf16View value) { return set_value(Utf16String::from_utf16(value)); }
     void change_attribute(Utf16String value);
@@ -47,9 +47,11 @@ public:
     // Always returns true: https://dom.spec.whatwg.org/#dom-attr-specified
     constexpr bool specified() const { return true; }
 
-    void handle_attribute_changes(Element&, Optional<Utf16String> const& old_value, Optional<Utf16String> const& new_value);
-
 private:
+    friend class NamedNodeMap;
+
+    void detach_from_element(Utf16String value);
+
     Attr(Document&, QualifiedName, Utf16String value, GC::Ptr<Element>);
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -75,7 +75,7 @@ DOMTokenList::DOMTokenList(Element& associated_element, Utf16FlyString associate
     // 1. Let element be set’s element.
     // 2. Let attributeName be set’s attribute name.
     // 3. Let value be the result of getting an attribute value given element and attributeName.
-    auto value = m_associated_element->get_attribute_value_view(m_associated_attribute).value_or({});
+    auto value = m_associated_element->attribute(m_associated_attribute).value_or({});
 
     // 4. Run the attribute change steps for element, attributeName, value, value, and null.
     associated_attribute_changed(value);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -66,10 +66,12 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/ElementRareData.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/MutationType.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/SelectorQuery.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/Editing/EditingHistory.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
@@ -162,6 +164,7 @@ void Element::RareData::visit_edges(Cell::Visitor& visitor)
 {
     Node::RareData::visit_edges(visitor);
     SlottableMixin::RareData::visit_edges(visitor);
+    visitor.visit(attribute_map);
     visitor.visit(class_list);
     visitor.visit(part_list);
     if (custom_element_reaction_queue) {
@@ -307,57 +310,75 @@ Element::Element(Document& document, DOM::QualifiedName qualified_name)
 
 Element::~Element() = default;
 
+Element::AttributeList& Element::ensure_attribute_list()
+{
+    if (!m_attributes)
+        m_attributes = make<AttributeList>();
+    return *m_attributes;
+}
+
+Optional<size_t> Element::find_attribute_index(Utf16FlyString const& qualified_name) const
+{
+    if (!m_attributes)
+        return {};
+
+    Utf16FlyString const* effective_name = &qualified_name;
+    Utf16FlyString lowercase_name;
+    if (namespace_uri() == Namespace::HTML && document().is_html_document()) {
+        lowercase_name = qualified_name.to_ascii_lowercase();
+        effective_name = &lowercase_name;
+    }
+
+    for (size_t index = 0; index < m_attributes->size(); ++index) {
+        if (m_attributes->at(index).name.as_string() == *effective_name)
+            return index;
+    }
+    return {};
+}
+
+Optional<size_t> Element::find_attribute_index_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const
+{
+    if (!m_attributes)
+        return {};
+
+    Optional<Utf16FlyString> normalized_namespace;
+    if (namespace_ != Utf16FlyString {})
+        normalized_namespace = namespace_;
+    for (size_t index = 0; index < m_attributes->size(); ++index) {
+        auto const& attribute = m_attributes->at(index);
+        if (attribute.name.namespace_() == normalized_namespace && attribute.name.local_name() == local_name)
+            return index;
+    }
+    return {};
+}
+
 void Element::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     Animatable::visit_edges(visitor);
 
-    visitor.visit(m_attributes);
     visitor.visit(m_inline_style);
     visitor.visit(m_shadow_root);
+}
+
+size_t Element::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (!m_attributes)
+        return size;
+
+    size = JS::saturating_add_external_memory_size(size, sizeof(AttributeList));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(*m_attributes));
+    for (auto const& attribute : *m_attributes)
+        size = JS::saturating_add_external_memory_size(size, JS::utf16_string_external_memory_size(attribute.value));
+    return size;
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute
 Optional<Utf16String> Element::get_attribute(Utf16FlyString const& name) const
 {
-    if (!m_attributes)
-        return {};
-
-    Utf16FlyString const* effective_name = &name;
-    Utf16FlyString lowercase_name;
-    if (namespace_uri() == Namespace::HTML && document().is_html_document()) {
-        lowercase_name = name.to_ascii_lowercase();
-        effective_name = &lowercase_name;
-    }
-
-    for (size_t i = 0; i < m_attributes->length(); ++i) {
-        auto const* attribute = m_attributes->item(i);
-        if (*effective_name == attribute->name())
-            return attribute->value();
-    }
-
-    return {};
-}
-
-Optional<Utf16View> Element::get_attribute_value_view(Utf16FlyString const& name) const
-{
-    if (!m_attributes)
-        return {};
-
-    Utf16FlyString const* effective_name = &name;
-    Utf16FlyString lowercase_name;
-    if (namespace_uri() == Namespace::HTML && document().is_html_document()) {
-        lowercase_name = name.to_ascii_lowercase();
-        effective_name = &lowercase_name;
-    }
-
-    for (size_t i = 0; i < m_attributes->length(); ++i) {
-        auto const* attribute = m_attributes->item(i);
-        if (*effective_name == attribute->name())
-            return attribute->value().utf16_view();
-    }
-
-    return {};
+    auto index = find_attribute_index(name);
+    return index.has_value() ? Optional<Utf16String> { m_attributes->at(*index).value } : Optional<Utf16String> {};
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattributens
@@ -366,14 +387,14 @@ Optional<Utf16String> Element::get_attribute_ns(Optional<Utf16FlyString> const& 
     // 1. Let attr be the result of getting an attribute given namespace, localName, and this.
     if (!m_attributes)
         return {};
-    auto const* attribute = m_attributes->get_attribute_ns(namespace_, name);
+    auto index = find_attribute_index_ns(namespace_, name);
 
     // 2. If attr is null, return null.
-    if (!attribute)
+    if (!index.has_value())
         return {};
 
     // 3. Return attr’s value.
-    return attribute->value();
+    return m_attributes->at(*index).value;
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-value
@@ -382,14 +403,14 @@ Utf16String Element::get_attribute_value(Utf16FlyString const& local_name, Optio
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
     if (!m_attributes)
         return {};
-    auto const* attribute = m_attributes->get_attribute_ns(namespace_, local_name);
+    auto index = find_attribute_index_ns(namespace_, local_name);
 
     // 2. If attr is null, then return the empty string.
-    if (!attribute)
+    if (!index.has_value())
         return {};
 
     // 3. Return attr’s value.
-    return attribute->value();
+    return m_attributes->at(*index).value;
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#get-an-element's-target
@@ -425,7 +446,7 @@ HTML::TokenizedFeature::NoOpener Element::get_an_elements_noopener(URL::URL cons
 {
     // To get an element's noopener, given an a, area, or form element element, a URL record url, and a string target,
     // perform the following steps. They return a boolean.
-    auto link_types = get_attribute_value_view(HTML::AttributeNames::rel).value_or({});
+    auto link_types = attribute(HTML::AttributeNames::rel).value_or({});
     auto has_link_type = [&](Utf16View link_type) {
         size_t start = 0;
         for (size_t i = 0; i <= link_types.length_in_code_units(); ++i) {
@@ -514,7 +535,7 @@ void Element::follow_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML:
         target_attribute_value = get_an_elements_target();
 
     // 4. Let urlRecord be the result of encoding-parsing a URL given subject's href attribute value, relative to subject's node document.
-    auto url_record = document().encoding_parse_url(get_attribute_value_view(HTML::AttributeNames::href).value_or({}));
+    auto url_record = document().encoding_parse_url(attribute(HTML::AttributeNames::href).value_or({}));
 
     // 5. If urlRecord is failure, then return.
     if (!url_record.has_value())
@@ -571,7 +592,7 @@ void Element::download_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTM
 
     // 3. Let urlString be the result of encoding-parsing-and-serializing a URL given subject's href attribute
     //    value, relative to subject's node document.
-    auto url_record = document().encoding_parse_url(get_attribute_value_view(HTML::AttributeNames::href).value_or({}));
+    auto url_record = document().encoding_parse_url(attribute(HTML::AttributeNames::href).value_or({}));
 
     // 4. If urlString is failure, then return.
     if (!url_record.has_value())
@@ -730,7 +751,7 @@ GC::Ptr<Attr> Element::get_attribute_node(Utf16FlyString const& name) const
     // The getAttributeNode(qualifiedName) method steps are to return the result of getting an attribute given qualifiedName and this.
     if (!m_attributes)
         return {};
-    return m_attributes->get_attribute(name);
+    return const_cast<Element&>(*this).attributes()->get_attribute(name);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattributenodens
@@ -739,27 +760,29 @@ GC::Ptr<Attr> Element::get_attribute_node_ns(Optional<Utf16FlyString> const& nam
     // The getAttributeNodeNS(namespace, localName) method steps are to return the result of getting an attribute given namespace, localName, and this.
     if (!m_attributes)
         return {};
-    return m_attributes->get_attribute_ns(namespace_, name);
+    return const_cast<Element&>(*this).attributes()->get_attribute_ns(namespace_, name);
 }
 
 void Element::set_attribute(FlyString qualified_name, Utf16String const& verified_value)
 {
     auto utf16_qualified_name = Utf16FlyString::from_fly_string(qualified_name);
     // Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
-    GC::Ptr<Attr> attribute = attributes()->get_attribute(utf16_qualified_name);
+    auto index = find_attribute_index(utf16_qualified_name);
 
     // If attribute is non-null, then change attribute to verifiedValue and return.
-    if (attribute) {
-        attribute->change_attribute(verified_value);
+    if (index.has_value()) {
+        auto& attribute = m_attributes->at(*index);
+        auto old_value = move(attribute.value);
+        attribute.value = verified_value;
+        auto name = attribute.name;
+        auto new_value = attribute.value;
+        handle_attribute_changes(move(name), move(old_value), move(new_value));
         return;
     }
 
     // Set attribute to a new attribute whose local name is qualifiedName, value is verifiedValue,
     // and node document is this’s node document.
-    attribute = Attr::create(document(), utf16_qualified_name, verified_value);
-
-    // Append attribute to this.
-    m_attributes->append_attribute(*attribute);
+    append_attribute(QualifiedName { utf16_qualified_name, {}, {} }, verified_value);
 }
 
 // https://dom.spec.whatwg.org/#valid-namespace-prefix
@@ -906,10 +929,51 @@ void Element::set_attribute_ns(QualifiedName const& qualified_name, Utf16String 
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-append
-// https://dom.spec.whatwg.org/#concept-element-attributes-append
 void Element::append_attribute(Attr& attribute)
 {
-    attributes()->append_attribute(attribute);
+    attributes()->append_attribute(GC::Ref { attribute });
+}
+
+void Element::append_attribute(QualifiedName name, Utf16String value)
+{
+    auto old_value = Optional<Utf16String> {};
+    auto& attributes = ensure_attribute_list();
+    attributes.empend(move(name), move(value));
+    auto& attribute = attributes.last();
+    auto attribute_name = attribute.name;
+    auto new_value = attribute.value;
+    handle_attribute_changes(move(attribute_name), move(old_value), move(new_value));
+}
+
+void Element::change_attribute_value(GC::Ref<Attr> attribute_node, Utf16String value)
+{
+    auto index = find_attribute_index_ns(attribute_node->namespace_uri(), attribute_node->local_name());
+    VERIFY(index.has_value());
+    auto& attribute = m_attributes->at(*index);
+    auto old_value = move(attribute.value);
+    attribute.value = move(value);
+    auto name = attribute.name;
+    auto new_value = attribute.value;
+    handle_attribute_changes(move(name), move(old_value), move(new_value));
+}
+
+// https://dom.spec.whatwg.org/#handle-attribute-changes
+void Element::handle_attribute_changes(QualifiedName name, Optional<Utf16String> old_value, Optional<Utf16String> new_value)
+{
+    // NB: Mutations during a recorded editing command must go through the Editing proxy functions.
+    if (auto history = document().editing_history_if_exists())
+        history->notify_dom_mutation();
+
+    // 1. Queue a mutation record of "attributes" for element with attribute’s local name, attribute’s namespace, oldValue, « », « », null, and null.
+    queue_mutation_record(MutationType::attributes, name.local_name(), name.namespace_(), old_value, {}, {}, nullptr, nullptr);
+
+    // 2. If element is custom, then enqueue a custom element callback reaction with element, callback name "attributeChangedCallback",
+    //    and « attribute’s local name, oldValue, newValue, attribute’s namespace ».
+    if (is_custom())
+        enqueue_an_attribute_changed_callback_reaction(name.local_name(), old_value, new_value, name.namespace_());
+
+    // 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
+    run_attribute_change_steps(name.local_name(), old_value, new_value, name.namespace_());
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-set-value
@@ -921,36 +985,40 @@ void Element::set_attribute_value(Utf16FlyString const& local_name, Utf16View va
 void Element::set_attribute_value(Utf16FlyString const& local_name, Utf16String value, Optional<Utf16FlyString> const& prefix, Optional<Utf16FlyString> const& namespace_)
 {
     // 1. Let attribute be the result of getting an attribute given namespace, localName, and element.
-    auto* attribute = attributes()->get_attribute_ns(namespace_, local_name);
+    auto index = find_attribute_index_ns(namespace_, local_name);
 
     // 2. If attribute is null, create an attribute whose namespace is namespace, namespace prefix is prefix, local name
     //    is localName, value is value, and node document is element’s node document, then append this attribute to element,
     //    and then return.
-    if (!attribute) {
+    if (!index.has_value()) {
         QualifiedName name { local_name, prefix, namespace_ };
 
-        auto new_attribute = Attr::create(document(), move(name), move(value));
-        m_attributes->append_attribute(new_attribute);
+        append_attribute(move(name), move(value));
 
         return;
     }
 
     // 3. Change attribute to value.
-    attribute->change_attribute(move(value));
+    auto& attribute = m_attributes->at(*index);
+    auto old_value = move(attribute.value);
+    attribute.value = move(value);
+    auto name = attribute.name;
+    auto new_value = attribute.value;
+    handle_attribute_changes(move(name), move(old_value), move(new_value));
 }
 
 // https://dom.spec.whatwg.org/#dom-element-setattributenode
 WebIDL::ExceptionOr<GC::Ptr<Attr>> Element::set_attribute_node(Attr& attr)
 {
     // The setAttributeNode(attr) and setAttributeNodeNS(attr) methods steps are to return the result of setting an attribute given attr and this.
-    return attributes()->set_attribute(attr);
+    return attributes()->set_attribute(GC::Ref { attr });
 }
 
 // https://dom.spec.whatwg.org/#dom-element-setattributenodens
 WebIDL::ExceptionOr<GC::Ptr<Attr>> Element::set_attribute_node_ns(Attr& attr)
 {
     // The setAttributeNode(attr) and setAttributeNodeNS(attr) methods steps are to return the result of setting an attribute given attr and this.
-    return attributes()->set_attribute(attr);
+    return attributes()->set_attribute(GC::Ref { attr });
 }
 
 // https://dom.spec.whatwg.org/#dom-element-removeattribute
@@ -967,7 +1035,8 @@ void Element::remove_attribute(Utf16FlyString const& name)
         effective_name = &lowercase_name;
     }
 
-    m_attributes->remove_attribute(*effective_name);
+    if (auto index = find_attribute_index(*effective_name); index.has_value())
+        remove_attribute_at(*index);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-removeattributens
@@ -976,7 +1045,18 @@ void Element::remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Ut
     // The removeAttributeNS(namespace, localName) method steps are to remove an attribute given namespace, localName, and this, and then return undefined.
     if (!m_attributes)
         return;
-    m_attributes->remove_attribute_ns(namespace_, name);
+    if (auto index = find_attribute_index_ns(namespace_, name); index.has_value())
+        remove_attribute_at(*index);
+}
+
+void Element::remove_attribute_at(size_t index)
+{
+    auto name = m_attributes->at(index).name;
+    auto old_value = m_attributes->at(index).value;
+    if (auto* rare_data = element_rare_data(); rare_data && rare_data->attribute_map)
+        rare_data->attribute_map->detach_attribute_node(name, old_value);
+    m_attributes->remove(index);
+    handle_attribute_changes(name, old_value, {});
 }
 
 // https://dom.spec.whatwg.org/#dom-element-removeattributenode
@@ -988,7 +1068,7 @@ WebIDL::ExceptionOr<GC::Ref<Attr>> Element::remove_attribute_node(GC::Ref<Attr> 
 // https://dom.spec.whatwg.org/#dom-element-hasattribute
 bool Element::has_attribute(Utf16FlyString const& name) const
 {
-    return get_attribute_value_view(name).has_value();
+    return attribute(name).has_value();
 }
 
 // https://dom.spec.whatwg.org/#dom-element-hasattributens
@@ -1000,9 +1080,9 @@ bool Element::has_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16
     // 1. If namespace is the empty string, then set it to null.
     // 2. Return true if this has an attribute whose namespace is namespace and local name is localName; otherwise false.
     if (namespace_ == Utf16FlyString {})
-        return m_attributes->get_attribute_ns(Optional<Utf16FlyString> {}, name) != nullptr;
+        return find_attribute_index_ns(Optional<Utf16FlyString> {}, name).has_value();
 
-    return m_attributes->get_attribute_ns(namespace_, name) != nullptr;
+    return find_attribute_index_ns(namespace_, name).has_value();
 }
 
 // https://dom.spec.whatwg.org/#dom-element-toggleattribute
@@ -1018,15 +1098,14 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(Utf16FlyString const& name, 
         effective_name = name.to_ascii_lowercase();
 
     // 3. Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
-    auto* attribute = attributes()->get_attribute(effective_name);
+    auto index = find_attribute_index(effective_name);
 
     // 4. If attribute is null, then:
-    if (!attribute) {
+    if (!index.has_value()) {
         // 1. If force is not given or is true, create an attribute whose local name is qualifiedName, value is the empty
         //    string, and node document is this’s node document, then append this attribute to this, and then return true.
         if (!force.has_value() || force.value()) {
-            auto new_attribute = Attr::create(document(), effective_name, Utf16String {});
-            m_attributes->append_attribute(new_attribute);
+            append_attribute(QualifiedName { effective_name, {}, {} }, {});
 
             return true;
         }
@@ -1037,7 +1116,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(Utf16FlyString const& name, 
 
     // 5. Otherwise, if force is not given or is false, remove an attribute given qualifiedName and this, and then return false.
     if (!force.has_value() || !force.value()) {
-        m_attributes->remove_attribute(effective_name);
+        remove_attribute_at(*index);
         return false;
     }
 
@@ -1052,10 +1131,8 @@ Vector<Utf16FlyString> Element::get_attribute_names() const
     if (!m_attributes)
         return {};
     Vector<Utf16FlyString> names;
-    for (size_t i = 0; i < m_attributes->length(); ++i) {
-        auto const* attribute = m_attributes->item(i);
-        names.append(attribute->name());
-    }
+    for (auto const& attribute : *m_attributes)
+        names.append(attribute.name.as_string());
     return names;
 }
 
@@ -2827,7 +2904,7 @@ bool Element::matches_local_link_pseudo_class() const
     if (!matches_link_pseudo_class())
         return false;
     auto document_url = document().url();
-    auto maybe_href = get_attribute_value_view(HTML::AttributeNames::href);
+    auto maybe_href = attribute(HTML::AttributeNames::href);
     if (!maybe_href.has_value())
         return false;
     auto target_url = document().encoding_parse_url(*maybe_href);
@@ -4396,12 +4473,14 @@ Optional<Utf16String> Element::locate_a_namespace_prefix(Optional<Utf16View> nam
         return this->prefix()->to_utf16_string();
 
     // 2. If element has an attribute whose namespace prefix is "xmlns" and value is namespace, then return element’s first such attribute’s local name.
-    if (auto attributes = this->attributes(); attributes && namespace_.has_value()) {
-        for (size_t i = 0; i < attributes->length(); ++i) {
-            auto& attr = *attributes->item(i);
-            if (attr.prefix() == u"xmlns"sv && attr.value().utf16_view() == *namespace_)
-                return attr.local_name().to_utf16_string();
-        }
+    if (namespace_.has_value()) {
+        Optional<Utf16String> matching_prefix;
+        for_each_attribute([&](QualifiedName name, Utf16String value) {
+            if (!matching_prefix.has_value() && name.prefix() == u"xmlns"sv && value == *namespace_)
+                matching_prefix = name.local_name().to_utf16_string();
+        });
+        if (matching_prefix.has_value())
+            return matching_prefix;
     }
 
     // 3. If element’s parent element is not null, then return the result of running locate a namespace prefix on that element using namespace.
@@ -4416,23 +4495,40 @@ void Element::for_each_attribute(Function<void(Attr&)> callback)
 {
     if (!m_attributes)
         return;
-    for (size_t i = 0; i < m_attributes->length(); ++i)
-        callback(*m_attributes->item(i));
+    auto attribute_map = attributes();
+    for (size_t i = 0; i < m_attributes->size(); ++i)
+        callback(*attribute_map->item(i));
 }
 
 void Element::for_each_attribute(Function<void(Attr const&)> callback) const
 {
     if (!m_attributes)
         return;
-    for (size_t i = 0; i < m_attributes->length(); ++i)
-        callback(*m_attributes->item(i));
+    auto attribute_map = attributes();
+    for (size_t i = 0; i < m_attributes->size(); ++i)
+        callback(*attribute_map->item(i));
 }
 
-void Element::for_each_attribute(Function<void(Utf16FlyString const&, Utf16View)> callback) const
+void Element::for_each_attribute(Function<void(Utf16FlyString, Utf16String)> callback) const
 {
-    for_each_attribute([&callback](Attr const& attr) {
-        callback(attr.name(), attr.value().utf16_view());
-    });
+    if (!m_attributes)
+        return;
+    for (size_t index = 0; index < m_attributes->size(); ++index) {
+        auto name = m_attributes->at(index).name.as_string();
+        auto value = m_attributes->at(index).value;
+        callback(move(name), move(value));
+    }
+}
+
+void Element::for_each_attribute(Function<void(QualifiedName, Utf16String)> callback) const
+{
+    if (!m_attributes)
+        return;
+    for (size_t index = 0; index < m_attributes->size(); ++index) {
+        auto name = m_attributes->at(index).name;
+        auto value = m_attributes->at(index).value;
+        callback(move(name), move(value));
+    }
 }
 
 Layout::NodeWithStyle* Element::layout_node()
@@ -4462,7 +4558,7 @@ bool Element::has_attributes() const
 
 size_t Element::attribute_list_size() const
 {
-    return m_attributes ? m_attributes->length() : 0;
+    return m_attributes ? m_attributes->size() : 0;
 }
 
 CSS::ComputedStyleRecordView Element::computed_style(Optional<CSS::PseudoElement> pseudo_element_type) const
@@ -5082,7 +5178,7 @@ Element::TranslationMode Element::translation_mode() const
     // translate-enabled state;
     // NOTE: The attribute is in the Yes state if the attribute is present and its value is the empty string or is a
     //       ASCII-case-insensitive match for "yes".
-    auto maybe_translate_attribute = get_attribute_value_view(HTML::AttributeNames::translate);
+    auto maybe_translate_attribute = attribute(HTML::AttributeNames::translate);
     if (maybe_translate_attribute.has_value() && (maybe_translate_attribute.value().is_empty() || maybe_translate_attribute.value().equals_ignoring_ascii_case(u"yes"sv)))
         return TranslationMode::TranslateEnabled;
 
@@ -5787,9 +5883,10 @@ bool Element::has_pointer_capture(WebIDL::Long pointer_id)
 
 GC::Ptr<NamedNodeMap> Element::attributes()
 {
-    if (!m_attributes)
-        m_attributes = NamedNodeMap::create(*this);
-    return m_attributes;
+    auto& attribute_map = ensure_element_rare_data().attribute_map;
+    if (!attribute_map)
+        attribute_map = NamedNodeMap::create(*this);
+    return attribute_map;
 }
 
 GC::Ptr<NamedNodeMap const> Element::attributes() const
@@ -5894,7 +5991,7 @@ bool Element::should_indicate_focus() const
 // https://html.spec.whatwg.org/multipage/interaction.html#tabindex-value
 bool Element::is_focusable() const
 {
-    return HTML::parse_integer(get_attribute_value_view(HTML::AttributeNames::tabindex).value_or({})).has_value()
+    return HTML::parse_integer(attribute(HTML::AttributeNames::tabindex).value_or({})).has_value()
         && meets_focusable_area_rendering_requirements();
 }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -209,7 +209,6 @@ public:
     Optional<Utf16String> get_attribute(Utf16FlyString const& name) const;
     Optional<Utf16String> get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name) const;
     Utf16String get_attribute_value(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& namespace_ = {}) const;
-    Optional<Utf16View> get_attribute_value_view(Utf16FlyString const& name) const;
 
     Utf16String get_an_elements_target(Optional<Utf16String> target = {}) const;
     HTML::TokenizedFeature::NoOpener get_an_elements_noopener(URL::URL const& url, Utf16View target) const;
@@ -235,6 +234,7 @@ public:
     WebIDL::ExceptionOr<GC::Ptr<Attr>> set_attribute_node_ns(Attr&);
 
     void append_attribute(Attr&);
+    void append_attribute(QualifiedName, Utf16String value);
     void remove_attribute(Utf16FlyString const& name);
     void remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name);
     WebIDL::ExceptionOr<GC::Ref<Attr>> remove_attribute_node(GC::Ref<Attr>);
@@ -304,7 +304,8 @@ public:
     void for_each_attribute(Function<void(Attr&)>);
     void for_each_attribute(Function<void(Attr const&)>) const;
 
-    void for_each_attribute(Function<void(Utf16FlyString const&, Utf16View)>) const;
+    void for_each_attribute(Function<void(QualifiedName, Utf16String)>) const;
+    void for_each_attribute(Function<void(Utf16FlyString, Utf16String)>) const;
 
     bool has_class(Utf16View, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     bool has_class(Utf16FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
@@ -805,6 +806,7 @@ protected:
     virtual void prepare_for_style_computation() { }
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     virtual bool id_reference_exists(Utf16View) const override;
 
@@ -821,6 +823,19 @@ protected:
     struct RareData;
 
 private:
+    struct Attribute {
+        QualifiedName name;
+        Utf16String value;
+    };
+    using AttributeList = Vector<Attribute, 1>;
+
+    AttributeList& ensure_attribute_list();
+    Optional<size_t> find_attribute_index(Utf16FlyString const& qualified_name) const;
+    Optional<size_t> find_attribute_index_ns(Optional<Utf16FlyString> const&, Utf16FlyString const& local_name) const;
+    void change_attribute_value(GC::Ref<Attr>, Utf16String value);
+    void handle_attribute_changes(QualifiedName, Optional<Utf16String> old_value, Optional<Utf16String> new_value);
+    void remove_attribute_at(size_t index);
+
     using PreservedPseudoElementStyles = Array<RefPtr<CSS::ComputedValues const>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)>;
     using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
 
@@ -856,7 +871,7 @@ private:
 
     QualifiedName m_qualified_name;
 
-    GC::Ptr<NamedNodeMap> m_attributes;
+    OwnPtr<AttributeList> m_attributes;
     GC::Ptr<CSS::CSSStyleProperties> m_inline_style;
     GC::Ptr<ShadowRoot> m_shadow_root;
 
@@ -875,6 +890,9 @@ private:
     CSS::StyleNodeID m_style_node_id;
 
     Optional<Utf16FlyString> m_id;
+
+    friend class Attr;
+    friend class NamedNodeMap;
 
     bool m_is_being_activated : 1 { false };
     bool m_in_top_layer : 1 { false };

--- a/Libraries/LibWeb/DOM/ElementRareData.h
+++ b/Libraries/LibWeb/DOM/ElementRareData.h
@@ -27,6 +27,7 @@ struct Element::RareData
     GC::Ptr<CSS::StylePropertyMap> attribute_style_map;
     GC::Ptr<DOMTokenList> class_list;
     GC::Ptr<DOMTokenList> part_list;
+    GC::Ptr<NamedNodeMap> attribute_map;
     mutable OwnPtr<PseudoElementData> pseudo_element_data;
     Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element;
     Vector<Utf16FlyString> parts;

--- a/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -42,7 +42,31 @@ void NamedNodeMap::visit_edges(GC::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_element);
-    visitor.visit(m_attributes);
+    visitor.visit(m_attribute_nodes);
+}
+
+size_t NamedNodeMap::length() const
+{
+    return associated_element().attribute_list_size();
+}
+
+GC::Ptr<Attr> NamedNodeMap::find_attribute_node(QualifiedName const& name) const
+{
+    for (auto& attribute : m_attribute_nodes) {
+        if (attribute->namespace_uri() == name.namespace_() && attribute->local_name() == name.local_name())
+            return attribute;
+    }
+    return nullptr;
+}
+
+GC::Ref<Attr> NamedNodeMap::ensure_attribute_node(QualifiedName const& name) const
+{
+    if (auto attribute = find_attribute_node(name))
+        return *attribute;
+    auto& element = const_cast<Element&>(associated_element());
+    auto attribute = Attr::create(element.document(), name, {}, element);
+    m_attribute_nodes.append(attribute);
+    return attribute;
 }
 
 // https://dom.spec.whatwg.org/#ref-for-dfn-supported-property-names%E2%91%A0
@@ -50,11 +74,12 @@ Vector<Utf16FlyString> NamedNodeMap::supported_property_names() const
 {
     // 1. Let names be the qualified names of the attributes in this NamedNodeMap object’s attribute list, with duplicates omitted, in order.
     Vector<Utf16FlyString> names;
-    names.ensure_capacity(m_attributes.size());
+    names.ensure_capacity(length());
 
-    for (auto const& attribute : m_attributes) {
-        if (!names.contains_slow(attribute->name()))
-            names.append(attribute->name());
+    for (size_t index = 0; index < length(); ++index) {
+        auto name = associated_element().m_attributes->at(index).name.as_string();
+        if (!names.contains_slow(name))
+            names.append(move(name));
     }
 
     // 2. If this NamedNodeMap object’s element is in the HTML namespace and its node document is an HTML document, then for each name of names:
@@ -69,29 +94,25 @@ Vector<Utf16FlyString> NamedNodeMap::supported_property_names() const
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-item
-Attr* NamedNodeMap::item(u32 index)
+GC::Ptr<Attr> NamedNodeMap::item(u32 index) const
 {
     // 1. If index is equal to or greater than this’s attribute list’s size, then return null.
-    if (index >= m_attributes.size())
+    if (index >= length())
         return nullptr;
 
     // 2. Otherwise, return this’s attribute list[index].
-    return m_attributes[index].ptr();
-}
-
-Attr const* NamedNodeMap::item(u32 index) const
-{
-    return const_cast<NamedNodeMap&>(*this).item(index);
+    auto name = associated_element().m_attributes->at(index).name;
+    return ensure_attribute_node(move(name));
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-getnameditem
-Attr const* NamedNodeMap::get_named_item(Utf16FlyString const& qualified_name) const
+GC::Ptr<Attr> NamedNodeMap::get_named_item(Utf16FlyString const& qualified_name) const
 {
     return get_attribute(qualified_name);
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-getnameditemns
-Attr const* NamedNodeMap::get_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const
+GC::Ptr<Attr> NamedNodeMap::get_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const
 {
     return get_attribute_ns(namespace_, local_name);
 }
@@ -99,128 +120,96 @@ Attr const* NamedNodeMap::get_named_item_ns(Optional<Utf16FlyString> const& name
 // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem
 WebIDL::ExceptionOr<GC::Ptr<Attr>> NamedNodeMap::set_named_item(Attr& attribute)
 {
-    return set_attribute(attribute);
+    return set_attribute(GC::Ref { attribute });
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns
 WebIDL::ExceptionOr<GC::Ptr<Attr>> NamedNodeMap::set_named_item_ns(Attr& attribute)
 {
-    return set_attribute(attribute);
+    return set_attribute(GC::Ref { attribute });
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
-WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(Utf16FlyString const& qualified_name)
+WebIDL::ExceptionOr<GC::Ref<Attr>> NamedNodeMap::remove_named_item(Utf16FlyString const& qualified_name)
 {
     // 1. Let attr be the result of removing an attribute given qualifiedName and element.
-    auto const* attribute = remove_attribute(qualified_name);
+    auto attribute = remove_attribute(qualified_name);
 
     // 2. If attr is null, then throw a "NotFoundError" DOMException.
     if (!attribute)
         return WebIDL::NotFoundError::create(Utf16String::formatted("Attribute with name '{}' not found", qualified_name));
 
     // 3. Return attr.
-    return attribute;
+    return GC::Ref { *attribute };
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
-WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name)
+WebIDL::ExceptionOr<GC::Ref<Attr>> NamedNodeMap::remove_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name)
 {
     // 1. Let attr be the result of removing an attribute given namespace, localName, and element.
-    auto const* attribute = remove_attribute_ns(namespace_, local_name);
+    auto attribute = remove_attribute_ns(namespace_, local_name);
 
     // 2. If attr is null, then throw a "NotFoundError" DOMException.
     if (!attribute)
         return WebIDL::NotFoundError::create(Utf16String::formatted("Attribute with namespace '{}' and local name '{}' not found", namespace_, local_name));
 
     // 3. Return attr.
-    return attribute;
+    return GC::Ref { *attribute };
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
-Attr* NamedNodeMap::get_attribute(Utf16FlyString const& qualified_name, size_t* item_index)
-{
-    return const_cast<Attr*>(const_cast<NamedNodeMap const*>(this)->get_attribute(qualified_name, item_index));
-}
-
-// https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
-Attr const* NamedNodeMap::get_attribute(Utf16FlyString const& qualified_name, size_t* item_index) const
+GC::Ptr<Attr> NamedNodeMap::get_attribute(Utf16FlyString const& qualified_name, size_t* item_index) const
 {
     if (item_index)
         *item_index = 0;
-
-    // 1. If element is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
-    Utf16FlyString const* effective_qualified_name = &qualified_name;
-    Utf16FlyString lowercase_qualified_name;
-    if (associated_element().namespace_uri() == Namespace::HTML && associated_element().document().is_html_document()) {
-        lowercase_qualified_name = qualified_name.to_ascii_lowercase();
-        effective_qualified_name = &lowercase_qualified_name;
-    }
-
-    // 2. Return the first attribute in element’s attribute list whose qualified name is qualifiedName; otherwise null.
-    for (auto const& attribute : m_attributes) {
-        if (attribute->name() == *effective_qualified_name)
-            return attribute.ptr();
-
-        if (item_index)
-            ++(*item_index);
-    }
-
-    return nullptr;
+    auto index = associated_element().find_attribute_index(qualified_name);
+    if (!index.has_value())
+        return nullptr;
+    if (item_index)
+        *item_index = *index;
+    auto name = associated_element().m_attributes->at(*index).name;
+    return ensure_attribute_node(move(name));
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
-Attr* NamedNodeMap::get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index)
-{
-    return const_cast<Attr*>(const_cast<NamedNodeMap const*>(this)->get_attribute_ns(namespace_, local_name, item_index));
-}
-
-// https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
-Attr const* NamedNodeMap::get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index) const
+GC::Ptr<Attr> NamedNodeMap::get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index) const
 {
     if (item_index)
         *item_index = 0;
-
-    // 1. If namespace is the empty string, then set it to null.
-    Optional<Utf16FlyString> normalized_namespace;
-    if (namespace_ != Utf16FlyString {})
-        normalized_namespace = namespace_;
-
-    // 2. Return the attribute in element’s attribute list whose namespace is namespace and local name is localName, if any; otherwise null.
-    for (auto const& attribute : m_attributes) {
-        if (attribute->namespace_uri() == normalized_namespace && attribute->local_name() == local_name)
-            return attribute.ptr();
-        if (item_index)
-            ++(*item_index);
-    }
-
-    return nullptr;
+    auto index = associated_element().find_attribute_index_ns(namespace_, local_name);
+    if (!index.has_value())
+        return nullptr;
+    if (item_index)
+        *item_index = *index;
+    auto name = associated_element().m_attributes->at(*index).name;
+    return ensure_attribute_node(move(name));
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-set
-WebIDL::ExceptionOr<GC::Ptr<Attr>> NamedNodeMap::set_attribute(Attr& attribute)
+WebIDL::ExceptionOr<GC::Ptr<Attr>> NamedNodeMap::set_attribute(GC::Ref<Attr> attribute)
 {
     // 1. Let verifiedValue be the result of calling get Trusted Types-compliant attribute value
     //    with attr’s local name, attr’s namespace, element, and attr’s value
     auto const verifiedValue = TRY(TrustedTypes::get_trusted_types_compliant_attribute_value(
-        attribute.local_name(),
-        attribute.namespace_uri(),
+        attribute->local_name(),
+        attribute->namespace_uri(),
         associated_element(),
-        attribute.value()));
+        attribute->value()));
 
     // 2. If attr’s element is neither null nor element, throw an "InUseAttributeError" DOMException.
-    if ((attribute.owner_element() != nullptr) && (attribute.owner_element() != &associated_element()))
+    if ((attribute->owner_element() != nullptr) && (attribute->owner_element() != &associated_element()))
         return WebIDL::InUseAttributeError::create("Attribute must not already be in use"_utf16);
 
     // 3. Let oldAttr be the result of getting an attribute given attr’s namespace, attr’s local name, and element.
     size_t old_attribute_index = 0;
-    auto* old_attribute = get_attribute_ns(attribute.namespace_uri(), attribute.local_name(), &old_attribute_index);
+    auto old_attribute = get_attribute_ns(attribute->namespace_uri(), attribute->local_name(), &old_attribute_index);
 
     // 4. If oldAttr is attr, return attr.
-    if (old_attribute == &attribute)
-        return &attribute;
+    if (old_attribute == attribute)
+        return attribute;
 
     // 5. Set attr’s value to verifiedValue.
-    TRY(attribute.set_value(verifiedValue));
+    TRY(attribute->set_value(verifiedValue));
 
     // 6. If oldAttr is non-null, then replace oldAttr with attr.
     if (old_attribute) {
@@ -236,72 +225,76 @@ WebIDL::ExceptionOr<GC::Ptr<Attr>> NamedNodeMap::set_attribute(Attr& attribute)
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-replace
-void NamedNodeMap::replace_attribute(Attr& old_attribute, Attr& new_attribute, size_t old_attribute_index)
+void NamedNodeMap::replace_attribute(GC::Ref<Attr> old_attribute, GC::Ref<Attr> new_attribute, size_t old_attribute_index)
 {
-    VERIFY(old_attribute.owner_element());
+    VERIFY(old_attribute->owner_element());
 
     // 1. Let element be oldAttribute’s element.
-    auto* element = old_attribute.owner_element();
+    auto* element = old_attribute->owner_element();
 
     // 2. Replace oldAttribute by newAttribute in element’s attribute list.
-    m_attributes.remove(old_attribute_index);
-    m_attributes.insert(old_attribute_index, new_attribute);
+    auto old_value = element->m_attributes->at(old_attribute_index).value;
+    auto new_name = new_attribute->m_qualified_name;
+    auto new_value = new_attribute->value();
+    element->m_attributes->at(old_attribute_index) = { new_name, new_value };
 
     // 3. Set newAttribute’s element to element.
-    new_attribute.set_owner_element(element);
+    new_attribute->set_owner_element(element);
 
     // 4. Set newAttribute’s node document to element’s node document.
-    new_attribute.set_document(Badge<NamedNodeMap> {}, element->document());
+    new_attribute->set_document(Badge<NamedNodeMap> {}, element->document());
 
     // 5. Set oldAttribute’s element to null.
-    old_attribute.set_owner_element(nullptr);
+    detach_attribute_node(old_attribute->m_qualified_name, old_value);
+    m_attribute_nodes.append(new_attribute);
 
     // 6. Handle attribute changes for oldAttribute with element, oldAttribute’s value, and newAttribute’s value.
-    old_attribute.handle_attribute_changes(*new_attribute.owner_element(), old_attribute.value(), new_attribute.value());
+    element->handle_attribute_changes(move(new_name), move(old_value), move(new_value));
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-append
-void NamedNodeMap::append_attribute(Attr& attribute)
+void NamedNodeMap::append_attribute(GC::Ref<Attr> attribute)
 {
     // 1. Append attribute to element’s attribute list.
-    m_attributes.append(attribute);
+    auto value = attribute->value();
+    associated_element().ensure_attribute_list().empend(attribute->m_qualified_name, value);
 
     // 2. Set attribute’s element to element.
-    attribute.set_owner_element(&associated_element());
+    attribute->set_owner_element(&associated_element());
 
     // 3. Set attribute’s node document to element’s node document.
-    attribute.set_document(Badge<NamedNodeMap> {}, associated_element().document());
+    attribute->set_document(Badge<NamedNodeMap> {}, associated_element().document());
+    m_attribute_nodes.append(attribute);
 
     // 4. Handle attribute changes for attribute with element, null, and attribute’s value.
-    attribute.handle_attribute_changes(associated_element(), {}, attribute.value());
+    associated_element().handle_attribute_changes(attribute->m_qualified_name, {}, value);
+}
+
+void NamedNodeMap::detach_attribute_node(QualifiedName const& name, Utf16String value)
+{
+    for (size_t index = 0; index < m_attribute_nodes.size(); ++index) {
+        auto& attribute = m_attribute_nodes[index];
+        if (attribute->namespace_uri() != name.namespace_() || attribute->local_name() != name.local_name())
+            continue;
+        attribute->detach_from_element(move(value));
+        m_attribute_nodes.remove(index);
+        return;
+    }
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-remove
 void NamedNodeMap::remove_attribute_at_index(size_t attribute_index)
 {
-    GC::Ref<Attr> attribute = m_attributes.at(attribute_index);
-
-    // 1. Let element be attribute’s element.
-    auto* element = attribute->owner_element();
-    VERIFY(element);
-
-    // 2. Remove attribute from element’s attribute list.
-    m_attributes.remove(attribute_index);
-
-    // 3. Set attribute’s element to null.
-    attribute->set_owner_element(nullptr);
-
-    // 4. Handle attribute changes for attribute with element, attribute’s value, and null.
-    attribute->handle_attribute_changes(*element, attribute->value(), {});
+    associated_element().remove_attribute_at(attribute_index);
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-name
-Attr const* NamedNodeMap::remove_attribute(Utf16FlyString const& qualified_name)
+GC::Ptr<Attr> NamedNodeMap::remove_attribute(Utf16FlyString const& qualified_name)
 {
     size_t item_index = 0;
 
     // 1. Let attr be the result of getting an attribute given qualifiedName and element.
-    auto const* attribute = get_attribute(qualified_name, &item_index);
+    auto attribute = get_attribute(qualified_name, &item_index);
 
     // 2. If attr is non-null, then remove attr.
     if (attribute)
@@ -312,12 +305,12 @@ Attr const* NamedNodeMap::remove_attribute(Utf16FlyString const& qualified_name)
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
-Attr const* NamedNodeMap::remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name)
+GC::Ptr<Attr> NamedNodeMap::remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name)
 {
     size_t item_index = 0;
 
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
-    auto const* attribute = get_attribute_ns(namespace_, local_name, &item_index);
+    auto attribute = get_attribute_ns(namespace_, local_name, &item_index);
 
     // 2. If attr is non-null, then remove attr.
     if (attribute)
@@ -331,12 +324,15 @@ Attr const* NamedNodeMap::remove_attribute_ns(Optional<Utf16FlyString> const& na
 WebIDL::ExceptionOr<GC::Ref<Attr>> NamedNodeMap::remove_attribute_node(GC::Ref<Attr> attr)
 {
     // 1. If this’s attribute list does not contain attr, then throw a "NotFoundError" DOMException.
-    auto index = m_attributes.find_first_index(attr);
+    if (attr->owner_element() != &associated_element())
+        return WebIDL::NotFoundError::create("Attribute not found"_utf16);
+
+    auto index = associated_element().find_attribute_index_ns(attr->namespace_uri(), attr->local_name());
     if (!index.has_value())
         return WebIDL::NotFoundError::create("Attribute not found"_utf16);
 
     // 2. Remove attr.
-    remove_attribute_at_index(index.value());
+    remove_attribute_at_index(*index);
 
     // 3. Return attr.
     return attr;

--- a/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -27,31 +27,29 @@ public:
 
     virtual Vector<Utf16FlyString> supported_property_names() const override;
 
-    size_t length() const { return m_attributes.size(); }
-    bool is_empty() const { return m_attributes.is_empty(); }
+    size_t length() const;
+    bool is_empty() const { return length() == 0; }
 
     // Methods defined by the spec for JavaScript:
-    Attr* item(u32 index);
-    Attr const* item(u32 index) const;
-    Attr const* get_named_item(Utf16FlyString const& qualified_name) const;
-    Attr const* get_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const;
+    GC::Ptr<Attr> item(u32 index) const;
+    GC::Ptr<Attr> get_named_item(Utf16FlyString const& qualified_name) const;
+    GC::Ptr<Attr> get_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const;
     WebIDL::ExceptionOr<GC::Ptr<Attr>> set_named_item(Attr& attribute);
     WebIDL::ExceptionOr<GC::Ptr<Attr>> set_named_item_ns(Attr& attribute);
-    WebIDL::ExceptionOr<Attr const*> remove_named_item(Utf16FlyString const& qualified_name);
-    WebIDL::ExceptionOr<Attr const*> remove_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name);
+    WebIDL::ExceptionOr<GC::Ref<Attr>> remove_named_item(Utf16FlyString const& qualified_name);
+    WebIDL::ExceptionOr<GC::Ref<Attr>> remove_named_item_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name);
 
     // Methods defined by the spec for internal use:
-    Attr* get_attribute(Utf16FlyString const& qualified_name, size_t* item_index = nullptr);
-    Attr const* get_attribute(Utf16FlyString const& qualified_name, size_t* item_index = nullptr) const;
-    WebIDL::ExceptionOr<GC::Ptr<Attr>> set_attribute(Attr& attribute);
-    void replace_attribute(Attr& old_attribute, Attr& new_attribute, size_t old_attribute_index);
-    void append_attribute(Attr& attribute);
+    GC::Ptr<Attr> get_attribute(Utf16FlyString const& qualified_name, size_t* item_index = nullptr) const;
+    WebIDL::ExceptionOr<GC::Ptr<Attr>> set_attribute(GC::Ref<Attr> attribute);
+    void replace_attribute(GC::Ref<Attr> old_attribute, GC::Ref<Attr> new_attribute, size_t old_attribute_index);
+    void append_attribute(GC::Ref<Attr> attribute);
+    void detach_attribute_node(QualifiedName const&, Utf16String value);
 
-    Attr* get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index = nullptr);
-    Attr const* get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index = nullptr) const;
+    GC::Ptr<Attr> get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name, size_t* item_index = nullptr) const;
 
-    Attr const* remove_attribute(Utf16FlyString const& qualified_name);
-    Attr const* remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name);
+    GC::Ptr<Attr> remove_attribute(Utf16FlyString const& qualified_name);
+    GC::Ptr<Attr> remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name);
 
     WebIDL::ExceptionOr<GC::Ref<Attr>> remove_attribute_node(GC::Ref<Attr>);
 
@@ -64,9 +62,11 @@ private:
     Element const& associated_element() const { return *m_element; }
 
     void remove_attribute_at_index(size_t attribute_index);
+    GC::Ptr<Attr> find_attribute_node(QualifiedName const&) const;
+    GC::Ref<Attr> ensure_attribute_node(QualifiedName const&) const;
 
     GC::Ref<DOM::Element> m_element;
-    Vector<GC::Ref<Attr>> m_attributes;
+    mutable Vector<GC::Ref<Attr>> m_attribute_nodes;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1671,23 +1671,11 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_single_node(Document& document, G
         auto element_copy = TRY(DOM::create_element(document, element->local_name(), element->namespace_uri(), element->prefix(), element->is_value(), false, registry));
 
         // 5. For each attribute of node’s attribute list:
-        Optional<WebIDL::Exception> maybe_exception;
-        element->for_each_attribute([&](Attr const& attr) {
+        element->for_each_attribute([&](QualifiedName const& name, Utf16View value) {
             // 1. Let copyAttribute be the result of cloning a single node given attribute, document, and null.
-            auto copy_attribute_or_error = attr.clone_single_node(document, nullptr);
-            if (copy_attribute_or_error.is_error()) {
-                maybe_exception = copy_attribute_or_error.release_error();
-                return;
-            }
-
-            auto copy_attribute = copy_attribute_or_error.release_value();
-
             // 2. Append copyAttribute to copy.
-            element_copy->append_attribute(as<Attr>(*copy_attribute));
+            element_copy->append_attribute(name, Utf16String::from_utf16(value));
         });
-
-        if (maybe_exception.has_value())
-            return *maybe_exception;
 
         copy = move(element_copy);
     }
@@ -2720,8 +2708,8 @@ bool Node::is_equal_node(GC::Ptr<Node const> other_node) const
             return false;
         // If A is an element, each attribute in its attribute list equals an attribute in B’s attribute list.
         bool has_same_attributes = true;
-        this_element.for_each_attribute([&](auto const& attribute) {
-            if (other_element.get_attribute_ns(attribute.namespace_uri(), attribute.local_name()) != attribute.value())
+        this_element.for_each_attribute([&](QualifiedName const& name, Utf16View value) {
+            if (other_element.get_attribute_ns(name.namespace_(), name.local_name()) != value)
                 has_same_attributes = false;
         });
         if (!has_same_attributes)
@@ -2823,7 +2811,7 @@ Vector<Utf16FlyString> Node::get_in_scope_prefixes() const
 
         if (auto attributes = current->attributes()) {
             for (size_t i = 0; i < attributes->length(); ++i) {
-                auto const* attr = attributes->item(i);
+                auto attr = attributes->item(i);
                 if (attr->namespace_uri() != Web::Namespace::XMLNS)
                     continue;
 

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementAlgorithms.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementAlgorithms.cpp
@@ -145,7 +145,7 @@ JS::ThrowCompletionOr<void> upgrade_custom_element(DOM::Element& element, GC::Re
     //    attribute's namespace ».
     if (auto attributes = element.attributes()) {
         for (size_t attribute_index = 0; attribute_index < attributes->length(); ++attribute_index) {
-            auto const* attribute = attributes->item(attribute_index);
+            auto attribute = attributes->item(attribute_index);
             VERIFY(attribute);
 
             element.enqueue_an_attribute_changed_callback_reaction(attribute->local_name(), {}, attribute->value(), attribute->namespace_uri());

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -211,7 +211,7 @@ bool HTMLAreaElement::is_focusable() const
 {
     // NB: Platform conventions decide whether an area element without a tabindex attribute is a focusable area. Like
     //     other engines, only area elements that create a hyperlink are considered focusable areas.
-    if (!creates_a_hyperlink() && !HTML::parse_integer(get_attribute_value_view(HTML::AttributeNames::tabindex).value_or({})).has_value())
+    if (!creates_a_hyperlink() && !HTML::parse_integer(attribute(HTML::AttributeNames::tabindex).value_or({})).has_value())
         return false;
 
     // The shapes of area elements in an image map associated with an img element that is being rendered and is not

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -75,7 +75,7 @@ void HTMLBaseElement::set_the_frozen_base_url(URL::URL const& old_base_url)
     auto& document = this->document();
 
     // 2. Let urlRecord be the result of parsing the value of element's href content attribute with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by itself.)
-    auto href = get_attribute_value_view(AttributeNames::href).value_or({});
+    auto href = attribute(AttributeNames::href).value_or({});
     auto encoding = document.encoding_or_default();
     auto url_record = DOMURL::parse(href, document.fallback_base_url(), encoding.utf16_view());
 

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -28,7 +28,7 @@ HTMLButtonElement::~HTMLButtonElement() = default;
 
 HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
 {
-    auto value = get_attribute_value_view(HTML::AttributeNames::type);
+    auto value = attribute(HTML::AttributeNames::type);
 
     if (value.has_value() && value->equals_ignoring_ascii_case(u"submit"sv))
         return HTMLButtonElement::TypeAttributeState::Submit;

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -102,8 +102,8 @@ void HTMLCanvasElement::apply_presentational_hints(Vector<CSS::StyleProperty>& p
 
     // https://html.spec.whatwg.org/multipage/rendering.html#map-to-the-aspect-ratio-property
     // if element has both attributes w and h, and parsing those attributes' values using the rules for parsing non-negative integers doesn't generate an error for either
-    auto w = parse_non_negative_integer(get_attribute_value_view(HTML::AttributeNames::width).value_or({}));
-    auto h = parse_non_negative_integer(get_attribute_value_view(HTML::AttributeNames::height).value_or({}));
+    auto w = parse_non_negative_integer(attribute(HTML::AttributeNames::width).value_or({}));
+    auto h = parse_non_negative_integer(attribute(HTML::AttributeNames::height).value_or({}));
 
     // then the user agent is expected to use the parsed integers as a presentational hint for the 'aspect-ratio' property of the form auto w / h.
     if (w.has_value() && h.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -632,7 +632,7 @@ void HTMLDialogElement::light_dismiss_open_dialogs(UIEvents::PointerEvent const&
 
         // 6. If topmostDialog's computed closed-by state is not Any, then return.
         // FIXME: This should use the "computed closed-by state" algorithm.
-        auto closedby = topmost_dialog->get_attribute_value_view(AttributeNames::closedby);
+        auto closedby = topmost_dialog->attribute(AttributeNames::closedby);
         if (!closedby.has_value() || !closedby.value().equals_ignoring_ascii_case(u"any"sv))
             return;
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -192,7 +192,7 @@ Utf16FlyString HTMLElement::dir() const
 {
     // FIXME: This should probably be `Reflect` in the IDL.
     // The dir IDL attribute on an element must reflect the dir content attribute of that element, limited to only known values.
-    auto dir = get_attribute_value_view(HTML::AttributeNames::dir);
+    auto dir = attribute(HTML::AttributeNames::dir);
 
     if (dir.has_value() && dir->equals_ignoring_ascii_case(u"ltr"sv))
         return "ltr"_utf16_fly_string;
@@ -2312,7 +2312,7 @@ Utf16String HTMLElement::access_key_label() const
 // https://html.spec.whatwg.org/multipage/dnd.html#dom-draggable
 bool HTMLElement::draggable() const
 {
-    auto attribute = get_attribute_value_view(HTML::AttributeNames::draggable);
+    auto attribute = this->attribute(HTML::AttributeNames::draggable);
 
     // If an element's draggable content attribute has the state True, the draggable IDL attribute must return true.
     if (attribute.has_value() && attribute->equals_ignoring_ascii_case(u"true"sv)) {
@@ -2333,7 +2333,7 @@ bool HTMLElement::draggable() const
 
     // If the element is an object element that represents an image, the draggable IDL attribute must return true.
     if (is<HTML::HTMLObjectElement>(*this)) {
-        if (auto type_attribute = get_attribute_value_view(HTML::AttributeNames::type); type_attribute.has_value() && type_attribute->equals_ignoring_ascii_case(u"image"sv))
+        if (auto type_attribute = this->attribute(HTML::AttributeNames::type); type_attribute.has_value() && type_attribute->equals_ignoring_ascii_case(u"image"sv))
             return true;
     }
 
@@ -2380,7 +2380,7 @@ bool HTMLElement::spellcheck() const
     // NOTE: We use "true-by-default" for elements which are editable, editing hosts, or form associated text control
     //       elements "false-by-default" for root elements, and "inherit-by-default" for other elements.
 
-    auto maybe_spellcheck_attribute = get_attribute_value_view(HTML::AttributeNames::spellcheck);
+    auto maybe_spellcheck_attribute = attribute(HTML::AttributeNames::spellcheck);
 
     // The spellcheck IDL attribute, on getting, must return true if the element's spellcheck content attribute is in the True state,
     if (maybe_spellcheck_attribute.has_value() && (maybe_spellcheck_attribute.value().equals_ignoring_ascii_case(u"true"sv) || maybe_spellcheck_attribute.value().is_empty()))
@@ -2429,7 +2429,7 @@ Utf16FlyString HTMLElement::writing_suggestions() const
     // The attribute's invalid value default is the True state.
 
     // 1. If element's writingsuggestions content attribute is in the False state, return "false".
-    auto maybe_writing_suggestions_attribute = get_attribute_value_view(HTML::AttributeNames::writingsuggestions);
+    auto maybe_writing_suggestions_attribute = attribute(HTML::AttributeNames::writingsuggestions);
 
     if (maybe_writing_suggestions_attribute.has_value() && maybe_writing_suggestions_attribute.value().equals_ignoring_ascii_case(u"false"sv))
         return "false"_utf16_fly_string;
@@ -2484,7 +2484,7 @@ HTMLElement::AutocapitalizationHint HTMLElement::own_autocapitalization_hint() c
     // To compute the own autocapitalization hint of an element element, run the following steps:
     // 1. If the autocapitalize content attribute is present on element, and its value is not the empty string, return the
     //    state of the attribute.
-    auto maybe_autocapitalize_attribute = get_attribute_value_view(HTML::AttributeNames::autocapitalize);
+    auto maybe_autocapitalize_attribute = attribute(HTML::AttributeNames::autocapitalize);
 
     if (maybe_autocapitalize_attribute.has_value() && !maybe_autocapitalize_attribute.value().is_empty()) {
         if (maybe_autocapitalize_attribute->equals_ignoring_ascii_case(u"off"sv)

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -1004,7 +1004,7 @@ void HTMLFormElement::plan_to_navigate_to(URL::URL url, DocumentResource post_re
     ReferrerPolicy::ReferrerPolicy referrer_policy = ReferrerPolicy::ReferrerPolicy::EmptyString;
 
     // 2. If the form element's link types include the noreferrer keyword, then set referrerPolicy to "no-referrer".
-    if (has_link_type(get_attribute_value_view(HTML::AttributeNames::rel).value_or({}), u"noreferrer"sv))
+    if (has_link_type(attribute(HTML::AttributeNames::rel).value_or({}), u"noreferrer"sv))
         referrer_policy = ReferrerPolicy::ReferrerPolicy::NoReferrer;
 
     // 3. If the form has a non-null planned navigation, remove it from its task queue.

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -171,7 +171,7 @@ void HTMLIFrameElement::process_the_iframe_attributes(InitialInsertion initial_i
     }
 
     // 4. Let referrerPolicy be the current state of element's referrerpolicy content attribute.
-    auto referrer_policy = ReferrerPolicy::from_string(get_attribute_value_view(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
+    auto referrer_policy = ReferrerPolicy::from_string(attribute(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
 
     // 5. Set element's current navigation was lazy loaded boolean to false.
     set_current_navigation_was_lazy_loaded(false);
@@ -368,7 +368,7 @@ ReferrerPolicy::ReferrerPolicy determine_iframe_element_referrer_policy(GC::Ptr<
     // 1. If embedder is an iframe element, then return embedder's referrerpolicy attribute's state's corresponding
     //    keyword.
     if (auto* iframe = as_if<HTMLIFrameElement>(embedder.ptr())) {
-        return ReferrerPolicy::from_string(iframe->get_attribute_value_view(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
+        return ReferrerPolicy::from_string(iframe->attribute(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
     }
 
     // 2. Return the empty string.

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1116,10 +1116,10 @@ after_step_7:
             request->set_initiator(Fetch::Infrastructure::Request::Initiator::ImageSet);
 
         // 22. Set request's referrer policy to the current state of the element's referrerpolicy attribute.
-        request->set_referrer_policy(ReferrerPolicy::from_string(get_attribute_value_view(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString));
+        request->set_referrer_policy(ReferrerPolicy::from_string(attribute(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString));
 
         // 23. Set request's priority to the current state of the element's fetchpriority attribute.
-        request->set_priority(Fetch::Infrastructure::request_priority_from_string(get_attribute_value_view(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto));
+        request->set_priority(Fetch::Infrastructure::request_priority_from_string(attribute(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto));
 
         // 25. If the will lazy load element steps given the img return true, then:
         if (will_lazy_load_element()) {
@@ -1380,7 +1380,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
         request->set_initiator(Fetch::Infrastructure::Request::Initiator::ImageSet);
 
         // 3. Set request's referrer policy to the current state of the element's referrerpolicy attribute.
-        request->set_referrer_policy(ReferrerPolicy::from_string(get_attribute_value_view(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString));
+        request->set_referrer_policy(ReferrerPolicy::from_string(attribute(HTML::AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString));
 
         // FIXME: 4. Set request's priority to the current state of the element's fetchpriority attribute.
 
@@ -1548,7 +1548,7 @@ static void update_the_source_set(DOM::Element& element)
             continue;
 
         // 4. Parse child's srcset attribute and let source set be the returned source set.
-        auto source_set = parse_a_srcset_attribute(child->get_attribute_value_view(HTML::AttributeNames::srcset).value_or({}));
+        auto source_set = parse_a_srcset_attribute(child->attribute(HTML::AttributeNames::srcset).value_or({}));
 
         // 5. If source set has zero image sources, continue to the next child.
         if (source_set.is_empty())
@@ -1557,18 +1557,18 @@ static void update_the_source_set(DOM::Element& element)
         // 6. If child has a media attribute, and its value does not match the environment, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::media)) {
             auto media_query = parse_media_query(CSS::Parser::ParsingParams { element.document() },
-                child->get_attribute_value_view(HTML::AttributeNames::media).value_or({}));
+                child->attribute(HTML::AttributeNames::media).value_or({}));
             if (!media_query || !media_query->evaluate(element.document())) {
                 continue;
             }
         }
 
         // 7. Parse child's sizes attribute with img, and let source set's source size be the returned value.
-        source_set.m_source_size = parse_a_sizes_attribute(*child, child->get_attribute_value_view(HTML::AttributeNames::sizes).value_or({}), img);
+        source_set.m_source_size = parse_a_sizes_attribute(*child, child->attribute(HTML::AttributeNames::sizes).value_or({}), img);
 
         // 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::type)) {
-            auto mime_type = child->get_attribute_value_view(HTML::AttributeNames::type).value_or({});
+            auto mime_type = child->attribute(HTML::AttributeNames::type).value_or({});
             if (!is_supported_image_type(mime_type))
                 continue;
         }
@@ -1620,7 +1620,7 @@ bool HTMLImageElement::allows_auto_sizes() const
     // - its sizes attribute's value is "auto" (ASCII case-insensitive), or starts with "auto," (ASCII case-insensitive).
     if (lazy_loading_attribute() != LazyLoading::Lazy)
         return false;
-    auto sizes = get_attribute_value_view(HTML::AttributeNames::sizes);
+    auto sizes = attribute(HTML::AttributeNames::sizes);
     if (!sizes.has_value())
         return false;
     return sizes->equals_ignoring_ascii_case(u"auto"sv)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -353,7 +353,7 @@ FileFilter HTMLInputElement::parse_accept_attribute() const
 
     // If specified, the attribute must consist of a set of comma-separated tokens, each of which must be an ASCII
     // case-insensitive match for one of the following:
-    auto accept = get_attribute_value_view(HTML::AttributeNames::accept).value_or({});
+    auto accept = attribute(HTML::AttributeNames::accept).value_or({});
 
     accept.for_each_split_view(',', SplitBehavior::Nothing, [&](Utf16View value) {
         // The string "audio/*"

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -369,7 +369,7 @@ GC::Ref<HTMLLinkElement::LinkProcessingOptions> HTMLLinkElement::create_link_opt
 
         // fetch priority
         //     the state of el's fetchpriority content attribute
-        Fetch::Infrastructure::request_priority_from_string(get_attribute_value_view(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto));
+        Fetch::Infrastructure::request_priority_from_string(attribute(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto));
 
     // 3. If el has an href attribute, then set options's href to the value of el's href attribute.
     if (auto maybe_href = get_attribute(AttributeNames::href); maybe_href.has_value())
@@ -564,7 +564,7 @@ void HTMLLinkElement::fetch_and_process_linked_preload_resource()
     auto options = create_link_options();
 
     // 3. Let destination be the result of translating the keyword representing the state of el's as attribute.
-    auto destination = translate_a_preload_destination(get_attribute_value_view(HTML::AttributeNames::as).value_or({}));
+    auto destination = translate_a_preload_destination(attribute(HTML::AttributeNames::as).value_or({}));
 
     // 4. If destination is null, then return.
     if (destination.has<Empty>())

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1182,7 +1182,7 @@ void HTMLMediaElement::select_resource()
             });
 
             // 1. ⌛ If the src attribute's value is the empty string, then end the synchronous section, and jump down to the failed with attribute step below.
-            auto source = self.get_attribute_value_view(HTML::AttributeNames::src).value_or({});
+            auto source = self.attribute(HTML::AttributeNames::src).value_or({});
             if (source.is_empty()) {
                 failed_with_attribute("The 'src' attribute is empty"_utf16);
                 return;
@@ -1312,7 +1312,7 @@ void HTMLMediaElement::load_url_resource(URL::URL const& url_record, Function<vo
 // https://html.spec.whatwg.org/multipage/media.html#attr-media-preload
 bool HTMLMediaElement::preload_attribute_is_in_none_state() const
 {
-    auto preload = get_attribute_value_view(HTML::AttributeNames::preload);
+    auto preload = attribute(HTML::AttributeNames::preload);
     return preload.has_value() && preload->equals_ignoring_ascii_case(u"none"sv);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -37,7 +37,7 @@ HTMLMetaElement::~HTMLMetaElement() = default;
 
 Optional<HTMLMetaElement::HttpEquivAttributeState> HTMLMetaElement::http_equiv_state() const
 {
-    auto value = get_attribute_value_view(HTML::AttributeNames::http_equiv).value_or({});
+    auto value = attribute(HTML::AttributeNames::http_equiv).value_or({});
 
 #define __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(keyword, state) \
     if (value.equals_ignoring_ascii_case(keyword##sv))             \
@@ -50,7 +50,7 @@ Optional<HTMLMetaElement::HttpEquivAttributeState> HTMLMetaElement::http_equiv_s
 
 void HTMLMetaElement::update_metadata(Optional<Utf16String> const& old_name)
 {
-    if (auto name = get_attribute_value_view(AttributeNames::name); name.has_value()) {
+    if (auto name = attribute(AttributeNames::name); name.has_value()) {
         if (name->equals_ignoring_ascii_case(u"theme-color"sv)) {
             document().obtain_theme_color();
         } else if (name->equals_ignoring_ascii_case(u"color-scheme"sv)) {
@@ -137,7 +137,7 @@ void HTMLMetaElement::inserted()
             if (!has_attribute(AttributeNames::content))
                 break;
 
-            auto input = get_attribute_value_view(AttributeNames::content).value_or({});
+            auto input = attribute(AttributeNames::content).value_or({});
             if (input.is_empty())
                 break;
 
@@ -163,7 +163,7 @@ void HTMLMetaElement::inserted()
                 break;
 
             // 2. If the element's content attribute contains a U+002C COMMA character (,), then return.
-            auto content = get_attribute_value_view(AttributeNames::content).value_or({});
+            auto content = attribute(AttributeNames::content).value_or({});
             if (content.contains(u","sv))
                 break;
 
@@ -200,7 +200,7 @@ void HTMLMetaElement::inserted()
                 break;
 
             // 2. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
-            auto input = get_attribute_value_view(AttributeNames::content).value_or({});
+            auto input = attribute(AttributeNames::content).value_or({});
             if (input.is_empty())
                 break;
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -530,7 +530,7 @@ void HTMLObjectElement::run_object_representation_fallback_steps()
 void HTMLObjectElement::load_image()
 {
     // FIXME: This currently reloads the image instead of reusing the resource we've already downloaded.
-    auto data = get_attribute_value_view(HTML::AttributeNames::data).value_or({});
+    auto data = attribute(HTML::AttributeNames::data).value_or({});
     auto url = document().encoding_parse_url(data);
 
     if (!url.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -32,7 +32,7 @@ void HTMLPreElement::apply_presentational_hints(Vector<CSS::StyleProperty>& prop
 {
     HTMLElement::apply_presentational_hints(properties);
 
-    for_each_attribute([&](auto const& name, auto const&) {
+    for_each_attribute([&](Utf16FlyString const& name, Utf16View) {
         if (name == HTML::AttributeNames::wrap)
             properties.append({ .property_id = CSS::PropertyID::TextWrapMode, .value = CSS::KeywordStyleValue::create(CSS::Keyword::Wrap) });
     });

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -328,10 +328,10 @@ void HTMLScriptElement::prepare_script()
     // 23. If el has an event attribute and a for attribute, and el's type is "classic", then:
     if (m_script_type == ScriptType::Classic && has_attribute(HTML::AttributeNames::event) && has_attribute(HTML::AttributeNames::for_)) {
         // 1. Let for be the value of el's' for attribute.
-        auto for_ = get_attribute_value_view(HTML::AttributeNames::for_).value_or({});
+        auto for_ = attribute(HTML::AttributeNames::for_).value_or({});
 
         // 2. Let event be the value of el's event attribute.
-        auto event = get_attribute_value_view(HTML::AttributeNames::event).value_or({});
+        auto event = attribute(HTML::AttributeNames::event).value_or({});
 
         // 3. Strip leading and trailing ASCII whitespace from event and for.
         for_ = for_.trim_ascii_whitespace();
@@ -356,7 +356,7 @@ void HTMLScriptElement::prepare_script()
     Optional<Utf16String> encoding;
 
     if (has_attribute(HTML::AttributeNames::charset)) {
-        auto charset = TextCodec::get_standardized_encoding(get_attribute_value_view(HTML::AttributeNames::charset).value_or({}));
+        auto charset = TextCodec::get_standardized_encoding(attribute(HTML::AttributeNames::charset).value_or({}));
         if (charset.has_value())
             encoding = Utf16String::from_ascii_without_validation(charset->bytes());
     }
@@ -387,7 +387,7 @@ void HTMLScriptElement::prepare_script()
     auto referrer_policy = m_referrer_policy;
 
     // 30. Let fetch priority be the current state of el's fetchpriority content attribute.
-    auto fetch_priority = Fetch::Infrastructure::request_priority_from_string(get_attribute_value_view(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto);
+    auto fetch_priority = Fetch::Infrastructure::request_priority_from_string(attribute(HTML::AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto);
 
     // 31. Let parser metadata be "parser-inserted" if el is parser-inserted, and "not-parser-inserted" otherwise.
     auto parser_metadata = is_parser_inserted()
@@ -423,7 +423,7 @@ void HTMLScriptElement::prepare_script()
         }
 
         // 2. Let src be the value of el's src attribute.
-        auto src = get_attribute_value_view(HTML::AttributeNames::src).value_or({});
+        auto src = attribute(HTML::AttributeNames::src).value_or({});
 
         // 3. If src is the empty string, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
         if (src.is_empty()) {

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -489,7 +489,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(WebIDL::Long index)
 
 unsigned int HTMLTableElement::border() const
 {
-    return parse_border(get_attribute_value_view(HTML::AttributeNames::border).value_or({}));
+    return parse_border(attribute(HTML::AttributeNames::border).value_or({}));
 }
 
 Optional<u32> HTMLTableElement::cellpadding() const

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -217,7 +217,7 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     auto url = URL::about_blank();
 
     // 2. If element has a src attribute specified, and its value is not the empty string, then:
-    auto src_attribute_value = get_attribute_value_view(HTML::AttributeNames::src);
+    auto src_attribute_value = attribute(HTML::AttributeNames::src);
     if (src_attribute_value.has_value() && !src_attribute_value->is_empty()) {
         // 1. Let maybeURL be the result of encoding-parsing a URL given that attribute's value, relative to element's node document.
         auto maybe_url = document().encoding_parse_url(*src_attribute_value);

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -871,8 +871,7 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
     // 11. Append each attribute in the given token to element.
     token.for_each_attribute([&](auto const& attribute) {
         DOM::QualifiedName qualified_name { attribute.local_name, attribute.prefix, attribute.namespace_ };
-        auto dom_attribute = DOM::Attr::create(*document, move(qualified_name), attribute.value, element);
-        element->append_attribute(dom_attribute);
+        element->append_attribute(move(qualified_name), attribute.value);
         return IterationDecision::Continue;
     });
 
@@ -1179,10 +1178,11 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
         attribute_prefixes.ensure_capacity(attributes->length());
         attribute_values.ensure_capacity(attributes->length());
         for (size_t i = 0; i < attributes->length(); ++i) {
-            auto const* attribute = attributes->item(i);
+            auto attribute = attributes->item(i);
             attribute_names.unchecked_append(utf16_code_units_for_ffi(attribute->local_name().view()));
             auto const& local_name = attribute_names.last();
-            attribute_values.unchecked_append(utf16_code_units_for_ffi(attribute->value().utf16_view()));
+            auto attribute_value = attribute->value();
+            attribute_values.unchecked_append(utf16_code_units_for_ffi(attribute_value));
             auto const& value = attribute_values.last();
             Vector<u16> const* prefix = nullptr;
             if (attribute->prefix().has_value()) {
@@ -1380,7 +1380,8 @@ Utf16String HTMLParser::serialize_html_fragment(DOM::Node const& node, Serializa
             }
 
             builder.append_ascii("=\""sv);
-            builder.append(escape_string(attribute.value().utf16_view(), AttributeMode::Yes));
+            auto attribute_value = attribute.value();
+            builder.append(escape_string(attribute_value.utf16_view(), AttributeMode::Yes));
             builder.append_ascii('"');
         });
 
@@ -2178,8 +2179,7 @@ extern "C" void ladybird_html_parser_add_missing_attribute(size_t element, u16 c
     if (dom_element.has_attribute(local_name))
         return;
     auto value = utf16_string_from_ffi(value_ptr, value_len);
-    auto attribute = DOM::Attr::create(dom_element.document(), move(local_name), move(value));
-    dom_element.append_attribute(attribute);
+    dom_element.append_attribute(DOM::QualifiedName { move(local_name), {}, {} }, move(value));
 }
 
 extern "C" void ladybird_html_parser_remove_node(size_t node)

--- a/Libraries/LibWeb/HTML/PopoverTargetAttributes.cpp
+++ b/Libraries/LibWeb/HTML/PopoverTargetAttributes.cpp
@@ -52,7 +52,7 @@ void PopoverTargetAttributes::popover_target_activation_behaviour(GC::Ref<DOM::N
         return;
 
     // 4. If node's popovertargetaction attribute is in the show state and popover's popover visibility state is showing, then return.
-    auto popover_target_action = as<DOM::Element>(*node).get_attribute_value_view(HTML::AttributeNames::popovertargetaction);
+    auto popover_target_action = as<DOM::Element>(*node).attribute(HTML::AttributeNames::popovertargetaction);
     if (popover_target_action.has_value() && popover_target_action->equals_ignoring_ascii_case(u"show"sv)
         && popover->popover_visibility_state() == HTMLElement::PopoverVisibilityState::Showing)
         return;

--- a/Libraries/LibWeb/HTML/XMLSerializer.cpp
+++ b/Libraries/LibWeb/HTML/XMLSerializer.cpp
@@ -260,7 +260,7 @@ static Optional<Utf16FlyString> record_namespace_information(DOM::Element const&
 
     // 2. Main: For each attribute attr in element's attributes, in the order they are specified in the element's attribute list:
     for (size_t attribute_index = 0; attribute_index < element.attributes()->length(); ++attribute_index) {
-        auto const* attribute = element.attributes()->item(attribute_index);
+        auto attribute = element.attributes()->item(attribute_index);
         VERIFY(attribute);
 
         // 1. Let attribute namespace be the value of attr's namespaceURI value.
@@ -357,7 +357,7 @@ static WebIDL::ExceptionOr<Utf16String> serialize_element_attributes(DOM::Elemen
 
     // 3. Loop: For each attribute attr in element's attributes, in the order they are specified in the element's attribute list:
     for (size_t attribute_index = 0; attribute_index < element.attributes()->length(); ++attribute_index) {
-        auto const* attribute = element.attributes()->item(attribute_index);
+        auto attribute = element.attributes()->item(attribute_index);
         VERIFY(attribute);
 
         // 1. If the require well-formed flag is set (its value is true), and the localname set contains a tuple whose values match those of a new tuple consisting of attr's namespaceURI attribute and localName attribute,
@@ -488,7 +488,8 @@ static WebIDL::ExceptionOr<Utf16String> serialize_element_attributes(DOM::Elemen
         result.append_ascii("=\""sv);
 
         // 3. The result of serializing an attribute value given attr's value attribute and the require well-formed flag as input;
-        result.append(TRY(serialize_an_attribute_value(attribute->value().utf16_view(), require_well_formed)));
+        auto attribute_value = attribute->value();
+        result.append(TRY(serialize_an_attribute_value(attribute_value.utf16_view(), require_well_formed)));
 
         // 4. """ (U+0022 QUOTATION MARK).
         result.append_ascii('"');

--- a/Libraries/LibWeb/MathML/MathMLAnchorElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLAnchorElement.cpp
@@ -52,7 +52,7 @@ void MathMLAnchorElement::set_href(Utf16String const& href)
 void MathMLAnchorElement::set_the_url()
 {
     // 1. If this element's href content attribute is absent, then return.
-    auto href = get_attribute_value_view(MathML::AttributeNames::href);
+    auto href = attribute(MathML::AttributeNames::href);
     if (!href.has_value())
         return;
 

--- a/Libraries/LibWeb/SVG/SVGLength.cpp
+++ b/Libraries/LibWeb/SVG/SVGLength.cpp
@@ -280,7 +280,7 @@ SVGLength::InternalValue SVGLength::internal_value() const
 
             // FIXME: Respect source.type once we support SMIL animation.
             // FIXME: Respect attribute namespaces
-            auto maybe_attribute_value = m_element->get_attribute_value_view(source.name);
+            auto maybe_attribute_value = m_element->attribute(source.name);
             if (!maybe_attribute_value.has_value())
                 return source.default_value;
 

--- a/Tests/LibWeb/Crash/HTML/details-name-reentrant-attribute-removal.html
+++ b/Tests/LibWeb/Crash/HTML/details-name-reentrant-attribute-removal.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<details id="first" name="group" open></details>
+<details id="second" open></details>
+<script>
+    second.setAttribute("name", "group");
+</script>


### PR DESCRIPTION
Store element attribute names and values in a compact native list. Create the NamedNodeMap and individual Attr GC objects only when they are exposed to script. Keep attached Attr values live through their element and snapshot each value when its wrapper is detached.

Have the HTML parsers, element cloning, and selector feature publication read native attribute records directly. Account for new storage in GC pacing and use GC handles throughout the NamedNodeMap attribute API.

Snapshot attribute names and values before running change steps so reentrant mutations cannot invalidate the compact list storage. Cover the grouped details-element path that removes open while changing name.

```
Benchmark     Old Score      New Score        Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  -------------  -------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  52.38 ± 5.40   54.57 ± 0.92                 1.042  9.45 ± 1.82            9.16 ± 0.47                1.032
Speedometer3  2.96 ± 0.36    2.91 ± 0.86                  0.984  9.31 ± 0.61            9.32 ± 2.93                0.998
StyleBench    48.54 ± 19.99  48.70 ± 23.80                1.003  5.17 ± 2.57            5.14 ± 2.35                1.007
```