### PR TITLE
LibWeb: Give equal computed values one canonical representation

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -4464,9 +4464,9 @@
     "initial": "0px",
     "requires-computation": "cascaded-value",
     "valid-types": [
-      "length [0,∞]",
-      "number [0,∞]",
-      "percentage [0,∞]"
+      "length [-∞,∞]",
+      "number [-∞,∞]",
+      "percentage [-∞,∞]"
     ],
     "percentages-resolve-to": "length"
   },

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1213,7 +1213,7 @@
     "_comment": "Follows the newer definition from: https://drafts.csswg.org/css-tables-3/#border-spacing-property",
     "animation-type": "by-computed-value",
     "inherited": true,
-    "initial": "0",
+    "initial": "0px 0px",
     "max-values": 2,
     "requires-computation": "cascaded-value",
     "valid-types": [

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -6325,6 +6325,11 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(
     case PropertyID::BorderTopWidth:
     case PropertyID::OutlineWidth:
         return compute_border_or_outline_width(absolutized_value, device_pixels_per_css_pixel);
+    case PropertyID::BorderSpacing: {
+        if (absolutized_value->is_value_list())
+            return absolutized_value;
+        return StyleValueList::create(StyleValueVector { absolutized_value, absolutized_value }, StyleValueList::Separator::Space);
+    }
     case PropertyID::Contain:
         return collapse_containment_list(absolutized_value);
     case PropertyID::CornerBottomLeftShape:

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -6232,6 +6232,13 @@ static NonnullRefPtr<StyleValue const> compute_style_value_list(NonnullRefPtr<St
     return StyleValueList::create(move(computed_entries), StyleValueList::Separator::Comma);
 }
 
+static NonnullRefPtr<StyleValue const> compute_svg_number_as_length(NonnullRefPtr<StyleValue const> const& style_value)
+{
+    if (!style_value->is_number())
+        return style_value;
+    return LengthStyleValue::create(Length::make_px(style_value->as_number().number()));
+}
+
 // https://drafts.csswg.org/css-contain-2/#contain-property
 static NonnullRefPtr<StyleValue const> collapse_containment_list(NonnullRefPtr<StyleValue const> const& style_value)
 {
@@ -6355,6 +6362,20 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(
         return compute_line_height(absolutized_value, computation_context.length_resolution_context.font_metrics.font_size);
     case PropertyID::MathDepth:
         return compute_math_depth(absolutized_value, inheritance_parent());
+    case PropertyID::StrokeDasharray:
+        // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
+        // as comma separated list of absolute lengths or percentages, numbers converted to
+        // absolute lengths first, or keyword specified
+        if (!absolutized_value->is_value_list())
+            return absolutized_value;
+        return compute_style_value_list(absolutized_value, [](NonnullRefPtr<StyleValue const> const& dash) {
+            return compute_svg_number_as_length(dash);
+        });
+    case PropertyID::StrokeDashoffset:
+    case PropertyID::StrokeWidth:
+        // https://svgwg.org/svg2-draft/painting.html#StrokeWidth
+        // an absolute length or percentage, numbers converted to absolute lengths first
+        return compute_svg_number_as_length(absolutized_value);
     case PropertyID::TransformOrigin:
         return compute_transform_origin(absolutized_value);
     default:

--- a/Libraries/LibWeb/Rust/src/css/absolutize.rs
+++ b/Libraries/LibWeb/Rust/src/css/absolutize.rs
@@ -223,6 +223,18 @@ fn rgb_color_function(r: f64, g: f64, b: f64, alpha: f64, color_syntax: u8) -> S
     }
 }
 
+/// The canonical computed form of a fully-resolved legacy sRGB color.
+fn canonical_legacy_rgb(value: &StyleValueData) -> Option<StyleValueData> {
+    let rgba = crate::css::color_resolution::to_color(value, &EMPTY_INPUT)?;
+    Some(rgb_color_function(
+        f64::from(rgba.r),
+        f64::from(rgba.g),
+        f64::from(rgba.b),
+        f64::from(rgba.a) / 255.0,
+        COLOR_SYNTAX_LEGACY,
+    ))
+}
+
 /// Port of hsl_to_absolutized_rgb() in ColorFunctionStyleValue.cpp.
 // https://drafts.csswg.org/css-color-4/#hsl-to-rgb
 fn hsl_to_absolutized_rgb(
@@ -392,13 +404,11 @@ fn absolutize_color_function(value: &StyleValueData, context: &AbsolutizationCon
         } else {
             hwb_to_absolutized_rgb(c1, c2, c3, alpha)
         };
-        return Some(Absolutized::Changed(retain_new(converted)));
+        let canonical = canonical_legacy_rgb(&converted).unwrap_or(converted);
+        return Some(Absolutized::Changed(retain_new(canonical)));
     }
 
-    if !changed {
-        return Some(Absolutized::Unchanged);
-    }
-    Some(Absolutized::Changed(retain_new(StyleValueData::ColorFunction {
+    let rebuilt = StyleValueData::ColorFunction {
         color_base: *color_base,
         channel_0: absolutized_c1,
         channel_1: absolutized_c2,
@@ -407,7 +417,21 @@ fn absolutize_color_function(value: &StyleValueData, context: &AbsolutizationCon
         has_name: *has_name,
         name: name.clone(),
         origin_color: retained_null(),
-    })))
+    };
+
+    if color_base.color_type == crate::css::color_conversion::RGB
+        && let Some(canonical) = canonical_legacy_rgb(&rebuilt)
+    {
+        if canonical == *value {
+            return Some(Absolutized::Unchanged);
+        }
+        return Some(Absolutized::Changed(retain_new(canonical)));
+    }
+
+    if !changed {
+        return Some(Absolutized::Unchanged);
+    }
+    Some(Absolutized::Changed(retain_new(rebuilt)))
 }
 
 /// Port of ColorMixStyleValue::absolutized: normalizes the mix percentages, resolves relative

--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -489,6 +489,7 @@ pub struct FontValues {
     pub math_shift_value: ComputedStyleValueHandle,
     pub math_style_value: ComputedStyleValueHandle,
     pub math_depth_value: ComputedStyleValueHandle,
+    pub font_size_value: ComputedStyleValueHandle,
 }
 
 pub const GRID_NO_INDEX: u32 = u32::MAX;

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -625,6 +625,7 @@ impl_computed_payload_clone_and_eq!(FontValues {
     math_shift_value,
     math_style_value,
     math_depth_value,
+    font_size_value,
 });
 impl_computed_payload_clone_and_eq!(InheritedSVGValues {
     fill,
@@ -3016,6 +3017,7 @@ impl FontValues {
             math_shift_value: initial(property_id::MATH_SHIFT),
             math_style_value: initial(property_id::MATH_STYLE),
             math_depth_value: initial(property_id::MATH_DEPTH),
+            font_size_value: initial(property_id::FONT_SIZE),
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -3606,9 +3606,9 @@ pub unsafe extern "C" fn rust_build_sizing_group(
 }
 
 /// Builds an inherited table group payload from the computed values, with the
-/// same sharing rules as the inherited box builder. Border-spacing must be an
-/// absolute pixel length; two-value spacings and anything else fall back to
-/// the C++ population path by returning null.
+/// same sharing rules as the inherited box builder. Border-spacing must be a
+/// pair of absolute pixel lengths; anything else falls back to the C++
+/// population path by returning null.
 ///
 /// # Safety
 /// The value pointers must be valid StyleValueData or null, and
@@ -3631,9 +3631,22 @@ pub unsafe extern "C" fn rust_build_inherited_table_group(
                 _ => None,
             }
         };
-        let spacing = match unsafe { (border_spacing as *const StyleValueData).as_ref() } {
-            Some(StyleValueData::Length { value, unit }) if *unit == crate::css::style_compute::px_length_unit() => {
-                crate::css::css_pixels::CssPixels::nearest_value_for(*value).raw_value()
+        let spacing_component = |data: &StyleValueData| -> Option<i32> {
+            match data {
+                StyleValueData::Length { value, unit } if *unit == crate::css::style_compute::px_length_unit() => {
+                    Some(crate::css::css_pixels::CssPixels::nearest_value_for(*value).raw_value())
+                }
+                _ => None,
+            }
+        };
+        let (horizontal_spacing, vertical_spacing) = match unsafe { (border_spacing as *const StyleValueData).as_ref() }
+        {
+            Some(StyleValueData::ValueList { values, .. }) if values.as_slice().len() == 2 => {
+                let components = values.as_slice();
+                (
+                    spacing_component(components[0].data())?,
+                    spacing_component(components[1].data())?,
+                )
             }
             _ => return None,
         };
@@ -3641,8 +3654,8 @@ pub unsafe extern "C" fn rust_build_inherited_table_group(
             border_collapse: keyword_code(border_collapse, crate::css::style_compute::keyword_to_border_collapse)?,
             caption_side: keyword_code(caption_side, crate::css::style_compute::keyword_to_caption_side)?,
             empty_cells: keyword_code(empty_cells, crate::css::style_compute::keyword_to_empty_cells)?,
-            border_spacing_horizontal: spacing,
-            border_spacing_vertical: spacing,
+            border_spacing_horizontal: horizontal_spacing,
+            border_spacing_vertical: vertical_spacing,
         };
 
         if !parent_payload.is_null() {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2356,6 +2356,44 @@ fn compute_position_area(value: &StyleValueData) -> Option<Arc<StyleValueData>> 
     }))
 }
 
+/// The computed dash list, with each number converted to the length it measures in user units.
+/// None when the list holds no numbers, so an unchanged list keeps its identity.
+#[allow(clippy::arc_with_non_send_sync)]
+fn stroke_dasharray_numbers_as_lengths(value: &StyleValueData) -> Option<Arc<StyleValueData>> {
+    let StyleValueData::ValueList {
+        values,
+        separator,
+        collapsible,
+    } = value
+    else {
+        return None;
+    };
+    let dashes = values.as_slice();
+    if !dashes
+        .iter()
+        .any(|dash| matches!(dash.data(), StyleValueData::Number { .. }))
+    {
+        return None;
+    }
+    let computed_dashes = dashes
+        .iter()
+        .map(|dash| match dash.data() {
+            StyleValueData::Number { value } => unsafe {
+                RetainedStyleValueData::from_retained_pointer(Arc::into_raw(Arc::new(StyleValueData::Length {
+                    value: *value,
+                    unit: px_length_unit(),
+                })))
+            },
+            _ => dash.clone_retained(),
+        })
+        .collect();
+    Some(Arc::new(StyleValueData::ValueList {
+        values: RetainedStyleValueDataList::from_retained_values(computed_dashes),
+        separator: *separator,
+        collapsible: *collapsible,
+    }))
+}
+
 // https://drafts.csswg.org/css-contain-2/#contain-property
 #[allow(clippy::arc_with_non_send_sync)]
 fn collapse_containment_list(value: &StyleValueData) -> Option<Arc<StyleValueData>> {
@@ -4051,6 +4089,46 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                         Some(value) => NativeValue::StyleValue(value),
                         None => NativeValue::Unchanged,
                     },
+                    (_, prop::STROKE_DASHOFFSET | prop::STROKE_WIDTH)
+                        if matches!(value_data, StyleValueData::Number { .. }) =>
+                    {
+                        let StyleValueData::Number { value } = value_data else {
+                            unreachable!("the guard accepted only numbers");
+                        };
+                        NativeValue::Px(*value)
+                    }
+                    (None, prop::STROKE_DASHARRAY) if matches!(value_data, StyleValueData::ValueList { .. }) => {
+                        let resolution_context =
+                            length_resolution_context.expect("a dash list must run with a resolution context");
+                        let absolutization_context = crate::css::absolutize::AbsolutizationContext {
+                            length: resolution_context,
+                            scheme: effective_color_scheme,
+                            resolved_viewport_relative_length: std::cell::Cell::new(false),
+                            tree_counting: tree_counting_context,
+                            random_base_values,
+                            document_base_url,
+                            style_sheet_resource_context,
+                        };
+                        let outcome = crate::css::absolutize::absolutize(value_data, &absolutization_context);
+                        if absolutization_context.resolved_viewport_relative_length.get() {
+                            results.depends_on_viewport_metrics = true;
+                        }
+                        match outcome {
+                            Some(crate::css::absolutize::Absolutized::Unchanged) => {
+                                match stroke_dasharray_numbers_as_lengths(value_data) {
+                                    Some(value) => NativeValue::StyleValue(value),
+                                    None => NativeValue::Unchanged,
+                                }
+                            }
+                            Some(crate::css::absolutize::Absolutized::Changed(value)) => {
+                                match stroke_dasharray_numbers_as_lengths(value.data()) {
+                                    Some(computed) => NativeValue::StyleValue(computed),
+                                    None => NativeValue::StyleValue(value.into_arc()),
+                                }
+                            }
+                            None => NativeValue::Unsupported,
+                        }
+                    }
                     (None, prop::TRANSFORM_ORIGIN) => {
                         let resolution_context =
                             length_resolution_context.expect("transform-origin requires a length resolution context");

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2394,6 +2394,17 @@ fn stroke_dasharray_numbers_as_lengths(value: &StyleValueData) -> Option<Arc<Sty
     }))
 }
 
+/// The computed two-value list for a `border-spacing` member used for both axes.
+#[allow(clippy::arc_with_non_send_sync)]
+fn border_spacing_pair(single: StyleValueData) -> Arc<StyleValueData> {
+    let single = unsafe { RetainedStyleValueData::from_retained_pointer(Arc::into_raw(Arc::new(single))) };
+    Arc::new(StyleValueData::ValueList {
+        values: RetainedStyleValueDataList::from_retained_values(vec![single.clone_retained(), single]),
+        separator: 0,
+        collapsible: true,
+    })
+}
+
 // https://drafts.csswg.org/css-contain-2/#contain-property
 #[allow(clippy::arc_with_non_send_sync)]
 fn collapse_containment_list(value: &StyleValueData) -> Option<Arc<StyleValueData>> {
@@ -4158,6 +4169,21 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                             }
                             None => NativeValue::Unsupported,
                         }
+                    }
+                    // https://drafts.csswg.org/css-tables-3/#border-spacing-property
+                    // two absolute lengths
+                    // A single specified length computes to the pair with both members equal, so
+                    // every computed border-spacing has the same two-value list shape; a specified
+                    // pair takes the generic arms below.
+                    (_, prop::BORDER_SPACING) if !matches!(value_data, StyleValueData::ValueList { .. }) => {
+                        let single = match absolutized {
+                            Some(Some(px)) => StyleValueData::Length {
+                                value: px,
+                                unit: px_length_unit(),
+                            },
+                            _ => value_data.clone(),
+                        };
+                        NativeValue::StyleValue(border_spacing_pair(single))
                     }
                     (_, prop::CONTAIN) => match collapse_containment_list(value_data) {
                         Some(value) => NativeValue::StyleValue(value),

--- a/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
+++ b/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
@@ -3090,6 +3090,7 @@ unsafe fn build_font_group(
         math_shift_value: retained(property_id::MATH_SHIFT),
         math_style_value: retained(property_id::MATH_STYLE),
         math_depth_value: retained(property_id::MATH_DEPTH),
+        font_size_value: retained(property_id::FONT_SIZE),
     };
     unsafe {
         crate::css::computed_values::build_group_payload_with_rust_fill(

--- a/Tests/LibWeb/Text/expected/MathML/presentational_hints.txt
+++ b/Tests/LibWeb/Text/expected/MathML/presentational_hints.txt
@@ -1,12 +1,12 @@
 direction: ltr
 direction: ltr
 direction: rtl
-color: red
 color: rgb(255, 0, 0)
-color: orange
-background-color: blue
+color: rgb(255, 0, 0)
+color: rgb(255, 165, 0)
 background-color: rgb(0, 0, 255)
-background-color: transparent
+background-color: rgb(0, 0, 255)
+background-color: rgba(0, 0, 0, 0)
 font-size: 10px
 font-size: 24px
 font-size: 32px

--- a/Tests/LibWeb/Text/expected/css/computed-values-svg-geometry.txt
+++ b/Tests/LibWeb/Text/expected/css/computed-values-svg-geometry.txt
@@ -1,4 +1,4 @@
 rx: 12px
 ry: 34px
-stroke-dasharray: 1px, 2
+stroke-dasharray: 1px, 2px
 stroke-width: 25%

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-border-spacing-pair.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-border-spacing-pair.txt
@@ -1,0 +1,3 @@
+pair: 10px
+single: 10px
+distinct pair: 10px 20px

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-color-canonical-form.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-color-canonical-form.txt
@@ -1,0 +1,6 @@
+named: rgb(255, 0, 0)
+functional: rgb(255, 0, 0)
+hex: rgb(119, 255, 255)
+functional: rgb(119, 255, 255)
+hsl: rgb(0, 255, 0)
+functional: rgb(0, 255, 0)

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-font-size-representation-change.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-font-size-representation-change.txt
@@ -1,0 +1,2 @@
+inherited: 20.1px
+after: 20.09375px

--- a/Tests/LibWeb/Text/expected/css/style-engine/targeted-direct-read-uses-reaction-batch.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/targeted-direct-read-uses-reaction-batch.txt
@@ -1,4 +1,4 @@
-color: green
+color: rgb(0, 128, 0)
 reaction batch runs: 1
 reaction elements: 1
 published reactions: 1

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/set-var-reference-thcrash.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/set-var-reference-thcrash.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Do not crash when referencing a variable with CSSVariableReferenceValue
+1 Pass
+Pass	Do not crash when referencing a variable with CSSVariableReferenceValue

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/stylevalue-serialization/cssStyleValue-cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/stylevalue-serialization/cssStyleValue-cssom.txt
@@ -2,9 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-2 Pass
-2 Fail
+3 Pass
+1 Fail
 Pass	CSSStyleValue from specified CSSOM serializes correctly
-Fail	CSSStyleValue from computed CSSOM serializes correctly
+Pass	CSSStyleValue from computed CSSOM serializes correctly
 Pass	Shorthand CSSStyleValue from inline CSSOM serializes correctly
 Fail	Shorthand CSSStyleValue from computed CSSOM serializes correctly

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dasharray-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dasharray-computed.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	Property stroke-dasharray value 'none'
+Pass	Property stroke-dasharray value '10'
+Pass	Property stroke-dasharray value 'calc(10px + 0.5em)'
+Pass	Property stroke-dasharray value 'calc(10px - 0.5em)'
+Pass	Property stroke-dasharray value '40%'
+Pass	Property stroke-dasharray value 'calc(50% + 60px)'
+Pass	Property stroke-dasharray value '10px 20% 30px'
+Pass	Property stroke-dasharray value '0, 5'

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dashoffset-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dashoffset-computed.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	Property stroke-dashoffset value '10'
+Pass	Property stroke-dashoffset value '0.5em'
+Pass	Property stroke-dashoffset value 'calc(10px + 0.5em)'
+Pass	Property stroke-dashoffset value 'calc(10px - 0.5em)'
+Pass	Property stroke-dashoffset value '-40%'
+Pass	Property stroke-dashoffset value 'calc(50% + 60px)'
+Pass	Property stroke-dashoffset value '254cm'
+Pass	Property stroke-dashoffset value '2540mm'
+Pass	Property stroke-dashoffset value '10160Q'
+Pass	Property stroke-dashoffset value '1in'
+Pass	Property stroke-dashoffset value '6pc'
+Pass	Property stroke-dashoffset value '72pt'

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dashoffset-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dashoffset-valid.txt
@@ -1,0 +1,15 @@
+Harness status: OK
+
+Found 9 tests
+
+8 Pass
+1 Fail
+Pass	e.style['stroke-dashoffset'] = "0" should set the property value
+Pass	e.style['stroke-dashoffset'] = "10px" should set the property value
+Pass	e.style['stroke-dashoffset'] = "-20%" should set the property value
+Pass	e.style['stroke-dashoffset'] = "30" should set the property value
+Fail	e.style['stroke-dashoffset'] = "40Q" should set the property value
+Pass	e.style['stroke-dashoffset'] = "calc(2em + 3ex)" should set the property value
+Pass	e.style['stroke-dashoffset'] = "calc(3)" should set the property value
+Pass	e.style['stroke-dashoffset'] = "calc(2 + 1)" should set the property value
+Pass	e.style['stroke-dashoffset'] = "calc(2 + (7 - 5))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-width-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-width-computed.txt
@@ -1,0 +1,25 @@
+Harness status: OK
+
+Found 20 tests
+
+20 Pass
+Pass	Property stroke-width value '10'
+Pass	Property stroke-width value 'calc(10px + 0.5em)'
+Pass	Property stroke-width value 'calc(10px - 0.5em)'
+Pass	Property stroke-width value '40%'
+Pass	Property stroke-width value 'calc(50% + 60px)'
+Pass	stroke-width computes em lengths
+Pass	stroke-width computes ex lengths
+Pass	stroke-width computes ch lengths
+Pass	stroke-width computes rem lengths
+Pass	stroke-width computes vw lengths
+Pass	stroke-width computes vh lengths
+Pass	stroke-width computes vmin lengths
+Pass	stroke-width computes vmax lengths
+Pass	stroke-width computes cm lengths
+Pass	stroke-width computes mm lengths
+Pass	stroke-width computes Q lengths
+Pass	stroke-width computes in lengths
+Pass	stroke-width computes pt lengths
+Pass	stroke-width computes pc lengths
+Pass	stroke-width computes px lengths

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-border-spacing-pair.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-border-spacing-pair.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<table id="target"></table>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        target.style.borderSpacing = "10px 10px";
+        println(`pair: ${getComputedStyle(target).borderSpacing}`);
+        target.style.borderSpacing = "10px";
+        println(`single: ${getComputedStyle(target).borderSpacing}`);
+        target.style.borderSpacing = "10px 20px";
+        println(`distinct pair: ${getComputedStyle(target).borderSpacing}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-color-canonical-form.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-color-canonical-form.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<div id="target"></div>
+<svg id="shape" width="1" height="1"></svg>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        target.style.textDecorationColor = "red";
+        println(`named: ${getComputedStyle(target).textDecorationColor}`);
+        target.style.textDecorationColor = "rgb(255, 0, 0)";
+        println(`functional: ${getComputedStyle(target).textDecorationColor}`);
+        shape.style.fill = "#77ffff";
+        println(`hex: ${getComputedStyle(shape).fill}`);
+        shape.style.fill = "rgb(119, 255, 255)";
+        println(`functional: ${getComputedStyle(shape).fill}`);
+        target.style.outlineColor = "hsl(120, 100%, 50%)";
+        println(`hsl: ${getComputedStyle(target).outlineColor}`);
+        target.style.outlineColor = "rgb(0, 255, 0)";
+        println(`functional: ${getComputedStyle(target).outlineColor}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-font-size-representation-change.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-font-size-representation-change.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<div id="outer" style="font-size: 20.1px"><div id="middle"><div id="target"></div></div></div>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        println(`inherited: ${getComputedStyle(target).fontSize}`);
+        middle.style.fontSize = "100%";
+        println(`after: ${getComputedStyle(target).fontSize}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dasharray-computed.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dasharray-computed.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: getComputedStyle().strokeDasharray</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:meta name="assert" content="stroke-dasharray computed value uses absolute lengths."/>
+  </metadata>
+  <g id="target"></g>
+  <style>
+    #target {
+      font-size: 40px;
+    }
+  </style>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-dasharray", "none");
+
+test_computed_value("stroke-dasharray", "10", "10px");
+test_computed_value("stroke-dasharray", "calc(10px + 0.5em)", "30px");
+test_computed_value("stroke-dasharray", "calc(10px - 0.5em)", "0px");
+test_computed_value("stroke-dasharray", "40%");
+test_computed_value("stroke-dasharray", "calc(50% + 60px)");
+
+test_computed_value("stroke-dasharray", "10px 20% 30px", "10px, 20%, 30px");
+test_computed_value("stroke-dasharray", "0, 5", "0px, 5px");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dashoffset-computed.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dashoffset-computed.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: getComputedStyle().strokeDashoffset</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:meta name="assert" content="stroke-dashoffset computed value is absolute length."/>
+  </metadata>
+  <g id="target"></g>
+  <style>
+    #target {
+      font-size: 40px;
+    }
+  </style>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-dashoffset", "10", "10px");
+test_computed_value("stroke-dashoffset", "0.5em", "20px");
+test_computed_value("stroke-dashoffset", "calc(10px + 0.5em)", "30px");
+test_computed_value("stroke-dashoffset", "calc(10px - 0.5em)", "-10px");
+test_computed_value("stroke-dashoffset", "-40%");
+test_computed_value("stroke-dashoffset", "calc(50% + 60px)");
+
+// https://www.w3.org/TR/css-values-3/#absolute-lengths
+test_computed_value("stroke-dashoffset", "254cm", "9600px");
+test_computed_value("stroke-dashoffset", "2540mm", "9600px");
+test_computed_value("stroke-dashoffset", "10160Q", "9600px");
+test_computed_value("stroke-dashoffset", "1in", "96px");
+test_computed_value("stroke-dashoffset", "6pc", "96px");
+test_computed_value("stroke-dashoffset", "72pt", "96px");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dashoffset-valid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dashoffset-valid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dashoffset with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty"/>
+    <h:meta name="assert" content="stroke-dashoffset supports the full grammar 'length-percentage'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("stroke-dashoffset", "0");
+test_valid_value("stroke-dashoffset", "10px");
+test_valid_value("stroke-dashoffset", "-20%");
+test_valid_value("stroke-dashoffset", "30");
+test_valid_value("stroke-dashoffset", "40Q", "40q");
+test_valid_value("stroke-dashoffset", "calc(2em + 3ex)");
+test_valid_value("stroke-dashoffset", "calc(3)");
+test_valid_value("stroke-dashoffset", "calc(2 + 1)", "calc(3)");
+test_valid_value("stroke-dashoffset", "calc(2 + (7 - 5))", "calc(4)");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-width-computed.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-width-computed.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: getComputedStyle().strokeWidth</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth"/>
+    <h:meta name="assert" content="stroke-width computed value is absolute length."/>
+  </metadata>
+  <g id="target"></g>
+  <g id="ref"></g>
+  <style>
+    #target, #ref {
+      font-size: 40px;
+    }
+  </style>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("stroke-width", "10", "10px");
+test_computed_value("stroke-width", "calc(10px + 0.5em)", "30px");
+test_computed_value("stroke-width", "calc(10px - 0.5em)", "0px");
+test_computed_value("stroke-width", "40%");
+test_computed_value("stroke-width", "calc(50% + 60px)");
+
+const lengthUnits = [
+  'em',
+  'ex',
+  'ch',
+  'rem',
+  'vw',
+  'vh',
+  'vmin',
+  'vmax',
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pt',
+  'pc',
+  'px'
+];
+
+for (let lengthUnit of lengthUnits) {
+  const length = '987' + lengthUnit;
+  test(() => {
+    const target = document.getElementById('target');
+    target.style.strokeWidth = length;
+
+    const ref = document.getElementById('ref');
+    ref.style.textIndent = length;
+
+    assert_equals(getComputedStyle(target).strokeWidth, getComputedStyle(ref).textIndent);
+  }, 'stroke-width computes ' + lengthUnit + ' lengths');
+}
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
See individual commits for details.

This prevents crashes in 33 / 1000 Domato test cases when run with the `LIBWEB_VERIFY_STYLE_DIFF_FAST_PATH` flag.

Fixes crashes in 4 tests when running `test-web --verify-style`. 