### PR TITLE
LibWeb: Speed up Rust paint recording

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -465,6 +465,7 @@ public:
     void update_layout(UpdateLayoutReason);
     void note_content_visibility_auto_style() { m_may_have_content_visibility_auto_style = true; }
     void note_default_scroll_shift_anchor() { m_may_have_default_scroll_shift_anchor = true; }
+    [[nodiscard]] bool may_have_default_scroll_shift_anchor() const { return m_may_have_default_scroll_shift_anchor; }
     enum class PartialRelayoutResult : u8 {
         NotEligible,
         Done,

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -576,6 +576,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     set_flag(RustFFI::NodeFlag::HasAnchorNames, has_anchor_names);
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, insets_use_anchor_functions);
     publish_style_record_to_node_data();
+    set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     synchronize_table_span_data();
     enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (m_owned_computed_values)
@@ -686,6 +687,7 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
     VERIFY(record_view);
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !record_view->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, record_view->inset_properties_contain_anchor_functions());
+    set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     // A style change can introduce the properties that make a node carry replaced-content facts,
     // such as size containment arriving on a kept layout node.
     enroll_for_arena_replaced_content_facts_sync_if_eligible();
@@ -1015,6 +1017,7 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !computed_values->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, computed_values->inset_properties_contain_anchor_functions());
     publish_style_record_to_node_data();
+    set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (m_owned_computed_values)
         pin_style_record_for_cxx_consumers();
@@ -1061,6 +1064,7 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, new_record_view->inset_properties_contain_anchor_functions());
     publish_style_record_to_node_data();
+    set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (should_repin_style_record)
         pin_style_record_for_cxx_consumers();

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -82,8 +82,10 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
     auto list = adopt_ref(*new HitTestDisplayList(visual_context_tree_version, arena, Layout::RustFFI::layout_arena_hit_test_list_generation(arena_handle)));
     auto item_count = Layout::RustFFI::layout_arena_hit_test_item_count(arena_handle);
     list->m_items.ensure_capacity(item_count);
-    for (size_t index = 0; index < item_count; ++index) {
-        auto exported = Layout::RustFFI::layout_arena_hit_test_item(arena_handle, index);
+    Vector<Layout::RustFFI::FfiHitTestItemExport> exported_items;
+    exported_items.resize(item_count);
+    Layout::RustFFI::layout_arena_export_hit_test_items(arena_handle, exported_items.data(), exported_items.size());
+    for (auto const& exported : exported_items) {
         VERIFY(exported.paintable_shell);
         auto& paintable = *static_cast<Paintable*>(exported.paintable_shell);
         switch (static_cast<ChromeWidgetKind>(exported.chrome_widget_kind)) {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -388,6 +388,7 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(Vie
             inputs.visual_viewport_offset_x = offset.x();
             inputs.visual_viewport_offset_y = offset.y();
             inputs.visual_viewport_scale = visual_viewport.scale();
+            inputs.may_have_default_scroll_shift_anchor = viewport_paintable.document().may_have_default_scroll_shift_anchor();
             return inputs;
         },
         .scroll_offset = [](void*, void* paintable_shell) -> Layout::RustFFI::FfiCssPixelPoint {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -615,19 +615,9 @@ void mirror_rust_set_needs_to_refresh_scroll_state(ViewportPaintable& viewport_p
     Layout::RustFFI::layout_arena_set_needs_to_refresh_scroll_state(viewport_paintable.rust_arena().handle(), value);
 }
 
-void mirror_rust_clear_visual_context_tree(ViewportPaintable& viewport_paintable)
-{
-    Layout::RustFFI::layout_arena_clear_visual_context_tree(viewport_paintable.rust_arena().handle());
-}
-
 void mirror_rust_reset_visual_context_state(ViewportPaintable& viewport_paintable)
 {
     Layout::RustFFI::layout_arena_reset_visual_context_state(viewport_paintable.rust_arena().handle());
-}
-
-void mirror_rust_clear_paint_cache_sources(ViewportPaintable& viewport_paintable)
-{
-    Layout::RustFFI::layout_arena_clear_paint_cache_sources(viewport_paintable.rust_arena().handle());
 }
 
 void mirror_rust_invalidate_paint_cache(Paintable const& paintable)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -48,9 +48,7 @@ WEB_API CSSPixelPoint rust_cumulative_scroll_offset_for_node(ViewportPaintable c
 WEB_API void mirror_rust_refresh_sticky_constraints(ViewportPaintable&);
 WEB_API void mirror_rust_clear_scroll_state(ViewportPaintable&);
 WEB_API void mirror_rust_set_needs_to_refresh_scroll_state(ViewportPaintable&, bool);
-WEB_API void mirror_rust_clear_visual_context_tree(ViewportPaintable&);
 WEB_API void mirror_rust_reset_visual_context_state(ViewportPaintable&);
-WEB_API void mirror_rust_clear_paint_cache_sources(ViewportPaintable&);
 WEB_API void mirror_rust_invalidate_paint_cache(Paintable const&);
 WEB_API void rust_invalidate_propagated_text_decoration_caches(Paintable const&);
 struct InspectorOverlayInputs {

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -107,13 +107,8 @@ void ViewportPaintable::reset_for_relayout()
 {
     PaintableWithLines::reset_for_relayout();
     clear_scroll_state();
-    m_display_list_used_as_paint_command_cache_source = nullptr;
-    m_paint_command_cache_source_referenced_resources = {};
-    mirror_rust_clear_paint_cache_sources(*this);
     m_paintable_boxes_with_auto_content_visibility.clear();
-    m_visual_context_tree.clear();
     m_visual_context_tree_needs_compositor_update = false;
-    mirror_rust_clear_visual_context_tree(*this);
 }
 
 void ViewportPaintable::build_stacking_context_tree_if_needed()

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -161,6 +161,7 @@ pub enum NodeFlag {
     HasAnchorNames = 1 << 24,
     InsetsUseAnchorFunctions = 1 << 25,
     HasSavedCommittedGeometry = 1 << 26,
+    HasPreserve3dTransformStyle = 1 << 27,
 }
 
 #[repr(C)]
@@ -264,6 +265,7 @@ mod tests {
     #[test]
     fn saved_committed_geometry_flag_uses_a_previously_unassigned_bit() {
         assert_eq!(NodeFlag::HasSavedCommittedGeometry as u32, 1 << 26);
+        assert_eq!(NodeFlag::HasPreserve3dTransformStyle as u32, 1 << 27);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -323,6 +323,18 @@ impl DisplayListRecorder {
         }
     }
 
+    /// Copies a cached command range without rewriting visual-context indices. The caller must
+    /// establish that the recorded indices are still valid for the current visual context tree.
+    pub fn append_cached_command_range_verbatim(&mut self, source: &[u8], range: CommandRange) -> CommandRange {
+        let offset = self
+            .builder
+            .append_command_range(source, range, VisualContextIndex(0), VisualContextIndex(0));
+        CommandRange {
+            offset,
+            size: range.size,
+        }
+    }
+
     pub fn fill_rect(&mut self, rect: IntRect, color: Color) {
         if rect.is_empty() || color.alpha() == 0 {
             return;

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -533,19 +533,6 @@ pub unsafe extern "C" fn layout_arena_reset_visual_context_state(arena: *mut c_v
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_clear_visual_context_tree(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let mut paintables = arena.paintables().borrow_mut();
-        paintables.visual_context.tree = None;
-        paintables.visual_context.paintables_with_mask_nodes.clear();
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_record_display_list(
     arena: *mut c_void,
     viewport: PaintableSlotId,
@@ -917,19 +904,6 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
         } else {
             paintables.invalidate_paint_cache(paintable);
         }
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_clear_paint_cache_sources(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let mut paintables = arena.paintables().borrow_mut();
-        paintables.paint_command_cache_source = None;
-        paintables.hit_test_item_cache_source = None;
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -360,14 +360,23 @@ pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
 ) -> bool {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let (mut tree, scroll_state, paintables_with_mask_nodes) = {
+        let (mut tree, scroll_state, paintables_with_mask_nodes, previous_assignments) = {
             let paintables = arena.paintables().borrow();
             if !paintables.is_live(viewport) {
                 return false;
             }
-            crate::painting::visual_context::build::build_visual_context_tree(arena, &paintables, &callbacks, viewport)
+            let previous_assignments = paintables.visual_context_assignments();
+            let (tree, scroll_state, paintables_with_mask_nodes) =
+                crate::painting::visual_context::build::build_visual_context_tree(
+                    arena,
+                    &paintables,
+                    &callbacks,
+                    viewport,
+                );
+            (tree, scroll_state, paintables_with_mask_nodes, previous_assignments)
         };
         let mut paintables = arena.paintables().borrow_mut();
+        let assignments_changed = previous_assignments != paintables.visual_context_assignments();
         let state = &mut paintables.visual_context;
         state.build_count += 1;
         let is_compatible = !force_incompatible_rebuild
@@ -386,6 +395,9 @@ pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
         state.scroll_state = scroll_state;
         state.scroll_state_snapshot.clear();
         state.needs_to_refresh_scroll_state = true;
+        if assignments_changed {
+            paintables.clear_descendant_subtree_caches();
+        }
         is_compatible
     })
 }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1347,15 +1347,17 @@ fn with_hit_test_list<R>(
 ) -> R {
     // SAFETY: The caller passes a live arena handle (documented on every entry point below).
     let arena = unsafe { arena_from_handle(arena) };
-    let mut paintables = arena.paintables().borrow_mut();
-    let crate::painting::paintable_arena::PaintableArena { hit_test_list, .. } = &mut *paintables;
-    let Some(list) = hit_test_list.as_mut() else {
+    // Query callbacks can reenter through C++ paintable geometry helpers, so keep only a shared
+    // arena borrow while the query is running.
+    let Some(mut list) = arena.paintables().borrow_mut().hit_test_list.take() else {
         return default;
     };
-    let list_ptr: *mut crate::painting::hit_test::HitTestList = list;
-    // SAFETY: `list` lives inside `paintables` and is disjoint from the arena data the queries
-    // read; nothing else touches it during the call.
-    query(unsafe { &mut *list_ptr }, &paintables)
+    let result = {
+        let paintables = arena.paintables().borrow();
+        query(&mut list, &paintables)
+    };
+    arena.paintables().borrow_mut().hit_test_list = Some(list);
+    result
 }
 
 fn css_point(x_raw: i32, y_raw: i32) -> crate::css::css_pixels::CssPixelPoint {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1146,48 +1146,46 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_count(arena: *mut c_void) ->
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`; `index` in range. The returned
-/// path pointer borrows the item's path and is only valid until the next recording.
+/// `arena` must be a live handle from `layout_arena_create`; `output` must point to writable
+/// storage for exactly `output_length` items, matching the current hit-test item count.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_hit_test_item(
+pub unsafe extern "C" fn layout_arena_export_hit_test_items(
     arena: *mut c_void,
-    index: usize,
-) -> crate::painting::host::FfiHitTestItemExport {
+    output: *mut crate::painting::host::FfiHitTestItemExport,
+    output_length: usize,
+) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let paintables = arena.paintables().borrow();
-        let item = &paintables.hit_test_list.as_ref().expect("no hit-test list").items[index];
-        let rect = |rect: crate::css::css_pixels::CssPixelRect| crate::layout::FfiCssPixelRect::from(rect);
-        let paintable_shell = if paintables.is_live(item.paintable) {
-            paintables.data_ref(item.paintable).shell
-        } else {
-            std::ptr::null_mut()
-        };
-        crate::painting::host::FfiHitTestItemExport {
-            kind: item.kind as u8,
-            paintable_shell,
-            chrome_widget_kind: item.chrome_widget_kind,
-            has_text_fragment_index: item.text_fragment_index.is_some(),
-            text_fragment_index: item.text_fragment_index.unwrap_or(0),
-            caret_node_shell: arena.shell_if_live(item.caret_node),
-            caret_offset: item.caret_offset,
-            rect: rect(item.rect),
-            caret_rect: rect(item.caret_rect),
-            has_caret_line_index: item.caret_line_index.is_some(),
-            caret_line_index: item.caret_line_index.unwrap_or(0),
-            has_caret_line_rect: item.caret_line_rect.is_some(),
-            caret_line_rect: rect(item.caret_line_rect.unwrap_or_default()),
-            has_block_container_margin_rect: item.block_container_margin_rect.is_some(),
-            block_container_margin_rect: rect(item.block_container_margin_rect.unwrap_or_default()),
-            visual_context_index: item.visual_context_index,
-            border_radii: item.border_radii.values.map(|value| value.raw_value()),
-            path: item
-                .path
-                .as_ref()
-                .map_or(std::ptr::null(), |path| path.as_raw().cast_const()),
-            winding_rule: item.winding_rule,
+        let items = &paintables.hit_test_list.as_ref().expect("no hit-test list").items;
+        assert_eq!(items.len(), output_length);
+        if items.is_empty() {
+            return;
         }
-    })
+        assert!(!output.is_null());
+        // SAFETY: The caller provides writable storage for exactly `output_length` exports.
+        let output = unsafe { std::slice::from_raw_parts_mut(output, output_length) };
+        for (output, item) in output.iter_mut().zip(items.iter()) {
+            let rect = |rect: crate::css::css_pixels::CssPixelRect| crate::layout::FfiCssPixelRect::from(rect);
+            assert!(
+                paintables.is_live(item.paintable),
+                "exporting a hit-test item for a non-live paintable"
+            );
+            let paintable_shell = paintables.data_ref(item.paintable).shell;
+            *output = crate::painting::host::FfiHitTestItemExport {
+                kind: item.kind as u8,
+                paintable_shell,
+                chrome_widget_kind: item.chrome_widget_kind,
+                has_text_fragment_index: item.text_fragment_index.is_some(),
+                text_fragment_index: item.text_fragment_index.unwrap_or(0),
+                caret_node_shell: arena.shell_if_live(item.caret_node),
+                caret_offset: item.caret_offset,
+                rect: rect(item.rect),
+                caret_rect: rect(item.caret_rect),
+                visual_context_index: item.visual_context_index,
+            };
+        }
+    });
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -227,16 +227,7 @@ pub struct FfiHitTestItemExport {
     pub caret_offset: usize,
     pub rect: crate::layout::FfiCssPixelRect,
     pub caret_rect: crate::layout::FfiCssPixelRect,
-    pub has_caret_line_index: bool,
-    pub caret_line_index: usize,
-    pub has_caret_line_rect: bool,
-    pub caret_line_rect: crate::layout::FfiCssPixelRect,
-    pub has_block_container_margin_rect: bool,
-    pub block_container_margin_rect: crate::layout::FfiCssPixelRect,
     pub visual_context_index: usize,
-    pub border_radii: [i32; 8],
-    pub path: *const c_void,
-    pub winding_rule: i32,
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -24,6 +24,7 @@ pub struct FfiVisualContextTreeInputs {
     pub visual_viewport_offset_x: f64,
     pub visual_viewport_offset_y: f64,
     pub visual_viewport_scale: f64,
+    pub may_have_default_scroll_shift_anchor: bool,
 }
 
 #[derive(Clone, Copy)]

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -43,7 +43,8 @@ pub struct PaintableArena {
     pub(crate) paint_command_cache_source: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) hit_test_item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
     pub(crate) paint_caches: std::cell::RefCell<Vec<Option<Box<crate::painting::record::cache::PaintCache>>>>,
-    absolute_rect_memo: std::cell::RefCell<Vec<Option<(PaintableSlotId, crate::css::css_pixels::CssPixelRect)>>>,
+    absolute_rect_memo: std::cell::RefCell<Vec<Option<(PaintableSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
+    absolute_rect_memo_epoch: Cell<u64>,
     pub(crate) scrollable_overflow_contained_boxes: std::collections::HashMap<NodeSlotId, Vec<NodeSlotId>>,
 }
 
@@ -53,21 +54,27 @@ impl PaintableArena {
     }
 
     pub fn memoized_absolute_rect(&self, id: PaintableSlotId) -> Option<crate::css::css_pixels::CssPixelRect> {
-        let (memoized_id, rect) = self
+        let (memoized_id, memoized_epoch, rect) = self
             .absolute_rect_memo
             .borrow()
             .get(id.slot_index() as usize)
             .copied()
             .flatten()?;
-        (memoized_id == id).then_some(rect)
+        (memoized_id == id && memoized_epoch == self.absolute_rect_memo_epoch.get()).then_some(rect)
     }
 
     pub fn memoize_absolute_rect(&self, id: PaintableSlotId, rect: crate::css::css_pixels::CssPixelRect) {
-        self.absolute_rect_memo.borrow_mut()[id.slot_index() as usize] = Some((id, rect));
+        self.absolute_rect_memo.borrow_mut()[id.slot_index() as usize] =
+            Some((id, self.absolute_rect_memo_epoch.get(), rect));
     }
 
     pub fn clear_absolute_rect_memo(&self) {
-        self.absolute_rect_memo.borrow_mut().fill(None);
+        self.absolute_rect_memo_epoch.set(
+            self.absolute_rect_memo_epoch
+                .get()
+                .checked_add(1)
+                .expect("absolute rect memo epoch overflowed"),
+        );
     }
 
     pub(crate) fn slot_count(&self) -> usize {
@@ -120,7 +127,7 @@ impl PaintableArena {
     }
 
     fn reset_row(&mut self, id: PaintableSlotId) {
-        self.absolute_rect_memo.get_mut().fill(None);
+        self.clear_absolute_rect_memo();
         self.remove_from_tree(id);
         while let Some(child) = self.first_child(id) {
             self.remove_from_tree(child);
@@ -366,7 +373,7 @@ impl PaintableArena {
     }
 
     pub fn reset_for_relayout(&mut self, id: PaintableSlotId) {
-        self.absolute_rect_memo.get_mut().fill(None);
+        self.clear_absolute_rect_memo();
         self.remove_from_tree(id);
         while let Some(child) = self.first_child(id) {
             self.remove_from_tree(child);

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -43,7 +43,7 @@ pub struct PaintableArena {
     pub(crate) paint_command_cache_source: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) hit_test_item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
     pub(crate) paint_caches: std::cell::RefCell<Vec<Option<Box<crate::painting::record::cache::PaintCache>>>>,
-    absolute_rect_memo: std::cell::RefCell<std::collections::HashMap<u32, crate::css::css_pixels::CssPixelRect>>,
+    absolute_rect_memo: std::cell::RefCell<Vec<Option<(PaintableSlotId, crate::css::css_pixels::CssPixelRect)>>>,
     pub(crate) scrollable_overflow_contained_boxes: std::collections::HashMap<NodeSlotId, Vec<NodeSlotId>>,
 }
 
@@ -53,15 +53,25 @@ impl PaintableArena {
     }
 
     pub fn memoized_absolute_rect(&self, id: PaintableSlotId) -> Option<crate::css::css_pixels::CssPixelRect> {
-        self.absolute_rect_memo.borrow().get(&id.index).copied()
+        let (memoized_id, rect) = self
+            .absolute_rect_memo
+            .borrow()
+            .get(id.slot_index() as usize)
+            .copied()
+            .flatten()?;
+        (memoized_id == id).then_some(rect)
     }
 
     pub fn memoize_absolute_rect(&self, id: PaintableSlotId, rect: crate::css::css_pixels::CssPixelRect) {
-        self.absolute_rect_memo.borrow_mut().insert(id.index, rect);
+        self.absolute_rect_memo.borrow_mut()[id.slot_index() as usize] = Some((id, rect));
     }
 
     pub fn clear_absolute_rect_memo(&self) {
-        self.absolute_rect_memo.borrow_mut().clear();
+        self.absolute_rect_memo.borrow_mut().fill(None);
+    }
+
+    pub(crate) fn slot_count(&self) -> usize {
+        self.side_data.len()
     }
 
     pub fn row_for_node(&mut self, layout_node: NodeSlotId, shell: *mut c_void) -> PaintableAllocation {
@@ -76,6 +86,7 @@ impl PaintableArena {
             }
             self.side_data.push(PaintableSideData::default());
             self.paint_caches.get_mut().push(None);
+            self.absolute_rect_memo.get_mut().push(None);
         }
 
         let generation = layout_node.generation();
@@ -86,6 +97,7 @@ impl PaintableArena {
         data.shell = shell;
         self.side_data[index as usize] = PaintableSideData::default();
         self.paint_caches.get_mut()[index as usize] = None;
+        self.absolute_rect_memo.get_mut()[index as usize] = None;
 
         PaintableAllocation {
             slot: PaintableSlotId::new(index, generation),
@@ -108,7 +120,7 @@ impl PaintableArena {
     }
 
     fn reset_row(&mut self, id: PaintableSlotId) {
-        self.absolute_rect_memo.get_mut().clear();
+        self.absolute_rect_memo.get_mut().fill(None);
         self.remove_from_tree(id);
         while let Some(child) = self.first_child(id) {
             self.remove_from_tree(child);
@@ -354,7 +366,7 @@ impl PaintableArena {
     }
 
     pub fn reset_for_relayout(&mut self, id: PaintableSlotId) {
-        self.absolute_rect_memo.get_mut().clear();
+        self.absolute_rect_memo.get_mut().fill(None);
         self.remove_from_tree(id);
         while let Some(child) = self.first_child(id) {
             self.remove_from_tree(child);

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -81,6 +81,28 @@ impl PaintableArena {
         self.side_data.len()
     }
 
+    pub(crate) fn visual_context_assignments(&self) -> Vec<(u32, bool, usize, usize, usize, usize)> {
+        (0..self.slot_count())
+            .map(|index| {
+                let data = self.data_by_index(index as u32);
+                (
+                    u32::from(data.slot_generation),
+                    data.has_accumulated_visual_context,
+                    data.accumulated_visual_context_index,
+                    data.accumulated_visual_context_for_descendants_index,
+                    data.visual_context_nodes_begin,
+                    data.visual_context_nodes_end,
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn clear_descendant_subtree_caches(&self) {
+        for cache in &self.paint_caches {
+            cache.clear_descendant_subtrees();
+        }
+    }
+
     pub fn row_for_node(&mut self, layout_node: NodeSlotId, shell: *mut c_void) -> PaintableAllocation {
         let index = layout_node.slot_index();
         assert!(
@@ -224,6 +246,11 @@ impl PaintableArena {
             return;
         }
         self.paint_caches[id.slot_index() as usize].clear();
+        let mut ancestor = self.data_ref(id).parent;
+        while !ancestor.is_invalid() {
+            self.paint_caches[ancestor.slot_index() as usize].clear_descendant_subtrees();
+            ancestor = self.data_ref(ancestor).parent;
+        }
     }
 
     pub(crate) fn invalidate_propagated_text_decoration_caches(
@@ -255,6 +282,11 @@ impl PaintableArena {
             if let Some(first_child) = self.first_child(current) {
                 stack.push(first_child);
             }
+        }
+        let mut ancestor = root;
+        while !ancestor.is_invalid() {
+            self.paint_caches[ancestor.slot_index() as usize].clear_descendant_subtrees();
+            ancestor = self.data_ref(ancestor).parent;
         }
     }
 
@@ -305,6 +337,8 @@ impl PaintableArena {
             self.append_child(parent, child);
             return;
         }
+        self.clear_descendant_subtree_caches_inclusive(child);
+        self.clear_descendant_subtree_caches_inclusive(parent);
         assert_eq!(
             self.data_ref(before).parent,
             parent,
@@ -329,6 +363,8 @@ impl PaintableArena {
             self.data_ref(child).parent.is_invalid(),
             "paintable appended while still parented"
         );
+        self.clear_descendant_subtree_caches_inclusive(child);
+        self.clear_descendant_subtree_caches_inclusive(parent);
         let last = self.data_ref(parent).last_child;
         self.update_data(child, |child_data| {
             child_data.parent = parent;
@@ -351,6 +387,7 @@ impl PaintableArena {
         if parent.is_invalid() {
             return;
         }
+        self.clear_descendant_subtree_caches_inclusive(id);
         if prev.is_invalid() {
             self.update_data(parent, |data| data.first_child = next);
         } else {
@@ -366,6 +403,14 @@ impl PaintableArena {
             data.prev_sibling = PaintableSlotId::INVALID;
             data.next_sibling = PaintableSlotId::INVALID;
         });
+    }
+
+    fn clear_descendant_subtree_caches_inclusive(&self, id: PaintableSlotId) {
+        let mut current = id;
+        while !current.is_invalid() {
+            self.paint_caches[current.slot_index() as usize].clear_descendant_subtrees();
+            current = self.data_ref(current).parent;
+        }
     }
 
     pub fn reset_for_relayout(&mut self, id: PaintableSlotId) {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -42,7 +42,7 @@ pub struct PaintableArena {
     pub(crate) last_recording: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) paint_command_cache_source: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) hit_test_item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
-    pub(crate) paint_caches: std::cell::RefCell<Vec<Option<Box<crate::painting::record::cache::PaintCache>>>>,
+    pub(crate) paint_caches: Vec<crate::painting::record::cache::PaintCache>,
     absolute_rect_memo: std::cell::RefCell<Vec<Option<(PaintableSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
     absolute_rect_memo_epoch: Cell<u64>,
     pub(crate) scrollable_overflow_contained_boxes: std::collections::HashMap<NodeSlotId, Vec<NodeSlotId>>,
@@ -92,7 +92,8 @@ impl PaintableArena {
                 self.chunks.push(new_chunk());
             }
             self.side_data.push(PaintableSideData::default());
-            self.paint_caches.get_mut().push(None);
+            self.paint_caches
+                .push(crate::painting::record::cache::PaintCache::default());
             self.absolute_rect_memo.get_mut().push(None);
         }
 
@@ -103,7 +104,7 @@ impl PaintableArena {
         data.layout_node = layout_node;
         data.shell = shell;
         self.side_data[index as usize] = PaintableSideData::default();
-        self.paint_caches.get_mut()[index as usize] = None;
+        self.paint_caches[index as usize].clear();
         self.absolute_rect_memo.get_mut()[index as usize] = None;
 
         PaintableAllocation {
@@ -135,7 +136,7 @@ impl PaintableArena {
         let index = id.slot_index();
         *self.data_mut_by_index(index) = PaintableData::default();
         self.side_data[index as usize] = PaintableSideData::default();
-        self.paint_caches.get_mut()[index as usize] = None;
+        self.paint_caches[index as usize].clear();
     }
 
     pub fn layout_node_freed(&mut self, layout_slot_index: u32) {
@@ -222,9 +223,7 @@ impl PaintableArena {
         if !self.is_live(id) {
             return;
         }
-        if let Some(entry) = self.paint_caches.borrow_mut().get_mut(id.slot_index() as usize) {
-            *entry = None;
-        }
+        self.paint_caches[id.slot_index() as usize].clear();
     }
 
     pub(crate) fn invalidate_propagated_text_decoration_caches(
@@ -240,7 +239,6 @@ impl PaintableArena {
         if let Some(first_child) = self.first_child(root) {
             stack.push(first_child);
         }
-        let mut caches = self.paint_caches.borrow_mut();
         while let Some(current) = stack.pop() {
             if let Some(next_sibling) = self.next_sibling(current) {
                 stack.push(next_sibling);
@@ -251,10 +249,8 @@ impl PaintableArena {
                 continue;
             }
             // Only fragment-painting paintables record propagated decorations.
-            if (data.kind.has_lines() || data.kind == PaintableKind::InlinePaintable)
-                && let Some(entry) = caches.get_mut(current.slot_index() as usize)
-            {
-                *entry = None;
+            if data.kind.has_lines() || data.kind == PaintableKind::InlinePaintable {
+                self.paint_caches[current.slot_index() as usize].clear();
             }
             if let Some(first_child) = self.first_child(current) {
                 stack.push(first_child);
@@ -406,7 +402,7 @@ impl PaintableArena {
             data.svg_viewport_transform = crate::layout::FfiAffineTransform::default();
             data.has_svg_viewport_transform = false;
         });
-        self.paint_caches.get_mut()[id.slot_index() as usize] = None;
+        self.paint_caches[id.slot_index() as usize].clear();
         self.side_mut(id).reset_for_relayout();
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -215,6 +215,25 @@ impl<'a> PaintableCommit<'a> {
             arena.remove_from_tree(slot);
             return slot;
         }
+        let style = self.callbacks.computed_values_view_if_styled(node);
+        let (position, floating, has_z_index, display) = match style {
+            Some(style) => {
+                let box_values = style.box_values();
+                (
+                    box_values.position,
+                    box_values.float_ != css_enums::float::NONE,
+                    box_values.has_z_index,
+                    style.display(),
+                )
+            }
+            None => (
+                css_enums::positioning::STATIC,
+                false,
+                false,
+                crate::css::display::FfiDisplay::none(),
+            ),
+        };
+        let is_item = data.flags & (NodeFlag::IsFlexItem as u32 | NodeFlag::IsGridItem as u32) != 0;
         if prepared.reused {
             debug_assert_eq!(
                 arena.paintable_of_node(node),
@@ -223,51 +242,44 @@ impl<'a> PaintableCommit<'a> {
             );
             arena.reset_for_relayout(slot);
         } else {
-            let style = self.callbacks.computed_values_view_if_styled(node);
-            let (position, floating, has_z_index, display) = match style {
-                Some(style) => {
-                    let box_values = style.box_values();
-                    (
-                        box_values.position,
-                        box_values.float_ != css_enums::float::NONE,
-                        box_values.has_z_index,
-                        style.display(),
-                    )
-                }
-                None => (
-                    css_enums::positioning::STATIC,
-                    false,
-                    false,
-                    crate::css::display::FfiDisplay::none(),
-                ),
-            };
-            let is_item = data.flags & (NodeFlag::IsFlexItem as u32 | NodeFlag::IsGridItem as u32) != 0;
             arena.update_data(slot, |paintable| {
                 paintable.layout_node = node;
                 paintable.kind = expected_kind;
-                // Flex and grid items with a z-index other than auto behave as if positioned.
-                paintable.set_flag(
-                    PaintableFlag::Positioned,
-                    (is_item && has_z_index) || position != css_enums::positioning::STATIC,
-                );
-                paintable.set_flag(PaintableFlag::FixedPosition, position == css_enums::positioning::FIXED);
-                paintable.set_flag(
-                    PaintableFlag::StickyPosition,
-                    position == css_enums::positioning::STICKY,
-                );
-                paintable.set_flag(
-                    PaintableFlag::AbsolutelyPositioned,
-                    position == css_enums::positioning::ABSOLUTE,
-                );
-                paintable.set_flag(
-                    PaintableFlag::Floating,
-                    floating && data.flags & NodeFlag::IsFlexItem as u32 == 0,
-                );
-                paintable.set_flag(PaintableFlag::Inline, facts.is_inline());
-                paintable.display = display.encoded();
             });
         }
-        arena.update_data(slot, |data| data.set_flag(PaintableFlag::PreparedByCommit, true));
+        arena.update_data(slot, |paintable| {
+            // Flex and grid items with a z-index other than auto behave as if positioned.
+            paintable.set_flag(
+                PaintableFlag::Positioned,
+                (is_item && has_z_index) || position != css_enums::positioning::STATIC,
+            );
+            paintable.set_flag(PaintableFlag::FixedPosition, position == css_enums::positioning::FIXED);
+            paintable.set_flag(
+                PaintableFlag::StickyPosition,
+                position == css_enums::positioning::STICKY,
+            );
+            paintable.set_flag(
+                PaintableFlag::AbsolutelyPositioned,
+                position == css_enums::positioning::ABSOLUTE,
+            );
+            paintable.set_flag(
+                PaintableFlag::Floating,
+                floating && data.flags & NodeFlag::IsFlexItem as u32 == 0,
+            );
+            paintable.set_flag(PaintableFlag::Inline, facts.is_inline());
+            paintable.set_flag(PaintableFlag::Anonymous, data.flags & NodeFlag::Anonymous as u32 != 0);
+            paintable.set_flag(
+                PaintableFlag::Replaced,
+                data.flags & NodeFlag::IsReplacedElement as u32 != 0,
+            );
+            paintable.set_flag(PaintableFlag::FlexOrGridItem, is_item);
+            paintable.set_flag(
+                PaintableFlag::ReplacedBox,
+                crate::layout::kind_is_replaced_box(data.kind),
+            );
+            paintable.set_flag(PaintableFlag::PreparedByCommit, true);
+            paintable.display = display.encoded();
+        });
         slot
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -142,6 +142,10 @@ pub enum PaintableFlag {
     Inline = 1 << 5,
     HasNonInvertibleCssTransform = 1 << 6,
     PreparedByCommit = 1 << 7,
+    Anonymous = 1 << 8,
+    Replaced = 1 << 9,
+    FlexOrGridItem = 1 << 10,
+    ReplacedBox = 1 << 11,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -212,6 +212,7 @@ impl PaintRecorder<'_> {
         if rect.is_empty() {
             return;
         }
+        self.prevent_descendant_subtree_caching();
         self.has_blocking_wheel_event_listeners = true;
         self.recorder
             .compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion { rect });

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use crate::painting::display_list::builder::CommandRange;
 use crate::painting::hit_test::HitTestItem;
 use crate::painting::record::PaintPhase;
+use crate::painting::record::traversal::StackingContextPaintPhase;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CachedCommands {
@@ -35,9 +36,19 @@ pub struct CachedHitTestItems {
     pub recorded_context_for_descendants_index: usize,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CachedDescendantSubtree {
+    pub source_display_list_id: u64,
+    pub command_range: CommandRange,
+    pub source_hit_test_display_list_id: u64,
+    pub hit_test_start: u32,
+    pub hit_test_count: u32,
+}
+
 pub struct PaintCache {
     commands: [Cell<Option<CachedCommands>>; PaintPhase::COUNT],
     hit_test_items: [Cell<Option<CachedHitTestItems>>; PaintPhase::COUNT],
+    descendant_subtrees: [Cell<Option<CachedDescendantSubtree>>; StackingContextPaintPhase::COUNT],
 }
 
 impl Default for PaintCache {
@@ -45,6 +56,7 @@ impl Default for PaintCache {
         Self {
             commands: std::array::from_fn(|_| Cell::new(None)),
             hit_test_items: std::array::from_fn(|_| Cell::new(None)),
+            descendant_subtrees: std::array::from_fn(|_| Cell::new(None)),
         }
     }
 }
@@ -66,6 +78,20 @@ impl PaintCache {
         self.hit_test_items[phase as usize].set(Some(hit_test_items));
     }
 
+    pub(crate) fn descendant_subtree(&self, phase: StackingContextPaintPhase) -> Option<CachedDescendantSubtree> {
+        self.descendant_subtrees[phase as usize].get()
+    }
+
+    pub(crate) fn set_descendant_subtree(&self, phase: StackingContextPaintPhase, subtree: CachedDescendantSubtree) {
+        self.descendant_subtrees[phase as usize].set(Some(subtree));
+    }
+
+    pub fn clear_descendant_subtrees(&self) {
+        for subtree in &self.descendant_subtrees {
+            subtree.set(None);
+        }
+    }
+
     pub fn clear(&self) {
         for commands in &self.commands {
             commands.set(None);
@@ -73,6 +99,7 @@ impl PaintCache {
         for hit_test_items in &self.hit_test_items {
             hit_test_items.set(None);
         }
+        self.clear_descendant_subtrees();
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::painting::display_list::builder::CommandRange;
@@ -34,25 +35,44 @@ pub struct CachedHitTestItems {
     pub recorded_context_for_descendants_index: usize,
 }
 
-// Paint commands and hit-test items are stamped independently within a frame, so each setter
-// must only ever assign its own sub-struct of the shared entry.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct PhaseCacheEntry {
-    pub commands: Option<CachedCommands>,
-    pub hit_test_items: Option<CachedHitTestItems>,
+pub struct PaintCache {
+    commands: [Cell<Option<CachedCommands>>; PaintPhase::COUNT],
+    hit_test_items: [Cell<Option<CachedHitTestItems>>; PaintPhase::COUNT],
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct PaintCache {
-    pub phases: [PhaseCacheEntry; PaintPhase::COUNT],
+impl Default for PaintCache {
+    fn default() -> Self {
+        Self {
+            commands: std::array::from_fn(|_| Cell::new(None)),
+            hit_test_items: std::array::from_fn(|_| Cell::new(None)),
+        }
+    }
 }
 
 impl PaintCache {
-    pub fn entry(&self, phase: PaintPhase) -> &PhaseCacheEntry {
-        &self.phases[phase as usize]
+    pub fn commands(&self, phase: PaintPhase) -> Option<CachedCommands> {
+        self.commands[phase as usize].get()
     }
-    pub fn entry_mut(&mut self, phase: PaintPhase) -> &mut PhaseCacheEntry {
-        &mut self.phases[phase as usize]
+
+    pub fn hit_test_items(&self, phase: PaintPhase) -> Option<CachedHitTestItems> {
+        self.hit_test_items[phase as usize].get()
+    }
+
+    pub fn set_commands(&self, phase: PaintPhase, commands: CachedCommands) {
+        self.commands[phase as usize].set(Some(commands));
+    }
+
+    pub fn set_hit_test_items(&self, phase: PaintPhase, hit_test_items: CachedHitTestItems) {
+        self.hit_test_items[phase as usize].set(Some(hit_test_items));
+    }
+
+    pub fn clear(&self) {
+        for commands in &self.commands {
+            commands.set(None);
+        }
+        for hit_test_items in &self.hit_test_items {
+            hit_test_items.set(None);
+        }
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -28,7 +28,7 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn is_anonymous(&self, paintable: PaintableSlotId) -> bool {
-        self.layout_flags(paintable) & NodeFlag::Anonymous as u32 != 0
+        self.data(paintable).has_flag(PaintableFlag::Anonymous)
     }
 
     fn is_generated_for_pseudo_element(&self, paintable: PaintableSlotId) -> bool {
@@ -37,14 +37,14 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn is_atomic_inline(&self, paintable: PaintableSlotId) -> bool {
-        if self.layout_flags(paintable) & NodeFlag::IsReplacedElement as u32 != 0 {
+        if self.data(paintable).has_flag(PaintableFlag::Replaced) {
             return true;
         }
         if self.layout_kind(paintable) == Some(NodeKind::ListItemMarkerBox) {
             return true;
         }
-        self.display(paintable)
-            .is_some_and(|display| display.is_inline_outside() && !display.is_flow_inside())
+        let display = self.display(paintable);
+        display.is_inline_outside() && !display.is_flow_inside()
     }
 
     pub(crate) fn record_foreign_object_descendant_hit_test_items(&mut self, paintable: PaintableSlotId) {

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -417,15 +417,12 @@ impl<'a> PaintRecorder<'a> {
         } else {
             (None, None)
         };
-        let can_produce_caret_position = {
+        let can_produce_caret_position = (self.is_atomic_inline(target) || self.is_replaced_box(target)) && {
             let negative_z = crate::painting::style_queries::effective_z_index(self.layout_arena, &self.data(target))
                 .unwrap_or(0)
                 < 0;
             let target_node = self.data(target).layout_node;
-            !negative_z
-                && self.node_has_dom_node(target_node)
-                && self.paintable_facts(target).dom_node_has_parent
-                && (self.is_atomic_inline(target) || self.is_replaced_box(target))
+            !negative_z && self.node_has_dom_node(target_node) && self.paintable_facts(target).dom_node_has_parent
         };
         let item = HitTestItem {
             rect,

--- a/Libraries/LibWeb/Rust/src/painting/record/masks.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/masks.rs
@@ -158,6 +158,7 @@ impl PaintRecorder<'_> {
                 .map(|(index, _)| *index)
                 .collect();
             assert!(!indices.is_empty(), "a mask display list without a mask node");
+            self.prevent_descendant_subtree_caching();
             self.recorder.register_mask_display_list(&indices, display_list_id);
         }
         any_svg_mask_layer_area_is_empty

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -79,6 +79,7 @@ pub struct PaintRecorder<'a> {
     hit_test_list_generation: u64,
     pub(crate) has_blocking_wheel_event_listeners: bool,
     spliced_capture_count: usize,
+    uncacheable_paint_generation: u64,
     list: HitTestList,
     base_paint_facts_cache: Vec<Option<(PaintableSlotId, BasePaintFacts)>>,
     paintable_facts_cache: Vec<Option<(PaintableSlotId, FfiHitTestPaintableFacts)>>,
@@ -95,6 +96,13 @@ pub(crate) struct BasePaintFacts {
 }
 
 impl<'a> PaintRecorder<'a> {
+    pub(crate) fn prevent_descendant_subtree_caching(&mut self) {
+        self.uncacheable_paint_generation = self
+            .uncacheable_paint_generation
+            .checked_add(1)
+            .expect("uncacheable paint generation overflowed");
+    }
+
     pub(crate) fn data(&self, paintable: PaintableSlotId) -> PaintableData {
         self.paintables.data_ref(paintable)
     }
@@ -147,6 +155,7 @@ impl<'a> PaintRecorder<'a> {
             hit_test_list_generation: self.hit_test_list_generation,
             has_blocking_wheel_event_listeners: false,
             spliced_capture_count: 0,
+            uncacheable_paint_generation: 0,
             list: HitTestList::default(),
             base_paint_facts_cache: vec![None; self.paintables.slot_count()],
             paintable_facts_cache: vec![None; self.paintables.slot_count()],

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -192,18 +192,12 @@ impl<'a> PaintRecorder<'a> {
         self.data(paintable).stacking_context != NO_STACKING_CONTEXT
     }
 
-    fn layout_flags(&self, paintable: PaintableSlotId) -> u32 {
-        self.layout_arena.node_flags_if_live(self.data(paintable).layout_node)
-    }
-
     fn layout_kind(&self, paintable: PaintableSlotId) -> Option<NodeKind> {
         self.layout_arena.node_kind_if_live(self.data(paintable).layout_node)
     }
 
-    fn display(&self, paintable: PaintableSlotId) -> Option<crate::css::display::FfiDisplay> {
-        self.layout_arena
-            .node_style_if_live(self.data(paintable).layout_node)
-            .map(|style| style.display())
+    fn display(&self, paintable: PaintableSlotId) -> crate::css::display::FfiDisplay {
+        crate::css::display::FfiDisplay::from_raw(self.data(paintable).display)
     }
 
     fn visibility_is_visible(&self, paintable: PaintableSlotId) -> bool {
@@ -221,8 +215,8 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn is_replaced_box(&self, paintable: PaintableSlotId) -> bool {
-        self.layout_kind(paintable)
-            .is_some_and(crate::layout::kind_is_replaced_box)
+        self.data(paintable)
+            .has_flag(crate::painting::paintable_data::PaintableFlag::ReplacedBox)
     }
 
     pub(crate) fn own_context_index(&self, paintable: PaintableSlotId) -> usize {

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -80,7 +80,7 @@ pub struct PaintRecorder<'a> {
     pub(crate) has_blocking_wheel_event_listeners: bool,
     spliced_capture_count: usize,
     list: HitTestList,
-    paintable_facts_cache: HashMap<u32, FfiHitTestPaintableFacts>,
+    paintable_facts_cache: Vec<Option<(PaintableSlotId, FfiHitTestPaintableFacts)>>,
     text_node_facts_cache: HashMap<u32, FfiHitTestTextNodeFacts>,
     pub(crate) wheel_hit_test_target_cache: HashMap<PaintableSlotId, usize>,
 }
@@ -107,12 +107,14 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn paintable_facts(&mut self, paintable: PaintableSlotId) -> FfiHitTestPaintableFacts {
-        let key = paintable.index;
-        if let Some(facts) = self.paintable_facts_cache.get(&key) {
-            return *facts;
+        let index = paintable.slot_index() as usize;
+        if let Some((memoized_id, facts)) = self.paintable_facts_cache[index]
+            && memoized_id == paintable
+        {
+            return facts;
         }
         let facts = self.host.paintable_facts(self.shell(paintable));
-        self.paintable_facts_cache.insert(key, facts);
+        self.paintable_facts_cache[index] = Some((paintable, facts));
         facts
     }
 
@@ -145,7 +147,7 @@ impl<'a> PaintRecorder<'a> {
             has_blocking_wheel_event_listeners: false,
             spliced_capture_count: 0,
             list: HitTestList::default(),
-            paintable_facts_cache: HashMap::new(),
+            paintable_facts_cache: vec![None; self.paintables.slot_count()],
             text_node_facts_cache: HashMap::new(),
             wheel_hit_test_target_cache: HashMap::new(),
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -80,6 +80,7 @@ pub struct PaintRecorder<'a> {
     pub(crate) has_blocking_wheel_event_listeners: bool,
     spliced_capture_count: usize,
     list: HitTestList,
+    base_paint_facts_cache: Vec<Option<(PaintableSlotId, BasePaintFacts)>>,
     paintable_facts_cache: Vec<Option<(PaintableSlotId, FfiHitTestPaintableFacts)>>,
     text_node_facts_cache: HashMap<u32, FfiHitTestTextNodeFacts>,
     pub(crate) wheel_hit_test_target_cache: HashMap<PaintableSlotId, usize>,
@@ -147,6 +148,7 @@ impl<'a> PaintRecorder<'a> {
             has_blocking_wheel_event_listeners: false,
             spliced_capture_count: 0,
             list: HitTestList::default(),
+            base_paint_facts_cache: vec![None; self.paintables.slot_count()],
             paintable_facts_cache: vec![None; self.paintables.slot_count()],
             text_node_facts_cache: HashMap::new(),
             wheel_hit_test_target_cache: HashMap::new(),
@@ -170,24 +172,34 @@ impl<'a> PaintRecorder<'a> {
     }
 
     pub(crate) fn base_paint_facts(&mut self, paintable: PaintableSlotId) -> BasePaintFacts {
+        let index = paintable.slot_index() as usize;
+        if let Some((memoized_id, facts)) = self.base_paint_facts_cache[index]
+            && memoized_id == paintable
+        {
+            return facts;
+        }
         let data = self.data(paintable);
         let Some(style) = self.layout_arena.node_style_if_live(data.layout_node) else {
-            return BasePaintFacts::default();
+            let facts = BasePaintFacts::default();
+            self.base_paint_facts_cache[index] = Some((paintable, facts));
+            return facts;
         };
         let effects = style.effects();
         let is_visible = style.visibility() == crate::css::css_enums::visibility::VISIBLE && effects.opacity != 0.0;
-        let empty_cells_property_applies = style.display().is_internal_table()
+        let empty_cells_property_applies = self.display(paintable).is_internal_table()
             && style.empty_cells() == crate::css::css_enums::empty_cells::HIDE
             && self.paintables.first_child(paintable).is_none();
         let has_backdrop_filter = effects.backdrop_filter.operations.length != 0;
         let paints_border_image = crate::painting::style_queries::handle_value(&style.border().border_image_source)
             .is_some_and(|source| matches!(source, crate::css::style_value::StyleValueData::Image { .. }));
-        BasePaintFacts {
+        let facts = BasePaintFacts {
             is_visible,
             empty_cells_property_applies,
             has_backdrop_filter,
             paints_border_image,
-        }
+        };
+        self.base_paint_facts_cache[index] = Some((paintable, facts));
+        facts
     }
 
     fn has_stacking_context(&self, paintable: PaintableSlotId) -> bool {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
@@ -141,6 +141,9 @@ pub(crate) fn paint_base_with(
     phase: PaintPhase,
     paint_background: fn(&mut PaintRecorder<'_>, PaintableSlotId),
 ) {
+    if phase == PaintPhase::Foreground {
+        return;
+    }
     let facts = recorder.base_paint_facts(paintable);
     if !facts.is_visible {
         return;

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
@@ -8,11 +8,18 @@ use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::painting::display_list::commands::VisualContextIndex;
 use crate::painting::display_list::recorder::{FillPathParams, PaintStyleOrColor};
-use crate::painting::paintable_data::PaintableSlotId;
+use crate::painting::paintable_data::{PaintableKind, PaintableSlotId};
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::{Color, FloatPoint, IntRect, LineStyle, ShouldAntiAlias, WindingRule};
 
 pub(crate) fn paint_overlay(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId) {
+    let data = recorder.data(paintable);
+    if data.kind != PaintableKind::ViewportPaintable
+        && data.own_scroll_node_index == 0
+        && !recorder.hit_test_facts(paintable).has_resizer
+    {
+        return;
+    }
     let facts = recorder.paint_host.overlay_facts(recorder.shell(paintable));
     let converter = recorder.converter;
 

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -97,6 +97,7 @@ pub(crate) fn record_display_list(
         has_blocking_wheel_event_listeners: false,
         spliced_capture_count: 0,
         list: HitTestList::default(),
+        base_paint_facts_cache: vec![None; paintables.slot_count()],
         paintable_facts_cache: vec![None; paintables.slot_count()],
         text_node_facts_cache: HashMap::new(),
         wheel_hit_test_target_cache: HashMap::new(),

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -25,12 +25,25 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum StackingContextPaintPhase {
-    BackgroundAndBorders,
-    Floats,
-    BackgroundAndBordersForInlineLevelAndReplaced,
-    Foreground,
+#[repr(u8)]
+pub(crate) enum StackingContextPaintPhase {
+    BackgroundAndBorders = 0,
+    Floats = 1,
+    BackgroundAndBordersForInlineLevelAndReplaced = 2,
+    Foreground = 3,
 }
+
+impl StackingContextPaintPhase {
+    pub(crate) const COUNT: usize = Self::Foreground as usize + 1;
+}
+
+const _: () = assert!(
+    StackingContextPaintPhase::Floats as usize == StackingContextPaintPhase::BackgroundAndBorders as usize + 1
+        && StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced as usize
+            == StackingContextPaintPhase::Floats as usize + 1
+        && StackingContextPaintPhase::Foreground as usize
+            == StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced as usize + 1
+);
 
 fn to_paint_phase(phase: StackingContextPaintPhase) -> PaintPhase {
     // There are not a fully correct mapping since some stacking context phases are combined.
@@ -96,6 +109,7 @@ pub(crate) fn record_display_list(
             .map_or(PaintableSlotId::INVALID, |root| root.paintable),
         has_blocking_wheel_event_listeners: false,
         spliced_capture_count: 0,
+        uncacheable_paint_generation: 0,
         list: HitTestList::default(),
         base_paint_facts_cache: vec![None; paintables.slot_count()],
         paintable_facts_cache: vec![None; paintables.slot_count()],
@@ -351,6 +365,9 @@ impl PaintRecorder<'_> {
         if phase != PaintPhase::Foreground {
             return;
         }
+        // SVG paint servers and filters are resolved while recording and can change without invalidating the
+        // paintable that references them. Do not cache an enclosing descendant subtree.
+        self.prevent_descendant_subtree_caching();
         self.paint_node(paintable, PaintPhase::Background);
         self.paint_node(paintable, PaintPhase::Border);
         self.paint_svg_box(paintable, phase);
@@ -361,83 +378,183 @@ impl PaintRecorder<'_> {
         let mut next_child = paintables.first_child(paintable);
         while let Some(child) = next_child {
             next_child = paintables.next_sibling(child);
-            let this = &mut *self;
-            if this.has_stacking_context(child) {
+            if self.append_cached_descendant_subtree(child, phase) {
                 continue;
             }
-            let child_data = this.data(child);
-            let positioned = child_data.has_flag(PaintableFlag::Positioned);
-            let floating = child_data.has_flag(PaintableFlag::Floating);
-            let inline = child_data.has_flag(PaintableFlag::Inline);
-            let child_kind = child_data.kind;
-
-            // Positioned descendants at stack level 0 are painted in a separate pass.
-            if positioned && this.z_index(child).unwrap_or(0) == 0 {
-                continue;
-            }
-
-            if child_kind == PaintableKind::SVGSVGPaintable {
-                this.paint_svg(child, to_paint_phase(phase));
-                continue;
-            }
-
-            let is_item = child_data.has_flag(PaintableFlag::FlexOrGridItem);
-            // NOTE: Flex and grid items should be treated the same way as CSS2 defines for inline-blocks:
-            //       - https://drafts.csswg.org/css-flexbox-1/#painting
-            //       - https://www.w3.org/TR/css-grid-2/#z-order
-            //       "For each one of these, treat the element as if it created a new stacking context, but any positioned
-            //       descendants and descendants which actually create a new stacking context should be considered part of
-            //       the parent stacking context, not this new one."
-            if is_item && this.z_index(child).is_none() {
-                // FIXME: This may not be fully correct with respect to the paint phases.
-                if phase == StackingContextPaintPhase::Foreground {
-                    this.paint_node_as_stacking_context(child);
-                }
-                continue;
-            }
-
-            // All non-positioned floating descendants, in tree order.
-            if floating && !positioned && this.z_index(child).is_none() {
-                if phase == StackingContextPaintPhase::Floats {
-                    this.paint_node_as_stacking_context(child);
-                }
-                continue;
-            }
-
-            let child_is_inline_or_replaced = inline || this.is_replaced_box(child);
-            let child_has_inline_level_painting_context = this.establishes_inline_level_painting_context(child);
-            match phase {
-                StackingContextPaintPhase::BackgroundAndBorders => {
-                    if !child_is_inline_or_replaced && !floating {
-                        this.paint_subtree_backgrounds_and_borders(child);
-                    } else if this.is_pure_inline_box(child) {
-                        this.paint_descendants(child, phase);
-                    }
-                }
-                StackingContextPaintPhase::Floats => {
-                    if floating {
-                        this.paint_subtree_backgrounds_and_borders(child);
-                    }
-                    // Atomic inline-level descendants participate in the parent's inline-level
-                    // painting step, so their internal floats are not painted early.
-                    if !child_has_inline_level_painting_context {
-                        this.paint_descendants(child, phase);
-                    }
-                }
-                StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced => {
-                    if child_is_inline_or_replaced {
-                        this.paint_inline_level_non_positioned_descendant(child);
-                    }
-                    this.paint_descendants(child, phase);
-                }
-                StackingContextPaintPhase::Foreground => {
-                    this.paint_node(child, PaintPhase::Foreground);
-                    this.paint_descendants(child, phase);
-                    this.paint_node(child, PaintPhase::Outline);
-                    this.paint_node(child, PaintPhase::Overlay);
-                }
+            let command_start = self.recorder.byte_size();
+            let hit_test_start = self.list.items.len();
+            let uncacheable_paint_generation = self.uncacheable_paint_generation;
+            self.paint_descendant(child, phase);
+            if self.uncacheable_paint_generation == uncacheable_paint_generation {
+                self.cache_descendant_subtree(child, phase, command_start, hit_test_start);
             }
         }
+    }
+
+    fn paint_descendant(&mut self, child: PaintableSlotId, phase: StackingContextPaintPhase) {
+        if self.has_stacking_context(child) {
+            return;
+        }
+        let child_data = self.data(child);
+        let positioned = child_data.has_flag(PaintableFlag::Positioned);
+        let floating = child_data.has_flag(PaintableFlag::Floating);
+        let inline = child_data.has_flag(PaintableFlag::Inline);
+        let child_kind = child_data.kind;
+
+        // Positioned descendants at stack level 0 are painted in a separate pass.
+        if positioned && self.z_index(child).unwrap_or(0) == 0 {
+            return;
+        }
+
+        if child_kind == PaintableKind::SVGSVGPaintable {
+            self.paint_svg(child, to_paint_phase(phase));
+            return;
+        }
+
+        let is_item = child_data.has_flag(PaintableFlag::FlexOrGridItem);
+        // NOTE: Flex and grid items should be treated the same way as CSS2 defines for inline-blocks:
+        //       - https://drafts.csswg.org/css-flexbox-1/#painting
+        //       - https://www.w3.org/TR/css-grid-2/#z-order
+        //       "For each one of these, treat the element as if it created a new stacking context, but any positioned
+        //       descendants and descendants which actually create a new stacking context should be considered part of
+        //       the parent stacking context, not this new one."
+        if is_item && self.z_index(child).is_none() {
+            // FIXME: This may not be fully correct with respect to the paint phases.
+            if phase == StackingContextPaintPhase::Foreground {
+                self.paint_node_as_stacking_context(child);
+            }
+            return;
+        }
+
+        // All non-positioned floating descendants, in tree order.
+        if floating && !positioned && self.z_index(child).is_none() {
+            if phase == StackingContextPaintPhase::Floats {
+                self.paint_node_as_stacking_context(child);
+            }
+            return;
+        }
+
+        let child_is_inline_or_replaced = inline || self.is_replaced_box(child);
+        let child_has_inline_level_painting_context = self.establishes_inline_level_painting_context(child);
+        match phase {
+            StackingContextPaintPhase::BackgroundAndBorders => {
+                if !child_is_inline_or_replaced && !floating {
+                    self.paint_subtree_backgrounds_and_borders(child);
+                } else if self.is_pure_inline_box(child) {
+                    self.paint_descendants(child, phase);
+                }
+            }
+            StackingContextPaintPhase::Floats => {
+                if floating {
+                    self.paint_subtree_backgrounds_and_borders(child);
+                }
+                // Atomic inline-level descendants participate in the parent's inline-level
+                // painting step, so their internal floats are not painted early.
+                if !child_has_inline_level_painting_context {
+                    self.paint_descendants(child, phase);
+                }
+            }
+            StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced => {
+                if child_is_inline_or_replaced {
+                    self.paint_inline_level_non_positioned_descendant(child);
+                }
+                self.paint_descendants(child, phase);
+            }
+            StackingContextPaintPhase::Foreground => {
+                self.paint_node(child, PaintPhase::Foreground);
+                self.paint_descendants(child, phase);
+                self.paint_node(child, PaintPhase::Outline);
+                self.paint_node(child, PaintPhase::Overlay);
+            }
+        }
+    }
+
+    fn append_cached_descendant_subtree(
+        &mut self,
+        paintable: PaintableSlotId,
+        phase: StackingContextPaintPhase,
+    ) -> bool {
+        if self.nested.is_some() {
+            return false;
+        }
+        let Some(command_source) = self.command_cache_source.as_ref() else {
+            return false;
+        };
+        let Some(item_source) = self.item_cache_source.as_ref() else {
+            return false;
+        };
+        let Some(cached) = self.paintables.paint_caches[paintable.slot_index() as usize].descendant_subtree(phase)
+        else {
+            return false;
+        };
+        if cached.source_display_list_id != command_source.id
+            || cached.source_hit_test_display_list_id != item_source.id
+        {
+            return false;
+        }
+
+        let command_range = self
+            .recorder
+            .append_cached_command_range_verbatim(&command_source.display_list_bytes, cached.command_range);
+        let hit_test_start = self.list.items.len();
+        let source_start = cached.hit_test_start as usize;
+        let source_end = source_start + cached.hit_test_count as usize;
+        for item in &item_source.items[source_start..source_end] {
+            self.list.append(item.clone());
+        }
+        if self.inputs.paint_command_cache_read_write {
+            self.set_cached_descendant_subtree(
+                paintable,
+                phase,
+                command_range,
+                hit_test_start,
+                cached.hit_test_count as usize,
+            );
+        }
+        self.spliced_capture_count += 1;
+        true
+    }
+
+    fn cache_descendant_subtree(
+        &self,
+        paintable: PaintableSlotId,
+        phase: StackingContextPaintPhase,
+        command_start: usize,
+        hit_test_start: usize,
+    ) {
+        if !self.inputs.paint_command_cache_read_write || self.nested.is_some() {
+            return;
+        }
+        self.set_cached_descendant_subtree(
+            paintable,
+            phase,
+            CommandRange {
+                offset: command_start as u32,
+                size: (self.recorder.byte_size() - command_start) as u32,
+            },
+            hit_test_start,
+            self.list.items.len() - hit_test_start,
+        );
+    }
+
+    fn set_cached_descendant_subtree(
+        &self,
+        paintable: PaintableSlotId,
+        phase: StackingContextPaintPhase,
+        command_range: CommandRange,
+        hit_test_start: usize,
+        hit_test_count: usize,
+    ) {
+        self.paintables.paint_caches[paintable.slot_index() as usize].set_descendant_subtree(
+            phase,
+            crate::painting::record::cache::CachedDescendantSubtree {
+                source_display_list_id: self.display_list_id,
+                command_range,
+                source_hit_test_display_list_id: self.hit_test_list_generation,
+                hit_test_start: hit_test_start as u32,
+                hit_test_count: hit_test_count as u32,
+            },
+        );
     }
 
     fn paint_svg_box(&mut self, svg_box: PaintableSlotId, phase: PaintPhase) {
@@ -525,6 +642,9 @@ impl PaintRecorder<'_> {
         let data = self.data(paintable);
         let skip_cache = data.has_fixed_background_visual_context
             || (data.kind.foreground_is_never_cached() && phase == PaintPhase::Foreground);
+        if skip_cache {
+            self.prevent_descendant_subtree_caching();
+        }
         let cache_writes_enabled = self.inputs.paint_command_cache_read_write && !is_nested;
 
         if phase_can_record_hit_test_items && !is_nested {

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -6,7 +6,7 @@
 
 use super::{PaintPhase, PaintRecorder};
 use crate::layout::LayoutNodeArena;
-use crate::layout::node_data::{NodeFlag, NodeKind};
+use crate::layout::node_data::NodeKind;
 use crate::painting::display_list::builder::CommandRange;
 use crate::painting::display_list::commands::VisualContextIndex;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
@@ -158,9 +158,8 @@ impl PaintRecorder<'_> {
         // actual child stacking contexts in the parent stacking context:
         // https://drafts.csswg.org/css2/#painting-order
         // https://drafts.csswg.org/css2/#elaborate-stacking-contexts
-        self.display(paintable).is_some_and(|display| {
-            display.is_inline_outside() && (display.is_flow_root_inside() || display.is_table_inside())
-        })
+        let display = self.display(paintable);
+        display.is_inline_outside() && (display.is_flow_root_inside() || display.is_table_inside())
     }
 
     fn is_pure_inline_box(&self, paintable: PaintableSlotId) -> bool {
@@ -381,7 +380,7 @@ impl PaintRecorder<'_> {
                 continue;
             }
 
-            let is_item = this.layout_flags(child) & (NodeFlag::IsFlexItem as u32 | NodeFlag::IsGridItem as u32) != 0;
+            let is_item = child_data.has_flag(PaintableFlag::FlexOrGridItem);
             // NOTE: Flex and grid items should be treated the same way as CSS2 defines for inline-blocks:
             //       - https://drafts.csswg.org/css-flexbox-1/#painting
             //       - https://www.w3.org/TR/css-grid-2/#z-order

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -97,7 +97,7 @@ pub(crate) fn record_display_list(
         has_blocking_wheel_event_listeners: false,
         spliced_capture_count: 0,
         list: HitTestList::default(),
-        paintable_facts_cache: HashMap::new(),
+        paintable_facts_cache: vec![None; paintables.slot_count()],
         text_node_facts_cache: HashMap::new(),
         wheel_hit_test_target_cache: HashMap::new(),
     };

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -632,9 +632,8 @@ impl PaintRecorder<'_> {
         phase_has_empty_effective_clip: bool,
     ) -> Option<(Rc<RecordingOutput>, crate::painting::record::cache::CachedCommands)> {
         let source = self.command_cache_source.as_ref()?;
-        let caches = self.paintables.paint_caches.borrow();
-        let cache = caches.get(paintable.slot_index() as usize)?.as_ref()?;
-        let entry = cache.entry(phase).commands?;
+        let cache = self.paintables.paint_caches.get(paintable.slot_index() as usize)?;
+        let entry = cache.commands(phase)?;
         if entry.source_display_list_id != source.id
             || entry.captured_under_empty_effective_clip != phase_has_empty_effective_clip
         {
@@ -651,9 +650,8 @@ impl PaintRecorder<'_> {
         for_descendants_index: usize,
     ) -> Option<(Rc<Vec<HitTestItem>>, usize, usize)> {
         let source = self.item_cache_source.as_ref()?;
-        let caches = self.paintables.paint_caches.borrow();
-        let cache = caches.get(paintable.slot_index() as usize)?.as_ref()?;
-        let entry = cache.entry(phase).hit_test_items?;
+        let cache = self.paintables.paint_caches.get(paintable.slot_index() as usize)?;
+        let entry = cache.hit_test_items(phase)?;
         if entry.source_hit_test_display_list_id != source.id
             || entry.recorded_context_index != own_index
             || entry.recorded_context_for_descendants_index != for_descendants_index
@@ -671,14 +669,16 @@ impl PaintRecorder<'_> {
         recorded_context_index: usize,
         captured_under_empty_effective_clip: bool,
     ) {
-        let mut caches = self.paintables.paint_caches.borrow_mut();
-        let cache = caches[paintable.slot_index() as usize].get_or_insert_with(Default::default);
-        cache.entry_mut(phase).commands = Some(crate::painting::record::cache::CachedCommands {
-            source_display_list_id: self.display_list_id,
-            range,
-            recorded_context_index,
-            captured_under_empty_effective_clip,
-        });
+        let cache = &self.paintables.paint_caches[paintable.slot_index() as usize];
+        cache.set_commands(
+            phase,
+            crate::painting::record::cache::CachedCommands {
+                source_display_list_id: self.display_list_id,
+                range,
+                recorded_context_index,
+                captured_under_empty_effective_clip,
+            },
+        );
     }
 
     fn set_cached_hit_test_items(
@@ -690,15 +690,17 @@ impl PaintRecorder<'_> {
         recorded_context_index: usize,
         recorded_context_for_descendants_index: usize,
     ) {
-        let mut caches = self.paintables.paint_caches.borrow_mut();
-        let cache = caches[paintable.slot_index() as usize].get_or_insert_with(Default::default);
-        cache.entry_mut(phase).hit_test_items = Some(crate::painting::record::cache::CachedHitTestItems {
-            source_hit_test_display_list_id: self.hit_test_list_generation,
-            start: start as u32,
-            count: count as u32,
-            recorded_context_index,
-            recorded_context_for_descendants_index,
-        });
+        let cache = &self.paintables.paint_caches[paintable.slot_index() as usize];
+        cache.set_hit_test_items(
+            phase,
+            crate::painting::record::cache::CachedHitTestItems {
+                source_hit_test_display_list_id: self.hit_test_list_generation,
+                start: start as u32,
+                count: count as u32,
+                recorded_context_index,
+                recorded_context_for_descendants_index,
+            },
+        );
     }
 
     fn paint(&mut self, paintable: PaintableSlotId, phase: PaintPhase) {

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -390,6 +390,9 @@ fn used_transform_style_is_preserve_3d(arena: &LayoutNodeArena, node: NodeSlotId
 }
 
 pub(crate) fn establishes_or_extends_a_3d_rendering_context(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
+    if !has_flag(arena, node, NodeFlag::HasPreserve3dTransformStyle) {
+        return false;
+    }
     used_transform_style_is_preserve_3d(arena, node) && is_transformable(arena, node)
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -88,6 +88,7 @@ impl BoxFacts {
         callbacks: &FfiVisualContextHostCallbacks,
         slot: PaintableSlotId,
         pixel_ratio: f64,
+        may_have_default_scroll_shift_anchor: bool,
     ) -> Self {
         let mut facts = Self {
             transform: None,
@@ -103,7 +104,11 @@ impl BoxFacts {
             backface_hidden: false,
             establishes_or_extends_3d_rendering_context: false,
             may_have_clip: false,
-            default_scroll_shift_anchor: callbacks.default_scroll_shift_anchor(paintables.data_ref(slot).shell),
+            default_scroll_shift_anchor: if may_have_default_scroll_shift_anchor {
+                callbacks.default_scroll_shift_anchor(paintables.data_ref(slot).shell)
+            } else {
+                NodeSlotId::INVALID
+            },
         };
         if let Some((transform, transform_is_invertible)) =
             super::node_values::compute_transform(layout_arena, paintables, callbacks, slot, pixel_ratio)
@@ -221,10 +226,14 @@ struct Builder<'a> {
     paintables_with_mask_nodes: Vec<PaintableSlotId>,
     pixel_ratio: f64,
     root_background_source: crate::painting::host::FfiRootBackgroundSource,
+    may_have_default_scroll_shift_anchor: bool,
 }
 
 impl Builder<'_> {
     fn default_scroll_shift_anchor(&self, slot: PaintableSlotId) -> NodeSlotId {
+        if !self.may_have_default_scroll_shift_anchor {
+            return NodeSlotId::INVALID;
+        }
         self.callbacks
             .default_scroll_shift_anchor(self.paintables.data_ref(slot).shell)
     }
@@ -275,6 +284,7 @@ impl Builder<'_> {
             self.callbacks,
             slot,
             self.pixel_ratio,
+            self.may_have_default_scroll_shift_anchor,
         );
         let (is_fixed, is_absolute, is_sticky, has_sticky_insets, layout_node) = {
             let data = self.paintables.data_ref(slot);
@@ -724,6 +734,7 @@ pub(crate) fn build_visual_context_tree(
         paintables_with_mask_nodes: Vec::new(),
         pixel_ratio: inputs.device_pixels_per_css_pixel,
         root_background_source: callbacks.root_background_source(),
+        may_have_default_scroll_shift_anchor: inputs.may_have_default_scroll_shift_anchor,
     };
 
     paintables.update_data(viewport, |data| data.enclosing_scroll_node_index = 0);

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
@@ -39,6 +39,7 @@ impl NestedBuilder<'_> {
             self.callbacks,
             slot,
             self.pixel_ratio,
+            false,
         );
         let mut own_state = inherited_state;
         if let Some(effects) = facts.effects_data() {

--- a/Tests/LibWeb/Text/expected/display_list/descendant-cache-visual-context-reassignment.txt
+++ b/Tests/LibWeb/Text/expected/display_list/descendant-cache-visual-context-reassignment.txt
@@ -1,0 +1,2 @@
+target command uses target context: true
+target hit test uses target context: true

--- a/Tests/LibWeb/Text/input/display_list/descendant-cache-visual-context-reassignment.html
+++ b/Tests/LibWeb/Text/input/display_list/descendant-cache-visual-context-reassignment.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    .box {
+        width: 40px;
+        height: 40px;
+    }
+    .content {
+        width: 80px;
+        height: 80px;
+    }
+    #before {
+        overflow: hidden;
+    }
+    #cached {
+        pointer-events: none;
+    }
+    #target {
+        overflow: hidden;
+    }
+    #before-content { background: red; }
+    #target-content { background: lime; pointer-events: auto; }
+    #after-content { background: blue; }
+</style>
+<div id="before" class="box"><div id="before-content" class="content"></div></div>
+<div id="cached" class="box"><div id="target" class="box"><div id="target-content" class="content"></div></div></div>
+<div id="after" class="box"><div id="after-content" class="content"></div></div>
+<script>
+    test(() => {
+        const targetContent = document.getElementById("target-content");
+        internals.asyncScrollingState();
+
+        // Keep the visual-context tree compatible while assigning its two sibling
+        // clip nodes to different paintables. The unchanged middle subtree
+        // must not replay commands or hit-test items with its old context index.
+        before.style.overflow = "visible";
+        after.style.overflow = "hidden";
+        const displayList = internals.dumpDisplayList();
+        const targetCommandContext = displayList.match(/FillRect@(\d+).*rgb\(0, 255, 0\)/)[1];
+        const afterCommandContext = displayList.match(/FillRect@(\d+).*rgb\(0, 0, 255\)/)[1];
+        println(`target command uses target context: ${targetCommandContext !== afterCommandContext}`);
+        println(`target hit test uses target context: ${document.elementFromPoint(10, 50) === targetContent}`);
+    });
+</script>


### PR DESCRIPTION
This reduces Rust display-list recording time on StyleBench from roughly 3.12 seconds to 1.23 seconds per run, an approximately 2.5x speedup. The published StyleBench score excludes asynchronous painting, so this was measured directly around the paint-recording path.

The changes:

- Retain frequently queried traversal and style facts in paintable data.
- Replace general-purpose recording memo tables with dense arena storage.
- Preserve compatible paint caches across relayout and reuse unchanged descendant subtrees.
- Batch hit-test exports and avoid unnecessary cross-language callbacks.
- Fast-reject no-op 3D context, caret, anchor, and overlay work.
- Make absolute-geometry memo invalidation constant time.
- Permit safe arena reentry from synchronous hit-testing callbacks.

Benchmark look mostly neutral since this happens outside the measured time windows:

```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  76.14 ± 7.22  76.35 ± 1.74                1.003  6.61 ± 0.41            6.63 ± 0.38                0.997
Speedometer3  4.20 ± 0.03   4.26 ± 0.64                 1.014  6.20 ± 0.24            6.24 ± 0.68                0.993
StyleBench    68.39 ± 5.51  68.06 ± 3.60                0.995  3.65 ± 0.25            3.67 ± 0.12                0.994
```