### PR TITLE
LibWeb: Resolve image paints as data instead of recording them

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -879,6 +879,7 @@ set(SOURCES
     Painting/FieldSetPaintable.cpp
     Painting/GradientPainting.cpp
     Painting/HitTestDisplayList.cpp
+    Painting/ImagePaint.cpp
     Painting/ImagePaintable.cpp
     Painting/InlinePaintable.cpp
     Painting/NavigableContainerViewportPaintable.cpp

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -67,6 +67,13 @@ void AbstractImageStyleValue::load_any_resources(Layout::NodeWithStyle const& la
     load_any_resources(const_cast<DOM::Document&>(layout_node.document()));
 }
 
+Optional<Painting::ImagePaint> AbstractImageStyleValue::image_paint(Painting::ImagePaintRequest const&, ResolvedImage const& resolved) const
+{
+    return resolved.visit(
+        [](Empty const&) -> Optional<Painting::ImagePaint> { return OptionalNone {}; },
+        [](auto const& gradient) -> Optional<Painting::ImagePaint> { return Painting::ImagePaint { gradient }; });
+}
+
 ColorStopListElement ColorStopListElement::absolutized(ComputationContext const& context) const
 {
     auto absolutize_if_nonnull = [&context](RefPtr<StyleValue const> const& input) -> RefPtr<StyleValue const> {

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -14,7 +14,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 #include <LibWeb/Export.h>
-#include <LibWeb/Painting/GradientData.h>
+#include <LibWeb/Painting/ImagePaint.h>
 
 namespace Web::CSS {
 
@@ -45,7 +45,7 @@ public:
     virtual ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const { return Empty {}; }
 
     virtual bool is_paintable(DOM::Document const&) const = 0;
-    virtual void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, ImageRendering, PreferredColorScheme, ResolvedImage const&) const = 0;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const;
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 
@@ -38,14 +37,6 @@ ResolvedImage ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyle co
         Painting::resolve_conic_gradient_data(node, *this),
         position_value()->resolved(CSSPixelRect { { 0, 0 }, size }),
     };
-}
-
-void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme, ResolvedImage const& resolved_image) const
-{
-    auto const& resolved = resolved_image.get<Painting::ResolvedConicGradient>();
-    auto destination_rect = dest_rect.to_type<int>();
-    auto position = context.rounded_device_point(resolved.position).to_type<int>();
-    context.display_list_recorder().fill_rect_with_conic_gradient(destination_rect, resolved.data, position);
 }
 
 ValueComparingNonnullRefPtr<StyleValue const> ConicGradientStyleValue::absolutized(ComputationContext const& context) const

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -30,8 +30,6 @@ public:
         return adopt_ref(*new (nothrow) ConicGradientStyleValue(move(from_angle), move(position), move(color_stop_list), repeating, move(color_interpolation_method), color_syntax));
     }
 
-    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme, ResolvedImage const&) const override;
-
     ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
     Vector<ColorStopListElement> color_stop_list() const
     {

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -16,8 +16,8 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ImagePaint.h>
 
 namespace Web::CSS {
 
@@ -104,19 +104,25 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
 
         // Paint the cursor into a bitmap.
         auto visual_context_tree = Painting::AccumulatedVisualContextTree::create();
-        auto display_list = Painting::DisplayList::create(visual_context_tree);
         Painting::DisplayListResourceStorage resource_storage;
-        Painting::DisplayListRecorder display_list_recorder(display_list, visual_context_tree, resource_storage);
-        DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 
         auto resolved_image = image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
         // A cursor image is not embedded by any element, so it follows the page's own preference.
-        image.paint(paint_context, document, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto, current_color_scheme, resolved_image);
-
-        auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
-        Painting::DisplayListPlayerSkia display_list_player;
-        display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
-        display_list_player.flush(*painting_surface);
+        Painting::ImagePaintRequest request {
+            .document = document,
+            .dest_rect = bitmap.rect().to_type<float>(),
+            .image_rendering = ImageRendering::Auto,
+            .color_scheme = current_color_scheme,
+            .accumulated_scale = { 1, 1 },
+            .resource_storage = resource_storage,
+        };
+        if (auto image_paint = image.image_paint(request, resolved_image); image_paint.has_value()) {
+            auto display_list = Painting::record_image_paint_display_list(*image_paint, request.dest_rect, ImageRendering::Auto, document.page().client().device_pixels_per_css_pixel(), visual_context_tree, resource_storage);
+            auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
+            Painting::DisplayListPlayerSkia display_list_player;
+            display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
+            display_list_player.flush(*painting_surface);
+        }
     }
 
     // "If the values are unspecified, then the natural hotspot defined inside the image resource itself is used.

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -15,7 +15,6 @@
 #include <LibWeb/HTML/SupportedImageTypes.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/DisplayListRecordingContext.h>
 
 namespace Web::CSS {
 
@@ -136,10 +135,11 @@ bool ImageSetStyleValue::is_paintable(DOM::Document const& document) const
     return false;
 }
 
-void ImageSetStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, ImageRendering image_rendering, PreferredColorScheme color_scheme, ResolvedImage const& resolved_image) const
+Optional<Painting::ImagePaint> ImageSetStyleValue::image_paint(Painting::ImagePaintRequest const& request, ResolvedImage const& resolved_image) const
 {
     if (m_selected_image)
-        m_selected_image->paint(context, document, dest_rect, image_rendering, color_scheme, resolved_image);
+        return m_selected_image->image_paint(request, resolved_image);
+    return {};
 }
 
 Optional<Gfx::Color> ImageSetStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -34,7 +34,7 @@ public:
 
     virtual ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
     virtual bool is_paintable(DOM::Document const&) const override;
-    virtual void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, ImageRendering, PreferredColorScheme, ResolvedImage const&) const override;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const override;
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
 
     AbstractImageStyleValue const* selected_image() const { return m_selected_image; }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -22,8 +22,6 @@
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/SharedResourceRequest.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
-#include <LibWeb/Painting/DisplayListRecordingContext.h>
 
 namespace Web::CSS {
 
@@ -184,22 +182,24 @@ bool ImageStyleValue::is_paintable(DOM::Document const& document) const
     return !!image_data(document);
 }
 
-void ImageStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme color_scheme, ResolvedImage const&) const
+Optional<Painting::ImagePaint> ImageStyleValue::image_paint(Painting::ImagePaintRequest const& request, ResolvedImage const&) const
 {
-    auto image_data = this->image_data(document);
+    auto image_data = this->image_data(request.document);
     if (!image_data)
-        return;
+        return {};
 
-    image_data->paint(context, dest_rect.to_type<int>().to_type<float>(), image_rendering, color_scheme);
+    auto integer_request = request;
+    integer_request.dest_rect = request.dest_rect.to_type<int>().to_type<float>();
+    return image_data->image_paint(integer_request);
 }
 
-Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, PreferredColorScheme color_scheme) const
+Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(Painting::DisplayListResourceStorage& resource_storage, DOM::Document const& document, DevicePixelRect const& dest_rect, PreferredColorScheme color_scheme) const
 {
     auto image_data = this->image_data(document);
     if (!image_data)
         return {};
 
-    return image_data->record_display_list(dest_rect.size().to_type<int>(), color_scheme, context.display_list_recorder().resource_storage());
+    return image_data->record_display_list(dest_rect.size().to_type<int>(), color_scheme, resource_storage);
 }
 
 Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DOM::Document const& document, DevicePixelRect const& dest_rect) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -84,8 +84,8 @@ public:
     Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
 
     virtual bool is_paintable(DOM::Document const&) const override;
-    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme, ResolvedImage const&) const override;
-    Optional<Painting::DisplayListResource> record_display_list(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, PreferredColorScheme) const;
+    Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const override;
+    Optional<Painting::DisplayListResource> record_display_list(Painting::DisplayListResourceStorage&, DOM::Document const&, DevicePixelRect const&, PreferredColorScheme) const;
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
     Optional<Gfx::DecodedImageFrame> current_frame(DOM::Document const&, DevicePixelRect const& dest_rect = {}) const;

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 
@@ -115,11 +114,6 @@ float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
 ResolvedImage LinearGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node, CSSPixelSize size) const
 {
     return Painting::resolve_linear_gradient_data(node, size, *this);
-}
-
-void LinearGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme, ResolvedImage const& resolved) const
-{
-    context.display_list_recorder().fill_rect_with_linear_gradient(dest_rect.to_type<int>(), resolved.get<Painting::LinearGradientData>());
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -80,7 +80,6 @@ public:
     ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 
     bool is_paintable(DOM::Document const&) const override { return true; }
-    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme, ResolvedImage const&) const override;
 
 private:
     friend class StyleValue;

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RadialSizeStyleValue.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 
@@ -70,14 +69,6 @@ ValueComparingNonnullRefPtr<StyleValue const> RadialGradientStyleValue::absoluti
     auto absolutized_color_interpolation_method = color_interpolation_method_value() ? ValueComparingRefPtr<StyleValue const> { color_interpolation_method_value()->absolutized(context) } : nullptr;
 
     return create(ending_shape(), move(absolutized_size), move(absolutized_position), move(absolutized_color_stops), (is_repeating() ? GradientRepeating::Yes : GradientRepeating::No), move(absolutized_color_interpolation_method));
-}
-
-void RadialGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme, ResolvedImage const& resolved_image) const
-{
-    auto const& resolved = resolved_image.get<Painting::ResolvedRadialGradient>();
-    auto center = context.rounded_device_point(resolved.center).to_type<int>();
-    auto size = context.rounded_device_size(resolved.gradient_size).to_type<int>();
-    context.display_list_recorder().fill_rect_with_radial_gradient(dest_rect.to_type<int>(), resolved.data, center, size);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -31,8 +31,6 @@ public:
         return adopt_ref(*new (nothrow) RadialGradientStyleValue(ending_shape, move(size), move(position), move(color_stop_list), repeating, move(color_interpolation_method), any_non_legacy ? ColorSyntax::Modern : ColorSyntax::Legacy));
     }
 
-    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme, ResolvedImage const&) const override;
-
     ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
 
     Vector<ColorStopListElement> color_stop_list() const

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -12,8 +12,6 @@
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/DOM/DocumentObserver.h>
 #include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
-#include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
@@ -251,15 +249,12 @@ Optional<CSSPixelFraction> AnimatedBitmapDecodedImageData::intrinsic_aspect_rati
     return CSSPixels(m_size.width()) / CSSPixels(m_size.height());
 }
 
-void AnimatedBitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::FloatRect dst_rect, CSS::ImageRendering image_rendering, CSS::PreferredColorScheme) const
+Optional<Painting::ImagePaint> AnimatedBitmapDecodedImageData::image_paint(Painting::ImagePaintRequest const&) const
 {
     auto decoded_frame = current_frame();
     if (!decoded_frame.has_value())
-        return;
-
-    auto scaling_mode = CSS::to_gfx_scaling_mode(image_rendering, m_size, dst_rect.to_rounded<int>().size());
-
-    context.display_list_recorder().draw_scaled_decoded_image_frame(dst_rect, *decoded_frame, scaling_mode);
+        return {};
+    return Painting::ImagePaint { Painting::ImagePaint::DecodedFrame { .frame = *decoded_frame, .natural_size = m_size } };
 }
 
 void AnimatedBitmapDecodedImageData::receive_frames(Vector<NonnullRefPtr<Gfx::Bitmap>> bitmaps, u32 start_frame_index)

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -46,7 +46,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::FloatRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const override;
 
     void receive_frames(Vector<NonnullRefPtr<Gfx::Bitmap>>, u32 start_frame_index);
 

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
@@ -9,8 +9,6 @@
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/HTML/BitmapDecodedImageData.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
-#include <LibWeb/Painting/DisplayListRecordingContext.h>
 
 namespace Web::HTML {
 
@@ -62,11 +60,9 @@ Optional<CSSPixelFraction> BitmapDecodedImageData::intrinsic_aspect_ratio() cons
     return CSSPixels(m_frame.width()) / CSSPixels(m_frame.height());
 }
 
-void BitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::FloatRect dst_rect, CSS::ImageRendering image_rendering, CSS::PreferredColorScheme) const
+Optional<Painting::ImagePaint> BitmapDecodedImageData::image_paint(Painting::ImagePaintRequest const&) const
 {
-    auto scaling_mode = CSS::to_gfx_scaling_mode(image_rendering, m_frame.size(), dst_rect.to_rounded<int>().size());
-
-    context.display_list_recorder().draw_scaled_decoded_image_frame(dst_rect, m_frame, scaling_mode);
+    return Painting::ImagePaint { Painting::ImagePaint::DecodedFrame { .frame = m_frame, .natural_size = m_frame.size() } };
 }
 
 }

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
@@ -32,7 +32,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::FloatRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const override;
 
 private:
     BitmapDecodedImageData(Gfx::DecodedImageFrame&& frame);

--- a/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ImagePaint.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::HTML {
@@ -40,7 +41,7 @@ public:
     [[nodiscard]] bool is_cors_cross_origin() const { return m_is_cors_cross_origin; }
     void set_is_cors_cross_origin(bool value) { m_is_cors_cross_origin = value; }
 
-    virtual void paint([[maybe_unused]] DisplayListRecordingContext&, [[maybe_unused]] Gfx::FloatRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const = 0;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const = 0;
     // An SVG used as an image resolves `prefers-color-scheme` from the used `color-scheme` of the
     // element referencing it, so the scheme is part of what is being asked for rather than a
     // property of the page.

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/ImagePaint.h>
 #include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 
@@ -384,7 +385,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 dest_rect.set_height(1);
 
             auto const& image_style_value = static_cast<CSS::ImageStyleValue const&>(image);
-            if (auto display_list = image_style_value.record_display_list(context, document, dest_rect, color_scheme); display_list.has_value()) {
+            if (auto display_list = image_style_value.record_display_list(display_list_recorder.resource_storage(), document, dest_rect, color_scheme); display_list.has_value()) {
                 apply_blend_layer();
                 auto dest_int_rect = dest_rect.to_type<int>();
                 auto scaling_mode = to_gfx_scaling_mode(image_rendering, dest_int_rect.size(), dest_int_rect.size());
@@ -421,7 +422,9 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             auto tile_display_list = DisplayList::create(visual_context_tree);
             DisplayListRecorder tile_recorder(*tile_display_list, visual_context_tree, display_list_recorder.resource_storage());
             auto tile_context = context.clone(tile_recorder);
-            image.paint(tile_context, document, tile_device_rect, image_rendering, color_scheme, resolved_image);
+            auto tile_request = image_paint_request_for_recording(tile_context, document, tile_device_rect.to_type<int>().to_type<float>(), image_rendering, color_scheme);
+            if (auto image_paint = image.image_paint(tile_request, resolved_image); image_paint.has_value())
+                record_image_paint(tile_context, *image_paint, tile_request.dest_rect, image_rendering);
 
             // A pattern repeats along both axes. On any non-repeating axis, constrain the coverage to a single tile.
             auto coverage = clip_rect;
@@ -448,8 +451,11 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             });
         } else {
             apply_blend_layer();
-            for_each_image_device_rect([&](auto const& image_device_rect) {
-                image.paint(context, document, image_device_rect, image_rendering, color_scheme, resolved_image);
+            auto request = image_paint_request_for_recording(context, document, {}, image_rendering, color_scheme);
+            for_each_image_device_rect([&](DevicePixelRect const& image_device_rect) {
+                request.dest_rect = image_device_rect.to_type<int>().to_type<float>();
+                if (auto image_paint = image.image_paint(request, resolved_image); image_paint.has_value())
+                    record_image_paint(context, *image_paint, request.dest_rect, image_rendering);
             });
         }
     }

--- a/Libraries/LibWeb/Painting/ImagePaint.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaint.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/DevicePixelConverter.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/ImagePaint.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+namespace Web::Painting {
+
+ImagePaintRequest image_paint_request_for_recording(DisplayListRecordingContext& context, DOM::Document const& document, Gfx::FloatRect dest_rect, CSS::ImageRendering image_rendering, CSS::PreferredColorScheme color_scheme)
+{
+    auto& recorder = context.display_list_recorder();
+    auto accumulated_scale = recorder.visual_context_tree().accumulated_2d_scale(
+        recorder.accumulated_visual_context(), ScrollStateSnapshot {}, AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+    return ImagePaintRequest {
+        .document = document,
+        .dest_rect = dest_rect,
+        .image_rendering = image_rendering,
+        .color_scheme = color_scheme,
+        .accumulated_scale = accumulated_scale,
+        .resource_storage = recorder.resource_storage(),
+    };
+}
+
+static void record_image_paint_with_recorder(DisplayListRecorder& recorder, DevicePixelConverter const& device_pixel_converter, ImagePaint const& image_paint, Gfx::FloatRect dest_rect, CSS::ImageRendering image_rendering)
+{
+    image_paint.value.visit(
+        [&](ImagePaint::DecodedFrame const& decoded_frame) {
+            auto scaling_mode = CSS::to_gfx_scaling_mode(image_rendering, decoded_frame.natural_size, dest_rect.to_rounded<int>().size());
+            recorder.draw_scaled_decoded_image_frame(dest_rect, decoded_frame.frame, scaling_mode);
+        },
+        [&](ImagePaint::NestedDisplayList const& nested_display_list) {
+            recorder.paint_nested_display_list(nested_display_list.resource, dest_rect, nested_display_list.list_size);
+        },
+        [&](LinearGradientData const& linear_gradient) {
+            recorder.fill_rect_with_linear_gradient(dest_rect.to_type<int>(), linear_gradient);
+        },
+        [&](ResolvedRadialGradient const& radial_gradient) {
+            auto center = device_pixel_converter.rounded_device_point(radial_gradient.center).to_type<int>();
+            auto size = device_pixel_converter.rounded_device_size(radial_gradient.gradient_size).to_type<int>();
+            recorder.fill_rect_with_radial_gradient(dest_rect.to_type<int>(), radial_gradient.data, center, size);
+        },
+        [&](ResolvedConicGradient const& conic_gradient) {
+            auto position = device_pixel_converter.rounded_device_point(conic_gradient.position).to_type<int>();
+            recorder.fill_rect_with_conic_gradient(dest_rect.to_type<int>(), conic_gradient.data, position);
+        });
+}
+
+void record_image_paint(DisplayListRecordingContext& context, ImagePaint const& image_paint, Gfx::FloatRect dest_rect, CSS::ImageRendering image_rendering)
+{
+    record_image_paint_with_recorder(context.display_list_recorder(), context.device_pixel_converter(), image_paint, dest_rect, image_rendering);
+}
+
+NonnullRefPtr<DisplayList> record_image_paint_display_list(ImagePaint const& image_paint, Gfx::FloatRect dest_rect, CSS::ImageRendering image_rendering, double device_pixels_per_css_pixel, AccumulatedVisualContextTree const& visual_context_tree, DisplayListResourceStorage& resource_storage)
+{
+    auto display_list = DisplayList::create(visual_context_tree);
+    DisplayListRecorder recorder(display_list, visual_context_tree, resource_storage);
+    record_image_paint_with_recorder(recorder, DevicePixelConverter { device_pixels_per_css_pixel }, image_paint, dest_rect, image_rendering);
+    return display_list;
+}
+
+}

--- a/Libraries/LibWeb/Painting/ImagePaint.h
+++ b/Libraries/LibWeb/Painting/ImagePaint.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Variant.h>
+#include <LibGC/Ptr.h>
+#include <LibGfx/DecodedImageFrame.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/Size.h>
+#include <LibWeb/CSS/Enums.h>
+#include <LibWeb/CSS/PreferredColorScheme.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/GradientData.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Painting {
+
+struct ImagePaint {
+    struct DecodedFrame {
+        Gfx::DecodedImageFrame frame;
+        Gfx::IntSize natural_size;
+    };
+    struct NestedDisplayList {
+        DisplayListResource resource;
+        Gfx::IntSize list_size;
+    };
+    Variant<DecodedFrame, NestedDisplayList, LinearGradientData, ResolvedRadialGradient, ResolvedConicGradient> value;
+};
+
+struct ImagePaintRequest {
+    GC::Ref<DOM::Document const> document;
+    Gfx::FloatRect dest_rect;
+    CSS::ImageRendering image_rendering;
+    CSS::PreferredColorScheme color_scheme;
+    Gfx::FloatSize accumulated_scale;
+    DisplayListResourceStorage& resource_storage;
+};
+
+WEB_API ImagePaintRequest image_paint_request_for_recording(DisplayListRecordingContext&, DOM::Document const&, Gfx::FloatRect dest_rect, CSS::ImageRendering, CSS::PreferredColorScheme);
+
+WEB_API void record_image_paint(DisplayListRecordingContext&, ImagePaint const&, Gfx::FloatRect dest_rect, CSS::ImageRendering);
+
+WEB_API NonnullRefPtr<DisplayList> record_image_paint_display_list(ImagePaint const&, Gfx::FloatRect dest_rect, CSS::ImageRendering, double device_pixels_per_css_pixel, AccumulatedVisualContextTree const&, DisplayListResourceStorage&);
+
+}

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/ImagePaint.h>
 #include <LibWeb/Painting/ImagePaintable.h>
 #include <LibWeb/Painting/ReplacedElementCommon.h>
 
@@ -54,7 +55,9 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
                     context.display_list_recorder().save();
                     context.display_list_recorder().add_clip_rect(image_int_rect_device_pixels);
                 }
-                decoded_image_data->paint(context, draw_rect.to_type<float>(), layout_node().image_rendering(), layout_node().color_scheme());
+                auto request = image_paint_request_for_recording(context, layout_node().document(), draw_rect.to_type<float>(), layout_node().image_rendering(), layout_node().color_scheme());
+                if (auto image_paint = decoded_image_data->image_paint(request); image_paint.has_value())
+                    record_image_paint(context, *image_paint, request.dest_rect, layout_node().image_rendering());
                 if (draw_rect_needs_clip)
                     context.display_list_recorder().restore();
             }

--- a/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/ImagePaint.h>
 #include <LibWeb/Painting/ReplacedElementCommon.h>
 #include <LibWeb/Painting/SVGImagePaintable.h>
 #include <LibWeb/SVG/SVGImageElement.h>
@@ -67,7 +68,9 @@ void SVGImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase p
         context.display_list_recorder().add_clip_rect(image_rect);
     }
 
-    decoded_image_data->paint(context, draw_rect, layout_box().image_rendering(), layout_box().color_scheme());
+    auto request = image_paint_request_for_recording(context, layout_box().document(), draw_rect, layout_box().image_rendering(), layout_box().color_scheme());
+    if (auto image_paint = decoded_image_data->image_paint(request); image_paint.has_value())
+        record_image_paint(context, *image_paint, request.dest_rect, layout_box().image_rendering());
 
     if (draw_rect_needs_clip)
         context.display_list_recorder().restore();

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -509,14 +509,14 @@ void SVGDecodedImageData::invalidate_cached_rendering()
     prune_cached_display_list_resources();
 }
 
-void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::FloatRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme color_scheme) const
+Optional<Painting::ImagePaint> SVGDecodedImageData::image_paint(Painting::ImagePaintRequest const& request) const
 {
     // The destination rect is in the recording's local units, which the visual context chain may
     // magnify arbitrarily (an SVG viewport's user units, a CSS transform); the raster resolution
     // follows the accumulated on-screen scale so the replayed content stays sharp.
-    auto const& recorder = context.display_list_recorder();
-    auto accumulated_scale = recorder.visual_context_tree().accumulated_2d_scale(
-        recorder.accumulated_visual_context(), Painting::ScrollStateSnapshot {}, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+    auto dst_rect = request.dest_rect;
+    auto accumulated_scale = request.accumulated_scale;
+    auto color_scheme = request.color_scheme;
     constexpr int maximum_raster_dimension = 16384;
     auto raster_dimension = [&](float local_size, float scale) {
         if (!(scale > 0))
@@ -535,7 +535,7 @@ void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::Float
     Optional<Painting::DisplayListResource> display_list;
     Gfx::IntSize list_size;
     if (m_root_element->active_view_box().has_value()) {
-        display_list = record_display_list(raster_size, color_scheme, context.display_list_recorder().resource_storage());
+        display_list = record_display_list(raster_size, color_scheme, request.resource_storage);
         list_size = raster_size;
     } else {
         auto css_size = CSSPixelSize {
@@ -547,16 +547,16 @@ void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::Float
             raster_scale = 1;
         auto maximum_raster_scale = static_cast<float>(maximum_raster_dimension) / max(css_size.width(), css_size.height()).to_float();
         raster_scale = min(raster_scale, maximum_raster_scale);
-        display_list = record_display_list_at_scale(css_size, raster_scale, color_scheme, context.display_list_recorder().resource_storage());
+        display_list = record_display_list_at_scale(css_size, raster_scale, color_scheme, request.resource_storage);
         list_size = {
             max(1, static_cast<int>(lroundf(css_size.width().to_float() * raster_scale))),
             max(1, static_cast<int>(lroundf(css_size.height().to_float() * raster_scale))),
         };
     }
     if (!display_list.has_value())
-        return;
+        return {};
 
-    context.display_list_recorder().paint_nested_display_list(*display_list, dst_rect, list_size);
+    return Painting::ImagePaint { Painting::ImagePaint::NestedDisplayList { .resource = *display_list, .list_size = list_size } };
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -45,7 +45,7 @@ public:
     virtual void finalize() override;
     virtual size_t external_memory_size() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::FloatRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
+    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const override;
 
     // The scheme the SVG document currently answers `prefers-color-scheme` with. Held on the image
     // rather than on the page, because the page is shared with every other image.


### PR DESCRIPTION
Image style values and decoded image data used to paint themselves: each override took a DisplayListRecordingContext and appended its own display list commands, spreading the recorder dependency across CSS, HTML and SVG image code even though every override ultimately produced one of a handful of command shapes.

Image code no longer touches a recorder, so any producer of display lists can ask an image how it paints. This is preparatory work for rewriting the painting subsystem in Rust: display-list recording moves behind this seam, while style values and decoded image data keep answering the same image_paint() question from C++.