### PR TITLE
LibWeb: Keep FontFaceSet pending until the document has fully loaded

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -575,8 +575,12 @@ void EventLoop::update_the_rendering()
         // - the document is still loading
         // - the document has pending stylesheet requests
         // FIXME: - the document has pending layout operations which might cause the user agent to request a font, or which depend on recently-loaded fonts
+        // AD-HOC: The specification is not clear with regard to what "still loading" means. We take it to mean that the
+        //         current ready state is not "complete". This means that the ready promise cannot resolve before the
+        //         load event.
+        //         Spec issue: https://github.com/w3c/csswg-drafts/issues/1081
         TemporaryExecutionContext context(document->relevant_settings_object(), TemporaryExecutionContext::CallbacksEnabled::Yes);
-        document->fonts()->set_is_pending_on_the_environment(document->readiness() == DocumentReadyState::Loading);
+        document->fonts()->set_is_pending_on_the_environment(document->readiness() != DocumentReadyState::Complete);
     }
 }
 

--- a/Tests/LibWeb/Text/expected/css/fonts-ready-waits-for-font-used-after-parsing.txt
+++ b/Tests/LibWeb/Text/expected/css/fonts-ready-waits-for-font-used-after-parsing.txt
@@ -1,0 +1,2 @@
+font status: loaded
+readyState: complete

--- a/Tests/LibWeb/Text/input/css/fonts-ready-waits-for-font-used-after-parsing.html
+++ b/Tests/LibWeb/Text/input/css/fonts-ready-waits-for-font-used-after-parsing.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    @font-face {
+        font-family: 'HashSans';
+        src: url('../../../Assets/HashSans.woff');
+    }
+</style>
+</head>
+<body>
+<iframe id="load-blocker"></iframe>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        // Keep the load event from firing, so the document stays at readiness "interactive".
+        const blockerDocument = document.getElementById("load-blocker").contentDocument;
+        blockerDocument.open();
+
+        // Let a full rendering update run before any content uses the font.
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+        const div = document.createElement("div");
+        div.style.fontFamily = "HashSans";
+        div.textContent = "X";
+        document.body.appendChild(div);
+
+        const readyPromise = document.fonts.ready.then(() => {
+            const fontFace = [...document.fonts][0];
+            println(`font status: ${fontFace.status}`);
+            println(`readyState: ${document.readyState}`);
+        });
+
+        blockerDocument.close();
+        await readyPromise;
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Previously, a FontFaceSet stopped being pending on the environment as soon as the document readiness left "loading". Deferred and module scripts run after that transition, so the `document.fonts.ready` promise could resolve before a script inserted the first content that uses a web font. Scripts waiting on the promise then measured fallback font metrics.

Treat the document as still loading until its readiness is "complete". The `document.fonts.ready` promise can then no longer resolve before the load event. A slow subresource that delays the load event now also delays the promise even when every font has finished loading.

This fixes some recent flakiness in the [`css/css-grid/abspos/orthogonal-positioned-grid-descendants-*`](https://wpt.fyi/results/css/css-grid/abspos?diff&filter=ADC&run_id=4721889888174080&run_id=6263225606995968) WPT tests.