### PR TITLE
LibWeb: Implement destination offsets in WebGL2 readPixels

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include <GLES2/gl2ext_angle.h>
 }
 
+#include <AK/Checked.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/TypedArray.h>
@@ -408,24 +409,48 @@ void WebGL2RenderingContextOverloads::uniform_matrix4fv(GC::Ptr<WebGLUniformLoca
     m_context->uniform_matrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
-void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
+// https://registry.khronos.org/webgl/specs/latest/1.0/index.html#5.14.12
+void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height,
+    WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
 {
-    m_context->make_current();
-
     if (pixels.has<Empty>()) {
         set_error(GL_INVALID_VALUE);
         return;
     }
 
     WebIDL::ArrayBufferView view { pixels.downcast<WebIDL::ArrayBufferViewVariant>() };
-    auto validated_view_or_error = WebIDL::validate_array_buffer_view(view);
+    read_pixels(x, y, width, height, format, type, view, 0);
+}
+
+// https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.10
+void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height,
+    WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::ArrayBufferView dst_data, WebIDL::UnsignedLongLong dst_offset)
+{
+    m_context->make_current();
+
+    // If a WebGLBuffer is bound to the PIXEL_PACK_BUFFER target, generates an INVALID_OPERATION error.
+    if (m_pixel_pack_buffer_binding) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+
+    // If pixel store parameter constraints are not met, generates an INVALID_OPERATION error.
+    auto validated_view_or_error = WebIDL::validate_array_buffer_view(dst_data);
     if (validated_view_or_error.is_error()) {
         set_error(GL_INVALID_OPERATION);
         return;
     }
     auto validated_view = validated_view_or_error.release_value();
 
-    auto bytes_or_error = ByteBuffer::create_uninitialized(validated_view.byte_length);
+    // If dstData doesn't have enough space for the read operation starting at dstOffset, generate INVALID_OPERATION.
+    Checked<size_t> dst_byte_offset = dst_offset;
+    dst_byte_offset *= validated_view.element_size;
+    if (dst_byte_offset.has_overflow() || dst_byte_offset.value() > validated_view.byte_length) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+
+    auto bytes_or_error = ByteBuffer::create_uninitialized(validated_view.byte_length - dst_byte_offset.value());
     if (bytes_or_error.is_error()) {
         set_error(GL_OUT_OF_MEMORY);
         return;
@@ -436,15 +461,18 @@ void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y
     if (bytes_read == 0)
         return;
     VERIFY(bytes_read > 0);
-    if (view.write_checked(ReadonlyBytes { bytes.data(), static_cast<size_t>(bytes_read) }).is_error()) [[unlikely]]
+
+    if (dst_data.write_checked({ bytes.data(), static_cast<size_t>(bytes_read) }, dst_byte_offset.value()).is_error()) [[unlikely]]
         set_error(GL_INVALID_OPERATION);
 }
 
+// https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.10
 void WebGL2RenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height,
     WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::LongLong offset)
 {
     m_context->make_current();
 
+    // If no WebGLBuffer is bound to the PIXEL_PACK_BUFFER target, generates an INVALID_OPERATION error.
     if (!m_pixel_pack_buffer_binding) {
         set_error(GL_INVALID_OPERATION);
         return;

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
@@ -52,6 +52,7 @@ public:
     void uniform_matrix3fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length);
     void uniform_matrix4fv(GC::Ptr<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length);
     void read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels);
+    void read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::ArrayBufferView dst_data, WebIDL::UnsignedLongLong dst_offset);
     void read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::LongLong offset);
 };
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -58,6 +58,6 @@ interface mixin WebGL2RenderingContextOverloads {
     // WebGL1:
     undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
     // WebGL2:
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView dstData, unsigned long long dstOffset);
     undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr offset);
-    [FIXME] undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView dstData, unsigned long long dstOffset);
 };

--- a/Tests/LibWeb/Text/expected/canvas/webgl2-read-pixels-destination-offset.txt
+++ b/Tests/LibWeb/Text/expected/canvas/webgl2-read-pixels-destination-offset.txt
@@ -1,0 +1,6 @@
+readPixels error: NO_ERROR
+at offset 0: 0,0,0,0
+at offset 32: 255,0,0,255
+Uint32Array readPixels error: NO_ERROR
+Uint32Array at offset 0: 0,0,0,0
+Uint32Array at offset 8: 255,0,0,255

--- a/Tests/LibWeb/Text/input/canvas/webgl2-read-pixels-destination-offset.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl2-read-pixels-destination-offset.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script src="webgl-helpers.js"></script>
+<script>
+    test(() => {
+        const canvas = document.createElement("canvas");
+        canvas.width = canvas.height = 8;
+
+        const gl = canvas.getContext("webgl2");
+
+        // Verify a non-zero destination offset with a byte-sized element type.
+        gl.clearColor(1, 0, 0, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        const pixels = new Uint8Array(64);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels, 32);
+
+        println(`readPixels error: ${errorName(gl, gl.getError())}`);
+        println(`at offset 0: ${pixels.slice(0, 4)}`);
+        println(`at offset 32: ${pixels.slice(32, 36)}`);
+
+        // Verify that destination offsets are measured in elements rather than bytes.
+        const framebuffer = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+
+        const renderbuffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA32UI, 1, 1);
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, renderbuffer);
+
+        gl.clearBufferuiv(gl.COLOR, 0, new Uint32Array([255, 0, 0, 255]));
+
+        const uint32Pixels = new Uint32Array(16);
+        gl.readPixels(0, 0, 1, 1, gl.RGBA_INTEGER, gl.UNSIGNED_INT, uint32Pixels, 8);
+
+        println(`Uint32Array readPixels error: ${errorName(gl, gl.getError())}`);
+        println(`Uint32Array at offset 0: ${uint32Pixels.slice(0, 4)}`);
+        println(`Uint32Array at offset 8: ${uint32Pixels.slice(8, 12)}`);
+    });
+</script>


### PR DESCRIPTION
The eight-argument `readPixels` overload was not exposed by the generated bindings, causing `dstOffset` to be ignored and pixel data to be written at the start of `dstData`.

Expose the overload, validate the remaining destination range, and write the pixel data at the computed byte offset.

Fixes #11250