### PR TITLE
AK: Allow using `to_array` on move-only types

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -171,7 +171,7 @@ namespace Detail {
 template<typename T, size_t N, size_t... Is>
 constexpr auto to_array_impl(T (&&a)[N], IndexSequence<Is...>) -> Array<T, sizeof...(Is)>
 {
-    return { { a[Is]... } };
+    return { { move(a[Is])... } };
 }
 
 }

--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -122,23 +122,26 @@ static_assert(CACHE_VERSION == 7, "Bumping CACHE_VERSION requires appending a Ca
 
 ErrorOr<Database::MigrationOutcome> CacheIndex::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 1> migrations { {
-        { .version = INDEX_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS CacheIndex (
-                cache_key INTEGER,
-                vary_key INTEGER,
-                url TEXT,
-                request_headers BLOB,
-                response_headers BLOB,
-                data_size INTEGER,
-                associated_data_size INTEGER,
-                request_time INTEGER,
-                response_time INTEGER,
-                last_access_time INTEGER,
-                PRIMARY KEY(cache_key, vary_key)
-            );
-        )#"sv },
-    } };
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = INDEX_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS CacheIndex (
+                    cache_key INTEGER,
+                    vary_key INTEGER,
+                    url TEXT,
+                    request_headers BLOB,
+                    response_headers BLOB,
+                    data_size INTEGER,
+                    associated_data_size INTEGER,
+                    request_time INTEGER,
+                    response_time INTEGER,
+                    last_access_time INTEGER,
+                    PRIMARY KEY(cache_key, vary_key)
+                );
+            )#"sv,
+        },
+    });
 
     return database.migrate("CacheIndex"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -39,25 +39,28 @@ ErrorOr<Database::MigrationOutcome> CookieJar::migrate_schema(Database::Database
     // SameSite value instead of deriving it from the enum.
     static_assert(to_underlying(HTTP::Cookie::SameSite::Lax) == 3);
 
-    Array<Database::Migration, 1> migrations { {
-        { .version = COOKIES_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS Cookies (
-                name TEXT,
-                value TEXT,
-                same_site INTEGER CHECK (same_site >= 0 AND same_site <= 3),
-                creation_time INTEGER,
-                last_access_time INTEGER,
-                expiry_time INTEGER,
-                domain TEXT,
-                path TEXT,
-                secure BOOLEAN,
-                http_only BOOLEAN,
-                host_only BOOLEAN,
-                persistent BOOLEAN,
-                PRIMARY KEY(name, domain, path)
-            );
-        )#"sv },
-    } };
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = COOKIES_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS Cookies (
+                    name TEXT,
+                    value TEXT,
+                    same_site INTEGER CHECK (same_site >= 0 AND same_site <= 3),
+                    creation_time INTEGER,
+                    last_access_time INTEGER,
+                    expiry_time INTEGER,
+                    domain TEXT,
+                    path TEXT,
+                    secure BOOLEAN,
+                    http_only BOOLEAN,
+                    host_only BOOLEAN,
+                    persistent BOOLEAN,
+                    PRIMARY KEY(name, domain, path)
+                );
+            )#"sv,
+        },
+    });
 
     return database.migrate("Cookies"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/DownloadStore.cpp
+++ b/Libraries/LibWebView/DownloadStore.cpp
@@ -71,26 +71,32 @@ static Optional<Vector<DownloadSegmentRecord>> deserialize_segments(StringView s
 
 ErrorOr<Database::MigrationOutcome> DownloadStore::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 2> migrations { {
-        { .version = DOWNLOAD_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS Downloads (
-                id INTEGER PRIMARY KEY,
-                url TEXT NOT NULL,
-                display_url TEXT NOT NULL,
-                destination TEXT NOT NULL,
-                temporary_destination TEXT NOT NULL,
-                total_size INTEGER NOT NULL,
-                etag TEXT NOT NULL,
-                last_modified TEXT NOT NULL,
-                segments TEXT NOT NULL,
-                created_time INTEGER NOT NULL,
-                updated_time INTEGER NOT NULL
-            );
-        )#"sv },
-        { .version = DOWNLOAD_SCHEMA_RESTARTABILITY_VERSION, .sql = R"#(
-            ALTER TABLE Downloads ADD COLUMN can_restart_from_zero INTEGER NOT NULL DEFAULT 0;
-        )#"sv },
-    } };
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = DOWNLOAD_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS Downloads (
+                    id INTEGER PRIMARY KEY,
+                    url TEXT NOT NULL,
+                    display_url TEXT NOT NULL,
+                    destination TEXT NOT NULL,
+                    temporary_destination TEXT NOT NULL,
+                    total_size INTEGER NOT NULL,
+                    etag TEXT NOT NULL,
+                    last_modified TEXT NOT NULL,
+                    segments TEXT NOT NULL,
+                    created_time INTEGER NOT NULL,
+                    updated_time INTEGER NOT NULL
+                );
+            )#"sv,
+        },
+        {
+            .version = DOWNLOAD_SCHEMA_RESTARTABILITY_VERSION,
+            .sql = R"#(
+                ALTER TABLE Downloads ADD COLUMN can_restart_from_zero INTEGER NOT NULL DEFAULT 0;
+            )#"sv,
+        },
+    });
 
     return database.migrate("Downloads"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/HSTSStore.cpp
+++ b/Libraries/LibWebView/HSTSStore.cpp
@@ -18,14 +18,19 @@ static constexpr u32 HSTS_SCHEMA_BASELINE_VERSION = 1u;
 
 ErrorOr<Database::MigrationOutcome> HSTSStore::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 1> migrations { {
-        { .version = HSTS_SCHEMA_BASELINE_VERSION, .sql = "CREATE TABLE IF NOT EXISTS HSTSPolicies ("
-                                                          "    domain TEXT PRIMARY KEY,"
-                                                          "    expiry_time INTEGER NOT NULL,"
-                                                          "    include_sub_domains BOOLEAN NOT NULL,"
-                                                          "    last_observed_time INTEGER NOT NULL"
-                                                          ");"sv },
-    } };
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = HSTS_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS HSTSPolicies (
+                    domain TEXT PRIMARY KEY,
+                    expiry_time INTEGER NOT NULL,
+                    include_sub_domains BOOLEAN NOT NULL,
+                    last_observed_time INTEGER NOT NULL
+                );
+           )#"sv,
+        },
+    });
 
     return database.migrate("HSTSPolicies"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -141,48 +141,57 @@ static void sort_matching_entries(Vector<HistoryEntry const*>& matches, StringVi
 
 ErrorOr<Database::MigrationOutcome> HistoryStore::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 3> migrations { {
-        { .version = HISTORY_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS History (
-                url TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                favicon TEXT,
-                visit_count INTEGER NOT NULL,
-                last_visited_time INTEGER NOT NULL
-            );
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = HISTORY_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS History (
+                    url TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    favicon TEXT,
+                    visit_count INTEGER NOT NULL,
+                    last_visited_time INTEGER NOT NULL
+                );
 
-            CREATE INDEX IF NOT EXISTS HistoryLastVisitedTimeIndex
-            ON History(last_visited_time DESC);
-        )#"sv },
-        { .version = HISTORY_SCHEMA_RANKING_SIGNALS_VERSION, .sql = R"#(
-            ALTER TABLE History ADD COLUMN direct_visit_count INTEGER NOT NULL DEFAULT 0;
-            ALTER TABLE History ADD COLUMN last_qualifying_visit_time INTEGER NOT NULL DEFAULT 0;
-            ALTER TABLE History ADD COLUMN last_direct_visit_time INTEGER NOT NULL DEFAULT 0;
-            ALTER TABLE History ADD COLUMN decayed_visit_score REAL NOT NULL DEFAULT 0;
-            ALTER TABLE History ADD COLUMN decayed_direct_score REAL NOT NULL DEFAULT 0;
-            ALTER TABLE History ADD COLUMN score_updated_at INTEGER NOT NULL DEFAULT 0;
+                CREATE INDEX IF NOT EXISTS HistoryLastVisitedTimeIndex
+                ON History(last_visited_time DESC);
+            )#"sv,
+        },
+        {
+            .version = HISTORY_SCHEMA_RANKING_SIGNALS_VERSION,
+            .sql = R"#(
+                ALTER TABLE History ADD COLUMN direct_visit_count INTEGER NOT NULL DEFAULT 0;
+                ALTER TABLE History ADD COLUMN last_qualifying_visit_time INTEGER NOT NULL DEFAULT 0;
+                ALTER TABLE History ADD COLUMN last_direct_visit_time INTEGER NOT NULL DEFAULT 0;
+                ALTER TABLE History ADD COLUMN decayed_visit_score REAL NOT NULL DEFAULT 0;
+                ALTER TABLE History ADD COLUMN decayed_direct_score REAL NOT NULL DEFAULT 0;
+                ALTER TABLE History ADD COLUMN score_updated_at INTEGER NOT NULL DEFAULT 0;
 
-            UPDATE History
-            SET last_qualifying_visit_time = last_visited_time,
-                decayed_visit_score = MIN(CAST(visit_count AS REAL), 8.0),
-                score_updated_at = last_visited_time;
-        )#"sv },
-        { .version = HISTORY_SCHEMA_OMNIBOX_ENGAGEMENTS_VERSION, .sql = R"#(
-            CREATE TABLE OmniboxEngagements (
-                normalized_input TEXT NOT NULL,
-                destination_kind INTEGER NOT NULL,
-                destination_key TEXT NOT NULL,
-                destination TEXT NOT NULL,
-                explicit_use_count INTEGER NOT NULL,
-                default_use_count INTEGER NOT NULL,
-                last_used_time INTEGER NOT NULL,
-                PRIMARY KEY (normalized_input, destination_kind, destination_key)
-            );
+                UPDATE History
+                SET last_qualifying_visit_time = last_visited_time,
+                    decayed_visit_score = MIN(CAST(visit_count AS REAL), 8.0),
+                    score_updated_at = last_visited_time;
+            )#"sv,
+        },
+        {
+            .version = HISTORY_SCHEMA_OMNIBOX_ENGAGEMENTS_VERSION,
+            .sql = R"#(
+                CREATE TABLE OmniboxEngagements (
+                    normalized_input TEXT NOT NULL,
+                    destination_kind INTEGER NOT NULL,
+                    destination_key TEXT NOT NULL,
+                    destination TEXT NOT NULL,
+                    explicit_use_count INTEGER NOT NULL,
+                    default_use_count INTEGER NOT NULL,
+                    last_used_time INTEGER NOT NULL,
+                    PRIMARY KEY (normalized_input, destination_kind, destination_key)
+                );
 
-            CREATE INDEX OmniboxEngagementsByInput
-            ON OmniboxEngagements(destination_kind, normalized_input);
-        )#"sv },
-    } };
+                CREATE INDEX OmniboxEngagementsByInput
+                ON OmniboxEngagements(destination_kind, normalized_input);
+            )#"sv,
+        },
+    });
 
     return database.migrate("History"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/SessionStore.cpp
+++ b/Libraries/LibWebView/SessionStore.cpp
@@ -38,157 +38,160 @@ static Optional<size_t> index_as_size(i64 index)
 
 ErrorOr<Database::MigrationOutcome> SessionStore::PersistedStorage::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 1> migrations { {
-        { .version = SESSIONS_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS Sessions (
-                id INTEGER PRIMARY KEY,
-                kind INTEGER NOT NULL,
-                closed_time INTEGER NOT NULL,
-                close_sequence INTEGER NOT NULL DEFAULT 0,
-                source_window_id INTEGER,
-                source_tab_index INTEGER,
-                origin INTEGER NOT NULL DEFAULT 0,
-                active_tab_index INTEGER NOT NULL
-            );
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = SESSIONS_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS Sessions (
+                    id INTEGER PRIMARY KEY,
+                    kind INTEGER NOT NULL,
+                    closed_time INTEGER NOT NULL,
+                    close_sequence INTEGER NOT NULL DEFAULT 0,
+                    source_window_id INTEGER,
+                    source_tab_index INTEGER,
+                    origin INTEGER NOT NULL DEFAULT 0,
+                    active_tab_index INTEGER NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionTabs (
-                id INTEGER PRIMARY KEY,
-                session_id INTEGER NOT NULL REFERENCES Sessions(id) ON DELETE CASCADE,
-                tab_ordinal INTEGER NOT NULL,
-                active_url TEXT NOT NULL,
-                current_used_step_index INTEGER NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionTabs (
+                    id INTEGER PRIMARY KEY,
+                    session_id INTEGER NOT NULL REFERENCES Sessions(id) ON DELETE CASCADE,
+                    tab_ordinal INTEGER NOT NULL,
+                    active_url TEXT NOT NULL,
+                    current_used_step_index INTEGER NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionUsedSteps (
-                tab_id INTEGER NOT NULL REFERENCES SessionTabs(id) ON DELETE CASCADE,
-                step_ordinal INTEGER NOT NULL,
-                step INTEGER NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionUsedSteps (
+                    tab_id INTEGER NOT NULL REFERENCES SessionTabs(id) ON DELETE CASCADE,
+                    step_ordinal INTEGER NOT NULL,
+                    step INTEGER NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionHistories (
-                id INTEGER PRIMARY KEY,
-                tab_id INTEGER NOT NULL REFERENCES SessionTabs(id) ON DELETE CASCADE
-            );
+                CREATE TABLE IF NOT EXISTS SessionHistories (
+                    id INTEGER PRIMARY KEY,
+                    tab_id INTEGER NOT NULL REFERENCES SessionTabs(id) ON DELETE CASCADE
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionNestedHistories (
-                parent_history_id INTEGER NOT NULL,
-                parent_entry_ordinal INTEGER NOT NULL,
-                nested_ordinal INTEGER NOT NULL,
-                nested_history_namespace_id INTEGER NOT NULL,
-                nested_history_local_id INTEGER NOT NULL,
-                child_history_id INTEGER NOT NULL UNIQUE REFERENCES SessionHistories(id) ON DELETE CASCADE,
-                FOREIGN KEY (parent_history_id, parent_entry_ordinal) REFERENCES SessionEntries(history_id, entry_ordinal) ON DELETE CASCADE
-            );
+                CREATE TABLE IF NOT EXISTS SessionNestedHistories (
+                    parent_history_id INTEGER NOT NULL,
+                    parent_entry_ordinal INTEGER NOT NULL,
+                    nested_ordinal INTEGER NOT NULL,
+                    nested_history_namespace_id INTEGER NOT NULL,
+                    nested_history_local_id INTEGER NOT NULL,
+                    child_history_id INTEGER NOT NULL UNIQUE REFERENCES SessionHistories(id) ON DELETE CASCADE,
+                    FOREIGN KEY (parent_history_id, parent_entry_ordinal) REFERENCES SessionEntries(history_id, entry_ordinal) ON DELETE CASCADE
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionEntries (
-                id INTEGER PRIMARY KEY,
-                history_id INTEGER NOT NULL REFERENCES SessionHistories(id) ON DELETE CASCADE,
-                entry_ordinal INTEGER NOT NULL,
-                step INTEGER NOT NULL,
-                url TEXT NOT NULL,
-                document_state_namespace_id INTEGER NOT NULL,
-                document_state_local_id INTEGER NOT NULL,
-                classic_state BLOB NOT NULL,
-                navigation_state BLOB NOT NULL,
-                navigation_api_key TEXT NOT NULL,
-                navigation_api_id TEXT NOT NULL,
-                scroll_restoration_mode INTEGER NOT NULL,
-                scroll_x_raw INTEGER,
-                scroll_y_raw INTEGER,
-                origin_kind INTEGER NOT NULL,
-                origin_nonce BLOB,
-                origin_scheme TEXT,
-                origin_host TEXT,
-                origin_port INTEGER,
-                origin_domain TEXT,
-                initiator_origin_kind INTEGER NOT NULL,
-                initiator_origin_nonce BLOB,
-                initiator_origin_scheme TEXT,
-                initiator_origin_host TEXT,
-                initiator_origin_port INTEGER,
-                initiator_origin_domain TEXT,
-                referrer_kind INTEGER NOT NULL,
-                referrer_url TEXT,
-                referrer_policy INTEGER NOT NULL,
-                resource_kind INTEGER NOT NULL,
-                resource_string TEXT,
-                about_base_url TEXT,
-                navigable_target_name TEXT NOT NULL,
-                ever_populated INTEGER NOT NULL,
-                reload_pending INTEGER NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionEntries (
+                    id INTEGER PRIMARY KEY,
+                    history_id INTEGER NOT NULL REFERENCES SessionHistories(id) ON DELETE CASCADE,
+                    entry_ordinal INTEGER NOT NULL,
+                    step INTEGER NOT NULL,
+                    url TEXT NOT NULL,
+                    document_state_namespace_id INTEGER NOT NULL,
+                    document_state_local_id INTEGER NOT NULL,
+                    classic_state BLOB NOT NULL,
+                    navigation_state BLOB NOT NULL,
+                    navigation_api_key TEXT NOT NULL,
+                    navigation_api_id TEXT NOT NULL,
+                    scroll_restoration_mode INTEGER NOT NULL,
+                    scroll_x_raw INTEGER,
+                    scroll_y_raw INTEGER,
+                    origin_kind INTEGER NOT NULL,
+                    origin_nonce BLOB,
+                    origin_scheme TEXT,
+                    origin_host TEXT,
+                    origin_port INTEGER,
+                    origin_domain TEXT,
+                    initiator_origin_kind INTEGER NOT NULL,
+                    initiator_origin_nonce BLOB,
+                    initiator_origin_scheme TEXT,
+                    initiator_origin_host TEXT,
+                    initiator_origin_port INTEGER,
+                    initiator_origin_domain TEXT,
+                    referrer_kind INTEGER NOT NULL,
+                    referrer_url TEXT,
+                    referrer_policy INTEGER NOT NULL,
+                    resource_kind INTEGER NOT NULL,
+                    resource_string TEXT,
+                    about_base_url TEXT,
+                    navigable_target_name TEXT NOT NULL,
+                    ever_populated INTEGER NOT NULL,
+                    reload_pending INTEGER NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionPolicyContainers (
-                id INTEGER PRIMARY KEY,
-                history_id INTEGER NOT NULL,
-                entry_ordinal INTEGER NOT NULL,
-                referrer_policy INTEGER NOT NULL,
-                embedder_policy_value INTEGER NOT NULL,
-                embedder_policy_report_only_value INTEGER NOT NULL,
-                embedder_policy_reporting_endpoint TEXT NOT NULL,
-                embedder_policy_report_only_reporting_endpoint TEXT NOT NULL,
-                FOREIGN KEY (history_id, entry_ordinal) REFERENCES SessionEntries(history_id, entry_ordinal) ON DELETE CASCADE
-            );
+                CREATE TABLE IF NOT EXISTS SessionPolicyContainers (
+                    id INTEGER PRIMARY KEY,
+                    history_id INTEGER NOT NULL,
+                    entry_ordinal INTEGER NOT NULL,
+                    referrer_policy INTEGER NOT NULL,
+                    embedder_policy_value INTEGER NOT NULL,
+                    embedder_policy_report_only_value INTEGER NOT NULL,
+                    embedder_policy_reporting_endpoint TEXT NOT NULL,
+                    embedder_policy_report_only_reporting_endpoint TEXT NOT NULL,
+                    FOREIGN KEY (history_id, entry_ordinal) REFERENCES SessionEntries(history_id, entry_ordinal) ON DELETE CASCADE
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionCspPolicies (
-                id INTEGER PRIMARY KEY,
-                container_id INTEGER NOT NULL REFERENCES SessionPolicyContainers(id) ON DELETE CASCADE,
-                policy_ordinal INTEGER NOT NULL,
-                disposition INTEGER NOT NULL,
-                source INTEGER NOT NULL,
-                self_origin_kind INTEGER NOT NULL,
-                self_origin_nonce BLOB,
-                self_origin_scheme TEXT,
-                self_origin_host TEXT,
-                self_origin_port INTEGER,
-                self_origin_domain TEXT,
-                pre_parsed_policy_string TEXT NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionCspPolicies (
+                    id INTEGER PRIMARY KEY,
+                    container_id INTEGER NOT NULL REFERENCES SessionPolicyContainers(id) ON DELETE CASCADE,
+                    policy_ordinal INTEGER NOT NULL,
+                    disposition INTEGER NOT NULL,
+                    source INTEGER NOT NULL,
+                    self_origin_kind INTEGER NOT NULL,
+                    self_origin_nonce BLOB,
+                    self_origin_scheme TEXT,
+                    self_origin_host TEXT,
+                    self_origin_port INTEGER,
+                    self_origin_domain TEXT,
+                    pre_parsed_policy_string TEXT NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionCspDirectives (
-                id INTEGER PRIMARY KEY,
-                policy_id INTEGER NOT NULL REFERENCES SessionCspPolicies(id) ON DELETE CASCADE,
-                directive_ordinal INTEGER NOT NULL,
-                name TEXT NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionCspDirectives (
+                    id INTEGER PRIMARY KEY,
+                    policy_id INTEGER NOT NULL REFERENCES SessionCspPolicies(id) ON DELETE CASCADE,
+                    directive_ordinal INTEGER NOT NULL,
+                    name TEXT NOT NULL
+                );
 
-            CREATE TABLE IF NOT EXISTS SessionCspDirectiveValues (
-                directive_id INTEGER NOT NULL REFERENCES SessionCspDirectives(id) ON DELETE CASCADE,
-                value_ordinal INTEGER NOT NULL,
-                value TEXT NOT NULL
-            );
+                CREATE TABLE IF NOT EXISTS SessionCspDirectiveValues (
+                    directive_id INTEGER NOT NULL REFERENCES SessionCspDirectives(id) ON DELETE CASCADE,
+                    value_ordinal INTEGER NOT NULL,
+                    value TEXT NOT NULL
+                );
 
-            CREATE INDEX IF NOT EXISTS SessionsRetentionIndex
-            ON Sessions(kind, close_sequence DESC, closed_time DESC, id DESC);
+                CREATE INDEX IF NOT EXISTS SessionsRetentionIndex
+                ON Sessions(kind, close_sequence DESC, closed_time DESC, id DESC);
 
-            CREATE INDEX IF NOT EXISTS SessionTabsBySessionIndex
-            ON SessionTabs(session_id);
+                CREATE INDEX IF NOT EXISTS SessionTabsBySessionIndex
+                ON SessionTabs(session_id);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionUsedStepsByTabIndex
-            ON SessionUsedSteps(tab_id, step_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionUsedStepsByTabIndex
+                ON SessionUsedSteps(tab_id, step_ordinal);
 
-            CREATE INDEX IF NOT EXISTS SessionHistoriesByTabIndex
-            ON SessionHistories(tab_id);
+                CREATE INDEX IF NOT EXISTS SessionHistoriesByTabIndex
+                ON SessionHistories(tab_id);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionNestedHistoriesByParentIndex
-            ON SessionNestedHistories(parent_history_id, parent_entry_ordinal, nested_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionNestedHistoriesByParentIndex
+                ON SessionNestedHistories(parent_history_id, parent_entry_ordinal, nested_ordinal);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionEntriesByHistoryIndex
-            ON SessionEntries(history_id, entry_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionEntriesByHistoryIndex
+                ON SessionEntries(history_id, entry_ordinal);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionPolicyContainersByHistoryIndex
-            ON SessionPolicyContainers(history_id, entry_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionPolicyContainersByHistoryIndex
+                ON SessionPolicyContainers(history_id, entry_ordinal);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionCspPoliciesByContainerIndex
-            ON SessionCspPolicies(container_id, policy_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionCspPoliciesByContainerIndex
+                ON SessionCspPolicies(container_id, policy_ordinal);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionCspDirectivesByPolicyIndex
-            ON SessionCspDirectives(policy_id, directive_ordinal);
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionCspDirectivesByPolicyIndex
+                ON SessionCspDirectives(policy_id, directive_ordinal);
 
-            CREATE UNIQUE INDEX IF NOT EXISTS SessionCspDirectiveValuesByDirectiveIndex
-            ON SessionCspDirectiveValues(directive_id, value_ordinal);
-        )#"sv },
-    } };
+                CREATE UNIQUE INDEX IF NOT EXISTS SessionCspDirectiveValuesByDirectiveIndex
+                ON SessionCspDirectiveValues(directive_id, value_ordinal);
+            )#"sv,
+        },
+    });
 
     return database.migrate("Sessions"sv, migrations, mode);
 }

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -19,18 +19,21 @@ static constexpr u32 WEB_STORAGE_SCHEMA_BASELINE_VERSION = 2u;
 
 ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 1> migrations { {
-        { .version = WEB_STORAGE_SCHEMA_BASELINE_VERSION, .sql = R"#(
-            CREATE TABLE IF NOT EXISTS WebStorage (
-                storage_endpoint INTEGER,
-                storage_key TEXT,
-                bottle_key TEXT,
-                bottle_value TEXT,
-                last_access_time INTEGER,
-                PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
-            );
-        )#"sv },
-    } };
+    auto migrations = to_array<Database::Migration>({
+        {
+            .version = WEB_STORAGE_SCHEMA_BASELINE_VERSION,
+            .sql = R"#(
+                CREATE TABLE IF NOT EXISTS WebStorage (
+                    storage_endpoint INTEGER,
+                    storage_key TEXT,
+                    bottle_key TEXT,
+                    bottle_value TEXT,
+                    last_access_time INTEGER,
+                    PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
+                );
+            )#"sv,
+        },
+    });
 
     return database.migrate("WebStorage"sv, migrations, mode);
 }

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/Array.h>
+#include <AK/Noncopyable.h>
 
 static constexpr int constexpr_sum(ReadonlySpan<int> const span)
 {
@@ -60,4 +61,29 @@ TEST_CASE(to_array)
     static_assert(array[0] == 0);
     static_assert(array[1] == 2);
     static_assert(array[2] == 1);
+}
+
+TEST_CASE(to_array_non_copyable)
+{
+    struct MoveOnlyType {
+        MoveOnlyType() = default;
+        AK_MAKE_NONCOPYABLE(MoveOnlyType);
+        AK_MAKE_DEFAULT_MOVABLE(MoveOnlyType);
+    };
+
+    struct MoveOnlyElement {
+        int value { 0 };
+        MoveOnlyType move_only {};
+    };
+
+    constexpr auto array = to_array<MoveOnlyElement>({
+        { .value = 1 },
+        { .value = 2 },
+        { .value = 3 },
+    });
+
+    static_assert(array.size() == 3uz);
+    static_assert(array[0].value == 1);
+    static_assert(array[1].value == 2);
+    static_assert(array[2].value == 3);
 }


### PR DESCRIPTION
Went to go use this on a `Database::Migration` array in a branch of mine to be hit with:
```
Array.h:174:16: error: no viable conversion from 'Database::Migration' to 'u32' (aka 'unsigned int')
```

which obviously means `Migration` is move-only