### PR TITLE
LibWeb: Synchronize CSSOM style mutations lazily

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -20,6 +20,15 @@ CSSStyleDeclaration::CSSStyleDeclaration(Computed computed, Readonly readonly)
 {
 }
 
+void CSSStyleDeclaration::prepare_to_update_style_attribute()
+{
+    VERIFY(!is_computed());
+    if (!owner_node().has_value())
+        return;
+
+    owner_node()->element().prepare_for_inline_style_change();
+}
+
 // https://drafts.csswg.org/cssom/#update-style-attribute-for
 void CSSStyleDeclaration::update_style_attribute()
 {
@@ -31,11 +40,19 @@ void CSSStyleDeclaration::update_style_attribute()
     if (!owner_node().has_value())
         return;
 
+    auto& element = owner_node()->element();
+    // OPTIMIZATION: Keep the parsed declaration block authoritative and serialize it only when
+    //               something observes the textual attribute value.
+    if (element.can_defer_inline_style_attribute_update()) {
+        element.did_update_inline_style();
+        return;
+    }
+
     // 4. Set declaration block’s updating flag.
     set_is_updating(true);
 
     // 5. Set an attribute value for owner node using "style" and the result of serializing declaration block.
-    owner_node()->element().set_attribute_value(HTML::AttributeNames::style, serialized());
+    element.set_attribute_value(HTML::AttributeNames::style, serialized());
 
     // 6. Unset declaration block’s updating flag.
     set_is_updating(false);

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -77,6 +77,7 @@ protected:
 
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
+    void prepare_to_update_style_attribute();
     void update_style_attribute();
 
 private:

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -239,6 +239,8 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_internal(PropertyName
     if (!component_value_list)
         return {};
 
+    prepare_to_update_style_attribute();
+
     // 7. Let updated be false.
     bool updated = false;
 
@@ -538,6 +540,8 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_style_value(PropertyN
             return {};
         }
 
+        prepare_to_update_style_attribute();
+
         m_custom_properties.set(property.name(),
             StyleProperty {
                 Important::No,
@@ -566,6 +570,8 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_style_value(PropertyN
         && !is_filter_style_value_list(*style_value)) {
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, Utf16String::formatted("Setting {} to '{}' is not allowed.", property.name(), style_value->to_string(SerializationMode::Normal)) };
     }
+
+    prepare_to_update_style_attribute();
 
     StyleComputer::for_each_property_expanding_shorthands(property.id(), style_value, [this](PropertyID longhand_id, StyleValue const& longhand_value) {
         m_properties.remove_first_matching([longhand_id](StyleProperty const& style_property) {
@@ -1509,6 +1515,7 @@ WebIDL::ExceptionOr<Utf16String> CSSStyleProperties::remove_property_internal(Op
             return removed;
         };
 
+        prepare_to_update_style_attribute();
         auto removed = remove_declaration(property.value());
 
         // 7. If removed is true, Update style attribute for the CSS declaration block.
@@ -1810,6 +1817,8 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_css_text(Utf16View css_text)
     if (is_readonly()) {
         return WebIDL::NoModificationAllowedError::create("Cannot modify properties: CSSStyleProperties is read-only."_utf16);
     }
+
+    prepare_to_update_style_attribute();
 
     // 2. Empty the declarations.
     // 3. Parse the given value and, if the return value is not the empty list, insert the items in the list into the declarations, in specified order.

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -446,6 +446,8 @@ static void update_style(DOM::Document& document)
     if (document.created_for_appropriate_template_contents())
         return;
 
+    document.synchronize_dirty_style_attributes();
+
     document.begin_style_stabilization_epoch();
     ScopeGuard end_stabilization_epoch = [&] {
         document.end_style_stabilization_epoch();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -592,6 +592,19 @@ Document::Document(Page& page, GC::Ref<EventTarget> relevant_global_event_target
 
 Document::~Document() = default;
 
+void Document::synchronize_dirty_style_attributes()
+{
+    if (!m_has_dirty_style_attributes)
+        return;
+
+    m_has_dirty_style_attributes = false;
+    for_each_shadow_including_descendant([](Node& node) {
+        if (auto* element = as_if<Element>(node))
+            element->synchronize_all_attributes();
+        return TraversalDecision::Continue;
+    });
+}
+
 Layout::NodeArena& Document::layout_node_arena()
 {
     // Created on first layout node so documents that never build a layout tree (e.g. temporary

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -794,6 +794,8 @@ public:
 
     bool has_completed_style_update() const { return m_has_completed_style_update; }
     void set_has_completed_style_update() { m_has_completed_style_update = true; }
+    void mark_style_attribute_dirty() { m_has_dirty_style_attributes = true; }
+    void synchronize_dirty_style_attributes();
     void build_registered_properties_cache_for_style_update() { build_registered_properties_cache(); }
     void set_needs_registered_properties_cache_update() { m_needs_registered_properties_cache_update = true; }
     void set_needs_container_query_evaluation_after_layout(Element const& query_container);
@@ -1645,6 +1647,7 @@ private:
     Vector<GC::Weak<CSS::MediaQueryList>> m_media_query_lists;
 
     bool m_has_completed_style_update { false };
+    bool m_has_dirty_style_attributes { false };
     bool m_suppresses_attribute_style_invalidation { false };
     HashTable<GC::Ref<Element>> m_query_containers_needing_container_query_evaluation_after_layout;
     bool m_needs_full_layout_tree_update { false };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -66,6 +66,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/ElementRareData.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/DOM/MutationType.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/DOM/SelectorQuery.h>
@@ -316,17 +317,36 @@ Element::AttributeList& Element::ensure_attribute_list()
     return *m_attributes;
 }
 
+void Element::synchronize_attribute(Utf16FlyString const& qualified_name) const
+{
+    if (m_style_attribute_is_dirty && qualified_name == HTML::AttributeNames::style)
+        synchronize_style_attribute();
+}
+
+void Element::synchronize_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const
+{
+    if (m_style_attribute_is_dirty && !namespace_.has_value() && local_name == HTML::AttributeNames::style)
+        synchronize_style_attribute();
+}
+
+void Element::synchronize_all_attributes() const
+{
+    synchronize_style_attribute();
+}
+
 Optional<size_t> Element::find_attribute_index(Utf16FlyString const& qualified_name) const
 {
-    if (!m_attributes)
-        return {};
-
     Utf16FlyString const* effective_name = &qualified_name;
     Utf16FlyString lowercase_name;
     if (namespace_uri() == Namespace::HTML && document().is_html_document()) {
         lowercase_name = qualified_name.to_ascii_lowercase();
         effective_name = &lowercase_name;
     }
+
+    synchronize_attribute(*effective_name);
+
+    if (!m_attributes)
+        return {};
 
     for (size_t index = 0; index < m_attributes->size(); ++index) {
         if (m_attributes->at(index).name.as_string() == *effective_name)
@@ -337,12 +357,15 @@ Optional<size_t> Element::find_attribute_index(Utf16FlyString const& qualified_n
 
 Optional<size_t> Element::find_attribute_index_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& local_name) const
 {
-    if (!m_attributes)
-        return {};
-
     Optional<Utf16FlyString> normalized_namespace;
     if (namespace_ != Utf16FlyString {})
         normalized_namespace = namespace_;
+
+    synchronize_attribute_ns(normalized_namespace, local_name);
+
+    if (!m_attributes)
+        return {};
+
     for (size_t index = 0; index < m_attributes->size(); ++index) {
         auto const& attribute = m_attributes->at(index);
         if (attribute.name.namespace_() == normalized_namespace && attribute.name.local_name() == local_name)
@@ -384,8 +407,6 @@ Optional<Utf16String> Element::get_attribute(Utf16FlyString const& name) const
 Optional<Utf16String> Element::get_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name) const
 {
     // 1. Let attr be the result of getting an attribute given namespace, localName, and this.
-    if (!m_attributes)
-        return {};
     auto index = find_attribute_index_ns(namespace_, name);
 
     // 2. If attr is null, return null.
@@ -400,8 +421,6 @@ Optional<Utf16String> Element::get_attribute_ns(Optional<Utf16FlyString> const& 
 Utf16String Element::get_attribute_value(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& namespace_) const
 {
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
-    if (!m_attributes)
-        return {};
     auto index = find_attribute_index_ns(namespace_, local_name);
 
     // 2. If attr is null, then return the empty string.
@@ -748,7 +767,7 @@ void Element::activate_the_hyperlink(Event const& event)
 GC::Ptr<Attr> Element::get_attribute_node(Utf16FlyString const& name) const
 {
     // The getAttributeNode(qualifiedName) method steps are to return the result of getting an attribute given qualifiedName and this.
-    if (!m_attributes)
+    if (!find_attribute_index(name).has_value())
         return {};
     return const_cast<Element&>(*this).attributes()->get_attribute(name);
 }
@@ -757,7 +776,7 @@ GC::Ptr<Attr> Element::get_attribute_node(Utf16FlyString const& name) const
 GC::Ptr<Attr> Element::get_attribute_node_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name) const
 {
     // The getAttributeNodeNS(namespace, localName) method steps are to return the result of getting an attribute given namespace, localName, and this.
-    if (!m_attributes)
+    if (!find_attribute_index_ns(namespace_, name).has_value())
         return {};
     return const_cast<Element&>(*this).attributes()->get_attribute_ns(namespace_, name);
 }
@@ -1024,9 +1043,6 @@ WebIDL::ExceptionOr<GC::Ptr<Attr>> Element::set_attribute_node_ns(Attr& attr)
 void Element::remove_attribute(Utf16FlyString const& name)
 {
     // The removeAttribute(qualifiedName) method steps are to remove an attribute given qualifiedName and this, and then return undefined.
-    if (!m_attributes)
-        return;
-
     Utf16FlyString const* effective_name = &name;
     Utf16FlyString lowercase_name;
     if (namespace_uri() == Namespace::HTML && document().is_html_document()) {
@@ -1042,8 +1058,6 @@ void Element::remove_attribute(Utf16FlyString const& name)
 void Element::remove_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name)
 {
     // The removeAttributeNS(namespace, localName) method steps are to remove an attribute given namespace, localName, and this, and then return undefined.
-    if (!m_attributes)
-        return;
     if (auto index = find_attribute_index_ns(namespace_, name); index.has_value())
         remove_attribute_at(*index);
 }
@@ -1073,9 +1087,6 @@ bool Element::has_attribute(Utf16FlyString const& name) const
 // https://dom.spec.whatwg.org/#dom-element-hasattributens
 bool Element::has_attribute_ns(Optional<Utf16FlyString> const& namespace_, Utf16FlyString const& name) const
 {
-    if (!m_attributes)
-        return false;
-
     // 1. If namespace is the empty string, then set it to null.
     // 2. Return true if this has an attribute whose namespace is namespace and local name is localName; otherwise false.
     if (namespace_ == Utf16FlyString {})
@@ -1127,6 +1138,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(Utf16FlyString const& name, 
 Vector<Utf16FlyString> Element::get_attribute_names() const
 {
     // The getAttributeNames() method steps are to return the qualified names of the attributes in this’s attribute list, in order; otherwise a new list.
+    synchronize_all_attributes();
     if (!m_attributes)
         return {};
     Vector<Utf16FlyString> names;
@@ -2470,6 +2482,96 @@ void Element::set_inline_style(GC::Ptr<CSS::CSSStyleProperties> style)
         CSS::ElementDeclarationKind::InlineStyle,
         had_declarations,
         style && !style->properties().is_empty());
+}
+
+void Element::prepare_for_inline_style_change()
+{
+    if (is_custom() || document().page().listen_for_dom_mutations()) {
+        synchronize_style_attribute();
+        return;
+    }
+
+    for (Node* node = this; node; node = node->parent()) {
+        auto* registered_observers = node->registered_observer_list();
+        if (!registered_observers)
+            continue;
+        for (auto const& registered_observer : *registered_observers) {
+            auto const& options = registered_observer->options();
+            if (node != this && !options.subtree)
+                continue;
+            if (!options.attributes.value_or(false))
+                continue;
+            if (options.attribute_filter.has_value() && !options.attribute_filter->contains_slow(HTML::AttributeNames::style))
+                continue;
+            synchronize_style_attribute();
+            return;
+        }
+    }
+}
+
+bool Element::can_defer_inline_style_attribute_update() const
+{
+    return !is_custom() && !document().page().listen_for_dom_mutations();
+}
+
+void Element::did_update_inline_style()
+{
+    VERIFY(can_defer_inline_style_attribute_update());
+    VERIFY(m_inline_style);
+
+    bool had_style_attribute = m_style_attribute_is_dirty;
+    Optional<Utf16String> old_value;
+    if (m_attributes) {
+        for (auto const& attribute : *m_attributes) {
+            if (!attribute.name.namespace_().has_value() && attribute.name.local_name() == HTML::AttributeNames::style) {
+                had_style_attribute = true;
+                old_value = attribute.value;
+                break;
+            }
+        }
+    }
+
+    if (auto history = document().editing_history_if_exists())
+        history->notify_dom_mutation();
+
+    m_style_attribute_is_dirty = true;
+    document().mark_style_attribute_dirty();
+    queue_mutation_record(MutationType::attributes, HTML::AttributeNames::style, {}, old_value, {}, {}, nullptr, nullptr);
+
+    if (!document().suppresses_attribute_style_invalidation())
+        CSS::record_element_declarations_changed(*this, CSS::ElementDeclarationKind::InlineStyle, had_style_attribute, true);
+    document().bump_dom_tree_version();
+}
+
+void Element::synchronize_style_attribute() const
+{
+    if (!m_style_attribute_is_dirty)
+        return;
+
+    auto& element = const_cast<Element&>(*this);
+    element.m_style_attribute_is_dirty = false;
+
+    Optional<Utf16String> old_value;
+    Optional<size_t> style_attribute_index;
+    if (element.m_attributes) {
+        for (size_t index = 0; index < element.m_attributes->size(); ++index) {
+            auto const& attribute = element.m_attributes->at(index);
+            if (!attribute.name.namespace_().has_value() && attribute.name.local_name() == HTML::AttributeNames::style) {
+                old_value = attribute.value;
+                style_attribute_index = index;
+                break;
+            }
+        }
+    }
+
+    auto new_value = element.m_inline_style->serialized();
+    if (style_attribute_index.has_value()) {
+        element.m_attributes->at(*style_attribute_index).value = new_value;
+    } else {
+        element.ensure_attribute_list().empend(QualifiedName { HTML::AttributeNames::style, {}, {} }, new_value);
+    }
+
+    CSS::record_element_attribute_changed(element, HTML::AttributeNames::style, {}, old_value, new_value);
 }
 
 // https://dom.spec.whatwg.org/#element-html-uppercased-qualified-name
@@ -4571,6 +4673,7 @@ Optional<Utf16String> Element::locate_a_namespace_prefix(Optional<Utf16View> nam
 
 void Element::for_each_attribute(Function<void(Attr&)> callback)
 {
+    synchronize_all_attributes();
     if (!m_attributes)
         return;
     auto attribute_map = attributes();
@@ -4580,6 +4683,7 @@ void Element::for_each_attribute(Function<void(Attr&)> callback)
 
 void Element::for_each_attribute(Function<void(Attr const&)> callback) const
 {
+    synchronize_all_attributes();
     if (!m_attributes)
         return;
     auto attribute_map = attributes();
@@ -4589,6 +4693,7 @@ void Element::for_each_attribute(Function<void(Attr const&)> callback) const
 
 void Element::for_each_attribute(Function<void(Utf16FlyString, Utf16String)> callback) const
 {
+    synchronize_all_attributes();
     if (!m_attributes)
         return;
     for (size_t index = 0; index < m_attributes->size(); ++index) {
@@ -4600,6 +4705,7 @@ void Element::for_each_attribute(Function<void(Utf16FlyString, Utf16String)> cal
 
 void Element::for_each_attribute(Function<void(QualifiedName, Utf16String)> callback) const
 {
+    synchronize_all_attributes();
     if (!m_attributes)
         return;
     for (size_t index = 0; index < m_attributes->size(); ++index) {
@@ -4631,11 +4737,13 @@ Layout::NodeWithStyle const* Element::unsafe_layout_node() const
 
 bool Element::has_attributes() const
 {
+    synchronize_all_attributes();
     return m_attributes && !m_attributes->is_empty();
 }
 
 size_t Element::attribute_list_size() const
 {
+    synchronize_all_attributes();
     return m_attributes ? m_attributes->size() : 0;
 }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -306,6 +306,7 @@ public:
 
     void for_each_attribute(Function<void(QualifiedName, Utf16String)>) const;
     void for_each_attribute(Function<void(Utf16FlyString, Utf16String)>) const;
+    void synchronize_all_attributes() const;
 
     bool has_class(Utf16View, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     bool has_class(Utf16FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
@@ -423,6 +424,9 @@ public:
     GC::Ptr<CSS::CSSStyleProperties> inline_style() { return m_inline_style; }
     GC::Ptr<CSS::CSSStyleProperties const> inline_style() const { return m_inline_style; }
     void set_inline_style(GC::Ptr<CSS::CSSStyleProperties>);
+    void prepare_for_inline_style_change();
+    bool can_defer_inline_style_attribute_update() const;
+    void did_update_inline_style();
 
     GC::Ref<CSS::CSSStyleProperties> style();
     GC::Ref<CSS::StylePropertyMap> attribute_style_map();
@@ -837,6 +841,9 @@ private:
     using AttributeList = Vector<Attribute, 1>;
 
     AttributeList& ensure_attribute_list();
+    void synchronize_attribute(Utf16FlyString const& qualified_name) const;
+    void synchronize_attribute_ns(Optional<Utf16FlyString> const&, Utf16FlyString const& local_name) const;
+    void synchronize_style_attribute() const;
     Optional<size_t> find_attribute_index(Utf16FlyString const& qualified_name) const;
     Optional<size_t> find_attribute_index_ns(Optional<Utf16FlyString> const&, Utf16FlyString const& local_name) const;
     void change_attribute_value(GC::Ref<Attr>, Utf16String value);
@@ -921,6 +928,7 @@ private:
     bool m_fullscreen_flag : 1 { false };
     bool m_uses_document_global_custom_element_registry : 1 { false };
     bool m_has_name : 1 { false };
+    mutable bool m_style_attribute_is_dirty : 1 { false };
 
     mutable Optional<Utf16String> m_lang_value;
 

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -109,6 +109,7 @@ static void collect_matches(ParentNode& root, Matcher&& matcher, Vector<GC::RawP
 
 static void settle_connected_selector_query(Document& document)
 {
+    document.synchronize_dirty_style_attributes();
     document.style_computer().style_engine().prepare_selector_query();
 }
 

--- a/Tests/LibWeb/Text/expected/css/cssom-style-attribute-synchronization.txt
+++ b/Tests/LibWeb/Text/expected/css/cssom-style-attribute-synchronization.txt
@@ -1,0 +1,42 @@
+color: red;
+color: red;
+true
+true
+<div style="color: red; background-color: blue;"></div>
+0
+false
+color: red;
+true
+color: red;
+getAttributeNode: color: red;
+getAttributeNS: color: red;
+hasAttributeNS: true
+getAttributeNodeNS: color: red;
+getNamedItemNS: color: red;
+Attr.value: color: red;
+getAttributeNames: style
+attributes.length: 1
+attributes.item: color: red;
+hasAttributes: true
+NamedNodeMap named property: color: red;
+outerHTML: <div style="color: red;"></div>
+cloneNode: color: red;
+matches: true
+querySelector: true
+setAttribute: color: green / green
+removeAttribute: false / 0
+removeAttributeNS: false / 0
+toggleAttribute: false / false / 0
+setAttributeNode: color: red; / green
+setNamedItem: color: red; / green
+removeAttributeNode: color: red; / false / 0
+removeNamedItem: color: red; / false
+removeNamedItemNS: color: red; / false
+namespace case-sensitive get: null
+namespace lowercase get: color: red;
+namespace case-sensitive named item: null
+namespace lowercase named item: color: red;
+SVG uppercase: null
+SVG lowercase: color: red;
+XML uppercase: null
+XML lowercase: color: red;

--- a/Tests/LibWeb/Text/input/css/cssom-style-attribute-synchronization.html
+++ b/Tests/LibWeb/Text/input/css/cssom-style-attribute-synchronization.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const element = document.createElement("div");
+        document.body.appendChild(element);
+
+        element.style.color = "red";
+        println(element.getAttribute("style"));
+        println(element.attributes.getNamedItem("style").value);
+        println(element.matches('[style="color: red;"]'));
+        println(document.querySelector('[style="color: red;"]') === element);
+
+        element.style.backgroundColor = "blue";
+        println(element.outerHTML);
+
+        element.removeAttribute("style");
+        println(element.style.length);
+        println(element.hasAttribute("style"));
+
+        const getAttributeElement = document.createElement("div");
+        getAttributeElement.setAttribute("style", "color: blue");
+        getAttributeElement.style.color = "red";
+        println(getAttributeElement.getAttribute("STYLE"));
+
+        const hasAttributeElement = document.createElement("div");
+        hasAttributeElement.style.color = "red";
+        println(hasAttributeElement.hasAttribute("STYLE"));
+
+        const namedItemElement = document.createElement("div");
+        namedItemElement.setAttribute("style", "color: blue");
+        namedItemElement.style.color = "red";
+        println(namedItemElement.attributes.getNamedItem("STYLE").value);
+
+        const makeElementWithDirtyStyle = (initialStyle = undefined) => {
+            const element = document.createElement("div");
+            if (initialStyle !== undefined)
+                element.setAttribute("style", initialStyle);
+            element.style.color = "red";
+            return element;
+        };
+
+        const attributeNodeElement = makeElementWithDirtyStyle("color: blue");
+        println(`getAttributeNode: ${attributeNodeElement.getAttributeNode("STYLE").value}`);
+
+        const getAttributeNSElement = makeElementWithDirtyStyle("color: blue");
+        println(`getAttributeNS: ${getAttributeNSElement.getAttributeNS(null, "style")}`);
+
+        const hasAttributeNSElement = makeElementWithDirtyStyle();
+        println(`hasAttributeNS: ${hasAttributeNSElement.hasAttributeNS(null, "style")}`);
+
+        const attributeNodeNSElement = makeElementWithDirtyStyle("color: blue");
+        println(`getAttributeNodeNS: ${attributeNodeNSElement.getAttributeNodeNS(null, "style").value}`);
+
+        const namedItemNSElement = makeElementWithDirtyStyle("color: blue");
+        println(`getNamedItemNS: ${namedItemNSElement.attributes.getNamedItemNS(null, "style").value}`);
+
+        const attributeValueElement = document.createElement("div");
+        attributeValueElement.setAttribute("style", "color: blue");
+        const styleAttribute = attributeValueElement.getAttributeNode("style");
+        attributeValueElement.style.color = "red";
+        println(`Attr.value: ${styleAttribute.value}`);
+
+        const attributeNamesElement = makeElementWithDirtyStyle();
+        println(`getAttributeNames: ${attributeNamesElement.getAttributeNames().join(",")}`);
+
+        const attributeLengthElement = makeElementWithDirtyStyle();
+        println(`attributes.length: ${attributeLengthElement.attributes.length}`);
+
+        const attributeItemElement = makeElementWithDirtyStyle("color: blue");
+        println(`attributes.item: ${attributeItemElement.attributes.item(0).value}`);
+
+        const hasAttributesElement = makeElementWithDirtyStyle();
+        println(`hasAttributes: ${hasAttributesElement.hasAttributes()}`);
+
+        const namedPropertyElement = makeElementWithDirtyStyle("color: blue");
+        println(`NamedNodeMap named property: ${namedPropertyElement.attributes.style.value}`);
+
+        const serializedElement = makeElementWithDirtyStyle();
+        println(`outerHTML: ${serializedElement.outerHTML}`);
+
+        const clonedElement = makeElementWithDirtyStyle("color: blue");
+        println(`cloneNode: ${clonedElement.cloneNode().getAttribute("style")}`);
+
+        const matchesElement = makeElementWithDirtyStyle();
+        println(`matches: ${matchesElement.matches('[STYLE="color: red;"]')}`);
+
+        const queryElement = makeElementWithDirtyStyle();
+        document.body.appendChild(queryElement);
+        println(`querySelector: ${document.querySelector('[STYLE="color: red;"]') === queryElement}`);
+        queryElement.remove();
+
+        const setAttributeElement = makeElementWithDirtyStyle("color: blue");
+        setAttributeElement.setAttribute("STYLE", "color: green");
+        println(`setAttribute: ${setAttributeElement.getAttribute("style")} / ${setAttributeElement.style.color}`);
+
+        const removeAttributeElement = makeElementWithDirtyStyle();
+        removeAttributeElement.removeAttribute("STYLE");
+        println(`removeAttribute: ${removeAttributeElement.hasAttribute("style")} / ${removeAttributeElement.style.length}`);
+
+        const removeAttributeNSElement = makeElementWithDirtyStyle();
+        removeAttributeNSElement.removeAttributeNS(null, "style");
+        println(`removeAttributeNS: ${removeAttributeNSElement.hasAttribute("style")} / ${removeAttributeNSElement.style.length}`);
+
+        const toggleAttributeElement = makeElementWithDirtyStyle();
+        println(`toggleAttribute: ${toggleAttributeElement.toggleAttribute("STYLE", false)} / ${toggleAttributeElement.hasAttribute("style")} / ${toggleAttributeElement.style.length}`);
+
+        const setAttributeNodeElement = makeElementWithDirtyStyle("color: blue");
+        const newStyleAttribute = document.createAttribute("style");
+        newStyleAttribute.value = "color: green";
+        const replacedStyleAttribute = setAttributeNodeElement.setAttributeNode(newStyleAttribute);
+        println(`setAttributeNode: ${replacedStyleAttribute.value} / ${setAttributeNodeElement.style.color}`);
+
+        const setNamedItemElement = makeElementWithDirtyStyle("color: blue");
+        const newNamedStyleAttribute = document.createAttribute("style");
+        newNamedStyleAttribute.value = "color: green";
+        const replacedNamedStyleAttribute = setNamedItemElement.attributes.setNamedItem(newNamedStyleAttribute);
+        println(`setNamedItem: ${replacedNamedStyleAttribute.value} / ${setNamedItemElement.style.color}`);
+
+        const removeAttributeNodeElement = document.createElement("div");
+        removeAttributeNodeElement.setAttribute("style", "color: blue");
+        const removedStyleAttribute = removeAttributeNodeElement.getAttributeNode("style");
+        removeAttributeNodeElement.style.color = "red";
+        removeAttributeNodeElement.removeAttributeNode(removedStyleAttribute);
+        println(`removeAttributeNode: ${removedStyleAttribute.value} / ${removeAttributeNodeElement.hasAttribute("style")} / ${removeAttributeNodeElement.style.length}`);
+
+        const removeNamedItemElement = makeElementWithDirtyStyle("color: blue");
+        const removedNamedItem = removeNamedItemElement.attributes.removeNamedItem("STYLE");
+        println(`removeNamedItem: ${removedNamedItem.value} / ${removeNamedItemElement.hasAttribute("style")}`);
+
+        const removeNamedItemNSElement = makeElementWithDirtyStyle("color: blue");
+        const removedNamedItemNS = removeNamedItemNSElement.attributes.removeNamedItemNS(null, "style");
+        println(`removeNamedItemNS: ${removedNamedItemNS.value} / ${removeNamedItemNSElement.hasAttribute("style")}`);
+
+        const namespaceCaseElement = makeElementWithDirtyStyle("color: blue");
+        println(`namespace case-sensitive get: ${namespaceCaseElement.getAttributeNS(null, "STYLE")}`);
+        println(`namespace lowercase get: ${namespaceCaseElement.getAttributeNS(null, "style")}`);
+
+        const namespaceCaseNamedItemElement = makeElementWithDirtyStyle("color: blue");
+        println(`namespace case-sensitive named item: ${namespaceCaseNamedItemElement.attributes.getNamedItemNS(null, "STYLE")}`);
+        println(`namespace lowercase named item: ${namespaceCaseNamedItemElement.attributes.getNamedItemNS(null, "style").value}`);
+
+        const svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svgElement.style.color = "red";
+        println(`SVG uppercase: ${svgElement.getAttribute("STYLE")}`);
+        println(`SVG lowercase: ${svgElement.getAttribute("style")}`);
+
+        const xmlDocument = new DOMParser().parseFromString('<html xmlns="http://www.w3.org/1999/xhtml"><body><div/></body></html>', "application/xml");
+        const xmlElement = xmlDocument.querySelector("div");
+        xmlElement.style.color = "red";
+        println(`XML uppercase: ${xmlElement.getAttribute("STYLE")}`);
+        println(`XML lowercase: ${xmlElement.getAttribute("style")}`);
+    });
+</script>


### PR DESCRIPTION
Keep parsed inline declarations authoritative after CSSOM mutations and serialize them into the style attribute only when attribute text is observed. Route qualified-name, namespace-aware, and full-list reads through centralized synchronization boundaries.

Normalize HTML qualified names before synchronization so mixed-case attribute APIs observe current values. Preserve immediate mutation records, custom element reactions, selector matching, and style-engine bookkeeping.

Add coverage for attribute getters and mutations, NamedNodeMap, live Attr values, selectors, serialization, cloning, and HTML, SVG, and XML name matching.

```
Benchmark    Suite    Test                          Speedup  Old Time (Mean ± Range)    New Time (Mean ± Range)
-----------  -------  --------------------------  ---------  -------------------------  -------------------------
WebKitCSS             CSSPropertySetterGetter         7.15   0.076 ± 0.002              0.011 ± 0.000
WebKitCSS             CSSPropertyUpdateValue          4.822  0.099 ± 0.003              0.021 ± 0.000
WebKitCSS             FontFaceSetUpdateStyle          0.996  0.105 ± 0.011              0.105 ± 0.012
WebKitCSS             HasWithChildCombinatorInIs      1.011  0.131 ± 0.001              0.129 ± 0.000
WebKitCSS             ManyMatchMediaInstances         0.989  0.017 ± 0.004              0.017 ± 0.003
WebKitCSS             PseudoClassSelectors            1.007  0.091 ± 0.001              0.090 ± 0.000
WebKitCSS             QuerySelector                   0.993  0.027 ± 0.000              0.027 ± 0.001
WebKitCSS             StyleSheetInsert                1      0.001 ± 0.000              0.001 ± 0.000
WebKitCSS             WhereIsClassRuleIndexing        1.001  0.106 ± 0.000              0.106 ± 0.001
WebKitCSS             WhereIsRuleIndexing             0.99   0.149 ± 0.001              0.151 ± 0.003

Benchmark      Speedup  Old Total Time (s)    New Total Time (s)
-----------  ---------  --------------------  --------------------
WebKitCSS        1.219  0.801 ± 0.009         0.658 ± 0.011
```