### PR TITLE
LibWeb: Route anchor-local :has() changes directly

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -1554,6 +1554,13 @@ impl StyleEngine {
         site: &RoutingSite<'_>,
         regions: &mut ImpactRegions,
     ) {
+        if anchor.input_is_on_the_anchor {
+            self.counters.bump(Counter::RelationalAnchorsConsidered);
+            let region = ImpactRegion::follow(witness, site.path, &self.tree);
+            self.add_narrowed_region(region, site, regions);
+            return;
+        }
+
         // The input is a step away from the witness, so no walk from it finds the anchors: the
         // step can leave the anchor's subtree, which puts the changed element above the anchor
         // rather than below it. What the query still says is what a witness of it must carry, and
@@ -1648,6 +1655,7 @@ impl StyleEngine {
                 program,
                 RelativeAnchor {
                     input_is_on_the_witness: true,
+                    input_is_on_the_anchor: false,
                     ..anchor
                 },
                 site,

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -2782,6 +2782,12 @@ pub struct RelativeAnchor {
     /// puts `.a` a step away from one, and that step can leave the anchor's subtree entirely - the
     /// element carrying `.a` is then an *ancestor* of the anchor, and no walk from it finds one.
     pub input_is_on_the_witness: bool,
+    /// Whether the input occurs on the anchor itself.
+    ///
+    /// In `:has(> :is(.active > li))`, `.active` is reached from the possible `li` witness by
+    /// exactly the inverse of the query's child axis. A change to that class already names the
+    /// anchor, so routing through every possible `li` witness would only rediscover it many times.
+    pub input_is_on_the_anchor: bool,
     /// How many siblings back of a witness this query's anchor can be, on an adjacent axis.
     ///
     /// `X:has(+ B)` anchors on the element beside the witness and `X:has(+ A + B)` two beside it, so
@@ -3164,9 +3170,17 @@ impl SelectorProgram {
             let depth = anchor.map_or(walk.path.len(), |(_, depth)| depth);
             walk.applied_path.clear();
             walk.applied_path.extend(walk.path[..depth].iter().rev().copied());
-            let anchor = anchor.map(|(anchor, depth)| RelativeAnchor {
-                input_is_on_the_witness: depth == walk.path.len(),
-                ..anchor
+            let anchor = anchor.map(|(anchor, depth)| {
+                let relative_path = &walk.path[depth..];
+                let input_is_on_the_anchor = matches!(
+                    (anchor.axis, relative_path),
+                    (RelativeAxis::Child, [InverseStep::Children])
+                );
+                RelativeAnchor {
+                    input_is_on_the_witness: relative_path.is_empty(),
+                    input_is_on_the_anchor,
+                    ..anchor
+                }
             });
             // The waypoints were collected subject-first, like the path, and the last one is the
             // subject's own compound rather than an intermediate. Reversed alongside the path, each
@@ -3266,6 +3280,7 @@ impl SelectorProgram {
                     query,
                     witness_dispatch: self.dispatch_key_of(compiled.compound),
                     input_is_on_the_witness: true,
+                    input_is_on_the_anchor: false,
                     // The anchor has to satisfy the compound the `:has()` sits in, which is what
                     // separates the handful of real anchors from every ancestor of the witness.
                     anchor_dispatch: self.dispatch_key_of(enclosing),

--- a/Tests/LibWeb/Text/expected/css/style-engine/has-child-anchor-local-input.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/has-child-anchor-local-input.txt
@@ -1,0 +1,7 @@
+changed anchors gain the relational style: true
+unchanged anchors do not gain the relational style: true
+addition routing: anchors=16, candidates=15
+addition avoids witness-scale matching: true
+changed anchors lose the relational style: true
+removal routing: anchors=16, candidates=15
+removal avoids document-scale witness matching: true

--- a/Tests/LibWeb/Text/input/css/style-engine/has-child-anchor-local-input.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/has-child-anchor-local-input.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    ol:has(> :is(.active > li)) { color: rgb(1, 2, 3); }
+</style>
+<main id="fixture"></main>
+<script>
+    test(() => {
+        for (let index = 0; index < 32; ++index) {
+            const list = document.createElement("ol");
+            for (let child = 0; child < 16; ++child)
+                list.appendChild(document.createElement("li"));
+            fixture.appendChild(list);
+        }
+
+        const lists = fixture.querySelectorAll("ol");
+        internals.updateStyle();
+
+        function measure(mutation) {
+            const before = internals.styleEngineCounters();
+            mutation();
+            internals.updateStyle();
+            const after = internals.styleEngineCounters();
+            return Object.fromEntries(Object.keys(after).map(name => [name, after[name] - before[name]]));
+        }
+
+        const addition = measure(() => {
+            for (let index = 0; index < lists.length; index += 2)
+                lists[index].classList.add("active");
+        });
+        println(`changed anchors gain the relational style: ${getComputedStyle(lists[0]).color === "rgb(1, 2, 3)"}`);
+        println(`unchanged anchors do not gain the relational style: ${getComputedStyle(lists[1]).color === "rgb(0, 0, 0)"}`);
+        println(`addition routing: anchors=${addition.relationalAnchorsConsidered}, candidates=${addition.candidateChecks}`);
+        println(`addition avoids witness-scale matching: ${addition.localFeatureTests < 200}`);
+
+        const removal = measure(() => {
+            for (let index = 0; index < lists.length; index += 2)
+                lists[index].classList.remove("active");
+        });
+        println(`changed anchors lose the relational style: ${getComputedStyle(lists[0]).color === "rgb(0, 0, 0)"}`);
+        println(`removal routing: anchors=${removal.relationalAnchorsConsidered}, candidates=${removal.candidateChecks}`);
+        println(`removal avoids document-scale witness matching: ${removal.localFeatureTests < 2000}`);
+    });
+</script>


### PR DESCRIPTION
Recognize when a changed selector input lies on the anchor of a child relative selector. Route that anchor directly rather than enumerating every possible witness and repeatedly rediscovering the same element.

Cover insertion and removal with work counters that keep routing cost proportional to the number of changed anchors.

```
Benchmark    Suite    Test                          Speedup  Old Time (Mean ± Range)    New Time (Mean ± Range)
-----------  -------  --------------------------  ---------  -------------------------  -------------------------
WebKitCSS             CSSPropertySetterGetter         0.953  0.011 ± 0.000              0.011 ± 0.000
WebKitCSS             CSSPropertyUpdateValue          0.975  0.021 ± 0.000              0.021 ± 0.000
WebKitCSS             FontFaceSetUpdateStyle          1.005  0.105 ± 0.012              0.105 ± 0.012
WebKitCSS             HasWithChildCombinatorInIs      4.046  0.129 ± 0.000              0.032 ± 0.000
WebKitCSS             ManyMatchMediaInstances         1.012  0.017 ± 0.003              0.017 ± 0.002
WebKitCSS             PseudoClassSelectors            0.985  0.090 ± 0.000              0.091 ± 0.002
WebKitCSS             QuerySelector                   1.004  0.027 ± 0.001              0.027 ± 0.000
WebKitCSS             StyleSheetInsert                1.08   0.001 ± 0.000              0.001
WebKitCSS             WhereIsClassRuleIndexing        0.991  0.106 ± 0.001              0.107 ± 0.000
WebKitCSS             WhereIsRuleIndexing             0.986  0.151 ± 0.003              0.153 ± 0.003

Benchmark      Speedup  Old Total Time (s)    New Total Time (s)
-----------  ---------  --------------------  --------------------
WebKitCSS        1.164  0.658 ± 0.011         0.565 ± 0.016
```