### PR TITLE
Implement our own alert/confirm/prompt dialogs on Qt

### DIFF
--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -612,6 +612,8 @@ void CanonicalTraversable::start_pending_browser_history_traversal(u64 generatio
         m_pending_browser_history_traversal.clear();
         for (auto& callback : callbacks)
             callback();
+        if (view->on_browser_history_traversal_complete)
+            view->on_browser_history_traversal_complete();
         promise->resolve({});
         return;
     }
@@ -2113,6 +2115,8 @@ void CanonicalTraversable::did_receive_changing_navigable_continuation_applied(W
                             view->m_client_state.site_url = move(active_document_url);
                         view->m_client_state.hosts_committed_entry = true;
                         view->m_external_url_request_policy.clear_page_request_allowance();
+                        if (view->on_top_level_navigation_commit)
+                            view->on_top_level_navigation_commit();
                     }
                 }
             }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -638,6 +638,8 @@ void ViewImplementation::did_finish_history_traversal(Web::HTML::CrossProcessId 
 
     complete_webdriver_history_traversal(operation_id);
     update_navigation_action_state();
+    if (on_browser_history_traversal_complete)
+        on_browser_history_traversal_complete();
     dump_session_history(result == Web::HTML::HistoryStepResult::Applied
             ? "webcontent-history-step-applied"sv
             : "webcontent-history-step-canceled"sv);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -366,6 +366,9 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
 
 void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     set_loading_state(true);
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
@@ -454,6 +457,9 @@ void ViewImplementation::open_url_in_new_window(URL::URL const& url, IsPrivate i
 
 void ViewImplementation::load_html(StringView html)
 {
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     set_loading_state(true);
     m_is_showing_crash_page = false;
     m_should_suppress_history_for_current_load = false;
@@ -498,6 +504,9 @@ void ViewImplementation::load_navigation_error_page(StringView text)
 
 void ViewImplementation::reload()
 {
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     m_history_visit_transition_for_next_load = HistoryVisitTransition::Reload;
 
     if (m_last_stopped_load_url.has_value()) {
@@ -558,6 +567,9 @@ void ViewImplementation::traverse_the_history_by_delta(
     CheckForCancelation check_for_cancelation,
     Function<void()> on_ready)
 {
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     m_top_level_traversable.traverse_the_history_by_delta(delta, check_for_cancelation, move(on_ready));
 }
 
@@ -574,6 +586,9 @@ void ViewImplementation::traverse_the_history_to_step(
     CheckForCancelation check_for_cancelation,
     Function<void()> on_ready)
 {
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     m_top_level_traversable.traverse_the_history_to_step(step, check_for_cancelation, move(on_ready));
 }
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -372,6 +372,8 @@ public:
     Function<void()> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
     Function<void(bool)> on_loading_state_change;
+    Function<void()> on_top_level_navigation_commit;
+    Function<void()> on_browser_history_traversal_complete;
     Function<void(ByteString const& path, i32)> on_request_file;
     Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
     Function<void(Optional<Gfx::Bitmap const&>)> on_favicon_change;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -385,6 +385,7 @@ public:
     Function<void(Utf16String const& message)> on_request_confirm;
     Function<void(Utf16String const& message, Utf16String const& default_)> on_request_prompt;
     Function<void(Utf16String const& message)> on_request_set_prompt_text;
+    Function<void()> on_before_browser_initiated_navigation;
     Function<void(URL::URL const&, URL::Origin const&, ExternalURLHandler const&, Function<void(bool)>)> on_request_external_url_confirmation;
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;

--- a/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
+++ b/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
@@ -93,6 +93,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     size_t loads_finished = 0;
     view->on_load_finish = [&](auto const&) { ++loads_finished; };
 
+    size_t browser_history_traversals_completed = 0;
+    view->on_browser_history_traversal_complete = [&] { ++browser_history_traversals_completed; };
+
     size_t expected_loads = 1;
     // Wait out the initial about:blank load; navigating before it completes would drop the navigation.
     Core::EventLoop::current().spin_until([&]() { return loads_finished >= expected_loads; });
@@ -185,6 +188,17 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&] { return loads_finished > loads_finished_before_javascript_url; });
     VERIFY(loads_started == loads_started_before_javascript_url + 1);
     VERIFY(view_is_at(url_c));
+
+    view->traverse_the_history_to_step(back_menu_items.last().step);
+    wait_until_at(url_a);
+
+    auto completed_traversals_before_history_boundary = browser_history_traversals_completed;
+    bool history_boundary_traversal_ready = false;
+    view->traverse_the_history_by_delta(-1, WebView::CheckForCancelation::Yes, [&] {
+        history_boundary_traversal_ready = true;
+    });
+    Core::EventLoop::current().spin_until([&] { return history_boundary_traversal_ready; });
+    VERIFY(browser_history_traversals_completed == completed_traversals_before_history_boundary + 1);
 
     outln("PASS: browser history traversal");
     return 0;

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -7,8 +7,24 @@ if (NOT Qt6_FOUND)
     return()
 endif()
 
+add_library(QtTestMain OBJECT
+    QtTestMain.cpp
+    "${LADYBIRD_SOURCE_DIR}/Libraries/LibTest/AssertionHandler.cpp"
+)
+target_link_libraries(QtTestMain PRIVATE AK LibCore LibTest Qt::Core Qt::Gui Qt::Widgets)
+
 ladybird_test("TestNativeWindowContainerFocus.cpp" UI/Qt LIBS Qt::Core Qt::Gui Qt::Widgets)
 target_sources(TestNativeWindowContainerFocus PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/NativeWindowContainer.cpp")
+
+ladybird_test("TestJavaScriptDialog.cpp" UI/Qt
+    CUSTOM_MAIN "$<TARGET_OBJECTS:QtTestMain>"
+    LIBS LibURL Qt::Core Qt::Gui Qt::Widgets
+)
+target_sources(TestJavaScriptDialog PRIVATE
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/ChromeStyle.cpp"
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/JavaScriptDialog.cpp"
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp"
+)
 
 ladybird_test("TestStringUtils.cpp" UI/Qt NAME TestQtStringUtils LIBS LibURL Qt::Core)
 target_sources(TestQtStringUtils PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp")

--- a/Tests/UI/Qt/QtTestMain.cpp
+++ b/Tests/UI/Qt/QtTestMain.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/Vector.h>
+#include <LibTest/TestSuite.h>
+
+#include <QApplication>
+
+int main(int argc, char** argv)
+{
+    if (argc < 1 || !argv[0] || '\0' == *argv[0]) {
+        warnln("Test main does not have a valid test name!");
+        return 1;
+    }
+
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    int result = 0;
+    {
+        QApplication application(argc, argv);
+
+        Vector<StringView> arguments;
+        arguments.ensure_capacity(argc);
+        for (auto i = 0; i < argc; ++i)
+            arguments.append({ argv[i], strlen(argv[i]) });
+
+        result = Test::TestSuite::the().main(argv[0], arguments);
+        Test::TestSuite::release();
+    }
+
+    // QApplication is destroyed before returning so Qt releases resources
+    // such as its font cache before LeakSanitizer runs.
+    return result != 0;
+}

--- a/Tests/UI/Qt/TestJavaScriptDialog.cpp
+++ b/Tests/UI/Qt/TestJavaScriptDialog.cpp
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QShortcut>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+#include <UI/Qt/JavaScriptDialog.h>
+
+namespace {
+
+struct Completion {
+    Optional<Ladybird::JavaScriptDialog::Type> type;
+    bool accepted { false };
+    QString prompt_text;
+};
+
+class MouseRecordingWidget final : public QWidget {
+public:
+    int mouse_presses { 0 };
+
+private:
+    virtual void mousePressEvent(QMouseEvent*) override
+    {
+        ++mouse_presses;
+    }
+};
+
+class KeyRecordingButton final : public QPushButton {
+public:
+    using QPushButton::QPushButton;
+
+    int right_key_presses { 0 };
+
+private:
+    virtual void keyPressEvent(QKeyEvent* event) override
+    {
+        if (event->key() == Qt::Key_Right)
+            ++right_key_presses;
+        QPushButton::keyPressEvent(event);
+    }
+};
+
+void record_completions(Ladybird::JavaScriptDialog& dialog, Completion& completion)
+{
+    dialog.on_complete = [&completion](auto type, bool accepted, auto const& prompt_text) {
+        completion.type = type;
+        completion.accepted = accepted;
+        completion.prompt_text = prompt_text;
+    };
+}
+
+void trigger_shortcut(Ladybird::JavaScriptDialog& dialog, int key)
+{
+    for (auto* shortcut : dialog.findChildren<QShortcut*>()) {
+        if (shortcut->key() != QKeySequence(key))
+            continue;
+        VERIFY(QMetaObject::invokeMethod(shortcut, "activated"));
+        QApplication::processEvents();
+        return;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+void send_key(QWidget& widget, int key)
+{
+    QKeyEvent press { QEvent::KeyPress, key, Qt::NoModifier };
+    QApplication::sendEvent(&widget, &press);
+    QKeyEvent release { QEvent::KeyRelease, key, Qt::NoModifier };
+    QApplication::sendEvent(&widget, &release);
+    QApplication::processEvents();
+}
+
+}
+
+TEST_CASE(alert_and_confirm_report_the_expected_results)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    Completion completion;
+    record_completions(dialog, completion);
+
+    dialog.show_alert("https://example.com", "Alert message");
+    EXPECT(dialog.is_open());
+    EXPECT(dialog.isVisible());
+    EXPECT_EQ(dialog.geometry(), web_view.rect());
+    auto* title_label = dialog.findChild<QLabel*>("LadybirdJavaScriptDialogTitle");
+    auto* button_box = dialog.findChild<QDialogButtonBox*>("LadybirdJavaScriptDialogButtons");
+    VERIFY(title_label);
+    VERIFY(button_box);
+    EXPECT(title_label->text() == "https://example.com");
+    VERIFY(button_box->button(QDialogButtonBox::Ok));
+    EXPECT(button_box->button(QDialogButtonBox::Ok)->isDefault());
+
+    dialog.dismiss();
+    EXPECT(!dialog.is_open());
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Alert);
+    EXPECT(completion.accepted);
+
+    completion = {};
+    dialog.show_confirm("https://example.com", "Confirm message");
+    auto* cancel_button = button_box->button(QDialogButtonBox::Cancel);
+    VERIFY(cancel_button);
+    cancel_button->setFocus();
+    send_key(*cancel_button, Qt::Key_Return);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Confirm);
+    EXPECT(!completion.accepted);
+
+    completion = {};
+    dialog.show_confirm("https://example.com", "Confirm message");
+    dialog.accept();
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Confirm);
+    EXPECT(completion.accepted);
+
+    completion = {};
+    dialog.show_alert("https://example.com", "Original alert");
+    dialog.show_confirm("https://ladybird.org", "Overlapping confirm");
+    EXPECT(dialog.is_open());
+    EXPECT(title_label->text() == "https://example.com");
+    EXPECT(!button_box->button(QDialogButtonBox::Cancel));
+    dialog.dismiss();
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Alert);
+    EXPECT(completion.accepted);
+}
+
+TEST_CASE(prompt_supports_defaults_updates_and_keyboard_completion)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    Completion completion;
+    record_completions(dialog, completion);
+
+    dialog.show_prompt("https://example.com", "Prompt message", "default text");
+    auto* prompt = dialog.findChild<QLineEdit*>("LadybirdJavaScriptDialogPrompt");
+    auto* button_box = dialog.findChild<QDialogButtonBox*>("LadybirdJavaScriptDialogButtons");
+    VERIFY(prompt);
+    VERIFY(button_box);
+    auto* ok_button = button_box->button(QDialogButtonBox::Ok);
+    VERIFY(ok_button);
+    EXPECT(prompt->isVisible());
+    EXPECT(prompt->text() == "default text");
+    EXPECT(prompt->hasSelectedText());
+    QApplication::processEvents();
+    EXPECT(!ok_button->isDefault());
+
+    dialog.set_prompt_text("updated text");
+    EXPECT(prompt->text() == "updated text");
+    send_key(*prompt, Qt::Key_Return);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Prompt);
+    EXPECT(completion.accepted);
+    EXPECT(completion.prompt_text == "updated text");
+
+    completion = {};
+    dialog.show_prompt("https://example.com", "Prompt message", "ignored");
+    trigger_shortcut(dialog, Qt::Key_Escape);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Prompt);
+    EXPECT(!completion.accepted);
+}
+
+TEST_CASE(dialog_resizes_with_and_blocks_only_its_parent_view)
+{
+    QWidget window;
+    auto* layout = new QVBoxLayout(&window);
+    auto* browser_button = new KeyRecordingButton("Browser control", &window);
+    auto* web_view = new MouseRecordingWidget;
+    web_view->setParent(&window);
+    web_view->setFocusPolicy(Qt::StrongFocus);
+    web_view->setMinimumSize(400, 300);
+    auto* page_button = new QPushButton("Page control", web_view);
+    layout->addWidget(browser_button);
+    layout->addWidget(web_view);
+    window.resize(800, 600);
+    window.show();
+
+    Ladybird::JavaScriptDialog dialog(web_view);
+    dialog.show_prompt("https://example.com", "Prompt message", "Prompt text");
+    QApplication::processEvents();
+
+    EXPECT_EQ(dialog.geometry(), web_view->rect());
+    EXPECT(web_view->childAt(1, 1) == &dialog);
+    EXPECT_EQ(dialog.focusPolicy(), Qt::NoFocus);
+    EXPECT_EQ(web_view->focusPolicy(), Qt::NoFocus);
+
+    auto* prompt = dialog.findChild<QLineEdit*>("LadybirdJavaScriptDialogPrompt");
+    VERIFY(prompt);
+    EXPECT(prompt->hasFocus());
+
+    auto global_mouse_position = dialog.mapToGlobal(QPoint { 1, 1 });
+    auto* mouse_target = QApplication::widgetAt(global_mouse_position);
+    VERIFY(mouse_target);
+    QMouseEvent mouse_press {
+        QEvent::MouseButtonPress,
+        mouse_target->mapFromGlobal(global_mouse_position),
+        global_mouse_position,
+        Qt::LeftButton,
+        Qt::LeftButton,
+        Qt::NoModifier,
+    };
+    QApplication::sendEvent(mouse_target, &mouse_press);
+    EXPECT_EQ(web_view->mouse_presses, 0);
+    EXPECT(prompt->hasFocus());
+
+    bool browser_button_clicked = false;
+    QObject::connect(browser_button, &QPushButton::clicked, [&] {
+        browser_button_clicked = true;
+    });
+    browser_button->click();
+    EXPECT(browser_button_clicked);
+
+    auto* button_box = dialog.findChild<QDialogButtonBox*>("LadybirdJavaScriptDialogButtons");
+    VERIFY(button_box);
+    auto* cancel_button = button_box->button(QDialogButtonBox::Cancel);
+    auto* ok_button = button_box->button(QDialogButtonBox::Ok);
+    VERIFY(cancel_button);
+    VERIFY(ok_button);
+
+    QWidget::setTabOrder(prompt, browser_button);
+    QWidget::setTabOrder(browser_button, ok_button);
+    QWidget::setTabOrder(ok_button, cancel_button);
+    dialog.dismiss();
+    dialog.show_prompt("https://example.com", "Prompt message", "Prompt text");
+
+    prompt = dialog.findChild<QLineEdit*>("LadybirdJavaScriptDialogPrompt");
+    cancel_button = button_box->button(QDialogButtonBox::Cancel);
+    ok_button = button_box->button(QDialogButtonBox::Ok);
+    VERIFY(prompt);
+    VERIFY(cancel_button);
+    VERIFY(ok_button);
+
+    prompt->setFocus();
+    send_key(*prompt, Qt::Key_Tab);
+    EXPECT(ok_button->hasFocus());
+
+    send_key(*ok_button, Qt::Key_Tab);
+    EXPECT(cancel_button->hasFocus());
+
+    send_key(*cancel_button, Qt::Key_Tab);
+    EXPECT(browser_button->hasFocus());
+
+    cancel_button->setFocus();
+    send_key(*cancel_button, Qt::Key_Right);
+    EXPECT(browser_button->hasFocus());
+
+    send_key(*browser_button, Qt::Key_Right);
+    EXPECT_EQ(browser_button->right_key_presses, 1);
+
+    QWidget::setTabOrder(browser_button, page_button);
+    QWidget::setTabOrder(page_button, prompt);
+    browser_button->setFocus();
+    send_key(*browser_button, Qt::Key_Tab);
+    EXPECT(!page_button->hasFocus());
+    EXPECT(prompt->hasFocus());
+
+    browser_button->setFocus();
+    dialog.dismiss();
+    EXPECT(browser_button->hasFocus());
+    EXPECT_EQ(web_view->focusPolicy(), Qt::StrongFocus);
+
+    web_view->resize(640, 480);
+    QApplication::processEvents();
+    EXPECT_EQ(dialog.geometry(), web_view->rect());
+}
+
+TEST_CASE(dialog_visibility_and_state_follow_the_owning_tab)
+{
+    QStackedWidget tabs;
+    auto* first_tab = new QWidget(&tabs);
+    auto* second_tab = new QWidget(&tabs);
+    tabs.addWidget(first_tab);
+    tabs.addWidget(second_tab);
+    tabs.resize(800, 600);
+    tabs.show();
+
+    Ladybird::JavaScriptDialog dialog(first_tab);
+    dialog.show_prompt("https://example.com", "Prompt message", "preserved text");
+    QApplication::processEvents();
+    EXPECT(dialog.isVisible());
+
+    tabs.setCurrentWidget(second_tab);
+    QApplication::processEvents();
+    EXPECT(dialog.is_open());
+    EXPECT(!dialog.isVisible());
+
+    tabs.setCurrentWidget(first_tab);
+    QApplication::processEvents();
+    EXPECT(dialog.isVisible());
+    auto* prompt = dialog.findChild<QLineEdit*>("LadybirdJavaScriptDialogPrompt");
+    VERIFY(prompt);
+    EXPECT(prompt->text() == "preserved text");
+}
+
+TEST_CASE(long_messages_remain_plain_text_and_bounded)
+{
+    QWidget web_view;
+    web_view.resize(480, 320);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    QString message = "<b>not markup</b> ";
+    message = message.repeated(100);
+    dialog.show_alert("https://example.com", message);
+    QApplication::processEvents();
+
+    auto* message_label = dialog.findChild<QLabel*>("LadybirdJavaScriptDialogMessage");
+    auto* message_area = dialog.findChild<QScrollArea*>("LadybirdJavaScriptDialogMessageArea");
+    VERIFY(message_label);
+    VERIFY(message_area);
+    EXPECT_EQ(message_label->textFormat(), Qt::PlainText);
+    EXPECT(message_label->text() == message);
+    EXPECT(message_area->height() <= 240);
+    EXPECT(message_area->verticalScrollBarPolicy() == Qt::ScrollBarAsNeeded);
+}
+
+TEST_CASE(dialog_keeps_controls_visible_with_a_large_font)
+{
+    QWidget web_view;
+    web_view.resize(480, 320);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    auto font = dialog.font();
+    font.setPointSize(24);
+    dialog.setFont(font);
+    dialog.show_prompt("https://example.com", QString("Long message ").repeated(100), "Prompt text");
+    QApplication::processEvents();
+
+    auto* button_box = dialog.findChild<QDialogButtonBox*>("LadybirdJavaScriptDialogButtons");
+    auto* prompt = dialog.findChild<QLineEdit*>("LadybirdJavaScriptDialogPrompt");
+    VERIFY(button_box);
+    VERIFY(prompt);
+    EXPECT(dialog.rect().contains(button_box->geometry().bottomRight() + button_box->parentWidget()->pos()));
+    EXPECT(dialog.rect().contains(prompt->geometry().bottomRight() + prompt->parentWidget()->pos()));
+}

--- a/Tests/UI/Qt/TestJavaScriptDialog.cpp
+++ b/Tests/UI/Qt/TestJavaScriptDialog.cpp
@@ -307,6 +307,29 @@ TEST_CASE(dialog_visibility_and_state_follow_the_owning_tab)
     EXPECT(prompt->text() == "preserved text");
 }
 
+TEST_CASE(reset_closes_without_reporting_completion)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.setFocusPolicy(Qt::StrongFocus);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    Completion completion;
+    record_completions(dialog, completion);
+
+    web_view.setFocus();
+    QApplication::processEvents();
+    VERIFY(web_view.hasFocus());
+    dialog.show_alert("https://example.com", "Alert message");
+    dialog.reset();
+
+    EXPECT(!dialog.is_open());
+    EXPECT(!dialog.isVisible());
+    EXPECT(!completion.type.has_value());
+    EXPECT(web_view.hasFocus());
+}
+
 TEST_CASE(long_messages_remain_plain_text_and_bounded)
 {
     QWidget web_view;

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(ladybird PRIVATE
     FindInPageWidget.cpp
     Icon.cpp
     InputMethodUtils.cpp
+    JavaScriptDialog.cpp
     LocationEdit.cpp
     Menu.cpp
     NativeWindowContainer.cpp

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -743,6 +743,118 @@ QWidget#LadybirdFindInPageBar QLabel {{
         background, surface, hover, pressed, border, control_border, accent, text, muted, no_results_background, no_results_border);
 }
 
+QString javascript_dialog_style_sheet(QPalette const& palette)
+{
+    auto surface = style_sheet_color(chrome_surface(palette));
+    auto recessed = style_sheet_color(chrome_surface_recessed(palette));
+    auto hover = style_sheet_color(chrome_control_surface_hover(palette));
+    auto pressed = style_sheet_color(chrome_control_surface_pressed(palette));
+    auto control_border = style_sheet_color(chrome_control_border(palette));
+    auto accent = style_sheet_color(chrome_accent(palette));
+    auto text = style_sheet_color(chrome_text(palette));
+    auto muted = style_sheet_color(chrome_muted_text(palette));
+    auto scrim = is_dark(palette) ? QColor(0, 0, 0, 150) : QColor(20, 22, 25, 120);
+    auto scrim_color = qformatted("rgba({}, {}, {}, {})", scrim.red(), scrim.green(), scrim.blue(), scrim.alpha());
+
+    return qformatted(R"(
+QWidget#LadybirdJavaScriptDialogOverlay {{
+    background: {0};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel {{
+    color: {7};
+    background: {1};
+    border: 1px solid {5};
+    border-radius: 12px;
+}}
+
+QLabel#LadybirdJavaScriptDialogTitle {{
+    color: {7};
+    background: transparent;
+    border: 0;
+    font-size: 15px;
+    font-weight: 600;
+}}
+
+QScrollArea#LadybirdJavaScriptDialogMessageArea,
+QWidget#LadybirdJavaScriptDialogMessageViewport,
+QLabel#LadybirdJavaScriptDialogMessage {{
+    color: {7};
+    background: transparent;
+    border: 0;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QLineEdit {{
+    color: {7};
+    background: {2};
+    border: 1px solid {5};
+    border-radius: 8px;
+    min-height: 26px;
+    padding: 2px 9px;
+    selection-background-color: {6};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QLineEdit:focus {{
+    border-color: {6};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QPushButton {{
+    color: {7};
+    background: {2};
+    border: 1px solid {5};
+    border-radius: 7px;
+    min-height: 26px;
+    min-width: 72px;
+    padding: 2px 12px;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QPushButton:hover {{
+    background: {3};
+    border-color: {5};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QPushButton:pressed {{
+    background: {4};
+    border-color: {5};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QPushButton:default {{
+    border-color: {6};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QPushButton:focus {{
+    border-color: {6};
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar:vertical {{
+    background: transparent;
+    width: 10px;
+    margin: 0;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::groove:vertical {{
+    background: transparent;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::handle:vertical {{
+    background: {8};
+    border-radius: 4px;
+    min-height: 20px;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::add-line:vertical,
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::sub-line:vertical {{
+    height: 0;
+}}
+
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::add-page:vertical,
+QFrame#LadybirdJavaScriptDialogPanel QScrollBar::sub-page:vertical {{
+    background: transparent;
+}}
+)",
+        scrim_color, surface, recessed, hover, pressed, control_border, accent, text, muted);
+}
+
 QString devtools_banner_style_sheet(QPalette const& palette)
 {
     auto background = style_sheet_color(chrome_background(palette));

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -39,6 +39,7 @@ QString menu_bar_style_sheet(QPalette const&);
 QString location_edit_style_sheet(QPalette const&);
 QString bookmarks_bar_style_sheet(QPalette const&);
 QString find_in_page_style_sheet(QPalette const&);
+QString javascript_dialog_style_sheet(QPalette const&);
 QString devtools_banner_style_sheet(QPalette const&);
 QString tab_widget_style_sheet(QPalette const&);
 QString autocomplete_popup_style_sheet(QPalette const&);

--- a/UI/Qt/JavaScriptDialog.cpp
+++ b/UI/Qt/JavaScriptDialog.cpp
@@ -191,6 +191,15 @@ void JavaScriptDialog::dismiss()
     complete(m_type == Type::Alert);
 }
 
+void JavaScriptDialog::reset()
+{
+    if (!m_type.has_value())
+        return;
+
+    m_type.clear();
+    restore_focus_after_close();
+}
+
 void JavaScriptDialog::complete(bool accepted)
 {
     auto type = m_type.release_value();

--- a/UI/Qt/JavaScriptDialog.cpp
+++ b/UI/Qt/JavaScriptDialog.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Qt/ChromeStyle.h>
+#include <UI/Qt/JavaScriptDialog.h>
+
+#include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QEvent>
+#include <QFocusEvent>
+#include <QFrame>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QResizeEvent>
+#include <QScrollArea>
+#include <QShortcut>
+#include <QShowEvent>
+#include <QVBoxLayout>
+
+namespace Ladybird {
+
+static constexpr int DIALOG_MAX_WIDTH = 520;
+static constexpr int DIALOG_MIN_WIDTH = 320;
+static constexpr int DIALOG_MAX_MESSAGE_HEIGHT = 240;
+static constexpr int DIALOG_MARGIN = 24;
+static constexpr int PANEL_HORIZONTAL_PADDING = 20;
+
+JavaScriptDialog::JavaScriptDialog(QWidget* parent)
+    : QWidget(parent)
+{
+    setObjectName("LadybirdJavaScriptDialogOverlay");
+    setAttribute(Qt::WA_StyledBackground);
+#if defined(AK_OS_MACOS) || defined(USE_DIRECTX) || defined(USE_VULKAN_DMABUF_IMAGES)
+    // Native rendering surfaces stack above ordinary child widgets. Match their native stacking level so the dialog
+    // remains above the page.
+    setAttribute(Qt::WA_NativeWindow);
+#endif
+    setFocusPolicy(Qt::NoFocus);
+    setAcceptDrops(true);
+    setMouseTracking(true);
+    setGeometry(parent->rect());
+    parent->installEventFilter(this);
+    QApplication::instance()->installEventFilter(this);
+
+    auto* overlay_layout = new QVBoxLayout(this);
+    overlay_layout->setContentsMargins(DIALOG_MARGIN, DIALOG_MARGIN, DIALOG_MARGIN, DIALOG_MARGIN);
+    overlay_layout->addStretch();
+
+    m_panel = new QFrame(this);
+    m_panel->setObjectName("LadybirdJavaScriptDialogPanel");
+    m_panel->setAttribute(Qt::WA_StyledBackground);
+    m_panel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
+
+    auto* panel_layout = new QVBoxLayout(m_panel);
+    panel_layout->setContentsMargins(PANEL_HORIZONTAL_PADDING, 18, PANEL_HORIZONTAL_PADDING, 18);
+    panel_layout->setSpacing(12);
+
+    m_title_label = new QLabel(m_panel);
+    m_title_label->setObjectName("LadybirdJavaScriptDialogTitle");
+    panel_layout->addWidget(m_title_label);
+
+    m_message_scroll_area = new QScrollArea(m_panel);
+    m_message_scroll_area->setObjectName("LadybirdJavaScriptDialogMessageArea");
+    m_message_scroll_area->setFrameShape(QFrame::NoFrame);
+    m_message_scroll_area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_message_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_message_scroll_area->setWidgetResizable(true);
+    m_message_scroll_area->viewport()->setObjectName("LadybirdJavaScriptDialogMessageViewport");
+
+    m_message_label = new QLabel(m_message_scroll_area);
+    m_message_label->setObjectName("LadybirdJavaScriptDialogMessage");
+    m_message_label->setTextFormat(Qt::PlainText);
+    m_message_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_message_label->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    m_message_label->setWordWrap(true);
+    m_message_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    m_message_scroll_area->setWidget(m_message_label);
+    panel_layout->addWidget(m_message_scroll_area);
+
+    m_prompt_text = new QLineEdit(m_panel);
+    m_prompt_text->setObjectName("LadybirdJavaScriptDialogPrompt");
+    panel_layout->addWidget(m_prompt_text);
+
+    m_button_box = new QDialogButtonBox(m_panel);
+    m_button_box->setObjectName("LadybirdJavaScriptDialogButtons");
+    panel_layout->addWidget(m_button_box);
+
+    overlay_layout->addWidget(m_panel, 0, Qt::AlignHCenter);
+    overlay_layout->addStretch();
+
+    QObject::connect(m_button_box, &QDialogButtonBox::accepted, this, [this] {
+        accept();
+    });
+    QObject::connect(m_button_box, &QDialogButtonBox::rejected, this, [this] {
+        dismiss();
+    });
+    QObject::connect(m_prompt_text, &QLineEdit::returnPressed, this, [this] {
+        accept();
+    });
+
+    new QShortcut(QKeySequence(Qt::Key_Escape), this, [this] { dismiss(); }, Qt::WidgetWithChildrenShortcut);
+
+    update_chrome_style();
+    hide();
+}
+
+void JavaScriptDialog::show_alert(QString const& title, QString const& message)
+{
+    open(Type::Alert, title, message);
+}
+
+void JavaScriptDialog::show_confirm(QString const& title, QString const& message)
+{
+    open(Type::Confirm, title, message);
+}
+
+void JavaScriptDialog::show_prompt(QString const& title, QString const& message, QString const& default_text)
+{
+    open(Type::Prompt, title, message, default_text);
+}
+
+void JavaScriptDialog::open(Type type, QString const& title, QString const& message, QString const& default_text)
+{
+    if (m_type.has_value())
+        return;
+    VERIFY(!m_parent_focus_policy.has_value());
+
+    m_previous_focus_widget = QApplication::focusWidget();
+    m_parent_focus_policy = parentWidget()->focusPolicy();
+    parentWidget()->setFocusPolicy(Qt::NoFocus);
+    m_type = type;
+    m_title_label->setText(title);
+    m_message_label->setText(message);
+    m_prompt_text->setVisible(type == Type::Prompt);
+    m_prompt_text->setText(default_text);
+
+    QDialogButtonBox::StandardButtons buttons { QDialogButtonBox::Ok };
+    if (type != Type::Alert)
+        buttons |= QDialogButtonBox::Cancel;
+    m_button_box->setStandardButtons(buttons);
+
+    for (auto* button : m_button_box->buttons()) {
+        button->installEventFilter(this);
+        if (auto* push_button = qobject_cast<QPushButton*>(button))
+            push_button->setAutoDefault(type != Type::Prompt);
+    }
+    auto* ok_button = m_button_box->button(QDialogButtonBox::Ok);
+    auto* cancel_button = m_button_box->button(QDialogButtonBox::Cancel);
+    if (ok_button)
+        ok_button->setDefault(type != Type::Prompt);
+
+    if (type == Type::Prompt && ok_button)
+        QWidget::setTabOrder(m_prompt_text, ok_button);
+    if (ok_button && cancel_button)
+        QWidget::setTabOrder(ok_button, cancel_button);
+
+    update_geometry_constraints();
+    show();
+    raise();
+    focus_dialog();
+
+    if (type == Type::Prompt && ok_button)
+        ok_button->setDefault(false);
+}
+
+void JavaScriptDialog::set_prompt_text(QString const& text)
+{
+    if (m_type != Type::Prompt)
+        return;
+    m_prompt_text->setText(text);
+}
+
+void JavaScriptDialog::accept()
+{
+    if (!m_type.has_value())
+        return;
+    complete(true);
+}
+
+void JavaScriptDialog::dismiss()
+{
+    if (!m_type.has_value())
+        return;
+    complete(m_type == Type::Alert);
+}
+
+void JavaScriptDialog::complete(bool accepted)
+{
+    auto type = m_type.release_value();
+    auto prompt_text = m_prompt_text->text();
+    restore_focus_after_close();
+
+    if (on_complete)
+        on_complete(type, accepted, prompt_text);
+}
+
+void JavaScriptDialog::restore_focus_after_close()
+{
+    auto* focus_widget = QApplication::focusWidget();
+    auto dialog_had_focus = focus_widget == this || isAncestorOf(focus_widget);
+    hide();
+    restore_parent_focus_policy();
+
+    auto previous_focus_widget = m_previous_focus_widget;
+    m_previous_focus_widget = nullptr;
+    if (dialog_had_focus && previous_focus_widget && previous_focus_widget->isVisible())
+        previous_focus_widget->setFocus();
+}
+
+bool JavaScriptDialog::event(QEvent* event)
+{
+    if (event->type() == QEvent::PaletteChange)
+        update_chrome_style();
+
+    switch (event->type()) {
+    case QEvent::ContextMenu:
+    case QEvent::DragEnter:
+    case QEvent::DragLeave:
+    case QEvent::DragMove:
+    case QEvent::Drop:
+    case QEvent::KeyPress:
+    case QEvent::KeyRelease:
+    case QEvent::MouseButtonDblClick:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+    case QEvent::MouseMove:
+    case QEvent::NativeGesture:
+    case QEvent::TabletMove:
+    case QEvent::TabletPress:
+    case QEvent::TabletRelease:
+    case QEvent::TouchBegin:
+    case QEvent::TouchCancel:
+    case QEvent::TouchEnd:
+    case QEvent::TouchUpdate:
+    case QEvent::Wheel:
+        event->accept();
+        return true;
+    default:
+        break;
+    }
+
+    return QWidget::event(event);
+}
+
+bool JavaScriptDialog::eventFilter(QObject* object, QEvent* event)
+{
+    if (object == parentWidget() && event->type() == QEvent::Resize)
+        setGeometry(parentWidget()->rect());
+
+    if (m_type.has_value() && event->type() == QEvent::FocusIn) {
+        auto* widget = qobject_cast<QWidget*>(object);
+        if (widget && is_blocked_content_widget(*widget)) {
+            auto reason = static_cast<QFocusEvent*>(event)->reason();
+            if (reason == Qt::TabFocusReason || reason == Qt::BacktabFocusReason)
+                focusNextPrevChild(reason == Qt::TabFocusReason);
+            else
+                focus_dialog();
+            return true;
+        }
+    }
+
+    if (m_type.has_value() && event->type() == QEvent::KeyPress) {
+        auto* button = qobject_cast<QPushButton*>(object);
+        if (button && is_dialog_widget(*button) && m_button_box->buttons().contains(button)) {
+            auto& key_event = static_cast<QKeyEvent&>(*event);
+            switch (key_event.key()) {
+            case Qt::Key_Enter:
+            case Qt::Key_Return:
+                button->click();
+                return true;
+            case Qt::Key_Down:
+            case Qt::Key_Right:
+                return focusNextPrevChild(true);
+            case Qt::Key_Left:
+            case Qt::Key_Up:
+                return focusNextPrevChild(false);
+            default:
+                break;
+            }
+        }
+    }
+
+    return QWidget::eventFilter(object, event);
+}
+
+bool JavaScriptDialog::focusNextPrevChild(bool next)
+{
+    auto* current = QApplication::focusWidget();
+    if (!current)
+        return true;
+
+    auto* candidate = next ? current->nextInFocusChain() : current->previousInFocusChain();
+    while (candidate != current) {
+        if (candidate->isVisible() && candidate->isEnabled() && (candidate->focusPolicy() & Qt::TabFocus) && !is_blocked_content_widget(*candidate)) {
+            candidate->setFocus(next ? Qt::TabFocusReason : Qt::BacktabFocusReason);
+            return true;
+        }
+        candidate = next ? candidate->nextInFocusChain() : candidate->previousInFocusChain();
+    }
+
+    return true;
+}
+
+bool JavaScriptDialog::is_dialog_widget(QWidget const& widget) const
+{
+    return &widget == this || isAncestorOf(&widget);
+}
+
+bool JavaScriptDialog::is_blocked_content_widget(QWidget const& widget) const
+{
+    return !is_dialog_widget(widget) && (&widget == parentWidget() || parentWidget()->isAncestorOf(&widget));
+}
+
+void JavaScriptDialog::restore_parent_focus_policy()
+{
+    if (!m_parent_focus_policy.has_value())
+        return;
+    parentWidget()->setFocusPolicy(m_parent_focus_policy.release_value());
+}
+
+void JavaScriptDialog::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    update_geometry_constraints();
+}
+
+void JavaScriptDialog::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    raise();
+    focus_dialog();
+}
+
+void JavaScriptDialog::focus_dialog()
+{
+    if (!m_type.has_value())
+        return;
+
+    if (m_type == Type::Prompt) {
+        m_prompt_text->setFocus(Qt::OtherFocusReason);
+        m_prompt_text->selectAll();
+        return;
+    }
+
+    if (auto* ok_button = m_button_box->button(QDialogButtonBox::Ok))
+        ok_button->setFocus(Qt::OtherFocusReason);
+}
+
+void JavaScriptDialog::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    setStyleSheet(ChromeStyle::javascript_dialog_style_sheet(palette()));
+    m_is_updating_chrome_style = false;
+}
+
+void JavaScriptDialog::update_geometry_constraints()
+{
+    auto available_width = max(0, width() - DIALOG_MARGIN * 2);
+    m_panel->setMinimumWidth(min(DIALOG_MIN_WIDTH, available_width));
+    m_panel->setMaximumWidth(min(DIALOG_MAX_WIDTH, available_width));
+
+    auto message_width = max(1, min(DIALOG_MAX_WIDTH - PANEL_HORIZONTAL_PADDING * 2, available_width - PANEL_HORIZONTAL_PADDING * 2));
+    auto desired_message_height = max(0, m_message_label->heightForWidth(message_width));
+    m_message_label->setMinimumHeight(desired_message_height);
+
+    // Exclude the message area while measuring the height required by the other dialog controls.
+    m_message_scroll_area->setFixedHeight(0);
+    auto reserved_height = m_panel->sizeHint().height();
+    auto available_message_height = max(0, height() - DIALOG_MARGIN * 2 - reserved_height);
+    m_message_scroll_area->setFixedHeight(min(desired_message_height, min(DIALOG_MAX_MESSAGE_HEIGHT, available_message_height)));
+}
+
+}

--- a/UI/Qt/JavaScriptDialog.h
+++ b/UI/Qt/JavaScriptDialog.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+
+#include <QPointer>
+#include <QWidget>
+
+class QDialogButtonBox;
+class QFrame;
+class QLabel;
+class QLineEdit;
+class QScrollArea;
+
+namespace Ladybird {
+
+class JavaScriptDialog final : public QWidget {
+public:
+    enum class Type {
+        Alert,
+        Confirm,
+        Prompt,
+    };
+
+    explicit JavaScriptDialog(QWidget* parent);
+
+    bool is_open() const { return m_type.has_value(); }
+
+    void show_alert(QString const& title, QString const& message);
+    void show_confirm(QString const& title, QString const& message);
+    void show_prompt(QString const& title, QString const& message, QString const& default_text);
+    void set_prompt_text(QString const& text);
+    void accept();
+    void dismiss();
+
+    Function<void(Type, bool accepted, QString const& prompt_text)> on_complete;
+
+protected:
+    virtual bool event(QEvent*) override;
+    virtual bool eventFilter(QObject*, QEvent*) override;
+    virtual bool focusNextPrevChild(bool next) override;
+    virtual void resizeEvent(QResizeEvent*) override;
+    virtual void showEvent(QShowEvent*) override;
+
+private:
+    bool is_dialog_widget(QWidget const&) const;
+    bool is_blocked_content_widget(QWidget const&) const;
+    void open(Type, QString const& title, QString const& message, QString const& default_text = {});
+    void complete(bool accepted);
+    void focus_dialog();
+    void restore_focus_after_close();
+    void restore_parent_focus_policy();
+    void update_chrome_style();
+    void update_geometry_constraints();
+
+    Optional<Type> m_type;
+    QFrame* m_panel { nullptr };
+    QLabel* m_title_label { nullptr };
+    QLabel* m_message_label { nullptr };
+    QScrollArea* m_message_scroll_area { nullptr };
+    QLineEdit* m_prompt_text { nullptr };
+    QDialogButtonBox* m_button_box { nullptr };
+    QPointer<QWidget> m_previous_focus_widget;
+    Optional<Qt::FocusPolicy> m_parent_focus_policy;
+    bool m_is_updating_chrome_style { false };
+};
+
+}

--- a/UI/Qt/JavaScriptDialog.h
+++ b/UI/Qt/JavaScriptDialog.h
@@ -38,6 +38,7 @@ public:
     void set_prompt_text(QString const& text);
     void accept();
     void dismiss();
+    void reset();
 
     Function<void(Type, bool accepted, QString const& prompt_text)> on_complete;
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -865,6 +865,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         }
     };
 
+    view().on_before_browser_initiated_navigation = [this] {
+        m_javascript_dialog->dismiss();
+    };
+
     view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
         if (m_javascript_dialog->is_open() || m_color_picker_dialog || m_external_url_confirmation_dialog) {
             on_complete(false);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -791,6 +791,18 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
     set_loading(view().is_loading());
 
+    view().on_load_finish = [this](auto const&) {
+        m_suppress_javascript_dialogs_until_navigation = false;
+    };
+
+    view().on_top_level_navigation_commit = [this] {
+        m_suppress_javascript_dialogs_until_navigation = false;
+    };
+
+    view().on_browser_history_traversal_complete = [this] {
+        m_suppress_javascript_dialogs_until_navigation = false;
+    };
+
     view().on_url_change = [this](auto const& url) {
         m_location_edit->set_url(url);
     };
@@ -833,14 +845,26 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_request_alert = [this, javascript_dialog_title](auto const& message) {
+        if (m_suppress_javascript_dialogs_until_navigation) {
+            view().alert_closed();
+            return;
+        }
         m_javascript_dialog->show_alert(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
     view().on_request_confirm = [this, javascript_dialog_title](auto const& message) {
+        if (m_suppress_javascript_dialogs_until_navigation) {
+            view().confirm_closed(false);
+            return;
+        }
         m_javascript_dialog->show_confirm(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
     view().on_request_prompt = [this, javascript_dialog_title](auto const& message, auto const& default_) {
+        if (m_suppress_javascript_dialogs_until_navigation) {
+            view().prompt_closed({});
+            return;
+        }
         m_javascript_dialog->show_prompt(javascript_dialog_title(), qstring_from_utf16_string(message), qstring_from_utf16_string(default_));
     };
 
@@ -866,6 +890,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_before_browser_initiated_navigation = [this] {
+        m_suppress_javascript_dialogs_until_navigation = true;
         m_javascript_dialog->dismiss();
     };
 
@@ -1619,6 +1644,7 @@ void Tab::find_next()
 
 void Tab::request_close()
 {
+    m_suppress_javascript_dialogs_until_navigation = true;
     m_javascript_dialog->dismiss();
 
     if (!view().needs_beforeunload_check()) {

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -20,6 +20,7 @@
 #include <UI/Qt/ChromeLayout.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
+#include <UI/Qt/JavaScriptDialog.h>
 #if defined(AK_OS_MACOS)
 #    include <UI/Qt/MacWindow.h>
 #endif
@@ -35,7 +36,6 @@
 #include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QImage>
-#include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
@@ -599,6 +599,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     m_view = new WebContentView(this, parent_client, page_index, AK::move(view_initial_state));
+    m_javascript_dialog = new JavaScriptDialog(m_view);
     m_find_in_page = new FindInPageWidget(this, m_view);
     m_find_in_page->setVisible(false);
 
@@ -824,57 +825,48 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         update_tab_icon();
     };
 
-    view().on_request_alert = [this](auto const& message) {
-        m_dialog = new QMessageBox(QMessageBox::Icon::Warning, "Ladybird", qstring_from_utf16_string(message), QMessageBox::StandardButton::Ok, &view());
-
-        QObject::connect(m_dialog, &QDialog::finished, this, [this]() {
-            view().alert_closed();
-            m_dialog = nullptr;
-        });
-
-        m_dialog->open();
+    auto javascript_dialog_title = [this] {
+        auto origin = view().url().origin();
+        if (!origin.is_opaque())
+            return qstring_from_ak_string(origin.serialize());
+        return qformatted("{}://", qstring_from_ak_string(view().url().scheme()));
     };
 
-    view().on_request_confirm = [this](auto const& message) {
-        m_dialog = new QMessageBox(QMessageBox::Icon::Question, "Ladybird", qstring_from_utf16_string(message), QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel, &view());
-
-        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
-            view().confirm_closed(result == QMessageBox::StandardButton::Ok || result == QDialog::Accepted);
-            m_dialog = nullptr;
-        });
-
-        m_dialog->open();
+    view().on_request_alert = [this, javascript_dialog_title](auto const& message) {
+        m_javascript_dialog->show_alert(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
-    view().on_request_prompt = [this](auto const& message, auto const& default_) {
-        m_dialog = new QInputDialog(&view());
+    view().on_request_confirm = [this, javascript_dialog_title](auto const& message) {
+        m_javascript_dialog->show_confirm(javascript_dialog_title(), qstring_from_utf16_string(message));
+    };
 
-        auto& dialog = static_cast<QInputDialog&>(*m_dialog);
-        dialog.setWindowTitle("Ladybird");
-        dialog.setLabelText(qstring_from_utf16_string(message));
-        dialog.setTextValue(qstring_from_utf16_string(default_));
-
-        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
-            if (result == QDialog::Accepted) {
-                auto& dialog = static_cast<QInputDialog&>(*m_dialog);
-                view().prompt_closed(utf16_string_from_qstring(dialog.textValue()));
-            } else {
-                view().prompt_closed({});
-            }
-
-            m_dialog = nullptr;
-        });
-
-        m_dialog->open();
+    view().on_request_prompt = [this, javascript_dialog_title](auto const& message, auto const& default_) {
+        m_javascript_dialog->show_prompt(javascript_dialog_title(), qstring_from_utf16_string(message), qstring_from_utf16_string(default_));
     };
 
     view().on_request_set_prompt_text = [this](auto const& message) {
-        if (m_dialog && is<QInputDialog>(*m_dialog))
-            static_cast<QInputDialog&>(*m_dialog).setTextValue(qstring_from_utf16_string(message));
+        m_javascript_dialog->set_prompt_text(qstring_from_utf16_string(message));
+    };
+
+    m_javascript_dialog->on_complete = [this](auto type, bool accepted, auto const& prompt_text) {
+        switch (type) {
+        case JavaScriptDialog::Type::Alert:
+            view().alert_closed();
+            break;
+        case JavaScriptDialog::Type::Confirm:
+            view().confirm_closed(accepted);
+            break;
+        case JavaScriptDialog::Type::Prompt:
+            if (accepted)
+                view().prompt_closed(utf16_string_from_qstring(prompt_text));
+            else
+                view().prompt_closed({});
+            break;
+        }
     };
 
     view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
-        if (m_dialog || m_external_url_confirmation_dialog) {
+        if (m_javascript_dialog->is_open() || m_color_picker_dialog || m_external_url_confirmation_dialog) {
             on_complete(false);
             return;
         }
@@ -909,37 +901,35 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_request_accept_dialog = [this]() {
-        if (m_dialog)
-            m_dialog->accept();
+        m_javascript_dialog->accept();
     };
 
     view().on_request_dismiss_dialog = [this]() {
-        if (m_dialog)
-            m_dialog->reject();
+        m_javascript_dialog->dismiss();
     };
 
     view().on_request_color_picker = [this](Color current_color) {
-        m_dialog = new QColorDialog(QColor(current_color.red(), current_color.green(), current_color.blue()), &view());
+        m_color_picker_dialog = new QColorDialog(QColor(current_color.red(), current_color.green(), current_color.blue()), &view());
 
-        auto& dialog = static_cast<QColorDialog&>(*m_dialog);
+        auto& dialog = *m_color_picker_dialog;
         dialog.setWindowTitle("Ladybird");
         dialog.setOption(QColorDialog::ShowAlphaChannel, false);
         QObject::connect(&dialog, &QColorDialog::currentColorChanged, this, [this](QColor const& color) {
             view().color_picker_update(Color(color.red(), color.green(), color.blue()), Web::HTML::ColorPickerUpdateState::Update);
         });
 
-        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
+        QObject::connect(m_color_picker_dialog, &QDialog::finished, this, [this](auto result) {
             if (result == QDialog::Accepted) {
-                auto& dialog = static_cast<QColorDialog&>(*m_dialog);
+                auto& dialog = *m_color_picker_dialog;
                 view().color_picker_update(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()), Web::HTML::ColorPickerUpdateState::Closed);
             } else {
                 view().color_picker_update({}, Web::HTML::ColorPickerUpdateState::Closed);
             }
 
-            m_dialog = nullptr;
+            m_color_picker_dialog = nullptr;
         });
 
-        m_dialog->open();
+        m_color_picker_dialog->open();
     };
 
     view().on_request_file_picker = [this](auto const& accepted_file_types, auto allow_multiple_files) {
@@ -1625,6 +1615,8 @@ void Tab::find_next()
 
 void Tab::request_close()
 {
+    m_javascript_dialog->dismiss();
+
     if (!view().needs_beforeunload_check()) {
         auto request_close = view().prepare_for_immediate_close();
         if (m_window->definitely_close_tab(tab_index()))

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -894,6 +894,11 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_javascript_dialog->dismiss();
     };
 
+    view().on_web_content_crashed = [this] {
+        m_suppress_javascript_dialogs_until_navigation = false;
+        m_javascript_dialog->reset();
+    };
+
     view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
         if (m_javascript_dialog->is_open() || m_color_picker_dialog || m_external_url_confirmation_dialog) {
             on_complete(false);

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -193,6 +193,7 @@ private:
     QPointer<QColorDialog> m_color_picker_dialog;
     QPointer<QMessageBox> m_external_url_confirmation_dialog;
 
+    bool m_suppress_javascript_dialogs_until_navigation { false };
     bool m_already_requested_close { false };
 };
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -27,12 +27,14 @@
 #include <QWidget>
 
 class QTimer;
+class QColorDialog;
 class QMessageBox;
 namespace Ladybird {
 
 class BrowserWindow;
 enum class ChromeIcon;
 class DownloadsPopover;
+class JavaScriptDialog;
 class PrivateSessionPopover;
 class WindowControlButton;
 
@@ -187,7 +189,8 @@ private:
     Optional<ChromeIcon> m_downloads_button_icon;
     QString m_downloads_button_tooltip;
 
-    QPointer<QDialog> m_dialog;
+    JavaScriptDialog* m_javascript_dialog { nullptr };
+    QPointer<QColorDialog> m_color_picker_dialog;
     QPointer<QMessageBox> m_external_url_confirmation_dialog;
 
     bool m_already_requested_close { false };


### PR DESCRIPTION
Previously, we had no way of escaping the classic `while (true) { alert("lol"); }` trap, because the modal system dialog would block all interaction with the browser window.

So, follow what other browsers do, and implement these dialogs ourselves, painting a semitransparent overlay over the WebView, which blocks any interaction, and then centering a QPanel over it with the dialog content. This keeps the rest of the browser UI interactable, letting you switch to a different tab and back, or just close the tab.

Here's a screenshot of `prompt()`:
<img width="988" height="736" alt="Screenshot_20260821_162758" src="https://github.com/user-attachments/assets/e87ea7a7-6db5-4e07-b171-8ed01cfe232f" />

AppKit will need its own changes if we decide to go ahead with this - this is a purely UI-side change, keeping the existing IPC for showing dialogs and reporting when they are closed.

We apparently also have an existing issue where we don't support showing dialogs from inside frames. I haven't touched that here.