### PR TITLE
LibWeb: Skip stacking context invalidation for detached paintables

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1378,6 +1378,8 @@ OwnPtr<Layout::FlexLayoutData> Paintable::flex_layout_data() const
 
 void Paintable::invalidate_stacking_context()
 {
+    if (!has_layout_node())
+        return;
     if (auto viewport_paintable = document().unsafe_paintable())
         viewport_paintable->invalidate_stacking_context_tree();
 }

--- a/Tests/LibWeb/Crash/Layout/stacking-context-invalidation-on-stale-viewport-paintable.html
+++ b/Tests/LibWeb/Crash/Layout/stacking-context-invalidation-on-stale-viewport-paintable.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    html, body, button {
+        display: table-column-group;
+    }
+    button {
+        animation: anim 1s paused;
+    }
+</style>
+<button></button>


### PR DESCRIPTION
Previously, invalidating the stacking context of a paintable that had been detached from its layout node crashed.

This change restores a guard that was recently added in 35ec147a17b then removed in 4b8b16d4989 (both in #11222).

Found with Domato.

