### PR TITLE
Make the Rust arena own paintable geometry

### DIFF
--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -304,11 +304,8 @@ RustFFI::FfiReplacedContentFacts Box::build_replaced_content_facts_for_arena() c
     return facts;
 }
 
-void Box::did_set_content_size()
+void Box::notify_content_navigable_of_committed_viewport()
 {
-    if (kind() != RustFFI::NodeKind::NavigableContainerViewport)
-        return;
-
     if (auto content_navigable = as<HTML::NavigableContainer>(*dom_node()).content_navigable()) {
         auto content_size = paintable_box()->content_size();
         as<HTML::LocalNavigable>(*content_navigable).set_viewport_size(content_size);

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -57,7 +57,7 @@ public:
 
     virtual ~Box() override;
 
-    void did_set_content_size();
+    void notify_content_navigable_of_committed_viewport();
     bool has_saved_abspos_layout_inputs() const { return has_flag(RustFFI::NodeFlag::HasSavedAbsposLayoutInputs); }
     bool has_saved_committed_geometry() const { return has_flag(RustFFI::NodeFlag::HasSavedCommittedGeometry); }
     bool saved_abspos_cb_derives_from_own_computed_values() const { return has_flag(RustFFI::NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues); }

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -494,49 +494,12 @@ void LayoutRustBridge::replay_saved_abspos_layout(Box& box)
     }
 }
 
-static CSSPixelPoint committed_content_offset_delta(HashMap<Painting::Paintable const*, CSSPixelPoint> const& content_offsets_before_commit, Painting::Paintable const& paintable)
-{
-    auto content_offset_before_commit = content_offsets_before_commit.get(&paintable);
-    if (!content_offset_before_commit.has_value())
-        return {};
-    return paintable.offset() - *content_offset_before_commit;
-}
-
-// The absolute movement of a reused subtree, accumulated over the same containing-block chain
-// (with the same SVG coordinate-space breaks) that Paintable::compute_absolute_rect walks.
-static CSSPixelPoint committed_absolute_position_delta(HashMap<Painting::Paintable const*, CSSPixelPoint> const& content_offsets_before_commit, Painting::Paintable const& reused_subtree_root)
-{
-    if (reused_subtree_root.is_svg_paintable()) {
-        for (auto const* ancestor = reused_subtree_root.layout_node().parent(); ancestor; ancestor = ancestor->parent()) {
-            if (ancestor->is_svg_svg_box())
-                return committed_content_offset_delta(content_offsets_before_commit, reused_subtree_root);
-        }
-    }
-
-    auto delta = committed_content_offset_delta(content_offsets_before_commit, reused_subtree_root);
-    for (auto block = reused_subtree_root.containing_block(); block; block = block->containing_block()) {
-        if (block->is_svg_svg_paintable() || block->is_svg_paintable())
-            break;
-        delta += committed_content_offset_delta(content_offsets_before_commit, *block);
-        if (block->is_svg_foreign_object_paintable())
-            break;
-    }
-    return delta;
-}
-
 RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
 {
     return {
         .context = this,
         .finish_commit = [](void* context) {
             auto& bridge = *static_cast<LayoutRustBridge*>(context);
-            for (auto& reused_subtree_root : bridge.m_reused_subtree_roots) {
-                auto delta = committed_absolute_position_delta(bridge.m_content_offsets_before_commit, *reused_subtree_root);
-                if (!delta.is_zero())
-                    reused_subtree_root->translate_reused_subtree_absolute_geometry(delta);
-            }
-            bridge.m_reused_subtree_roots.clear();
-            bridge.m_content_offsets_before_commit.clear();
             for (auto& navigable_container_viewport : bridge.m_committed_navigable_container_viewports)
                 as<Box>(navigable_container_viewport->layout_node()).notify_content_navigable_of_committed_viewport();
             bridge.m_committed_navigable_container_viewports.clear(); },
@@ -550,11 +513,8 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                 // Inline boxes that never went through inline layout (so they have no used values) still
                 // need a paintable so DOM geometry queries have something to answer from.
                 paintable = node.paintable();
-                if (paintable)
-                    bridge.m_content_offsets_before_commit.set(paintable.ptr(), paintable->offset());
                 if (reuses_committed_subtree) {
                     VERIFY(paintable);
-                    bridge.m_reused_subtree_roots.append(*paintable);
                 } else if (paintable) {
                     paintable->reset_for_relayout();
                     reused = true;

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -536,7 +536,10 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                     reused_subtree_root->translate_reused_subtree_absolute_geometry(delta);
             }
             bridge.m_reused_subtree_roots.clear();
-            bridge.m_content_offsets_before_commit.clear(); },
+            bridge.m_content_offsets_before_commit.clear();
+            for (auto& navigable_container_viewport : bridge.m_committed_navigable_container_viewports)
+                as<Box>(navigable_container_viewport->layout_node()).notify_content_navigable_of_committed_viewport();
+            bridge.m_committed_navigable_container_viewports.clear(); },
         .prepare_node = [](void* context, void* node_pointer, bool has_used_values, bool reuses_committed_subtree) -> RustFFI::FfiPreparedPaintable {
             auto& bridge = *static_cast<LayoutRustBridge*>(context);
             auto& node = *static_cast<Node*>(node_pointer);
@@ -559,6 +562,8 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                     paintable = node.create_paintable();
                 }
                 node.set_paintable(paintable);
+                if (node.kind() == RustFFI::NodeKind::NavigableContainerViewport && paintable)
+                    bridge.m_committed_navigable_container_viewports.append(*paintable);
             } else if (node.paintable_ptr()) {
                 // A paintable surviving from a previous layout on a node this pass did not lay out is
                 // stale; drop it so the layout tree only points into the paint tree built by this commit.
@@ -570,20 +575,12 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                 .reused = reused,
             };
         },
-        .set_box_metrics = [](void*, void* paintable_pointer, RustFFI::FfiCommittedBoxMetrics metrics) {
+        .content_size_changed = [](void*, void* paintable_pointer, RustFFI::FfiCssPixelSize old_size, RustFFI::FfiCssPixelSize new_size) {
             auto& paintable = *static_cast<Painting::Paintable*>(paintable_pointer);
-            paintable.set_offset({
-                CSSPixels::from_raw(metrics.content_offset.x),
-                CSSPixels::from_raw(metrics.content_offset.y),
-            });
-            CSSPixelSize content_size {
-                CSSPixels::from_raw(metrics.content_inline_size),
-                CSSPixels::from_raw(metrics.content_block_size)
-            };
-            if (metrics.reuses_committed_subtree)
-                VERIFY(paintable.content_size() == content_size);
-            else
-                paintable.set_content_size(content_size); },
+            Painting::invalidate_descendant_styles_for_container_query_size_change(
+                paintable,
+                { CSSPixels::from_raw(old_size.width), CSSPixels::from_raw(old_size.height) },
+                { CSSPixels::from_raw(new_size.width), CSSPixels::from_raw(new_size.height) }); },
         .finish_node = [](void*, void* node_pointer, void* paintable_pointer) {
             auto& node = *static_cast<Node*>(node_pointer);
             auto* paintable = static_cast<Painting::Paintable*>(paintable_pointer);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -589,7 +589,6 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                 paintable->set_dom_node(dom_node);
                 if (dom_node)
                     dom_node->set_paintable(paintable);
-                paintable->invalidate_absolute_geometry_cache(Painting::Paintable::InvalidateDescendantGeometry::No);
             } else if (dom_node) {
                 dom_node->clear_paintable();
             } },

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -51,6 +51,7 @@ private:
 
     Box const* m_commit_root { nullptr };
     Vector<NonnullRefPtr<Painting::Paintable>> m_reused_subtree_roots;
+    Vector<NonnullRefPtr<Painting::Paintable>> m_committed_navigable_container_viewports;
     // Content offsets of the paintables surviving into this commit, captured before the
     // commit overwrites them; finish_commit derives each reused subtree's absolute movement
     // from these instead of reading absolute rects mid-commit, when ancestor offsets are

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
@@ -50,13 +49,7 @@ private:
     [[nodiscard]] RustFFI::FfiCommitSink commit_sink();
 
     Box const* m_commit_root { nullptr };
-    Vector<NonnullRefPtr<Painting::Paintable>> m_reused_subtree_roots;
     Vector<NonnullRefPtr<Painting::Paintable>> m_committed_navigable_container_viewports;
-    // Content offsets of the paintables surviving into this commit, captured before the
-    // commit overwrites them; finish_commit derives each reused subtree's absolute movement
-    // from these instead of reading absolute rects mid-commit, when ancestor offsets are
-    // already new and any cached absolute position may be stale or missing.
-    HashMap<Painting::Paintable const*, CSSPixelPoint> m_content_offsets_before_commit;
 };
 
 [[nodiscard]] Optional<RustFFI::FfiFormattingContextType> formatting_context_type_created_by_box(Box const&);

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -63,26 +63,6 @@ CSSPixelPoint InlinePaintable::box_type_agnostic_position() const
     return { CSSPixels::from_raw(result.x), CSSPixels::from_raw(result.y) };
 }
 
-static CSSPixelRect from_ffi_css_pixel_rect(Layout::RustFFI::FfiCssPixelRect const& rect)
-{
-    return {
-        CSSPixels::from_raw(rect.x),
-        CSSPixels::from_raw(rect.y),
-        CSSPixels::from_raw(rect.width),
-        CSSPixels::from_raw(rect.height),
-    };
-}
-
-CSSPixelRect InlinePaintable::compute_absolute_padding_box_rect() const
-{
-    return from_ffi_css_pixel_rect(rust_data().local_padding_box_union).translated(absolute_rect().location());
-}
-
-CSSPixelRect InlinePaintable::compute_absolute_border_box_rect() const
-{
-    return from_ffi_css_pixel_rect(rust_data().local_border_box_union).translated(absolute_rect().location());
-}
-
 bool InlinePaintable::has_content() const
 {
     // Interrupting block-in-inline children produce only placeholder pieces, so any child

--- a/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -33,9 +33,6 @@ public:
 private:
     explicit InlinePaintable(Layout::NodeWithStyle const&);
 
-    virtual CSSPixelRect compute_absolute_padding_box_rect() const override;
-    virtual CSSPixelRect compute_absolute_border_box_rect() const override;
-
     bool has_content_pieces() const;
 
 public:

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1015,16 +1015,6 @@ void Paintable::scroll_into_view(CSSPixelRect rect)
     set_scroll_offset(new_offset);
 }
 
-void Paintable::translate_reused_subtree_absolute_geometry(CSSPixelPoint delta)
-{
-    for_each_in_inclusive_subtree([&](Paintable& paintable) {
-        Layout::RustFFI::layout_arena_paintable_translate_scrollable_overflow(paintable.m_rust_arena->handle(), paintable.m_rust_slot, { delta.x().raw_value(), delta.y().raw_value() });
-        // Recorded paint commands bake absolute coordinates.
-        paintable.invalidate_paint_cache();
-        return TraversalDecision::Continue;
-    });
-}
-
 CSSPixelPoint Paintable::offset() const
 {
     return { CSSPixels::from_raw(rust_data().offset.x), CSSPixels::from_raw(rust_data().offset.y) };

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -803,8 +803,6 @@ void Paintable::reset_for_relayout()
     // (e.g. scrollbars on a scroll container) is only known after the new layout is painted.
     detach_chrome_widgets();
 
-    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
-
     invalidate_stacking_context();
 }
 
@@ -1017,25 +1015,9 @@ void Paintable::scroll_into_view(CSSPixelRect rect)
     set_scroll_offset(new_offset);
 }
 
-void Paintable::invalidate_absolute_geometry_cache(InvalidateDescendantGeometry invalidate_descendants)
-{
-    m_absolute_rect.clear();
-    m_absolute_padding_box_rect.clear();
-    m_absolute_border_box_rect.clear();
-
-    if (invalidate_descendants == InvalidateDescendantGeometry::No)
-        return;
-
-    for_each_child_of_type<Paintable>([](auto& child) {
-        child.invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::Yes);
-        return IterationDecision::Continue;
-    });
-}
-
 void Paintable::translate_reused_subtree_absolute_geometry(CSSPixelPoint delta)
 {
     for_each_in_inclusive_subtree([&](Paintable& paintable) {
-        paintable.invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
         Layout::RustFFI::layout_arena_paintable_translate_scrollable_overflow(paintable.m_rust_arena->handle(), paintable.m_rust_slot, { delta.x().raw_value(), delta.y().raw_value() });
         // Recorded paint commands bake absolute coordinates.
         paintable.invalidate_paint_cache();
@@ -1048,54 +1030,14 @@ CSSPixelPoint Paintable::offset() const
     return { CSSPixels::from_raw(rust_data().offset.x), CSSPixels::from_raw(rust_data().offset.y) };
 }
 
-CSSPixelRect Paintable::compute_absolute_rect() const
-{
-    if (is_svg_paintable()) {
-        // SVG content geometry lives in the user space of the nearest ancestor viewport, and layout
-        // places every box viewport-relative already, so no ancestor offsets accumulate.
-        for (auto const* ancestor = layout_node().parent(); ancestor; ancestor = ancestor->parent()) {
-            if (ancestor->is_svg_svg_box())
-                return { offset(), content_size() };
-        }
-    }
-
-    CSSPixelRect rect { offset(), content_size() };
-    for (auto block = containing_block(); block; block = block->containing_block()) {
-        // SVG content offsets are viewport-relative: accumulation never crosses into an enclosing
-        // SVG coordinate space, and a foreignObject's own offset is the last one that applies to
-        // the CSS content inside it.
-        if (block->is_svg_svg_paintable() || block->is_svg_paintable())
-            break;
-        rect.translate_by(block->offset());
-        if (block->is_svg_foreign_object_paintable())
-            break;
-    }
-    return rect;
-}
-
 CSSPixelRect Paintable::absolute_rect() const
 {
-    if (!m_absolute_rect.has_value())
-        m_absolute_rect = compute_absolute_rect();
-    return *m_absolute_rect;
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_rect(m_rust_arena->handle(), m_rust_slot));
 }
 
 CSSPixelRect Paintable::absolute_padding_box_rect() const
 {
-    if (!m_absolute_padding_box_rect.has_value())
-        m_absolute_padding_box_rect = compute_absolute_padding_box_rect();
-    return *m_absolute_padding_box_rect;
-}
-
-CSSPixelRect Paintable::compute_absolute_padding_box_rect() const
-{
-    auto absolute_rect = this->absolute_rect();
-    CSSPixelRect rect;
-    rect.set_x(absolute_rect.x() - box_model().padding.left);
-    rect.set_width(content_width() + box_model().padding.left + box_model().padding.right);
-    rect.set_y(absolute_rect.y() - box_model().padding.top);
-    rect.set_height(content_height() + box_model().padding.top + box_model().padding.bottom);
-    return rect;
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_padding_box_rect(m_rust_arena->handle(), m_rust_slot));
 }
 
 Optional<CSSPixelRect> Paintable::absolute_resizer_rect(ChromeMetrics const& metrics) const
@@ -1110,32 +1052,7 @@ Optional<CSSPixelRect> Paintable::absolute_resizer_rect(ChromeMetrics const& met
 
 CSSPixelRect Paintable::absolute_border_box_rect() const
 {
-    if (!m_absolute_border_box_rect.has_value())
-        m_absolute_border_box_rect = compute_absolute_border_box_rect();
-    return *m_absolute_border_box_rect;
-}
-
-CSSPixelRect Paintable::compute_absolute_border_box_rect() const
-{
-    auto padded_rect = this->absolute_padding_box_rect();
-    CSSPixelRect rect;
-    auto use_collapsing_borders_model = uses_collapsing_borders_model();
-    // Implement the collapsing border model https://www.w3.org/TR/CSS22/tables.html#collapsing-borders.
-    auto border_top = box_model().border.top;
-    auto border_bottom = box_model().border.bottom;
-    auto border_left = box_model().border.left;
-    auto border_right = box_model().border.right;
-    if (use_collapsing_borders_model) {
-        border_top = round(border_top / 2);
-        border_bottom = round(border_bottom / 2);
-        border_left = round(border_left / 2);
-        border_right = round(border_right / 2);
-    }
-    rect.set_x(padded_rect.x() - border_left);
-    rect.set_width(padded_rect.width() + border_left + border_right);
-    rect.set_y(padded_rect.y() - border_top);
-    rect.set_height(padded_rect.height() + border_top + border_bottom);
-    return rect;
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_border_box_rect(m_rust_arena->handle(), m_rust_slot));
 }
 
 RefPtr<Scrollbar> Paintable::scrollbar(ScrollDirection direction) const

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -481,7 +481,7 @@ static bool content_size_change_affects_container_queries(Paintable const& paint
     return old_size.height() != new_size.height();
 }
 
-static void invalidate_descendant_styles_for_container_query_size_change(Paintable& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
+void invalidate_descendant_styles_for_container_query_size_change(Paintable& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
 {
     if (!content_size_change_affects_container_queries(paintable_box, old_size, new_size))
         return;
@@ -1015,25 +1015,6 @@ void Paintable::scroll_into_view(CSSPixelRect rect)
         new_offset.set_y(content_rect.top());
 
     set_scroll_offset(new_offset);
-}
-
-void Paintable::set_offset(CSSPixelPoint offset)
-{
-    if (this->offset() == offset)
-        return;
-
-    rust_data().offset = { offset.x().raw_value(), offset.y().raw_value() };
-    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::Yes);
-}
-
-void Paintable::set_content_size(CSSPixelSize size)
-{
-    auto old_size = content_size();
-    rust_data().content_size = { size.width().raw_value(), size.height().raw_value() };
-    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
-    if (auto layout_box = as_if<Layout::Box>(layout_node()))
-        layout_box->did_set_content_size();
-    invalidate_descendant_styles_for_container_query_size_change(*this, old_size, size);
 }
 
 void Paintable::invalidate_absolute_geometry_cache(InvalidateDescendantGeometry invalidate_descendants)

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -509,13 +509,9 @@ public:
     Optional<CSSPixelRect> absolute_resizer_rect(ChromeMetrics const& chrome_metrics) const;
 
 private:
-    friend class Layout::LayoutRustBridge;
-
     void detach_from_layout_node(Badge<Layout::Node>);
     void detach_chrome_widgets();
     GC::Ptr<DOM::EventTarget> scroll_event_target();
-
-    void translate_reused_subtree_absolute_geometry(CSSPixelPoint);
 
     bool has_flag(Layout::RustFFI::PaintableFlag flag) const { return (rust_data().flags & to_underlying(flag)) != 0; }
     Layout::RustFFI::PaintableData& rust_data() { return *m_rust_data; }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -503,10 +503,6 @@ protected:
 
 public:
 protected:
-    CSSPixelRect compute_absolute_rect() const;
-    virtual CSSPixelRect compute_absolute_padding_box_rect() const;
-    virtual CSSPixelRect compute_absolute_border_box_rect() const;
-
     CSSPixels available_scrollbar_length(ScrollDirection direction, ChromeMetrics const& chrome_metrics) const;
 
 public:
@@ -515,16 +511,10 @@ public:
 private:
     friend class Layout::LayoutRustBridge;
 
-    enum class InvalidateDescendantGeometry {
-        No,
-        Yes,
-    };
-
     void detach_from_layout_node(Badge<Layout::Node>);
     void detach_chrome_widgets();
     GC::Ptr<DOM::EventTarget> scroll_event_target();
 
-    void invalidate_absolute_geometry_cache(InvalidateDescendantGeometry);
     void translate_reused_subtree_absolute_geometry(CSSPixelPoint);
 
     bool has_flag(Layout::RustFFI::PaintableFlag flag) const { return (rust_data().flags & to_underlying(flag)) != 0; }
@@ -538,10 +528,6 @@ private:
     Layout::RustFFI::PaintableSlotId m_rust_slot {};
     u32 m_rust_slot_generation { 0 };
     Layout::RustFFI::PaintableData* m_rust_data { nullptr };
-
-    Optional<CSSPixelRect> mutable m_absolute_rect;
-    Optional<CSSPixelRect> mutable m_absolute_padding_box_rect;
-    Optional<CSSPixelRect> mutable m_absolute_border_box_rect;
 
     ResolvedCSSFilter m_filter;
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -64,6 +64,8 @@ WEB_API Gfx::FloatRect svg_viewport_user_rect(Paintable const& viewport_paintabl
 
 bool body_background_is_propagated_to_root(Layout::NodeWithStyle const&);
 
+void invalidate_descendant_styles_for_container_query_size_change(Paintable&, CSSPixelSize old_content_size, CSSPixelSize new_content_size);
+
 // Used grid track data captured at layout time as plain values; getComputedStyle
 // reflection mints style values from it on demand.
 struct UsedGridTrackList {
@@ -358,15 +360,7 @@ public:
     ScrollHandled scroll_by(double delta_x, double delta_y);
     void scroll_into_view(CSSPixelRect);
 
-    void set_offset(CSSPixelPoint);
-    void set_offset(float x, float y) { set_offset({ x, y }); }
-
     CSSPixelSize content_size() const;
-    void set_content_size(CSSPixelSize);
-    void set_content_size(CSSPixels width, CSSPixels height) { set_content_size({ width, height }); }
-
-    void set_content_width(CSSPixels width) { set_content_size(width, content_height()); }
-    void set_content_height(CSSPixels height) { set_content_size(content_width(), height); }
     CSSPixels content_width() const { return content_size().width(); }
     CSSPixels content_height() const { return content_size().height(); }
 

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -64,7 +64,8 @@ pub struct FfiCommitSink {
     pub context: *mut c_void,
     pub finish_commit: unsafe extern "C" fn(*mut c_void),
     pub prepare_node: unsafe extern "C" fn(*mut c_void, *mut c_void, bool, bool) -> crate::painting::paintable_build::FfiPreparedPaintable,
-    pub set_box_metrics: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCommittedBoxMetrics),
+    pub content_size_changed:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, crate::layout::FfiCssPixelSize, crate::layout::FfiCssPixelSize),
     pub finish_node: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
 }
 
@@ -172,12 +173,14 @@ fn commit_subtree(
             has_containing_line_box_index: link.containing_line_box_index.is_some(),
             uses_collapsing_borders_model: fragment.uses_collapsing_borders_model,
         };
-        // SAFETY: Every callback below copies its plain-data argument or
-        // consumes one retained handle synchronously.
-        unsafe {
-            (sink.set_box_metrics)(sink.context, paintable, box_metrics);
+        let content_size_change = paintables.set_box_metrics(paintable_slot, &box_metrics);
+        if let Some((old_content_size, new_content_size)) = content_size_change {
+            // SAFETY: Every callback below copies its plain-data argument or
+            // consumes one retained handle synchronously.
+            unsafe {
+                (sink.content_size_changed)(sink.context, paintable, old_content_size, new_content_size);
+            }
         }
-        paintables.set_box_metrics(paintable_slot, &box_metrics);
 
         if !reuses_committed_subtree && let Some(line_data) = &fragment.line_data {
             has_pending_inline_box_geometry = paintables.set_line_data(paintable_slot, line_data, fragment.content_inline_size);

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -284,6 +284,7 @@ pub(crate) fn commit_replacing(
         &paintables,
         &mut scopes,
     );
+    paintables.translate_reused_subtrees();
     paintables.discard_absolute_rects_memoized_during_commit();
     unsafe {
         (sink.finish_commit)(sink.context);

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -284,6 +284,7 @@ pub(crate) fn commit_replacing(
         &paintables,
         &mut scopes,
     );
+    paintables.discard_absolute_rects_memoized_during_commit();
     unsafe {
         (sink.finish_commit)(sink.context);
     }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -284,6 +284,60 @@ pub unsafe extern "C" fn layout_arena_paintable_translate_scrollable_overflow(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_absolute_rect(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiCssPixelRect {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelRect::default();
+        }
+        crate::painting::paintable_geometry::absolute_rect(&paintables, slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_absolute_padding_box_rect(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiCssPixelRect {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelRect::default();
+        }
+        crate::painting::paintable_geometry::absolute_padding_box_rect(&paintables, slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_absolute_border_box_rect(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiCssPixelRect {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelRect::default();
+        }
+        crate::painting::paintable_geometry::absolute_border_box_rect(&paintables, slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxes(
     arena: *mut c_void,
     root: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -261,29 +261,6 @@ pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_translate_scrollable_overflow(
-    arena: *mut c_void,
-    slot: PaintableSlotId,
-    delta: FfiCssPixelPoint,
-) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintables = arena.paintables().borrow();
-        if paintables.is_live(slot) {
-            paintables.update_data(slot, |data| {
-                if data.has_overflow {
-                    data.overflow.rect.x += delta.x;
-                    data.overflow.rect.y += delta.y;
-                }
-            });
-        }
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_absolute_rect(
     arena: *mut c_void,
     slot: PaintableSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -283,8 +283,13 @@ impl<'a> PaintableCommit<'a> {
         slot
     }
 
-    pub(crate) fn set_box_metrics(&self, slot: PaintableSlotId, metrics: &FfiCommittedBoxMetrics) {
+    pub(crate) fn set_box_metrics(
+        &self,
+        slot: PaintableSlotId,
+        metrics: &FfiCommittedBoxMetrics,
+    ) -> Option<(FfiCssPixelSize, FfiCssPixelSize)> {
         let arena = self.arena.borrow();
+        let mut content_size_change = None;
         arena.update_data(slot, |data| {
             if data.layout_fragment_identity != metrics.fragment_identity {
                 data.layout_fragment_identity = metrics.fragment_identity;
@@ -315,10 +320,18 @@ impl<'a> PaintableCommit<'a> {
                 bottom: metrics.margin_bottom,
                 left: metrics.margin_left,
             };
-            data.content_size = FfiCssPixelSize {
+            let new_content_size = FfiCssPixelSize {
                 width: metrics.content_inline_size,
                 height: metrics.content_block_size,
             };
+            if data.content_size != new_content_size {
+                assert!(
+                    !metrics.reuses_committed_subtree,
+                    "a reused committed subtree changed its content size"
+                );
+                content_size_change = Some((data.content_size, new_content_size));
+            }
+            data.content_size = new_content_size;
             data.offset = metrics.content_offset;
             if metrics.has_containing_line_box_index {
                 data.containing_line_box_index = metrics.containing_line_box_index;
@@ -326,6 +339,7 @@ impl<'a> PaintableCommit<'a> {
             }
             data.uses_collapsing_borders_model = metrics.uses_collapsing_borders_model;
         });
+        content_size_change
     }
 
     pub(crate) fn set_line_data(

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -74,9 +74,54 @@ pub(crate) fn paintable_kind_for_node(facts: &NodeFacts<'_>, kind: NodeKind) -> 
     }
 }
 
+fn committed_offset_delta(
+    arena: &PaintableArena,
+    offsets_before_commit: &std::collections::HashMap<PaintableSlotId, FfiCssPixelPoint>,
+    slot: PaintableSlotId,
+) -> FfiCssPixelPoint {
+    let Some(offset_before_commit) = offsets_before_commit.get(&slot) else {
+        return FfiCssPixelPoint::default();
+    };
+    let offset = arena.data_ref(slot).offset;
+    FfiCssPixelPoint {
+        x: offset.x - offset_before_commit.x,
+        y: offset.y - offset_before_commit.y,
+    }
+}
+
+fn reused_subtree_absolute_position_delta(
+    arena: &PaintableArena,
+    offsets_before_commit: &std::collections::HashMap<PaintableSlotId, FfiCssPixelPoint>,
+    root: PaintableSlotId,
+) -> FfiCssPixelPoint {
+    let mut delta = committed_offset_delta(arena, offsets_before_commit, root);
+    if crate::painting::paintable_geometry::is_svg_paintable(arena.data_ref(root).kind) {
+        return delta;
+    }
+    let mut block = arena.data_ref(root).containing_block;
+    while !block.is_invalid() && arena.is_live(block) {
+        let block_data = arena.data_ref(block);
+        if block_data.kind == PaintableKind::SVGSVGPaintable
+            || crate::painting::paintable_geometry::is_svg_paintable(block_data.kind)
+        {
+            break;
+        }
+        let block_delta = committed_offset_delta(arena, offsets_before_commit, block);
+        delta.x += block_delta.x;
+        delta.y += block_delta.y;
+        if block_data.kind == PaintableKind::SVGForeignObjectPaintable {
+            break;
+        }
+        block = block_data.containing_block;
+    }
+    delta
+}
+
 pub(crate) struct PaintableCommit<'a> {
     callbacks: &'a FfiLayoutFcCallbacks,
     arena: &'a RefCell<PaintableArena>,
+    offsets_before_commit: RefCell<std::collections::HashMap<PaintableSlotId, FfiCssPixelPoint>>,
+    reused_subtree_roots: RefCell<Vec<PaintableSlotId>>,
 }
 
 impl<'a> PaintableCommit<'a> {
@@ -84,11 +129,37 @@ impl<'a> PaintableCommit<'a> {
         Self {
             callbacks,
             arena: callbacks.arena().paintables(),
+            offsets_before_commit: RefCell::new(std::collections::HashMap::new()),
+            reused_subtree_roots: RefCell::new(Vec::new()),
         }
     }
 
     pub(crate) fn discard_absolute_rects_memoized_during_commit(&self) {
         self.arena.borrow().clear_absolute_rect_memo();
+    }
+
+    pub(crate) fn translate_reused_subtrees(&self) {
+        let roots = self.reused_subtree_roots.borrow();
+        if roots.is_empty() {
+            return;
+        }
+        let arena = self.arena.borrow();
+        let offsets_before_commit = self.offsets_before_commit.borrow();
+        for &root in roots.iter() {
+            let delta = reused_subtree_absolute_position_delta(&arena, &offsets_before_commit, root);
+            if delta == FfiCssPixelPoint::default() {
+                continue;
+            }
+            arena.for_each_in_subtree(root, |slot| {
+                arena.update_data(slot, |data| {
+                    if data.has_overflow {
+                        data.overflow.rect.x += delta.x;
+                        data.overflow.rect.y += delta.y;
+                    }
+                });
+                arena.invalidate_paint_cache(slot);
+            });
+        }
     }
 
     pub(crate) fn begin_commit(&self, root: Node) -> CommitAnchors {
@@ -216,6 +287,10 @@ impl<'a> PaintableCommit<'a> {
                 "reused subtree root is not the node's own paintable"
             );
             debug_assert!(!prepared.reused, "a kept subtree's shell must not have been reset");
+            self.offsets_before_commit
+                .borrow_mut()
+                .insert(slot, arena.data_ref(slot).offset);
+            self.reused_subtree_roots.borrow_mut().push(slot);
             arena.remove_from_tree(slot);
             return slot;
         }
@@ -244,6 +319,9 @@ impl<'a> PaintableCommit<'a> {
                 slot,
                 "reused paintable is not the node's own"
             );
+            self.offsets_before_commit
+                .borrow_mut()
+                .insert(slot, arena.data_ref(slot).offset);
             arena.reset_for_relayout(slot);
         } else {
             arena.update_data(slot, |paintable| {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -87,6 +87,10 @@ impl<'a> PaintableCommit<'a> {
         }
     }
 
+    pub(crate) fn discard_absolute_rects_memoized_during_commit(&self) {
+        self.arena.borrow().clear_absolute_rect_memo();
+    }
+
     pub(crate) fn begin_commit(&self, root: Node) -> CommitAnchors {
         let arena = self.arena.borrow();
         arena.clear_absolute_rect_memo();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -31,6 +31,10 @@ pub fn absolute_rect(arena: &PaintableArena, slot: PaintableSlotId) -> CssPixelR
     }
     let data = arena.data_ref(slot);
     let mut rect = CssPixelRect::from_location_and_size(data.offset.into(), data.content_size.into());
+    if is_svg_paintable(data.kind) {
+        arena.memoize_absolute_rect(slot, rect);
+        return rect;
+    }
     let mut block = data.containing_block;
     while !block.is_invalid() && arena.is_live(block) {
         let block_data = arena.data_ref(block);


### PR DESCRIPTION
Layout commit wrote each box's offset and content size twice (from C++ and from the Rust commit), and absolute rect computation existed as two hand-synchronized implementations with separate caches. This series makes the Rust commit the only writer of box metrics and paintable_geometry the only absolute-rect implementation, deleting the C++ caches, compute walks, invalidation machinery and the reused-subtree delta mirror. Along the way it fixes page_did_update_child_frame_viewport sending containing-block-relative rects (it fired before containing blocks were stamped) and unifies the SVG rule where painted mask content under a <foreignObject> referencer disagreed with DOM APIs.