### PR TITLE
LibWeb: Collapse equivalent `contain` lists to keywords when computing

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1419,17 +1419,6 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
 
         // -> Any other property
         //    The resolved value is the computed value.
-    case PropertyID::Contain: {
-        auto contain = layout_node.contain();
-        if (contain.layout_containment && contain.style_containment && contain.paint_containment) {
-            if (contain.size_containment)
-                return KeywordStyleValue::create(Keyword::Strict);
-            if (!contain.inline_size_containment)
-                return KeywordStyleValue::create(Keyword::Content);
-        }
-
-        return get_computed_value(property_id);
-    }
     case PropertyID::WebkitTextFillColor:
         return resolve_color_style_value(*get_computed_value(property_id), layout_node.webkit_text_fill_color(), &color_resolution_context);
     case PropertyID::LetterSpacing: {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1598,8 +1598,7 @@
     "animation-type": "none",
     "inherited": false,
     "initial": "none",
-    "needs-layout-node-for-resolved-value": true,
-    "requires-computation": "never",
+    "requires-computation": "cascaded-value",
     "valid-types": [
       "contain"
     ]

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -6184,6 +6184,43 @@ static NonnullRefPtr<StyleValue const> compute_style_value_list(NonnullRefPtr<St
     return StyleValueList::create(move(computed_entries), StyleValueList::Separator::Comma);
 }
 
+// https://drafts.csswg.org/css-contain-2/#contain-property
+static NonnullRefPtr<StyleValue const> collapse_containment_list(NonnullRefPtr<StyleValue const> const& style_value)
+{
+    auto const* containment_list = as_if<StyleValueList>(*style_value);
+    if (!containment_list)
+        return style_value;
+
+    bool contains_size = false;
+    bool contains_layout = false;
+    bool contains_style = false;
+    bool contains_paint = false;
+
+    for (auto const& containment : containment_list->values()) {
+        switch (containment->to_keyword()) {
+        case Keyword::Size:
+            contains_size = true;
+            break;
+        case Keyword::Layout:
+            contains_layout = true;
+            break;
+        case Keyword::Style:
+            contains_style = true;
+            break;
+        case Keyword::Paint:
+            contains_paint = true;
+            break;
+        default:
+            return style_value;
+        }
+    }
+
+    if (!contains_layout || !contains_style || !contains_paint)
+        return style_value;
+
+    return KeywordStyleValue::create(contains_size ? Keyword::Strict : Keyword::Content);
+}
+
 static NonnullRefPtr<StyleValue const> repeat_style_value_list_to_n_elements(NonnullRefPtr<StyleValue const> const& style_value, size_t n)
 {
     auto const& value_list = style_value->as_value_list();
@@ -6233,6 +6270,8 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(
     case PropertyID::BorderTopWidth:
     case PropertyID::OutlineWidth:
         return compute_border_or_outline_width(absolutized_value, device_pixels_per_css_pixel);
+    case PropertyID::Contain:
+        return collapse_containment_list(absolutized_value);
     case PropertyID::CornerBottomLeftShape:
     case PropertyID::CornerBottomRightShape:
     case PropertyID::CornerTopLeftShape:

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2356,6 +2356,42 @@ fn compute_position_area(value: &StyleValueData) -> Option<Arc<StyleValueData>> 
     }))
 }
 
+// https://drafts.csswg.org/css-contain-2/#contain-property
+#[allow(clippy::arc_with_non_send_sync)]
+fn collapse_containment_list(value: &StyleValueData) -> Option<Arc<StyleValueData>> {
+    let StyleValueData::ValueList { values, .. } = value else {
+        return None;
+    };
+
+    let mut contains_size = false;
+    let mut contains_layout = false;
+    let mut contains_style = false;
+    let mut contains_paint = false;
+
+    for containment in values.as_slice() {
+        match containment.data() {
+            StyleValueData::Keyword { keyword } if *keyword == keyword::SIZE => contains_size = true,
+            StyleValueData::Keyword { keyword } if *keyword == keyword::LAYOUT => contains_layout = true,
+            StyleValueData::Keyword { keyword } if *keyword == keyword::STYLE => contains_style = true,
+            StyleValueData::Keyword { keyword } if *keyword == keyword::PAINT => contains_paint = true,
+            _ => return None,
+        }
+    }
+
+    if !contains_layout || !contains_style || !contains_paint {
+        return None;
+    }
+
+    let collapsed_keyword = if contains_size {
+        keyword::STRICT
+    } else {
+        keyword::CONTENT
+    };
+    Some(Arc::new(StyleValueData::Keyword {
+        keyword: collapsed_keyword,
+    }))
+}
+
 /// The per-longhand initial values as shared Rust value identities.
 struct InitialValueTable {
     values: Vec<crate::css::style_value::RetainedStyleValueData>,
@@ -2747,6 +2783,7 @@ fn property_has_dedicated_compute_rule(property_id: u16) -> bool {
             | prop::BORDER_LEFT_WIDTH
             | prop::BORDER_RIGHT_WIDTH
             | prop::BORDER_TOP_WIDTH
+            | prop::CONTAIN
             | prop::OUTLINE_WIDTH
             | prop::CORNER_BOTTOM_LEFT_SHAPE
             | prop::CORNER_BOTTOM_RIGHT_SHAPE
@@ -4044,6 +4081,10 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                             None => NativeValue::Unsupported,
                         }
                     }
+                    (_, prop::CONTAIN) => match collapse_containment_list(value_data) {
+                        Some(value) => NativeValue::StyleValue(value),
+                        None => NativeValue::Unchanged,
+                    },
                     (Some(absolutized), _) if !property_has_dedicated_compute_rule(inherited_property_id) => {
                         match absolutized {
                             Some(px) => NativeValue::Px(px),

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-contain-list-collapse.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-contain-list-collapse.txt
@@ -1,0 +1,8 @@
+layout style paint: resolved=content computed=content
+content: resolved=content computed=content
+size style layout paint: resolved=strict computed=strict
+strict: resolved=strict computed=strict
+inline-size layout style paint: resolved=inline-size layout style paint computed=inline-size layout style paint
+size layout paint: resolved=size layout paint computed=size layout paint
+layout style paint without layout node: resolved=content computed=content
+strict without layout node: resolved=strict computed=strict

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-contain-list-collapse.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-contain-list-collapse.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<div id="target"></div>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        const printContain = (label) => {
+            const computed = target.computedStyleMap().get("contain").toString();
+            println(`${label}: resolved=${getComputedStyle(target).contain} computed=${computed}`);
+        };
+
+        target.style.contain = "layout style paint";
+        printContain("layout style paint");
+        target.style.contain = "content";
+        printContain("content");
+        target.style.contain = "size style layout paint";
+        printContain("size style layout paint");
+        target.style.contain = "strict";
+        printContain("strict");
+        target.style.contain = "inline-size layout style paint";
+        printContain("inline-size layout style paint");
+        target.style.contain = "size layout paint";
+        printContain("size layout paint");
+
+        target.style.display = "none";
+        target.style.contain = "layout style paint";
+        printContain("layout style paint without layout node");
+        target.style.contain = "strict";
+        printContain("strict without layout node");
+    });
+</script>


### PR DESCRIPTION
A containment list equivalent to `strict` or `content` now computes to that keyword, so a containment set has a single computed value. Previously, the specified form survived computation and the resolved value collapsed the list only when serializing, which required a layout node.

This fixes a crash in the `css/css-contain/parsing/contain-computed.html` imported WPT when it is run with the `LIBWEB_VERIFY_STYLE_DIFF_FAST_PATH` flag enabled.