### PR TITLE
UI/AppKit: Compare pasteboard types by value, not by pointer

### DIFF
--- a/Tests/UI/AppKit/CMakeLists.txt
+++ b/Tests/UI/AppKit/CMakeLists.txt
@@ -1,0 +1,8 @@
+if (NOT APPLE)
+    return()
+endif()
+
+ladybird_test("TestClipboardTypes.mm" UI/AppKit NAME TestAppKitClipboardTypes LIBS LibWebView)
+target_sources(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Application/ClipboardTypes.mm")
+target_include_directories(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")
+target_link_libraries(TestAppKitClipboardTypes PRIVATE "-framework Cocoa")

--- a/Tests/UI/AppKit/TestClipboardTypes.mm
+++ b/Tests/UI/AppKit/TestClipboardTypes.mm
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <Application/ClipboardTypes.h>
+
+#include <LibTest/TestCase.h>
+
+TEST_CASE(maps_the_appkit_type_constants)
+{
+    EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(NSPasteboardTypeString), "text/plain"_string);
+    EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(NSPasteboardTypeHTML), "text/html"_string);
+    EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(NSPasteboardTypePNG), "image/png"_string);
+}
+
+// The general pasteboard reports types as NSString instances distinct from the AppKit constants — so matching them
+// with pointer equality drops every representation and a paste from another app silently does nothing. Build equally
+// distinct instances here, rather than reading the user's clipboard. Note: -initWithString on an immutable string
+// returns the receiver — so it can't be used for this.
+TEST_CASE(maps_types_that_are_not_the_constant_instances)
+{
+    auto* built = [NSString stringWithUTF8String:"public.utf8-plain-text"];
+    EXPECT_NE(built, NSPasteboardTypeString);
+    EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(built), "text/plain"_string);
+
+    auto* formatted = [NSString stringWithFormat:@"%@", NSPasteboardTypeHTML];
+    EXPECT_NE(formatted, NSPasteboardTypeHTML);
+    EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(formatted), "text/html"_string);
+}
+
+// A smoke test over the shape the read path actually walks. Note: this doesn't stand in for the case above. A
+// pasteboard read back in the process that wrote it can hand back the interned constant — in which case pointer
+// equality would happen to work here.
+TEST_CASE(maps_the_types_a_real_pasteboard_reports)
+{
+    auto* pasteboard = [NSPasteboard pasteboardWithUniqueName];
+    [pasteboard clearContents];
+    [pasteboard setData:[@"hello" dataUsingEncoding:NSUTF8StringEncoding] forType:NSPasteboardTypeString];
+
+    bool found_text_plain = false;
+    for (NSPasteboardType type : [pasteboard types]) {
+        if (auto mime_type = Ladybird::mime_type_for_pasteboard_type(type); mime_type == "text/plain"_string)
+            found_text_plain = true;
+    }
+    [pasteboard releaseGlobally];
+
+    EXPECT(found_text_plain);
+}
+
+TEST_CASE(ignores_unknown_types)
+{
+    EXPECT(!Ladybird::mime_type_for_pasteboard_type(NSPasteboardTypeColor).has_value());
+    EXPECT(!Ladybird::mime_type_for_pasteboard_type(@"com.example.private-format").has_value());
+}
+
+TEST_CASE(maps_mime_types_back_to_pasteboard_types)
+{
+    EXPECT([Ladybird::pasteboard_type_for_mime_type("text/plain"sv) isEqualToString:NSPasteboardTypeString]);
+    EXPECT([Ladybird::pasteboard_type_for_mime_type("text/html"sv) isEqualToString:NSPasteboardTypeHTML]);
+    EXPECT([Ladybird::pasteboard_type_for_mime_type("image/png"sv) isEqualToString:NSPasteboardTypePNG]);
+    EXPECT_EQ(Ladybird::pasteboard_type_for_mime_type("application/pdf"sv), nil);
+}
+
+TEST_CASE(round_trips_every_supported_mime_type)
+{
+    for (auto mime_type : { "text/plain"sv, "text/html"sv, "image/png"sv }) {
+        auto* pasteboard_type = Ladybird::pasteboard_type_for_mime_type(mime_type);
+        EXPECT_NE(pasteboard_type, nil);
+        EXPECT_EQ(Ladybird::mime_type_for_pasteboard_type(pasteboard_type), MUST(String::from_utf8(mime_type)));
+    }
+}

--- a/Tests/UI/CMakeLists.txt
+++ b/Tests/UI/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(AppKit)
 add_subdirectory(Qt)

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -17,6 +17,7 @@
 
 #import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
+#import <Application/ClipboardTypes.h>
 #import <Interface/BookmarksBar.h>
 #import <Interface/LadybirdWebView.h>
 #import <Interface/LocationSearchField.h>
@@ -223,19 +224,12 @@ Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_ent
     auto* paste_board = [NSPasteboard generalPasteboard];
 
     for (NSPasteboardType type : [paste_board types]) {
-        String mime_type;
-
-        if (type == NSPasteboardTypeString)
-            mime_type = "text/plain"_string;
-        else if (type == NSPasteboardTypeHTML)
-            mime_type = "text/html"_string;
-        else if (type == NSPasteboardTypePNG)
-            mime_type = "image/png"_string;
-        else
+        auto mime_type = Ladybird::mime_type_for_pasteboard_type(type);
+        if (!mime_type.has_value())
             continue;
 
         auto data = Ladybird::ns_data_to_string([paste_board dataForType:type]);
-        representations.empend(move(data), move(mime_type));
+        representations.empend(move(data), mime_type.release_value());
     }
 
     return representations;
@@ -247,16 +241,8 @@ void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item
     [paste_board clearContents];
 
     for (auto const& entry : item.system_clipboard_representations) {
-        NSPasteboardType pasteboard_type = nil;
-
-        // https://w3c.github.io/clipboard-apis/#os-specific-well-known-format
-        if (entry.mime_type == "text/plain"sv)
-            pasteboard_type = NSPasteboardTypeString;
-        else if (entry.mime_type == "text/html"sv)
-            pasteboard_type = NSPasteboardTypeHTML;
-        else if (entry.mime_type == "image/png"sv)
-            pasteboard_type = NSPasteboardTypePNG;
-        else
+        NSPasteboardType pasteboard_type = Ladybird::pasteboard_type_for_mime_type(entry.mime_type);
+        if (!pasteboard_type)
             continue;
 
         [paste_board setData:Ladybird::string_to_ns_data(entry.data)

--- a/UI/AppKit/Application/ClipboardTypes.h
+++ b/UI/AppKit/Application/ClipboardTypes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+
+namespace Ladybird {
+
+// https://w3c.github.io/clipboard-apis/#os-specific-well-known-format
+Optional<String> mime_type_for_pasteboard_type(NSPasteboardType);
+NSPasteboardType pasteboard_type_for_mime_type(StringView mime_type);
+
+}

--- a/UI/AppKit/Application/ClipboardTypes.mm
+++ b/UI/AppKit/Application/ClipboardTypes.mm
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <Application/ClipboardTypes.h>
+
+namespace Ladybird {
+
+Optional<String> mime_type_for_pasteboard_type(NSPasteboardType type)
+{
+    if ([type isEqualToString:NSPasteboardTypeString])
+        return "text/plain"_string;
+    if ([type isEqualToString:NSPasteboardTypeHTML])
+        return "text/html"_string;
+    if ([type isEqualToString:NSPasteboardTypePNG])
+        return "image/png"_string;
+    return {};
+}
+
+NSPasteboardType pasteboard_type_for_mime_type(StringView mime_type)
+{
+    if (mime_type == "text/plain"sv)
+        return NSPasteboardTypeString;
+    if (mime_type == "text/html"sv)
+        return NSPasteboardTypeHTML;
+    if (mime_type == "image/png"sv)
+        return NSPasteboardTypePNG;
+    return nil;
+}
+
+}

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ladybird_impl STATIC
     Application/Application.mm
     Application/ApplicationDelegate.mm
+    Application/ClipboardTypes.mm
     Application/EventLoopImplementationMacOS.mm
     Interface/Autocomplete.mm
     Interface/BookmarkFolder.mm


### PR DESCRIPTION
**Problem:** Pasting into text-input areas in web content didn’t work.

**Cause:** We were using `==` to match each `NSPasteboardType` against AppKit constants — comparing `NSString` pointers rather than their text.

**Fix:** Use `isEqualToString` to compare by value. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11189.
