### PR TITLE
LibWeb: Don't block rendering after the body element is removed

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5929,7 +5929,7 @@ void Document::abort_a_document_and_its_descendants()
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#active-parser
-GC::Ptr<HTML::HTMLParser> Document::active_parser()
+GC::Ptr<HTML::HTMLParser> Document::active_parser() const
 {
     if (!m_parser)
         return nullptr;
@@ -8365,7 +8365,12 @@ bool Document::is_render_blocked() const
     if (!m_pending_css_import_rules.is_empty())
         return true;
 
-    return !m_render_blocking_elements.is_empty() || allows_adding_render_blocking_elements();
+    if (!m_render_blocking_elements.is_empty())
+        return true;
+
+    // AD-HOC: A document can only be render blocked before the body element is inserted. We check that the parser is
+    //         still active so that the document doesn't become render blocked if the body element is later removed.
+    return allows_adding_render_blocking_elements() && active_parser();
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#allows-adding-render-blocking-elements

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -878,7 +878,7 @@ public:
     void unload_a_document_and_its_descendants(GC::Ptr<Document> new_document, GC::Ptr<GC::Function<void()>> after_all_unloads = {});
 
     // https://html.spec.whatwg.org/multipage/dom.html#active-parser
-    GC::Ptr<HTML::HTMLParser> active_parser();
+    GC::Ptr<HTML::HTMLParser> active_parser() const;
 
     // https://html.spec.whatwg.org/multipage/dom.html#load-timing-info
     DocumentLoadTimingInfo& load_timing_info() { return m_load_timing_info; }

--- a/Tests/LibWeb/Crash/wpt-import/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/html/dom/render-blocking/render-blocking-during-update-the-rendering-crash.html
@@ -1,0 +1,11 @@
+<body>
+    <link rel="help" href="https://github.com/servo/servo/issues/46303">
+    <div id="container">
+        <link id="link" href="x">
+    </div>
+
+    <script>
+        document.replaceChild(container, document.childNodes[0]);
+        requestAnimationFrame(() => { link.rel = "stylesheet" });
+    </script>
+</body>


### PR DESCRIPTION
Previously, a HTML document whose body element was null counted as render-blocked. This included documents whose body element was removed after parsing finished. In this case, animation frame callbacks stopped running and screenshot requests were never served. We now require the parser not to be active for a document to be considered render blocking.

I found this when trying to import https://wpt.live/css/css-pseudo/first-letter-of-html-root-refcrash.html after fixing an otherwise unrelated issue.