### PR TITLE
LibWeb: Accept an empty override span from C++ in the style FFI

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
+++ b/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
@@ -3215,10 +3215,8 @@ pub unsafe extern "C" fn rust_build_group_payloads_from_table(
         let out = unsafe { std::slice::from_raw_parts_mut(out_payloads, group_count) };
         let values = EffectiveValues {
             table,
-            override_properties: unsafe {
-                std::slice::from_raw_parts(inputs.override_properties, inputs.override_count)
-            },
-            override_values: unsafe { std::slice::from_raw_parts(inputs.override_values, inputs.override_count) },
+            override_properties: unsafe { crate::slice_from_raw(inputs.override_properties, inputs.override_count) },
+            override_values: unsafe { crate::slice_from_raw(inputs.override_values, inputs.override_count) },
         };
         let color_input = unsafe { &*inputs.color_input.cast::<FfiColorResolutionInput>() };
         let channels = relative_color_context_from_ffi(color_input);

--- a/Libraries/LibWeb/Rust/src/lib.rs
+++ b/Libraries/LibWeb/Rust/src/lib.rs
@@ -38,6 +38,20 @@ fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
     }
 }
 
+/// Borrows a span handed over from C++, yielding an empty slice for an empty span without
+/// inspecting the pointer. An empty AK::Vector with no inline capacity has a null data pointer,
+/// while `slice::from_raw_parts` requires a non-null aligned pointer even for a zero-length slice.
+///
+/// # Safety
+/// When `len` is non-zero, `data` must point at `len` initialized values of type `T` that stay live
+/// for `'a`.
+unsafe fn slice_from_raw<'a, T>(data: *const T, len: usize) -> &'a [T] {
+    if len == 0 {
+        return &[];
+    }
+    unsafe { std::slice::from_raw_parts(data, len) }
+}
+
 unsafe fn bytes_from_raw<'a>(bytes: *const u8, len: usize) -> Option<&'a [u8]> {
     unsafe {
         if len == 0 {
@@ -48,5 +62,25 @@ unsafe fn bytes_from_raw<'a>(bytes: *const u8, len: usize) -> Option<&'a [u8]> {
             return None;
         }
         Some(std::slice::from_raw_parts(bytes, len))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slice_from_raw;
+
+    #[test]
+    fn slice_from_raw_accepts_an_empty_span_with_a_null_pointer() {
+        // C++ represents an empty range as a null pointer with length zero — which
+        // slice::from_raw_parts rejects outright.
+        let empty = unsafe { slice_from_raw::<u16>(std::ptr::null(), 0) };
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn slice_from_raw_borrows_a_populated_span() {
+        let values: [u16; 3] = [7, 8, 9];
+        let borrowed = unsafe { slice_from_raw(values.as_ptr(), values.len()) };
+        assert_eq!(borrowed, &values[..]);
     }
 }


### PR DESCRIPTION
**Problem:** Rust panic in Debug builds: _“unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null”._

**Cause:** `create_internal()` collects the effective longhand overrides into plain `AK::Vector`s and passes their `data()` and `size()` to the table-group builder. `collect_effective_longhand_overrides()` returns early without touching either vector when there’s nothing to collect. So a vector that never allocated stays empty — and a `Vector` with no inline capacity returns its null outline buffer straight from `data()`. The Rust side then borrows the span with `slice::from_raw_parts` — which requires a non-null aligned pointer even for a zero-length slice. So the empty span on its own is UB, and trips a check compiled in only under `debug_assertions`.

**Fix:** Borrow the span through a `slice_from_raw()` helper that yields an empty slice for a zero length without reading the pointer — the way `bytes_from_raw()` already treats an empty byte span. C++ represents an empty range as a null pointer with length zero. So the FFI boundary is where that convention has to be accepted — rather than at every caller.

The problem was reported on Discord: https://discord.com/channels/1247070541085671459/1247070543136690270/1539926273294336061
