### PR TITLE
Fix a crash on the MacRumors.com site — and on any page that restyles <select> elements while a rule matching on the “style” attribute is around

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -3050,6 +3050,94 @@ mod tests {
     }
 
     #[test]
+    fn staged_facts_land_while_a_traversal_borrows_the_primary_rows() {
+        let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+        let mut nodes = [0_u32; 3];
+        engine.allocate_style_nodes(&mut nodes);
+        let initial_tree = [
+            FfiTreeDelta {
+                node: nodes[0],
+                old_connected: false,
+                new_connected: true,
+                old_relations: no_relations(),
+                new_relations: no_relations(),
+            },
+            FfiTreeDelta {
+                node: nodes[1],
+                old_connected: false,
+                new_connected: true,
+                old_relations: no_relations(),
+                new_relations: FfiTreeRelations {
+                    parent: nodes[0],
+                    ..no_relations()
+                },
+            },
+            FfiTreeDelta {
+                node: nodes[2],
+                old_connected: false,
+                new_connected: true,
+                old_relations: no_relations(),
+                new_relations: FfiTreeRelations {
+                    parent: nodes[1],
+                    ..no_relations()
+                },
+            },
+        ];
+        let initial_features = nodes.map(|node| FfiLocalFeatureDelta {
+            node,
+            feature_kind: FfiFeatureKind::TagName,
+            name_atom: 0,
+            old_kind: FfiFeatureValueKind::Absent,
+            old_atom: 0,
+            new_kind: FfiFeatureValueKind::Atom,
+            new_atom: 1,
+        });
+        engine.apply_transaction_batch(&initial_tree, (&[], &[]), &initial_features, &[], &[], &[]);
+
+        let root = StyleNodeID::from_raw(nodes[0]).unwrap();
+        assert!(!engine.take_style_transaction(root, |_, _, _| {}));
+
+        // The style update begins its traversal over the prepared broad plan — whose batch is a borrowed view of the
+        // primary rows.
+        assert!(engine.begin_cold_matching_batch(root));
+        assert!(engine.facts.primary_rows_are_shared());
+
+        // Matching publishes attribute value text on selector demand — which moves the store's catalogs ahead of the
+        // catalogs handle the borrowed rows carry.
+        engine.facts.set_attribute_value_text(StyleAtomID(3), &[b'a' as u16]);
+        assert!(engine.facts.primary_attribute_catalogs_are_stale());
+
+        // An attribute change staged between reaction batches becomes the next transaction of the same stabilization
+        // epoch, taken while the traversal still borrows the rows.
+        let feedback_features = [FfiLocalFeatureDelta {
+            node: nodes[2],
+            feature_kind: FfiFeatureKind::Attribute,
+            name_atom: 2,
+            old_kind: FfiFeatureValueKind::Absent,
+            old_atom: 0,
+            new_kind: FfiFeatureValueKind::Atom,
+            new_atom: 3,
+        }];
+        engine.apply_transaction_batch(&[], (&[], &[]), &feedback_features, &[], &[], &[]);
+        engine.take_style_transaction(root, |_, _, _| {});
+
+        // The committed rows advanced onto the transaction's facts — and the traversal whose plan described the retired
+        // facts went with its answers.
+        let node = StyleNodeID::from_raw(nodes[2]).unwrap();
+        let committed = engine.facts.primary();
+        let committed_row = committed.row_of(node).unwrap();
+        assert_eq!(
+            committed
+                .attribute_of(committed_row, StyleAtomID(2))
+                .map(|fact| fact.value),
+            Some(StyleAtomID(3))
+        );
+        assert!(engine.batch_matching_traversal.is_none());
+        // The style update's bracket still closes over the retired traversal without complaint.
+        engine.end_cold_matching_batch();
+    }
+
+    #[test]
     fn one_batch_carries_every_typed_delta_kind() {
         let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
         let mut nodes = [0_u32; 3];

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -1007,6 +1007,9 @@ impl StyleEngine {
                 let reuse_active_batch_matching_traversal =
                     transaction_reaches_no_selector && self.batch_matching_traversal.is_some();
                 if !reuse_active_batch_matching_traversal {
+                    // The active traversal's plan and answers describe the facts this selector-reaching transaction
+                    // retires — so the traversal goes with them.
+                    self.discard_batch_matching_traversal();
                     self.begin_published_match_answer_completion_batch(root, prefer_complete_batch);
                 }
                 let retained_answer_dispatch = retained_answer_patch

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -3694,7 +3694,7 @@ impl ElementFactStore {
         if Rc::ptr_eq(&self.rows.attribute_catalogs, &self.attribute_catalogs) {
             return;
         }
-        let rows = Rc::get_mut(&mut self.rows).expect("attribute catalog synchronization requires unique primary rows");
+        let rows = Rc::make_mut(&mut self.rows);
         rows.attribute_catalogs = Rc::clone(&self.attribute_catalogs);
     }
 
@@ -4748,6 +4748,13 @@ impl ElementFactStore {
     #[cfg(test)]
     pub(super) fn primary_rows_are_shared(&self) -> bool {
         Rc::strong_count(&self.rows) != 1
+    }
+
+    /// Whether catalog publication has moved past the attribute-catalogs handle the primary rows carry — so the next
+    /// synchronization has to advance the rows.
+    #[cfg(test)]
+    pub(super) fn primary_attribute_catalogs_are_stale(&self) -> bool {
+        !Rc::ptr_eq(&self.rows.attribute_catalogs, &self.attribute_catalogs)
     }
 
     pub(super) fn sweep_auxiliary_catalogs_without_sync(&mut self) {

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -163,6 +163,34 @@ impl StyleEngine {
         }
     }
 
+    /// Retire an active traversal whose plan describes the previous transaction's facts.
+    ///
+    /// A selector-reaching transaction taken between the reaction batches of one style update
+    /// retires the answers it names — and with them, the traversal that produced those answers.
+    /// The completion batch that follows serves the new transaction's answers instead.
+    pub(super) fn discard_batch_matching_traversal(&mut self) {
+        let Some(mut traversal) = self.batch_matching_traversal.take() else {
+            return;
+        };
+        if let Some(batch) = traversal.batch.take() {
+            self.memory
+                .release(MemoryCategory::BatchScratch, batch.capacity_bytes());
+        }
+        if let Some(topology) = traversal.topology.take() {
+            self.memory
+                .release(MemoryCategory::BatchScratch, topology.capacity_bytes());
+        }
+        traversal.ancestor_requirements.release(&mut self.memory);
+        self.memory
+            .release(MemoryCategory::BatchScratch, traversal.match_workspace_bytes);
+        self.memory
+            .release(MemoryCategory::BatchScratch, traversal.dispatch_workspace_bytes);
+        self.memory.release(
+            MemoryCategory::BatchScratch,
+            traversal.cascade_compaction_workspace_bytes,
+        );
+    }
+
     pub(super) fn discard_published_match_answers(&mut self) {
         let published = std::mem::take(&mut self.published_match_answers);
         verify_published_style_transaction(self, |verifier| {

--- a/Tests/LibWeb/Crash/CSS/select-restyle-style-attribute-feedback.html
+++ b/Tests/LibWeb/Crash/CSS/select-restyle-style-attribute-feedback.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<!-- Restyling a select rewrites the inline style of its user-agent shadow children, and the [style*=] rule makes the
+     style attribute one whose value texts selectors demand. Both land as staged style-engine input in the middle of the
+     same style update — whose traversal still borrows a view of the primary fact rows. -->
+<style>
+    [style*="margin"] {
+        color: rgb(1, 2, 3);
+    }
+</style>
+<select><option>one</option></select>


### PR DESCRIPTION
> [!NOTE]
> The actual code change to review here is literally a one-line fix:
> ```diff
> -        let rows = Rc::get_mut(&mut self.rows).expect("attribute catalog synchronization requires unique primary rows");
> +        let rows = Rc::make_mut(&mut self.rows);
> ```
> The rest of the changes are either tests, or changes necessary for enabling the tests to run as expected.

**Problem:** Crash on the MacRumors.com site with Rust panic _“attribute catalog synchronization requires unique primary rows”._ And any page that restyles a `<select>` element while a rule like `[style*=…]` (that is, matching on the `style` attribute) is present reproduces the crash.

**Cause:** cbcf0db88d2 added both (1) traversals that borrow an immutable view of the primary fact rows, and (2) a synchronization that expects those rows to be uniquely owned — which contradict: When a feedback transaction taken mid-update stages element facts, `staged_before_facts()` must move the committed rows onto the freshly published attribute catalogs — and `Rc::get_mut()` fails on the borrowed second reference. Restyling a `<select>` as described above triggers it because it rewrites inline style of its UA shadow children in `computed_properties_changed()`, which stages attribute facts in the middle of the update.

**Fix:** Advance the rows with `Rc::make_mut()` in the synchronization too — as `apply_staged()` already does under a live view. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11252.
