### PR TITLE
LibWeb: Reduce overhead in some common DOM and parser paths

### DIFF
--- a/Libraries/LibWeb/Bindings/Wrappable.cpp
+++ b/Libraries/LibWeb/Bindings/Wrappable.cpp
@@ -181,9 +181,16 @@ JS::Realm& wrapper_realm_for_wrappable(WrapperWorld const& wrapper_world, JS::Re
 
 GC::Ref<PlatformObject> wrap(WrapperWorld& wrapper_world, JS::Realm& preferred_realm, GC::Ref<Wrappable> wrappable)
 {
+    if (wrapper_world.is_main_world()) {
+        if (auto cached_wrapper = wrappable->cached_main_world_wrapper(wrapper_world))
+            return *cached_wrapper;
+    }
+
     auto& actual_wrapper_realm = wrapper_realm_for_wrappable(wrapper_world, preferred_realm, wrappable);
-    if (auto cached_wrapper = wrapper_world.wrapper_for(wrappable, actual_wrapper_realm))
-        return *cached_wrapper;
+    if (!wrapper_world.is_main_world()) {
+        if (auto cached_wrapper = wrapper_world.wrapper_for(wrappable, actual_wrapper_realm))
+            return *cached_wrapper;
+    }
 
     auto wrapper = wrappable->create_wrapper(actual_wrapper_realm);
 #ifndef NDEBUG

--- a/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/CustomElementInvalidator.cpp
@@ -15,6 +15,9 @@ namespace Web::CSS::Invalidation {
 
 void invalidate_style_after_custom_element_state_change(DOM::Element& element)
 {
+    if (element.style_node_id() == 0)
+        return;
+
     record_element_state_changed(element, PseudoClass::Defined, element.is_defined());
     record_element_state_changed(element, PseudoClass::Enabled, SelectorMatching::element_matches_state(element, PseudoClass::Enabled));
     record_element_state_changed(element, PseudoClass::Disabled, SelectorMatching::element_matches_state(element, PseudoClass::Disabled));

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5608,24 +5608,24 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
     // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:concept-element-attributes-change-ext
     // 1. If localName is not attr or namespace is not null, then return.
     // 2. Set element's explicitly set attr-element to null.
-#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute)    \
-    else if (local_name == ARIA::AttributeNames::referencing_attribute) \
-    {                                                                   \
-        set_##attribute({});                                            \
+    if (local_name.view().starts_with(u"aria-"sv)) {
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
+    if (local_name == ARIA::AttributeNames::referencing_attribute) { \
+        set_##attribute({});                                         \
     }
-    ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
+        ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 
-    // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:concept-element-attributes-change-ext-2
-    // 1. If localName is not attr or namespace is not null, then return.
-    // 2. Set element's explicitly set attr-elements to null.
-#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute)    \
-    else if (local_name == ARIA::AttributeNames::referencing_attribute) \
-    {                                                                   \
-        set_##attribute({});                                            \
+        // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:concept-element-attributes-change-ext-2
+        // 1. If localName is not attr or namespace is not null, then return.
+        // 2. Set element's explicitly set attr-elements to null.
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
+    if (local_name == ARIA::AttributeNames::referencing_attribute) { \
+        set_##attribute({});                                         \
     }
-    ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
+        ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
+    }
 
     // Every attribute mutation publishes its own typed effects: a selector feature always, and for
     // some names an element declaration or an attr() input as well. Routing sends each to its own

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementName.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementName.cpp
@@ -12,6 +12,11 @@ namespace Web::HTML {
 
 bool is_valid_custom_element_name(Utf16View const& name)
 {
+    // OPTIMIZATION: A valid custom element name must contain a hyphen. Check this first so ordinary built-in element
+    //               names do not need the more expensive element local name validation below.
+    if (!name.contains('-'))
+        return false;
+
     // A string name is a valid custom element name if all of the following are true:
     // - name is a valid element local name;
     if (!DOM::is_valid_element_local_name(name))
@@ -24,16 +29,13 @@ bool is_valid_custom_element_name(Utf16View const& name)
     // - name does not contain any ASCII upper alphas;
     // - name contains a U+002D (-); and
     bool contains_ascii_upper_alpha = false;
-    bool contains_hyphen = false;
     for (auto code_point : name) {
         if (is_ascii_upper_alpha(code_point)) {
             contains_ascii_upper_alpha = true;
             break;
         }
-        if (code_point == '-')
-            contains_hyphen = true;
     }
-    if (contains_ascii_upper_alpha || !contains_hyphen)
+    if (contains_ascii_upper_alpha)
         return false;
 
     // - name is not one of the following:

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -539,6 +539,11 @@ GC::Ptr<CustomElementDefinition> look_up_a_custom_element_definition(GC::Ptr<Cus
     if (namespace_ != Namespace::HTML)
         return nullptr;
 
+    // OPTIMIZATION: Without an `is` value, an ordinary built-in local name cannot match either kind of custom
+    //               element definition. Avoid searching the registry for names that cannot be registered.
+    if (!is.has_value() && !is_valid_custom_element_name(local_name))
+        return nullptr;
+
     // 3. If registry's custom element definition set contains an item with name and local name both equal to
     //    localName, then return that item.
     if (auto maybe_definition = registry->get_definition_with_name_and_local_name(local_name, local_name))

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -878,13 +878,15 @@ void HTMLElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16St
 
     // 1. If namespace is not null, or localName is not the name of an event handler content attribute on element, then return.
     // FIXME: Add the namespace part once we support attribute namespaces.
+    if (name.view().starts_with(u"on"sv)) {
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)               \
     if (name == HTML::AttributeNames::attribute_name) {       \
         element_event_handler_attribute_changed(name, value); \
     }
-    ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
+        ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
+    }
 
     [&]() {
         // https://html.spec.whatwg.org/multipage/popover.html#the-popover-attribute:concept-element-attributes-change-ext

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -2245,7 +2245,9 @@ void HTMLElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor
 
     // 5. If removedNode's popover attribute is not in the No Popover state, then run the hide popover algorithm given
     //    removedNode, false, false, false, true, and null.
-    if (popover().has_value())
+    // OPTIMIZATION: The hide popover algorithm immediately returns for a hidden popover, so avoid parsing the
+    //               attribute unless removal can actually hide it.
+    if (popover_visibility_state() == PopoverVisibilityState::Showing)
         MUST(hide_popover(FocusPreviousElement::No, FireEvents::No, ThrowExceptions::No, IgnoreDomState::Yes, nullptr));
 
     // AD-HOC: Update inertness

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -547,9 +547,14 @@ impl TreeBuilder {
         // SAFETY: TreeBuilder is only constructed with a tokenizer pointer owned by the C++
         // HTMLParser's Rust tokenizer handle, and the handle outlives each parser run.
         unsafe {
-            self.tokenizer
-                .as_mut()
-                .next_token(stop_at_insertion_point, cdata_allowed)
+            let tokenizer = self.tokenizer.as_mut();
+            if !stop_at_insertion_point && let Some((code_point, position)) = tokenizer.try_fast_data_char() {
+                let mut token = Token::new_character(code_point);
+                token.start_position = position;
+                token.end_position = position;
+                return Some(token);
+            }
+            tokenizer.next_token(stop_at_insertion_point, cdata_allowed)
         }
     }
 
@@ -561,6 +566,33 @@ impl TreeBuilder {
 
     fn run(&mut self, stop_at_insertion_point: bool) {
         loop {
+            if !stop_at_insertion_point
+                && !self.next_line_feed_can_be_ignored
+                && self.insertion_mode == InsertionMode::InBody
+                && self
+                    .adjusted_current_node()
+                    .is_some_and(|node| node.namespace_ == RustFfiHtmlNamespace::Html)
+            {
+                // SAFETY: TreeBuilder is only constructed with a tokenizer pointer owned by the
+                // C++ HTMLParser's Rust tokenizer handle, and the handle outlives each parser run.
+                let has_fast_data_run = unsafe { self.tokenizer.as_ref().has_fast_data_run() };
+                if has_fast_data_run {
+                    self.reconstruct_the_active_formatting_elements();
+                    // SAFETY: See above. Reconstructing the active formatting elements does not
+                    // run the tokenizer, so the same Data-state run is still available.
+                    let contains_non_whitespace = unsafe {
+                        self.tokenizer
+                            .as_mut()
+                            .try_fast_data_run(&mut self.pending_text)
+                            .unwrap()
+                    };
+                    if contains_non_whitespace {
+                        self.frameset_ok = false;
+                    }
+                    continue;
+                }
+            }
+
             let cdata_allowed = self
                 .adjusted_current_node()
                 .is_some_and(|node| node.namespace_ != RustFfiHtmlNamespace::Html);

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -3047,7 +3047,6 @@ impl TreeBuilder {
     fn insert_html_element_for_document(&mut self, token: &Token, document: usize) -> usize {
         self.flush_character_insertions();
         let attributes = attributes_from_token(token, RustFfiHtmlNamespace::Html);
-        let owned_attributes = owned_attributes_from_token(token, RustFfiHtmlNamespace::Html);
         let local_name = token.tag_name();
         let element = self.create_element(
             document,
@@ -3064,7 +3063,7 @@ impl TreeBuilder {
             local_name: local_name.to_string(),
             namespace_: RustFfiHtmlNamespace::Html,
             namespace_uri: None,
-            attributes: owned_attributes,
+            attributes: Vec::new(),
             template_content: None,
         });
         element
@@ -3089,7 +3088,11 @@ impl TreeBuilder {
         let adjusted_insertion_location = self.appropriate_place_for_inserting_node(None);
         let local_name = adjusted_foreign_tag_name(token.tag_name(), namespace_);
         let attributes = attributes_from_token(token, namespace_);
-        let owned_attributes = owned_attributes_from_token(token, namespace_);
+        let owned_attributes = if namespace_ == RustFfiHtmlNamespace::MathMl && local_name == "annotation-xml" {
+            owned_attributes_from_token(token, namespace_)
+        } else {
+            Vec::new()
+        };
         let namespace_uri = if namespace_ == RustFfiHtmlNamespace::Other {
             self.adjusted_current_node()
                 .and_then(|node| node.namespace_uri.as_ref())

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/tokenizer.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/tokenizer.rs
@@ -584,6 +584,67 @@ impl HtmlTokenizer {
         Some((cp, pos))
     }
 
+    /// Append a run of ordinary ASCII characters from the Data state to
+    /// `output`. The caller can process the run as character tokens without
+    /// constructing and dispatching a `Token` for each code point.
+    #[inline(always)]
+    pub fn try_fast_data_run(&mut self, output: &mut String) -> Option<bool> {
+        if !self.has_fast_data_run() {
+            return None;
+        }
+
+        let start_offset = self.current_offset;
+        let input_len = self.fast_scan_limit();
+        let mut offset = start_offset;
+        let mut contains_non_whitespace = false;
+        while offset < input_len {
+            let code_point = self.input[offset];
+            if code_point == 0x3C
+                || code_point == 0x26
+                || code_point == 0x00
+                || code_point == 0x0D
+                || code_point >= 0x80
+            {
+                break;
+            }
+            if !is_whitespace(code_point) {
+                contains_non_whitespace = true;
+            }
+            offset += 1;
+        }
+        if offset == start_offset {
+            self.sync_source_positions();
+            return None;
+        }
+
+        output.reserve(offset - start_offset);
+        for &code_point in &self.input[start_offset..offset] {
+            // SAFETY: The scan above only accepts ASCII code points.
+            unsafe { output.as_mut_vec().push(code_point as u8) };
+            if code_point == 0x0A {
+                self.current_line += 1;
+                self.current_column = 0;
+            } else {
+                self.current_column += 1;
+            }
+        }
+        self.prev_offset = offset - 1;
+        self.current_offset = offset;
+        Some(contains_non_whitespace)
+    }
+
+    #[inline(always)]
+    pub fn has_fast_data_run(&self) -> bool {
+        if self.aborted || self.state != State::Data || !self.queued_tokens.is_empty() {
+            return false;
+        }
+        if self.current_offset >= self.fast_scan_limit() {
+            return false;
+        }
+        let code_point = self.input[self.current_offset];
+        code_point != 0x3C && code_point != 0x26 && code_point != 0x00 && code_point != 0x0D && code_point < 0x80
+    }
+
     /// Resynchronise `source_positions` with the scalar current_line /
     /// current_column after a run of fast-path character emissions.
     #[inline(always)]

--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicyFactory.cpp
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicyFactory.cpp
@@ -314,7 +314,8 @@ Optional<TrustedTypeData> get_trusted_type_data_for_attribute(ElementInterface c
     auto const& [element_name, element_ns] = element;
 
     // 2. If attributeNs is null, « HTML namespace, SVG namespace, MathML namespace » contains element’s namespace, and attribute is the name of an event handler content attribute:
-    if (!attribute_ns.has_value()
+    if (attribute.starts_with("on"sv)
+        && !attribute_ns.has_value()
         && (Namespace::HTML == element_ns || Namespace::SVG == element_ns || Namespace::MathML == element_ns)) {
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)                                                                                                                        \
@@ -326,6 +327,10 @@ Optional<TrustedTypeData> get_trusted_type_data_for_attribute(ElementInterface c
         ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
     }
+
+    // OPTIMIZATION: Every remaining row has one of these three attribute names.
+    if (!attribute.is_one_of(HTML::AttributeNames::srcdoc, HTML::AttributeNames::src, HTML::AttributeNames::href))
+        return {};
 
     static auto const& table = *new Vector<TrustedTypeData> {
         { "HTMLIFrameElement"_utf16, {}, HTML::AttributeNames::srcdoc, TrustedTypeName::TrustedHTML, InjectionSink::HTMLIFrameElement_srcdoc },


### PR DESCRIPTION
Process ordinary parser text in runs, retain stack attributes only where the tree builder needs them, and reject impossible custom element lookups early. Filter attribute-name checks by relevant prefixes, skip state and popover work when it cannot have an effect, and return cached main-world wrappers before rediscovering their realm.

These changes preserve existing behavior while reducing lookups, allocations, and per-character parser dispatch.

```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  53.54 ± 3.75  54.98 ± 7.27                1.027  9.36 ± 0.45            9.01 ± 0.68                1.038
Speedometer3  2.94 ± 0.20   2.93 ± 0.74                 0.999  9.34 ± 0.74            9.15 ± 1.32                1.021
StyleBench    48.31 ± 4.29  50.21 ± 8.97                1.039  5.19 ± 0.56            4.99 ± 1.03                1.041
```