### PR TITLE
Meta: Run Rust workspace tests in CI

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -538,6 +538,7 @@ fn retained_answer_delta_memo_accounts_its_tuple_capacity() {
             new_cascade_input: MatchAnswerID(4),
             winner_state: None,
             winners_updated: false,
+            cascade_winners_are_complete: false,
         },
     };
 

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5207,8 +5207,8 @@ pub unsafe extern "C" fn rust_compute_font_weight(
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_compute_context_anchor(_context: *const c_void) {}
 
-// The standalone cargo test binary has no C++ side, so the release callbacks
-// that StyleValueData's retained members call on drop are stubbed out here.
+// The standalone cargo test binary has no C++ side, so release callbacks are
+// stubbed out here.
 #[cfg(test)]
 mod ffi_test_stubs {
     #[unsafe(no_mangle)]
@@ -5226,6 +5226,10 @@ mod ffi_test_stubs {
     extern "C" fn ladybird_animated_properties_unref(_values: *const std::ffi::c_void) {}
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_font_cascade_list_unref(_raw: *const std::ffi::c_void) {}
+    #[unsafe(no_mangle)]
+    extern "C" fn ladybird_gfx_font_unref(_raw: *const std::ffi::c_void) {}
+    #[unsafe(no_mangle)]
+    extern "C" fn ladybird_gfx_filter_destroy(_filter: *mut std::ffi::c_void) {}
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_path_destroy(_path: *mut std::ffi::c_void) {}
 }

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5231,7 +5231,11 @@ mod ffi_test_stubs {
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_filter_destroy(_filter: *mut std::ffi::c_void) {}
     #[unsafe(no_mangle)]
+    extern "C" fn ladybird_gfx_glyph_run_unref(_retained: *mut std::ffi::c_void) {}
+    #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_path_destroy(_path: *mut std::ffi::c_void) {}
+    #[unsafe(no_mangle)]
+    extern "C" fn unicode_layout_segmenter_destroy(_handle: *mut std::ffi::c_void) {}
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1799,6 +1799,8 @@ pub unsafe extern "C" fn layout_arena_set_raw_table_column_span(
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use crate::layout::layout_node_arena::{
         Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
         SLOTS_PER_CHUNK,

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -21,6 +21,18 @@ add_subdirectory(LibWasm)
 add_subdirectory(LibXML)
 add_subdirectory(Meta)
 
+if (NOT WIN32)
+    # FIXME: Provide standalone implementations of the C++ FFI callbacks
+    #        required by Rust test binaries on Windows.
+    add_test(
+        NAME RustWorkspace
+        COMMAND "${CMAKE_COMMAND}" -E env
+            "CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/cargo/build"
+            "${RUST_CARGO}" test --workspace --target "${RUST_TARGET_TRIPLE}"
+        WORKING_DIRECTORY "${LADYBIRD_SOURCE_DIR}"
+    )
+endif()
+
 if (ENABLE_GUI_TARGETS)
     add_subdirectory(Compositor)
     add_subdirectory(LibDevTools)


### PR DESCRIPTION
Register the native Rust unit-test harness with CTest so the existing CI test matrix runs it alongside the other test suites. This compiles `cfg(test)` modules and prevents test fixtures from silently falling out of sync with production types.