### PR TITLE
LibWeb: Cache live node list contents

### DIFF
--- a/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/InsertionSort.h>
 #include <LibGC/Heap.h>
+#include <LibGC/WeakInlines.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -85,8 +86,10 @@ void HTMLCollection::update_name_to_element_mappings_if_needed() const
 
 void HTMLCollection::update_cache_if_needed() const
 {
+    auto& document = root()->document();
+
     // Nothing to do, the DOM hasn't updated since we last built the cache.
-    if (m_cached_dom_tree_version == root()->document().dom_tree_version())
+    if (m_cached_document.ptr().ptr() == &document && m_cached_dom_tree_version == document.dom_tree_version())
         return;
 
     m_cached_elements.clear();
@@ -111,7 +114,8 @@ void HTMLCollection::update_cache_if_needed() const
         });
     }
 
-    m_cached_dom_tree_version = root()->document().dom_tree_version();
+    m_cached_document = document;
+    m_cached_dom_tree_version = document.dom_tree_version();
 }
 
 GC::RootVector<GC::Ref<Element>> HTMLCollection::collect_matching_elements() const

--- a/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -9,6 +9,7 @@
 
 #include <AK/Function.h>
 #include <LibGC/Ptr.h>
+#include <LibGC/Weak.h>
 #include <LibGC/WeakContainer.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Forward.h>
@@ -61,6 +62,7 @@ private:
     void update_cache_if_needed() const;
     void update_name_to_element_mappings_if_needed() const;
 
+    mutable GC::Weak<Document const> m_cached_document;
     mutable u64 m_cached_dom_tree_version { 0 };
     mutable Vector<GC::RawPtr<Element>> m_cached_elements;
     mutable OwnPtr<OrderedHashMap<Utf16FlyString, GC::RawPtr<Element>>> m_cached_name_to_element_mappings;

--- a/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -6,7 +6,9 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibGC/WeakInlines.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/LiveNodeList.h>
 #include <LibWeb/DOM/Node.h>
 
@@ -21,6 +23,7 @@ GC::Ref<NodeList> LiveNodeList::create(Node const& root, Scope scope, Function<b
 
 LiveNodeList::LiveNodeList(Node const& root, Scope scope, Function<bool(Node const&)> filter)
     : NodeList()
+    , GC::WeakContainer(heap())
     , m_root(root)
     , m_filter(move(filter))
     , m_scope(scope)
@@ -36,62 +39,69 @@ void LiveNodeList::visit_edges(GC::Cell::Visitor& visitor)
     visitor.visit_possible_values(m_filter.raw_capture_range());
 }
 
-GC::RootVector<Node*> LiveNodeList::collection() const
+GC::Cell const& LiveNodeList::owner_cell(Badge<GC::Heap>) const
 {
-    GC::RootVector<Node*> nodes;
+    return *this;
+}
+
+void LiveNodeList::remove_dead_cells(Badge<GC::Heap>)
+{
+    m_cached_nodes.remove_all_matching([&](GC::RawPtr<Node> const& node) {
+        auto* block = GC::HeapBlock::from_cell(node.ptr());
+        return !heap().is_live_heap_block(block) || node->state() != Cell::State::Live || !node->is_marked();
+    });
+}
+
+void LiveNodeList::update_cache_if_needed() const
+{
+    auto& document = m_root->document();
+    if (m_cached_document.ptr().ptr() == &document && m_cached_dom_tree_version == document.dom_tree_version())
+        return;
+
+    m_cached_nodes.clear();
     if (m_scope == Scope::Descendants) {
         m_root->for_each_in_subtree([&](auto& node) {
             if (m_filter(node))
-                nodes.append(const_cast<Node*>(&node));
+                m_cached_nodes.append(const_cast<Node&>(node));
             return TraversalDecision::Continue;
         });
     } else {
         m_root->for_each_child([&](auto& node) {
             if (m_filter(node))
-                nodes.append(const_cast<Node*>(&node));
+                m_cached_nodes.append(const_cast<Node&>(node));
             return IterationDecision::Continue;
         });
     }
-    return nodes;
+
+    m_cached_document = document;
+    m_cached_dom_tree_version = document.dom_tree_version();
 }
 
 Node* LiveNodeList::first_matching(Function<bool(Node const&)> const& filter) const
 {
-    Node* matched_node = nullptr;
-    if (m_scope == Scope::Descendants) {
-        m_root->for_each_in_subtree([&](auto& node) {
-            if (m_filter(node) && filter(node)) {
-                matched_node = const_cast<Node*>(&node);
-                return TraversalDecision::Break;
-            }
-            return TraversalDecision::Continue;
-        });
-    } else {
-        m_root->for_each_child([&](auto& node) {
-            if (m_filter(node) && filter(node)) {
-                matched_node = const_cast<Node*>(&node);
-                return IterationDecision::Break;
-            }
-            return IterationDecision::Continue;
-        });
+    update_cache_if_needed();
+    for (auto& node : m_cached_nodes) {
+        if (filter(*node))
+            return node.ptr();
     }
-    return matched_node;
+    return nullptr;
 }
 
 // https://dom.spec.whatwg.org/#dom-nodelist-length
 u32 LiveNodeList::length() const
 {
-    return collection().size();
+    update_cache_if_needed();
+    return m_cached_nodes.size();
 }
 
 // https://dom.spec.whatwg.org/#dom-nodelist-item
 Node const* LiveNodeList::item(u32 index) const
 {
     // The item(index) method must return the indexth node in the collection. If there is no indexth node in the collection, then the method must return null.
-    auto nodes = collection();
-    if (index >= nodes.size())
+    update_cache_if_needed();
+    if (index >= m_cached_nodes.size())
         return nullptr;
-    return nodes[index];
+    return m_cached_nodes[index].ptr();
 }
 
 }

--- a/Libraries/LibWeb/DOM/LiveNodeList.h
+++ b/Libraries/LibWeb/DOM/LiveNodeList.h
@@ -8,13 +8,17 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <LibGC/Weak.h>
+#include <LibGC/WeakContainer.h>
 #include <LibWeb/DOM/NodeList.h>
 
 namespace Web::DOM {
 
-// FIXME: Just like HTMLCollection, LiveNodeList currently does no caching.
+class Document;
 
-class LiveNodeList : public NodeList {
+class LiveNodeList
+    : public NodeList
+    , public GC::WeakContainer {
     WEB_NON_IDL_WRAPPABLE(LiveNodeList, NodeList);
     GC_DECLARE_ALLOCATOR(LiveNodeList);
 
@@ -37,8 +41,14 @@ protected:
 
 private:
     virtual void visit_edges(GC::Cell::Visitor&) override;
+    virtual void remove_dead_cells(Badge<GC::Heap>) override;
+    virtual GC::Cell const& owner_cell(Badge<GC::Heap>) const override;
 
-    GC::RootVector<Node*> collection() const;
+    void update_cache_if_needed() const;
+
+    mutable GC::Weak<Document const> m_cached_document;
+    mutable u64 m_cached_dom_tree_version { 0 };
+    mutable Vector<GC::RawPtr<Node>> m_cached_nodes;
 
     GC::Ref<Node const> m_root;
     Function<bool(Node const&)> m_filter;

--- a/Tests/LibWeb/Text/expected/DOM/live-collections-after-adoption.txt
+++ b/Tests/LibWeb/Text/expected/DOM/live-collections-after-adoption.txt
@@ -1,0 +1,4 @@
+childNodes before adoption: 1
+childNodes after adoption: 2
+children before adoption: 1
+children after adoption: 2

--- a/Tests/LibWeb/Text/expected/DOM/live-node-list-cache.txt
+++ b/Tests/LibWeb/Text/expected/DOM/live-node-list-cache.txt
@@ -1,0 +1,7 @@
+2: first, span
+3: last
+2: span, last
+2: last, span
+before name: 0
+with name: 1, true
+after name: 0

--- a/Tests/LibWeb/Text/input/DOM/live-collections-after-adoption.html
+++ b/Tests/LibWeb/Text/input/DOM/live-collections-after-adoption.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const oldDocument = document.implementation.createHTMLDocument("");
+        const newDocument = document.implementation.createHTMLDocument("");
+        const root = oldDocument.createElement("div");
+        root.append(oldDocument.createElement("span"));
+        const childNodes = root.childNodes;
+
+        println(`childNodes before adoption: ${childNodes.length}`);
+        newDocument.adoptNode(root);
+        root.append(newDocument.createTextNode("text"));
+        println(`childNodes after adoption: ${childNodes.length}`);
+
+        const oldDocument2 = document.implementation.createHTMLDocument("");
+        const newDocument2 = document.implementation.createHTMLDocument("");
+        const root2 = oldDocument2.createElement("div");
+        root2.append(oldDocument2.createElement("span"));
+        const children = root2.children;
+
+        println(`children before adoption: ${children.length}`);
+        newDocument2.adoptNode(root2);
+        root2.append(newDocument2.createElement("span"));
+        println(`children after adoption: ${children.length}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/live-node-list-cache.html
+++ b/Tests/LibWeb/Text/input/DOM/live-node-list-cache.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const root = document.createElement("div");
+        root.append("first", document.createElement("span"));
+        const childNodes = root.childNodes;
+
+        println(`${childNodes.length}: ${childNodes[0].data}, ${childNodes[1].localName}`);
+
+        const last = document.createComment("last");
+        root.append(last);
+        println(`${childNodes.length}: ${childNodes[2].data}`);
+
+        root.firstChild.remove();
+        println(`${childNodes.length}: ${childNodes[0].localName}, ${childNodes[1].data}`);
+
+        root.prepend(last);
+        println(`${childNodes.length}: ${childNodes[0].data}, ${childNodes[1].localName}`);
+
+        const input = document.createElement("input");
+        document.documentElement.append(input);
+        const namedNodes = document.getElementsByName("target");
+
+        println(`before name: ${namedNodes.length}`);
+        input.name = "target";
+        println(`with name: ${namedNodes.length}, ${namedNodes[0] === input}`);
+        input.name = "other";
+        println(`after name: ${namedNodes.length}`);
+    });
+</script>


### PR DESCRIPTION
Avoid rebuilding a live node list for every length and indexed access. Cache weak node pointers and invalidate them using the root document identity and DOM tree version.

Track document identity in HTMLCollection caches as well. Document-local version counters can collide when a collection root is adopted into another document, otherwise allowing stale cache contents to survive.

Add regression coverage for structural and filter-changing mutations and for live collection roots adopted across documents.