### PR TITLE
Meta: Run Flap tests with CTest

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -50,8 +50,6 @@ jobs:
           cargo fmt --manifest-path Libraries/LibJS/Flap/Cargo.toml -- --check
           cargo clippy --manifest-path Libraries/LibJS/Flap/Cargo.toml \
             --all-targets -- -D clippy::all
-          cargo test --manifest-path Libraries/LibJS/Flap/Cargo.toml \
-            --all-targets
 
       - name: Generate and assemble the Flap interpreter
         run: |

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -31,6 +31,16 @@ if (NOT WIN32)
             "${RUST_CARGO}" test --workspace --target "${RUST_TARGET_TRIPLE}"
         WORKING_DIRECTORY "${LADYBIRD_SOURCE_DIR}"
     )
+
+    add_test(
+        NAME Flap
+        COMMAND "${CMAKE_COMMAND}" -E env
+            "CARGO_TARGET_DIR=${CMAKE_BINARY_DIR}/cargo/flap-tests"
+            "${RUST_CARGO}" test
+                --manifest-path "${LADYBIRD_SOURCE_DIR}/Libraries/LibJS/Flap/Cargo.toml"
+                --target "${RUST_TARGET_TRIPLE}"
+                --all-targets
+    )
 endif()
 
 if (ENABLE_GUI_TARGETS)


### PR DESCRIPTION
Register Flap's Cargo suite with CTest so it runs through the standard local and CI test paths on every supported platform. This also lets the existing CTest regex filter select the suite by name.

Remove the duplicate Linux-only Cargo test command from the lint CI job.