### PR TITLE
LibWeb: Implement content encoding changes from meta elements

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8686,7 +8686,6 @@ void Document::parse_html_from_a_string(Utf16View html)
     // 2. Let parser be a new HTML parser whose allow declarative shadow roots is document's allow declarative shadow roots,
     //    associated with document.
     // 3. Place html into the input stream for parser. The encoding confidence is irrelevant.
-    // FIXME: We don't have the concept of encoding confidence yet.
     auto scripting_mode = is_scripting_enabled() ? HTML::ParserScriptingMode::Normal : HTML::ParserScriptingMode::Disabled;
     auto parser = HTML::HTMLParser::create_for_decoded_string(*this, html, scripting_mode, "UTF-8"_utf16);
     parser->set_allow_declarative_shadow_roots(allow_declarative_shadow_roots());

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -289,7 +289,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::Navi
     //    load event to be fired.
     // FIXME: Parse as we receive the document data, instead of waiting for the whole document to be fetched first.
     auto process_body = GC::create_function(GC::Heap::the(), [document, url = navigation_params.response->url().value(), mime = type](ByteBuffer data) {
-        auto encoding = HTML::run_encoding_sniffing_algorithm(document, data, mime);
+        auto [encoding, confidence] = HTML::run_encoding_sniffing_algorithm(document, data, mime);
         dbgln_if(HTML_PARSER_DEBUG, "The encoding sniffing algorithm returned encoding '{}'", encoding);
 
         auto run_text_parser = [document, data = move(data), url, encoding = move(encoding)] {

--- a/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
@@ -490,13 +490,12 @@ ByteString extract_tld_hint(URL::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding
-ByteString run_encoding_sniffing_algorithm(DOM::Document& document, ReadonlyBytes input, Optional<MimeSniff::MimeType> maybe_mime_type)
+EncodingSniffingResult run_encoding_sniffing_algorithm(DOM::Document& document, ReadonlyBytes input, Optional<MimeSniff::MimeType> maybe_mime_type)
 {
     // 1. If the result of BOM sniffing is an encoding, return that encoding with confidence certain.
-    // FIXME: There is no concept of decoding certainty yet.
     auto bom = run_bom_sniff(input);
     if (bom.has_value())
-        return bom.value();
+        return { bom.release_value(), EncodingConfidence::Certain };
     // 2. FIXME: If the user has explicitly instructed the user agent to override the document's character encoding with a specific encoding,
     //    optionally return that encoding with the confidence certain.
 
@@ -510,7 +509,7 @@ ByteString run_encoding_sniffing_algorithm(DOM::Document& document, ReadonlyByte
         // FIXME: This is awkward because lecacy_extract_an_encoding can not fail
         auto maybe_transport_encoding = Fetch::Infrastructure::legacy_extract_an_encoding(maybe_mime_type, "invalid"sv);
         if (maybe_transport_encoding != "invalid"sv)
-            return maybe_transport_encoding;
+            return { maybe_transport_encoding, EncodingConfidence::Certain };
     }
 
     // 5. Optionally, prescan the byte stream to determine its encoding, with the end condition being when the user agent decides that scanning further bytes would not
@@ -519,7 +518,7 @@ ByteString run_encoding_sniffing_algorithm(DOM::Document& document, ReadonlyByte
     //    The aforementioned algorithm returns either a character encoding or failure. If it returns a character encoding, then return the same encoding, with confidence tentative.
     auto prescan = run_prescan_byte_stream_algorithm(document, input);
     if (prescan.has_value())
-        return prescan.value();
+        return { prescan.release_value(), EncodingConfidence::Tentative };
 
     // 6. FIXME: If the HTML parser for which this algorithm is being run is associated with a Document d whose container document is non-null, then:
     // 1. Let parentDocument be d's container document.
@@ -552,13 +551,13 @@ ByteString run_encoding_sniffing_algorithm(DOM::Document& document, ReadonlyByte
         auto detected = StringView { reinterpret_cast<char const*>(encoding_name_ptr), encoding_name_len };
         auto standardized = TextCodec::get_standardized_encoding(detected);
         if (standardized.has_value())
-            return ByteString { standardized.value() };
+            return { ByteString { standardized.value() }, EncodingConfidence::Tentative };
     }
 
     // 9. Otherwise, return an implementation-defined or user-specified default character encoding, with the confidence tentative.
     //    In controlled environments or in environments where the encoding of documents can be prescribed (for example, for user agents intended for dedicated use in new
     //    networks), the comprehensive UTF-8 encoding is suggested.
-    return "UTF-8";
+    return { "UTF-8", EncodingConfidence::Tentative };
 }
 
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -16,6 +16,17 @@
 
 namespace Web::HTML {
 
+enum class EncodingConfidence : u8 {
+    Tentative,
+    Certain,
+    Irrelevant,
+};
+
+struct EncodingSniffingResult {
+    ByteString encoding;
+    EncodingConfidence confidence;
+};
+
 Optional<StringView> extract_character_encoding_from_meta_element(ByteString const&);
 GC::Ptr<DOM::Attr> prescan_get_attribute(DOM::Document&, ReadonlyBytes input, size_t& position);
 Optional<ByteString> run_prescan_byte_stream_algorithm(DOM::Document&, ReadonlyBytes input);
@@ -26,7 +37,7 @@ Optional<ByteString> run_bom_sniff(ReadonlyBytes input);
 // an absent/empty TLD as equivalent to ".com".
 ByteString extract_tld_hint(URL::URL const&);
 
-ByteString run_encoding_sniffing_algorithm(DOM::Document&, ReadonlyBytes input,
+EncodingSniffingResult run_encoding_sniffing_algorithm(DOM::Document&, ReadonlyBytes input,
     Optional<MimeSniff::MimeType> maybe_mime_type = {});
 
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1228,46 +1228,35 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
 GC::Ref<HTMLParser> HTMLParser::create_for_scripting(DOM::Document& document)
 {
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
-    auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, ScriptCreatedParser::Yes);
-    parser->initialize(document.relevant_settings_object().realm());
-    return parser;
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::Yes);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_with_open_input_stream(DOM::Document& document)
 {
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
-    auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, ScriptCreatedParser::No);
-    parser->initialize(document.relevant_settings_object().realm());
-    return parser;
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::No);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_with_uncertain_encoding(DOM::Document& document, ByteBuffer const& input, Optional<MimeSniff::MimeType> maybe_mime_type)
 {
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
-    if (document.has_encoding()) {
-        auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, input, document.encoding().value().to_byte_string());
-        parser->initialize(document.relevant_settings_object().realm());
-        return parser;
-    }
+
+    if (document.has_encoding())
+        return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, document.encoding().value().to_byte_string());
+
     auto encoding = run_encoding_sniffing_algorithm(document, input, maybe_mime_type);
     dbgln_if(HTML_PARSER_DEBUG, "The encoding sniffing algorithm returned encoding '{}'", encoding);
-    auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, input, encoding);
-    parser->initialize(document.relevant_settings_object().realm());
-    return parser;
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_from_byte_string(DOM::Document& document, StringView input, ParserScriptingMode scripting_mode, StringView encoding)
 {
-    auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, input, encoding);
-    parser->initialize(document.relevant_settings_object().realm());
-    return parser;
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_for_decoded_string(DOM::Document& document, Utf16View input, ParserScriptingMode scripting_mode, Utf16View encoding)
 {
-    auto parser = GC::Heap::the().allocate<HTMLParser>(document, scripting_mode, input, encoding);
-    parser->initialize(document.relevant_settings_object().realm());
-    return parser;
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
 }
 
 enum class AttributeMode {

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -38,6 +38,7 @@
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLLinkElement.h>
+#include <LibWeb/HTML/HTMLMetaElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
@@ -122,6 +123,7 @@ extern "C" void ladybird_html_parser_handle_element_popped(size_t);
 extern "C" void ladybird_html_parser_prepare_svg_script(void*, size_t, size_t);
 extern "C" void ladybird_html_parser_set_script_source_line(void*, size_t, size_t);
 extern "C" void ladybird_html_parser_mark_script_already_started(void*, size_t);
+extern "C" void ladybird_html_parser_process_meta_element(void*, size_t);
 extern "C" size_t ladybird_html_parser_parent_node(size_t);
 extern "C" size_t ladybird_html_parser_node_index(size_t);
 extern "C" size_t ladybird_html_parser_create_element(void*, size_t, RustFfiHtmlNamespace, u16 const*, size_t, u16 const*, size_t, RustFfiHtmlParserAttribute const*, size_t, bool, size_t, bool);
@@ -133,9 +135,10 @@ extern "C" size_t ladybird_html_parser_attach_declarative_shadow_root(size_t, Ru
 extern "C" void ladybird_html_parser_set_template_content(size_t, size_t);
 extern "C" bool ladybird_html_parser_is_shadow_host(size_t);
 
-HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, StringView input, StringView encoding)
+HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, StringView input, StringView encoding, EncodingConfidence encoding_confidence)
     : m_tokenizer(decode_html_parser_input(input, encoding))
     , m_scripting_mode(scripting_mode)
+    , m_encoding_confidence(encoding_confidence)
     , m_document(document)
 {
     m_rust_parser = rust_html_parser_create();
@@ -145,9 +148,10 @@ HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mo
     m_document->set_encoding(utf16_string_from_standardized_encoding_label(standardized_encoding.value()));
 }
 
-HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, Utf16View input, Utf16View encoding)
+HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, Utf16View input, Utf16View encoding, EncodingConfidence encoding_confidence)
     : m_tokenizer(input)
     , m_scripting_mode(scripting_mode)
+    , m_encoding_confidence(encoding_confidence)
     , m_document(document)
 {
     m_rust_parser = rust_html_parser_create();
@@ -161,15 +165,17 @@ HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mo
     : m_tokenizer(input)
     , m_parsing_fragment(fragment_parser == FragmentParser::Yes)
     , m_scripting_mode(scripting_mode)
+    , m_encoding_confidence(EncodingConfidence::Irrelevant)
     , m_document(document)
 {
     VERIFY(m_parsing_fragment);
     m_rust_parser = rust_html_parser_create();
 }
 
-HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, ScriptCreatedParser script_created)
+HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, ScriptCreatedParser script_created, EncodingConfidence encoding_confidence)
     : m_scripting_mode(scripting_mode)
     , m_script_created(script_created == ScriptCreatedParser::Yes)
+    , m_encoding_confidence(encoding_confidence)
     , m_document(document)
 {
     m_rust_parser = rust_html_parser_create();
@@ -195,6 +201,8 @@ void HTMLParser::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_context_element);
     visitor.visit(m_root_insertion_target);
     visitor.visit(m_active_speculative_html_parser);
+    visitor.visit(m_change_encoding_callback);
+    visitor.visit(m_parsing_complete_callback);
 
     rust_html_parser_visit_edges(m_rust_parser, &visitor);
 }
@@ -388,6 +396,101 @@ void HTMLParser::set_script_source_line_from_rust_parser(DOM::Element& element, 
 void HTMLParser::mark_script_already_started_from_rust_parser(HTMLScriptElement& script)
 {
     script.set_already_started(Badge<HTMLParser> {}, true);
+}
+
+// https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
+// -> A start tag whose tag name is "meta"
+void HTMLParser::process_meta_element_from_rust_parser(HTMLMetaElement& element)
+{
+    // If the active speculative HTML parser is null:
+    if (m_active_speculative_html_parser)
+        return;
+
+    // NB: Both steps below require tentative confidence.
+    if (m_encoding_confidence != EncodingConfidence::Tentative)
+        return;
+
+    // 1. If the element has a charset attribute, and getting an encoding from its value results in an encoding, and the
+    //    confidence is currently tentative, then change the encoding to the resulting encoding.
+    if (auto charset = element.get_attribute(AttributeNames::charset); charset.has_value()) {
+        if (auto encoding = TextCodec::get_standardized_encoding(charset->utf16_view()); encoding.has_value()) {
+            change_the_encoding(*encoding);
+            return;
+        }
+    }
+
+    // 2. Otherwise, if the element has an http-equiv attribute whose value is an ASCII case-insensitive match for
+    //    "Content-Type", and the element has a content attribute, and applying the algorithm for extracting a character
+    //    encoding from a meta element to that attribute's value returns an encoding, and the confidence is currently
+    //    tentative, then change the encoding to the extracted encoding.
+    if (element.http_equiv_state() != HTMLMetaElement::HttpEquivAttributeState::EncodingDeclaration)
+        return;
+
+    auto content = element.get_attribute(AttributeNames::content);
+    if (!content.has_value())
+        return;
+
+    auto content_as_utf8 = content->to_utf8_but_should_be_ported_to_utf16().to_byte_string();
+    if (auto encoding = extract_character_encoding_from_meta_element(content_as_utf8); encoding.has_value())
+        change_the_encoding(*encoding);
+}
+
+// https://html.spec.whatwg.org/multipage/parsing.html#change-the-encoding
+void HTMLParser::change_the_encoding(StringView new_encoding)
+{
+    VERIFY(m_encoding_confidence == EncodingConfidence::Tentative);
+    VERIFY(m_document->has_encoding());
+
+    auto current_encoding = TextCodec::get_standardized_encoding(m_document->encoding().value());
+    VERIFY(current_encoding.has_value());
+
+    // 1. If the encoding that is already being used to interpret the input stream is UTF-16BE/LE, then set the
+    //    confidence to certain and return. The new encoding is ignored; if it was anything but the same encoding, then
+    //    it would be clearly incorrect.
+    if (current_encoding->is_one_of_ignoring_ascii_case("UTF-16BE"sv, "UTF-16LE"sv)) {
+        m_encoding_confidence = EncodingConfidence::Certain;
+        return;
+    }
+
+    // 2. If the new encoding is UTF-16BE/LE, then change it to UTF-8.
+    if (new_encoding.is_one_of_ignoring_ascii_case("UTF-16BE"sv, "UTF-16LE"sv))
+        new_encoding = "UTF-8"sv;
+
+    // 3. If the new encoding is x-user-defined, then change it to windows-1252.
+    if (new_encoding.equals_ignoring_ascii_case("x-user-defined"sv))
+        new_encoding = "windows-1252"sv;
+
+    // 4. If the new encoding is identical or equivalent to the encoding that is already being used to interpret the
+    //    input stream, then set the confidence to certain and return. This happens when the encoding information found
+    //    in the file matches what the encoding sniffing algorithm determined to be the encoding, and in the second pass
+    //    through the parser if the first pass found that the encoding sniffing algorithm described in the earlier
+    //    section failed to find the right encoding.
+    if (current_encoding->equals_ignoring_ascii_case(new_encoding)) {
+        m_encoding_confidence = EncodingConfidence::Certain;
+        return;
+    }
+
+    // 5. If all the bytes up to the last byte converted by the current decoder have the same Unicode interpretations in
+    //    both the current encoding and the new encoding, and if the user agent supports changing the converter on the
+    //    fly, then the user agent may change to the new converter for the encoding on the fly. Set the document's
+    //    character encoding and the encoding used to convert the input stream to the new encoding, set the confidence
+    //    to certain, and return.
+    if (m_change_encoding_callback && m_change_encoding_callback->function()(new_encoding)) {
+        m_document->set_encoding(utf16_string_from_standardized_encoding_label(new_encoding));
+        m_encoding_confidence = EncodingConfidence::Certain;
+        return;
+    }
+
+    // FIXME: 6. Otherwise, restart the navigate algorithm, with historyHandling set to "replace" and other inputs kept the
+    //           same, but this time skip the encoding sniffing algorithm and instead just set the encoding to the new encoding
+    //           and the confidence to certain. Whenever possible, this should be done without actually contacting the network
+    //           layer (the bytes should be re-parsed from memory), even if, e.g., the document is marked as not being
+    //           cacheable. If this is not possible and contacting the network layer would involve repeating a request that
+    //           uses a method other than `GET`, then instead set the confidence to certain and ignore the new encoding. The
+    //           resource will be misinterpreted. User agents may notify the user of the situation, to aid in application
+    //           development.
+    dbgln_if(HTML_PARSER_DEBUG, "Unable to change HTML parser encoding from '{}' to '{}' without restarting navigation", *current_encoding, new_encoding);
+    m_encoding_confidence = EncodingConfidence::Certain;
 }
 
 void HTMLParser::stop_parsing_from_rust_parser()
@@ -1034,6 +1137,8 @@ void HTMLParser::resume_after_parser_blocking_script()
 
 void HTMLParser::invoke_post_parse_action()
 {
+    if (auto callback = exchange(m_parsing_complete_callback, nullptr))
+        callback->function()();
     if (auto action = exchange(m_post_parse_action, nullptr))
         action();
 }
@@ -1228,13 +1333,13 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
 GC::Ref<HTMLParser> HTMLParser::create_for_scripting(DOM::Document& document)
 {
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
-    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::Yes);
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::Yes, EncodingConfidence::Irrelevant);
 }
 
-GC::Ref<HTMLParser> HTMLParser::create_with_open_input_stream(DOM::Document& document)
+GC::Ref<HTMLParser> HTMLParser::create_with_open_input_stream(DOM::Document& document, EncodingConfidence encoding_confidence)
 {
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
-    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::No);
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, ScriptCreatedParser::No, encoding_confidence);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_with_uncertain_encoding(DOM::Document& document, ByteBuffer const& input, Optional<MimeSniff::MimeType> maybe_mime_type)
@@ -1242,21 +1347,21 @@ GC::Ref<HTMLParser> HTMLParser::create_with_uncertain_encoding(DOM::Document& do
     auto scripting_mode = document.is_scripting_enabled() ? ParserScriptingMode::Normal : ParserScriptingMode::Disabled;
 
     if (document.has_encoding())
-        return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, document.encoding().value().to_byte_string());
+        return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, document.encoding().value().to_byte_string(), EncodingConfidence::Certain);
 
-    auto encoding = run_encoding_sniffing_algorithm(document, input, maybe_mime_type);
+    auto [encoding, confidence] = run_encoding_sniffing_algorithm(document, input, maybe_mime_type);
     dbgln_if(HTML_PARSER_DEBUG, "The encoding sniffing algorithm returned encoding '{}'", encoding);
-    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding, confidence);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_from_byte_string(DOM::Document& document, StringView input, ParserScriptingMode scripting_mode, StringView encoding)
 {
-    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding, EncodingConfidence::Certain);
 }
 
 GC::Ref<HTMLParser> HTMLParser::create_for_decoded_string(DOM::Document& document, Utf16View input, ParserScriptingMode scripting_mode, Utf16View encoding)
 {
-    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding);
+    return document.relevant_settings_object().realm().create<HTMLParser>(document, scripting_mode, input, encoding, EncodingConfidence::Irrelevant);
 }
 
 enum class AttributeMode {
@@ -2209,6 +2314,11 @@ extern "C" void ladybird_html_parser_mark_script_already_started(void* parser, s
 {
     if (auto* script = as_if<HTMLScriptElement>(node_from_html_parser_ffi(element)))
         parser_from_html_parser_ffi(parser).mark_script_already_started_from_rust_parser(*script);
+}
+
+extern "C" void ladybird_html_parser_process_meta_element(void* parser, size_t element)
+{
+    parser_from_html_parser_ffi(parser).process_meta_element_from_rust_parser(as<HTMLMetaElement>(node_from_html_parser_ffi(element)));
 }
 
 extern "C" size_t ladybird_html_parser_parent_node(size_t node)

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1064,6 +1064,8 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
     DOM::Element* context = target.has<GC::Ref<DOM::Element>>()
         ? target.get<GC::Ref<DOM::Element>>().ptr()
         : target.get<GC::Ref<DOM::DocumentFragment>>()->host();
+
+    // 3. Assert: context is non-null.
     VERIFY(context);
 
     // 4. Let document be a Document node whose type is "html".

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -23,16 +23,7 @@
 
 struct RustFfiHtmlParserHandle;
 
-namespace Web::SVG {
-
-class SVGScriptElement;
-
-}
-
 namespace Web::HTML {
-
-class HTMLScriptElement;
-class HTMLFormElement;
 
 class WEB_API HTMLParser final : public JS::Cell {
     GC_CELL(HTMLParser, JS::Cell);

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
+#include <LibGC/Function.h>
 #include <LibGfx/Color.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/Forward.h>
@@ -16,6 +17,7 @@
 #include <LibWeb/DOM/FragmentSerializationMode.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/Parser/HTMLEncodingDetection.h>
 #include <LibWeb/HTML/Parser/HTMLTokenizer.h>
 #include <LibWeb/HTML/Parser/ParserScriptingMode.h>
 #include <LibWeb/MimeSniff/MimeType.h>
@@ -35,7 +37,7 @@ public:
     virtual ~HTMLParser() override;
 
     static GC::Ref<HTMLParser> create_for_scripting(DOM::Document&);
-    static GC::Ref<HTMLParser> create_with_open_input_stream(DOM::Document&);
+    static GC::Ref<HTMLParser> create_with_open_input_stream(DOM::Document&, EncodingConfidence = EncodingConfidence::Irrelevant);
     static GC::Ref<HTMLParser> create_with_uncertain_encoding(DOM::Document&, ByteBuffer const& input, Optional<MimeSniff::MimeType> maybe_mime_type = {});
     static GC::Ref<HTMLParser> create_from_byte_string(DOM::Document&, StringView input, ParserScriptingMode, StringView encoding);
     static GC::Ref<HTMLParser> create_for_decoded_string(DOM::Document&, Utf16View input, ParserScriptingMode, Utf16View encoding);
@@ -76,6 +78,7 @@ public:
     void prepare_svg_script_for_rust_parser(SVG::SVGScriptElement&, size_t source_line_number);
     void set_script_source_line_from_rust_parser(DOM::Element&, size_t source_line_number);
     void mark_script_already_started_from_rust_parser(HTMLScriptElement&);
+    void process_meta_element_from_rust_parser(HTMLMetaElement&);
     void stop_parsing_from_rust_parser();
     bool process_script_end_tag_from_rust_parser(HTMLScriptElement&);
     bool process_svg_script_end_tag_from_rust_parser(SVG::SVGScriptElement&);
@@ -87,6 +90,10 @@ public:
     bool stopped() const { return m_stop_parsing; }
     bool is_paused() const { return m_parser_pause_flag; }
     bool is_script_created() const { return m_script_created; }
+
+    EncodingConfidence encoding_confidence() const { return m_encoding_confidence; }
+    void set_change_encoding_callback(GC::Ref<GC::Function<bool(StringView)>> callback) { m_change_encoding_callback = callback; }
+    void set_parsing_complete_callback(GC::Ref<GC::Function<void()>> callback) { m_parsing_complete_callback = callback; }
 
     size_t script_nesting_level() const { return m_script_nesting_level; }
 
@@ -105,10 +112,10 @@ private:
         Yes,
     };
 
-    HTMLParser(DOM::Document&, ParserScriptingMode, StringView input, StringView encoding);
-    HTMLParser(DOM::Document&, ParserScriptingMode, Utf16View input, Utf16View encoding);
+    HTMLParser(DOM::Document&, ParserScriptingMode, StringView input, StringView encoding, EncodingConfidence);
+    HTMLParser(DOM::Document&, ParserScriptingMode, Utf16View input, Utf16View encoding, EncodingConfidence);
     HTMLParser(DOM::Document&, ParserScriptingMode, Utf16View input, FragmentParser);
-    HTMLParser(DOM::Document&, ParserScriptingMode, ScriptCreatedParser);
+    HTMLParser(DOM::Document&, ParserScriptingMode, ScriptCreatedParser, EncodingConfidence);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
@@ -123,6 +130,7 @@ private:
     GC::Ref<DOM::Element> create_element_for(HTMLToken const&, Optional<Utf16FlyString> const& namespace_, DOM::Node& intended_parent);
     void increment_script_nesting_level();
     void decrement_script_nesting_level();
+    void change_the_encoding(StringView new_encoding);
 
     void resume_after_parser_blocking_script();
     void invoke_post_parse_action();
@@ -146,6 +154,11 @@ private:
     bool m_stop_parsing { false };
     bool m_resume_check_pending { false };
     size_t m_script_nesting_level { 0 };
+
+    // https://html.spec.whatwg.org/multipage/parsing.html#concept-encoding-confidence
+    EncodingConfidence m_encoding_confidence;
+    GC::Ptr<GC::Function<bool(StringView)>> m_change_encoding_callback;
+    GC::Ptr<GC::Function<void()>> m_parsing_complete_callback;
 
     Function<void()> m_post_parse_action;
 

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.cpp
@@ -76,11 +76,13 @@ void IncrementalDocumentParser::initialize_parser(ReadonlyBytes sniff_bytes)
     // https://html.spec.whatwg.org/multipage/parsing.html#parsing-with-a-known-character-encoding
     // https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding
     Optional<StringView> standardized_encoding;
+    auto encoding_confidence = EncodingConfidence::Certain;
     if (m_document->has_encoding()) {
         standardized_encoding = TextCodec::get_standardized_encoding(m_document->encoding().value());
     } else {
-        auto encoding = run_encoding_sniffing_algorithm(m_document, sniff_bytes, m_mime_type);
+        auto [encoding, confidence] = run_encoding_sniffing_algorithm(m_document, sniff_bytes, m_mime_type);
         standardized_encoding = TextCodec::get_standardized_encoding(encoding);
+        encoding_confidence = confidence;
     }
     VERIFY(standardized_encoding.has_value());
     dbgln_if(HTML_PARSER_DEBUG, "The incremental HTML parser selected encoding '{}'", standardized_encoding.value());
@@ -93,9 +95,19 @@ void IncrementalDocumentParser::initialize_parser(ReadonlyBytes sniff_bytes)
     // to use for the input byte stream.
     m_document->set_encoding(utf16_string_from_standardized_encoding_label(standardized_encoding.value()));
 
-    // FIXME: Implement the spec's "change the encoding while parsing" algorithm.
     m_document->set_url(m_url);
-    m_parser = HTMLParser::create_with_open_input_stream(m_document);
+    m_parser = HTMLParser::create_with_open_input_stream(m_document, encoding_confidence);
+    m_parser->set_change_encoding_callback(GC::create_function(GC::Heap::the(), [this](StringView encoding) {
+        auto result = change_encoding(encoding);
+        if (result.is_error()) {
+            release_encoding_change_buffers();
+            return false;
+        }
+        return result.release_value();
+    }));
+    m_parser->set_parsing_complete_callback(GC::create_function(GC::Heap::the(), [this]() {
+        release_encoding_change_buffers();
+    }));
     m_parser->set_allow_declarative_shadow_roots(m_allow_declarative_shadow_roots);
 
     start_incremental_read();
@@ -133,22 +145,69 @@ void IncrementalDocumentParser::append_decoded(Utf16View decoded)
 
 void IncrementalDocumentParser::process_body_chunk(ByteBuffer bytes)
 {
-    if (!should_continue())
+    if (!should_continue()) {
+        release_encoding_change_buffers();
         return;
+    }
 
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // Each task that the networking task source places on the task queue while fetching runs must
     // fill the parser's input byte stream with the fetched bytes and cause the HTML parser to
     // perform the appropriate processing of the input stream.
-    auto decoded = m_decoder->to_utf16(bytes.bytes()).release_value_but_fixme_should_propagate_errors();
-    append_decoded(decoded);
-    pump();
+    auto bytes_to_decode = bytes.bytes();
+
+    if (m_parser->encoding_confidence() == EncodingConfidence::Tentative) {
+        auto current_encoding = TextCodec::get_standardized_encoding(m_document->encoding().value());
+        VERIFY(current_encoding.has_value());
+
+        // If a meta declaration precedes the first encoding-sensitive byte in this chunk, allow the parser to process
+        // the encoding-independent prefix first. This lets the declaration switch the decoder before the remainder of
+        // the chunk is decoded, while still allowing charset-less documents to parse progressively.
+        if (!current_encoding->is_one_of_ignoring_ascii_case("UTF-16BE"sv, "UTF-16LE"sv)) {
+            size_t encoding_independent_prefix_length = 0;
+            while (encoding_independent_prefix_length < bytes_to_decode.size()) {
+                auto byte = bytes_to_decode[encoding_independent_prefix_length];
+
+                // Non-ASCII bytes may have different Unicode interpretations in different encodings. ESC is also
+                // encoding-sensitive because it can change the state of an ISO-2022-JP decoder, affecting how
+                // subsequent ASCII-range bytes are interpreted.
+                if (!is_ascii(byte) || byte == 0x1B)
+                    break;
+
+                ++encoding_independent_prefix_length;
+            }
+
+            if (encoding_independent_prefix_length > 0) {
+                auto encoding_independent_prefix = bytes_to_decode.trim(encoding_independent_prefix_length);
+                m_input_bytes.append(encoding_independent_prefix);
+                decode_and_process(encoding_independent_prefix);
+
+                if (!should_continue()) {
+                    release_encoding_change_buffers();
+                    return;
+                }
+
+                bytes_to_decode = bytes_to_decode.slice(encoding_independent_prefix_length);
+            }
+        }
+    }
+
+    if (!bytes_to_decode.is_empty()) {
+        if (m_parser->encoding_confidence() == EncodingConfidence::Tentative)
+            m_input_bytes.append(bytes_to_decode);
+        decode_and_process(bytes_to_decode);
+    }
+
+    if (!should_continue() || m_parser->encoding_confidence() != EncodingConfidence::Tentative)
+        release_encoding_change_buffers();
 }
 
 void IncrementalDocumentParser::process_end_of_body()
 {
-    if (!should_continue())
+    if (!should_continue()) {
+        release_encoding_change_buffers();
         return;
+    }
 
     auto decoded = m_decoder->finish_to_utf16().release_value_but_fixme_should_propagate_errors();
     append_decoded(decoded);
@@ -156,12 +215,62 @@ void IncrementalDocumentParser::process_end_of_body()
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // When no more bytes are available, have the parser process the implied EOF character.
     m_document->set_source(m_source.to_string());
+    m_reached_end_of_body = true;
     m_parser->tokenizer().close_input_stream();
     pump();
+
+    if (!should_continue())
+        release_encoding_change_buffers();
+}
+
+ErrorOr<bool> IncrementalDocumentParser::change_encoding(StringView new_encoding)
+{
+    // If all bytes converted so far have the same interpretation in the new encoding, retain the replacement
+    // streaming decoder after feeding it those bytes. Feeding the prefix both performs the required comparison and
+    // restores any decoder state needed to continue at the current byte position.
+    auto decoder = make<TextCodec::StreamingDecoder>(new_encoding, TextCodec::IgnoreBOM::No, TextCodec::ErrorMode::Replacement);
+
+    Utf16StringBuilder builder;
+    builder.append(TRY(decoder->to_utf16(m_input_bytes.bytes())));
+    if (m_reached_end_of_body)
+        builder.append(TRY(decoder->finish_to_utf16()));
+    auto redecoded_source = builder.to_string();
+
+    auto current_source = m_reached_end_of_body ? m_document->source().utf16_view() : m_source.view();
+    if (!redecoded_source.starts_with(current_source)
+        || (m_reached_end_of_body && redecoded_source.length_in_code_units() != current_source.length_in_code_units())) {
+        // FIXME: A mismatch requires restarting the navigation with the new encoding, as described by step 6 of the
+        //        change-the-encoding algorithm.
+        release_encoding_change_buffers();
+        return false;
+    }
+
+    auto additionally_decoded_source = redecoded_source.utf16_view().substring_view(current_source.length_in_code_units());
+    if (!additionally_decoded_source.is_empty()) {
+        VERIFY(!m_reached_end_of_body);
+        append_decoded(additionally_decoded_source);
+    }
+
+    m_decoder = move(decoder);
+    release_encoding_change_buffers();
+    return true;
+}
+
+void IncrementalDocumentParser::decode_and_process(ReadonlyBytes bytes)
+{
+    auto decoded = m_decoder->to_utf16(bytes).release_value_but_fixme_should_propagate_errors();
+    append_decoded(decoded);
+    pump();
+}
+
+void IncrementalDocumentParser::release_encoding_change_buffers()
+{
+    m_input_bytes.clear();
 }
 
 void IncrementalDocumentParser::process_body_error(JS::Value)
 {
+    release_encoding_change_buffers();
     dbgln("FIXME: Load html page with an error if incremental read of body failed.");
     HTMLParser::the_end(m_document, m_parser);
 }

--- a/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
+++ b/Libraries/LibWeb/HTML/Parser/IncrementalDocumentParser.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/Utf16StringBuilder.h>
@@ -41,7 +42,10 @@ private:
     void process_body_chunk(ByteBuffer);
     void process_end_of_body();
     void process_body_error(JS::Value);
+    ErrorOr<bool> change_encoding(StringView);
 
+    void decode_and_process(ReadonlyBytes);
+    void release_encoding_change_buffers();
     void append_decoded(Utf16View);
     void pump();
     void register_deferred_start();
@@ -56,7 +60,9 @@ private:
     GC::Ptr<HTMLParser> m_parser;
     OwnPtr<TextCodec::StreamingDecoder> m_decoder;
 
+    ByteBuffer m_input_bytes;
     Utf16StringBuilder m_source;
+    bool m_reached_end_of_body { false };
 };
 
 }

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -855,100 +855,178 @@ impl TreeBuilder {
 
     // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead
     fn handle_in_head(&mut self, token: Token) {
+        // -> A character token that is one of U+0009 CHARACTER TABULATION, U+000A LINE FEED (LF), U+000C FORM FEED (FF),
+        //    U+000D CARRIAGE RETURN (CR), or U+0020 SPACE
         if token.is_parser_whitespace() {
+            // Insert the character.
             self.insert_character(token.code_point);
             return;
         }
 
+        // -> A comment token
         if token.token_type == TokenType::Comment {
+            // Insert a comment.
             self.insert_comment(token.comment_data(), None);
             return;
         }
 
+        // FIXME: -> A processing instruction token
+        //     Insert a processing instruction.
+
+        // -> A DOCTYPE token
         if token.token_type == TokenType::Doctype {
             // Parse error. Ignore the token.
             self.parse_error("DOCTYPE token in in head insertion mode");
             return;
         }
 
+        // -> A start tag whose tag name is "html"
         if token.is_start_tag_named("html") {
+            // Process the token using the rules for the "in body" insertion mode.
             self.process_using_the_rules_for(InsertionMode::InBody, token);
             return;
         }
 
-        if token.is_start_tag_one_of(&["base", "basefont", "bgsound", "link", "meta"]) {
+        // -> A start tag whose tag name is one of: "base", "basefont", "bgsound", "link"
+        if token.is_start_tag_one_of(&["base", "basefont", "bgsound", "link"]) {
+            // Insert an HTML element for the token. Immediately pop the current node off the stack of open elements.
             self.insert_html_element_for(&token);
             self.pop_current_node();
+
+            // FIXME: Acknowledge the token's self-closing flag, if it is set.
             return;
         }
 
+        // -> A start tag whose tag name is "meta"
+        if token.is_start_tag_named("meta") {
+            // Insert an HTML element for the token. Immediately pop the current node off the stack of open elements.
+            self.insert_html_element_for(&token);
+            self.pop_current_node();
+
+            // FIXME: Acknowledge the token's self-closing flag, if it is set.
+
+            // FIXME: If the active speculative HTML parser is null:
+            //     1. If the element has a charset attribute, and getting an encoding from its value results in an
+            //        encoding, and the confidence is currently tentative, then change the encoding to the resulting
+            //        encoding.
+            //     2. Otherwise, if the element has an http-equiv attribute whose value is an ASCII case-insensitive
+            //        match for "Content-Type", and the element has a content attribute, and applying the algorithm for
+            //        extracting a character encoding from a meta element to that attribute's value returns an encoding,
+            //        and the confidence is currently tentative, then change the encoding to the extracted encoding.
+
+            // NOTE: The speculative HTML parser doesn't speculatively apply character encoding declarations in order to
+            //       reduce implementation complexity.
+        }
+
+        // -> A start tag whose tag name is "title"
         if token.is_start_tag_named("title") {
+            // Follow the generic RCDATA element parsing algorithm.
             self.parse_generic_rcdata_element(token);
             return;
         }
 
+        // -> A start tag whose tag name is "noscript", if scripting mode is not Disabled
+        // -> A start tag whose tag name is one of: "noframes", "style"
         if token.is_start_tag_one_of(&["style", "noframes"])
             || (token.is_start_tag_named("noscript") && self.scripting_enabled)
         {
+            // Follow the generic raw text element parsing algorithm.
             self.parse_generic_raw_text_element(token);
             return;
         }
 
+        // -> A start tag whose tag name is "noscript", if scripting mode is Disabled
         if token.is_start_tag_named("noscript") && !self.scripting_enabled {
+            // Insert an HTML element for the token.
             self.insert_html_element_for(&token);
+
+            // Switch the insertion mode to "in head noscript".
             self.insertion_mode = InsertionMode::InHeadNoscript;
             return;
         }
 
-        if token.is_start_tag_named("template") {
-            self.handle_template_start_tag(&token);
-            return;
-        }
-
+        // -> A start tag whose tag name is "script"
         if token.is_start_tag_named("script") {
             // Run these steps:
             //
             // 1. Let the adjustedInsertionLocation be the appropriate place for inserting a node.
             // 2. Create an element for the token in the HTML namespace, with the intended parent being the element in
             //    which the adjustedInsertionLocation finds itself.
+            // 3. If the scripting mode is not Fragment, then set the element's parser document to the Document.
+            // NOTE: The Fragment scripting mode treats parser-inserted scripts as if they were not parser-inserted,
+            //       allowing, for example, executing scripts when applying a fragment created by
+            //       createContextualFragment().
+            // 4. Set the element's force async to false.
+            // NOTE: This ensures that, if the script is external, any document.write() calls in the script will execute
+            //       in-line, instead of blowing the document away, as would happen in most other cases. It also
+            //       prevents the script from executing until the end tag is seen.
+            // 5. If the parser's scripting mode is Inert, then set the script element's already started to true.
+            //    (fragment case)
+            // 6. If the parser was invoked via the document.write() or document.writeln() methods, then optionally set
+            //    the script element's already started to true. (For example, the user agent might use this clause to
+            //    prevent execution of cross-origin scripts inserted via document.write() under slow network conditions,
+            //    or when the page has already taken a long time to load.)
+            // 7. Insert the newly created element at the adjusted insertion location given adjustedInsertionLocation.
+            // 8. Push the element onto the stack of open elements so that it is the new current node.
             self.insert_html_element_for(&token);
+
             // 9. Switch the tokenizer to the script data state.
             self.switch_tokenizer_to(State::ScriptData);
+
             // 10. Set the original insertion mode to the current insertion mode.
             self.original_insertion_mode = self.insertion_mode;
+
             // 11. Switch the insertion mode to "text".
             self.insertion_mode = InsertionMode::Text;
             return;
         }
 
+        // -> An end tag whose tag name is "head"
         if token.is_end_tag_named("head") {
+            // Pop the current node (which will be the head element) off the stack of open elements.
             self.pop_current_node();
+
+            // Switch the insertion mode to "after head".
             self.insertion_mode = InsertionMode::AfterHead;
             return;
         }
 
-        if token.is_end_tag_named("template") {
-            self.handle_template_end_tag();
-            return;
-        }
-
+        // -> An end tag whose tag name is one of: "body", "html", "br"
         if token.is_end_tag_one_of(&["body", "html", "br"]) {
+            // Act as described in the "anything else" entry below.
             self.pop_current_node();
             self.insertion_mode = InsertionMode::AfterHead;
             self.process_using_the_rules_for(InsertionMode::AfterHead, token);
             return;
         }
 
+        // -> A start tag whose tag name is "template"
+        if token.is_start_tag_named("template") {
+            self.handle_template_start_tag(&token);
+            return;
+        }
+
+        // -> An end tag whose tag name is "template"
+        if token.is_end_tag_named("template") {
+            self.handle_template_end_tag();
+            return;
+        }
+
+        // -> A start tag whose tag name is "head"
+        // -> Any other end tag
         if token.is_start_tag_named("head") || token.is_end_tag() {
             // Parse error. Ignore the token.
             self.parse_error("unexpected tag in in head insertion mode");
             return;
         }
 
+        // -> Anything else
         // Pop the current node (which will be the head element) off the stack of open elements.
         self.pop_current_node();
+
         // Switch the insertion mode to "after head".
         self.insertion_mode = InsertionMode::AfterHead;
+
         // Reprocess the token.
         self.process_using_the_rules_for(InsertionMode::AfterHead, token);
     }

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -129,6 +129,7 @@ unsafe extern "C" {
     fn ladybird_html_parser_prepare_svg_script(parser: *mut c_void, element: usize, source_line_number: usize);
     fn ladybird_html_parser_set_script_source_line(parser: *mut c_void, element: usize, source_line_number: usize);
     fn ladybird_html_parser_mark_script_already_started(parser: *mut c_void, element: usize);
+    fn ladybird_html_parser_process_meta_element(parser: *mut c_void, element: usize);
     fn ladybird_html_parser_parent_node(node: usize) -> usize;
     fn ladybird_html_parser_node_index(node: usize) -> usize;
     fn ladybird_html_parser_create_element(
@@ -900,22 +901,13 @@ impl TreeBuilder {
         // -> A start tag whose tag name is "meta"
         if token.is_start_tag_named("meta") {
             // Insert an HTML element for the token. Immediately pop the current node off the stack of open elements.
-            self.insert_html_element_for(&token);
+            let element = self.insert_html_element_for(&token);
             self.pop_current_node();
 
             // FIXME: Acknowledge the token's self-closing flag, if it is set.
 
-            // FIXME: If the active speculative HTML parser is null:
-            //     1. If the element has a charset attribute, and getting an encoding from its value results in an
-            //        encoding, and the confidence is currently tentative, then change the encoding to the resulting
-            //        encoding.
-            //     2. Otherwise, if the element has an http-equiv attribute whose value is an ASCII case-insensitive
-            //        match for "Content-Type", and the element has a content attribute, and applying the algorithm for
-            //        extracting a character encoding from a meta element to that attribute's value returns an encoding,
-            //        and the confidence is currently tentative, then change the encoding to the extracted encoding.
-
-            // NOTE: The speculative HTML parser doesn't speculatively apply character encoding declarations in order to
-            //       reduce implementation complexity.
+            unsafe { ladybird_html_parser_process_meta_element(self.host, element) };
+            return;
         }
 
         // -> A start tag whose tag name is "title"

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
@@ -25,9 +25,7 @@ GC_DEFINE_ALLOCATOR(SpeculativeHTMLParser);
 
 GC::Ref<SpeculativeHTMLParser> SpeculativeHTMLParser::create(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url)
 {
-    auto parser = GC::Heap::the().allocate<SpeculativeHTMLParser>(document, move(pending_input), move(base_url));
-    parser->initialize(document->relevant_settings_object().realm());
-    return parser;
+    return document->relevant_settings_object().realm().create<SpeculativeHTMLParser>(document, move(pending_input), move(base_url));
 }
 
 SpeculativeHTMLParser::SpeculativeHTMLParser(GC::Ref<DOM::Document> document, Utf16String pending_input, URL::URL base_url)

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -42,9 +42,7 @@ ModuleScript::ModuleScript(Optional<URL::URL> base_url, ByteString filename, Env
 
 GC::Ref<ModuleScript> ModuleScript::create_internal(Optional<URL::URL> base_url, ByteString const& filename, EnvironmentSettingsObject& settings)
 {
-    auto script = GC::Heap::the().allocate<ModuleScript>(move(base_url), filename, settings);
-    script->initialize(settings.realm());
-    return script;
+    return settings.realm().create<ModuleScript>(move(base_url), filename, settings);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-javascript-module-script

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -64,6 +64,7 @@ Text/input/navigation/location-reload-fetch.html
 Text/input/HTML/image-load-after-adoption-from-removed-iframe.html
 Text/input/HTML/session-storage-event-fired-to-lazy-window.html
 Text/input/HTML/parser-streams-bytes.html
+Text/input/HTML/parser-streams-late-meta-charset.html
 Text/input/HTML/parser-streams-with-document-write.html
 Text/input/HTML/parser-streams-utf8-split.html
 Text/input/wpt-import/html/interaction/focus/processing-model/preventScroll.html

--- a/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset.txt
+++ b/Tests/LibWeb/Text/expected/HTML/parser-streams-late-meta-charset.txt
@@ -1,0 +1,9 @@
+charset charset: UTF-8
+charset script: you’re
+charset body: ©
+http-equiv charset: UTF-8
+http-equiv script: you’re
+http-equiv body: ©
+charset-less progressive: true
+post-eof charset: UTF-8
+post-eof script: true

--- a/Tests/LibWeb/Text/input/HTML/parser-streams-late-meta-charset.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-streams-late-meta-charset.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<meta charset="UTF-8" />
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(5000);
+
+        const httpServer = httpTestServer();
+        const token = crypto.randomUUID().replaceAll("-", "");
+        async function runCase(name, declaration) {
+            const scriptURL = await httpServer.createEcho("GET", `/parser-streams-late-meta-script-${name}-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/javascript",
+                },
+                body: `window.decodedScriptText = "you’re";`,
+            });
+
+            const body = `<!DOCTYPE html><head><!--${"a".repeat(2000)}-->${declaration}<script src="${scriptURL}"><\/script></head><body><span id="target">©</span>`;
+            const url = await httpServer.createEcho("GET", `/parser-streams-late-meta-${name}-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/html",
+                },
+                body,
+            });
+
+            const frame = document.createElement("iframe");
+            await new Promise(resolve => {
+                frame.onload = resolve;
+                frame.src = `${url}?chunks=1500&chunk_delay_ms=50`;
+                document.body.appendChild(frame);
+            });
+
+            println(`${name} charset: ${frame.contentDocument.characterSet}`);
+            println(`${name} script: ${frame.contentWindow.decodedScriptText}`);
+            println(`${name} body: ${frame.contentDocument.getElementById("target").textContent}`);
+            frame.remove();
+        }
+
+        async function runProgressiveCase() {
+            const body = `<!DOCTYPE html><body>©<span id="target">ready</span>${" ".repeat(6000)}`;
+            const url = await httpServer.createEcho("GET", `/parser-streams-tentative-progressive-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/html",
+                },
+                body,
+            });
+
+            const frame = document.createElement("iframe");
+            let didLoad = false;
+            const loadPromise = new Promise(resolve => {
+                frame.onload = () => {
+                    didLoad = true;
+                    resolve();
+                };
+            });
+            frame.src = `${url}?chunks=1500&chunk_delay_ms=100`;
+            document.body.appendChild(frame);
+
+            while (!didLoad && !frame.contentDocument.getElementById("target"))
+                await new Promise(resolve => setTimeout(resolve, 10));
+            const parsedBeforeLoad = !didLoad && !!frame.contentDocument.getElementById("target");
+
+            await loadPromise;
+            println(`charset-less progressive: ${parsedBeforeLoad}`);
+            frame.remove();
+        }
+
+        async function runPostEOFCase() {
+            const scriptURL = await httpServer.createEcho("GET", `/parser-streams-post-eof-script-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/javascript",
+                },
+                body: `window.postEOFScriptRan = true;`,
+                delay_ms: 500,
+            });
+
+            const body = `<!DOCTYPE html><head><script type="application/json">"<meta charset=windows-1252>"<\/script><!--${"a".repeat(1200)}--><script src="${scriptURL}"><\/script><meta charset="UTF-8"></head><body>ASCII`;
+            const url = await httpServer.createEcho("GET", `/parser-streams-post-eof-meta-${token}`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/html",
+                },
+                body,
+            });
+
+            const frame = document.createElement("iframe");
+            await new Promise(resolve => {
+                frame.onload = resolve;
+                frame.src = url;
+                document.body.appendChild(frame);
+            });
+
+            println(`post-eof charset: ${frame.contentDocument.characterSet}`);
+            println(`post-eof script: ${frame.contentWindow.postEOFScriptRan}`);
+            frame.remove();
+        }
+
+        await runCase("charset", `<meta charset="UTF-8">`);
+        await runCase("http-equiv", `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">`);
+        await runProgressiveCase();
+        await runPostEOFCase();
+        done();
+    });
+</script>


### PR DESCRIPTION
Some sites like icloud.com put their content encoding tags well after our current 1kb prescan buffer. By that point, we had committed to windows-1252 encoding, and would render UTF-8-encoded characters as mojibake.

This PR implements the content encoding change steps to switch to a UTF-8 decoder when the meta tag is parsed.

| Before | After |
|--|--|
| <img width="493" height="628" alt="before" src="https://github.com/user-attachments/assets/a31a7a38-f76d-43d4-915e-85dd28e11610" /> | <img width="493" height="628" alt="after" src="https://github.com/user-attachments/assets/6c6f46b4-917d-4cde-b663-849e904ce587" /> |

(see the "you're" on the bottom line)