### PR TITLE
LibWeb: Reduce repeated geometry query overhead

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1811,7 +1811,7 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     // contained-boxes map; refresh it before overflow measurement follows them. A pending full
     // recalculation rebuilds the map inside its own measurement traversal instead.
     if (layout_tree_changed == LayoutTreeChanged::Yes && !m_needs_full_scrollable_overflow_recalculation)
-        m_scrollable_overflow_contained_boxes_from_last_layout = Layout::collect_scrollable_overflow_contained_boxes(*m_layout_root);
+        Layout::collect_scrollable_overflow_contained_boxes(*m_layout_root, m_scrollable_overflow_contained_boxes_from_last_layout);
     if (layout_commit_scope == LayoutCommitScope::Full)
         update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::HandledByFullLayoutCommit, boxes_needing_eager_overflow_measurement);
     else
@@ -2211,8 +2211,8 @@ void Document::update_layout(UpdateLayoutReason reason)
             viewport_rect.width(),
             viewport_rect.height(),
             should_collect_devtools_layout_data);
-        m_scrollable_overflow_contained_boxes_from_last_layout = Layout::collect_scrollable_overflow_contained_boxes(
-            *m_layout_root, [&](Layout::Box const& box) {
+        Layout::collect_scrollable_overflow_contained_boxes(
+            *m_layout_root, m_scrollable_overflow_contained_boxes_from_last_layout, [&](Layout::Box const& box) {
                 auto paintable = box.paintable_box();
                 if (&box == m_layout_root.ptr() || box.is_scroll_container() || (paintable && !paintable->scroll_offset().is_zero()))
                     boxes_needing_eager_overflow_measurement.append(&box);
@@ -2522,8 +2522,8 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
     };
 
     if (needs_full_recalculation) {
-        m_scrollable_overflow_contained_boxes_from_last_layout = Layout::collect_scrollable_overflow_contained_boxes(
-            *m_layout_root, [&](Layout::Box const& box) { record_and_clear_overflow_data(box); });
+        Layout::collect_scrollable_overflow_contained_boxes(
+            *m_layout_root, m_scrollable_overflow_contained_boxes_from_last_layout, [&](Layout::Box const& box) { record_and_clear_overflow_data(box); });
     } else {
         for (auto const& weak_paintable : pending_paintables) {
             auto paintable = weak_paintable.strong_ref();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1825,9 +1825,10 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
 
     if (layout_tree_changed == LayoutTreeChanged::Yes) {
         // Broadcast the current viewport rect to any new paintables, so they know whether
-        // they're visible or not, and re-collect the content-visibility:auto set.
+        // they're visible or not. If necessary, re-collect the content-visibility:auto set.
         inform_all_viewport_clients_about_the_current_viewport_rect();
-        collect_paintable_boxes_with_auto_content_visibility();
+        if (m_may_have_content_visibility_auto_style)
+            collect_paintable_boxes_with_auto_content_visibility();
     }
 
     m_document->set_needs_repaint();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -191,6 +191,7 @@
 #include <LibWeb/Infra/SerializedURL.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
+#include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/ScrollableOverflow.h>
@@ -2668,8 +2669,13 @@ bool Document::can_compute_client_rects_without_accumulated_visual_contexts_upda
             continue;
         if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
             return false;
-        if (auto paintable = node->paintable(); paintable && !paintable->scroll_offset().is_zero())
+        if (auto const* box = as_if<Layout::Box>(*node); box && box->default_scroll_shift_anchor())
             return false;
+        // A scroll container's contents move, but its own border box does not.
+        if (node != &layout_node) {
+            if (auto paintable = node->paintable(); paintable && !paintable->scroll_offset().is_zero())
+                return false;
+        }
     }
     return true;
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2669,8 +2669,10 @@ bool Document::can_compute_client_rects_without_accumulated_visual_contexts_upda
             continue;
         if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
             return false;
-        if (auto const* box = as_if<Layout::Box>(*node); box && box->default_scroll_shift_anchor())
-            return false;
+        if (m_may_have_default_scroll_shift_anchor) {
+            if (auto const* box = as_if<Layout::Box>(*node); box && box->default_scroll_shift_anchor())
+                return false;
+        }
         // A scroll container's contents move, but its own border box does not.
         if (node != &layout_node) {
             if (auto paintable = node->paintable(); paintable && !paintable->scroll_offset().is_zero())

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2226,10 +2226,8 @@ void Document::update_layout(UpdateLayoutReason reason)
 
         after_layout_commit(LayoutTreeChanged::Yes, LayoutCommitScope::Full, boxes_needing_eager_overflow_measurement);
 
-        m_layout_root->for_each_in_inclusive_subtree([](auto& node) {
-            node.reset_needs_layout_update();
-            return TraversalDecision::Continue;
-        });
+        Layout::RustFFI::layout_arena_reset_layout_update_flags_in_subtree(
+            layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root.ptr()));
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("LAYOUT {} {} µs", to_string(reason), timer.elapsed_time().to_microseconds());

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2655,25 +2655,24 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
         paintable->refresh_scroll_state();
 }
 
-bool Document::can_compute_client_rects_without_accumulated_visual_contexts_update() const
+bool Document::can_compute_client_rects_without_accumulated_visual_contexts_update(Layout::Node const& layout_node) const
 {
     if (!m_needs_accumulated_visual_contexts_update || !m_layout_root)
         return false;
 
-    auto decision = m_layout_root->for_each_in_inclusive_subtree([](Layout::Node const& node) {
-        if (node.is_svg_box() || node.is_svg_svg_box() || node.is_svg_foreign_object_box())
-            return TraversalDecision::Break;
+    for (auto const* node = &layout_node; node; node = node->parent()) {
+        if (node->is_svg_box() || node->is_svg_svg_box() || node->is_svg_foreign_object_box())
+            return false;
 
-        auto const* node_with_style = as_if<Layout::NodeWithStyle>(node);
+        auto const* node_with_style = as_if<Layout::NodeWithStyle>(*node);
         if (!node_with_style)
-            return TraversalDecision::Continue;
+            continue;
         if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
-            return TraversalDecision::Break;
-        if (auto paintable = node.paintable(); paintable && !paintable->scroll_offset().is_zero())
-            return TraversalDecision::Break;
-        return TraversalDecision::Continue;
-    });
-    return decision != TraversalDecision::Break;
+            return false;
+        if (auto paintable = node->paintable(); paintable && !paintable->scroll_offset().is_zero())
+            return false;
+    }
+    return true;
 }
 
 void Document::set_normal_link_color(Optional<Color> color)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2655,6 +2655,27 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
         paintable->refresh_scroll_state();
 }
 
+bool Document::can_compute_client_rects_without_accumulated_visual_contexts_update() const
+{
+    if (!m_needs_accumulated_visual_contexts_update || !m_layout_root)
+        return false;
+
+    auto decision = m_layout_root->for_each_in_inclusive_subtree([](Layout::Node const& node) {
+        if (node.is_svg_box() || node.is_svg_svg_box() || node.is_svg_foreign_object_box())
+            return TraversalDecision::Break;
+
+        auto const* node_with_style = as_if<Layout::NodeWithStyle>(node);
+        if (!node_with_style)
+            return TraversalDecision::Continue;
+        if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
+            return TraversalDecision::Break;
+        if (auto paintable = node.paintable(); paintable && !paintable->scroll_offset().is_zero())
+            return TraversalDecision::Break;
+        return TraversalDecision::Continue;
+    });
+    return decision != TraversalDecision::Break;
+}
+
 void Document::set_normal_link_color(Optional<Color> color)
 {
     if (m_normal_link_color == color)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1113,7 +1113,7 @@ public:
     void record_layout_tree_build(u64 rebuilt_subtree_root_count, bool escaped_rebuild_roots);
 
     void set_needs_accumulated_visual_contexts_update(bool);
-    bool can_compute_client_rects_without_accumulated_visual_contexts_update() const;
+    bool can_compute_client_rects_without_accumulated_visual_contexts_update(Layout::Node const&) const;
     void schedule_accumulated_visual_context_value_update(Element&);
     void schedule_accumulated_visual_context_value_update(Layout::Node const&);
     void schedule_scrollable_overflow_recalculation(Element&);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -464,6 +464,7 @@ public:
     bool update_style_for_element(AbstractElement const&, StyleUpdateMode);
     void update_layout(UpdateLayoutReason);
     void note_content_visibility_auto_style() { m_may_have_content_visibility_auto_style = true; }
+    void note_default_scroll_shift_anchor() { m_may_have_default_scroll_shift_anchor = true; }
     enum class PartialRelayoutResult : u8 {
         NotEligible,
         Done,
@@ -1491,6 +1492,7 @@ private:
     RefPtr<Layout::NodeArena> m_layout_node_arena;
     RefPtr<Layout::Viewport> m_layout_root;
     bool m_may_have_content_visibility_auto_style { false };
+    bool m_may_have_default_scroll_shift_anchor { false };
 
     GC::Ptr<Node> m_hovered_node;
     GC::Ptr<Node> m_inspected_node;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1113,6 +1113,7 @@ public:
     void record_layout_tree_build(u64 rebuilt_subtree_root_count, bool escaped_rebuild_roots);
 
     void set_needs_accumulated_visual_contexts_update(bool);
+    bool can_compute_client_rects_without_accumulated_visual_contexts_update() const;
     void schedule_accumulated_visual_context_value_update(Element&);
     void schedule_accumulated_visual_context_value_update(Layout::Node const&);
     void schedule_scrollable_overflow_recalculation(Element&);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -463,6 +463,7 @@ public:
     bool update_style_for_element(AbstractElement const&);
     bool update_style_for_element(AbstractElement const&, StyleUpdateMode);
     void update_layout(UpdateLayoutReason);
+    void note_content_visibility_auto_style() { m_may_have_content_visibility_auto_style = true; }
     enum class PartialRelayoutResult : u8 {
         NotEligible,
         Done,
@@ -1489,6 +1490,7 @@ private:
 
     RefPtr<Layout::NodeArena> m_layout_node_arena;
     RefPtr<Layout::Viewport> m_layout_root;
+    bool m_may_have_content_visibility_auto_style { false };
 
     GC::Ptr<Node> m_hovered_node;
     GC::Ptr<Node> m_inspected_node;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2536,13 +2536,21 @@ CSSPixelRect Element::get_bounding_client_rect() const
     return bounding_rect_from_client_rects(get_client_rects());
 }
 
-static void append_transformed_border_box_rect(Vector<CSSPixelRect>& rects, Painting::Paintable const& paintable_box)
+enum class VisualContextTransform {
+    Apply,
+    Identity,
+};
+
+static void append_border_box_rect(Vector<CSSPixelRect>& rects, Painting::Paintable const& paintable_box, VisualContextTransform visual_context_transform)
 {
     auto absolute_rect = paintable_box.absolute_border_box_rect();
-    rects.append(paintable_box.transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+    if (visual_context_transform == VisualContextTransform::Identity)
+        rects.append(absolute_rect);
+    else
+        rects.append(paintable_box.transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
 }
 
-static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element)
+static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element, VisualContextTransform visual_context_transform = VisualContextTransform::Apply)
 {
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
     //    object and stop this algorithm.
@@ -2567,17 +2575,20 @@ static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element c
             if (piece.is_geometry_only_placeholder)
                 return;
             auto absolute_rect = inline_paintable->absolute_piece_border_box_rect(piece);
-            rects.append(inline_paintable->transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+            if (visual_context_transform == VisualContextTransform::Identity)
+                rects.append(absolute_rect);
+            else
+                rects.append(inline_paintable->transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
         });
         // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
         // we still report its (zero-sized) border area instead of an empty list.
         if (rects.is_empty())
-            append_transformed_border_box_rect(rects, *inline_paintable);
+            append_border_box_rect(rects, *inline_paintable, visual_context_transform);
         return rects;
     }
 
     if (auto paintable_box = element.paintable_box()) {
-        append_transformed_border_box_rect(rects, *paintable_box);
+        append_border_box_rect(rects, *paintable_box, visual_context_transform);
     } else if (element.paintable()) {
         dbgln("FIXME: Failed to get client rects for element ({})", element.debug_description());
     }
@@ -2597,6 +2608,9 @@ Vector<CSSPixelRect> Element::get_client_rects() const
 
     if (!layout_node())
         return {};
+
+    if (document().can_compute_client_rects_without_accumulated_visual_contexts_update())
+        return compute_client_rects_assuming_layout_clean(*this, VisualContextTransform::Identity);
 
     // NOTE: Make sure CSS transforms are resolved before they are used to calculate the rect position.
     const_cast<Document&>(document()).update_paint_and_hit_testing_properties_if_needed();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2609,7 +2609,7 @@ Vector<CSSPixelRect> Element::get_client_rects() const
     if (!layout_node())
         return {};
 
-    if (document().can_compute_client_rects_without_accumulated_visual_contexts_update())
+    if (document().can_compute_client_rects_without_accumulated_visual_contexts_update(*layout_node()))
         return compute_client_rects_assuming_layout_clean(*this, VisualContextTransform::Identity);
 
     // NOTE: Make sure CSS transforms are resolved before they are used to calculate the rect position.

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -37,6 +37,15 @@ Box::~Box()
 {
 }
 
+void Box::set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)
+{
+    m_default_scroll_shift_anchor = move(anchor);
+    set_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll, compensates_for_horizontal_scroll);
+    set_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll, compensates_for_vertical_scroll);
+    if (m_default_scroll_shift_anchor)
+        document().note_default_scroll_shift_anchor();
+}
+
 static ImageProvider const& image_provider_for_element(DOM::Element const& element)
 {
     if (auto const* image = as_if<HTML::HTMLImageElement>(element))

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -69,12 +69,7 @@ public:
     bool abspos_descendant_escapes() const { return has_flag(RustFFI::NodeFlag::AbsposDescendantEscapes); }
     void set_abspos_descendant_escapes(bool value) { set_flag(RustFFI::NodeFlag::AbsposDescendantEscapes, value); }
 
-    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)
-    {
-        m_default_scroll_shift_anchor = move(anchor);
-        set_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll, compensates_for_horizontal_scroll);
-        set_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll, compensates_for_vertical_scroll);
-    }
+    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll);
     Node* default_scroll_shift_anchor() const { return m_default_scroll_shift_anchor.ptr(); }
     bool compensates_for_horizontal_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll); }
     bool compensates_for_vertical_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll); }

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1365,6 +1365,8 @@ void NodeWithStyle::publish_style_record_to_node_data()
     auto const* payloads = document().style_computer().style_engine().style_record_payloads(m_style_record_identity);
     VERIFY(payloads);
     node_data().style = payloads;
+    if (content_visibility() == CSS::ContentVisibility::Auto)
+        document().note_content_visibility_auto_style();
 }
 
 bool NodeWithStyle::synchronize_table_span_data()

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -16,9 +16,9 @@
 
 namespace Web::Layout {
 
-ContainedBoxesMap collect_scrollable_overflow_contained_boxes(Node const& root, Function<void(Box const&)> box_visitor)
+void collect_scrollable_overflow_contained_boxes(Node const& root, ContainedBoxesMap& contained_boxes_map, Function<void(Box const&)> box_visitor)
 {
-    ContainedBoxesMap contained_boxes_map;
+    contained_boxes_map.clear_with_capacity();
     root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
         if (!box.paintable_box())
             return TraversalDecision::Continue;
@@ -28,7 +28,6 @@ ContainedBoxesMap collect_scrollable_overflow_contained_boxes(Node const& root, 
             contained_boxes_map.ensure(containing_block).append(box.template make_weak_ptr<Box const>());
         return TraversalDecision::Continue;
     });
-    return contained_boxes_map;
 }
 
 struct AxisDirection {

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -18,7 +18,8 @@ namespace Web::Layout {
 
 void collect_scrollable_overflow_contained_boxes(Node const& root, ContainedBoxesMap& contained_boxes_map, Function<void(Box const&)> box_visitor)
 {
-    contained_boxes_map.clear_with_capacity();
+    for (auto& entry : contained_boxes_map)
+        entry.value.clear_with_capacity();
     root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
         if (!box.paintable_box())
             return TraversalDecision::Continue;
@@ -28,6 +29,7 @@ void collect_scrollable_overflow_contained_boxes(Node const& root, ContainedBoxe
             contained_boxes_map.ensure(containing_block).append(box.template make_weak_ptr<Box const>());
         return TraversalDecision::Continue;
     });
+    contained_boxes_map.remove_all_matching([](auto const&, auto const& boxes) { return boxes.is_empty(); });
 }
 
 struct AxisDirection {

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.h
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.h
@@ -28,7 +28,7 @@ struct PhysicalOverflowDirections {
 
 [[nodiscard]] PhysicalOverflowDirections physical_overflow_directions(Box const&);
 
-[[nodiscard]] ContainedBoxesMap collect_scrollable_overflow_contained_boxes(Node const& root, Function<void(Box const&)> box_visitor = {});
+void collect_scrollable_overflow_contained_boxes(Node const& root, ContainedBoxesMap& contained_boxes_map, Function<void(Box const&)> box_visitor = {});
 
 // https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region
 // Measures the scrollable overflow of the given box and stores it on the box's paintable.

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -2202,13 +2202,18 @@ impl PrefixStates {
             expiring.extend_from_slice(self.expiring_in(source_state));
         }
         let delta = arena.delta(delta);
-        additions
-            .retain(|&step| arena.sign_in_spans(delta.persisting_additions, delta.persisting_removals, step) != -1);
+        let removals = arena.get(delta.persisting_removals);
+        if !removals.is_empty() {
+            additions.retain(|step| removals.binary_search(step).is_err());
+        }
         additions.extend_from_slice(arena.get(delta.persisting_additions));
         additions.retain(|&step| !self.persisting_state_contains_step(new_base_state, step));
         additions.sort_unstable();
         additions.dedup();
-        expiring.retain(|&step| arena.sign_in_spans(delta.expiring_additions, delta.expiring_removals, step) != -1);
+        let removals = arena.get(delta.expiring_removals);
+        if !removals.is_empty() {
+            expiring.retain(|step| removals.binary_search(step).is_err());
+        }
         expiring.extend_from_slice(arena.get(delta.expiring_additions));
         expiring.sort_unstable();
         expiring.dedup();

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -475,6 +475,54 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn reset_layout_update_flags_in_subtree(&self, root: NodeSlotId) {
+        self.assert_owner_thread();
+        let flags_to_clear = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
+        let mut current = root;
+        loop {
+            let data = self.data(current);
+            // SAFETY: data() validated that current names a live slot, and layout tree mutation
+            // is serialized on the arena's owner thread.
+            let (parent, first_child, next_sibling) = unsafe {
+                let flags = &raw mut (*data).flags;
+                flags.write(flags.read() & !flags_to_clear);
+                (
+                    (&raw const (*data).parent).read(),
+                    (&raw const (*data).first_child).read(),
+                    (&raw const (*data).next_sibling).read(),
+                )
+            };
+
+            if !first_child.is_invalid() {
+                current = first_child;
+                continue;
+            }
+            if current == root {
+                break;
+            }
+            if !next_sibling.is_invalid() {
+                current = next_sibling;
+                continue;
+            }
+
+            current = parent;
+            while current != root {
+                // SAFETY: Parent links from a live subtree node name live slots in the same tree.
+                let data = self.data(current);
+                let next_sibling = unsafe { (&raw const (*data).next_sibling).read() };
+                if !next_sibling.is_invalid() {
+                    current = next_sibling;
+                    break;
+                }
+                // SAFETY: data() validated current and the topology is stable during this call.
+                current = unsafe { (&raw const (*data).parent).read() };
+            }
+            if current == root {
+                break;
+            }
+        }
+    }
+
     fn slot_for_data(&self, data: *const NodeData) -> (u32, SlotMetadata) {
         assert!(!data.is_null(), "layout node arena data pointer is null");
         let data_address = data as usize;
@@ -1399,6 +1447,18 @@ pub unsafe extern "C" fn layout_arena_node_data(arena: *mut c_void, id: NodeSlot
 
 /// # Safety
 ///
+/// The arena must remain valid for the duration of the call, and `root` must
+/// name the root of a live subtree in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_reset_layout_update_flags_in_subtree(arena: *mut c_void, root: NodeSlotId) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+        unsafe { LayoutNodeArena::from_handle(arena) }.reset_layout_update_flags_in_subtree(root);
+    });
+}
+
+/// # Safety
+///
 /// The arena must remain valid for the duration of the call, and `parent`,
 /// `child`, and a valid `before` must name live nodes in this arena.
 #[unsafe(no_mangle)]
@@ -1502,6 +1562,7 @@ mod tests {
         Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
         SLOTS_PER_CHUNK,
     };
+    use crate::layout::node_data::{NodeFlag, NodeSlotId};
     use crate::layout::{AvailableSize, CssPixels};
 
     #[test]
@@ -1548,6 +1609,35 @@ mod tests {
         assert_ne!(second.slot, first.slot);
         assert_ne!(second.generation, first.generation);
         arena.free(second.slot, second.generation);
+    }
+
+    #[test]
+    fn layout_update_flags_are_reset_only_in_the_requested_subtree() {
+        let mut arena = LayoutNodeArena::new();
+        let root = arena.allocate();
+        let child = arena.allocate();
+        let detached = arena.allocate();
+        arena.insert_child(root.slot, child.slot, NodeSlotId::INVALID);
+        let update_flags = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
+        // SAFETY: All three allocations remain live for the duration of the test.
+        unsafe {
+            (*root.data).flags |= update_flags;
+            (*child.data).flags |= update_flags;
+            (*detached.data).flags |= update_flags;
+        }
+
+        arena.reset_layout_update_flags_in_subtree(root.slot);
+
+        // SAFETY: The allocations remain live and the arena keeps their addresses stable.
+        unsafe {
+            assert_eq!((*root.data).flags & update_flags, 0);
+            assert_eq!((*child.data).flags & update_flags, 0);
+            assert_eq!((*detached.data).flags & update_flags, update_flags);
+        }
+        arena.remove_child(root.slot, child.slot);
+        arena.free(root.slot, root.generation);
+        arena.free(child.slot, child.generation);
+        arena.free(detached.slot, detached.generation);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -651,6 +651,12 @@ pub(crate) fn resolve_background_for_paint<'a>(
         });
     }
 
+    if libgfx_rust::Color(style.background().background_color).alpha() == 0
+        && !style_queries::background_layers_have_image(style)
+    {
+        return None;
+    }
+
     // HACK: If the Box has a border, use the bordered_rect to paint the background.
     //       This way if we have a border-radius there will be no gap between the filling and actual border.
     let zero = CssPixels::from_raw(0);

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -370,7 +370,7 @@ fn used_transform_style_is_preserve_3d(arena: &LayoutNodeArena, node: NodeSlotId
 }
 
 pub(crate) fn establishes_or_extends_a_3d_rendering_context(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
-    is_transformable(arena, node) && used_transform_style_is_preserve_3d(arena, node)
+    used_transform_style_is_preserve_3d(arena, node) && is_transformable(arena, node)
 }
 
 fn participates_in_a_3d_rendering_context(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -58,6 +58,13 @@ pub(crate) fn is_abstract_image(value: &StyleValueData) -> bool {
     )
 }
 
+pub(crate) fn background_layers_have_image(style: ComputedValuesView<'_>) -> bool {
+    let Some(value) = handle_value(&style.background().background_image) else {
+        return false;
+    };
+    for_each_comma_item(value, is_abstract_image)
+}
+
 fn fly_string_equals_ascii(string: &RetainedUtf16FlyString, expected: &[u8]) -> bool {
     with_fly_string_units(string, |units| match units {
         StringUnits::Ascii(bytes) => bytes == expected,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -217,24 +217,13 @@ struct Builder<'a> {
     scroll_state: ScrollState,
     paintables_with_mask_nodes: Vec<PaintableSlotId>,
     pixel_ratio: f64,
-    facts_cache: std::collections::HashMap<PaintableSlotId, std::rc::Rc<BoxFacts>>,
     root_background_source: crate::painting::host::FfiRootBackgroundSource,
 }
 
 impl Builder<'_> {
-    fn facts(&mut self, slot: PaintableSlotId) -> std::rc::Rc<BoxFacts> {
-        if let Some(facts) = self.facts_cache.get(&slot) {
-            return facts.clone();
-        }
-        let facts = std::rc::Rc::new(BoxFacts::gather(
-            self.layout_arena,
-            self.paintables,
-            self.callbacks,
-            slot,
-            self.pixel_ratio,
-        ));
-        self.facts_cache.insert(slot, facts.clone());
-        facts
+    fn default_scroll_shift_anchor(&self, slot: PaintableSlotId) -> NodeSlotId {
+        self.callbacks
+            .default_scroll_shift_anchor(self.paintables.data_ref(slot).shell)
     }
 
     fn register_scroll_node(&mut self, node_index: usize, paintable: PaintableSlotId, parent_index: usize) {
@@ -277,7 +266,13 @@ impl Builder<'_> {
         may_be_root_element: bool,
     ) -> DescendantVisualContexts {
         let first_visual_context_node_index = self.tree.nodes.len();
-        let facts = self.facts(slot);
+        let facts = BoxFacts::gather(
+            self.layout_arena,
+            self.paintables,
+            self.callbacks,
+            slot,
+            self.pixel_ratio,
+        );
         let (is_fixed, is_absolute, is_sticky, has_sticky_insets, layout_node) = {
             let data = self.paintables.data_ref(slot);
             (
@@ -343,9 +338,8 @@ impl Builder<'_> {
             let mut compensate_vertical_scroll = true;
             let mut visited: Vec<NodeSlotId> = Vec::new();
             const MAX_ANCHOR_CHAIN_DEPTH: usize = 32;
-            let mut box_facts = std::rc::Rc::clone(&facts);
+            let mut anchor_node = facts.default_scroll_shift_anchor;
             while !box_node.is_invalid() && !visited.contains(&box_node) && visited.len() < MAX_ANCHOR_CHAIN_DEPTH {
-                let anchor_node = box_facts.default_scroll_shift_anchor;
                 if anchor_node.is_invalid() {
                     break;
                 }
@@ -398,7 +392,7 @@ impl Builder<'_> {
                     s = self.scroll_state.state_at_slot(s).parent_slot;
                 }
                 box_node = anchor_node;
-                box_facts = self.facts(anchor_paintable);
+                anchor_node = self.default_scroll_shift_anchor(anchor_paintable);
             }
         }
 
@@ -665,8 +659,8 @@ impl Builder<'_> {
         }
     }
 
-    fn has_default_scroll_shift_anchor(&mut self, slot: PaintableSlotId) -> bool {
-        !self.facts(slot).default_scroll_shift_anchor.is_invalid()
+    fn has_default_scroll_shift_anchor(&self, slot: PaintableSlotId) -> bool {
+        !self.default_scroll_shift_anchor(slot).is_invalid()
     }
 }
 
@@ -692,7 +686,6 @@ pub(crate) fn build_visual_context_tree(
         scroll_state: ScrollState::default(),
         paintables_with_mask_nodes: Vec::new(),
         pixel_ratio: inputs.device_pixels_per_css_pixel,
-        facts_cache: std::collections::HashMap::new(),
         root_background_source: callbacks.root_background_source(),
     };
 
@@ -781,8 +774,8 @@ pub(crate) fn build_visual_context_tree(
     );
 
     let anchor_is_awaiting_build =
-        |builder: &mut Builder<'_>, slot: PaintableSlotId, awaiting: &HashSet<PaintableSlotId>| {
-            let anchor_node = builder.facts(slot).default_scroll_shift_anchor;
+        |builder: &Builder<'_>, slot: PaintableSlotId, awaiting: &HashSet<PaintableSlotId>| {
+            let anchor_node = builder.default_scroll_shift_anchor(slot);
             let mut paintable = builder.paintables.paintable_of_node(anchor_node);
             while !paintable.is_invalid() {
                 if awaiting.contains(&paintable) {

--- a/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
+++ b/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
@@ -2,6 +2,7 @@ offset width: 110
 offset width: 120
 offset width: 130
 builds after layout-only reads: 0
+extra layouts after clean read: 0
 bounding rect width: 130
 builds after identity transform read: 0
 bounding rect with transformed child: 130

--- a/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
+++ b/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
@@ -3,4 +3,6 @@ offset width: 120
 offset width: 130
 builds after layout-only reads: 0
 bounding rect width: 130
-builds after transform-sensitive read: 1
+builds after identity transform read: 0
+transformed rect x: 18
+builds after non-identity transform read: 1

--- a/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
+++ b/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
@@ -4,5 +4,7 @@ offset width: 130
 builds after layout-only reads: 0
 bounding rect width: 130
 builds after identity transform read: 0
+bounding rect with transformed child: 130
+builds after unrelated transform read: 0
 transformed rect x: 18
 builds after non-identity transform read: 1

--- a/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
+++ b/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
@@ -15,6 +15,9 @@
         }
 
         lines.push(`builds after layout-only reads: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        const fullLayoutCount = internals.fullLayoutCount();
+        target.offsetWidth;
+        lines.push(`extra layouts after clean read: ${internals.fullLayoutCount() - fullLayoutCount}`);
 
         lines.push(`bounding rect width: ${target.getBoundingClientRect().width}`);
         lines.push(`builds after identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);

--- a/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
+++ b/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
@@ -19,6 +19,12 @@
         lines.push(`bounding rect width: ${target.getBoundingClientRect().width}`);
         lines.push(`builds after identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
 
+        const transformedChild = document.createElement('div');
+        transformedChild.style.transform = 'translateX(10px)';
+        target.appendChild(transformedChild);
+        lines.push(`bounding rect with transformed child: ${target.getBoundingClientRect().width}`);
+        lines.push(`builds after unrelated transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+
         target.style.transform = 'translateX(10px)';
         lines.push(`transformed rect x: ${target.getBoundingClientRect().x}`);
         lines.push(`builds after non-identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);

--- a/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
+++ b/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
@@ -17,7 +17,11 @@
         lines.push(`builds after layout-only reads: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
 
         lines.push(`bounding rect width: ${target.getBoundingClientRect().width}`);
-        lines.push(`builds after transform-sensitive read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        lines.push(`builds after identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+
+        target.style.transform = 'translateX(10px)';
+        lines.push(`transformed rect x: ${target.getBoundingClientRect().x}`);
+        lines.push(`builds after non-identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
 
         for (const line of lines)
             println(line);


### PR DESCRIPTION
Reduce the work and allocations performed by repeated geometry queries.

Defer accumulated visual context rebuilds when the queried box and its ancestors have identity coordinate mappings. Reset layout dirty flags directly in the Rust arena, and reuse scrollable overflow map and vector allocations across layouts.

Skip unnecessary work for documents without anchor positioning or content-visibility: auto, empty backgrounds, and selector-prefix rebases without removals. Also streamline visual context construction and extend coverage for the lazy client rect path and its fallbacks.


Benchmarks happy:

```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  78.42 ± 2.87  79.14 ± 9.15                1.009  6.37 ± 0.70            6.35 ± 0.57                1.003
Speedometer3  4.38 ± 0.83   4.42 ± 0.30                 1.009  6.04 ± 0.69            5.90 ± 0.17                1.025
StyleBench    57.74 ± 6.21  71.97 ± 5.26                1.247  4.50 ± 0.44            3.48 ± 0.22                1.294
```