### PR TITLE
Stop walking the paint tree from C++

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6450,9 +6450,15 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect t
     // 2. Let container be the containing block of target.
     // 3. While container is not root:
     if (auto target_paintable = target->paintable_box()) {
-        for (auto container = target_paintable->containing_block(); container; container = container->containing_block()) {
+        Layout::Box* root_layout_box = nullptr;
+        if (root_paintable && root_paintable->has_layout_node())
+            root_layout_box = as<Layout::Box>(&root_paintable->layout_node());
+        for (auto* container_box = target_paintable->layout_node().containing_block(); container_box; container_box = container_box->containing_block()) {
             // Stop when we reach the intersection root.
-            if (container == root_paintable)
+            if (container_box == root_layout_box)
+                break;
+            auto container = container_box->paintable();
+            if (!container)
                 break;
 
             // FIXME: 3.1. If container is the document of a nested browsing context, update

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2269,12 +2269,19 @@ void Document::update_layout(UpdateLayoutReason reason)
 void Document::collect_paintable_boxes_with_auto_content_visibility()
 {
     Vector<WeakPtr<Painting::Paintable>> paintables_with_auto_content_visibility;
-    unsafe_paintable()->for_each_in_subtree_of_type<Painting::Paintable>([&](auto& paintable) {
-        if (paintable.dom_node()
-            && paintable.dom_node()->is_element()
-            && paintable.layout_node().content_visibility() == CSS::ContentVisibility::Auto) {
-            paintables_with_auto_content_visibility.append(paintable);
+    unsafe_layout_node()->for_each_in_inclusive_subtree([&](Layout::Node& node) {
+        switch (node.kind()) {
+        case Layout::RustFFI::NodeKind::SVGMaskBox:
+        case Layout::RustFFI::NodeKind::SVGClipBox:
+        case Layout::RustFFI::NodeKind::SVGPatternBox:
+            return TraversalDecision::SkipChildrenAndContinue;
+        default:
+            break;
         }
+        auto* paintable = node.paintable_ptr();
+        if (paintable && node.dom_node() && node.dom_node()->is_element()
+            && paintable->layout_node().content_visibility() == CSS::ContentVisibility::Auto)
+            paintables_with_auto_content_visibility.append(*paintable);
         return TraversalDecision::Continue;
     });
     unsafe_paintable()->set_paintable_boxes_with_auto_content_visibility(move(paintables_with_auto_content_visibility));

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9543,11 +9543,20 @@ Utf16String Document::dump_display_list()
         return "No display list"_utf16;
 
     HashMap<size_t, RefPtr<Painting::Paintable const>> context_id_to_paintable;
-    viewport_paintable->for_each_in_inclusive_subtree_of_type<Painting::Paintable>([&](auto const& paintable_box) {
-        auto visual_context_index = paintable_box.accumulated_visual_context_index();
-        (void)context_id_to_paintable.try_set(visual_context_index.value(), paintable_box);
-        return TraversalDecision::Continue;
-    });
+    auto entry_count = Layout::RustFFI::layout_arena_paint_tree_dump_entry_count(viewport_paintable->rust_arena().handle(), viewport_paintable->rust_slot());
+    Vector<Layout::RustFFI::FfiPaintTreeDumpEntry> entries;
+    entries.resize(entry_count);
+    Layout::RustFFI::layout_arena_export_paint_tree_dump_entries(viewport_paintable->rust_arena().handle(), viewport_paintable->rust_slot(), entries.data(), entries.size());
+    for (auto const& entry : entries) {
+        if (!entry.layout_node_shell)
+            continue;
+        auto& layout_node = *static_cast<Layout::Node*>(entry.layout_node_shell);
+        auto paintable = layout_node.paintable();
+        if (!paintable)
+            continue;
+        auto visual_context_index = paintable->accumulated_visual_context_index();
+        (void)context_id_to_paintable.try_set(visual_context_index.value(), paintable);
+    }
 
     StringBuilder builder;
     builder.append("AccumulatedVisualContext Tree:\n"sv);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9092,14 +9092,7 @@ Optional<Painting::HitTestResult> Document::hit_test(CSSPixelPoint position, Pai
         return {};
     viewport_paintable->refresh_scroll_state();
     auto result = hit_test_display_list->hit_test(position, type, *viewport_paintable, page().client().device_pixels_per_css_pixel(), page().chrome_metrics());
-    auto has_dom_node_for_event_dispatch = [](Painting::Paintable& paintable) {
-        for (auto const* current = &paintable; current; current = current->parent()) {
-            if (current->dom_node())
-                return true;
-        }
-        return false;
-    };
-    if (result.has_value() && (result->chrome_widget || has_dom_node_for_event_dispatch(result->paintable)))
+    if (result.has_value() && (result->chrome_widget || Painting::event_dispatch_dom_node_for(result->paintable)))
         return result;
 
     if (auto* body_element = body(); body_element && body_element->paintable())

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -510,27 +510,38 @@ void dump_tree(StringBuilder& builder, Painting::Paintable const& paintable, boo
         color_off = "\033[0m"sv;
     }
 
-    for (int i = 0; i < indent; ++i)
-        builder.append("  "sv);
+    auto entry_count = Layout::RustFFI::layout_arena_paint_tree_dump_entry_count(paintable.rust_arena().handle(), paintable.rust_slot());
+    Vector<Layout::RustFFI::FfiPaintTreeDumpEntry> entries;
+    entries.resize(entry_count);
+    Layout::RustFFI::layout_arena_export_paint_tree_dump_entries(paintable.rust_arena().handle(), paintable.rust_slot(), entries.data(), entries.size());
+    for (auto const& entry : entries) {
+        if (!entry.layout_node_shell)
+            continue;
+        auto& layout_node = *static_cast<Layout::Node*>(entry.layout_node_shell);
+        auto entry_paintable = layout_node.paintable();
+        if (!entry_paintable)
+            continue;
 
-    if (is<Painting::PaintableWithLines>(paintable))
-        builder.append(paintable_with_lines_color_on);
-    else
-        builder.append(paintable_box_color_on);
+        auto entry_indent = indent + static_cast<int>(entry.depth);
+        for (int i = 0; i < entry_indent; ++i)
+            builder.append("  "sv);
 
-    builder.appendff("{}{} ({})", paintable.class_name(), color_off, paintable.layout_node().debug_description());
+        if (is<Painting::PaintableWithLines>(*entry_paintable))
+            builder.append(paintable_with_lines_color_on);
+        else
+            builder.append(paintable_box_color_on);
 
-    builder.appendff(" {}", paintable.absolute_border_box_rect());
+        builder.appendff("{}{} ({})", entry_paintable->class_name(), color_off, layout_node.debug_description());
 
-    if (paintable.has_scrollable_overflow())
-        builder.appendff(" overflow: {}", paintable.scrollable_overflow_rect());
+        builder.appendff(" {}", entry_paintable->absolute_border_box_rect());
 
-    if (!paintable.scroll_offset().is_zero())
-        builder.appendff(" scroll-offset: {}", paintable.scroll_offset());
-    builder.append("\n"sv);
+        if (entry_paintable->has_scrollable_overflow())
+            builder.appendff(" overflow: {}", entry_paintable->scrollable_overflow_rect());
 
-    for (auto child = paintable.first_child(); child; child = child->next_sibling())
-        dump_tree(builder, *child, colorize, indent + 1);
+        if (!entry_paintable->scroll_offset().is_zero())
+            builder.appendff(" scroll-offset: {}", entry_paintable->scroll_offset());
+        builder.append("\n"sv);
+    }
 }
 
 }

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/Layout/Box.h>
 #include <LibWeb/Page/AutoScrollHandler.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
@@ -127,7 +128,8 @@ GC::Ptr<DOM::Element> AutoScrollHandler::find_scrollable_ancestor(Painting::Pain
                 return const_cast<DOM::Element*>(scrolling_element.ptr());
         }
 
-        paintable_box = paintable_box->containing_block();
+        auto* containing_block_box = paintable_box->layout_node().containing_block();
+        paintable_box = containing_block_box ? containing_block_box->paintable() : nullptr;
     }
     return {};
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -779,7 +779,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 if (handled_scroll_event)
                     return EventResult::Handled;
 
-                containing_block = containing_block->containing_block();
+                auto* containing_block_box = containing_block->layout_node().containing_block();
+                containing_block = containing_block_box ? containing_block_box->paintable() : nullptr;
             }
 
             auto document = m_navigable->active_document();
@@ -1324,7 +1325,8 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         while (containing_block) {
             if (containing_block->handle_mousewheel({}, {}, 0, 0, delta_x, delta_y))
                 return true;
-            containing_block = containing_block->containing_block();
+            auto* containing_block_box = containing_block->layout_node().containing_block();
+            containing_block = containing_block_box ? containing_block_box->paintable() : nullptr;
         }
         return false;
     };

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -215,15 +215,7 @@ void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
 
 static GC::Ptr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable& paintable)
 {
-    if (auto node = paintable.dom_node())
-        return node;
-    auto parent = paintable.parent();
-    while (parent) {
-        if (auto node = parent->dom_node())
-            return node;
-        parent = parent->parent();
-    }
-    return nullptr;
+    return event_dispatch_dom_node_for(paintable);
 }
 
 static CSS::UserSelect user_select_used_value_for_caret_position(Painting::CaretPosition const& caret_position)

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -422,11 +422,7 @@ DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(Item const
     if (item.kind == ItemKind::EmptyLine)
         return item_dom_node(item);
 
-    for (auto const* current = item.paintable.ptr(); current; current = current->parent()) {
-        if (auto node = current->dom_node())
-            return node.ptr();
-    }
-    return nullptr;
+    return event_dispatch_dom_node_for(*item.paintable).ptr();
 }
 
 bool HitTestDisplayList::item_is_direct_caret_target(Item const& item) const

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -92,19 +92,4 @@ Optional<PaintableWithLines::CaretPaint> InlinePaintable::resolve_empty_editable
     };
 }
 
-void InlinePaintable::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
-{
-    Paintable::set_needs_repaint(should_invalidate_display_list);
-
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
-        // This box's glyphs are recorded in an ancestor's foreground commands: the containing
-        // block's, or a self-painting inline ancestor's.
-        for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-            ancestor->invalidate_paint_cache();
-            if (is<PaintableWithLines>(*ancestor))
-                break;
-        }
-    }
-}
-
 }

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -67,7 +67,7 @@ bool InlinePaintable::has_content() const
 {
     // Interrupting block-in-inline children produce only placeholder pieces, so any child
     // paintable also counts as content.
-    return has_content_pieces() || has_children();
+    return has_content_pieces() || Layout::RustFFI::layout_arena_paintable_has_child_paintables(rust_arena().handle(), rust_slot());
 }
 
 Optional<PaintableWithLines::CaretPaint> InlinePaintable::resolve_empty_editable_caret_paint() const

--- a/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -28,8 +28,6 @@ public:
 
     bool has_content() const;
 
-    virtual void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes) override;
-
 private:
     explicit InlinePaintable(Layout::NodeWithStyle const&);
 

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -130,21 +130,6 @@ DOM::Document& Paintable::document()
     return layout_node().document();
 }
 
-RefPtr<Paintable> Paintable::containing_block() const
-{
-    return const_cast<Paintable*>(containing_block_ptr());
-}
-
-Paintable const* Paintable::containing_block_ptr() const
-{
-    return shell_from_slot(rust_data().containing_block);
-}
-
-Paintable* Paintable::shell_from_slot(Layout::RustFFI::PaintableSlotId slot) const
-{
-    return static_cast<Paintable*>(Layout::RustFFI::layout_arena_paintable_shell(m_rust_arena->handle(), slot));
-}
-
 bool Paintable::is_visible() const
 {
     return layout_node().visibility() == CSS::Visibility::Visible && layout_node().opacity() != 0;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -187,16 +187,20 @@ bool Paintable::has_stacking_context() const
     return rust_data().stacking_context != Layout::RustFFI::NO_STACKING_CONTEXT;
 }
 
+GC::Ptr<DOM::Node> event_dispatch_dom_node_for(Paintable const& paintable)
+{
+    auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(paintable.rust_arena().handle(), paintable.rust_slot());
+    if (!layout_node_shell)
+        return nullptr;
+    return static_cast<Layout::Node*>(layout_node_shell)->dom_node();
+}
+
 DOM::Node* HitTestResult::dom_node()
 {
     if (dom_node_override)
         return dom_node_override.ptr();
 
-    for (auto* current = paintable.ptr(); current; current = current->parent()) {
-        if (auto node = current->dom_node())
-            return node.ptr();
-    }
-    return nullptr;
+    return event_dispatch_dom_node_for(*paintable).ptr();
 }
 
 DOM::Node const* HitTestResult::dom_node() const
@@ -204,11 +208,7 @@ DOM::Node const* HitTestResult::dom_node() const
     if (dom_node_override)
         return dom_node_override.ptr();
 
-    for (auto const* current = paintable.ptr(); current; current = current->parent()) {
-        if (auto node = current->dom_node())
-            return node.ptr();
-    }
-    return nullptr;
+    return event_dispatch_dom_node_for(*paintable).ptr();
 }
 
 CSSPixelPoint Paintable::box_type_agnostic_position() const

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1427,14 +1427,7 @@ bool Paintable::resizer_contains(CSSPixelPoint adjusted_position, ChromeMetrics 
 void Paintable::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
 {
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
-        invalidate_paint_cache();
-
-        // Recurse into anonymous child nodes so we properly invalidate nested contents of e.g. <button>s.
-        for_each_child_of_type<Paintable>([&](auto& child) {
-            if (child.layout_node().is_anonymous())
-                child.set_needs_repaint(should_invalidate_display_list);
-            return IterationDecision::Continue;
-        });
+        Layout::RustFFI::layout_arena_paintable_invalidate_for_repaint(rust_arena().handle(), rust_slot());
 
         // The root element paints the body's propagated background, so a body repaint must also refresh the
         // root's cached background. A root repaint can conversely flip whether propagation applies, changing

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -440,7 +440,7 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
             cursor_rect.set_y(cursor_rect.y() - 1);
         cursor_rect.set_height(1);
     }
-    for (auto* ancestor = static_cast<Paintable*>(result.owner_paintable); ancestor; ancestor = ancestor->containing_block().ptr()) {
+    for (auto* ancestor = static_cast<Paintable*>(result.owner_paintable); ancestor;) {
         if (ancestor->has_scrollable_overflow()) {
             if (scroll_block_direction == ScrollBlockDirection::No) {
                 auto snapport = ancestor->scroll_snapport_rect();
@@ -455,6 +455,8 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
             ancestor->scroll_into_view(cursor_rect);
             return;
         }
+        auto* containing_block_box = ancestor->layout_node().containing_block();
+        ancestor = containing_block_box ? containing_block_box->paintable_ptr() : nullptr;
     }
 }
 
@@ -1571,13 +1573,16 @@ CSSPixels Paintable::outline_offset() const
 
 RefPtr<Paintable const> Paintable::nearest_scrollable_ancestor() const
 {
-    auto paintable = this->containing_block();
-    while (paintable) {
+    if (!has_layout_node())
+        return nullptr;
+    for (auto const* box = layout_node().containing_block(); box; box = box->containing_block()) {
+        auto const* paintable = box->paintable_ptr();
+        if (!paintable)
+            return nullptr;
         if (paintable->could_be_scrolled_by_wheel_event())
             return paintable;
         if (paintable->is_fixed_position())
             return nullptr;
-        paintable = paintable->containing_block();
     }
     return nullptr;
 }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/IterationDecision.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
@@ -41,7 +40,6 @@
 #include <LibWeb/Painting/ShadowData.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/TextAffinity.h>
-#include <LibWeb/TreeTraversal.h>
 
 namespace Web::Painting {
 
@@ -101,113 +99,6 @@ public:
 
     bool has_stacking_context() const;
 
-    Paintable* parent_ptr() { return shell_from_slot(rust_data().parent); }
-    Paintable const* parent_ptr() const { return shell_from_slot(rust_data().parent); }
-    RefPtr<Paintable> parent() { return parent_ptr(); }
-    RefPtr<Paintable const> parent() const { return parent_ptr(); }
-    Paintable* first_child_ptr() { return shell_from_slot(rust_data().first_child); }
-    Paintable const* first_child_ptr() const { return shell_from_slot(rust_data().first_child); }
-    RefPtr<Paintable> first_child() { return first_child_ptr(); }
-    RefPtr<Paintable const> first_child() const { return first_child_ptr(); }
-    Paintable* next_sibling_ptr() { return shell_from_slot(rust_data().next_sibling); }
-    Paintable const* next_sibling_ptr() const { return shell_from_slot(rust_data().next_sibling); }
-    RefPtr<Paintable> next_sibling() { return next_sibling_ptr(); }
-    RefPtr<Paintable const> next_sibling() const { return next_sibling_ptr(); }
-    bool has_children() const { return rust_data().first_child.index != Layout::RustFFI::INVALID_PAINTABLE_SLOT_INDEX; }
-
-    template<typename Callback>
-    TraversalDecision for_each_in_inclusive_subtree(Callback callback)
-    {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, move(callback));
-    }
-    template<typename Callback>
-    TraversalDecision for_each_in_inclusive_subtree(Callback callback) const
-    {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, move(callback));
-    }
-    template<typename U, typename Callback>
-    TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback)
-    {
-        return for_each_in_inclusive_subtree([callback = move(callback)](Paintable& paintable) {
-            if (auto* paintable_of_type = as_if<U>(paintable))
-                return callback(*paintable_of_type);
-            return TraversalDecision::Continue;
-        });
-    }
-    template<typename U, typename Callback>
-    TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback) const
-    {
-        return for_each_in_inclusive_subtree([callback = move(callback)](Paintable const& paintable) {
-            if (auto const* paintable_of_type = as_if<U>(paintable))
-                return callback(*paintable_of_type);
-            return TraversalDecision::Continue;
-        });
-    }
-    template<typename Callback>
-    TraversalDecision for_each_in_subtree(Callback callback)
-    {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::No, move(callback));
-    }
-    template<typename Callback>
-    TraversalDecision for_each_in_subtree(Callback callback) const
-    {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::No, move(callback));
-    }
-    template<typename U, typename Callback>
-    TraversalDecision for_each_in_subtree_of_type(Callback callback)
-    {
-        return for_each_in_subtree([callback = move(callback)](Paintable& paintable) {
-            if (auto* paintable_of_type = as_if<U>(paintable))
-                return callback(*paintable_of_type);
-            return TraversalDecision::Continue;
-        });
-    }
-    template<typename U, typename Callback>
-    TraversalDecision for_each_in_subtree_of_type(Callback callback) const
-    {
-        return for_each_in_subtree([callback = move(callback)](Paintable const& paintable) {
-            if (auto const* paintable_of_type = as_if<U>(paintable))
-                return callback(*paintable_of_type);
-            return TraversalDecision::Continue;
-        });
-    }
-    template<typename Callback>
-    void for_each_child(Callback callback)
-    {
-        for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-            if (callback(*child) == IterationDecision::Break)
-                return;
-        }
-    }
-    template<typename Callback>
-    void for_each_child(Callback callback) const
-    {
-        for (auto const* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-            if (callback(*child) == IterationDecision::Break)
-                return;
-        }
-    }
-    template<typename U, typename Callback>
-    void for_each_child_of_type(Callback callback)
-    {
-        for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-            if (auto* child_of_type = as_if<U>(*child)) {
-                if (callback(*child_of_type) == IterationDecision::Break)
-                    return;
-            }
-        }
-    }
-    template<typename U, typename Callback>
-    void for_each_child_of_type(Callback callback) const
-    {
-        for (auto const* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-            if (auto const* child_of_type = as_if<U>(*child)) {
-                if (callback(*child_of_type) == IterationDecision::Break)
-                    return;
-            }
-        }
-    }
-
     bool has_layout_node() const { return m_layout_node; }
     Layout::NodeWithStyle const& layout_node() const
     {
@@ -225,9 +116,6 @@ public:
     bool visible_for_hit_testing() const;
 
     GC::Ptr<HTML::LocalNavigable> navigable() const;
-
-    RefPtr<Paintable> containing_block() const;
-    Paintable const* containing_block_ptr() const;
 
     template<typename T>
     bool fast_is() const = delete;
@@ -517,8 +405,6 @@ private:
 
     bool has_flag(Layout::RustFFI::PaintableFlag flag) const { return (rust_data().flags & to_underlying(flag)) != 0; }
     Layout::RustFFI::PaintableData& rust_data() { return *m_rust_data; }
-    Paintable* shell_from_slot(Layout::RustFFI::PaintableSlotId) const;
-
     GC::Weak<DOM::Node> m_dom_node;
     WeakPtr<Layout::NodeWithStyle const> m_layout_node;
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -62,6 +62,8 @@ WEB_API Paintable const* nearest_svg_viewport_paintable_of(Layout::Node const&);
 // The viewport's rect in its own user units: the active viewBox rect, else {0,0} + the used size.
 WEB_API Gfx::FloatRect svg_viewport_user_rect(Paintable const& viewport_paintable);
 
+GC::Ptr<DOM::Node> event_dispatch_dom_node_for(Paintable const&);
+
 bool body_background_is_propagated_to_root(Layout::NodeWithStyle const&);
 
 void invalidate_descendant_styles_for_container_query_size_change(Paintable&, CSSPixelSize old_content_size, CSSPixelSize new_content_size);

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -402,7 +402,7 @@ public:
     Optional<CachedOverflowData> cached_overflow_data() const;
     void clear_cached_overflow_data();
 
-    virtual void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
+    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
 
     virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y);
 

--- a/Libraries/LibWeb/Painting/SVGMasking.cpp
+++ b/Libraries/LibWeb/Painting/SVGMasking.cpp
@@ -89,19 +89,27 @@ static Optional<CSSPixelRect> svg_clip_path_geometry_bounds(Paintable const& pai
     // which paint can be applied. Thus, a point is inside the clipping path if it is inside any of the
     // children of the clipPath.
     Gfx::BoundingBox<CSSPixels> bounding_box;
-    paintable.for_each_child_of_type<Paintable>([&](Paintable const& child) {
-        if (!child.is_svg_paintable())
-            return IterationDecision::Continue;
+    for (auto const* child = paintable.layout_node().first_child_ptr(); child; child = child->next_sibling_ptr()) {
+        switch (child->kind()) {
+        case Layout::RustFFI::NodeKind::SVGMaskBox:
+        case Layout::RustFFI::NodeKind::SVGClipBox:
+        case Layout::RustFFI::NodeKind::SVGPatternBox:
+            continue;
+        default:
+            break;
+        }
+        auto const* child_paintable = child->paintable_ptr();
+        if (!child_paintable || !child_paintable->is_svg_paintable())
+            continue;
 
-        auto child_transform = Gfx::AffineTransform { additional_transform }.multiply(child.layout_node().used_svg_element_transform());
-        auto child_bounds = svg_clip_path_geometry_bounds(child, child_transform);
+        auto child_transform = Gfx::AffineTransform { additional_transform }.multiply(child_paintable->layout_node().used_svg_element_transform());
+        auto child_bounds = svg_clip_path_geometry_bounds(*child_paintable, child_transform);
         if (!child_bounds.has_value())
-            return IterationDecision::Continue;
+            continue;
 
         bounding_box.add_point(child_bounds->left(), child_bounds->top());
         bounding_box.add_point(child_bounds->right(), child_bounds->bottom());
-        return IterationDecision::Continue;
-    });
+    }
 
     if (bounding_box.has_no_points())
         return {};

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -196,10 +196,7 @@ void ViewportPaintable::append_paint_command_cache_source_resources(DisplayListR
 
 void ViewportPaintable::invalidate_all_cached_paint()
 {
-    for_each_in_inclusive_subtree([](auto& paintable) {
-        paintable.invalidate_paint_cache();
-        return TraversalDecision::Continue;
-    });
+    Layout::RustFFI::layout_arena_invalidate_all_paint_caches(rust_arena().handle());
     set_needs_repaint();
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -134,6 +134,21 @@ pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
     })
 }
 
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_has_child_paintables(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> bool {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        paintables.is_live(slot) && !paintables.data_ref(slot).first_child.is_invalid()
+    })
+}
+
 unsafe fn ffi_slice<'a, T>(data: *const T, length: usize) -> &'a [T] {
     assert!(!data.is_null() || length == 0);
     if length == 0 {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1970,6 +1970,75 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
     });
 }
 
+fn paint_tree_dump_entries(
+    arena: &LayoutNodeArena,
+    paintables: &crate::painting::paintable_arena::PaintableArena,
+    root: PaintableSlotId,
+) -> Vec<crate::painting::host::FfiPaintTreeDumpEntry> {
+    fn visit(
+        arena: &LayoutNodeArena,
+        paintables: &crate::painting::paintable_arena::PaintableArena,
+        slot: PaintableSlotId,
+        depth: u32,
+        entries: &mut Vec<crate::painting::host::FfiPaintTreeDumpEntry>,
+    ) {
+        entries.push(crate::painting::host::FfiPaintTreeDumpEntry {
+            layout_node_shell: arena.shell_if_live(paintables.data_ref(slot).layout_node),
+            depth,
+        });
+        let mut child = paintables.first_child(slot);
+        while let Some(current) = child {
+            visit(arena, paintables, current, depth + 1, entries);
+            child = paintables.next_sibling(current);
+        }
+    }
+
+    if !paintables.is_live(root) {
+        return Vec::new();
+    }
+    let mut entries = Vec::new();
+    visit(arena, paintables, root, 0, &mut entries);
+    entries
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paint_tree_dump_entry_count(arena: *mut c_void, root: PaintableSlotId) -> usize {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        paint_tree_dump_entries(arena, &paintables, root).len()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`; `output` must point to writable
+/// storage for exactly `output_length` items, matching the current paint-tree dump entry count.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_export_paint_tree_dump_entries(
+    arena: *mut c_void,
+    root: PaintableSlotId,
+    output: *mut crate::painting::host::FfiPaintTreeDumpEntry,
+    output_length: usize,
+) {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        let entries = paint_tree_dump_entries(arena, &paintables, root);
+        assert_eq!(entries.len(), output_length);
+        if entries.is_empty() {
+            return;
+        }
+        assert!(!output.is_null());
+        // SAFETY: The caller provides writable storage for exactly `output_length` exports.
+        let output = unsafe { std::slice::from_raw_parts_mut(output, output_length) };
+        output.copy_from_slice(&entries);
+    });
+}
+
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -110,6 +110,30 @@ pub unsafe extern "C" fn layout_arena_paintable_shell(arena: *mut c_void, slot: 
     })
 }
 
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> *mut c_void {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        let mut current = slot;
+        while !current.is_invalid() && paintables.is_live(current) {
+            let layout_node = paintables.data_ref(current).layout_node;
+            let flags = arena.node_flags_if_live(layout_node);
+            if flags & crate::layout::node_data::NodeFlag::Anonymous as u32 == 0 {
+                return arena.shell_if_live(layout_node);
+            }
+            current = paintables.data_ref(current).parent;
+        }
+        std::ptr::null_mut()
+    })
+}
+
 unsafe fn ffi_slice<'a, T>(data: *const T, length: usize) -> &'a [T] {
     assert!(!data.is_null() || length == 0);
     if length == 0 {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -99,21 +99,6 @@ pub unsafe extern "C" fn layout_arena_paintable_transfer_fragments_to_replacemen
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_shell(arena: *mut c_void, slot: PaintableSlotId) -> *mut c_void {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintables = arena.paintables().borrow();
-        if !paintables.is_live(slot) {
-            return std::ptr::null_mut();
-        }
-        paintables.data_ref(slot).shell
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
     arena: *mut c_void,
     slot: PaintableSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -980,6 +980,17 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_invalidate_for_repaint(arena: *mut c_void, paintable: PaintableSlotId) {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.paintables().borrow().invalidate_for_repaint(arena, paintable);
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_invalidate_all_paint_caches(arena: *mut c_void) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -980,6 +980,20 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_invalidate_all_paint_caches(arena: *mut c_void) {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        for cache in &paintables.paint_caches {
+            cache.clear();
+        }
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_computed_svg_path(
     arena: *mut c_void,
     paintable: PaintableSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -375,6 +375,13 @@ pub struct FfiStackingContextNodeExport {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct FfiPaintTreeDumpEntry {
+    pub layout_node_shell: *mut c_void,
+    pub depth: u32,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct FfiPaintHostCallbacks {
     pub context: *mut c_void,
     pub async_scroll_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAsyncScrollFacts,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, LayoutNodeArena};
 use crate::painting::paintable_data::*;
 use std::cell::Cell;
@@ -274,6 +274,36 @@ impl PaintableArena {
         while !ancestor.is_invalid() {
             self.paint_caches[ancestor.slot_index() as usize].clear_descendant_subtrees();
             ancestor = self.data_ref(ancestor).parent;
+        }
+    }
+
+    pub(crate) fn invalidate_for_repaint(&self, layout_arena: &LayoutNodeArena, id: PaintableSlotId) {
+        if !self.is_live(id) {
+            return;
+        }
+        self.invalidate_paint_cache(id);
+        let mut stack = vec![id];
+        while let Some(current) = stack.pop() {
+            let mut child = self.first_child(current);
+            while let Some(child_slot) = child {
+                let child_layout_node = self.data_ref(child_slot).layout_node;
+                let child_flags = layout_arena.node_flags_if_live(child_layout_node);
+                if child_flags & NodeFlag::Anonymous as u32 != 0 {
+                    self.paint_caches[child_slot.slot_index() as usize].clear();
+                    stack.push(child_slot);
+                }
+                child = self.next_sibling(child_slot);
+            }
+        }
+        if self.data_ref(id).kind == PaintableKind::InlinePaintable {
+            let mut ancestor = self.parent(id);
+            while let Some(current) = ancestor {
+                self.invalidate_paint_cache(current);
+                if self.data_ref(current).kind.has_lines() {
+                    break;
+                }
+                ancestor = self.parent(current);
+            }
         }
     }
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -396,11 +396,21 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
         if (!self_paintable)
             return Geometry::DOMRect::create();
         Gfx::FloatRect united_rect;
-        self_paintable->for_each_child([&](Painting::Paintable const& child) {
-            auto child_rect = child.layout_node().used_svg_element_transform().map(child.absolute_rect().to_type<float>());
+        for (auto const* child = self_paintable->layout_node().first_child_ptr(); child; child = child->next_sibling_ptr()) {
+            switch (child->kind()) {
+            case Layout::RustFFI::NodeKind::SVGMaskBox:
+            case Layout::RustFFI::NodeKind::SVGClipBox:
+            case Layout::RustFFI::NodeKind::SVGPatternBox:
+                continue;
+            default:
+                break;
+            }
+            auto const* child_paintable = child->paintable_ptr();
+            if (!child_paintable)
+                continue;
+            auto child_rect = child_paintable->layout_node().used_svg_element_transform().map(child_paintable->absolute_rect().to_type<float>());
             united_rect.unite(child_rect);
-            return IterationDecision::Continue;
-        });
+        }
         if (united_rect.is_empty())
             return Geometry::DOMRect::create();
         return Geometry::DOMRect::create(united_rect);


### PR DESCRIPTION
We want to remove paintables completely. The end goal is that layout fragments are the only source of layout results, and C++ gets data through functions exposed by Rust instead of paintable objects. For that, C++ code must not depend on paint tree structure.

This PR changes every place where C++ walked the paint tree (event target lookup, containing block chains for scrolling and IntersectionObserver, SVG children, content-visibility collection, repaint invalidation, debug dumps). Each one now walks the layout tree or calls a Rust function that does the walk and returns the result. After that, the parent/child/sibling/containing-block API on Paintable is deleted.