### PR TITLE
LibWeb: Resolve table caption preferred widths from computed style

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -2296,15 +2296,6 @@ impl SizingContext {
         }
     }
 
-    pub(crate) fn calculate_inner_inline_width(
-        &self,
-        node: Node,
-        available: AvailableSize,
-        constraints: ContainingBlockConstraints,
-    ) -> CssPixels {
-        self.calculate_inner_inline_size(node, available, self.style(node).width(), constraints)
-    }
-
     pub(crate) fn should_treat_size_as_auto(
         &self,
         node: Node,

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -1777,13 +1777,21 @@ impl TableFormattingContext {
                     + style.margin_right().to_px(basis)
             };
             let mut contribution = outer(self.calculate_min_content_inline_size(caption));
-            if !style.width().is_auto() && !style.width().contains_percentage() {
-                let preferred = self.sizing().calculate_inner_inline_width(
-                    caption,
-                    AvailableSize::definite(basis),
-                    self.participant_constraints,
-                );
+            let width = style.width();
+            if width.is_length_percentage() && !width.contains_percentage() {
+                let mut preferred = width.to_px(basis);
+                if style.box_sizing() == box_sizing::BORDER_BOX {
+                    preferred = subtract_border_box_adjustment(
+                        preferred,
+                        style.border_left_width(),
+                        style.padding_left().to_px(basis),
+                        style.border_right_width(),
+                        style.padding_right().to_px(basis),
+                    );
+                }
                 contribution = contribution.max(outer(preferred));
+            } else if width.is_max_content() {
+                contribution = contribution.max(outer(self.calculate_max_content_inline_size(caption)));
             }
             capmin = capmin.max(contribution);
         }

--- a/Tests/LibWeb/Layout/expected/table/caption-width-contributions.txt
+++ b/Tests/LibWeb/Layout/expected/table/caption-width-contributions.txt
@@ -1,0 +1,83 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 89 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 73 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 100 0+0+684] [0+0+0 31 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,28] table-box [0+0+0 100 0+0+0] [0+0+0 11 0+0+0] [TFC] children: not-inline
+          BlockContainer <caption> at [8,8] [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 9, rect: [13,8 90x10] baseline: 8
+                "AAAA BBBB"
+            frag 1 from TextNode start: 10, length: 4, rect: [38,18 40x10] baseline: 8
+                "CCCC"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,28] table-row-group [0+0+0 100 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+            Box <tr> at [8,28] table-row [0+0+0 100 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+              BlockContainer <td> at [8,28] table-cell [0+0+0 100 0+0+0] [0+0+0 11 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,27 10x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,39] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,39] [0+0+0 140 0+0+644] [0+0+0 21 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,49] table-box [0+0+0 140 0+0+0] [0+0+0 11 0+0+0] [TFC] children: not-inline
+          BlockContainer <caption> at [8,39] [0+0+0 140 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 14, rect: [8,39 140x10] baseline: 8
+                "AAAA BBBB CCCC"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,49] table-row-group [0+0+0 140 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+            Box <tr> at [8,49] table-row [0+0+0 140 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+              BlockContainer <td> at [8,49] table-cell [0+0+0 140 0+0+0] [0+0+0 11 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,48 10x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,60] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,60] [0+0+0 200 0+0+584] [0+0+0 21 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,70] table-box [0+0+0 200 0+0+0] [0+0+0 11 0+0+0] [TFC] children: not-inline
+          BlockContainer <caption> at [28,60] [0+0+20 160 20+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 4, rect: [88,60 40x10] baseline: 8
+                "AAAA"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,70] table-row-group [0+0+0 200 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+            Box <tr> at [8,70] table-row [0+0+0 200 0+0+0] [0+0+0 11 0+0+0] children: not-inline
+              BlockContainer <td> at [8,70] table-cell [0+0+0 200 0+0+0] [0+0+0 11 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,69 10x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,81] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x89]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x73]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 100x31]
+        Paintable (Box<TABLE>) [8,28 100x11]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,8 100x20]
+          Paintable (Box<TBODY>) [8,28 100x11]
+            Paintable (Box<TR>) [8,28 100x11]
+              PaintableWithLines (BlockContainer<TD>) [8,28 100x11]
+      PaintableWithLines (BlockContainer(anonymous)) [8,39 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,39 140x21]
+        Paintable (Box<TABLE>) [8,49 140x11]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,39 140x10]
+          Paintable (Box<TBODY>) [8,49 140x11]
+            Paintable (Box<TR>) [8,49 140x11]
+              PaintableWithLines (BlockContainer<TD>) [8,49 140x11]
+      PaintableWithLines (BlockContainer(anonymous)) [8,60 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,60 200x21]
+        Paintable (Box<TABLE>) [8,70 200x11]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,60 200x10]
+          Paintable (Box<TBODY>) [8,70 200x11]
+            Paintable (Box<TR>) [8,70 200x11]
+              PaintableWithLines (BlockContainer<TD>) [8,70 200x11]
+      PaintableWithLines (BlockContainer(anonymous)) [8,81 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x89] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/caption-width-contributions.html
+++ b/Tests/LibWeb/Layout/input/table/caption-width-contributions.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: 'Ahem';
+    src: url('../../../Ref/data/fonts/Ahem.ttf');
+}
+table {
+    border-spacing: 0;
+    font: 10px/1 Ahem;
+}
+td {
+    padding: 0;
+}
+</style>
+<!-- A fit-content caption contributes its min-content size, so it does not widen the table -->
+<table>
+    <caption style="width: fit-content">AAAA BBBB CCCC</caption>
+    <tr><td style="width: 100px">x</td></tr>
+</table>
+<!-- A max-content caption contributes its max-content size -->
+<table>
+    <caption style="width: max-content">AAAA BBBB CCCC</caption>
+    <tr><td style="width: 100px">x</td></tr>
+</table>
+<!-- A border-box caption width contributes the specified width, not the width plus padding -->
+<table>
+    <caption style="width: 200px; box-sizing: border-box; padding: 0 20px">AAAA</caption>
+    <tr><td style="width: 100px">x</td></tr>
+</table>


### PR DESCRIPTION
Previously, the caption width minimum asked the shared sizing helpers for the caption's inner inline width. Those helpers read used values that only exist for a box that is mid-layout in the current run. Captions are laid out later by the table wrapper, so a caption width whose resolution required those values crashed the process.

The preferred width is now resolved from the computed value, as cell measures already are. A `fit-content` width now contributes the caption's min-content size.

Fixes a crash found by Domato.