### PR TITLE
Compute GlyphRun bounds and intercepts with HarfBuzz, not Skia

### DIFF
--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -84,6 +84,36 @@ hb_face_t* Typeface::harfbuzz_typeface() const
     return m_harfbuzz_face;
 }
 
+Typeface::BoundingBoxInFontUnits Typeface::bounding_box_in_font_units() const
+{
+    if (m_bounding_box_in_font_units.has_value())
+        return *m_bounding_box_in_font_units;
+
+    BoundingBoxInFontUnits bounding_box;
+    auto* face = harfbuzz_typeface();
+    auto* head_table = hb_face_reference_table(face, HB_TAG('h', 'e', 'a', 'd'));
+    unsigned head_table_length = 0;
+    auto const* head_table_data = reinterpret_cast<u8 const*>(hb_blob_get_data(head_table, &head_table_length));
+
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/head
+    // xMin, yMin, xMax and yMax are big-endian int16 values at byte offsets 36, 38, 40 and 42 of a 54-byte table.
+    constexpr unsigned head_table_size = 54;
+    if (head_table_data && head_table_length >= head_table_size) {
+        auto read_i16 = [&](unsigned offset) {
+            return static_cast<i16>((head_table_data[offset] << 8) | head_table_data[offset + 1]);
+        };
+        bounding_box.x_min = read_i16(36);
+        bounding_box.y_min = read_i16(38);
+        bounding_box.x_max = read_i16(40);
+        bounding_box.y_max = read_i16(42);
+        bounding_box.units_per_em = hb_face_get_upem(face);
+    }
+    hb_blob_destroy(head_table);
+
+    m_bounding_box_in_font_units = bounding_box;
+    return bounding_box;
+}
+
 hb_face_t* Typeface::create_harfbuzz_face() const
 {
     if (!m_harfbuzz_blob)

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -71,6 +71,19 @@ public:
 
     hb_face_t* harfbuzz_typeface() const;
 
+    // Union of all glyph bounding boxes as recorded in the `head` table, in font units with y pointing up.
+    // is_empty() when the face has no usable `head` table (e.g. bitmap-only fonts).
+    struct BoundingBoxInFontUnits {
+        i16 x_min { 0 };
+        i16 y_min { 0 };
+        i16 x_max { 0 };
+        i16 y_max { 0 };
+        u16 units_per_em { 0 };
+
+        bool is_empty() const { return x_min >= x_max || y_min >= y_max || units_per_em == 0; }
+    };
+    BoundingBoxInFontUnits bounding_box_in_font_units() const;
+
     template<typename T>
     bool fast_is() const = delete;
 
@@ -108,6 +121,7 @@ private:
     mutable HashMap<FontCacheKey, NonnullRefPtr<Font>> m_fonts;
     mutable hb_blob_t* m_harfbuzz_blob { nullptr };
     mutable hb_face_t* m_harfbuzz_face { nullptr };
+    mutable Optional<BoundingBoxInFontUnits> m_bounding_box_in_font_units;
 };
 
 }

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -7,26 +7,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/BitCast.h>
 #include <AK/HashFunctions.h>
+#include <AK/Math.h>
+#include <AK/NumericLimits.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/TextLayout.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <RustFFI.h>
-#include <core/SkFont.h>
-#include <core/SkTextBlob.h>
 #include <harfbuzz/hb.h>
 
 namespace Gfx {
-
-struct GlyphRun::CachedTextBlob {
-    sk_sp<SkTextBlob> blob;
-    FloatRect bounds;
-    float scale { 0 };
-};
 
 GlyphRun::GlyphRun(Vector<DrawGlyph>&& glyphs, NonnullRefPtr<Font const> font, TextType text_type, float width)
     : m_glyphs(move(glyphs))
@@ -52,75 +48,352 @@ NonnullRefPtr<GlyphRun> GlyphRun::slice(size_t start, size_t length) const
     return adopt_ref(*new GlyphRun(move(sliced_glyphs), m_font, m_text_type, width));
 }
 
-void GlyphRun::ensure_text_blob(float scale) const
+FloatRect GlyphRun::bounding_box(float scale) const
 {
-    if (m_cached_text_blob && m_cached_text_blob->scale == scale)
-        return;
+    auto font_ascent = m_font->pixel_metrics().ascent;
 
-    auto sk_font = m_font->skia_font(scale);
-    size_t glyph_count = 0;
-    for (auto const& glyph : m_glyphs) {
-        if (glyph.should_paint)
-            ++glyph_count;
-    }
-
-    m_cached_text_blob = make<CachedTextBlob>();
-    m_cached_text_blob->scale = scale;
-
-    if (glyph_count == 0)
-        return;
-
-    SkTextBlobBuilder builder;
-    auto const& run = builder.allocRunPos(sk_font, glyph_count);
-
-    float font_ascent = m_font->pixel_metrics().ascent;
-    size_t painted_glyph_index = 0;
+    // NOTE: This is a plain min/max rather than FloatRect::unite(), because a run with a single glyph must still
+    //       produce a (zero-sized) origin box that gets expanded by the font bounds below.
+    bool has_painted_glyphs = false;
+    float min_x = NumericLimits<float>::max();
+    float min_y = NumericLimits<float>::max();
+    float max_x = NumericLimits<float>::lowest();
+    float max_y = NumericLimits<float>::lowest();
     for (auto const& glyph : m_glyphs) {
         if (!glyph.should_paint)
             continue;
-        run.glyphs[painted_glyph_index] = glyph.glyph_id;
-        run.pos[painted_glyph_index * 2] = glyph.position.x() * scale;
-        run.pos[painted_glyph_index * 2 + 1] = (glyph.position.y() + font_ascent) * scale;
-        ++painted_glyph_index;
+        auto origin_x = glyph.position.x() * scale;
+        auto origin_y = (glyph.position.y() + font_ascent) * scale;
+        if (!__builtin_isfinite(origin_x) || !__builtin_isfinite(origin_y))
+            return {};
+        min_x = min(min_x, origin_x);
+        min_y = min(min_y, origin_y);
+        max_x = max(max_x, origin_x);
+        max_y = max(max_y, origin_y);
+        has_painted_glyphs = true;
     }
-
-    m_cached_text_blob->blob = builder.make();
-
-    if (m_cached_text_blob->blob) {
-        auto const& sk_bounds = m_cached_text_blob->blob->bounds();
-        m_cached_text_blob->bounds = { sk_bounds.x(), sk_bounds.y(), sk_bounds.width(), sk_bounds.height() };
-    }
-}
-
-FloatRect GlyphRun::cached_blob_bounds() const
-{
-    if (!m_cached_text_blob)
+    if (!has_painted_glyphs)
         return {};
-    return m_cached_text_blob->bounds;
+
+    auto font_bounding_box = m_font->typeface().bounding_box_in_font_units();
+    if (!font_bounding_box.is_empty()) {
+        auto font_units_to_pixels = m_font->pixel_size() * scale / font_bounding_box.units_per_em;
+        // Font units have y pointing up, device pixels have y pointing down.
+        auto left = min_x + font_bounding_box.x_min * font_units_to_pixels;
+        auto right = max_x + font_bounding_box.x_max * font_units_to_pixels;
+        auto top = min_y - font_bounding_box.y_max * font_units_to_pixels;
+        auto bottom = max_y - font_bounding_box.y_min * font_units_to_pixels;
+        return { left, top, right - left, bottom - top };
+    }
+
+    // The font doesn't record an overall bounding box (e.g. bitmap-only fonts), so unite the glyphs' own extents.
+    auto* hb_font = m_font->harfbuzz_font();
+    int x_scale = 0;
+    int y_scale = 0;
+    hb_font_get_scale(hb_font, &x_scale, &y_scale);
+    if (x_scale <= 0 || y_scale <= 0)
+        return {};
+    auto units_to_pixels_x = m_font->pixel_size() * scale / x_scale;
+    auto units_to_pixels_y = m_font->pixel_size() * scale / y_scale;
+
+    FloatRect bounds;
+    for (auto const& glyph : m_glyphs) {
+        if (!glyph.should_paint)
+            continue;
+        hb_glyph_extents_t extents;
+        if (!hb_font_get_glyph_extents(hb_font, glyph.glyph_id, &extents))
+            continue;
+        auto origin_x = glyph.position.x() * scale;
+        auto origin_y = (glyph.position.y() + font_ascent) * scale;
+        // HarfBuzz extents have y pointing up, so `height` is negative for ink above the baseline.
+        FloatRect glyph_bounds {
+            origin_x + extents.x_bearing * units_to_pixels_x,
+            origin_y - extents.y_bearing * units_to_pixels_y,
+            extents.width * units_to_pixels_x,
+            -extents.height * units_to_pixels_y,
+        };
+        bounds.unite(glyph_bounds);
+    }
+    return bounds;
 }
 
-SkTextBlob* GlyphRun::cached_skia_text_blob() const
+namespace {
+
+struct OutlinePoint {
+    double x { 0 };
+    double y { 0 };
+};
+
+// Roots of a*t^2 + b*t + c = 0 with t in [0, 1]. Duplicate roots may be reported twice.
+size_t quadratic_roots_in_unit_interval(double a, double b, double c, Array<double, 2>& roots)
 {
-    if (!m_cached_text_blob || !m_cached_text_blob->blob)
-        return nullptr;
-    return m_cached_text_blob->blob.get();
+    size_t count = 0;
+    auto add_root = [&](double t) {
+        // NOTE: Written so that a NaN root (e.g. from a degenerate division) is rejected too.
+        if (t >= 0 && t <= 1)
+            roots[count++] = t;
+    };
+
+    if (a == 0) {
+        if (b != 0)
+            add_root(-c / b);
+        return count;
+    }
+
+    auto discriminant = b * b - 4 * a * c;
+    if (discriminant < 0)
+        return 0;
+
+    // The numerically stable form: computing the smaller root as c / q instead of (-b - sqrt(d)) / 2a avoids
+    // catastrophic cancellation when |a| is tiny compared to |b| (a nearly-linear curve).
+    auto q = -0.5 * (b + __builtin_copysign(AK::sqrt(discriminant), b));
+    add_root(q / a);
+    if (q != 0)
+        add_root(c / q);
+    return count;
+}
+
+// Roots of a*t^3 + b*t^2 + c*t + d = 0 with t in [0, 1]. The polynomial is split at the extrema of its derivative,
+// so each piece is monotonic and has at most one root, which is then found by bisection. Unlike a closed-form
+// solution, this can neither miss nor invent roots inside the interval.
+size_t cubic_roots_in_unit_interval(double a, double b, double c, double d, Array<double, 3>& roots)
+{
+    auto evaluate = [&](double t) {
+        return ((a * t + b) * t + c) * t + d;
+    };
+
+    Array<double, 4> breakpoints {};
+    size_t breakpoint_count = 0;
+    breakpoints[breakpoint_count++] = 0;
+    Array<double, 2> extrema;
+    auto extrema_count = quadratic_roots_in_unit_interval(3 * a, 2 * b, c, extrema);
+    if (extrema_count == 2 && extrema[0] > extrema[1])
+        swap(extrema[0], extrema[1]);
+    for (size_t i = 0; i < extrema_count; ++i) {
+        if (extrema[i] > 0 && extrema[i] < 1 && extrema[i] != breakpoints[breakpoint_count - 1])
+            breakpoints[breakpoint_count++] = extrema[i];
+    }
+    breakpoints[breakpoint_count++] = 1;
+
+    constexpr double value_tolerance = 1e-6;
+    constexpr double parameter_tolerance = 1e-7;
+
+    size_t count = 0;
+    for (size_t i = 0; i + 1 < breakpoint_count; ++i) {
+        auto start = breakpoints[i];
+        auto end = breakpoints[i + 1];
+        auto value_at_start = evaluate(start);
+        auto value_at_end = evaluate(end);
+        if (AK::fabs(value_at_start) <= value_tolerance) {
+            roots[count++] = start;
+            continue;
+        }
+        if (AK::fabs(value_at_end) <= value_tolerance) {
+            roots[count++] = end;
+            continue;
+        }
+        if ((value_at_start < 0) == (value_at_end < 0))
+            continue;
+        while (end - start > parameter_tolerance) {
+            auto middle = 0.5 * (start + end);
+            auto value_at_middle = evaluate(middle);
+            if (value_at_middle == 0) {
+                start = end = middle;
+                break;
+            }
+            if ((value_at_middle < 0) == (value_at_start < 0)) {
+                start = middle;
+                value_at_start = value_at_middle;
+            } else {
+                end = middle;
+            }
+        }
+        roots[count++] = 0.5 * (start + end);
+    }
+    return count;
+}
+
+// Tracks the horizontal extent of a glyph outline's ink inside a horizontal band, in glyph-local device pixels with
+// y pointing down. This mirrors how Skia computes text blob intercepts: every point where an outline segment
+// crosses the top or bottom edge of the band widens the extent, and so does every segment point (including
+// control points) that lies strictly inside the band.
+struct InkExtentInBand {
+    double band_top { 0 };
+    double band_bottom { 0 };
+    double units_to_pixels_x { 0 };
+    double units_to_pixels_y { 0 };
+    double left { NumericLimits<double>::max() };
+    double right { NumericLimits<double>::lowest() };
+
+    OutlinePoint to_device_pixels(float x, float y) const
+    {
+        // HarfBuzz outlines have y pointing up.
+        return { x * units_to_pixels_x, -y * units_to_pixels_y };
+    }
+
+    void expand(double x)
+    {
+        left = min(left, x);
+        right = max(right, x);
+    }
+
+    bool overlaps_band(double segment_top, double segment_bottom) const
+    {
+        return band_top <= segment_bottom && segment_top <= band_bottom;
+    }
+
+    void expand_by_points_strictly_inside_band(ReadonlySpan<OutlinePoint> points)
+    {
+        for (auto const& point : points) {
+            if (band_top < point.y && point.y < band_bottom)
+                expand(point.x);
+        }
+    }
+
+    void add_line(OutlinePoint p0, OutlinePoint p1)
+    {
+        if (!overlaps_band(min(p0.y, p1.y), max(p0.y, p1.y)))
+            return;
+        for (auto offset : { band_top, band_bottom }) {
+            // NOTE: A horizontal line makes this a division by zero; the resulting inf/NaN fails the range check.
+            auto t = (offset - p0.y) / (p1.y - p0.y);
+            if (t >= 0 && t < 1)
+                expand(p0.x + t * (p1.x - p0.x));
+        }
+        expand_by_points_strictly_inside_band(Array { p0, p1 });
+    }
+
+    void add_quadratic(OutlinePoint p0, OutlinePoint p1, OutlinePoint p2)
+    {
+        if (!overlaps_band(min(p0.y, min(p1.y, p2.y)), max(p0.y, max(p1.y, p2.y))))
+            return;
+        // y(t) = (y0 - 2*y1 + y2) * t^2 + 2 * (y1 - y0) * t + y0
+        auto a = p0.y - 2 * p1.y + p2.y;
+        auto b = 2 * (p1.y - p0.y);
+        for (auto offset : { band_top, band_bottom }) {
+            Array<double, 2> roots;
+            auto count = quadratic_roots_in_unit_interval(a, b, p0.y - offset, roots);
+            for (size_t i = 0; i < count; ++i) {
+                auto t = roots[i];
+                auto u = 1 - t;
+                expand(u * u * p0.x + 2 * u * t * p1.x + t * t * p2.x);
+            }
+        }
+        expand_by_points_strictly_inside_band(Array { p0, p1, p2 });
+    }
+
+    void add_cubic(OutlinePoint p0, OutlinePoint p1, OutlinePoint p2, OutlinePoint p3)
+    {
+        if (!overlaps_band(min(min(p0.y, p1.y), min(p2.y, p3.y)), max(max(p0.y, p1.y), max(p2.y, p3.y))))
+            return;
+        // y(t) = (-y0 + 3*y1 - 3*y2 + y3) * t^3 + (3*y0 - 6*y1 + 3*y2) * t^2 + (-3*y0 + 3*y1) * t + y0
+        auto a = -p0.y + 3 * p1.y - 3 * p2.y + p3.y;
+        auto b = 3 * p0.y - 6 * p1.y + 3 * p2.y;
+        auto c = -3 * p0.y + 3 * p1.y;
+        for (auto offset : { band_top, band_bottom }) {
+            Array<double, 3> roots;
+            auto count = cubic_roots_in_unit_interval(a, b, c, p0.y - offset, roots);
+            for (size_t i = 0; i < count; ++i) {
+                auto t = roots[i];
+                auto u = 1 - t;
+                expand(u * u * u * p0.x + 3 * u * u * t * p1.x + 3 * u * t * t * p2.x + t * t * t * p3.x);
+            }
+        }
+        expand_by_points_strictly_inside_band(Array { p0, p1, p2, p3 });
+    }
+};
+
+// NOTE: HarfBuzz emits the implicit line that closes each contour as a regular line_to before close_path, so only
+//       the segment callbacks are needed. The quadratic callback must be set, otherwise HarfBuzz converts quadratic
+//       segments to cubics.
+hb_draw_funcs_t* ink_extent_draw_funcs()
+{
+    static hb_draw_funcs_t* draw_funcs = [] {
+        auto* funcs = hb_draw_funcs_create();
+        hb_draw_funcs_set_line_to_func(
+            funcs, [](hb_draw_funcs_t*, void* draw_data, hb_draw_state_t* state, float to_x, float to_y, void*) {
+                auto& ink_extent = *static_cast<InkExtentInBand*>(draw_data);
+                ink_extent.add_line(
+                    ink_extent.to_device_pixels(state->current_x, state->current_y),
+                    ink_extent.to_device_pixels(to_x, to_y));
+            },
+            nullptr, nullptr);
+        hb_draw_funcs_set_quadratic_to_func(
+            funcs, [](hb_draw_funcs_t*, void* draw_data, hb_draw_state_t* state, float control_x, float control_y, float to_x, float to_y, void*) {
+                auto& ink_extent = *static_cast<InkExtentInBand*>(draw_data);
+                ink_extent.add_quadratic(
+                    ink_extent.to_device_pixels(state->current_x, state->current_y),
+                    ink_extent.to_device_pixels(control_x, control_y),
+                    ink_extent.to_device_pixels(to_x, to_y));
+            },
+            nullptr, nullptr);
+        hb_draw_funcs_set_cubic_to_func(
+            funcs, [](hb_draw_funcs_t*, void* draw_data, hb_draw_state_t* state, float control1_x, float control1_y, float control2_x, float control2_y, float to_x, float to_y, void*) {
+                auto& ink_extent = *static_cast<InkExtentInBand*>(draw_data);
+                ink_extent.add_cubic(
+                    ink_extent.to_device_pixels(state->current_x, state->current_y),
+                    ink_extent.to_device_pixels(control1_x, control1_y),
+                    ink_extent.to_device_pixels(control2_x, control2_y),
+                    ink_extent.to_device_pixels(to_x, to_y));
+            },
+            nullptr, nullptr);
+        hb_draw_funcs_make_immutable(funcs);
+        return funcs;
+    }();
+    return draw_funcs;
+}
+
 }
 
 Vector<float> GlyphRun::get_glyph_intercepts(float scale, float y_top, float y_bottom) const
 {
-    ensure_text_blob(scale);
-    auto* blob = cached_skia_text_blob();
-    if (!blob)
+    if (!(scale > 0) || !__builtin_isfinite(scale))
         return {};
 
-    Array<SkScalar, 2> bounds { y_top, y_bottom };
-    int count = blob->getIntercepts(bounds.data(), nullptr);
-    if (count < 2)
+    auto* hb_font = m_font->harfbuzz_font();
+    int x_scale = 0;
+    int y_scale = 0;
+    hb_font_get_scale(hb_font, &x_scale, &y_scale);
+    if (x_scale <= 0 || y_scale <= 0)
         return {};
+    auto units_to_pixels_x = static_cast<double>(m_font->pixel_size()) * scale / x_scale;
+    auto units_to_pixels_y = static_cast<double>(m_font->pixel_size()) * scale / y_scale;
+    auto font_ascent = m_font->pixel_metrics().ascent;
 
     Vector<float> intervals;
-    intervals.resize(count);
-    blob->getIntercepts(bounds.data(), intervals.data());
+    for (auto const& glyph : m_glyphs) {
+        if (!glyph.should_paint)
+            continue;
+        auto origin_x = static_cast<double>(glyph.position.x()) * scale;
+        auto origin_y = (static_cast<double>(glyph.position.y()) + font_ascent) * scale;
+
+        // Move the band into glyph-local coordinates, with the origin at the glyph's baseline origin.
+        auto band_top = y_top - origin_y;
+        auto band_bottom = y_bottom - origin_y;
+
+        // Skip glyphs whose bounding box doesn't reach the band before decoding their outline.
+        hb_glyph_extents_t extents;
+        if (hb_font_get_glyph_extents(hb_font, glyph.glyph_id, &extents)) {
+            auto glyph_top = -extents.y_bearing * units_to_pixels_y;
+            auto glyph_bottom = -(extents.y_bearing + extents.height) * units_to_pixels_y;
+            if (glyph_bottom < band_top || band_bottom < glyph_top)
+                continue;
+        }
+
+        InkExtentInBand ink_extent {
+            .band_top = band_top,
+            .band_bottom = band_bottom,
+            .units_to_pixels_x = units_to_pixels_x,
+            .units_to_pixels_y = units_to_pixels_y,
+        };
+        hb_font_draw_glyph(hb_font, glyph.glyph_id, ink_extent_draw_funcs(), &ink_extent);
+
+        // Glyphs without an outline (e.g. spaces) never widen the extent and produce no interval.
+        if (ink_extent.left < ink_extent.right) {
+            intervals.append(static_cast<float>(ink_extent.left + origin_x));
+            intervals.append(static_cast<float>(ink_extent.right + origin_x));
+        }
+    }
     return intervals;
 }
 

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -10,7 +10,6 @@
 
 #include <AK/AtomicRefCounted.h>
 #include <AK/Forward.h>
-#include <AK/OwnPtr.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/FontCascadeList.h>
@@ -18,8 +17,6 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/ShapeFeature.h>
-
-class SkTextBlob;
 
 namespace Gfx {
 
@@ -63,11 +60,14 @@ public:
 
     [[nodiscard]] NonnullRefPtr<GlyphRun> slice(size_t start, size_t length) const;
 
-    void ensure_text_blob(float scale) const;
+    // Conservative bounds of the painted glyphs in device pixels, relative to the run's baseline origin (glyph
+    // positions scaled by `scale`, with the font ascent added to y). The bounding box of the glyph origins is
+    // expanded by the font's overall glyph bounding box, falling back to tight per-glyph extents when the font
+    // doesn't record one.
+    [[nodiscard]] FloatRect bounding_box(float scale) const;
 
-    FloatRect cached_blob_bounds() const;
-    SkTextBlob* cached_skia_text_blob() const;
-
+    // Pairs of [start, end] device-pixel x values, relative to the run's baseline origin, where glyph ink intersects
+    // the horizontal band [y_top, y_bottom]. One pair per painted glyph that has ink inside the band, in run order.
     [[nodiscard]] Vector<float> get_glyph_intercepts(float scale, float y_top, float y_bottom) const;
 
 private:
@@ -75,9 +75,6 @@ private:
     NonnullRefPtr<Font const> m_font;
     TextType m_text_type;
     float m_width { 0 };
-
-    struct CachedTextBlob;
-    mutable OwnPtr<CachedTextBlob> m_cached_text_blob;
 };
 
 NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, float word_spacing, Utf16View const&, Gfx::Font const& font, GlyphRun::TextType, TrailingWhitespace* = nullptr);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -966,8 +966,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto glyph_run = fragment.glyph_run();
             if (!glyph_run)
                 return facts;
-            glyph_run->ensure_text_blob(scale);
-            auto bounds = glyph_run->cached_blob_bounds();
+            auto bounds = glyph_run->bounding_box(static_cast<float>(scale));
             facts.blob_bounds[0] = bounds.x();
             facts.blob_bounds[1] = bounds.y();
             facts.blob_bounds[2] = bounds.width();
@@ -1353,10 +1352,9 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto font = Platform::FontPlugin::the().default_font(css_font_size);
             auto label_font = font->with_size(font->point_size() * context.device_pixels_per_css_pixel);
             auto glyph_run = Gfx::shape_text({}, 0, 0, text.utf16_view(), label_font, Gfx::GlyphRun::TextType::Ltr);
-            glyph_run->ensure_text_blob(1.0);
             for (auto const& glyph : glyph_run->glyphs())
                 Layout::RustFFI::layout_arena_paint_push_overlay_glyph(sink, glyph.glyph_id, glyph.position.x(), glyph.position.y());
-            auto bounds = glyph_run->cached_blob_bounds();
+            auto bounds = glyph_run->bounding_box(1.0f);
             auto metrics = label_font->pixel_metrics();
             return Layout::RustFFI::FfiOverlayLabelFacts {
                 .font_id = context.resource_storage.add_font(glyph_run->font()).value(),

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -19,6 +19,7 @@ endforeach()
 target_link_libraries(BenchmarkJPEGLoader PRIVATE LibImageDecoders)
 target_link_libraries(TestImageDecoder PRIVATE LibImageDecoders)
 target_link_libraries(TestImageWriter PRIVATE LibImageDecoders)
+target_link_libraries(TestFont PRIVATE harfbuzz)
 
 ladybird_test(TestBitmapSequence.cpp LibGfx LIBS LibGfx LibIPC)
 ladybird_test(TestShareableBitmap.cpp LibGfx LIBS LibGfx LibIPC)

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -9,7 +9,9 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/TextLayout.h>
 #include <LibTest/TestCase.h>
+#include <harfbuzz/hb.h>
 
 #define TEST_INPUT(x) ("test-inputs/" x)
 
@@ -50,4 +52,102 @@ TEST_CASE(monochrome_emoji_font_is_not_emoji_font)
 TEST_CASE(text_font_is_not_emoji_font)
 {
     EXPECT(!font_is_emoji(TEST_INPUT("fonts/text.ttf"sv)));
+}
+
+static NonnullRefPtr<Gfx::Font> load_text_font(float point_size)
+{
+    auto file = MUST(Core::MappedFile::map(TEST_INPUT("fonts/text.ttf"sv)));
+    // The typeface outlives the mapping, so let it own a copy of the font data.
+    auto typeface = MUST(Gfx::Typeface::try_load_from_temporary_memory(file->bytes()));
+    return adopt_ref(*new Gfx::Font(typeface, point_size, point_size, {}, {}));
+}
+
+static NonnullRefPtr<Gfx::GlyphRun> shape(Gfx::Font const& font, StringView text)
+{
+    auto utf16_text = Utf16String::from_utf8(text);
+    return Gfx::shape_text({}, 0, 0, utf16_text.utf16_view(), font, Gfx::GlyphRun::TextType::Common);
+}
+
+// The run's bounding box is conservative: it contains every glyph's own extents at the glyph's origin, and it
+// scales with the device scale.
+TEST_CASE(glyph_run_bounding_box_contains_glyph_extents)
+{
+    auto font = load_text_font(16);
+    auto run = shape(font, "abc"sv);
+    EXPECT_EQ(run->glyphs().size(), 3u);
+
+    auto bounds = run->bounding_box(1);
+    EXPECT(!bounds.is_empty());
+
+    auto* hb_font = font->harfbuzz_font();
+    int x_scale = 0;
+    int y_scale = 0;
+    hb_font_get_scale(hb_font, &x_scale, &y_scale);
+    auto font_ascent = font->pixel_metrics().ascent;
+    for (auto const& glyph : run->glyphs()) {
+        hb_glyph_extents_t extents {};
+        EXPECT(hb_font_get_glyph_extents(hb_font, glyph.glyph_id, &extents));
+        Gfx::FloatRect glyph_bounds {
+            glyph.position.x() + extents.x_bearing * font->pixel_size() / x_scale,
+            glyph.position.y() + font_ascent - extents.y_bearing * font->pixel_size() / y_scale,
+            extents.width * font->pixel_size() / x_scale,
+            -extents.height * font->pixel_size() / y_scale,
+        };
+        EXPECT(!glyph_bounds.is_empty());
+        EXPECT(bounds.contains(glyph_bounds));
+    }
+
+    auto scaled_bounds = run->bounding_box(2);
+    EXPECT_APPROXIMATE(scaled_bounds.x(), bounds.x() * 2);
+    EXPECT_APPROXIMATE(scaled_bounds.y(), bounds.y() * 2);
+    EXPECT_APPROXIMATE(scaled_bounds.width(), bounds.width() * 2);
+    EXPECT_APPROXIMATE(scaled_bounds.height(), bounds.height() * 2);
+
+    auto empty_run = shape(font, ""sv);
+    EXPECT(empty_run->bounding_box(1).is_empty());
+}
+
+// Glyph intercepts report one [start, end] interval per glyph whose ink crosses the band, in run order and in
+// run-local device pixels.
+TEST_CASE(glyph_run_intercepts)
+{
+    auto font = load_text_font(16);
+    auto run = shape(font, "abc"sv);
+
+    // Bands are relative to the run's baseline origin; ink above the baseline has negative y.
+    auto mid_x_height = -font->pixel_metrics().x_height / 2;
+    auto intercepts = run->get_glyph_intercepts(1, mid_x_height - 1, mid_x_height + 1);
+    EXPECT_EQ(intercepts.size(), 6u);
+    float previous_end = 0;
+    for (size_t i = 0; i + 1 < intercepts.size(); i += 2) {
+        EXPECT(intercepts[i] < intercepts[i + 1]);
+        EXPECT(intercepts[i] >= previous_end);
+        EXPECT(intercepts[i + 1] <= run->width() + 1);
+        previous_end = intercepts[i + 1];
+    }
+
+    // At twice the scale the intervals scale with it.
+    auto scaled_intercepts = run->get_glyph_intercepts(2, (mid_x_height - 1) * 2, (mid_x_height + 1) * 2);
+    EXPECT_EQ(scaled_intercepts.size(), 6u);
+    for (size_t i = 0; i < intercepts.size(); ++i)
+        EXPECT(AK::fabs(scaled_intercepts[i] - intercepts[i] * 2) < 0.01f);
+
+    // A band far above the ascender touches no ink.
+    EXPECT(run->get_glyph_intercepts(1, -200, -190).is_empty());
+
+    // A band just below the top of the 'b' ascender is only reached by that glyph.
+    auto* hb_font = font->harfbuzz_font();
+    int x_scale = 0;
+    int y_scale = 0;
+    hb_font_get_scale(hb_font, &x_scale, &y_scale);
+    hb_glyph_extents_t b_extents {};
+    EXPECT(hb_font_get_glyph_extents(hb_font, run->glyphs()[1].glyph_id, &b_extents));
+    auto b_top = -b_extents.y_bearing * font->pixel_size() / y_scale;
+    auto ascender_intercepts = run->get_glyph_intercepts(1, b_top + 0.5f, b_top + 1.5f);
+    EXPECT_EQ(ascender_intercepts.size(), 2u);
+    EXPECT(ascender_intercepts[0] >= run->glyphs()[1].position.x());
+    EXPECT(ascender_intercepts[1] <= run->glyphs()[2].position.x());
+
+    // A degenerate scale produces nothing.
+    EXPECT(run->get_glyph_intercepts(0, mid_x_height - 1, mid_x_height + 1).is_empty());
 }


### PR DESCRIPTION
GlyphRun used to build and cache an SkTextBlob, which was its only Skia dependency. Nothing draws with that blob anymore (the display list player rebuilds its own from the inline glyph data); it only answered two questions: the conservative bounds of the run used for display list culling, and the glyph ink intercepts used by text-decoration-skip-ink.

Both are now answered from HarfBuzz:

- bounding_box() mirrors Skia's conservative run bounds: the bounding box of the glyph origins expanded by the typeface's `head` bounding box, which Typeface now reads once and caches. Fonts without one fall back to the union of per-glyph extents, as Skia did.

- get_glyph_intercepts() walks the unhinted outlines from hb_font_draw_glyph() and ports Skia's path gap computation: every crossing of the band's top and bottom edges widens the extent, as does every segment point strictly inside the band. Quadratics use the stable closed form; cubics are split into monotonic pieces and bisected.

This is preparation work to convert GlyphRun to Rust.