### PR TITLE
Record nested display lists in a pre-pass before traversal

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -886,6 +886,7 @@ set(SOURCES
     Painting/PaintStyle.cpp
     Painting/PaintableFragment.cpp
     Painting/PaintableWithLines.cpp
+    Painting/PrerecordedNestedDisplayLists.cpp
     Painting/RadioButtonPaintable.cpp
     Painting/ReplacedElementCommon.cpp
     Painting/ResolvedCSSFilter.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -209,6 +209,7 @@
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
@@ -5129,6 +5130,18 @@ void Document::unregister_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUse
     m_svg_use_elements.remove(use_element);
 }
 
+void Document::register_svg_pattern_referencing_element(Element& referencing_element)
+{
+    m_svg_pattern_referencing_elements.remove_all_matching([](auto& weak_element) {
+        return !weak_element;
+    });
+    for (auto const& weak_element : m_svg_pattern_referencing_elements) {
+        if (weak_element == &referencing_element)
+            return;
+    }
+    m_svg_pattern_referencing_elements.append(referencing_element);
+}
+
 void Document::increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>)
 {
     ++m_number_of_things_delaying_the_load_event;
@@ -9028,6 +9041,10 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     }
     viewport_paintable.refresh_scroll_state();
     viewport_paintable.initialize_async_scrolling_metadata_recording(context);
+
+    Painting::PrerecordedNestedDisplayLists prerecorded_nested_display_lists;
+    context.set_prerecorded_nested_display_lists(&prerecorded_nested_display_lists);
+    Painting::prerecord_nested_display_lists(context, viewport_paintable);
 
     viewport_paintable.paint_all_phases(context);
     viewport_paintable.finalize_async_scrolling_metadata_recording(context, *navigable(), viewport_rect.to_type<int>());

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -773,6 +773,9 @@ public:
     void unregister_svg_use_element(Badge<SVG::SVGUseElement>, SVG::SVGUseElement&);
     SVG::SVGUseElement::DocumentUseElementList& svg_use_elements() { return m_svg_use_elements; }
 
+    void register_svg_pattern_referencing_element(Element&);
+    Vector<GC::Weak<Element>>& svg_pattern_referencing_elements() { return m_svg_pattern_referencing_elements; }
+
     template<typename Callback>
     void for_each_node_iterator(Callback callback)
     {
@@ -1657,6 +1660,8 @@ private:
     // removal. This lets SVG elements notify interested use elements about mutations without traversing the entire
     // document. Not visited: registered elements are connected and thus kept alive by the tree.
     SVG::SVGUseElement::DocumentUseElementList m_svg_use_elements;
+
+    Vector<GC::Weak<Element>> m_svg_pattern_referencing_elements;
 
     // https://html.spec.whatwg.org/multipage/dom.html#is-initial-about:blank
     bool m_is_initial_about_blank { false };

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -95,6 +95,8 @@ void LayoutTreeBuilderAccess::detach_layout_node(DOM::Node& node)
 void LayoutTreeBuilderAccess::register_svg_resource_reference(SVG::SVGElement& resource, DOM::Element& referencing_element)
 {
     resource.register_resource_box_referencing_element({}, referencing_element);
+    if (is<SVG::SVGPatternElement>(resource))
+        referencing_element.document().register_svg_pattern_referencing_element(referencing_element);
 }
 
 void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& element, CSS::PseudoElement pseudo_element, Layout::NodeWithStyle* layout_node)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -567,7 +567,10 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         if (auto clip_path_data = compute_basic_shape_clip_path_data(paintable_box, converter, scale); clip_path_data.has_value())
             append_to_own_and_positioned_descendant_contexts(clip_path_data.value());
 
-        for (auto const& mask_layer : paintable_box.mask_layer_presence(MaskLayerSet::CssAndSvg))
+        auto mask_layer_presence = paintable_box.mask_layer_presence(MaskLayerSet::CssAndSvg);
+        if (!mask_layer_presence.is_empty())
+            viewport_paintable.register_paintable_with_mask_nodes(paintable_box);
+        for (auto const& mask_layer : mask_layer_presence)
             append_to_own_and_positioned_descendant_contexts(MaskData { converter.enclosing_device_rect(mask_layer.area), mask_layer.kind, mask_layer.origin });
 
         paintable_box.set_accumulated_visual_context(own_state);

--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -26,6 +26,7 @@ class AccumulatedVisualContextTree;
 class DisplayList;
 class HitTestDisplayList;
 class ScrollState;
+struct PrerecordedNestedDisplayLists;
 
 enum class PaintCommandCacheMode : u8 {
     ReadOnly,
@@ -75,6 +76,9 @@ public:
     Optional<Painting::NestedVisualContextAssignments> const& nested_visual_context_assignments() const { return m_nested_visual_context_assignments; }
     void set_nested_visual_context_assignments(Painting::NestedVisualContextAssignments assignments) { m_nested_visual_context_assignments = move(assignments); }
 
+    Painting::PrerecordedNestedDisplayLists* prerecorded_nested_display_lists() const { return m_prerecorded_nested_display_lists; }
+    void set_prerecorded_nested_display_lists(Painting::PrerecordedNestedDisplayLists* prerecorded) { m_prerecorded_nested_display_lists = prerecorded; }
+
     Painting::VisualContextIndex accumulated_visual_context_index_of(Painting::Paintable const&) const;
     Painting::VisualContextIndex accumulated_visual_context_for_descendants_index_of(Painting::Paintable const&) const;
 
@@ -94,6 +98,7 @@ public:
         clone.m_device_viewport_rect = m_device_viewport_rect;
         clone.m_should_show_line_box_borders = m_should_show_line_box_borders;
         clone.m_should_paint_overlay = m_should_paint_overlay;
+        clone.m_prerecorded_nested_display_lists = m_prerecorded_nested_display_lists;
         return clone;
     }
 
@@ -149,6 +154,7 @@ private:
     bool m_should_paint_overlay { true };
     bool m_draw_svg_geometry_for_clip_path { false };
     Optional<Painting::NestedVisualContextAssignments> m_nested_visual_context_assignments;
+    Painting::PrerecordedNestedDisplayLists* m_prerecorded_nested_display_lists { nullptr };
     u64 m_paint_generation_id { 0 };
     UniqueNodeID m_async_scrolling_document_id {};
     Painting::AccumulatedVisualContextTree const* m_async_scrolling_visual_context_tree { nullptr };

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -57,6 +57,7 @@
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
 #include <LibWeb/Painting/ResizeHandle.h>
 #include <LibWeb/Painting/SVGForeignObjectPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
@@ -146,10 +147,15 @@ Vector<MaskLayerPresence, 3> Paintable::mask_layer_presence(MaskLayerSet mask_la
     return presence;
 }
 
-void register_mask_display_lists(DisplayListRecordingContext& context, Paintable const& paintable, ReadonlySpan<MaskLayerDisplayList> mask_display_lists)
+bool register_mask_display_lists(DisplayListRecordingContext& context, Paintable const& paintable, MaskLayerSet mask_layer_set)
 {
-    if (mask_display_lists.is_empty())
-        return;
+    auto const* prerecorded = context.prerecorded_nested_display_lists();
+    VERIFY(prerecorded);
+    auto mask_layers = prerecorded->mask_entries.get(&paintable);
+    if (!mask_layers.has_value()) {
+        VERIFY(paintable.mask_layer_presence(mask_layer_set).is_empty());
+        return false;
+    }
 
     auto const& visual_context_tree = context.display_list_recorder().visual_context_tree();
 
@@ -164,15 +170,27 @@ void register_mask_display_lists(DisplayListRecordingContext& context, Paintable
         }
     }
 
-    for (auto const& mask_display_list : mask_display_lists) {
+    bool any_svg_mask_layer_area_is_empty = false;
+    for (auto const& mask_layer : *mask_layers) {
+        if (mask_layer_set == MaskLayerSet::SvgOnly) {
+            if (mask_layer.origin == MaskLayerOrigin::CssMaskLayers)
+                continue;
+            if (mask_layer.mask_layer_area_is_empty) {
+                any_svg_mask_layer_area_is_empty = true;
+                continue;
+            }
+        }
+        if (!mask_layer.resource.has_value())
+            continue;
         Vector<VisualContextIndex, 3> node_indices_for_origin;
         for (auto node_index : mask_node_indices) {
-            if (visual_context_tree.node_at(node_index).data.get<MaskData>().origin == mask_display_list.origin)
+            if (visual_context_tree.node_at(node_index).data.get<MaskData>().origin == mask_layer.origin)
                 node_indices_for_origin.append(node_index);
         }
         VERIFY(!node_indices_for_origin.is_empty());
-        context.display_list_recorder().register_mask_display_list(node_indices_for_origin, mask_display_list.resource);
+        context.display_list_recorder().register_mask_display_list(node_indices_for_origin, *mask_layer.resource);
     }
+    return any_svg_mask_layer_area_is_empty;
 }
 
 bool Paintable::visible_for_hit_testing() const

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -83,12 +83,7 @@ enum class MaskLayerSet : u8 {
     SvgOnly,
 };
 
-struct MaskLayerDisplayList {
-    MaskLayerOrigin origin;
-    DisplayListResource resource;
-};
-
-void register_mask_display_lists(DisplayListRecordingContext&, Paintable const&, ReadonlySpan<MaskLayerDisplayList>);
+bool register_mask_display_lists(DisplayListRecordingContext&, Paintable const&, MaskLayerSet);
 
 class WEB_API Paintable
     : public RefCounted<Paintable>

--- a/Libraries/LibWeb/Painting/PrerecordedNestedDisplayLists.cpp
+++ b/Libraries/LibWeb/Painting/PrerecordedNestedDisplayLists.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BackgroundPainting.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
+#include <LibWeb/Painting/SVGPathPaintable.h>
+#include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
+#include <LibWeb/SVG/SVGGradientElement.h>
+#include <LibWeb/SVG/SVGGraphicsElement.h>
+#include <LibWeb/SVG/SVGPatternElement.h>
+
+namespace Web::Painting {
+
+static bool record_mask_entry(DisplayListRecordingContext& context, PrerecordedNestedDisplayLists& prerecorded, Paintable const& paintable, MaskLayerSet mask_layer_set)
+{
+    auto presence = paintable.mask_layer_presence(mask_layer_set);
+    if (presence.is_empty())
+        return false;
+
+    bool any_svg_mask_layer_area_is_empty = false;
+    Vector<PrerecordedMaskLayerDisplayList, 3> layers;
+    for (auto const& mask_layer : presence) {
+        switch (mask_layer.origin) {
+        case MaskLayerOrigin::CssMaskLayers: {
+            auto visual_context_tree = AccumulatedVisualContextTree::create();
+            auto mask_display_list = DisplayList::create(visual_context_tree);
+            DisplayListRecorder display_list_recorder(*mask_display_list, visual_context_tree, context.display_list_recorder().resource_storage());
+            auto mask_painting_context = context.clone(display_list_recorder);
+            auto mask_rect = CSSPixelRect { {}, mask_layer.area.size() };
+            auto resolved_mask = resolve_mask_layers(paintable.layout_node().mask_layers(), paintable, mask_rect);
+
+            // FIXME: Respect `image-rendering` here.
+            paint_background(mask_painting_context, paintable, CSS::ImageRendering::Auto, resolved_mask, {});
+            layers.append({ MaskLayerOrigin::CssMaskLayers, mask_layer.area.is_empty(), DisplayListResource { *mask_display_list, move(visual_context_tree) } });
+            break;
+        }
+        case MaskLayerOrigin::SvgMask:
+        case MaskLayerOrigin::SvgClip: {
+            bool mask_layer_area_is_empty = mask_layer.area.is_empty();
+            any_svg_mask_layer_area_is_empty |= mask_layer_area_is_empty;
+            bool stacking_context_site_consumes_the_layer = mask_layer_set == MaskLayerSet::CssAndSvg && paintable.layout_node().establishes_stacking_context();
+            if (mask_layer_area_is_empty && !stacking_context_site_consumes_the_layer) {
+                layers.append({ mask_layer.origin, true, {} });
+                continue;
+            }
+            auto mask_display_list = mask_layer.origin == MaskLayerOrigin::SvgMask
+                ? paintable.calculate_mask(context, mask_layer.area)
+                : paintable.calculate_clip(context, mask_layer.area);
+            layers.append({ mask_layer.origin, mask_layer_area_is_empty, move(mask_display_list) });
+            break;
+        }
+        }
+    }
+    prerecorded.mask_entries.set(&paintable, move(layers));
+    return any_svg_mask_layer_area_is_empty;
+}
+
+static void record_pattern_paint_styles(DisplayListRecordingContext& context, PrerecordedNestedDisplayLists& prerecorded, Paintable const& paintable)
+{
+    auto const* path_paintable = as_if<SVGPathPaintable>(paintable);
+    if (!path_paintable || !path_paintable->fill_and_stroke_paint_styles_are_resolved(context))
+        return;
+    auto const& graphics_element = path_paintable->dom_node();
+    auto fill_pattern = graphics_element.fill_pattern();
+    auto stroke_pattern = graphics_element.stroke_pattern();
+    if (!fill_pattern && !stroke_pattern)
+        return;
+
+    auto paint_context = path_paintable->svg_paint_context(context);
+    auto content_scale = context.display_list_recorder().visual_context_tree().accumulated_2d_scale(
+        context.accumulated_visual_context_index_of(*path_paintable),
+        ScrollStateSnapshot {},
+        AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+
+    for (auto const* pattern : { fill_pattern.ptr(), stroke_pattern.ptr() }) {
+        if (!pattern)
+            continue;
+        auto pattern_paintable = pattern->resolve_pattern_paintable(path_paintable->layout_node());
+        if (!pattern_paintable)
+            continue;
+        prerecorded.pattern_paint_styles.ensure(pattern_paintable.ptr(), [&] {
+            return pattern->record_pattern_paint_style(paint_context, context, *pattern_paintable, content_scale);
+        });
+    }
+}
+
+static void prerecord_nested_display_lists_for_svg_subtree(DisplayListRecordingContext& context, Paintable const& root)
+{
+    auto* prerecorded = context.prerecorded_nested_display_lists();
+    VERIFY(prerecorded);
+    auto const& nested_assignments = context.nested_visual_context_assignments();
+    VERIFY(nested_assignments.has_value());
+    root.for_each_in_inclusive_subtree([&](Paintable const& paintable) {
+        bool any_svg_mask_layer_area_is_empty = nested_assignments->mask_node_indices.contains(&paintable)
+            && record_mask_entry(context, *prerecorded, paintable, MaskLayerSet::SvgOnly);
+        if (any_svg_mask_layer_area_is_empty)
+            return TraversalDecision::SkipChildrenAndContinue;
+        record_pattern_paint_styles(context, *prerecorded, paintable);
+        return TraversalDecision::Continue;
+    });
+}
+
+DisplayListResource record_nested_svg_display_list(DisplayListRecordingContext& context, Paintable const& paintable, TransformData root_transform, IncludeRootElementTransform include_root_element_transform, bool draw_svg_geometry_for_clip_path)
+{
+    NestedVisualContextAssignments nested_visual_context_assignments;
+    auto visual_context_tree = build_nested_svg_visual_context_tree(const_cast<Paintable&>(paintable), move(root_transform), nested_visual_context_assignments, include_root_element_transform);
+    auto display_list = DisplayList::create(visual_context_tree);
+    DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, context.display_list_recorder().resource_storage());
+    auto paint_context = context.clone(display_list_recorder);
+    paint_context.set_nested_visual_context_assignments(move(nested_visual_context_assignments));
+    paint_context.set_draw_svg_geometry_for_clip_path(draw_svg_geometry_for_clip_path);
+    prerecord_nested_display_lists_for_svg_subtree(paint_context, paintable);
+    StackingContext::paint_svg(paint_context, paintable, PaintPhase::Foreground);
+    return DisplayListResource { *display_list, move(visual_context_tree) };
+}
+
+static bool recorded_mask_entry_has_empty_svg_mask_layer_area(PrerecordedNestedDisplayLists const& prerecorded, Paintable const& paintable)
+{
+    auto mask_layers = prerecorded.mask_entries.get(&paintable);
+    if (!mask_layers.has_value())
+        return false;
+    for (auto const& mask_layer : *mask_layers) {
+        if (mask_layer.origin != MaskLayerOrigin::CssMaskLayers && mask_layer.mask_layer_area_is_empty)
+            return true;
+    }
+    return false;
+}
+
+static bool layout_node_is_inside_svg_resource_box(Layout::Node const& layout_node)
+{
+    for (auto const* ancestor = layout_node.parent(); ancestor; ancestor = ancestor->parent()) {
+        if (ancestor->is_svg_pattern_box() || ancestor->is_svg_mask_box() || ancestor->is_svg_clip_box())
+            return true;
+    }
+    return false;
+}
+
+void prerecord_nested_display_lists(DisplayListRecordingContext& context, ViewportPaintable& viewport_paintable)
+{
+    auto* prerecorded = context.prerecorded_nested_display_lists();
+    VERIFY(prerecorded);
+
+    for (auto const& weak_paintable : viewport_paintable.paintables_with_mask_nodes()) {
+        auto paintable = weak_paintable.strong_ref();
+        if (!paintable)
+            continue;
+        record_mask_entry(context, *prerecorded, *paintable, MaskLayerSet::CssAndSvg);
+    }
+
+    auto& document = viewport_paintable.document();
+    auto& pattern_referencing_elements = document.svg_pattern_referencing_elements();
+    pattern_referencing_elements.remove_all_matching([](auto const& weak_element) {
+        return !weak_element;
+    });
+    for (auto const& weak_element : pattern_referencing_elements) {
+        auto element = weak_element.ptr();
+        if (!element || &element->document() != &document)
+            continue;
+        auto paintable = element->paintable();
+        if (!paintable)
+            continue;
+        if (layout_node_is_inside_svg_resource_box(paintable->layout_node()))
+            continue;
+        if (recorded_mask_entry_has_empty_svg_mask_layer_area(*prerecorded, *paintable))
+            continue;
+        record_pattern_paint_styles(context, *prerecorded, *paintable);
+    }
+}
+
+Optional<PaintStyle> prerecorded_pattern_paint_style(DisplayListRecordingContext& context, SVG::SVGPatternElement const& pattern, Layout::Node const& target_layout_node)
+{
+    auto pattern_paintable = pattern.resolve_pattern_paintable(target_layout_node);
+    if (!pattern_paintable)
+        return {};
+    auto const* prerecorded = context.prerecorded_nested_display_lists();
+    VERIFY(prerecorded);
+    auto pattern_paint_style = prerecorded->pattern_paint_styles.get(pattern_paintable.ptr());
+    VERIFY(pattern_paint_style.has_value());
+    return *pattern_paint_style;
+}
+
+}

--- a/Libraries/LibWeb/Painting/PrerecordedNestedDisplayLists.h
+++ b/Libraries/LibWeb/Painting/PrerecordedNestedDisplayLists.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/PaintStyle.h>
+#include <LibWeb/Painting/Paintable.h>
+
+namespace Web::Painting {
+
+struct PrerecordedMaskLayerDisplayList {
+    MaskLayerOrigin origin;
+    bool mask_layer_area_is_empty { false };
+    Optional<DisplayListResource> resource;
+};
+
+struct PrerecordedNestedDisplayLists {
+    HashMap<Paintable const*, Vector<PrerecordedMaskLayerDisplayList, 3>> mask_entries;
+    HashMap<Paintable const*, Optional<PaintStyle>> pattern_paint_styles;
+};
+
+void prerecord_nested_display_lists(DisplayListRecordingContext&, ViewportPaintable&);
+
+DisplayListResource record_nested_svg_display_list(DisplayListRecordingContext&, Paintable const&, TransformData root_transform, IncludeRootElementTransform, bool draw_svg_geometry_for_clip_path);
+
+Optional<PaintStyle> prerecorded_pattern_paint_style(DisplayListRecordingContext&, SVG::SVGPatternElement const&, Layout::Node const& target_layout_node);
+
+}

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -8,14 +8,14 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/Blending.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
 #include <LibWeb/Painting/ResolvedCSSFilter.h>
 #include <LibWeb/Painting/SVGClipPaintable.h>
 #include <LibWeb/Painting/SVGForeignObjectPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGPaintable.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
-#include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGMaskElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
@@ -134,15 +134,7 @@ static Optional<DisplayListResource> paint_mask_or_clip_to_display_list(
                                    .translate(-surface_origin)
                                    .multiply(content_units_transform_in_recorded_space);
     TransformData root_transform { recorded_to_surface.to_matrix(), {} };
-    NestedVisualContextAssignments nested_visual_context_assignments;
-    auto visual_context_tree = build_nested_svg_visual_context_tree(const_cast<Paintable&>(paintable), move(root_transform), nested_visual_context_assignments);
-    auto display_list = DisplayList::create(visual_context_tree);
-    DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, context.display_list_recorder().resource_storage());
-    auto paint_context = context.clone(display_list_recorder);
-    paint_context.set_nested_visual_context_assignments(move(nested_visual_context_assignments));
-    paint_context.set_draw_svg_geometry_for_clip_path(is_clip_path);
-    StackingContext::paint_svg(paint_context, paintable, PaintPhase::Foreground);
-    return DisplayListResource { *display_list, move(visual_context_tree) };
+    return record_nested_svg_display_list(context, paintable, root_transform, IncludeRootElementTransform::Yes, is_clip_path);
 }
 
 Gfx::AffineTransform SVGMaskable::object_bounding_box_content_units_transform() const

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -46,6 +46,26 @@ static Gfx::WindingRule to_gfx_winding_rule(SVG::FillRule fill_rule)
     }
 }
 
+bool SVGPathPaintable::fill_and_stroke_paint_styles_are_resolved(DisplayListRecordingContext const& context) const
+{
+    return computed_path().has_value() && !context.draw_svg_geometry_for_clip_path() && is_visible();
+}
+
+SVG::SVGPaintContext SVGPathPaintable::svg_paint_context(DisplayListRecordingContext const& context) const
+{
+    // Content below the viewport transform node records in user units scaled by the device pixel
+    // ratio; the visual context tree applies the viewport and element transforms at replay.
+    auto device_scale = static_cast<float>(context.device_pixels_per_css_pixel());
+    Gfx::FloatRect viewport_rect {};
+    if (auto const* viewport_paintable = nearest_svg_viewport_paintable_of(layout_node()))
+        viewport_rect = svg_viewport_user_rect(*viewport_paintable);
+    return SVG::SVGPaintContext {
+        .viewport = viewport_rect,
+        .path_bounding_box = computed_path()->bounding_box(),
+        .paint_transform = Gfx::AffineTransform {}.scale(device_scale, device_scale),
+    };
+}
+
 void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase phase) const
 {
     if (!computed_path().has_value())
@@ -65,8 +85,6 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
 
     auto& graphics_element = dom_node();
 
-    // Content below the viewport transform node records in user units scaled by the device pixel
-    // ratio; the visual context tree applies the viewport and element transforms at replay.
     auto device_scale = static_cast<float>(context.device_pixels_per_css_pixel());
     auto paint_transform = Gfx::AffineTransform {}.scale(device_scale, device_scale);
     auto path = computed_path()->copy_transformed(paint_transform);
@@ -85,14 +103,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
         return;
     }
 
-    Gfx::FloatRect viewport_rect {};
-    if (auto const* viewport_paintable = nearest_svg_viewport_paintable_of(layout_node()))
-        viewport_rect = svg_viewport_user_rect(*viewport_paintable);
-    SVG::SVGPaintContext paint_context {
-        .viewport = viewport_rect,
-        .path_bounding_box = computed_path()->bounding_box(),
-        .paint_transform = paint_transform,
-    };
+    auto paint_context = svg_paint_context(context);
 
     auto paint_fill = [&] {
         auto fill_opacity = graphics_element.fill_opacity().value_or(1);

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.h
@@ -11,6 +11,12 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
 
+namespace Web::SVG {
+
+struct SVGPaintContext;
+
+}
+
 namespace Web::Painting {
 
 class WEB_API SVGPathPaintable final : public SVGGraphicsPaintable {
@@ -24,6 +30,9 @@ public:
     virtual void record_hit_test_items(DisplayListRecordingContext&, PaintPhase) const override;
 
     SVG::SVGGraphicsElement const& dom_node() const { return as<SVG::SVGGraphicsElement>(*Paintable::dom_node()); }
+
+    bool fill_and_stroke_paint_styles_are_resolved(DisplayListRecordingContext const&) const;
+    SVG::SVGPaintContext svg_paint_context(DisplayListRecordingContext const&) const;
 
     // The identity is process-unique per layout-side path allocation and never
     // reused, so a match proves the already-held path is byte-identical and the

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -43,26 +43,9 @@ void SVGSVGPaintable::paint_svg_box(DisplayListRecordingContext& context, Painta
         context.display_list_recorder().fill_rect_transparent(device_rect);
     }
 
-    // Collect masks (SVG <mask>, SVG <clipPath>).
-    Vector<MaskLayerDisplayList> masks;
+    bool any_svg_mask_layer_area_is_empty = register_mask_display_lists(context, svg_box, MaskLayerSet::SvgOnly);
 
-    bool skip_painting = false;
-
-    for (auto const& mask_layer : svg_box.mask_layer_presence(MaskLayerSet::SvgOnly)) {
-        if (mask_layer.area.is_empty()) {
-            skip_painting = true;
-            continue;
-        }
-        auto mask_display_list = mask_layer.origin == MaskLayerOrigin::SvgMask
-            ? svg_box.calculate_mask(context, mask_layer.area)
-            : svg_box.calculate_clip(context, mask_layer.area);
-        if (mask_display_list.has_value())
-            masks.append({ mask_layer.origin, mask_display_list.release_value() });
-    }
-
-    register_mask_display_lists(context, svg_box, masks);
-
-    if (!skip_painting) {
+    if (!any_svg_mask_layer_area_is_empty) {
         svg_box.record_hit_test_items(context, phase);
         if (svg_box.layout_node().is_svg_foreign_object_box())
             record_foreign_object_descendant_hit_test_items(context, svg_box);

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -16,7 +16,6 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
@@ -486,8 +485,6 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
         VERIFY(context.display_list_recorder().m_save_nesting_level == 0);
     });
 
-    auto const& mask_layers = paintable_box().layout_node().mask_layers();
-
     auto effective_context_index = context.accumulated_visual_context_index_of(paintable_box());
     context.display_list_recorder().set_accumulated_visual_context(effective_context_index);
 
@@ -498,36 +495,7 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
         context.display_list_recorder().fill_rect_transparent(device_rect);
     }
 
-    // Collect all masks (CSS mask-image, SVG <mask>, SVG <clipPath>).
-    Vector<MaskLayerDisplayList> masks;
-
-    for (auto const& mask_layer : paintable_box().mask_layer_presence(MaskLayerSet::CssAndSvg)) {
-        switch (mask_layer.origin) {
-        case MaskLayerOrigin::CssMaskLayers: {
-            auto visual_context_tree = AccumulatedVisualContextTree::create();
-            auto mask_display_list = DisplayList::create(visual_context_tree);
-            DisplayListRecorder display_list_recorder(*mask_display_list, visual_context_tree, context.display_list_recorder().resource_storage());
-            auto mask_painting_context = context.clone(display_list_recorder);
-            auto mask_rect = CSSPixelRect { {}, mask_layer.area.size() };
-            auto resolved_mask = resolve_mask_layers(mask_layers, paintable_box(), mask_rect);
-
-            // FIXME: Respect `image-rendering` here.
-            paint_background(mask_painting_context, paintable_box(), CSS::ImageRendering::Auto, resolved_mask, {});
-            masks.append({ MaskLayerOrigin::CssMaskLayers, { *mask_display_list, move(visual_context_tree) } });
-            break;
-        }
-        case MaskLayerOrigin::SvgMask:
-            if (auto mask_display_list = paintable_box().calculate_mask(context, mask_layer.area); mask_display_list.has_value())
-                masks.append({ MaskLayerOrigin::SvgMask, mask_display_list.release_value() });
-            break;
-        case MaskLayerOrigin::SvgClip:
-            if (auto clip_display_list = paintable_box().calculate_clip(context, mask_layer.area); clip_display_list.has_value())
-                masks.append({ MaskLayerOrigin::SvgClip, clip_display_list.release_value() });
-            break;
-        }
-    }
-
-    register_mask_display_lists(context, paintable_box(), masks);
+    register_mask_display_lists(context, paintable_box(), MaskLayerSet::CssAndSvg);
 
     auto context_before_children = context.display_list_recorder().accumulated_visual_context();
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -118,6 +118,7 @@ void ViewportPaintable::reset_for_relayout()
     m_paint_command_cache_source_referenced_resources = {};
     document().clear_hit_test_item_cache_source();
     m_paintable_boxes_with_auto_content_visibility.clear();
+    m_paintables_with_mask_nodes.clear();
     m_visual_context_tree.clear();
     m_visual_context_tree_needs_compositor_update = false;
 }
@@ -236,6 +237,11 @@ void ViewportPaintable::register_scroll_node(AccumulatedVisualContextTree& visua
     visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
 }
 
+void ViewportPaintable::register_paintable_with_mask_nodes(Paintable const& paintable_box)
+{
+    m_paintables_with_mask_nodes.append(paintable_box);
+}
+
 void ViewportPaintable::register_sticky_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
     auto slot = m_scroll_state.register_sticky_node(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
@@ -251,6 +257,7 @@ CSSPixelPoint ViewportPaintable::cumulative_scroll_offset_for_node(VisualContext
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
     clear_scroll_state();
+    m_paintables_with_mask_nodes.clear_with_capacity();
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
     ++m_accumulated_visual_context_tree_build_count;
     auto is_compatible = m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree);

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -30,6 +30,8 @@ public:
 
     void register_scroll_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
     void register_sticky_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
+    void register_paintable_with_mask_nodes(Paintable const&);
+    Vector<WeakPtr<Paintable>> const& paintables_with_mask_nodes() const { return m_paintables_with_mask_nodes; }
     void refresh_scroll_state();
     void refresh_sticky_constraints();
     CSSPixelPoint cumulative_scroll_offset_for_node(VisualContextIndex scroll_node_index) const;
@@ -94,6 +96,8 @@ private:
     bool m_has_non_viewport_wheel_scroll_target_candidate { false };
 
     Vector<WeakPtr<Paintable>> m_paintable_boxes_with_auto_content_visibility;
+
+    Vector<WeakPtr<Paintable>> m_paintables_with_mask_nodes;
 
     RefPtr<DisplayList const> m_display_list_used_as_paint_command_cache_source;
     DisplayListResourceSet m_paint_command_cache_source_referenced_resources;

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
 #include <LibWeb/Painting/SVGForeignObjectPaintable.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
@@ -54,7 +55,7 @@ Optional<Painting::PaintStyle> SVGGraphicsElement::svg_paint_computed_value_to_g
     }
     if (auto pattern = try_resolve_url_to<SVG::SVGPatternElement const>(paint_value->as_url())) {
         if (recording_context && layout_node())
-            return pattern->to_gfx_paint_style(paint_context, *recording_context, *layout_node());
+            return Painting::prerecorded_pattern_paint_style(*recording_context, *pattern, *layout_node());
     }
     return {};
 }

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -8,12 +8,10 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/DisplayList.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/PaintStyle.h>
+#include <LibWeb/Painting/PrerecordedNestedDisplayLists.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
-#include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/FragmentIdentifier.h>
@@ -228,11 +226,11 @@ NumberPercentage SVGPatternElement::pattern_height_impl(GC::RootHashTable<SVGPat
     return NumberPercentage::create_number(0);
 }
 
-Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintContext const& paint_context, DisplayListRecordingContext& recording_context, Layout::Node const& target_layout_node) const
+RefPtr<Painting::Paintable const> SVGPatternElement::resolve_pattern_paintable(Layout::Node const& target_layout_node) const
 {
     auto content_element = pattern_content_element();
     if (!content_element)
-        return {};
+        return nullptr;
 
     Layout::Box const* pattern_box = nullptr;
     target_layout_node.for_each_child_of_type<Layout::Box>([&](auto const& candidate) {
@@ -243,12 +241,13 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
         return IterationDecision::Continue;
     });
     if (!pattern_box)
-        return {};
+        return nullptr;
 
-    auto pattern_paintable = pattern_box->paintable_box();
-    if (!pattern_paintable)
-        return {};
+    return pattern_box->paintable_box();
+}
 
+Optional<Painting::PaintStyle> SVGPatternElement::record_pattern_paint_style(SVGPaintContext const& paint_context, DisplayListRecordingContext& recording_context, Painting::Paintable const& pattern_paintable, Gfx::FloatSize content_scale) const
+{
     float tile_x = 0;
     float tile_y = 0;
     float tile_width = 0;
@@ -278,17 +277,6 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
     if (tile_rect.is_empty())
         return {};
 
-    auto paintable = target_layout_node.paintable();
-
-    // The tile rasterizes into a fixed-size surface, so its resolution must include the scale the
-    // visual context chain applies to the target, or tiles under scaled ancestors come out blurry.
-    auto content_scale = Gfx::FloatSize { 1, 1 };
-    if (paintable) {
-        content_scale = recording_context.display_list_recorder().visual_context_tree().accumulated_2d_scale(
-            recording_context.accumulated_visual_context_index_of(*paintable),
-            Painting::ScrollStateSnapshot {},
-            Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-    }
     if (!(content_scale.width() > 0 && content_scale.height() > 0))
         content_scale = { 1, 1 };
 
@@ -313,14 +301,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
                                   .multiply(content_to_tile_transform);
     }
     Painting::TransformData tile_content_transform { recorded_to_surface.to_matrix(), {} };
-    Painting::NestedVisualContextAssignments nested_visual_context_assignments;
-    auto visual_context_tree = Painting::build_nested_svg_visual_context_tree(const_cast<Painting::Paintable&>(*pattern_paintable), move(tile_content_transform), nested_visual_context_assignments, Painting::IncludeRootElementTransform::No);
-    auto display_list = Painting::DisplayList::create(visual_context_tree);
-    Painting::DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, recording_context.display_list_recorder().resource_storage());
-    auto paint_context_copy = recording_context.clone(display_list_recorder);
-    paint_context_copy.set_nested_visual_context_assignments(move(nested_visual_context_assignments));
-
-    Painting::StackingContext::paint_svg(paint_context_copy, *pattern_paintable, Painting::PaintPhase::Foreground);
+    auto tile_display_list = Painting::record_nested_svg_display_list(recording_context, pattern_paintable, tile_content_transform, Painting::IncludeRootElementTransform::No, false);
 
     Optional<Gfx::AffineTransform> user_space_pattern_transform;
     auto style = computed_style();
@@ -328,7 +309,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
     if (style->has_transformations()) {
         auto matrix = Gfx::FloatMatrix4x4::identity();
         style->for_each_transformation([&](auto const& css_transform) {
-            matrix = matrix * css_transform.to_matrix(*pattern_paintable);
+            matrix = matrix * css_transform.to_matrix(pattern_paintable);
         });
 
         user_space_pattern_transform = extract_2d_affine_transform(matrix);
@@ -348,7 +329,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
         }
     }
 
-    return Painting::PaintStyle { Painting::PatternPaintStyle { { *display_list, move(visual_context_tree) }, tile_rect, content_scale, device_pattern_transform } };
+    return Painting::PaintStyle { Painting::PatternPaintStyle { move(tile_display_list), tile_rect, content_scale, device_pattern_transform } };
 }
 
 // Reflected length accessors are generated by SVGElement's reflection macro.

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -52,7 +52,8 @@ public:
 
     GC::Ptr<SVGPatternElement const> pattern_content_element() const;
 
-    Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&, DisplayListRecordingContext&, Layout::Node const& target_layout_node) const;
+    RefPtr<Painting::Paintable const> resolve_pattern_paintable(Layout::Node const& target_layout_node) const;
+    Optional<Painting::PaintStyle> record_pattern_paint_style(SVGPaintContext const&, DisplayListRecordingContext&, Painting::Paintable const& pattern_paintable, Gfx::FloatSize content_scale) const;
 
     virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override { return nullptr; }
 


### PR DESCRIPTION
Mask, clip-path, and SVG pattern content used to be recorded in the middle of the paint traversal: reaching a masked box or resolving a pattern fill created a fresh recorder and re-entered the paint code while the outer recording waited. Now Document::record_display_list runs a pre-pass that records every nested display list the frame needs into a frame-local table, and the traversal only looks entries up. A lookup miss for a masked box or a resolved pattern is a hard failure instead of silently unmasked or unfilled rendering.

The pre-pass finds its work through two registries instead of walking the paintable tree, so it costs nothing on pages without masks or patterns: the accumulated visual context tree build registers every box it appends mask nodes for, and the layout tree builder registers every element it builds an SVGPatternBox for. Both are refreshed by machinery that already runs before any recording. Pattern entries must live as long as the element: a style-only fill change away from a pattern and back reuses the lingering per-use box without any tree update happening in between to re-register it. Recorded content and mask registration are unchanged; SVGPatternElement::to_gfx_paint_style is split into resolve_pattern_paintable and record_pattern_paint_style so the pre-pass can supply the tile content scale itself.

This is preparation for porting the paint traversal to Rust. C++ can start a nested recording anywhere because each site clones the recording context with a fresh recorder. The Rust recorder is a single mutable state machine, so the same structure forces swapping recorder state in and out mid-traversal and threading a nested mode through index resolution and hit-test recording. With all nested display lists recorded before the traversal starts, the ported traversal is a plain append loop and that machinery disappears.