### PR TITLE
LibWeb: Canonicalize editing carets in comments

### DIFF
--- a/Libraries/LibWeb/Selection/CaretNavigation.cpp
+++ b/Libraries/LibWeb/Selection/CaretNavigation.cpp
@@ -7,9 +7,11 @@
 #include <AK/Platform.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
+#include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Editing/Internal/Algorithms.h>
@@ -273,7 +275,15 @@ CaretLocation CaretNavigator::canonical_location_for_editing(CaretLocation const
         return (previous_sibling && Editing::is_prohibited_paragraph_child(const_cast<DOM::Node&>(*previous_sibling)))
             || (next_sibling && Editing::is_prohibited_paragraph_child(const_cast<DOM::Node&>(*next_sibling)));
     };
-    if (is_formatting_whitespace(*node)) {
+    if (is<DOM::Comment>(*node) || is<DOM::ProcessingInstruction>(*node)) {
+        // INTEROP: Comments and processing instructions cannot contain rendered carets, and DOM range insertion
+        //          rejects them. Normalize the caret to the parent boundary immediately before the node, matching the
+        //          insertParagraph command's comment handling and giving insertion commands a valid boundary.
+        if (!node->parent())
+            return location;
+        offset = node->index();
+        node = *node->parent();
+    } else if (is_formatting_whitespace(*node)) {
         // INTEROP: Source indentation between block children of an editing host is not a rendered caret position.
         //          Blink and WebKit associate it with the following paragraph, or the preceding paragraph when the
         //          whitespace trails the final block.

--- a/Tests/LibWeb/Crash/Editing/execCommand-comment-boundary.html
+++ b/Tests/LibWeb/Crash/Editing/execCommand-comment-boundary.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<div contenteditable><!----></div>
+<script>
+    getSelection().setPosition(document.querySelector("div").firstChild);
+    document.execCommand("insertImage", false, "x");
+</script>

--- a/Tests/LibWeb/Crash/Editing/execCommand-insertions-at-invisible-boundary.html
+++ b/Tests/LibWeb/Crash/Editing/execCommand-insertions-at-invisible-boundary.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<div contenteditable></div>
+<script>
+    const host = document.querySelector("div");
+    for (const [command, value, offset] of [
+        ["insertHorizontalRule", "", 1],
+        ["insertHTML", "x", 1],
+        ["insertLineBreak", "", 1],
+        ["insertText", "x", 1],
+    ]) {
+        host.innerHTML = "<!--xy-->";
+        getSelection().setPosition(host.firstChild, offset);
+        document.execCommand(command, false, value);
+    }
+
+    const processingInstruction = document.createProcessingInstruction("x", "y");
+    host.replaceChildren(processingInstruction);
+    getSelection().setPosition(processingInstruction);
+    document.execCommand("insertImage", false, "x");
+</script>

--- a/Tests/LibWeb/Text/expected/Editing/editing-caret-canonicalization.txt
+++ b/Tests/LibWeb/Text/expected/Editing/editing-caret-canonicalization.txt
@@ -5,6 +5,7 @@ typing at host start before a list: "<ul><li>xone</li><li>two</li></ul>" sel=#te
 formatBlock at host start: "<h2>alpha</h2>" sel=#text@0->#text@0
 bold toggle at host start: "<b>bold</b>rest" sel=host@0->host@0
 undo restores canonical caret: "<div>alpha</div>" sel=#text@0->#text@0
+typing in a comment: "ax<!--xy-->b" sel=#text@2->#text@2
 paste at equivalent text edge: "<div><strong>:</strong>pasted) rest</div>" sel=#text@6->#text@6
 undo restores upstream caret: "<div><strong>:</strong>) rest</div>" sel=#text@1->#text@1
 typing after a real line break: "<div>one<br>xtwo</div>" sel=#text@1->#text@1

--- a/Tests/LibWeb/Text/input/Editing/editing-caret-canonicalization.html
+++ b/Tests/LibWeb/Text/input/Editing/editing-caret-canonicalization.html
@@ -64,6 +64,13 @@
         document.execCommand("undo");
         println(`undo restores canonical caret: ${JSON.stringify(host.innerHTML)} sel=${selectionString()}`);
 
+        // Comments have no rendered caret position. Chrome and Firefox insert text immediately before a comment when
+        // the script-provided caret is inside it, regardless of the comment offset.
+        newHost("a<!--xy-->b");
+        sel.collapse(host.childNodes[1], 1);
+        document.execCommand("insertText", false, "x");
+        println(`typing in a comment: ${JSON.stringify(host.innerHTML)} sel=${selectionString()}`);
+
         // Capturing the upstream equivalent for history must not move the live caret before the edit. Chromium
         // inserts at the text boundary selected by script, then restores the equivalent preceding text edge on undo.
         newHost("<div><strong>:</strong>) rest</div>");


### PR DESCRIPTION
Comments and processing instructions have no rendered caret, so insertion commands use their parent boundary.

Fixes #11203.