### PR TITLE
LibWeb: Cache querySelector results

### DIFF
--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -348,9 +348,19 @@ GC::Ptr<Element const> SelectorQuery::closest(Element const& element) const
 // stopping at the first match.
 GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
 {
+    auto cache_result = [&](GC::Ptr<Element> result) {
+        if (m_is_result_cacheable) {
+            Vector<GC::RawPtr<Element>> elements;
+            if (result)
+                elements.append(*result);
+            root.document().query_selector_result_cache().set(root.document(), root, *this, QuerySelectorResultCache::ResultType::FirstOnly, move(elements));
+        }
+        return result;
+    };
+
     if (m_is_result_cacheable) {
         auto& document = root.document();
-        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this))
+        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this, QuerySelectorResultCache::ResultType::FirstOnly))
             return cached_elements->is_empty() ? nullptr : cached_elements->first().ptr();
     }
 
@@ -358,14 +368,14 @@ GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
         auto& tree_root = as<ParentNode>(root.root());
         if (m_is_result_cacheable) {
             auto& engine = isolated_engine_for(tree_root);
-            return first_match(root, [&](auto& element) { return engine.matches(element, root); });
+            return cache_result(first_match(root, [&](auto& element) { return engine.matches(element, root); }));
         }
         IsolatedSelectorQueryEngine engine(tree_root, m_selectors);
         return first_match(root, [&](auto& element) { return engine.matches(element, root); });
     }
 
     settle_connected_selector_query(root.document());
-    return first_match(root, [&](auto& element) { return matches_in_style_engine(element, root); });
+    return cache_result(first_match(root, [&](auto& element) { return matches_in_style_engine(element, root); }));
 }
 
 static GC::Ref<NodeList> create_node_list(Vector<GC::RawPtr<Element>> const& elements)
@@ -384,7 +394,7 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
     auto& document = root.document();
 
     if (m_is_result_cacheable) {
-        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this))
+        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this, QuerySelectorResultCache::ResultType::All))
             return create_node_list(*cached_elements);
     }
 
@@ -405,7 +415,7 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
 
     auto node_list = create_node_list(elements);
     if (m_is_result_cacheable)
-        document.query_selector_result_cache().set(document, root, *this, move(elements));
+        document.query_selector_result_cache().set(document, root, *this, QuerySelectorResultCache::ResultType::All, move(elements));
     return node_list;
 }
 
@@ -417,7 +427,7 @@ void QuerySelectorResultCache::clear_if_dom_tree_changed(Document const& documen
     m_dom_tree_version = document.dom_tree_version();
 }
 
-Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const& document, ParentNode const& root, SelectorQuery const& query)
+Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const& document, ParentNode const& root, SelectorQuery const& query, ResultType result_type)
 {
     clear_if_dom_tree_changed(document);
 
@@ -431,20 +441,23 @@ Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const&
         m_entries.remove(it);
         return nullptr;
     }
+    if (result_type == ResultType::All && entry.result_type != ResultType::All)
+        return nullptr;
 
     return &entry.elements;
 }
 
-void QuerySelectorResultCache::set(Document const& document, ParentNode const& root, SelectorQuery const& query, Vector<GC::RawPtr<Element>> elements)
+void QuerySelectorResultCache::set(Document const& document, ParentNode const& root, SelectorQuery const& query, ResultType result_type, Vector<GC::RawPtr<Element>> elements)
 {
     static constexpr size_t MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE = 64;
 
     clear_if_dom_tree_changed(document);
 
-    if (m_entries.size() >= MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE)
+    auto key = Key { &root, &query };
+    if (!m_entries.contains(key) && m_entries.size() >= MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE)
         m_entries.remove(m_entries.begin());
 
-    m_entries.set(Key { &root, &query }, Entry { root, query, document.character_data_version(), move(elements) });
+    m_entries.set(key, Entry { root, query, document.character_data_version(), result_type, move(elements) });
 }
 
 void QuerySelectorResultCache::visit_edges(GC::Cell::Visitor&)

--- a/Libraries/LibWeb/DOM/SelectorQuery.h
+++ b/Libraries/LibWeb/DOM/SelectorQuery.h
@@ -64,19 +64,24 @@ private:
     mutable Vector<NonnullOwnPtr<IsolatedSelectorQueryCacheEntry>> m_isolated_engine_cache;
 };
 
-// Caches querySelectorAll element lists per (query root, selector query) so that repeated queries against an
-// unchanged document can skip the subtree walk. Entries are validated lazily against the document's mutation
-// version counters, so no notification on DOM mutation is needed: the whole cache is emptied on first use after
-// dom_tree_version has changed.
+// Caches querySelector first matches and querySelectorAll element lists per (query root, selector query), allowing
+// repeated queries against an unchanged document to skip the subtree walk. Entries are validated lazily against
+// the document's mutation version counters, so no notification on DOM mutation is needed: the whole cache is
+// emptied on first use after dom_tree_version changes.
 class QuerySelectorResultCache {
     AK_MAKE_NONCOPYABLE(QuerySelectorResultCache);
     AK_MAKE_NONMOVABLE(QuerySelectorResultCache);
 
 public:
+    enum class ResultType {
+        FirstOnly,
+        All,
+    };
+
     QuerySelectorResultCache() = default;
 
-    Vector<GC::RawPtr<Element>> const* get(Document const&, ParentNode const& root, SelectorQuery const&);
-    void set(Document const&, ParentNode const& root, SelectorQuery const&, Vector<GC::RawPtr<Element>>);
+    Vector<GC::RawPtr<Element>> const* get(Document const&, ParentNode const& root, SelectorQuery const&, ResultType);
+    void set(Document const&, ParentNode const& root, SelectorQuery const&, ResultType, Vector<GC::RawPtr<Element>>);
     void visit_edges(GC::Cell::Visitor&);
 
 private:
@@ -101,6 +106,7 @@ private:
         NonnullRefPtr<SelectorQuery const> query;
 
         u64 character_data_version { 0 };
+        ResultType result_type { ResultType::FirstOnly };
 
         // Raw pointers are safe here: the elements were descendants of root when cached, and with dom_tree_version
         // unchanged no node in this document has been inserted or removed since, so they are still descendants of

--- a/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
@@ -35,6 +35,20 @@ traveler .y count: 1
 traveler .y count after adopt roundtrip: 2
 querySelector agrees with querySelectorAll[0]: true
 querySelector after remove: true
+connected querySelector found first match: true
+querySelectorAll after connected querySelector: 2
+disconnected querySelector found first match: true
+querySelectorAll after disconnected querySelector: 2
+shadow querySelector found first match: true
+querySelectorAll after shadow querySelector: 2
+fragment querySelector found first match: true
+querySelectorAll after fragment querySelector: 2
+querySelector before tree mutation found match: true
+querySelector after tree mutation found new first: true
+querySelectorAll after tree mutation: 2
+querySelector before character-data mutation found match: true
+querySelector after character-data mutation found new first: true
+querySelectorAll after character-data mutation: 1
 repeated query returns distinct objects: true
 repeated query returns identical non-empty results: true
 querySelector agrees with repeated querySelectorAll[0]: true

--- a/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
@@ -143,6 +143,57 @@
         host.removeChild(firstItem);
         println(`querySelector after remove: ${host.querySelector(".item") === host.querySelectorAll(".item")[0]}`);
 
+        // A cached querySelector result must not be treated as a complete querySelectorAll result.
+        const connectedProbe = document.createElement("div");
+        connectedProbe.innerHTML = `<span class="connected-probe"></span><span class="connected-probe"></span>`;
+        host.appendChild(connectedProbe);
+        const connectedFirst = connectedProbe.querySelector(".connected-probe");
+        println(`connected querySelector found first match: ${connectedFirst === connectedProbe.firstElementChild}`);
+        println(`querySelectorAll after connected querySelector: ${connectedProbe.querySelectorAll(".connected-probe").length}`);
+
+        const disconnectedProbe = document.createElement("div");
+        disconnectedProbe.innerHTML = `<span class="disconnected-probe"></span><span class="disconnected-probe"></span>`;
+        const disconnectedFirst = disconnectedProbe.querySelector(".disconnected-probe");
+        println(`disconnected querySelector found first match: ${disconnectedFirst === disconnectedProbe.firstElementChild}`);
+        println(`querySelectorAll after disconnected querySelector: ${disconnectedProbe.querySelectorAll(".disconnected-probe").length}`);
+
+        const shadowProbeHost = document.createElement("div");
+        host.appendChild(shadowProbeHost);
+        const shadowProbe = shadowProbeHost.attachShadow({ mode: "open" });
+        shadowProbe.innerHTML = `<span class="shadow-probe"></span><span class="shadow-probe"></span>`;
+        const shadowFirst = shadowProbe.querySelector(".shadow-probe");
+        println(`shadow querySelector found first match: ${shadowFirst === shadowProbe.firstElementChild}`);
+        println(`querySelectorAll after shadow querySelector: ${shadowProbe.querySelectorAll(".shadow-probe").length}`);
+
+        const fragmentProbe = document.createDocumentFragment();
+        const fragmentFirstElement = document.createElement("span");
+        fragmentFirstElement.className = "fragment-probe";
+        fragmentProbe.append(fragmentFirstElement, fragmentFirstElement.cloneNode());
+        const fragmentFirst = fragmentProbe.querySelector(".fragment-probe");
+        println(`fragment querySelector found first match: ${fragmentFirst === fragmentFirstElement}`);
+        println(`querySelectorAll after fragment querySelector: ${fragmentProbe.querySelectorAll(".fragment-probe").length}`);
+
+        // Structural and character-data mutations invalidate first-only results too.
+        const mutationProbe = document.createElement("div");
+        mutationProbe.innerHTML = `<span class="mutation-probe"></span>`;
+        host.appendChild(mutationProbe);
+        const mutationFirst = mutationProbe.querySelector(".mutation-probe");
+        println(`querySelector before tree mutation found match: ${mutationFirst === mutationProbe.firstElementChild}`);
+        const mutationNewFirst = document.createElement("span");
+        mutationNewFirst.className = "mutation-probe";
+        mutationProbe.prepend(mutationNewFirst);
+        println(`querySelector after tree mutation found new first: ${mutationProbe.querySelector(".mutation-probe") === mutationNewFirst}`);
+        println(`querySelectorAll after tree mutation: ${mutationProbe.querySelectorAll(".mutation-probe").length}`);
+
+        const characterDataProbe = document.createElement("div");
+        characterDataProbe.innerHTML = `<span>first</span><span>second</span>`;
+        host.appendChild(characterDataProbe);
+        const nonEmptyFirst = characterDataProbe.querySelector("span:not(:empty)");
+        println(`querySelector before character-data mutation found match: ${nonEmptyFirst === characterDataProbe.firstElementChild}`);
+        characterDataProbe.firstElementChild.firstChild.data = "";
+        println(`querySelector after character-data mutation found new first: ${characterDataProbe.querySelector("span:not(:empty)") === characterDataProbe.lastElementChild}`);
+        println(`querySelectorAll after character-data mutation: ${characterDataProbe.querySelectorAll("span:not(:empty)").length}`);
+
         // Repeated identical queries with no intervening mutation return the same elements
         // in fresh NodeList objects.
         const repeatA = document.querySelectorAll("span.item");


### PR DESCRIPTION
Store querySelector first matches, including empty results, in the existing selector-result cache. Repeated identical queries previously paid for a complete selector walk even though querySelectorAll already populated the same cache.

```
Benchmark     Old Score      New Score        Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  -------------  -------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  80.64 ± 16.66  80.85 ± 12.63                1.003  6.16 ± 1.10            6.12 ± 0.43                1.007
Speedometer3  4.53 ± 0.90    4.56 ± 1.03                  1.007  5.86 ± 0.86            5.80 ± 0.89                1.01
StyleBench    63.58 ± 4.25   63.97 ± 7.61                 1.006  4.01 ± 0.23            3.98 ± 0.41                1.007
```