### PR TITLE
LibWeb: Use enum values for websocket binary types

### DIFF
--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -374,37 +374,42 @@ void WebSocket::on_open()
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
 void WebSocket::on_message(ByteBuffer message, bool is_text)
 {
-    if (m_websocket->ready_state() != Requests::WebSocket::ReadyState::Open)
-        return;
-
     // When a WebSocket message has been received with type type and data data, the user agent must queue a task to follow these steps:
-    HTML::queue_a_task(HTML::Task::Source::WebSocket, nullptr, nullptr, GC::create_function(GC::Heap::the(), [this, message = move(message), is_text] {
+    HTML::queue_a_task(HTML::Task::Source::WebSocket, nullptr, nullptr, GC::create_function(GC::Heap::the(), [this, message = move(message), is_text] mutable {
+        // 1. If ready state is not OPEN (1), then return.
+        if (m_websocket->ready_state() != Requests::WebSocket::ReadyState::Open)
+            return;
+
         auto& realm = HTML::relevant_realm(relevant_global_object());
-        if (is_text) {
-            auto text_message = ByteString(ReadonlyBytes(message));
-            HTML::MessageEventInit event_init;
-            event_init.data = JS::PrimitiveString::create(realm.vm(), Utf16String::from_utf8(StringView { text_message.bytes() }));
-            dispatch_event(HTML::MessageEvent::create(realm.global_object(), HTML::EventNames::message, event_init, m_url.origin()));
-            return;
-        }
 
-        if (m_binary_type == Bindings::BinaryType::Blob) {
-            // type indicates that the data is Binary and binaryType is "blob"
-            HTML::MessageEventInit event_init;
-            event_init.data = Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, FileAPI::Blob::create(move(message), "text/plain;charset=utf-8"_string));
-            dispatch_event(HTML::MessageEvent::create(realm.global_object(), HTML::EventNames::message, event_init, m_url.origin()));
-            return;
-        }
+        // 2. Let dataForEvent be determined by switching on type and binary type:
+        auto data_for_event = [&]() -> JS::Value {
+            // -> type indicates that the data is Text
+            if (is_text) {
+                // a new DOMString containing data
+                return JS::PrimitiveString::create(realm.vm(), Utf16String::from_utf8(message));
+            }
+            // -> type indicates that the data is Binary and binary type is "blob"
+            if (m_binary_type == Bindings::BinaryType::Blob) {
+                // a new Blob object, created in the relevant Realm of the WebSocket object, that represents data as its raw data [FILEAPI]
+                return Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, FileAPI::Blob::create(move(message), "text/plain;charset=utf-8"_string));
+            }
+            // -> type indicates that the data is Binary and binary type is "arraybuffer"
+            if (m_binary_type == Bindings::BinaryType::Arraybuffer) {
+                // a new ArrayBuffer object, created in the relevant Realm of the WebSocket object, whose contents are data
+                return JS::ArrayBuffer::create(realm, move(message));
+            }
 
-        if (m_binary_type == Bindings::BinaryType::Arraybuffer) {
-            // type indicates that the data is Binary and binaryType is "arraybuffer"
-            HTML::MessageEventInit event_init;
-            event_init.data = JS::ArrayBuffer::create(realm, message);
-            dispatch_event(HTML::MessageEvent::create(realm.global_object(), HTML::EventNames::message, event_init, m_url.origin()));
-            return;
-        }
+            VERIFY_NOT_REACHED();
+        }();
 
-        VERIFY_NOT_REACHED();
+        // 3. Fire an event named message at the WebSocket object, using MessageEvent, with the origin attribute
+        //    initialized to the serialization of the WebSocket object’s url’s origin, and the data attribute
+        //    initialized to dataForEvent.
+        HTML::MessageEventInit event_init;
+        event_init.data = data_for_event;
+
+        dispatch_event(HTML::MessageEvent::create(realm.global_object(), HTML::EventNames::message, event_init, m_url.origin()));
     }));
 }
 

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -392,7 +392,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
             // -> type indicates that the data is Binary and binary type is "blob"
             if (m_binary_type == Bindings::BinaryType::Blob) {
                 // a new Blob object, created in the relevant Realm of the WebSocket object, that represents data as its raw data [FILEAPI]
-                return Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, FileAPI::Blob::create(move(message), "text/plain;charset=utf-8"_string));
+                return Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, FileAPI::Blob::create(move(message), Utf16String {}));
             }
             // -> type indicates that the data is Binary and binary type is "arraybuffer"
             if (m_binary_type == Bindings::BinaryType::Arraybuffer) {

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -388,7 +388,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
             return;
         }
 
-        if (m_binary_type == "blob"_utf16) {
+        if (m_binary_type == Bindings::BinaryType::Blob) {
             // type indicates that the data is Binary and binaryType is "blob"
             HTML::MessageEventInit event_init;
             event_init.data = Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, FileAPI::Blob::create(move(message), "text/plain;charset=utf-8"_string));
@@ -396,7 +396,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
             return;
         }
 
-        if (m_binary_type == "arraybuffer"_utf16) {
+        if (m_binary_type == Bindings::BinaryType::Arraybuffer) {
             // type indicates that the data is Binary and binaryType is "arraybuffer"
             HTML::MessageEventInit event_init;
             event_init.data = JS::ArrayBuffer::create(realm, message);
@@ -404,8 +404,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
             return;
         }
 
-        dbgln("Unsupported WebSocket message type {}", m_binary_type);
-        TODO();
+        VERIFY_NOT_REACHED();
     }));
 }
 

--- a/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -15,6 +15,7 @@
 #include <LibRequests/Forward.h>
 #include <LibRequests/WebSocket.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Bindings/WebSocket.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebIDL/Buffers.h>
@@ -56,8 +57,8 @@ public:
     Utf16String extensions() const;
     WebIDL::ExceptionOr<Utf16String> protocol() const;
 
-    Utf16String const& binary_type() { return m_binary_type; }
-    void set_binary_type(Utf16String const& type) { m_binary_type = type; }
+    Bindings::BinaryType binary_type() { return m_binary_type; }
+    void set_binary_type(Bindings::BinaryType binary_type) { m_binary_type = binary_type; }
 
     WebIDL::ExceptionOr<void> close(Optional<u16> code, Optional<Utf16String> reason);
     WebIDL::ExceptionOr<void> send(WebSocketSendData const& data);
@@ -85,7 +86,7 @@ private:
     void update_activity_root();
 
     URL::URL m_url;
-    Utf16String m_binary_type { "blob"_utf16 };
+    Bindings::BinaryType m_binary_type { Bindings::BinaryType::Blob };
     RefPtr<Requests::WebSocket> m_websocket;
     GC::Ref<DOM::EventTarget> m_global_object;
     GC::ActivityRoot m_activity_root;

--- a/Libraries/LibWeb/WebSockets/WebSocket.idl
+++ b/Libraries/LibWeb/WebSockets/WebSocket.idl
@@ -1,3 +1,5 @@
+enum BinaryType { "blob", "arraybuffer" };
+
 // https://websockets.spec.whatwg.org/#websocket
 [Exposed=(Window,Worker)]
 interface WebSocket : EventTarget {
@@ -24,6 +26,6 @@ interface WebSocket : EventTarget {
 
     // messaging
     attribute EventHandler onmessage;
-    attribute Utf16DOMString binaryType;
+    attribute BinaryType binaryType;
     undefined send((BufferSource or Blob or Utf16USVString) data);
 };

--- a/Tests/LibWeb/Text/expected/WebSocket/binary-type.txt
+++ b/Tests/LibWeb/Text/expected/WebSocket/binary-type.txt
@@ -1,0 +1,5 @@
+blob
+blob
+arraybuffer
+arraybuffer
+arraybuffer

--- a/Tests/LibWeb/Text/expected/WebSocket/blob.txt
+++ b/Tests/LibWeb/Text/expected/WebSocket/blob.txt
@@ -1,0 +1,2 @@
+type=""
+text="hello"

--- a/Tests/LibWeb/Text/input/WebSocket/binary-type.html
+++ b/Tests/LibWeb/Text/input/WebSocket/binary-type.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const ws = new WebSocket(`ws://localhost:${internals.getEchoServerPort()}/`);
+        println(ws.binaryType);
+
+        ws.binaryType = "lol";
+        println(ws.binaryType);
+
+        ws.binaryType = "arraybuffer";
+        println(ws.binaryType);
+
+        ws.binaryType = "rofl";
+        println(ws.binaryType);
+
+        // The binaryType is case-sensitive.
+        ws.binaryType = "bLoB";
+        println(ws.binaryType);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/WebSocket/blob.html
+++ b/Tests/LibWeb/Text/input/WebSocket/blob.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const ws = new WebSocket(`ws://localhost:${internals.getEchoServerPort()}/`);
+
+        ws.onopen = () => {
+            ws.onmessage = async ev => {
+                println(`type="${ev.data.type}"`);
+                println(`text="${await ev.data.text()}"`);
+                ws.close();
+            };
+
+            ws.send(new Blob(["hello"], { type: "text/plain" }));
+        };
+
+        ws.onclose = () => {
+            done();
+        };
+    });
+</script>


### PR DESCRIPTION
The `binaryType` property is an enum in the spec's IDL. Update our implementation to match, in order to reject invalid values.

Fixes #11205