### PR TITLE
Make dead-key composing of characters like ü work in Discord.com etc., by reporting input-method state for contenteditable/designMode

### DIFF
--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2130,6 +2130,31 @@ void ConnectionFromClient::update_input_method_state(u64 page_id)
                 text_before_cursor = Utf16String::from_utf16(value.substring_view(text_before_start, cursor - text_before_start));
                 text_after_cursor = Utf16String::from_utf16(value.substring_view(cursor, text_after_length));
             }
+        } else if (auto focused_area = document->focused_area(); focused_area && focused_area->is_editable_or_editing_host()) {
+            // The focused area is contenteditable, or a document with designMode enabled. Qt answers Qt::ImEnabled from
+            // this. While it's false, no composition begins: A dead key would be dropped before the engine ever saw it.
+            is_enabled = true;
+
+            // Approximate the surrounding text as the contents of the Text node containing the selection focus. This
+            // reports exactly the text a replacement request can reach. With the caret between elements, an empty
+            // context is reported: Composition still works — but the input method just gets no surrounding text.
+            if (auto selection = document->get_selection()) {
+                if (auto const* text_node = as_if<Web::DOM::Text>(selection->focus_node().ptr())) {
+                    auto const& data = text_node->data();
+                    auto data_length = data.length_in_code_units();
+                    auto cursor = min(static_cast<size_t>(selection->focus_offset()), data_length);
+                    auto anchor = selection->anchor_node() == selection->focus_node()
+                        ? min(static_cast<size_t>(selection->anchor_offset()), data_length)
+                        : cursor;
+                    auto text_before_start = cursor > maximum_input_method_surrounding_text_length ? cursor - maximum_input_method_surrounding_text_length : 0;
+                    auto text_after_length = min(data_length - cursor, maximum_input_method_surrounding_text_length);
+
+                    cursor_position = AK::clamp_to<i32>(cursor);
+                    anchor_position = AK::clamp_to<i32>(anchor);
+                    text_before_cursor = Utf16String::from_utf16(data.substring_view(text_before_start, cursor - text_before_start));
+                    text_after_cursor = Utf16String::from_utf16(data.substring_view(cursor, text_after_length));
+                }
+            }
         }
     }
 

--- a/Tests/LibWebView/TestInputMethodState.cpp
+++ b/Tests/LibWebView/TestInputMethodState.cpp
@@ -113,6 +113,91 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     VERIFY(!observed_state.is_enabled);
     VERIFY(observed_state.text_before_cursor.is_empty());
 
+    // Editing hosts must report IME state too: The Qt UI refuses to start composition at all when ImEnabled is false —
+    // which drops input from dead keys and IMEs into contenteditable editors entirely (#11182). The state values are
+    // derived from the DOM selection; the surrounding text is the content of the Text node holding the selection focus.
+    view->load_html("<!DOCTYPE html><div contenteditable>abc</div>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 3; });
+
+    view->run_javascript("document.querySelector('div').focus(); getSelection().collapse(document.querySelector('div').firstChild, 2)"_string);
+
+    // Unmarking with no composition in progress leaves the page alone, but still pushes fresh IME state.
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 4; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 2);
+    VERIFY(observed_state.anchor_position == 2);
+    VERIFY(observed_state.text_before_cursor == "ab"_utf16);
+    VERIFY(observed_state.text_after_cursor == "c"_utf16);
+
+    // Committing composes into the editing host; the pushed state reflects the mutated Text node.
+    view->commit_text_from_input_method("ü"_utf16);
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 5; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 3);
+    VERIFY(observed_state.text_before_cursor == "abü"_utf16);
+    VERIFY(observed_state.text_after_cursor == "c"_utf16);
+
+    // A range selection within one Text node reports the focus as the cursor and the anchor separately.
+    view->run_javascript("getSelection().setBaseAndExtent(document.querySelector('div').firstChild, 1, document.querySelector('div').firstChild, 3)"_string);
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 6; });
+    VERIFY(observed_state.cursor_position == 3);
+    VERIFY(observed_state.anchor_position == 1);
+    VERIFY(observed_state.text_before_cursor == "abü"_utf16);
+    VERIFY(observed_state.text_after_cursor == "c"_utf16);
+
+    // A selection whose anchor lies in a different node is reported as collapsed at the cursor.
+    view->load_html("<!DOCTYPE html><div contenteditable><b>xy</b>zw</div>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 4; });
+    view->run_javascript("document.querySelector('div').focus(); getSelection().setBaseAndExtent(document.querySelector('b').firstChild, 1, document.querySelector('div').lastChild, 1)"_string);
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 7; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 1);
+    VERIFY(observed_state.anchor_position == 1);
+    VERIFY(observed_state.text_before_cursor == "z"_utf16);
+    VERIFY(observed_state.text_after_cursor == "w"_utf16);
+
+    // An empty editing host is still IME-enabled, with no surrounding text to draw context from.
+    view->load_html("<!DOCTYPE html><div contenteditable></div>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 5; });
+    view->run_javascript("document.querySelector('div').focus()"_string);
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 8; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 0);
+    VERIFY(observed_state.anchor_position == 0);
+    VERIFY(observed_state.text_before_cursor.is_empty());
+    VERIFY(observed_state.text_after_cursor.is_empty());
+
+    // Composing into it creates the Text node; the pushed state reflects it.
+    view->commit_text_from_input_method("あ"_utf16);
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 9; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 1);
+    VERIFY(observed_state.text_before_cursor == "あ"_utf16);
+
+    // designMode makes the document an editing host.
+    view->load_html("<!DOCTYPE html><p>hi</p>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 6; });
+    view->run_javascript("document.designMode = 'on'; getSelection().collapse(document.querySelector('p').firstChild, 2)"_string);
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 10; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 2);
+    VERIFY(observed_state.text_before_cursor == "hi"_utf16);
+    VERIFY(observed_state.text_after_cursor.is_empty());
+
+    // A focused element that's not editable must not enable the IME.
+    view->load_html("<!DOCTYPE html><div tabindex=\"0\">plain</div>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 7; });
+    view->run_javascript("document.querySelector('div').focus()"_string);
+    view->unmark_text_from_input_method();
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 11; });
+    VERIFY(!observed_state.is_enabled);
+    VERIFY(observed_state.text_before_cursor.is_empty());
+
     outln("PASS: every input-method state change notified the view");
     return 0;
 }

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -12,3 +12,7 @@ target_sources(TestNativeWindowContainerFocus PRIVATE "${LADYBIRD_SOURCE_DIR}/UI
 
 ladybird_test("TestStringUtils.cpp" UI/Qt NAME TestQtStringUtils LIBS LibURL Qt::Core)
 target_sources(TestQtStringUtils PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp")
+
+ladybird_test("TestWebContentViewInputMethod.cpp" UI/Qt LIBS LibWebView LibWeb LibGfx LibIPC LibURL Qt::Core Qt::Gui Qt::Widgets)
+target_sources(TestWebContentViewInputMethod PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/WebContentView.cpp" "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp")
+set_target_properties(TestWebContentViewInputMethod PROPERTIES AUTOMOC ON)

--- a/Tests/UI/Qt/TestWebContentViewInputMethod.cpp
+++ b/Tests/UI/Qt/TestWebContentViewInputMethod.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf16String.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/PixelUnits.h>
+#include <UI/Qt/WebContentView.h>
+
+#include <QRectF>
+#include <QString>
+
+namespace Ladybird {
+
+// WebContentView.cpp references this to pick the initial page background color; it's defined in UI/Qt/main.cpp, which
+// this test doesn't link (LibTest provides main). The value is irrelevant here.
+bool is_using_dark_system_theme(QWidget&);
+bool is_using_dark_system_theme(QWidget&)
+{
+    return false;
+}
+
+}
+
+// The platform input method decides whether to compose from inputMethodQuery(Qt::ImEnabled). WebContent pushes
+// InputMethodState to the UI (did_update_input_method_state), and the Qt view answers inputMethodQuery from the
+// most-recent push via input_method_query_for_state(). If that stops tracking is_enabled, the platform input method
+// silently never starts composing — and input from dead keys and IMEs into editable content is dropped (#11182).
+
+TEST_CASE(enabled_state_maps_to_im_enabled_and_im_read_only)
+{
+    WebView::ViewImplementation::InputMethodState state;
+    state.is_enabled = true;
+
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImEnabled, 1.0).toBool());
+    EXPECT(!Ladybird::input_method_query_for_state(state, Qt::ImReadOnly, 1.0).toBool());
+
+    state.is_enabled = false;
+    EXPECT(!Ladybird::input_method_query_for_state(state, Qt::ImEnabled, 1.0).toBool());
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImReadOnly, 1.0).toBool());
+
+    // Both queries must be answered from the state (a false bool is still a valid answer), never left to the base widget.
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImEnabled, 1.0).isValid());
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImReadOnly, 1.0).isValid());
+}
+
+TEST_CASE(cursor_and_surrounding_text_map_to_queries)
+{
+    WebView::ViewImplementation::InputMethodState state {
+        .is_enabled = true,
+        .cursor_position = 3,
+        .anchor_position = 1,
+        .text_before_cursor = "ab"_utf16,
+        .text_after_cursor = "c"_utf16,
+        .caret_rect = {},
+    };
+
+    EXPECT_EQ(Ladybird::input_method_query_for_state(state, Qt::ImCursorPosition, 1.0).toInt(), 3);
+    EXPECT_EQ(Ladybird::input_method_query_for_state(state, Qt::ImAbsolutePosition, 1.0).toInt(), 3);
+    EXPECT_EQ(Ladybird::input_method_query_for_state(state, Qt::ImAnchorPosition, 1.0).toInt(), 1);
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImTextBeforeCursor, 1.0).toString() == QStringLiteral("ab"));
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImTextAfterCursor, 1.0).toString() == QStringLiteral("c"));
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImSurroundingText, 1.0).toString() == QStringLiteral("abc"));
+}
+
+TEST_CASE(caret_rect_scales_by_device_pixel_ratio_and_falls_back_when_absent)
+{
+    WebView::ViewImplementation::InputMethodState state;
+    state.caret_rect = Web::DevicePixelRect { 10, 20, 2, 30 };
+
+    // Device pixels map to logical pixels; width and height are clamped to at least 1 — so the input-method overlay
+    // anchor is never empty.
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImCursorRectangle, 2.0).toRectF() == QRectF(5, 10, 1, 15));
+    EXPECT(Ladybird::input_method_query_for_state(state, Qt::ImAnchorRectangle, 2.0).toRectF() == QRectF(5, 10, 1, 15));
+
+    // Without a caret rect (and for queries the state cannot answer) an invalid QVariant tells the caller to fall
+    // back to the base widget's answer.
+    state.caret_rect = {};
+    EXPECT(!Ladybird::input_method_query_for_state(state, Qt::ImCursorRectangle, 2.0).isValid());
+    EXPECT(!Ladybird::input_method_query_for_state(state, Qt::ImHints, 1.0).isValid());
+}

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -599,18 +599,16 @@ static Optional<QRectF> input_method_rect_for_caret(Optional<Web::DevicePixelRec
     };
 }
 
-QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery query) const
+QVariant input_method_query_for_state(WebView::ViewImplementation::InputMethodState const& state, Qt::InputMethodQuery query, double device_pixel_ratio)
 {
-    auto const& state = input_method_state();
-
     switch (query) {
     case Qt::ImEnabled:
         return state.is_enabled;
     case Qt::ImCursorRectangle:
     case Qt::ImAnchorRectangle:
-        if (auto rect = input_method_rect_for_caret(state.caret_rect, device_pixel_ratio()); rect.has_value())
+        if (auto rect = input_method_rect_for_caret(state.caret_rect, device_pixel_ratio); rect.has_value())
             return *rect;
-        return WebContentViewBase::inputMethodQuery(query);
+        return {};
     case Qt::ImAbsolutePosition:
     case Qt::ImCursorPosition:
         return state.cursor_position;
@@ -625,8 +623,15 @@ QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery query) const
     case Qt::ImReadOnly:
         return !state.is_enabled;
     default:
-        return WebContentViewBase::inputMethodQuery(query);
+        return {};
     }
+}
+
+QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery query) const
+{
+    if (auto result = input_method_query_for_state(input_method_state(), query, device_pixel_ratio()); result.isValid())
+        return result;
+    return WebContentViewBase::inputMethodQuery(query);
 }
 
 void WebContentView::leaveEvent(QEvent* event)

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -24,6 +24,7 @@
 #include <QPixmap>
 #include <QTimer>
 #include <QUrl>
+#include <QVariant>
 
 #ifdef AK_OS_MACOS
 #    define LADYBIRD_QT_USE_METAL_RHI_WIDGET 1
@@ -62,6 +63,8 @@ using WebContentViewBase = QRhiWidget;
 #else
 using WebContentViewBase = QWidget;
 #endif
+
+QVariant input_method_query_for_state(WebView::ViewImplementation::InputMethodState const& state, Qt::InputMethodQuery query, double device_pixel_ratio);
 
 struct WebContentViewInitialState {
     WebView::IsPrivate is_private { WebView::IsPrivate::No };


### PR DESCRIPTION
**Problem:** Under the Qt UI, dead-key composition in a `contenteditable` produced only a plain base character, rather than the expected one — making users unable to dead-key compose characters like`ü` in https://Discord.com etc. See #11182.

**Cause:** Dead-key composition already worked as expected in `input` and `textarea` element content because `update_input_method_state()` computed the `is_enabled` flag for those — **but not for `contenteditable` or `designMode` content.** The Qt UI answers `Qt::ImEnabled` from that `is_enabled` flag — and the platform input method never starts composition while `ImEnabled` is false. So, dead keys input in `contenteditable` or `designMode` content got discarded before the engine saw any composition at all. (The AppKit UI lacked the problem because it works differently.)

**Fix:** Give `update_input_method_state()` an editing-host (`contenteditable`/`designMode`) branch, reporting `is_enabled` true when the focused area is `is_editable_or_editing_host()` — the same routing `active_input_events_target()` uses to accept composition input. Derive the cursor and anchor positions and surrounding text from the document selection, scoped to the `Text` node holding selection focus. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11182.

Two commits: The first has the changes described above. The second extracts the input-method query mapping into a free function `inputMethodQuery()` delegates to, and adds `TestWebContentViewInputMethod`, with additional regression tests that rely on that function. Otherwise, without the added delegation layer and tests, if we regress such that we end making input from dead keys and IMEs into editable content die completely, all other existing tests would still stay green.
