### PR TITLE
LibIPC+LibWasm: Remove 32-bit AnonymousBuffer size restrictions

### DIFF
--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/IPv4Address.h>
 #include <AK/IPv6Address.h>
 #include <AK/JsonValue.h>
@@ -174,10 +175,13 @@ ErrorOr<Core::AnonymousBuffer> decode(Decoder& decoder)
     if (auto valid = TRY(decoder.decode<bool>()); !valid)
         return Core::AnonymousBuffer {};
 
-    // NOTE: We don't use decode_size() here since AnonymousBuffer is backed by
-    // shared memory, not heap allocation. The MAX_DECODED_SIZE limit doesn't
-    // apply because the memory is already allocated by the sender.
-    auto size = static_cast<size_t>(TRY(decoder.decode<u32>()));
+    // We don't use decode_size() here since AnonymousBuffer is backed by shared memory, not heap allocation. The
+    // MAX_DECODED_SIZE limit doesn't apply because the memory is already allocated by the sender.
+    auto encoded_size = TRY(decoder.decode<u64>());
+    if (!AK::is_within_range<size_t>(encoded_size))
+        return Error::from_string_literal("Anonymous buffer size does not fit on this platform");
+
+    auto size = static_cast<size_t>(encoded_size);
     auto anon_file = TRY(decoder.decode<IPC::File>());
 
     return Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), size);

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -197,7 +197,7 @@ ErrorOr<void> encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
     TRY(encoder.encode(buffer.is_valid()));
 
     if (buffer.is_valid()) {
-        TRY(encoder.encode_size(buffer.size()));
+        TRY(encoder.encode(static_cast<u64>(buffer.size())));
         TRY(encoder.encode(TRY(IPC::File::clone_fd(buffer.fd()))));
     }
 

--- a/Libraries/LibWasm/CraneliftBridge.cpp
+++ b/Libraries/LibWasm/CraneliftBridge.cpp
@@ -108,6 +108,20 @@ static size_t align_up(size_t value, size_t alignment)
     return remainder == 0 ? value : value + (alignment - remainder);
 }
 
+static ErrorOr<size_t> try_align_up(size_t value, size_t alignment)
+{
+    VERIFY(alignment > 0);
+    auto remainder = value % alignment;
+    if (remainder == 0)
+        return value;
+
+    Checked<size_t> result = value;
+    result += alignment - remainder;
+    if (result.has_overflow())
+        return Error::from_string_literal("Cranelift output size overflow");
+    return result.value();
+}
+
 static ErrorOr<size_t> compute_output_buffer_size(size_t function_count, size_t instruction_count)
 {
     Checked<size_t> output_entries_size = sizeof(OutputFunctionEntry);
@@ -120,7 +134,7 @@ static ErrorOr<size_t> compute_output_buffer_size(size_t function_count, size_t 
     if (output_size.has_overflow())
         return Error::from_string_literal("Cranelift output size overflow");
 
-    output_size = align_up(output_size.value(), SERIALIZED_CODE_ALIGNMENT);
+    output_size = TRY(try_align_up(output_size.value(), SERIALIZED_CODE_ALIGNMENT));
 
     Checked<size_t> maximum_code_size = instruction_count;
     maximum_code_size *= oop_code_bytes_per_insn;
@@ -131,7 +145,7 @@ static ErrorOr<size_t> compute_output_buffer_size(size_t function_count, size_t 
     if (output_size.has_overflow())
         return Error::from_string_literal("Cranelift output size overflow");
 
-    output_size = align_up(output_size.value(), alignof(HelperReloc));
+    output_size = TRY(try_align_up(output_size.value(), alignof(HelperReloc)));
 
     Checked<size_t> maximum_reloc_size = instruction_count;
     maximum_reloc_size *= oop_reloc_bytes_per_insn;
@@ -139,7 +153,7 @@ static ErrorOr<size_t> compute_output_buffer_size(size_t function_count, size_t 
         return Error::from_string_literal("Cranelift output size overflow");
 
     output_size += max(oop_reloc_region_min_size, maximum_reloc_size.value());
-    if (output_size.has_overflow() || output_size.value() > NumericLimits<u32>::max())
+    if (output_size.has_overflow())
         return Error::from_string_literal("Cranelift output is too large");
 
     return output_size.value();

--- a/Tests/LibIPC/TestConnection.cpp
+++ b/Tests/LibIPC/TestConnection.cpp
@@ -8,12 +8,16 @@
 #include <AK/ByteReader.h>
 #include <AK/ByteString.h>
 #include <AK/Function.h>
+#include <AK/MemoryStream.h>
 #include <AK/Queue.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/EventLoop.h>
 #include <LibIPC/Connection.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibIPC/Message.h>
 #include <LibIPC/Stub.h>
 #include <LibIPC/Transport.h>
@@ -96,6 +100,28 @@ private:
     }
 };
 
+}
+
+TEST_CASE(anonymous_buffer_size_uses_64_bits)
+{
+    constexpr size_t buffer_size = 4096;
+    auto buffer = MUST(Core::AnonymousBuffer::create_with_size(buffer_size));
+
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(buffer));
+    EXPECT_EQ(message_buffer.data().size(), sizeof(bool) + sizeof(u64));
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+
+    Queue<IPC::Attachment> attachments;
+    for (auto& attachment : message_buffer.take_attachments())
+        attachments.enqueue(move(attachment));
+
+    IPC::Decoder decoder { stream, attachments };
+    auto decoded_buffer = MUST(decoder.decode<Core::AnonymousBuffer>());
+    EXPECT_EQ(decoded_buffer.size(), buffer_size);
 }
 
 // Regression test for #9582. wait_for_specific_endpoint_message_impl is reachable from any sync IPC call, including


### PR DESCRIPTION
We encoded every buffer size as a `u32`, but this restriction isn't really needed for `AnonymousBuffer`, which is transferred via its fd. We can then remove the analogous restriction on compiled wasm buffers.