### PR TITLE
LibWeb: Refine live collection cache invalidation

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -277,6 +277,12 @@ public:
     u64 dom_tree_version() const { return m_dom_tree_version; }
     void bump_dom_tree_version() { ++m_dom_tree_version; }
 
+    u64 form_associated_custom_element_version() const { return m_form_associated_custom_element_version; }
+    void bump_form_associated_custom_element_version() { ++m_form_associated_custom_element_version; }
+
+    u64 option_selectedness_version() const { return m_option_selectedness_version; }
+    void bump_option_selectedness_version() { ++m_option_selectedness_version; }
+
     // Everything a style input record cannot name by an identity of its own: a stylesheet rule's
     // declarations changing under a block that has not moved, a font finishing loading, the
     // viewport moving, a registration or counter style arriving. A record taken under one version
@@ -1831,6 +1837,8 @@ private:
     Optional<AK::UnixDateTime> m_last_modified;
 
     u64 m_dom_tree_version { 0 };
+    u64 m_form_associated_custom_element_version { 0 };
+    u64 m_option_selectedness_version { 0 };
     u64 m_style_environment_version { 0 };
     u64 m_next_counter_style_environment_identity { 1 };
     u64 m_character_data_version { 0 };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4377,12 +4377,19 @@ GC::Ptr<HTML::CustomElementDefinition> Element::custom_element_definition() cons
 
 void Element::set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinition> definition)
 {
+    auto old_definition = custom_element_definition();
+    bool was_form_associated = old_definition && old_definition->form_associated();
+    bool is_form_associated = definition && definition->form_associated();
+
     if (!definition) {
         if (auto* rare_data = element_rare_data())
             rare_data->custom_element_definition = nullptr;
-        return;
+    } else {
+        ensure_element_rare_data().custom_element_definition = definition;
     }
-    ensure_element_rare_data().custom_element_definition = definition;
+
+    if (was_form_associated != is_form_associated)
+        document().bump_form_associated_custom_element_version();
 }
 
 GC::Ptr<HTML::CustomElementRegistry> Element::custom_element_registry() const

--- a/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -19,17 +19,18 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(HTMLCollection);
 
-GC::Ref<HTMLCollection> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort)
+GC::Ref<HTMLCollection> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort, Kind kind)
 {
-    return GC::Heap::the().allocate<HTMLCollection>(root, scope, move(filter), move(sort));
+    return GC::Heap::the().allocate<HTMLCollection>(root, scope, move(filter), move(sort), kind);
 }
 
-HTMLCollection::HTMLCollection(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort)
+HTMLCollection::HTMLCollection(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort, Kind kind)
     : GC::WeakContainer(heap())
     , m_root(root)
     , m_filter(move(filter))
     , m_sort(move(sort))
     , m_scope(scope)
+    , m_kind(kind)
 {
 }
 
@@ -87,10 +88,14 @@ void HTMLCollection::update_name_to_element_mappings_if_needed() const
 void HTMLCollection::update_cache_if_needed() const
 {
     auto& document = root()->document();
+    auto invalidation_version = this->invalidation_version(document);
 
     // Nothing to do, the DOM hasn't updated since we last built the cache.
-    if (m_cached_document.ptr().ptr() == &document && m_cached_dom_tree_version == document.dom_tree_version())
+    if (m_cached_document.ptr().ptr() == &document
+        && m_cached_dom_tree_version == document.dom_tree_version()
+        && m_cached_invalidation_version == invalidation_version) {
         return;
+    }
 
     m_cached_elements.clear();
     m_cached_name_to_element_mappings = nullptr;
@@ -116,6 +121,20 @@ void HTMLCollection::update_cache_if_needed() const
 
     m_cached_document = document;
     m_cached_dom_tree_version = document.dom_tree_version();
+    m_cached_invalidation_version = invalidation_version;
+}
+
+u64 HTMLCollection::invalidation_version(Document const& document) const
+{
+    switch (m_kind) {
+    case Kind::Generic:
+        return 0;
+    case Kind::FormControls:
+        return document.form_associated_custom_element_version();
+    case Kind::SelectedOptions:
+        return document.option_selectedness_version();
+    }
+    VERIFY_NOT_REACHED();
 }
 
 GC::RootVector<GC::Ref<Element>> HTMLCollection::collect_matching_elements() const

--- a/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -34,7 +34,14 @@ public:
         Children,
         Descendants,
     };
-    [[nodiscard]] static GC::Ref<HTMLCollection> create(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr);
+
+    enum class Kind {
+        Generic,
+        FormControls,
+        SelectedOptions,
+    };
+
+    [[nodiscard]] static GC::Ref<HTMLCollection> create(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
 
     virtual ~HTMLCollection() override;
 
@@ -48,10 +55,11 @@ public:
     virtual bool is_supported_property_name(Utf16FlyString const&) const override;
 
 protected:
-    HTMLCollection(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr);
+    HTMLCollection(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
 
     GC::Ref<ParentNode> root() { return *m_root; }
     GC::Ref<ParentNode const> root() const { return *m_root; }
+    bool element_matches_filter(Element const& element) const { return m_filter(element); }
 
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
@@ -61,9 +69,11 @@ private:
 
     void update_cache_if_needed() const;
     void update_name_to_element_mappings_if_needed() const;
+    u64 invalidation_version(Document const&) const;
 
     mutable GC::Weak<Document const> m_cached_document;
     mutable u64 m_cached_dom_tree_version { 0 };
+    mutable u64 m_cached_invalidation_version { 0 };
     mutable Vector<GC::RawPtr<Element>> m_cached_elements;
     mutable OwnPtr<OrderedHashMap<Utf16FlyString, GC::RawPtr<Element>>> m_cached_name_to_element_mappings;
 
@@ -72,6 +82,7 @@ private:
     Function<bool(Element const&, Element const&)> m_sort;
 
     Scope m_scope { Scope::Descendants };
+    Kind m_kind { Kind::Generic };
 };
 
 }

--- a/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -16,17 +16,18 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(LiveNodeList);
 
-GC::Ref<NodeList> LiveNodeList::create(Node const& root, Scope scope, Function<bool(Node const&)> filter)
+GC::Ref<NodeList> LiveNodeList::create(Node const& root, Scope scope, Function<bool(Node const&)> filter, Kind kind)
 {
-    return GC::Heap::the().allocate<LiveNodeList>(root, scope, move(filter));
+    return GC::Heap::the().allocate<LiveNodeList>(root, scope, move(filter), kind);
 }
 
-LiveNodeList::LiveNodeList(Node const& root, Scope scope, Function<bool(Node const&)> filter)
+LiveNodeList::LiveNodeList(Node const& root, Scope scope, Function<bool(Node const&)> filter, Kind kind)
     : NodeList()
     , GC::WeakContainer(heap())
     , m_root(root)
     , m_filter(move(filter))
     , m_scope(scope)
+    , m_kind(kind)
 {
 }
 
@@ -55,8 +56,12 @@ void LiveNodeList::remove_dead_cells(Badge<GC::Heap>)
 void LiveNodeList::update_cache_if_needed() const
 {
     auto& document = m_root->document();
-    if (m_cached_document.ptr().ptr() == &document && m_cached_dom_tree_version == document.dom_tree_version())
+    auto invalidation_version = this->invalidation_version(document);
+    if (m_cached_document.ptr().ptr() == &document
+        && m_cached_dom_tree_version == document.dom_tree_version()
+        && m_cached_invalidation_version == invalidation_version) {
         return;
+    }
 
     m_cached_nodes.clear();
     if (m_scope == Scope::Descendants) {
@@ -75,6 +80,19 @@ void LiveNodeList::update_cache_if_needed() const
 
     m_cached_document = document;
     m_cached_dom_tree_version = document.dom_tree_version();
+    m_cached_invalidation_version = invalidation_version;
+}
+
+u64 LiveNodeList::invalidation_version(Document const& document) const
+{
+    switch (m_kind) {
+    case Kind::Generic:
+        return 0;
+    case Kind::Labels:
+    case Kind::FormControls:
+        return document.form_associated_custom_element_version();
+    }
+    VERIFY_NOT_REACHED();
 }
 
 Node* LiveNodeList::first_matching(Function<bool(Node const&)> const& filter) const

--- a/Libraries/LibWeb/DOM/LiveNodeList.h
+++ b/Libraries/LibWeb/DOM/LiveNodeList.h
@@ -28,14 +28,20 @@ public:
         Descendants,
     };
 
-    [[nodiscard]] static GC::Ref<NodeList> create(Node const& root, Scope, ESCAPING Function<bool(Node const&)> filter);
+    enum class Kind {
+        Generic,
+        Labels,
+        FormControls,
+    };
+
+    [[nodiscard]] static GC::Ref<NodeList> create(Node const& root, Scope, ESCAPING Function<bool(Node const&)> filter, Kind = Kind::Generic);
     virtual ~LiveNodeList() override;
 
     virtual u32 length() const override;
     virtual Node const* item(u32 index) const override;
 
 protected:
-    LiveNodeList(Node const& root, Scope, ESCAPING Function<bool(Node const&)> filter);
+    LiveNodeList(Node const& root, Scope, ESCAPING Function<bool(Node const&)> filter, Kind = Kind::Generic);
 
     Node* first_matching(Function<bool(Node const&)> const& filter) const;
 
@@ -45,14 +51,17 @@ private:
     virtual GC::Cell const& owner_cell(Badge<GC::Heap>) const override;
 
     void update_cache_if_needed() const;
+    u64 invalidation_version(Document const&) const;
 
     mutable GC::Weak<Document const> m_cached_document;
     mutable u64 m_cached_dom_tree_version { 0 };
+    mutable u64 m_cached_invalidation_version { 0 };
     mutable Vector<GC::RawPtr<Node>> m_cached_nodes;
 
     GC::Ref<Node const> m_root;
     Function<bool(Node const&)> m_filter;
     Scope m_scope { Scope::Descendants };
+    Kind m_kind { Kind::Generic };
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1016,10 +1016,11 @@ GC::Ptr<DOM::NodeList> HTMLElement::labels()
 
     auto& labels = ensure_html_element_rare_data().labels;
     if (!labels) {
-        labels = DOM::LiveNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, [&](DOM::Node const& node) {
+        auto filter = [&](DOM::Node const& node) {
             auto const* label_element = as_if<HTMLLabelElement>(node);
             return label_element && label_element->control().ptr() == this;
-        });
+        };
+        labels = DOM::LiveNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, move(filter), DOM::LiveNodeList::Kind::Labels);
     }
 
     return labels;

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -70,12 +70,13 @@ GC::Ptr<DOM::HTMLCollection> const& HTMLFieldSetElement::elements()
 {
     // The elements IDL attribute must return an HTMLCollection rooted at the fieldset element, whose filter matches listed elements.
     if (!m_elements) {
-        m_elements = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [](DOM::Element const& element) {
+        auto filter = [](DOM::Element const& element) {
             if (auto const* form_associated_element = as_if<FormAssociatedElement>(element); form_associated_element && form_associated_element->is_listed())
                 return true;
 
             return false;
-        });
+        };
+        m_elements = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), nullptr, DOM::HTMLCollection::Kind::FormControls);
     }
     return m_elements;
 }

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
@@ -33,7 +33,7 @@ GC::Ref<HTMLFormControlsCollection> HTMLFormControlsCollection::create(DOM::Pare
 }
 
 HTMLFormControlsCollection::HTMLFormControlsCollection(DOM::ParentNode& root, Scope scope, HTMLFormElement& form, Function<bool(DOM::Element const&)> filter)
-    : DOM::HTMLCollection(root, scope, move(filter))
+    : DOM::HTMLCollection(root, scope, move(filter), nullptr, Kind::FormControls)
     , m_form(form)
 {
 }
@@ -79,13 +79,15 @@ Variant<Empty, GC::Ref<DOM::Element>, GC::Ref<RadioNodeList>> HTMLFormControlsCo
     //    RadioNodeList object are those that have either an id attribute or a name attribute equal to name. The nodes in the RadioNodeList object must be sorted in tree
     //    order. Return that RadioNodeList object.
     auto name_copy = Utf16String::from_utf16(name);
-    return RadioNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, [name = move(name_copy)](auto const& node) {
+    auto filter = [collection = GC::Ref { *this }, name = move(name_copy)](auto const& node) {
         if (!is<DOM::Element>(node))
             return false;
 
         auto const& element = as<DOM::Element>(node);
-        return radio_node_list_element_matches_name(element, radio_node_list_name_view(name));
-    });
+        return collection->element_matches_filter(element)
+            && radio_node_list_element_matches_name(element, radio_node_list_name_view(name));
+    };
+    return RadioNodeList::create(root(), DOM::LiveNodeList::Scope::Descendants, move(filter), DOM::LiveNodeList::Kind::FormControls);
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -1151,7 +1151,7 @@ Variant<Empty, GC::Ref<DOM::Node>, GC::Ref<RadioNodeList>> HTMLFormElement::name
     // 1. Let candidates be a live RadioNodeList object containing all the listed elements, whose form owner is the form
     //    element, that have either an id attribute or a name attribute equal to name, with the exception of input
     //    elements whose type attribute is in the Image Button state, in tree order.
-    auto candidates = RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, [this, name](auto& node) -> bool {
+    auto filter = [this, name](auto& node) -> bool {
         if (!is<DOM::Element>(node))
             return false;
         auto const& element = static_cast<DOM::Element const&>(node);
@@ -1162,7 +1162,8 @@ Variant<Empty, GC::Ref<DOM::Node>, GC::Ref<RadioNodeList>> HTMLFormElement::name
             return false;
 
         return name == element.id() || name == element.name();
-    });
+    };
+    auto candidates = RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, move(filter), DOM::LiveNodeList::Kind::FormControls);
 
     // 2. If candidates is empty, let candidates be a live RadioNodeList object containing all the img elements,
     //    whose form owner is the form element, that have either an id attribute or a name attribute equal to name,

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -84,15 +84,14 @@ void HTMLOptionElement::set_selected(bool selected)
 
 void HTMLOptionElement::set_selected_internal(bool selected)
 {
-    if (m_selected != selected)
+    if (m_selected != selected) {
         CSS::Invalidation::invalidate_style_after_option_selected_state_change(*this, selected);
+        document().bump_option_selectedness_version();
+    }
 
     m_selected = selected;
     if (selected)
         m_selectedness_update_index = m_next_selectedness_update_index++;
-
-    // this is here to invalidate the cache on the HTMLCollection in HTMLSelectElement::selected_options
-    document().bump_dom_tree_version();
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -197,13 +197,14 @@ GC::Ref<DOM::HTMLCollection> HTMLSelectElement::selected_options()
     // The selectedOptions IDL attribute must return an HTMLCollection rooted at the select node,
     // whose filter matches the elements in the list of options that have their selectedness set to true.
     if (!m_selected_options) {
-        m_selected_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [this](Element const& element) {
+        auto filter = [this](Element const& element) {
             auto const* maybe_option = as_if<HTML::HTMLOptionElement>(element);
             if (maybe_option && maybe_option->nearest_select_element().ptr() == this) {
                 return maybe_option->selected();
             }
             return false;
-        });
+        };
+        m_selected_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), nullptr, DOM::HTMLCollection::Kind::SelectedOptions);
     }
     return *m_selected_options;
 }

--- a/Libraries/LibWeb/HTML/RadioNodeList.cpp
+++ b/Libraries/LibWeb/HTML/RadioNodeList.cpp
@@ -13,13 +13,13 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(RadioNodeList);
 
-GC::Ref<RadioNodeList> RadioNodeList::create(DOM::Node const& root, Scope scope, Function<bool(DOM::Node const&)> filter)
+GC::Ref<RadioNodeList> RadioNodeList::create(DOM::Node const& root, Scope scope, Function<bool(DOM::Node const&)> filter, Kind kind)
 {
-    return GC::Heap::the().allocate<RadioNodeList>(root, scope, move(filter));
+    return GC::Heap::the().allocate<RadioNodeList>(root, scope, move(filter), kind);
 }
 
-RadioNodeList::RadioNodeList(DOM::Node const& root, Scope scope, Function<bool(DOM::Node const&)> filter)
-    : DOM::LiveNodeList(root, scope, move(filter))
+RadioNodeList::RadioNodeList(DOM::Node const& root, Scope scope, Function<bool(DOM::Node const&)> filter, Kind kind)
+    : DOM::LiveNodeList(root, scope, move(filter), kind)
 {
 }
 

--- a/Libraries/LibWeb/HTML/RadioNodeList.h
+++ b/Libraries/LibWeb/HTML/RadioNodeList.h
@@ -17,7 +17,7 @@ class RadioNodeList : public DOM::LiveNodeList {
     GC_DECLARE_ALLOCATOR(RadioNodeList);
 
 public:
-    [[nodiscard]] static GC::Ref<RadioNodeList> create(DOM::Node const& root, Scope scope, ESCAPING Function<bool(DOM::Node const&)> filter);
+    [[nodiscard]] static GC::Ref<RadioNodeList> create(DOM::Node const& root, Scope scope, ESCAPING Function<bool(DOM::Node const&)> filter, Kind = Kind::Generic);
 
     virtual ~RadioNodeList() override;
 
@@ -25,7 +25,7 @@ public:
     void set_value(Utf16View);
 
 private:
-    explicit RadioNodeList(DOM::Node const& root, Scope scope, ESCAPING Function<bool(DOM::Node const&)> filter);
+    explicit RadioNodeList(DOM::Node const& root, Scope scope, ESCAPING Function<bool(DOM::Node const&)> filter, Kind);
 };
 
 }

--- a/Tests/LibWeb/Text/expected/DOM/live-collection-cache-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/DOM/live-collection-cache-invalidation.txt
@@ -1,0 +1,11 @@
+labels before upgrade: 1
+labels after upgrade: 0
+
+controls before upgrade: 3, 2, 2, 2
+controls after upgrade: 4, 3, 3, 3
+
+labels during failed upgrade: 0
+labels after failed upgrade: 1
+
+selected options before change: 1
+selected options after change: 1, true

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/fieldset-elements.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/fieldset-elements.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Form associated custom elements should work with fieldset.elements
+1 Pass
+Pass	Form associated custom elements should work with fieldset.elements

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/form-associated-callback.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/form-associated-callback.txt
@@ -2,10 +2,10 @@ Harness status: OK
 
 Found 5 tests
 
-3 Pass
-2 Fail
+4 Pass
+1 Fail
 Pass	Associate by parser, customized at element creation
-Fail	Parsed, connected, then upgraded
+Pass	Parsed, connected, then upgraded
 Pass	Disassociation
 Pass	Updating "form" content attribute
 Fail	Updating "id" attribute of form element

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/form-elements-namedItem.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/form-elements-namedItem.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-1 Pass
-2 Fail
-Fail	Form associated custom elements should work with document.forms.elements.namedItem()
-Fail	Form associated custom elements should work with document.forms.elements.namedItem() after upgrading
+3 Pass
+Pass	Form associated custom elements should work with document.forms.elements.namedItem()
+Pass	Form associated custom elements should work with document.forms.elements.namedItem() after upgrading
 Pass	Form associated custom elements should work with document.forms.elements.namedItem() after updating the name attribute

--- a/Tests/LibWeb/Text/input/DOM/live-collection-cache-invalidation.html
+++ b/Tests/LibWeb/Text/input/DOM/live-collection-cache-invalidation.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        {
+            const label = document.createElement("label");
+            const customElement = document.createElement("cache-label-control");
+            const input = document.createElement("input");
+            label.append(customElement, input);
+            document.body.append(label);
+
+            const labels = input.labels;
+            println(`labels before upgrade: ${labels.length}`);
+
+            customElements.define("cache-label-control", class extends HTMLElement {
+                static formAssociated = true;
+            });
+
+            println(`labels after upgrade: ${labels.length}`);
+        }
+        println("");
+
+        {
+            const form = document.createElement("form");
+            const fieldset = document.createElement("fieldset");
+            const firstInput = document.createElement("input");
+            const secondInput = document.createElement("input");
+            const customElement = document.createElement("cache-form-control");
+            firstInput.name = "control";
+            secondInput.name = "control";
+            customElement.setAttribute("name", "control");
+            fieldset.append(firstInput, secondInput, customElement);
+            form.append(fieldset);
+            document.body.append(form);
+
+            const formElements = form.elements;
+            const fieldsetElements = fieldset.elements;
+            const namedControls = form.control;
+            const namedCollectionControls = formElements.control;
+            println(`controls before upgrade: ${formElements.length}, ${fieldsetElements.length}, ${namedControls.length}, ${namedCollectionControls.length}`);
+
+            customElements.define("cache-form-control", class extends HTMLElement {
+                static formAssociated = true;
+            });
+
+            println(`controls after upgrade: ${formElements.length}, ${fieldsetElements.length}, ${namedControls.length}, ${namedCollectionControls.length}`);
+        }
+        println("");
+
+        {
+            const label = document.createElement("label");
+            const customElement = document.createElement("cache-failed-control");
+            const input = document.createElement("input");
+            label.append(customElement, input);
+            document.body.append(label);
+
+            const labels = input.labels;
+            let labelsLengthDuringUpgrade;
+            removeTestErrorHandler();
+            window.addEventListener("error", event => event.preventDefault(), { once: true });
+
+            customElements.define("cache-failed-control", class extends HTMLElement {
+                static formAssociated = true;
+
+                constructor() {
+                    super();
+                    labelsLengthDuringUpgrade = labels.length;
+                    throw new Error("Expected upgrade failure");
+                }
+            });
+
+            println(`labels during failed upgrade: ${labelsLengthDuringUpgrade}`);
+            println(`labels after failed upgrade: ${labels.length}`);
+        }
+        println("");
+
+        {
+            const select = document.createElement("select");
+            const firstOption = document.createElement("option");
+            const secondOption = document.createElement("option");
+            select.append(firstOption, secondOption);
+
+            const selectedOptions = select.selectedOptions;
+            println(`selected options before change: ${selectedOptions.length}`);
+            secondOption.selected = true;
+            println(`selected options after change: ${selectedOptions.length}, ${selectedOptions[0] === secondOption}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Live collection filters can depend on semantic state that changes without a structural DOM mutation. Give LiveNodeList and HTMLCollection explicit kinds, then key label and form-control caches on form-associated custom element state and selectedOptions caches on option selectedness.

Also preserve the source HTMLFormControlsCollection filter when creating a RadioNodeList. This prevents unresolved custom elements from appearing in named form-control lists before they become form-associated.

Add focused coverage for successful and failed custom element upgrades, form and fieldset collections, retained named lists, selectedness changes, and update the expectations for the newly passing form-associated custom element WPT cases.