### PR TITLE
LibWeb: Keep the content navigable of a re-inserted container

### DIFF
--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -339,8 +339,14 @@ void NavigableContainer::destroy_the_child_navigable()
     auto after_document_destruction = GC::create_function(GC::Heap::the(), [this, navigable] {
         // 3. Set container's content navigable to null.
         as<LocalNavigable>(*navigable).set_container({}, nullptr);
-        m_content_navigable = nullptr;
-        document().schedule_html_parser_end_check();
+
+        // AD-HOC: In the spec this step runs synchronously, before the container could possibly acquire another content
+        //         navigable. Since we defer it, the container may have been re-inserted in the meantime and hold a new
+        //         content navigable, which this step must not clear.
+        if (m_content_navigable == navigable) {
+            m_content_navigable = nullptr;
+            document().schedule_html_parser_end_check();
+        }
 
         // Not in the spec:
         navigable->remove_from_all_local_navigables();

--- a/Tests/LibWeb/Crash/HTML/iframe-removed-and-reinserted.html
+++ b/Tests/LibWeb/Crash/HTML/iframe-removed-and-reinserted.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<iframe id="frame"></iframe>
+<script>
+    const frame = document.getElementById("frame");
+    frame.remove();
+    document.body.appendChild(frame);
+</script>

--- a/Tests/LibWeb/Text/expected/HTML/iframe-removed-and-reinserted-content-navigable.txt
+++ b/Tests/LibWeb/Text/expected/HTML/iframe-removed-and-reinserted-content-navigable.txt
@@ -1,0 +1,3 @@
+after re-insertion: contentWindow is null: false
+after re-insertion: contentWindow is a new window: true
+after pending tasks: contentWindow is null: false

--- a/Tests/LibWeb/Text/input/HTML/iframe-removed-and-reinserted-content-navigable.html
+++ b/Tests/LibWeb/Text/input/HTML/iframe-removed-and-reinserted-content-navigable.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<iframe id="frame"></iframe>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const frame = document.getElementById("frame");
+        const originalContentWindow = frame.contentWindow;
+
+        frame.remove();
+        document.body.appendChild(frame);
+
+        println(`after re-insertion: contentWindow is null: ${frame.contentWindow === null}`);
+        println(`after re-insertion: contentWindow is a new window: ${frame.contentWindow !== originalContentWindow}`);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        println(`after pending tasks: contentWindow is null: ${frame.contentWindow === null}`);
+    });
+</script>


### PR DESCRIPTION
Destroying a child navigable defers clearing the container's content navigable until the content document has been unloaded. Previously, that deferred step cleared the pointer unconditionally. A container removed and re-inserted before the step ran acquired a new content navigable, which the step then cleared. This left a connected container with a null content navigable, and painting it failed an assertion.

Clear the content navigable only while it still refers to the navigable being destroyed.

Fixes a regression introduced by c191ac4.

Found with Domato.