### PR TITLE
LibWeb: Create MessagePort transports lazily

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -86,7 +86,7 @@ void MessagePort::visit_edges(Cell::Visitor& visitor)
 
 bool MessagePort::is_entangled() const
 {
-    return m_transport;
+    return m_remote_port || m_transport;
 }
 
 void MessagePort::set_worker_event_target(GC::Ref<DOM::EventTarget> target)
@@ -97,21 +97,22 @@ void MessagePort::set_worker_event_target(GC::Ref<DOM::EventTarget> target)
 // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports:transfer-steps
 WebIDL::ExceptionOr<void> MessagePort::transfer_steps(JS::Realm& realm, HTML::TransferDataEncoder& data_holder)
 {
-    // 1. Set value's has been shipped flag to true.
-    m_has_been_shipped = true;
-
     bool has_remote_port_handle = false;
     IPC::TransportHandle remote_port_handle;
+    GC::Ptr<MessagePort> remote_port;
+    OwnPtr<IPC::Transport> remote_port_transport;
 
     // 3. If value is entangled with another port remotePort, then:
-    if (is_entangled()) {
-        // 1. Set remotePort's has been shipped flag to true.
+    if (m_remote_port) {
+        remote_port = m_remote_port;
 
-        // NOTE: We have to null check here because we can be entangled with a port living in another agent.
-        //       In that case, we'll have a transport, but no remote port object.
-        if (m_remote_port)
-            m_remote_port->m_has_been_shipped = true;
-
+        // NB: Same-agent ports do not need a transport until one endpoint is shipped. Keep the endpoint
+        //     remaining in this agent and transfer the other endpoint to the receiving agent.
+        auto paired = MUST(IPC::Transport::create_paired());
+        remote_port_transport = move(paired.local);
+        remote_port_handle = move(paired.remote_handle);
+        has_remote_port_handle = true;
+    } else if (m_transport) {
         // NOTE: release_for_transfer() stops the IO thread before drain_transport() reads the message buffer
         //       below (step 2). Stopping first ensures a consistent snapshot: no new messages arrive between
         //       the drain and the handle being handed to the new owner.
@@ -121,24 +122,49 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_steps(JS::Realm& realm, HTML::Tr
 
     // 2. Set dataHolder.[[PortMessageQueue]] to value's port message queue.
 
-    // Drain any incoming transport state into this port before serializing it so received messages and
-    // a pending shutdown move with the transferred port instead of being left behind on the old transport.
+    // NB: Drain any incoming transport state into this port before serializing it so received messages and
+    //     a pending shutdown move with the transferred port instead of being left behind on the old transport.
     drain_transport();
     TRY(encode_or_throw_data_clone_error(realm, data_holder, m_pending_incoming_messages));
     TRY(encode_or_throw_data_clone_error(realm, data_holder, m_pending_outgoing_messages));
     TRY(encode_or_throw_data_clone_error(realm, data_holder, m_should_shutdown_on_enable));
 
     if (has_remote_port_handle) {
-        m_transport.clear();
-
         // 2. Set dataHolder.[[RemotePort]] to remotePort.
         TRY(encode_or_throw_data_clone_error(realm, data_holder, IPC_FILE_TAG));
+        if (m_fail_next_transfer_for_testing) {
+            m_fail_next_transfer_for_testing = false;
+            return WebIDL::DataCloneError::create("Forced MessagePort transfer failure"_utf16);
+        }
         TRY(encode_or_throw_data_clone_error(realm, data_holder, remote_port_handle));
     }
     // 4. Otherwise, set dataHolder.[[RemotePort]] to null.
     else {
         TRY(encode_or_throw_data_clone_error(realm, data_holder, static_cast<u8>(0)));
     }
+
+    // NB: Commit the entanglement conversion only after every fallible encoding succeeds.
+    // 1. Set value's has been shipped flag to true.
+    m_has_been_shipped = true;
+
+    if (remote_port) {
+        // 1. Set remotePort's has been shipped flag to true.
+        remote_port->m_has_been_shipped = true;
+        remote_port->m_transport = move(remote_port_transport);
+        remote_port->m_remote_port = nullptr;
+        m_remote_port = nullptr;
+
+        remote_port->m_transport->set_up_read_hook([remote_port = GC::make_root(remote_port)]() {
+            remote_port->read_from_transport();
+        });
+        remote_port->flush_pending_outgoing_messages();
+    } else if (has_remote_port_handle) {
+        m_transport.clear();
+    }
+
+    m_pending_incoming_messages.clear();
+    m_pending_outgoing_messages.clear();
+    m_should_shutdown_on_enable = false;
 
     return {};
 }
@@ -161,6 +187,7 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(JS::Realm& realm
     if (fd_tag == IPC_FILE_TAG) {
         auto handle = TRY(decode_or_throw_data_clone_error<IPC::TransportHandle>(realm, data_holder));
         m_transport = MUST(handle.create_transport());
+        m_has_ever_been_entangled = true;
 
         m_transport->set_up_read_hook([strong_this = GC::make_root(this)]() {
             strong_this->read_from_transport();
@@ -201,35 +228,17 @@ void MessagePort::entangle_with(MessagePort& remote_port)
 
     // 1. If one of the ports is already entangled, then disentangle it and the port that it was entangled with.
 
-    // NB: A port with an active transport should not have pending messages as outgoing messages are flushed when the
-    // transport is created, and incoming messages should only be pending on a port that has been transferred.
-    if (is_entangled()) {
-        VERIFY(m_pending_incoming_messages.is_empty());
-        VERIFY(m_pending_outgoing_messages.is_empty());
+    if (is_entangled())
         disentangle();
-    }
-    if (remote_port.is_entangled()) {
-        VERIFY(remote_port.m_pending_incoming_messages.is_empty());
-        VERIFY(remote_port.m_pending_outgoing_messages.is_empty());
+    if (remote_port.is_entangled())
         remote_port.disentangle();
-    }
 
     // 2. Associate the two ports to be entangled, so that they form the two parts of a new channel.
     //    (There is no MessageChannel object that represents this channel.)
     remote_port.m_remote_port = this;
     m_remote_port = &remote_port;
-
-    auto paired = MUST(IPC::Transport::create_paired());
-    m_transport = move(paired.local);
-    m_remote_port->m_transport = MUST(paired.remote_handle.create_transport());
-
-    m_transport->set_up_read_hook([strong_this = GC::make_root(this)]() {
-        strong_this->read_from_transport();
-    });
-
-    m_remote_port->m_transport->set_up_read_hook([remote_port = GC::make_root(m_remote_port)]() {
-        remote_port->read_from_transport();
-    });
+    remote_port.m_has_ever_been_entangled = true;
+    m_has_ever_been_entangled = true;
 
     flush_pending_outgoing_messages();
     m_remote_port->flush_pending_outgoing_messages();
@@ -289,17 +298,8 @@ WebIDL::ExceptionOr<void> MessagePort::message_port_post_message_steps(JS::Realm
 
     // 6. If targetPort is null, or if doomed is true, then return.
 
-    // IMPLEMENTATION DEFINED: A port can exist before it has a transport to send on. Keep the serialized
-    // record on the port and flush it once the port becomes entangled.
-    if (doomed) {
+    if (doomed)
         return {};
-    }
-
-    if (!m_transport) {
-        if (!is_detached())
-            m_pending_outgoing_messages.append(move(serialize_with_transfer_result));
-        return {};
-    }
 
     // 7. Add a task that runs the following steps to the port message queue of targetPort:
     if (m_remote_port && !m_has_been_shipped) {
@@ -308,8 +308,12 @@ WebIDL::ExceptionOr<void> MessagePort::message_port_post_message_steps(JS::Realm
             if (target->m_enabled)
                 target->dispatch_pending_messages();
         }));
-    } else {
+    } else if (m_transport) {
         post_port_message(serialize_with_transfer_result);
+    } else if (!is_detached() && !m_has_been_shipped && !m_has_ever_been_entangled) {
+        // AD-HOC: A port can exist before it has a transport to send on. Keep the serialized record on the port
+        //         and flush it once the port becomes entangled.
+        m_pending_outgoing_messages.append(move(serialize_with_transfer_result));
     }
 
     return {};
@@ -327,6 +331,19 @@ ErrorOr<void> MessagePort::send_message_on_transport(SerializedTransferRecord co
 
 void MessagePort::flush_pending_outgoing_messages()
 {
+    if (m_remote_port && !m_has_been_shipped) {
+        if (m_pending_outgoing_messages.is_empty())
+            return;
+
+        auto pending_outgoing_messages = move(m_pending_outgoing_messages);
+        m_remote_port->m_pending_incoming_messages.extend(move(pending_outgoing_messages));
+        queue_global_task(Task::Source::PostedMessage, m_remote_port->relevant_global_object(), GC::create_function(heap(), [target = GC::make_root(m_remote_port)] {
+            if (target->m_enabled)
+                target->dispatch_pending_messages();
+        }));
+        return;
+    }
+
     if (!m_transport || !m_transport->is_open())
         return;
 

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -54,6 +54,8 @@ public:
 
     GC::Ptr<MessagePort> entangled_port() { return m_remote_port; }
     GC::Ptr<MessagePort const> entangled_port() const { return m_remote_port; }
+    size_t pending_outgoing_message_count() const { return m_pending_outgoing_messages.size(); }
+    void fail_next_transfer_for_testing() { m_fail_next_transfer_for_testing = true; }
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage
     WebIDL::ExceptionOr<void> post_message(JS::Realm&, JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer);
@@ -104,6 +106,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#has-been-shipped
     bool m_has_been_shipped { false };
+    bool m_has_ever_been_entangled { false };
+    bool m_fail_next_transfer_for_testing { false };
 
     OwnPtr<IPC::Transport> m_transport;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -66,6 +66,7 @@
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
@@ -287,6 +288,21 @@ bool Internals::has_activity_root(JS::Object& object)
     if (auto* web_socket = Bindings::impl_from<WebSockets::WebSocket>(&object))
         return web_socket->has_activity_root();
     return false;
+}
+
+WebIDL::UnsignedLongLong Internals::message_port_pending_outgoing_message_count(HTML::MessagePort& port)
+{
+    return port.pending_outgoing_message_count();
+}
+
+void Internals::fail_next_message_port_transfer(HTML::MessagePort& port)
+{
+    port.fail_next_transfer_for_testing();
+}
+
+bool Internals::message_ports_are_directly_entangled(HTML::MessagePort& first, HTML::MessagePort& second)
+{
+    return first.entangled_port().ptr() == &second && second.entangled_port().ptr() == &first;
 }
 
 GC::Ref<XHR::XMLHttpRequest> Internals::create_xml_http_request_for_document(DOM::Document& document)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -58,6 +58,9 @@ public:
     WebIDL::ExceptionOr<void> mark_as_garbage(Utf16String const& variable_name);
     bool wrapper_is_preserved(JS::Object&);
     bool has_activity_root(JS::Object&);
+    WebIDL::UnsignedLongLong message_port_pending_outgoing_message_count(HTML::MessagePort&);
+    void fail_next_message_port_transfer(HTML::MessagePort&);
+    bool message_ports_are_directly_entangled(HTML::MessagePort&, HTML::MessagePort&);
     GC::Ref<XHR::XMLHttpRequest> create_xml_http_request_for_document(DOM::Document&);
     Optional<Painting::HitTestResult> hit_test(double x, double y);
     GC::Ptr<JS::Object> hit_test_result(double x, double y);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -17,6 +17,9 @@ interface Internals {
     undefined markAsGarbage(DOMString variableName);
     boolean wrapperIsPreserved(object object);
     boolean hasActivityRoot(object object);
+    unsigned long long messagePortPendingOutgoingMessageCount(MessagePort port);
+    undefined failNextMessagePortTransfer(MessagePort port);
+    boolean messagePortsAreDirectlyEntangled(MessagePort first, MessagePort second);
     XMLHttpRequest createXMLHttpRequestForDocument(Document document);
     [ImplementedAs=hit_test_result] object hitTest(double x, double y);
 

--- a/Tests/LibWeb/Text/expected/Messaging/MessagePort-lazy-transport.txt
+++ b/Tests/LibWeb/Text/expected/Messaging/MessagePort-lazy-transport.txt
@@ -1,0 +1,11 @@
+created many local channels
+first, second, third
+closed port retained messages: 0
+closed port received message: false
+after GC
+before transfer, after transfer
+detached port received message: false
+reply after transfer
+transfer failed: DataCloneError
+directly entangled after failed transfer: true
+after failed transfer

--- a/Tests/LibWeb/Text/input/Messaging/MessagePort-lazy-transport.html
+++ b/Tests/LibWeb/Text/input/Messaging/MessagePort-lazy-transport.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        function nextMessage(target) {
+            return new Promise(resolve => {
+                target.addEventListener("message", resolve, { once: true });
+                target.start?.();
+            });
+        }
+
+        for (let i = 0; i < 10_000; ++i)
+            new MessageChannel();
+        println("created many local channels");
+
+        const orderedChannel = new MessageChannel();
+        const orderedMessages = [];
+        const receivedOrderedMessages = new Promise(resolve => {
+            orderedChannel.port1.onmessage = event => {
+                orderedMessages.push(event.data);
+                if (orderedMessages.length === 3)
+                    resolve();
+            };
+        });
+        orderedChannel.port2.postMessage("first");
+        orderedChannel.port2.postMessage("second");
+        orderedChannel.port2.postMessage("third");
+        await receivedOrderedMessages;
+        println(orderedMessages.join(", "));
+
+        const closedChannel = new MessageChannel();
+        let closedPortReceivedMessage = false;
+        closedChannel.port1.onmessage = () => closedPortReceivedMessage = true;
+        closedChannel.port1.close();
+        closedChannel.port2.postMessage("must not arrive");
+        for (let i = 0; i < 16; ++i) {
+            const buffer = new ArrayBuffer(256 * 1024);
+            closedChannel.port2.postMessage(buffer, [buffer]);
+        }
+        println(`closed port retained messages: ${internals.messagePortPendingOutgoingMessageCount(closedChannel.port2)}`);
+
+        const controlChannel = new MessageChannel();
+        const controlMessage = nextMessage(controlChannel.port1);
+        controlChannel.port2.postMessage("control");
+        await controlMessage;
+        println(`closed port received message: ${closedPortReceivedMessage}`);
+
+        let receiveAfterGC;
+        const sender = (() => {
+            const channel = new MessageChannel();
+            receiveAfterGC = nextMessage(channel.port1);
+            return channel.port2;
+        })();
+        await internals.gcAsync();
+        sender.postMessage("after GC");
+        println((await receiveAfterGC).data);
+
+        const transferredChannel = new MessageChannel();
+        let detachedPortReceivedMessage = false;
+        transferredChannel.port1.onmessage = () => detachedPortReceivedMessage = true;
+        transferredChannel.port2.postMessage("before transfer");
+
+        const portTransferred = nextMessage(window);
+        window.postMessage({ port: transferredChannel.port1 }, "*", [transferredChannel.port1]);
+        transferredChannel.port2.postMessage("after transfer");
+
+        const transferredPort = (await portTransferred).data.port;
+        const messagesAroundTransfer = [];
+        const receivedMessagesAroundTransfer = new Promise(resolve => {
+            transferredPort.onmessage = event => {
+                messagesAroundTransfer.push(event.data);
+                if (messagesAroundTransfer.length === 2)
+                    resolve();
+            };
+        });
+        await receivedMessagesAroundTransfer;
+        println(messagesAroundTransfer.join(", "));
+        println(`detached port received message: ${detachedPortReceivedMessage}`);
+
+        const reply = nextMessage(transferredChannel.port2);
+        transferredPort.postMessage("reply after transfer");
+        println((await reply).data);
+
+        const failedTransferChannel = new MessageChannel();
+        internals.failNextMessagePortTransfer(failedTransferChannel.port1);
+        try {
+            window.postMessage({ port: failedTransferChannel.port1 }, "*", [failedTransferChannel.port1]);
+        } catch (error) {
+            println(`transfer failed: ${error.name}`);
+        }
+        println(`directly entangled after failed transfer: ${internals.messagePortsAreDirectlyEntangled(failedTransferChannel.port1, failedTransferChannel.port2)}`);
+
+        const messageAfterFailedTransfer = nextMessage(failedTransferChannel.port1);
+        failedTransferChannel.port2.postMessage("after failed transfer");
+        println((await messageAfterFailedTransfer).data);
+    });
+</script>


### PR DESCRIPTION
Keep newly entangled same-agent ports connected through their in-process relationship. Create a paired IPC transport only when one endpoint is transferred, and move queued state to the replacement port so messages straddling the handoff retain their order.

Add coverage for high-volume local channel creation, delivery ordering, local close and GC behavior, and messages around transfer.

Fixes an issue where we'd crash from excessive thread creation when running WebKit's MessagePort performance tests (which like to create thousands and thousands of message ports..)