### PR TITLE
CI: Do not install binaries for web-benchmarks

### DIFF
--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -102,9 +102,7 @@ jobs:
 
       - name: 'Build'
         working-directory: ${{ github.workspace }}/Build
-        run: |
-          cmake --build .
-          cmake --install . --strip --prefix "${GITHUB_WORKSPACE}/Install"
+        run: cmake --build .
 
       - name: 'Save Caches'
         uses: ./.github/actions/cache-save
@@ -124,9 +122,9 @@ jobs:
           python3 -m pip install -r requirements.txt
 
           if [ "${{ matrix.os_name }}" = "macOS" ]; then
-            executable="${GITHUB_WORKSPACE}/Install/bundle/Ladybird.app/Contents/MacOS/Ladybird"
+            executable="${GITHUB_WORKSPACE}/Build/bin/Ladybird.app/Contents/MacOS/Ladybird"
           else
-            executable="${GITHUB_WORKSPACE}/Install/bin/Ladybird"
+            executable="${GITHUB_WORKSPACE}/Build/bin/Ladybird"
           fi
 
           ./run.py --iterations=5 --executable="${executable}"


### PR DESCRIPTION
The `cmake --install` had no sizeable impact on Linux, but on macOS we lost code signing on the installed binaries. Let's not do that. Losing `--strip` has no effect on macOS, on Linux it does reduce the binaries' sizes but does not affect performance.