### PR TITLE
LibWebView: Defer launching devtools until the app is fully initialized

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1295,8 +1295,13 @@ ErrorOr<void> Application::launch_services()
 #endif
     TRY(launch_compositor_process());
 
-    if (m_browser_options.devtools_port.has_value())
-        TRY(launch_devtools_server());
+    if (m_browser_options.devtools_port.has_value()) {
+        // Defer launching devtools until the entire application is initialized.
+        Core::deferred_invoke([this]() {
+            if (auto result = launch_devtools_server(); result.is_error())
+                warnln("Unable to launch devtools server: {}", result.error());
+        });
+    }
 
     return {};
 }


### PR DESCRIPTION
Commit c3c7127d3f had to swap the order of launching app services and creating the app menu to accommodate the favicon store. This regressed launching the devtools server at startup, which will try to update the devtools app menu item that now doesn't exist yet.

We can defer launching the devtools server (and make failure to launch the server non-fatal, as we're in a deferred_invoke now).