### PR TITLE
Continue migrating layout and painting internals to Rust

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1777,24 +1777,18 @@ static void relayout_subtree(Layout::Box& subtree_root)
     });
 }
 
-// The pre-order traversal visits ancestors before the descendants that mark them, so clearing
-// the flag on visit and marking upwards compose within one walk.
-void Document::recompute_containing_block_and_derive_abspos_escape_flags(Layout::Node& layout_node)
+// Recomputes containing blocks and derives the abspos escape flags for the inclusive subtree
+// inside the Rust arena; the DOM-ancestry half of the inline containing-block workaround stays
+// on the C++ side as the callback.
+static void recompute_containing_blocks_in_inclusive_subtree(Layout::NodeArena& arena, Layout::Node& subtree_root)
 {
-    layout_node.recompute_containing_block({});
-
-    auto* box = as_if<Layout::Box>(layout_node);
-    if (!box)
-        return;
-    box->set_abspos_descendant_escapes(false);
-
-    if (!box->is_absolutely_positioned())
-        return;
-    auto const* containing_block = box->containing_block();
-    for (auto* ancestor = box->parent(); ancestor && ancestor != containing_block; ancestor = ancestor->parent()) {
-        if (auto* ancestor_box = as_if<Layout::Box>(*ancestor))
-            ancestor_box->set_abspos_descendant_escapes(true);
-    }
+    Layout::RustFFI::layout_arena_recompute_containing_blocks(
+        arena.handle(), Layout::Node::slot_id(&subtree_root),
+        [](void* node_shell, void* containing_block_shell) -> Layout::RustFFI::NodeSlotId {
+            auto const& node = *static_cast<Layout::Node const*>(node_shell);
+            auto const& containing_block = *static_cast<Layout::Box const*>(containing_block_shell);
+            return Layout::Node::slot_id(node.find_inline_containing_block(containing_block));
+        });
 }
 
 // Refreshes every structure derived from committed layout results, shared by the partial and
@@ -2028,12 +2022,8 @@ Document::PartialRelayoutResult Document::try_partial_relayout(HashTable<WeakPtr
     // Nodes created by the incremental build have no containing blocks assigned yet, and the
     // mutation may have moved where existing out-of-flow descendants belong; recompute both so
     // boundary qualification below reads facts matching the just-built tree.
-    for (auto* rebuilt_root : rebuilt_subtree_roots) {
-        rebuilt_root->for_each_in_inclusive_subtree([](Layout::Node& node) {
-            recompute_containing_block_and_derive_abspos_escape_flags(node);
-            return TraversalDecision::Continue;
-        });
-    }
+    for (auto* rebuilt_root : rebuilt_subtree_roots)
+        recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *rebuilt_root);
 
     // Collect the live boundary set from the post-build tree: registered boundaries that
     // survived the build, plus the nearest boundary containing each rebuilt subtree - which
@@ -2195,11 +2185,7 @@ void Document::update_layout(UpdateLayoutReason reason)
             });
         }
 
-        m_layout_root->for_each_in_inclusive_subtree([&](auto& layout_node) {
-            recompute_containing_block_and_derive_abspos_escape_flags(layout_node);
-
-            return TraversalDecision::Continue;
-        });
+        recompute_containing_blocks_in_inclusive_subtree(layout_node_arena(), *m_layout_root);
 
         // The walk above re-derived every fact partial relayout boundary qualification depends
         // on, so pending changes that escaped classification are accounted for from here on.

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1424,7 +1424,6 @@ private:
     bool needs_style_update_after_layout();
     bool any_anchor_names_are_registered() const;
     PartialRelayoutResult try_partial_relayout(HashTable<WeakPtr<Layout::Box>> registered_partial_relayout_roots, bool& needs_layout_tree_rebuild, bool should_collect_devtools_layout_data);
-    static void recompute_containing_block_and_derive_abspos_escape_flags(Layout::Node&);
     enum class LayoutTreeChanged : u8 {
         No,
         Yes,

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -783,21 +783,6 @@ bool NodeWithStyle::is_sticky_position() const
     return position == CSS::Positioning::Sticky;
 }
 
-bool NodeWithStyle::is_text_decoration_propagation_boundary() const
-{
-    // NB: Anonymous wrappers must stay transparent to propagation so an element's own decorations still reach
-    //     its text. The principal box of a pseudo-element is not a wrapper and must be checked like any other
-    //     element, and a table wrapper carries the float and position of the table it wraps, so it is the only
-    //     box where an out-of-flow table is observable.
-    if (is_anonymous() && !is_pseudo_element_principal_box() && !is_table_wrapper())
-        return false;
-
-    // https://drafts.csswg.org/css-text-decor-4/#decorating-box
-    // NOTE: Note that text decorations are not propagated to any out-of-flow descendants, nor to the contents
-    //       of atomic inline-level descendants such as inline blocks and inline tables.
-    return is_out_of_flow() || is_atomic_inline();
-}
-
 NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, CSS::LayoutStyle style, RustFFI::NodeKind kind)
     : Node(document, node)
 {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -436,31 +436,6 @@ bool NodeWithStyle::establishes_a_fixed_positioning_containing_block() const
     return style_establishes_fixed_positioning_containing_block(*this);
 }
 
-NodeWithStyle::PositioningContainingBlockEstablishment NodeWithStyle::establishes_positioning_containing_blocks() const
-{
-    if (!is<Box>(*this))
-        return {};
-
-    // https://github.com/w3c/fxtf-drafts/issues/307#issuecomment-499612420
-    // foreignObject establishes a containing block for absolutely and fixed positioned elements.
-    if (is_svg_foreign_object_box())
-        return { true, true };
-
-    auto establishes_fixed_positioning_containing_block = style_establishes_fixed_positioning_containing_block(*this);
-    if (establishes_fixed_positioning_containing_block)
-        return { true, true };
-
-    auto establishes_absolute_positioning_containing_block = position() != CSS::Positioning::Static
-        || (!will_change().is_auto() && will_change().has_property(CSS::PropertyID::Position));
-    if (establishes_absolute_positioning_containing_block)
-        return { true, false };
-
-    if (is<Viewport>(*this))
-        return { true, false };
-
-    return {};
-}
-
 // FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
 //
 //        The CSS specification defines the containing block as a *rectangle*, not a box. For most cases,
@@ -520,144 +495,6 @@ NodeWithStyle const* Node::find_inline_containing_block(Box const& containing_bl
             return static_cast<NodeWithStyle const*>(layout_node);
     }
     return nullptr;
-}
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-bool NodeWithStyle::establishes_stacking_context() const
-{
-    // NOTE: While MDN is not authoritative, there isn't a single convenient location
-    //       in the CSS specifications where the rules for stacking contexts is described.
-    //       That's why the "spec link" here points to MDN.
-
-    if (is_svg_box())
-        return false;
-
-    // We make a stacking context for the viewport. Painting and hit testing starts from here.
-    if (is_viewport())
-        return true;
-
-    // Root element of the document (<html>).
-    if (is_root_element())
-        return true;
-
-    auto position = this->position();
-
-    // https://drafts.csswg.org/css-will-change/#will-change
-    // If any non-initial value of a property would create a stacking context on the element, specifying that property
-    // in will-change must create a stacking context on the element.
-    auto will_change_value = will_change();
-    auto will_change_property = [&](CSS::PropertyID property_id) {
-        return will_change_value.has_property(property_id);
-    };
-
-    auto has_z_index = z_index().has_value() || will_change_property(CSS::PropertyID::ZIndex);
-
-    // Element with a position value absolute or relative and z-index value other than auto.
-    if (position == CSS::Positioning::Absolute || position == CSS::Positioning::Relative) {
-        if (has_z_index) {
-            return true;
-        }
-    }
-
-    // Element with a position value fixed or sticky.
-    if (position == CSS::Positioning::Fixed || position == CSS::Positioning::Sticky
-        || will_change_property(CSS::PropertyID::Position)) {
-        return true;
-    }
-
-    if (is_transformable()) {
-        if (has_transformations() || will_change_property(CSS::PropertyID::Transform))
-            return true;
-
-        if (has_translate() || will_change_property(CSS::PropertyID::Translate))
-            return true;
-
-        if (has_rotate() || will_change_property(CSS::PropertyID::Rotate))
-            return true;
-
-        if (has_scale() || will_change_property(CSS::PropertyID::Scale))
-            return true;
-    }
-
-    // Element that is a child of a flex container, with z-index value other than auto.
-    if (parent() && parent()->display().is_flex_inside() && has_z_index)
-        return true;
-
-    // Element that is a child of a grid container, with z-index value other than auto.
-    if (parent() && parent()->display().is_grid_inside() && has_z_index)
-        return true;
-
-    // https://drafts.fxtf.org/filter-effects/#FilterProperty
-    // https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation
-    // A computed value of other than none results in the creation of both a stacking context
-    // [CSS21] and a Containing Block for absolute and fixed position descendants, unless the
-    // element it applies to is a document root element in the current browsing context.
-    // Spec Note: This rule works in the same way as for the filter property.
-    if (backdrop_filter().has_filters() || filter().has_filters()
-        || will_change_property(CSS::PropertyID::BackdropFilter)
-        || will_change_property(CSS::PropertyID::Filter)) {
-        return true;
-    }
-
-    // Element with any of the following properties with value other than none:
-    // - transform
-    // - filter
-    // - backdrop-filter
-    // - perspective
-    // - clip-path
-    // - mask / mask-image / mask-border
-    if (mask().has_value() || clip_path().has_value() || mask_image()
-        || will_change_property(CSS::PropertyID::Mask)
-        || will_change_property(CSS::PropertyID::ClipPath)
-        || will_change_property(CSS::PropertyID::MaskImage)) {
-        return true;
-    }
-
-    if (is_svg_foreign_object_box())
-        return true;
-
-    // https://drafts.fxtf.org/compositing/#propdef-isolation
-    // For CSS, setting isolation to isolate will turn the element into a stacking context.
-    if (isolation() == CSS::Isolation::Isolate || will_change_property(CSS::PropertyID::Isolation))
-        return true;
-
-    // https://drafts.csswg.org/css-contain-2/#containment-types
-    // 5. The layout containment box creates a stacking context.
-    // 3. The paint containment box creates a stacking context.
-    if (has_layout_containment() || has_paint_containment() || will_change_property(CSS::PropertyID::Contain))
-        return true;
-
-    // https://drafts.fxtf.org/compositing/#mix-blend-mode
-    // Applying a blendmode other than normal to the element must establish a new stacking context.
-    if (mix_blend_mode() != CSS::MixBlendMode::Normal || will_change_property(CSS::PropertyID::MixBlendMode))
-        return true;
-
-    // https://drafts.csswg.org/css-view-transitions-1/#named-and-transitioning
-    // Elements captured in a view transition during a view transition or whose view-transition-name computed value is
-    // not 'none' (at any time):
-    // - Form a stacking context.
-    if (view_transition_name().has_value() || will_change_property(CSS::PropertyID::ViewTransitionName))
-        return true;
-
-    // https://drafts.csswg.org/css-transforms-2/#propdef-perspective
-    // The use of this property with any value other than 'none' establishes a stacking context.
-    if (is_transformable() && (perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)))
-        return true;
-
-    // https://drafts.csswg.org/css-transforms-2/#transform-style-property
-    // A computed value of 'preserve-3d' for 'transform-style' on a transformable element establishes both a
-    // stacking context and a containing block for all descendants.
-    if (is_transformable() && (transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
-        return true;
-
-    // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
-    // A computed value of hidden for backface-visibility on a transformable element that participates in a 3D
-    // rendering context establishes both a stacking context and a containing block for all descendants.
-    if ((style_group<CSS::ComputedValues::TransformValues>().backface_visibility_value() == CSS::BackfaceVisibility::Hidden || will_change_property(CSS::PropertyID::BackfaceVisibility))
-        && is_transformable() && participates_in_a_3d_rendering_context())
-        return true;
-
-    return opacity() < 1.0f || will_change_property(CSS::PropertyID::Opacity);
 }
 
 GC::Ptr<HTML::LocalNavigable> Node::navigable() const
@@ -982,14 +819,6 @@ bool NodeWithStyle::is_inline_table() const
 bool Node::is_replaced_element() const
 {
     return has_flag(RustFFI::NodeFlag::IsReplacedElement);
-}
-
-bool NodeWithStyle::has_replaced_element_table_display_adjustment() const
-{
-    if (!is_replaced_element())
-        return false;
-    auto display = display_before_box_type_transformation();
-    return display.is_table_inside() || display.is_internal_table() || display.is_table_caption();
 }
 
 bool Node::is_atomic_inline() const
@@ -1587,33 +1416,6 @@ bool NodeWithStyle::has_size_containment() const
         return true;
 
     if (container_type().is_size_container)
-        return true;
-
-    return false;
-}
-// https://drafts.csswg.org/css-contain-2/#containment-inline-size
-bool NodeWithStyle::has_inline_size_containment() const
-{
-    // Giving an element inline-size containment has no effect if any of the following are true:
-
-    // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
-    // Note: This is the principal box
-
-    // - if its inner display type is 'table'
-    if (display().is_table_inside())
-        return false;
-
-    // - if its principal box is an internal table box
-    if (display().is_internal_table())
-        return false;
-
-    // - if its principal box is an internal ruby box or a non-atomic inline-level box
-    // FIXME: Implement this.
-
-    if (contain().inline_size_containment)
-        return true;
-
-    if (container_type().is_inline_size_container)
         return true;
 
     return false;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -243,16 +243,14 @@ void Node::remove()
     parent->remove_child(*this);
 }
 
-void Node::set_containing_block(Box* containing_block)
+Box const* Node::containing_block() const
 {
-    m_containing_block = containing_block;
-    m_data->containing_block = slot_id(containing_block);
+    return static_cast<Box const*>(tree_node_from_slot_if_live(m_data->containing_block));
 }
 
-void Node::set_inline_containing_block(NodeWithStyle const* containing_block)
+Box* Node::containing_block()
 {
-    m_inline_containing_block_if_applicable = containing_block;
-    m_data->inline_containing_block = slot_id(containing_block);
+    return static_cast<Box*>(tree_node_from_slot_if_live(m_data->containing_block));
 }
 
 static void invalidate_paint_caches(Node& node)
@@ -463,136 +461,65 @@ NodeWithStyle::PositioningContainingBlockEstablishment NodeWithStyle::establishe
     return {};
 }
 
-static Box* nearest_ancestor_capable_of_forming_a_containing_block(Node& node)
+// FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
+//
+//        The CSS specification defines the containing block as a *rectangle*, not a box. For most cases,
+//        this rectangle is derived from the padding box of the nearest positioned ancestor Box. However,
+//        when the positioned ancestor is an *inline* element (e.g., a <span> with position: relative),
+//        the containing block rectangle should be the bounding box of that inline's fragments.
+//
+//        Currently, the stored containing block can only name a Box, which cannot represent inline
+//        elements. The proper fix would be to:
+//        1. Separate the concept of "the node that establishes the containing block" from "the containing
+//           block rectangle".
+//        2. Store a reference to the establishing node (which could be InlineNode or Box).
+//        3. Compute the containing block rectangle on demand based on the establishing node's type.
+//
+//        For now, we use a workaround: check if there's an inline element with position:relative (or
+//        other containing-block-establishing properties) between this node and its containing block
+//        in the DOM tree. If found, it is stored in the arena's inline_containing_block slot.
+//
+//        We check the DOM tree here (rather than the layout tree) because when a block element is inside
+//        an inline element, the layout tree restructures so the block becomes a sibling of the inline.
+//        But the CSS containing block relationship is based on the DOM structure.
+NodeWithStyle const* Node::find_inline_containing_block(Box const& containing_block) const
 {
-    for (auto* ancestor = node.parent(); ancestor; ancestor = ancestor->parent()) {
-        if ((ancestor->is_block_container() && !ancestor->is_fragmented_inline())
-            || ancestor->display().is_flex_inside()
-            || ancestor->display().is_grid_inside()
-            || ancestor->is_replaced_box_with_children()) {
-            return static_cast<Box*>(ancestor);
-        }
+    auto const* containing_block_dom_node = containing_block.dom_node();
+
+    // For pseudo-elements, we need to start from the generating element itself, since it may
+    // be the inline containing block. For regular elements, start from parent_element().
+    GC::Ptr<DOM::Element const> first_ancestor_to_check;
+    if (is_generated_for_pseudo_element()) {
+        first_ancestor_to_check = m_pseudo_element_generator.ptr();
+    } else if (auto const* this_dom_node = dom_node()) {
+        first_ancestor_to_check = this_dom_node->parent_element();
+    }
+
+    for (auto dom_ancestor = first_ancestor_to_check; dom_ancestor; dom_ancestor = dom_ancestor->parent_element()) {
+        // Stop if we reach the DOM node of the containing block.
+        if (dom_ancestor.ptr() == containing_block_dom_node)
+            break;
+
+        // NB: Called during containing block recomputation as part of layout.
+        // Check if this DOM element has an InlineNode in the layout tree.
+        auto layout_node = dom_ancestor->unsafe_layout_node();
+        if (!layout_node || !layout_node->is_inline_node())
+            continue;
+
+        // Restrict the per-property trigger set to those that actually apply to
+        // non-atomic inlines: `position` and filter/backdrop-filter. transform,
+        // contain, perspective and friends from
+        // style_establishes_absolute_positioning_containing_block()
+        // explicitly do not apply to non-atomic inlines per their respective specs.
+        auto const& will_change = layout_node->will_change();
+        bool const inline_establishes_cb = layout_node->is_positioned()
+            || will_change.has_property(CSS::PropertyID::Position)
+            || layout_node->filter().has_filters() || will_change.has_property(CSS::PropertyID::Filter)
+            || layout_node->backdrop_filter().has_filters() || will_change.has_property(CSS::PropertyID::BackdropFilter);
+        if (inline_establishes_cb)
+            return static_cast<NodeWithStyle const*>(layout_node);
     }
     return nullptr;
-}
-
-void Node::recompute_containing_block(Badge<DOM::Document>)
-{
-    // Reset the inline containing block - we'll set it below if applicable.
-    set_inline_containing_block(nullptr);
-
-    if (is<TextNode>(*this)) {
-        set_containing_block(nearest_ancestor_capable_of_forming_a_containing_block(*this));
-        return;
-    }
-
-    auto position = as<NodeWithStyle>(*this).position();
-
-    // https://drafts.csswg.org/css-position-3/#absolute-cb
-    if (position == CSS::Positioning::Absolute) {
-        auto* ancestor = parent();
-        while (ancestor && !ancestor->establishes_an_absolute_positioning_containing_block())
-            ancestor = ancestor->parent();
-        set_containing_block(static_cast<Box*>(ancestor));
-
-        // FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
-        //
-        //        The CSS specification defines the containing block as a *rectangle*, not a box. For most cases,
-        //        this rectangle is derived from the padding box of the nearest positioned ancestor Box. However,
-        //        when the positioned ancestor is an *inline* element (e.g., a <span> with position: relative),
-        //        the containing block rectangle should be the bounding box of that inline's fragments.
-        //
-        //        Currently, m_containing_block is typed as Box*, which cannot represent inline elements.
-        //        The proper fix would be to:
-        //        1. Separate the concept of "the node that establishes the containing block" from "the containing
-        //           block rectangle".
-        //        2. Store a reference to the establishing node (which could be InlineNode or Box).
-        //        3. Compute the containing block rectangle on demand based on the establishing node's type.
-        //
-        //        For now, we use a workaround: check if there's an inline element with position:relative (or
-        //        other containing-block-establishing properties) between this node and its containing_block()
-        //        in the DOM tree. If found, store it in m_inline_containing_block_if_applicable.
-        //
-        //        We check the DOM tree here (rather than the layout tree) because when a block element is inside
-        //        an inline element, the layout tree restructures so the block becomes a sibling of the inline.
-        //        But the CSS containing block relationship is based on the DOM structure.
-        if (m_containing_block) {
-            auto const* containing_block_dom_node = m_containing_block->dom_node();
-
-            // For pseudo-elements, we need to start from the generating element itself, since it may
-            // be the inline containing block. For regular elements, start from parent_element().
-            GC::Ptr<DOM::Element const> first_ancestor_to_check;
-            if (is_generated_for_pseudo_element()) {
-                first_ancestor_to_check = m_pseudo_element_generator.ptr();
-            } else if (auto const* this_dom_node = dom_node()) {
-                first_ancestor_to_check = this_dom_node->parent_element();
-            }
-
-            for (auto dom_ancestor = first_ancestor_to_check; dom_ancestor; dom_ancestor = dom_ancestor->parent_element()) {
-                // Stop if we reach the DOM node of the containing block.
-                if (dom_ancestor.ptr() == containing_block_dom_node)
-                    break;
-
-                // NB: Called during containing block recomputation as part of layout.
-                // Check if this DOM element has an InlineNode in the layout tree.
-                auto layout_node = dom_ancestor->unsafe_layout_node();
-                if (!layout_node || !layout_node->is_inline_node())
-                    continue;
-
-                // Restrict the per-property trigger set to those that actually apply to
-                // non-atomic inlines: `position` and filter/backdrop-filter. transform,
-                // contain, perspective and friends from
-                // style_establishes_absolute_positioning_containing_block()
-                // explicitly do not apply to non-atomic inlines per their respective specs.
-                auto const& will_change = layout_node->will_change();
-                bool const inline_establishes_cb = layout_node->is_positioned()
-                    || will_change.has_property(CSS::PropertyID::Position)
-                    || layout_node->filter().has_filters() || will_change.has_property(CSS::PropertyID::Filter)
-                    || layout_node->backdrop_filter().has_filters() || will_change.has_property(CSS::PropertyID::BackdropFilter);
-                if (inline_establishes_cb) {
-                    set_inline_containing_block(static_cast<NodeWithStyle const*>(layout_node));
-                    break;
-                }
-            }
-        }
-
-        return;
-    }
-
-    // https://drafts.csswg.org/css-position-3/#fixed-cb
-    if (position == CSS::Positioning::Fixed) {
-        // The containing block is established by the nearest ancestor box that establishes an fixed positioning
-        // containing block, with the bounds of the containing block determined identically to the absolute positioning
-        // containing block.
-        auto* ancestor = parent();
-        while (ancestor && !ancestor->establishes_a_fixed_positioning_containing_block())
-            ancestor = ancestor->parent();
-        // If no ancestor establishes one, the box’s fixed positioning containing block is the initial fixed containing
-        // block:
-        if (!ancestor) {
-            //  - in continuous media, the layout viewport (whose size matches the dynamic viewport size); as a result,
-            //    fixed boxes do not move when the document is scrolled.
-            ancestor = &root();
-            // FIXME: - in paged media, the page area of each page; fixed positioned boxes are thus replicated on every
-            //   page. (They are fixed with respect to the page box only, and are not affected by being seen through a
-            //   viewport; as in the case of print preview, for example.)
-        }
-        set_containing_block(static_cast<Box*>(ancestor));
-        return;
-    }
-
-    set_containing_block(nearest_ancestor_capable_of_forming_a_containing_block(*this));
-}
-
-Box const* Node::non_anonymous_containing_block() const
-{
-    auto nearest_ancestor_box = containing_block();
-    VERIFY(nearest_ancestor_box);
-    while (nearest_ancestor_box->is_anonymous()) {
-        nearest_ancestor_box = nearest_ancestor_box->containing_block();
-        VERIFY(nearest_ancestor_box);
-    }
-    return nearest_ancestor_box;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -365,22 +365,17 @@ public:
         return true;
     }
 
-    [[nodiscard]] Box const* containing_block() const { return m_containing_block; }
-    [[nodiscard]] Box* containing_block() { return m_containing_block; }
+    // The containing block is computed inside the Rust arena
+    // (layout_arena_recompute_containing_blocks); the stored slot is always a Box or invalid.
+    // The tolerant resolution yields null when the containing block's slot has been freed.
+    [[nodiscard]] Box const* containing_block() const;
+    [[nodiscard]] Box* containing_block();
 
-    // Returns the inline node that actually establishes the containing block for this absolutely
-    // positioned element, if applicable. This is needed because m_containing_block can only hold
-    // a Box*, but CSS allows inline elements (like a <span> with position:relative) to establish
-    // containing blocks for their absolutely positioned descendants.
-    [[nodiscard]] NodeWithStyle const* inline_containing_block_if_applicable() const { return m_inline_containing_block_if_applicable; }
-
-    void recompute_containing_block(Badge<DOM::Document>);
-
-    // Closest non-anonymous ancestor box, to be used when resolving percentage values.
-    // Anonymous block boxes are ignored when resolving percentage values that would refer to it:
-    // the closest non-anonymous ancestor box is used instead.
-    // https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level
-    Box const* non_anonymous_containing_block() const;
+    // For an absolutely positioned node, finds a containing-block-establishing *inline* element
+    // (e.g. a <span> with position:relative) between this node and its containing block by
+    // walking the DOM tree. Invoked from the Rust containing-block recomputation, which owns
+    // the layout-tree half of the walk but cannot see DOM ancestry.
+    [[nodiscard]] NodeWithStyle const* find_inline_containing_block(Box const& containing_block) const;
 
     Gfx::Font const& first_available_font() const;
     Gfx::Font const& font(float scale_factor) const;
@@ -435,14 +430,17 @@ private:
         return static_cast<u8>(pseudo_element) + 1;
     }
 
-    void set_containing_block(Box*);
-    void set_inline_containing_block(NodeWithStyle const*);
-
     Node* tree_node_from_slot(RustFFI::NodeSlotId id) const
     {
         if (id.index == RustFFI::NodeSlotId_INVALID.index)
             return nullptr;
         return static_cast<Node*>(RustFFI::layout_arena_node_data(m_arena->handle(), id)->shell);
+    }
+
+    // Unlike tree_node_from_slot, tolerates freed and stale slots by resolving them to null.
+    Node* tree_node_from_slot_if_live(RustFFI::NodeSlotId id) const
+    {
+        return static_cast<Node*>(RustFFI::layout_arena_node_shell_if_live(m_arena->handle(), id));
     }
 
 protected:
@@ -454,15 +452,6 @@ private:
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
     GC::Root<DOM::Node> m_dom_node;
     RefPtr<Painting::Paintable> m_paintable;
-
-    Box* m_containing_block { nullptr };
-
-    // For absolutely positioned elements, if there's an inline element (like a <span> with
-    // position:relative) that should be the containing block but can't be stored in m_containing_block
-    // (because it's not a Box), we store it here. This happens when a block element is inside an
-    // inline element - the layout tree restructures so the block becomes a sibling of the inline,
-    // but the CSS containing block relationship is based on the DOM structure.
-    NodeWithStyle const* m_inline_containing_block_if_applicable { nullptr };
 
     GC::Weak<DOM::Element> m_pseudo_element_generator;
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -778,8 +778,6 @@ public:
     bool is_fixed_position() const;
     bool is_sticky_position() const;
 
-    bool is_text_decoration_propagation_boundary() const;
-
     // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
     // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
     bool is_out_of_flow() const { return is_floating() || is_absolutely_positioned(); }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -517,7 +517,6 @@ public:
     }
 
     CSS::Display display() const { return CSS::display_from_ffi_display(style_group<CSS::ComputedValues::BoxValues>().display); }
-    CSS::Display display_before_box_type_transformation() const { return CSS::display_from_ffi_display(style_group<CSS::ComputedValues::BoxValues>().display_before_box_type_transformation); }
     CSS::Float float_() const { return static_cast<CSS::Float>(style_group<CSS::ComputedValues::BoxValues>().float_); }
     CSS::Clear clear() const { return static_cast<CSS::Clear>(style_group<CSS::ComputedValues::BoxValues>().clear); }
     CSS::Positioning position() const { return static_cast<CSS::Positioning>(style_group<CSS::ComputedValues::BoxValues>().position); }
@@ -599,9 +598,6 @@ public:
     CSS::PointerEvents pointer_events() const { return style_group<CSS::ComputedValues::InheritedUIValues>().pointer_events_value(); }
     CSS::ScrollbarColorData scrollbar_color() const { return style_group<CSS::ComputedValues::InheritedUIValues>().scrollbar_color_value(); }
     CSS::Appearance appearance() const { return static_cast<CSS::Appearance>(style_group<CSS::ComputedValues::MiscResetValues>().appearance); }
-    CSS::ObjectFit object_fit() const { return static_cast<CSS::ObjectFit>(style_group<CSS::ComputedValues::MiscResetValues>().object_fit); }
-    CSS::Position object_position() const { return style_group<CSS::ComputedValues::MiscResetValues>().object_position_value(); }
-    CSS::OverflowClipMarginData overflow_clip_margin() const { return style_group<CSS::ComputedValues::MiscResetValues>().overflow_clip_margin_value(); }
     CSS::LengthBox scroll_padding() const { return length_box(style_group<CSS::ComputedValues::MiscResetValues>().scroll_padding); }
     CSS::ScrollbarWidth scrollbar_width() const { return static_cast<CSS::ScrollbarWidth>(style_group<CSS::ComputedValues::MiscResetValues>().scrollbar_width); }
     CSS::UserSelect user_select() const { return static_cast<CSS::UserSelect>(style_group<CSS::ComputedValues::MiscResetValues>().user_select); }
@@ -612,7 +608,6 @@ public:
     CSS::OutlineStyle outline_style() const { return static_cast<CSS::OutlineStyle>(style_group<CSS::ComputedValues::MiscResetValues>().outline_style); }
     CSSPixels outline_width() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::MiscResetValues>().outline_width); }
     Color background_color() const { return style_group<CSS::ComputedValues::BackgroundValues>().background_color_value(); }
-    CSS::BackgroundBox background_color_clip() const { return style_group<CSS::ComputedValues::BackgroundValues>().background_color_clip_value(); }
     Vector<CSS::BackgroundLayerData> const& background_layers() const
     {
         if (!m_background_layers.has_value())
@@ -625,7 +620,6 @@ public:
             m_mask_layers = style_group<CSS::ComputedValues::MaskValues>().mask_layers_value();
         return *m_mask_layers;
     }
-    RefPtr<CSS::AbstractImageStyleValue const> mask_image() const { return style_group<CSS::ComputedValues::MaskValues>().mask_image_value(); }
     CSS::ListStyleType const& list_style_type() const
     {
         if (!m_list_style_type.has_value()) {
@@ -663,34 +657,18 @@ public:
     CSS::BorderRadiusData border_bottom_right_radius() const { return style_group<CSS::ComputedValues::BorderValues>().border_bottom_right_radius_value(); }
     CSS::BorderRadiusData border_top_left_radius() const { return style_group<CSS::ComputedValues::BorderValues>().border_top_left_radius_value(); }
     CSS::BorderRadiusData border_top_right_radius() const { return style_group<CSS::ComputedValues::BorderValues>().border_top_right_radius_value(); }
-    CSS::BorderCollapse border_collapse() const { return static_cast<CSS::BorderCollapse>(style_group<CSS::ComputedValues::InheritedTableValues>().border_collapse); }
-    CSS::EmptyCells empty_cells() const { return static_cast<CSS::EmptyCells>(style_group<CSS::ComputedValues::InheritedTableValues>().empty_cells); }
     Color color() const { return style_group<CSS::ComputedValues::InheritedTextValues>().color_value(); }
     Color webkit_text_fill_color() const { return style_group<CSS::ComputedValues::InheritedTextValues>().webkit_text_fill_color_value(); }
     CSSPixels letter_spacing() const { return style_group<CSS::ComputedValues::InheritedTextValues>().letter_spacing_value(); }
     ReadonlySpan<CSS::ShadowData> text_shadow() const { return style_group<CSS::ComputedValues::InheritedTextValues>().text_shadow_span(); }
     CSS::TextTransform text_transform() const { return style_group<CSS::ComputedValues::InheritedTextValues>().text_transform_value(); }
     CSS::WhiteSpaceCollapse white_space_collapse() const { return style_group<CSS::ComputedValues::InheritedTextValues>().white_space_collapse_value(); }
-    CSS::TextDecorationSkipInk text_decoration_skip_ink() const { return style_group<CSS::ComputedValues::InheritedTextValues>().text_decoration_skip_ink_value(); }
-    CSSPixels text_underline_offset() const { return style_group<CSS::ComputedValues::InheritedTextValues>().text_underline_offset_value(); }
-    CSS::TextUnderlinePosition text_underline_position() const { return style_group<CSS::ComputedValues::InheritedTextValues>().text_underline_position_value(); }
-    ReadonlySpan<CSS::TextDecorationLine> text_decoration_line() const { return style_group<CSS::ComputedValues::TextResetValues>().decoration_lines(); }
-    CSS::TextDecorationThickness text_decoration_thickness() const { return style_group<CSS::ComputedValues::TextResetValues>().decoration_thickness(); }
     Color text_decoration_color() const { return Color::from_bgra(style_group<CSS::ComputedValues::TextResetValues>().text_decoration_color); }
-    CSS::TextDecorationStyle text_decoration_style() const { return static_cast<CSS::TextDecorationStyle>(style_group<CSS::ComputedValues::TextResetValues>().text_decoration_style); }
     Optional<CSS::ContentData> const& content() const { return m_content; }
     CSSPixels line_height() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::FontValues>().line_height_used); }
     CSSPixels font_size() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::FontValues>().font_size); }
     Gfx::FontCascadeList const& font_list() const { return style_group<CSS::ComputedValues::FontValues>().font_list_value(); }
-    CSS::FlexBasis flex_basis() const
-    {
-        auto const& value = style_group<CSS::ComputedValues::AlignmentValues>().flex_basis;
-        if (value.is_content)
-            return CSS::FlexBasisContent {};
-        return CSS::Size::view(value.size);
-    }
     CSS::FlexDirection flex_direction() const { return static_cast<CSS::FlexDirection>(style_group<CSS::ComputedValues::AlignmentValues>().flex_direction); }
-    CSS::FlexWrap flex_wrap() const { return static_cast<CSS::FlexWrap>(style_group<CSS::ComputedValues::AlignmentValues>().flex_wrap); }
     CSS::AlignSelf align_self() const { return static_cast<CSS::AlignSelf>(style_group<CSS::ComputedValues::AlignmentValues>().align_self); }
     CSS::JustifySelf justify_self() const { return static_cast<CSS::JustifySelf>(style_group<CSS::ComputedValues::AlignmentValues>().justify_self); }
     i32 order() const { return style_group<CSS::ComputedValues::AlignmentValues>().order; }
@@ -710,7 +688,6 @@ public:
     {
         style_group<CSS::ComputedValues::TransformValues>().for_each_transformation(callback);
     }
-    bool has_resolved_transforms() const { return style_group<CSS::ComputedValues::TransformValues>().has_resolved_transforms(); }
     template<typename Callback>
     void for_each_resolved_transform(Callback callback) const
     {
@@ -726,7 +703,6 @@ public:
     bool has_translate() const { return translate() != nullptr; }
     bool has_scale() const { return scale() != nullptr; }
     Optional<CSSPixels> perspective() const { return style_group<CSS::ComputedValues::TransformValues>().perspective_value(); }
-    CSS::Position perspective_origin() const { return style_group<CSS::ComputedValues::TransformValues>().perspective_origin_value(); }
     Optional<CSS::MaskReference> mask() const { return style_group<CSS::ComputedValues::MaskValues>().mask_value(); }
     CSS::MaskType mask_type() const { return style_group<CSS::ComputedValues::MaskValues>().mask_type_value(); }
     Optional<CSS::ClipPathReference> clip_path() const { return style_group<CSS::ComputedValues::MaskValues>().clip_path_value(); }
@@ -745,16 +721,8 @@ public:
     CSS::ClipRule clip_rule() const { return style_group<CSS::ComputedValues::InheritedSVGValues>().clip_rule_value(); }
     CSS::PaintOrderList paint_order() const { return style_group<CSS::ComputedValues::InheritedSVGValues>().paint_order_value(); }
     CSS::TextAnchor text_anchor() const { return style_group<CSS::ComputedValues::InheritedSVGValues>().text_anchor_value(); }
-    CSS::ShapeRendering shape_rendering() const { return style_group<CSS::ComputedValues::InheritedSVGValues>().shape_rendering_value(); }
-    CSS::LengthPercentage const& cx() const { return CSS::LengthPercentage::view(style_group<CSS::ComputedValues::SVGResetValues>().cx); }
-    CSS::LengthPercentage const& cy() const { return CSS::LengthPercentage::view(style_group<CSS::ComputedValues::SVGResetValues>().cy); }
-    CSS::LengthPercentage const& r() const { return CSS::LengthPercentage::view(style_group<CSS::ComputedValues::SVGResetValues>().r); }
-    CSS::LengthPercentage const& x() const { return CSS::LengthPercentage::view(style_group<CSS::ComputedValues::SVGResetValues>().x); }
-    CSS::LengthPercentage const& y() const { return CSS::LengthPercentage::view(style_group<CSS::ComputedValues::SVGResetValues>().y); }
-    CSS::VectorEffect vector_effect() const { return static_cast<CSS::VectorEffect>(style_group<CSS::ComputedValues::SVGResetValues>().vector_effect); }
     bool is_inline_block() const;
     bool is_inline_table() const;
-    bool has_replaced_element_table_display_adjustment() const;
     bool is_transformable() const;
     Gfx::AffineTransform used_svg_element_transform() const;
     CSS::TransformStyle used_transform_style() const;
@@ -771,24 +739,12 @@ public:
     // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
     bool is_out_of_flow() const { return is_floating() || is_absolutely_positioned(); }
 
-    // An element is called in-flow if it is not out-of-flow.
-    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
-    bool is_in_flow() const { return !is_out_of_flow(); }
-
-    bool establishes_stacking_context() const;
     bool style_establishes_absolute_positioning_containing_block() const;
     bool establishes_an_absolute_positioning_containing_block() const;
     bool establishes_a_fixed_positioning_containing_block() const;
 
-    struct PositioningContainingBlockEstablishment {
-        bool absolute;
-        bool fixed;
-    };
-    PositioningContainingBlockEstablishment establishes_positioning_containing_blocks() const;
-
     // https://drafts.csswg.org/css-contain-2/#containment-types
     bool has_size_containment() const;
-    bool has_inline_size_containment() const;
     bool has_layout_containment() const;
     bool has_style_containment() const;
     bool has_paint_containment() const;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -805,24 +805,12 @@ void Paintable::invalidate_paint_cache() const
     mirror_rust_invalidate_paint_cache(*this);
 }
 
-void Paintable::invalidate_propagated_text_decoration_caches() const
-{
-    for_each_in_subtree([](Paintable const& descendant) {
-        if (descendant.layout_node().is_text_decoration_propagation_boundary())
-            return TraversalDecision::SkipChildrenAndContinue;
-        // Only fragment-painting paintables record propagated decorations.
-        if (descendant.is_paintable_with_lines() || descendant.is_inline_paintable())
-            descendant.invalidate_paint_cache();
-        return TraversalDecision::Continue;
-    });
-}
-
 void Paintable::repaint_after_style_change(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
     if (invalidation.needs_repaint())
         set_needs_repaint();
     if (invalidation.repaint_propagated_text_decorations)
-        invalidate_propagated_text_decoration_caches();
+        rust_invalidate_propagated_text_decoration_caches(*this);
 }
 
 void Paintable::reset_for_relayout()

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -489,7 +489,6 @@ public:
     CSSPixelPoint inverse_transform_point(CSSPixelPoint screen_position) const;
 
     void invalidate_paint_cache() const;
-    void invalidate_propagated_text_decoration_caches() const;
     void repaint_after_style_change(CSS::RequiredInvalidationAfterStyleChange const&);
 
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -632,7 +632,12 @@ void mirror_rust_clear_paint_cache_sources(ViewportPaintable& viewport_paintable
 
 void mirror_rust_invalidate_paint_cache(Paintable const& paintable)
 {
-    Layout::RustFFI::layout_arena_paintable_invalidate_paint_cache(paintable.rust_arena().handle(), paintable.rust_slot());
+    Layout::RustFFI::layout_arena_paintable_invalidate_paint_cache(paintable.rust_arena().handle(), paintable.rust_slot(), false);
+}
+
+void rust_invalidate_propagated_text_decoration_caches(Paintable const& paintable)
+{
+    Layout::RustFFI::layout_arena_paintable_invalidate_paint_cache(paintable.rust_arena().handle(), paintable.rust_slot(), true);
 }
 
 void rust_build_stacking_context_tree(ViewportPaintable& viewport_paintable)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -52,6 +52,7 @@ WEB_API void mirror_rust_clear_visual_context_tree(ViewportPaintable&);
 WEB_API void mirror_rust_reset_visual_context_state(ViewportPaintable&);
 WEB_API void mirror_rust_clear_paint_cache_sources(ViewportPaintable&);
 WEB_API void mirror_rust_invalidate_paint_cache(Paintable const&);
+WEB_API void rust_invalidate_propagated_text_decoration_caches(Paintable const&);
 struct InspectorOverlayInputs {
     Paintable const* highlighted_paintable { nullptr };
     Color tooltip_color;

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -523,6 +523,206 @@ impl LayoutNodeArena {
         }
     }
 
+    fn node_is_capable_of_forming_a_containing_block(&self, id: NodeSlotId) -> bool {
+        // SAFETY: data() validated that id names a live slot.
+        let data = unsafe { &*self.data(id) };
+        if crate::layout::kind_is_block_container(data.kind)
+            && !crate::painting::fragment_ownership::node_is_fragmented_inline(self, id)
+        {
+            return true;
+        }
+        if let Some(style) = self.node_style_if_live(id) {
+            let display = style.display();
+            if display.is_flex_inside() || display.is_grid_inside() {
+                return true;
+            }
+        }
+        crate::layout::kind_is_replaced_box(data.kind) && crate::layout::node_can_have_children(data)
+    }
+
+    fn nearest_ancestor_capable_of_forming_a_containing_block(&self, node: NodeSlotId) -> NodeSlotId {
+        // SAFETY: Callers pass a node validated by the subtree walk, and parent
+        // links from a live tree node name live slots.
+        let mut ancestor = unsafe { (&raw const (*self.data(node)).parent).read() };
+        while !ancestor.is_invalid() {
+            if self.node_is_capable_of_forming_a_containing_block(ancestor) {
+                return ancestor;
+            }
+            // SAFETY: As above.
+            ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+        }
+        NodeSlotId::INVALID
+    }
+
+    fn recompute_containing_block_for_node(
+        &self,
+        node: NodeSlotId,
+        inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    ) {
+        use crate::css::css_enums::positioning;
+        use crate::painting::style_queries::establishes_positioning_containing_blocks;
+
+        let data = self.data(node);
+        // Reset the inline containing block - we'll set it below if applicable.
+        // SAFETY: data() validated that node names a live slot, and layout
+        // serializes arena mutation on the owner thread.
+        unsafe { (&raw mut (*data).inline_containing_block).write(NodeSlotId::INVALID) };
+
+        // SAFETY: As above.
+        let kind = unsafe { (&raw const (*data).kind).read() };
+        if crate::layout::kind_is_text(kind) {
+            let containing_block = self.nearest_ancestor_capable_of_forming_a_containing_block(node);
+            // SAFETY: As above.
+            unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+            return;
+        }
+
+        let position = self
+            .node_style_if_live(node)
+            .map_or(positioning::STATIC, |style| style.box_values().position);
+
+        // https://drafts.csswg.org/css-position-3/#absolute-cb
+        if position == positioning::ABSOLUTE {
+            // SAFETY: As above; parent links from a live tree name live slots.
+            let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+            while !ancestor.is_invalid() && !establishes_positioning_containing_blocks(self, ancestor).0 {
+                // SAFETY: As above.
+                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            }
+            // SAFETY: As above.
+            unsafe { (&raw mut (*data).containing_block).write(ancestor) };
+            if !ancestor.is_invalid() {
+                // SAFETY: Both slots are live; the callback only reads DOM ancestry
+                // and per-node facts through the shells and does not mutate the tree.
+                let inline_containing_block = unsafe {
+                    let node_shell = (&raw const (*data).shell).read();
+                    let ancestor_shell = (&raw const (*self.data(ancestor)).shell).read();
+                    inline_cb_lookup(node_shell, ancestor_shell)
+                };
+                // SAFETY: As above.
+                unsafe { (&raw mut (*data).inline_containing_block).write(inline_containing_block) };
+            }
+            return;
+        }
+
+        // https://drafts.csswg.org/css-position-3/#fixed-cb
+        if position == positioning::FIXED {
+            // The containing block is established by the nearest ancestor box that establishes an fixed positioning
+            // containing block, with the bounds of the containing block determined identically to the absolute positioning
+            // containing block.
+            let mut last_visited = node;
+            // SAFETY: As above.
+            let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+            while !ancestor.is_invalid() && !establishes_positioning_containing_blocks(self, ancestor).1 {
+                last_visited = ancestor;
+                // SAFETY: As above.
+                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            }
+            // If no ancestor establishes one, the box's fixed positioning containing block is the initial fixed containing
+            // block:
+            //  - in continuous media, the layout viewport (whose size matches the dynamic viewport size); as a result,
+            //    fixed boxes do not move when the document is scrolled.
+            // FIXME: - in paged media, the page area of each page; fixed positioned boxes are thus replicated on every
+            //   page. (They are fixed with respect to the page box only, and are not affected by being seen through a
+            //   viewport; as in the case of print preview, for example.)
+            let containing_block = if ancestor.is_invalid() { last_visited } else { ancestor };
+            // SAFETY: As above.
+            unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+            return;
+        }
+
+        let containing_block = self.nearest_ancestor_capable_of_forming_a_containing_block(node);
+        // SAFETY: As above.
+        unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+    }
+
+    fn derive_abspos_escape_flags_for_node(&self, node: NodeSlotId) {
+        let data = self.data(node);
+        // SAFETY: data() validated that node names a live slot.
+        let kind = unsafe { (&raw const (*data).kind).read() };
+        if !crate::layout::kind_is_box(kind) {
+            return;
+        }
+        self.set_node_flag(node, NodeFlag::AbsposDescendantEscapes, false);
+        if !self
+            .node_style_if_live(node)
+            .is_some_and(|style| style.is_absolutely_positioned())
+        {
+            return;
+        }
+        // SAFETY: As above; parent links from a live tree name live slots.
+        let containing_block = unsafe { (&raw const (*data).containing_block).read() };
+        let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+        while !ancestor.is_invalid() && ancestor != containing_block {
+            // SAFETY: As above.
+            let ancestor_kind = unsafe { (&raw const (*self.data(ancestor)).kind).read() };
+            if crate::layout::kind_is_box(ancestor_kind) {
+                self.set_node_flag(ancestor, NodeFlag::AbsposDescendantEscapes, true);
+            }
+            // SAFETY: As above.
+            ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+        }
+    }
+
+    /// Recomputes `containing_block` and `inline_containing_block` and derives
+    /// the `AbsposDescendantEscapes` flag for every node in the inclusive
+    /// subtree of `root`. The pre-order traversal visits ancestors before the
+    /// descendants that mark them, so clearing the flag on visit and marking
+    /// upwards compose within one walk; the marking follows plain parent links
+    /// and so reaches ancestors above `root` when the containing block lies
+    /// outside the subtree.
+    pub(crate) fn recompute_containing_blocks_in_subtree(
+        &self,
+        root: NodeSlotId,
+        inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    ) {
+        self.assert_owner_thread();
+        let mut current = root;
+        loop {
+            self.recompute_containing_block_for_node(current, inline_cb_lookup);
+            self.derive_abspos_escape_flags_for_node(current);
+
+            let data = self.data(current);
+            // SAFETY: data() validated that current names a live slot, and the
+            // topology is stable during this call.
+            let (parent, first_child, next_sibling) = unsafe {
+                (
+                    (&raw const (*data).parent).read(),
+                    (&raw const (*data).first_child).read(),
+                    (&raw const (*data).next_sibling).read(),
+                )
+            };
+
+            if !first_child.is_invalid() {
+                current = first_child;
+                continue;
+            }
+            if current == root {
+                break;
+            }
+            if !next_sibling.is_invalid() {
+                current = next_sibling;
+                continue;
+            }
+
+            current = parent;
+            while current != root {
+                // SAFETY: Parent links from a live subtree node name live slots in the same tree.
+                let data = self.data(current);
+                let next_sibling = unsafe { (&raw const (*data).next_sibling).read() };
+                if !next_sibling.is_invalid() {
+                    current = next_sibling;
+                    break;
+                }
+                // SAFETY: data() validated current and the topology is stable during this call.
+                current = unsafe { (&raw const (*data).parent).read() };
+            }
+            if current == root {
+                break;
+            }
+        }
+    }
+
     fn slot_for_data(&self, data: *const NodeData) -> (u32, SlotMetadata) {
         assert!(!data.is_null(), "layout node arena data pointer is null");
         let data_address = data as usize;
@@ -1455,6 +1655,38 @@ pub unsafe extern "C" fn layout_arena_reset_layout_update_flags_in_subtree(arena
         // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
         unsafe { LayoutNodeArena::from_handle(arena) }.reset_layout_update_flags_in_subtree(root);
     });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `root` must
+/// name the root of a live subtree in this arena. `inline_cb_lookup` is invoked
+/// for each absolutely positioned node with a resolved containing block; it
+/// receives the two nodes' shell pointers, must not mutate the layout tree or
+/// its styles, and must return the slot of the intervening inline containing
+/// block or the invalid slot id.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_recompute_containing_blocks(
+    arena: *mut c_void,
+    root: NodeSlotId,
+    inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+        unsafe { LayoutNodeArena::from_handle(arena) }.recompute_containing_blocks_in_subtree(root, inline_cb_lookup);
+    });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call. `id` may be
+/// invalid or stale; null is returned in that case.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_shell_if_live(arena: *mut c_void, id: NodeSlotId) -> *mut c_void {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+        unsafe { LayoutNodeArena::from_handle(arena) }.shell_if_live(id)
+    })
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -904,10 +904,19 @@ pub unsafe extern "C" fn layout_arena_last_recording_has_blocking_wheel_event_li
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(arena: *mut c_void, paintable: PaintableSlotId) {
+pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
+    arena: *mut c_void,
+    paintable: PaintableSlotId,
+    propagated_text_decorations: bool,
+) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        arena.paintables().borrow().invalidate_paint_cache(paintable);
+        let paintables = arena.paintables().borrow();
+        if propagated_text_decorations {
+            paintables.invalidate_propagated_text_decoration_caches(arena, paintable);
+        } else {
+            paintables.invalidate_paint_cache(paintable);
+        }
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize};
+use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, LayoutNodeArena};
 use crate::painting::paintable_data::*;
 use std::cell::Cell;
 use std::ffi::c_void;
@@ -205,6 +205,41 @@ impl PaintableArena {
         }
         if let Some(entry) = self.paint_caches.borrow_mut().get_mut(id.slot_index() as usize) {
             *entry = None;
+        }
+    }
+
+    pub(crate) fn invalidate_propagated_text_decoration_caches(
+        &self,
+        layout_arena: &LayoutNodeArena,
+        root: PaintableSlotId,
+    ) {
+        if !self.is_live(root) {
+            return;
+        }
+
+        let mut stack = Vec::new();
+        if let Some(first_child) = self.first_child(root) {
+            stack.push(first_child);
+        }
+        let mut caches = self.paint_caches.borrow_mut();
+        while let Some(current) = stack.pop() {
+            if let Some(next_sibling) = self.next_sibling(current) {
+                stack.push(next_sibling);
+            }
+
+            let data = self.data_ref(current);
+            if crate::painting::style_queries::is_text_decoration_propagation_boundary(layout_arena, data.layout_node) {
+                continue;
+            }
+            // Only fragment-painting paintables record propagated decorations.
+            if (data.kind.has_lines() || data.kind == PaintableKind::InlinePaintable)
+                && let Some(entry) = caches.get_mut(current.slot_index() as usize)
+            {
+                *entry = None;
+            }
+            if let Some(first_child) = self.first_child(current) {
+                stack.push(first_child);
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -468,12 +468,20 @@ pub(crate) fn is_text_decoration_propagation_boundary(arena: &LayoutNodeArena, n
     let Some(kind) = arena.node_kind_if_live(node) else {
         return false;
     };
+    // NB: Anonymous wrappers must stay transparent to propagation so an element's own decorations still reach
+    //     its text. The principal box of a pseudo-element is not a wrapper and must be checked like any other
+    //     element, and a table wrapper carries the float and position of the table it wraps, so it is the only
+    //     box where an out-of-flow table is observable.
     if has_flag(arena, node, NodeFlag::Anonymous)
         && !arena.node_is_generated_for_pseudo_element(node)
         && kind != NodeKind::TableWrapper
     {
         return false;
     }
+
+    // https://drafts.csswg.org/css-text-decor-4/#decorating-box
+    // NOTE: Note that text decorations are not propagated to any out-of-flow descendants, nor to the contents
+    //       of atomic inline-level descendants such as inline blocks and inline tables.
     if arena.node_is_out_of_flow_if_live(node) {
         return true;
     }


### PR DESCRIPTION
Moves propagated text-decoration cache invalidation into PaintableArena and containing-block recomputation into LayoutNodeArena. Retains the DOM-dependent inline containing-block lookup as a C++ callback, removes obsolete mirror state and C++ helpers, and deletes 30 dead NodeWithStyle methods.