### PR TITLE
LibWeb: Read box geometry and status through layout-node views

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Animations {
@@ -980,10 +981,8 @@ AnimationUpdateContext::~AnimationUpdateContext()
         auto* repaint_layout_node = element.pseudo_element().has_value()
             ? target->pseudo_element_unsafe_layout_node(*element.pseudo_element())
             : target->unsafe_layout_node();
-        if (repaint_layout_node) {
-            if (auto paintable = repaint_layout_node->paintable())
-                paintable->repaint_after_style_change(invalidation);
-        }
+        if (repaint_layout_node && Painting::has_committed_box(*repaint_layout_node))
+            Painting::repaint_after_style_change(*repaint_layout_node, invalidation);
         if (invalidation.needs_stacking_context_tree_rebuild())
             element.document().invalidate_stacking_context_tree();
     }

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Animations {
@@ -126,11 +127,11 @@ static Optional<ScrollOffsetData> compute_scroll_offset_data(Variant<GC::Ptr<DOM
 
     auto const& paintable_box = propagated_source.visit([](auto const& source) -> RefPtr<Painting::Paintable const> { return source->unsafe_paintable_box(); });
 
-    if (!paintable_box || !paintable_box->has_scrollable_overflow())
+    if (!paintable_box || !Painting::has_scrollable_overflow(*layout_node))
         return {};
 
-    auto const& scrollable_overflow_rect = paintable_box->scrollable_overflow_rect().value();
-    auto const& computed_axis = computed_scroll_axis(axis, paintable_box->layout_node().writing_mode(), paintable_box->layout_node().direction());
+    auto const& scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node).value();
+    auto const& computed_axis = computed_scroll_axis(axis, layout_node->writing_mode(), layout_node->direction());
 
     // FIXME: Scroll offset is currently incorrect as it is always relative to the top left of the scrollable overflow
     //        rect when it should instead be relative to the scroll origin.
@@ -142,8 +143,8 @@ static Optional<ScrollOffsetData> compute_scroll_offset_data(Variant<GC::Ptr<DOM
             ? paintable_box->scroll_offset().y().to_double()
             : paintable_box->scroll_offset().x().to_double(),
         .max_scroll_offset = computed_axis.is_vertical
-            ? scrollable_overflow_rect.height().to_double() - paintable_box->content_height().to_double()
-            : scrollable_overflow_rect.width().to_double() - paintable_box->content_width().to_double(),
+            ? scrollable_overflow_rect.height().to_double() - Painting::content_height(*layout_node).to_double()
+            : scrollable_overflow_rect.width().to_double() - Painting::content_width(*layout_node).to_double(),
     };
 }
 

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -857,6 +857,7 @@ set(SOURCES
     Painting/AccumulatedVisualContext.cpp
     Painting/Blending.cpp
     Painting/BoxModelMetrics.cpp
+    Painting/BoxViews.cpp
     Painting/Canvas2DCommandStream.cpp
     Painting/ChromeWidget.cpp
     Painting/DepthSortedReplayPlan.cpp

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -41,7 +41,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BoxModelMetrics.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::CSS {
 
@@ -1006,14 +1006,12 @@ Optional<Utf16String> CSSStyleProperties::serialized_computed_value_from_stored_
     // track sizes, so only serialize the computed value when no used track list exists.
     // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
     if (property_id == PropertyID::GridTemplateColumns || property_id == PropertyID::GridTemplateRows) {
-        if (layout_node) {
-            if (auto paintable = layout_node->paintable(); auto const* paintable_box = paintable.ptr()) {
-                auto const& used_values = property_id == PropertyID::GridTemplateColumns
-                    ? paintable_box->used_values_for_grid_template_columns()
-                    : paintable_box->used_values_for_grid_template_rows();
-                if (used_values.has_value())
-                    return {};
-            }
+        if (layout_node && Painting::has_committed_box(*layout_node)) {
+            auto const& used_values = property_id == PropertyID::GridTemplateColumns
+                ? Painting::used_values_for_grid_template_columns(*layout_node)
+                : Painting::used_values_for_grid_template_rows(*layout_node);
+            if (used_values.has_value())
+                return {};
         }
     }
 
@@ -1055,30 +1053,25 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         return nullptr;
     }
 
-    auto used_value_for_property = [&layout_node, property_id](Function<CSSPixels(Painting::Paintable const&)>&& used_value_getter) -> Optional<CSSPixels> {
+    auto used_value_for_property = [&layout_node](Function<CSSPixels(Layout::Node const&)>&& used_value_getter) -> Optional<CSSPixels> {
         auto display = layout_node.display();
-        if (!display.is_none() && !display.is_contents()) {
-            auto paintable = layout_node.paintable();
-            if (auto const* paintable_box = paintable.ptr())
-                return used_value_getter(*paintable_box);
-            if (paintable)
-                dbgln("FIXME: Support getting used value for property `{}` on {}", string_from_property_id(property_id), layout_node.debug_description());
-        }
+        if (!display.is_none() && !display.is_contents() && Painting::has_committed_box(layout_node))
+            return used_value_getter(layout_node);
         return {};
     };
 
     auto used_size_for_property = [&layout_node, &used_value_for_property]<typename ContentBoxGetter, typename BorderBoxGetter>(ContentBoxGetter content_box_getter, BorderBoxGetter border_box_getter) -> Optional<CSSPixels> {
-        return used_value_for_property([&layout_node, content_box_getter, border_box_getter](Painting::Paintable const& paintable_box) {
+        return used_value_for_property([&layout_node, content_box_getter, border_box_getter](Layout::Node const& box_layout_node) {
             if (layout_node.box_sizing() == BoxSizing::BorderBox)
-                return border_box_getter(paintable_box);
-            return content_box_getter(paintable_box);
+                return border_box_getter(box_layout_node);
+            return content_box_getter(box_layout_node);
         });
     };
 
     auto& element = owner_node()->element();
     auto pseudo_element = owner_node()->pseudo_element();
 
-    auto used_value_for_inset = [&layout_node, used_value_for_property](LengthPercentageOrAuto const& start_side, LengthPercentageOrAuto const& end_side, Function<CSSPixels(Painting::Paintable const&)>&& used_value_getter) -> Optional<CSSPixels> {
+    auto used_value_for_inset = [&layout_node, used_value_for_property](LengthPercentageOrAuto const& start_side, LengthPercentageOrAuto const& end_side, Function<CSSPixels(Layout::Node const&)>&& used_value_getter) -> Optional<CSSPixels> {
         if (!layout_node.is_positioned())
             return {};
 
@@ -1206,48 +1199,48 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // Otherwise the resolved value is the computed value.
     case PropertyID::Height: {
         auto maybe_used_height = used_size_for_property(
-            [](auto const& paintable_box) { return paintable_box.content_height(); },
-            [](auto const& paintable_box) { return paintable_box.absolute_border_box_rect().height(); });
+            [](auto const& box_layout_node) { return Painting::content_height(box_layout_node); },
+            [](auto const& box_layout_node) { return Painting::absolute_border_box_rect(box_layout_node).height(); });
         if (maybe_used_height.has_value())
             return style_value_for_size(Size::make_px(maybe_used_height.release_value()));
         return style_value_for_size(layout_node.height());
     }
     case PropertyID::MarginBottom:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().margin.bottom; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).margin.bottom; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.margin().bottom());
     case PropertyID::MarginLeft:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().margin.left; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).margin.left; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.margin().left());
     case PropertyID::MarginRight:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().margin.right; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).margin.right; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.margin().right());
     case PropertyID::MarginTop:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().margin.top; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).margin.top; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.margin().top());
     case PropertyID::PaddingBottom:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().padding.bottom; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).padding.bottom; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.padding().bottom());
     case PropertyID::PaddingLeft:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().padding.left; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).padding.left; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.padding().left());
     case PropertyID::PaddingRight:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().padding.right; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).padding.right; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.padding().right());
     case PropertyID::PaddingTop:
-        if (auto maybe_used_value = used_value_for_property([](auto const& paintable_box) { return paintable_box.box_model().padding.top; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_property([](auto const& box_layout_node) { return Painting::box_model(box_layout_node).padding.top; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.padding().top());
     case PropertyID::Width: {
         auto maybe_used_width = used_size_for_property(
-            [](auto const& paintable_box) { return paintable_box.content_width(); },
-            [](auto const& paintable_box) { return paintable_box.absolute_border_box_rect().width(); });
+            [](auto const& box_layout_node) { return Painting::content_width(box_layout_node); },
+            [](auto const& box_layout_node) { return Painting::absolute_border_box_rect(box_layout_node).width(); });
         if (maybe_used_width.has_value())
             return style_value_for_size(Size::make_px(maybe_used_width.release_value()));
         return style_value_for_size(layout_node.width());
@@ -1267,27 +1260,27 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         //    Otherwise the resolved value is the computed value.
     case PropertyID::Bottom: {
         auto inset = layout_node.inset();
-        if (auto maybe_used_value = used_value_for_inset(inset.bottom(), inset.top(), [](auto const& paintable_box) { return paintable_box.box_model().inset.bottom; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_inset(inset.bottom(), inset.top(), [](auto const& box_layout_node) { return Painting::box_model(box_layout_node).inset.bottom; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
 
         return style_value_for_length_percentage_or_auto(inset.bottom());
     }
     case PropertyID::Left: {
         auto inset = layout_node.inset();
-        if (auto maybe_used_value = used_value_for_inset(inset.left(), inset.right(), [](auto const& paintable_box) { return paintable_box.box_model().inset.left; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_inset(inset.left(), inset.right(), [](auto const& box_layout_node) { return Painting::box_model(box_layout_node).inset.left; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(inset.left());
     }
     case PropertyID::Right: {
         auto inset = layout_node.inset();
-        if (auto maybe_used_value = used_value_for_inset(inset.right(), inset.left(), [](auto const& paintable_box) { return paintable_box.box_model().inset.right; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_inset(inset.right(), inset.left(), [](auto const& box_layout_node) { return Painting::box_model(box_layout_node).inset.right; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
 
         return style_value_for_length_percentage_or_auto(inset.right());
     }
     case PropertyID::Top: {
         auto inset = layout_node.inset();
-        if (auto maybe_used_value = used_value_for_inset(inset.top(), inset.bottom(), [](auto const& paintable_box) { return paintable_box.box_model().inset.top; }); maybe_used_value.has_value())
+        if (auto maybe_used_value = used_value_for_inset(inset.top(), inset.bottom(), [](auto const& box_layout_node) { return Painting::box_model(box_layout_node).inset.top; }); maybe_used_value.has_value())
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
 
         return style_value_for_length_percentage_or_auto(inset.top());
@@ -1307,11 +1300,9 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         auto transform = FloatMatrix4x4::identity();
 
         // 2. Post-multiply all <transform-function>s in <transform-list> to transform.
-        auto paintable = layout_node.paintable();
-        VERIFY(paintable);
-        auto const& paintable_box = *paintable;
+        VERIFY(Painting::has_committed_box(layout_node));
         layout_node.for_each_transformation([&](auto const& transformation) {
-            transform = transform * transformation.to_matrix(paintable_box);
+            transform = transform * transformation.to_matrix(&layout_node);
         });
 
         // https://drafts.csswg.org/css-transforms-1/#2d-matrix
@@ -1382,8 +1373,8 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // The transform-origin property is a resolved value special case property like height. [CSSOM]
         Optional<CSSPixelRect> reference_box;
         if (auto display = layout_node.display(); !display.is_none() && !display.is_contents()) {
-            if (auto paintable = layout_node.paintable())
-                reference_box = paintable->transform_reference_box();
+            if (Painting::has_committed_box(layout_node))
+                reference_box = Painting::transform_reference_box(layout_node);
         }
         return style_value_for_transform_origin(layout_node.transform_origin(), reference_box);
     }
@@ -1441,13 +1432,13 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // For grid-template-columns and grid-template-rows the resolved value is the used value.
         // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
         if (property_id == PropertyID::GridTemplateColumns) {
-            if (auto paintable = layout_node.paintable(); auto const* paintable_box = paintable.ptr()) {
-                if (auto const& used_values = paintable_box->used_values_for_grid_template_columns(); used_values.has_value())
+            if (Painting::has_committed_box(layout_node)) {
+                if (auto const& used_values = Painting::used_values_for_grid_template_columns(layout_node); used_values.has_value())
                     return style_value_for_used_grid_track_list(*used_values);
             }
         } else if (property_id == PropertyID::GridTemplateRows) {
-            if (auto paintable = layout_node.paintable(); auto const* paintable_box = paintable.ptr()) {
-                if (auto const& used_values = paintable_box->used_values_for_grid_template_rows(); used_values.has_value())
+            if (Painting::has_committed_box(layout_node)) {
+                if (auto const& used_values = Painting::used_values_for_grid_template_rows(layout_node); used_values.has_value())
                     return style_value_for_used_grid_track_list(*used_values);
             }
         }

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -33,7 +33,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::CSS {
 
@@ -88,11 +88,11 @@ bool size_feature_type_is_range(SizeFeatureID id)
     VERIFY_NOT_REACHED();
 }
 
-static FeatureValue size_feature_value_for_query_container(SizeFeatureID id, Painting::Paintable const& paintable_box)
+static FeatureValue size_feature_value_for_query_container(SizeFeatureID id, Layout::NodeWithStyle const& layout_node)
 {
-    auto width = paintable_box.content_width();
-    auto height = paintable_box.content_height();
-    auto inline_axis_horizontal = paintable_box.layout_node().writing_mode() == WritingMode::HorizontalTb;
+    auto width = Painting::content_width(layout_node);
+    auto height = Painting::content_height(layout_node);
+    auto inline_axis_horizontal = layout_node.writing_mode() == WritingMode::HorizontalTb;
 
     auto length_feature_value = [](CSSPixels length) {
         return FeatureValue(FeatureValue::Type::Length, LengthStyleValue::create(Length::make_px(length)));
@@ -137,16 +137,16 @@ MatchResult SizeFeature::evaluate(BooleanExpressionEvaluationContext const& cont
     if (!context.query_container)
         return MatchResult::Unknown;
 
-    auto paintable_box = context.query_container->unsafe_paintable_box();
-    if (!paintable_box) {
+    auto const* layout_node = context.query_container->unsafe_layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node)) {
         if (!context.query_container->document().layout_is_up_to_date())
             const_cast<DOM::Document&>(context.query_container->document()).set_needs_container_query_evaluation_after_layout(*context.query_container);
         return MatchResult::Unknown;
     }
 
-    auto queried_value = size_feature_value_for_query_container(id(), *paintable_box);
+    auto queried_value = size_feature_value_for_query_container(id(), *layout_node);
     ComputationContext computation_context {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(paintable_box->layout_node()),
+        .length_resolution_context = Length::ResolutionContext::for_layout_node(*layout_node),
         .abstract_element = DOM::AbstractElement { *context.query_container },
     };
 

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -21,7 +21,7 @@
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::CSS {
 
@@ -158,8 +158,8 @@ double Length::container_relative_length_to_px_without_rounding(ResolutionContex
             return viewport_length.to_double();
         }
 
-        auto paintable_box = query_container->unsafe_paintable_box();
-        if (!paintable_box) {
+        auto const* layout_node = query_container->unsafe_layout_node();
+        if (!layout_node || !Painting::has_committed_box(*layout_node)) {
             // A running partial relayout pass reports layout as up to date, but a container
             // with no paintable yet still needs the post-layout evaluation, which routes the
             // follow-up pass to the full layout path that resolves the container's size.
@@ -168,7 +168,7 @@ double Length::container_relative_length_to_px_without_rounding(ResolutionContex
             return 0.0;
         }
 
-        auto container_length = physical_axis == ContainerRelativeAxis::Width ? paintable_box->content_width() : paintable_box->content_height();
+        auto container_length = physical_axis == ContainerRelativeAxis::Width ? Painting::content_width(*layout_node) : Painting::content_height(*layout_node);
         return container_length.to_double();
     };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -104,7 +104,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/FontPlugin.h>
 #include <LibWeb/StyleValueRustFFI.h>
 #include <math.h>
@@ -926,8 +926,8 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             .transform_reference_box_width = 0,
             .transform_reference_box_height = 0,
         };
-        if (auto paintable = prepared_values.first().effect->target()->unsafe_paintable(); paintable && paintable->has_layout_node()) {
-            auto reference_box = paintable->transform_reference_box();
+        if (auto const* layout_node = prepared_values.first().effect->target()->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
+            auto reference_box = Painting::transform_reference_box(*layout_node);
             animation_context.has_transform_reference_box = true;
             animation_context.transform_reference_box_width = reference_box.width().to_double();
             animation_context.transform_reference_box_height = reference_box.height().to_double();
@@ -1330,13 +1330,8 @@ Vector<GC::Ref<Animations::KeyframeEffect>> StyleComputer::start_needed_transiti
         .transform_reference_box_width = 0,
         .transform_reference_box_height = 0,
     };
-    // A paintable outlives the layout node it was made for, and a style recompute can reach an
-    // element whose layout node is already gone: the layout tree builder updates the style of an
-    // element a bypass path reached, and `display: none` leaves the flag set until then. A reference
-    // box is a fact about a layout box, so without one there is none - exactly as when the element
-    // was never painted at all.
-    if (auto paintable = abstract_element.element().unsafe_paintable(); paintable && paintable->has_layout_node()) {
-        auto reference_box = paintable->transform_reference_box();
+    if (auto const* layout_node = abstract_element.element().unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
+        auto reference_box = Painting::transform_reference_box(*layout_node);
         transition_animation_context.has_transform_reference_box = true;
         transition_animation_context.transform_reference_box_width = reference_box.width().to_double();
         transition_animation_context.transform_reference_box_height = reference_box.height().to_double();

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
@@ -33,7 +33,7 @@
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/Geometry/DOMMatrix.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::CSS {
 
@@ -73,7 +73,7 @@ bool TransformationStyleValue::can_be_converted_to_matrix_without_reference_box(
     return true;
 }
 
-FloatMatrix4x4 TransformationStyleValue::to_matrix(Optional<Painting::Paintable const&> paintable_box) const
+FloatMatrix4x4 TransformationStyleValue::to_matrix(Layout::Node const* layout_node) const
 {
     auto values = this->values();
     auto count = values.size();
@@ -99,8 +99,8 @@ FloatMatrix4x4 TransformationStyleValue::to_matrix(Optional<Painting::Paintable 
 
     Optional<CSSPixels> width;
     Optional<CSSPixels> height;
-    if (paintable_box.has_value()) {
-        auto reference_box = paintable_box->transform_reference_box();
+    if (layout_node) {
+        auto reference_box = Painting::transform_reference_box(*layout_node);
         width = reference_box.width();
         height = reference_box.height();
     }

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
@@ -30,7 +30,7 @@ public:
     }
 
     bool can_be_converted_to_matrix_without_reference_box() const;
-    FloatMatrix4x4 to_matrix(Optional<Painting::Paintable const&>) const;
+    FloatMatrix4x4 to_matrix(Layout::Node const*) const;
 
     void serialize(StringBuilder&, SerializationMode) const;
     GC::Ptr<CSSTransformComponent> reify_a_transform_function() const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6903,6 +6903,16 @@ RefPtr<Painting::ViewportPaintable> Document::unsafe_paintable()
     return as<Painting::ViewportPaintable>(*paintable);
 }
 
+Painting::AccumulatedVisualContextTree const& Document::visual_context_tree() const
+{
+    return paintable()->visual_context_tree();
+}
+
+Painting::ScrollStateSnapshot const& Document::scroll_state_snapshot() const
+{
+    return paintable()->scroll_state_snapshot();
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-the-history-object-state
 void Document::restore_the_history_object_state(NonnullRefPtr<HTML::SessionHistoryEntry> entry)
 {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2487,7 +2487,7 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
     // For every box that will be re-measured, the overflow data it had before, so the diff below
     // can tell what actually changed; an empty value means the box's paintable was reset by a
     // subtree layout commit and the old data is unknown.
-    HashMap<Layout::Box const*, Optional<Painting::Paintable::OverflowData>> old_overflow_data_by_box;
+    HashMap<Layout::Box const*, Optional<Painting::OverflowData>> old_overflow_data_by_box;
 
     auto pending_paintables = move(m_paintable_boxes_needing_scrollable_overflow_recalculation);
     auto needs_full_recalculation = exchange(m_needs_full_scrollable_overflow_recalculation, false);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2997,24 +2997,24 @@ static CSSPixelPoint hover_event_page_offset(Optional<HoverEventData> const& hov
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx
-static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting::Paintable const& paintable)
+static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Layout::Node const& layout_node)
 {
-    auto inverse_transform_point = [](Painting::Paintable const& paintable_box, CSSPixelPoint position) -> Optional<CSSPixelPoint> {
-        auto viewport_paintable = paintable_box.document().unsafe_paintable();
+    auto inverse_transform_point = [](Layout::Node const& layout_node, CSSPixelPoint position) -> Optional<CSSPixelPoint> {
+        auto viewport_paintable = layout_node.document().unsafe_paintable();
         if (!viewport_paintable)
             return {};
-        auto pixel_ratio = static_cast<float>(paintable_box.document().page().client().device_pixels_per_css_pixel());
+        auto pixel_ratio = static_cast<float>(layout_node.document().page().client().device_pixels_per_css_pixel());
         auto const& visual_context_tree = viewport_paintable->visual_context_tree();
         auto transformed_position = visual_context_tree.inverse_transform_point(
-            paintable_box.accumulated_visual_context_index(), position.to_type<float>() * pixel_ratio);
+            Painting::accumulated_visual_context_index(layout_node), position.to_type<float>() * pixel_ratio);
         return (transformed_position / pixel_ratio).to_type<CSSPixels>();
     };
 
     CSSPixelPoint offset_position = position;
-    if (auto transformed_position = inverse_transform_point(paintable, position); transformed_position.has_value())
+    if (auto transformed_position = inverse_transform_point(layout_node, position); transformed_position.has_value())
         offset_position = *transformed_position;
 
-    auto const top_left_of_layout_node = paintable.box_type_agnostic_position();
+    auto const top_left_of_layout_node = Painting::box_type_agnostic_position(layout_node);
     return offset_position - top_left_of_layout_node;
 }
 
@@ -3030,11 +3030,10 @@ static CSSPixelPoint hover_event_offset_for_target(Optional<HoverEventData> cons
     if (!layout_node)
         return hover_event_data->viewport_position;
 
-    auto paintable = layout_node->paintable();
-    if (!paintable)
+    if (!Painting::has_committed_box(*layout_node))
         return hover_event_data->viewport_position;
 
-    return compute_mouse_event_offset(hover_event_data->page_offset, *paintable);
+    return compute_mouse_event_offset(hover_event_data->page_offset, *layout_node);
 }
 
 static void mark_mouse_transition_event_as_trusted_if_needed(Event& event, Optional<HoverEventData> const& hover_event_data)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8820,11 +8820,10 @@ Optional<CSSPixelRect> Document::current_caret_rect()
     // Empty editable elements have no fragments; fall back to the caret position for the cursor's child offset
     // (which accounts for empty lines rendered by <br>), or the padding-box corner.
     if (auto* node_with_style = as_if<Layout::NodeWithStyle>(*layout_node)) {
-        auto paintable = node_with_style->paintable();
-        if (auto const* with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr()))
-            return to_viewport_rect(with_lines->caret_rect_for_child_offset(position->offset()));
-        if (auto const* box = paintable.ptr()) {
-            auto content_box = box->absolute_padding_box_rect();
+        if (Painting::is_paintable_with_lines(*node_with_style))
+            return to_viewport_rect(Painting::caret_rect_for_child_offset(*node_with_style, position->offset()));
+        if (Painting::has_committed_box(*node_with_style)) {
+            auto content_box = Painting::absolute_padding_box_rect(*node_with_style);
             return to_viewport_rect(CSSPixelRect { content_box.x(), content_box.y(), 1, node_with_style->line_height() });
         }
     }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -581,9 +581,9 @@ Document::Document(Page& page, GC::Ref<EventTarget> relevant_global_event_target
                     return;
                 m_cursor_blink_state = !m_cursor_blink_state;
                 layout_text_node->set_needs_repaint();
-            } else if (node->unsafe_paintable()) {
+            } else if (auto const* layout_node = node->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
                 m_cursor_blink_state = !m_cursor_blink_state;
-                node->set_needs_repaint();
+                Painting::set_needs_repaint(*layout_node);
             }
         }));
     }
@@ -2467,7 +2467,7 @@ static void rebuild_sticky_insets(Layout::Node const& root)
         auto nearest_scrollable_ancestor = box_paintable->nearest_scrollable_ancestor();
         CSSPixelSize scrollport_size;
         if (nearest_scrollable_ancestor)
-            scrollport_size = nearest_scrollable_ancestor->absolute_rect().size();
+            scrollport_size = Painting::absolute_rect(nearest_scrollable_ancestor->layout_node()).size();
 
         if (!inset.top().is_auto())
             sticky_insets->top = inset.top().to_px_or_zero(scrollport_size.height());
@@ -2477,7 +2477,7 @@ static void rebuild_sticky_insets(Layout::Node const& root)
             sticky_insets->bottom = inset.bottom().to_px_or_zero(scrollport_size.height());
         if (!inset.left().is_auto())
             sticky_insets->left = inset.left().to_px_or_zero(scrollport_size.width());
-        box_paintable->set_sticky_insets(move(sticky_insets));
+        Painting::set_sticky_insets(layout_node, move(sticky_insets));
         return TraversalDecision::Continue;
     });
 }
@@ -2524,13 +2524,12 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
     }
 
     auto record_and_clear_overflow_data = [&](Layout::Box const& box) {
-        auto box_paintable = box.paintable_box();
-        if (!box_paintable)
+        if (!Painting::has_committed_box(box))
             return true;
         if (old_overflow_data_by_box.contains(&box))
             return false;
-        old_overflow_data_by_box.set(&box, box_paintable->overflow_data());
-        const_cast<Painting::Paintable&>(*box_paintable).clear_overflow_data();
+        old_overflow_data_by_box.set(&box, Painting::overflow_data(box));
+        Painting::clear_overflow_data(box);
         return true;
     };
 
@@ -2548,8 +2547,7 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
             auto const* box = as_if<Layout::Box>(paintable->layout_node());
             if (!box)
                 continue;
-            auto box_paintable = box->paintable_box();
-            bool was_reset_by_subtree_layout_commit = box_paintable && !box_paintable->overflow_data().has_value();
+            bool was_reset_by_subtree_layout_commit = Painting::has_committed_box(*box) && !Painting::overflow_data(*box).has_value();
             if (was_reset_by_subtree_layout_commit) {
                 box->for_each_in_inclusive_subtree_of_type<Layout::Box>([&](auto& subtree_box) {
                     record_and_clear_overflow_data(subtree_box);
@@ -2557,8 +2555,8 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
                 });
             }
             for (auto const* containing_block = box->containing_block(); containing_block; containing_block = containing_block->containing_block()) {
-                if (auto containing_block_paintable = containing_block->paintable_box())
-                    const_cast<Painting::Paintable&>(*containing_block_paintable).clear_cached_overflow_data();
+                if (Painting::has_committed_box(*containing_block))
+                    Painting::clear_cached_overflow_data(*containing_block);
                 if (!record_and_clear_overflow_data(*containing_block))
                     break;
             }
@@ -2586,23 +2584,24 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
     bool any_overflow_changed = false;
     bool any_has_scrollable_overflow_flipped = false;
     for (auto const& [box, old_overflow_data] : old_overflow_data_by_box) {
-        auto box_paintable = box->paintable_box();
-        if (!box_paintable || !box_paintable->overflow_data().has_value())
+        if (!Painting::has_committed_box(*box))
+            continue;
+        auto new_overflow_data = Painting::overflow_data(*box);
+        if (!new_overflow_data.has_value())
             continue;
         // A box with no prior overflow data was just created or reset by the layout commit, so
         // its paint cache is already clean.
         if (!old_overflow_data.has_value())
             continue;
-        auto const& new_overflow_data = *box_paintable->overflow_data();
-        bool rect_changed = old_overflow_data->scrollable_overflow_rect != new_overflow_data.scrollable_overflow_rect;
-        bool has_scrollable_overflow_flipped = old_overflow_data->has_scrollable_overflow != new_overflow_data.has_scrollable_overflow;
+        bool rect_changed = old_overflow_data->scrollable_overflow_rect != new_overflow_data->scrollable_overflow_rect;
+        bool has_scrollable_overflow_flipped = old_overflow_data->has_scrollable_overflow != new_overflow_data->has_scrollable_overflow;
         if (!rect_changed && !has_scrollable_overflow_flipped)
             continue;
         // Cached paint commands and hit-test items capture scrollbar geometry and per-direction
         // scrollability derived from the overflow rect, so they cannot be reused once it changes.
         // This must also run for the after-layout-commit path: a subtree relayout re-measures a
         // surviving ancestor's overflow without resetting the ancestor's paintable.
-        box_paintable->invalidate_paint_cache();
+        Painting::invalidate_paint_cache(*box);
         any_overflow_changed = true;
         any_has_scrollable_overflow_flipped |= has_scrollable_overflow_flipped;
     }
@@ -2633,7 +2632,7 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
 void Document::ensure_scrollable_overflow_is_measured(Layout::Box const& box) const
 {
     auto paintable = box.paintable_box();
-    if (!paintable || paintable->overflow_data().has_value() || paintable->cached_overflow_data().has_value())
+    if (!paintable || Painting::overflow_data(box).has_value() || Painting::cached_overflow_data(box).has_value())
         return;
     Painting::rust_measure_scrollable_overflow(*paintable);
 }
@@ -2851,14 +2850,14 @@ void Document::set_highlighted_node(GC::Ptr<Node> node, Optional<CSS::PseudoElem
     if (m_highlighted_node == node && m_highlighted_pseudo_element == pseudo_element)
         return;
 
-    if (auto layout_node = highlighted_layout_node(); layout_node && layout_node->paintable())
-        layout_node->paintable()->set_needs_repaint();
+    if (auto layout_node = highlighted_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        Painting::set_needs_repaint(*layout_node);
 
     m_highlighted_node = node;
     m_highlighted_pseudo_element = pseudo_element;
 
-    if (auto layout_node = highlighted_layout_node(); layout_node && layout_node->paintable())
-        layout_node->paintable()->set_needs_repaint();
+    if (auto layout_node = highlighted_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        Painting::set_needs_repaint(*layout_node);
 }
 
 void Document::set_grid_highlighted_node(GC::Ptr<Node> node, Painting::GridInspectorOverlayOptions options)
@@ -5262,8 +5261,9 @@ void Document::set_page_showing(bool page_showing)
 void Document::invalidate_stacking_context_tree()
 {
     // NB: Called during stacking context invalidation.
-    if (auto paintable_box = this->unsafe_paintable_box())
-        paintable_box->invalidate_stacking_context();
+    auto const* layout_node = this->unsafe_layout_node();
+    if (layout_node && Painting::has_committed_box(*layout_node))
+        Painting::invalidate_stacking_context(*layout_node);
 }
 
 void Document::check_favicon_after_loading_link_resource()
@@ -8969,8 +8969,8 @@ void Document::schedule_scrollable_overflow_recalculation(Layout::Node const& la
 
     if (auto const* box = as_if<Layout::Box>(layout_node)) {
         for (auto const* containing_box = box; containing_box; containing_box = containing_box->containing_block()) {
-            if (auto paintable = containing_box->paintable_box())
-                const_cast<Painting::Paintable&>(*paintable).clear_cached_overflow_data();
+            if (Painting::has_committed_box(*containing_box))
+                Painting::clear_cached_overflow_data(*containing_box);
         }
     }
 
@@ -9558,7 +9558,7 @@ Utf16String Document::dump_display_list()
     if (!display_list)
         return "No display list"_utf16;
 
-    HashMap<size_t, RefPtr<Painting::Paintable const>> context_id_to_paintable;
+    HashMap<size_t, Layout::Node const*> context_id_to_layout_node;
     auto entry_count = Layout::RustFFI::layout_arena_paint_tree_dump_entry_count(viewport_paintable->rust_arena().handle(), viewport_paintable->rust_slot());
     Vector<Layout::RustFFI::FfiPaintTreeDumpEntry> entries;
     entries.resize(entry_count);
@@ -9567,11 +9567,10 @@ Utf16String Document::dump_display_list()
         if (!entry.layout_node_shell)
             continue;
         auto& layout_node = *static_cast<Layout::Node*>(entry.layout_node_shell);
-        auto paintable = layout_node.paintable();
-        if (!paintable)
+        if (!Painting::has_committed_box(layout_node))
             continue;
-        auto visual_context_index = paintable->accumulated_visual_context_index();
-        (void)context_id_to_paintable.try_set(visual_context_index.value(), paintable);
+        auto visual_context_index = Painting::accumulated_visual_context_index(layout_node);
+        (void)context_id_to_layout_node.try_set(visual_context_index.value(), &layout_node);
     }
 
     StringBuilder builder;
@@ -9600,8 +9599,8 @@ Utf16String Document::dump_display_list()
         builder.append_repeated(' ', indent * 2);
         builder.appendff("[{}] ", node_index);
         visual_context_tree.dump(Painting::VisualContextIndex(node_index), builder);
-        if (auto it = context_id_to_paintable.find(node_index); it != context_id_to_paintable.end())
-            builder.appendff(" ({})", it->value->debug_description());
+        if (auto it = context_id_to_layout_node.find(node_index); it != context_id_to_layout_node.end())
+            builder.appendff(" ({})", Painting::debug_description(*it->value));
         builder.append('\n');
         for (auto child_node_index : children.get(node_index).value_or({}))
             dump_context(child_node_index, indent + 1);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -203,6 +203,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
@@ -6442,23 +6443,20 @@ void Document::queue_an_intersection_observer_entry(IntersectionObserver::Inters
 }
 
 // https://www.w3.org/TR/intersection-observer/#compute-the-intersection
-static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect target_rect, IntersectionObserver::IntersectionObserver const& observer, RefPtr<Painting::Paintable> root_paintable, CSSPixelRect const& root_bounds)
+static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect target_rect, IntersectionObserver::IntersectionObserver const& observer, Layout::Box const* root_layout_box, CSSPixelRect const& root_bounds)
 {
     // 1. Let intersectionRect be the result of getting the bounding box for target.
     auto intersection_rect = target_rect;
 
     // 2. Let container be the containing block of target.
     // 3. While container is not root:
-    if (auto target_paintable = target->paintable_box()) {
-        Layout::Box* root_layout_box = nullptr;
-        if (root_paintable && root_paintable->has_layout_node())
-            root_layout_box = as<Layout::Box>(&root_paintable->layout_node());
-        for (auto* container_box = target_paintable->layout_node().containing_block(); container_box; container_box = container_box->containing_block()) {
+    auto const* target_layout_node = target->layout_node();
+    if (target_layout_node && Painting::has_committed_box(*target_layout_node)) {
+        for (auto const* container_box = target_layout_node->containing_block(); container_box; container_box = container_box->containing_block()) {
             // Stop when we reach the intersection root.
             if (container_box == root_layout_box)
                 break;
-            auto container = container_box->paintable();
-            if (!container)
+            if (!Painting::has_committed_box(*container_box))
                 break;
 
             // FIXME: 3.1. If container is the document of a nested browsing context, update
@@ -6474,16 +6472,15 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect t
             // 3.4. If container has a content clip or a css clip-path property, update intersectionRect
             //      by applying container’s clip.
             // FIXME: Handle clip-path.
-            auto overflow_x = container->layout_node().overflow_x();
-            auto overflow_y = container->layout_node().overflow_y();
+            auto overflow_x = container_box->overflow_x();
+            auto overflow_y = container_box->overflow_y();
             bool has_content_clip = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
             if (has_content_clip) {
-                auto clip_rect = container->transform_rect_to_viewport(container->absolute_padding_box_rect(), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+                auto clip_rect = Painting::transform_rect_to_viewport(*container_box, Painting::absolute_padding_box_rect(*container_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
 
                 // Apply scroll margin to expand the scrollport for scroll containers.
                 auto& scroll_margin = observer.scroll_margin_values();
-                auto const& layout_node = container->layout_node();
-                if (layout_node.is_scroll_container() && !scroll_margin.is_empty()) {
+                if (container_box->is_scroll_container() && !scroll_margin.is_empty()) {
                     clip_rect.inflate(
                         scroll_margin[0].to_px(clip_rect.height()),
                         scroll_margin[1].to_px(clip_rect.width()),
@@ -6527,7 +6524,9 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
 
         // Pre-compute per-observer values to avoid repeated work in the per-target loop.
         auto intersection_root_node = observer->intersection_root_node();
-        auto root_paintable = intersection_root_node->paintable_box();
+        Layout::Box const* root_layout_box = nullptr;
+        if (auto const* root_layout_node = intersection_root_node->layout_node(); root_layout_node && Painting::has_committed_box(*root_layout_node))
+            root_layout_box = as<Layout::Box>(root_layout_node);
         bool is_implicit_root = observer->is_implicit_root();
         bool root_is_element = intersection_root_node->is_element();
 
@@ -6564,7 +6563,7 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
 
                 // 5. Let intersectionRect be the result of running the compute the intersection algorithm on target and
                 //    observer’s intersection root.
-                intersection_rect = compute_intersection(target, target_rect, *observer, root_paintable, root_bounds);
+                intersection_rect = compute_intersection(target, target_rect, *observer, root_layout_box, root_bounds);
 
                 // 6. Let targetArea be targetRect’s area.
                 auto target_area = target_rect.width() * target_rect.height();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1224,7 +1224,7 @@ public:
     GC::Ptr<HTML::LocalNavigable> navigable() const;
     void set_navigable(GC::Ptr<HTML::LocalNavigable>);
 
-    void set_needs_repaint(Badge<Node, Painting::Paintable, HTML::LocalNavigable, CSS::VisualViewport, Web::EventHandler>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
+    void set_needs_repaint(Badge<Node, Painting::BoxViewRepaintAccess, HTML::LocalNavigable, CSS::VisualViewport, Web::EventHandler>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
     {
         set_needs_repaint(should_invalidate_display_list);
     }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -515,6 +515,9 @@ public:
     RefPtr<Painting::ViewportPaintable const> unsafe_paintable() const;
     RefPtr<Painting::ViewportPaintable> unsafe_paintable();
 
+    Painting::AccumulatedVisualContextTree const& visual_context_tree() const;
+    Painting::ScrollStateSnapshot const& scroll_state_snapshot() const;
+
     GC::Ref<NodeList> get_elements_by_name(Utf16View);
 
     GC::Ref<HTMLCollection> applets();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5135,7 +5135,8 @@ bool Element::check_visibility(CheckVisibilityOptions const& options)
     document().update_layout_if_needed_for_node(*this, UpdateLayoutReason::ElementCheckVisibility);
 
     // 1. If this does not have an associated box, return false.
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return false;
 
     // 2. If an ancestor of this in the flat tree has content-visibility: hidden, return false.
@@ -5999,7 +6000,8 @@ void Element::invalidate_lang_value()
 bool Element::not_rendered() const
 {
     // An element is not rendered if it does not have an associated box.
-    if (!layout_node() || !paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return true;
 
     return false;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -137,9 +137,7 @@
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
-#include <LibWeb/Painting/InlinePaintable.h>
-#include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
@@ -2643,20 +2641,21 @@ enum class VisualContextTransform {
     Identity,
 };
 
-static void append_border_box_rect(Vector<CSSPixelRect>& rects, Painting::Paintable const& paintable_box, VisualContextTransform visual_context_transform)
+static void append_border_box_rect(Vector<CSSPixelRect>& rects, Layout::Node const& layout_node, VisualContextTransform visual_context_transform)
 {
-    auto absolute_rect = paintable_box.absolute_border_box_rect();
+    auto absolute_rect = Painting::absolute_border_box_rect(layout_node);
     if (visual_context_transform == VisualContextTransform::Identity)
         rects.append(absolute_rect);
     else
-        rects.append(paintable_box.transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+        rects.append(Painting::transform_rect_to_viewport(layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
 }
 
 static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element, VisualContextTransform visual_context_transform = VisualContextTransform::Apply)
 {
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
     //    object and stop this algorithm.
-    if (!element.layout_node())
+    auto const* layout_node = element.layout_node();
+    if (!layout_node)
         return {};
 
     // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single
@@ -2672,36 +2671,24 @@ static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element c
     //          are left in the final list.
 
     Vector<CSSPixelRect> rects;
-    if (auto const* inline_paintable = as_if<Painting::InlinePaintable>(element.layout_node()->paintable().ptr())) {
+    if (Painting::is_inline_paintable(*layout_node)) {
         Vector<CSSPixelRect> piece_border_box_rects;
-        Layout::RustFFI::layout_arena_inline_paintable_piece_border_box_rects(
-            inline_paintable->rust_arena().handle(), inline_paintable->rust_slot(), &piece_border_box_rects,
-            [](void* context, Layout::RustFFI::FfiCssPixelRect rect) {
-                static_cast<Vector<CSSPixelRect>*>(context)->append({
-                    CSSPixels::from_raw(rect.x),
-                    CSSPixels::from_raw(rect.y),
-                    CSSPixels::from_raw(rect.width),
-                    CSSPixels::from_raw(rect.height),
-                });
-            });
+        Painting::inline_piece_border_box_rects(*layout_node, piece_border_box_rects);
         for (auto const& absolute_rect : piece_border_box_rects) {
             if (visual_context_transform == VisualContextTransform::Identity)
                 rects.append(absolute_rect);
             else
-                rects.append(inline_paintable->transform_rect_to_viewport(absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
+                rects.append(Painting::transform_rect_to_viewport(*layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
         }
         // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
         // we still report its (zero-sized) border area instead of an empty list.
         if (rects.is_empty())
-            append_border_box_rect(rects, *inline_paintable, visual_context_transform);
+            append_border_box_rect(rects, *layout_node, visual_context_transform);
         return rects;
     }
 
-    if (auto paintable_box = element.paintable_box()) {
-        append_border_box_rect(rects, *paintable_box, visual_context_transform);
-    } else if (element.paintable()) {
-        dbgln("FIXME: Failed to get client rects for element ({})", element.debug_description());
-    }
+    if (Painting::has_committed_box(*layout_node))
+        append_border_box_rect(rects, *layout_node, visual_context_transform);
 
     return rects;
 }
@@ -2806,12 +2793,13 @@ int Element::client_width() const
     const_cast<Document&>(document()).update_layout_if_needed_for_node(*this, UpdateLayoutReason::ElementClientWidth);
 
     // 1. If the element has no associated CSS layout box or if the CSS layout box is inline, return zero.
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 3. Return the width of the padding edge excluding the width of any rendered scrollbar between the padding edge and the border edge,
     // ignoring any transforms that apply to the element and its ancestors.
-    return paintable_box()->absolute_padding_box_rect().width().to_int();
+    return Painting::absolute_padding_box_rect(*layout_node).width().to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-clientheight
@@ -2831,12 +2819,13 @@ int Element::client_height() const
     const_cast<Document&>(document()).update_layout_if_needed_for_node(*this, UpdateLayoutReason::ElementClientHeight);
 
     // 1. If the element has no associated CSS layout box or if the CSS layout box is inline, return zero.
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 3. Return the height of the padding edge excluding the height of any rendered scrollbar between the padding edge and the border edge,
     //    ignoring any transforms that apply to the element and its ancestors.
-    return paintable_box()->absolute_padding_box_rect().height().to_int();
+    return Painting::absolute_padding_box_rect(*layout_node).height().to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom
@@ -3497,12 +3486,15 @@ int Element::scroll_width()
 
     // NOTE: Ensure that layout is up-to-date before looking at metrics.
     document.update_layout(UpdateLayoutReason::ElementScrollWidth);
-    VERIFY(document.paintable_box() && document.paintable()->scrollable_overflow_rect().has_value());
+    auto const* viewport_layout_node = document.layout_node();
+    VERIFY(viewport_layout_node && Painting::has_committed_box(*viewport_layout_node));
+    auto viewport_scrollable_overflow_rect = Painting::scrollable_overflow_rect(*viewport_layout_node);
+    VERIFY(viewport_scrollable_overflow_rect.has_value());
 
     // 3. Let viewport width be the width of the viewport excluding the width of the scroll bar, if any,
     //    or zero if there is no viewport.
     auto viewport_width = document.viewport_rect().width().to_int();
-    auto viewport_scrolling_area_width = document.paintable()->scrollable_overflow_rect()->width().to_int();
+    auto viewport_scrolling_area_width = viewport_scrollable_overflow_rect->width().to_int();
 
     // 4. If the element is the root element and document is not in quirks mode
     //    return max(viewport scrolling area width, viewport width).
@@ -3515,11 +3507,12 @@ int Element::scroll_width()
         return max(viewport_scrolling_area_width, viewport_width);
 
     // 6. If the element does not have any associated box return zero and terminate these steps.
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 7. Return the width of the element’s scrolling area.
-    if (auto scrollable_overflow_rect = paintable_box()->scrollable_overflow_rect(); scrollable_overflow_rect.has_value())
+    if (auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node); scrollable_overflow_rect.has_value())
         return scrollable_overflow_rect->width().to_int();
 
     return 0;
@@ -3537,12 +3530,15 @@ int Element::scroll_height()
 
     // NOTE: Ensure that layout is up-to-date before looking at metrics.
     document.update_layout(UpdateLayoutReason::ElementScrollHeight);
-    VERIFY(document.paintable_box() && document.paintable()->scrollable_overflow_rect().has_value());
+    auto const* viewport_layout_node = document.layout_node();
+    VERIFY(viewport_layout_node && Painting::has_committed_box(*viewport_layout_node));
+    auto viewport_scrollable_overflow_rect = Painting::scrollable_overflow_rect(*viewport_layout_node);
+    VERIFY(viewport_scrollable_overflow_rect.has_value());
 
     // 3. Let viewport height be the height of the viewport excluding the height of the scroll bar, if any,
     //    or zero if there is no viewport.
     auto viewport_height = document.viewport_rect().height().to_int();
-    auto viewport_scrolling_area_height = document.paintable()->scrollable_overflow_rect()->height().to_int();
+    auto viewport_scrolling_area_height = viewport_scrollable_overflow_rect->height().to_int();
 
     // 4. If the element is the root element and document is not in quirks mode
     //    return max(viewport scrolling area height, viewport height).
@@ -3555,11 +3551,12 @@ int Element::scroll_height()
         return max(viewport_scrolling_area_height, viewport_height);
 
     // 6. If the element does not have any associated box return zero and terminate these steps.
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 7. Return the height of the element’s scrolling area.
-    if (auto scrollable_overflow_rect = paintable_box()->scrollable_overflow_rect(); scrollable_overflow_rect.has_value()) {
+    if (auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node); scrollable_overflow_rect.has_value()) {
         return scrollable_overflow_rect->height().to_int();
     }
     return 0;
@@ -4130,7 +4127,8 @@ static void scroll_an_element_into_view(Element& target, Element::ScrollBehavior
     auto* ancestor = target.parent();
     Vector<Node&> scrolling_boxes;
     while (ancestor) {
-        if (ancestor->paintable_box() && ancestor->paintable_box()->has_scrollable_overflow())
+        auto const* ancestor_layout_node = ancestor->layout_node();
+        if (ancestor_layout_node && Painting::has_committed_box(*ancestor_layout_node) && Painting::has_scrollable_overflow(*ancestor_layout_node))
             scrolling_boxes.append(*ancestor);
         ancestor = ancestor->parent();
     }
@@ -4155,7 +4153,9 @@ static void scroll_an_element_into_view(Element& target, Element::ScrollBehavior
             if (auto paintable_box = scrolling_box.paintable_box()) {
                 target_bounding_border_box.translate_by(paintable_box->scroll_offset() - paintable_box->clamp_scroll_offset(position));
 
-                auto scrollport_rect = paintable_box->transform_rect_to_viewport(paintable_box->absolute_padding_box_rect(), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+                auto const* layout_node = scrolling_box.layout_node();
+                VERIFY(layout_node && Painting::has_committed_box(*layout_node));
+                auto scrollport_rect = Painting::transform_rect_to_viewport(*layout_node, Painting::absolute_padding_box_rect(*layout_node), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
                 auto visible_rect = target_bounding_border_box.intersected(scrollport_rect);
                 if (!visible_rect.is_empty())
                     target_bounding_border_box = visible_rect;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5194,7 +5194,7 @@ void Element::determine_proximity_to_the_viewport()
     // viewport soon. A margin of 50% is suggested as a reasonable default.
     viewport_rect.inflate(viewport_rect.width(), viewport_rect.height());
     // FIXME: We don't have paint containment or the overflow clip edge yet, so this is just using the absolute rect for now.
-    if (paintable_box()->absolute_rect().intersects(viewport_rect)) {
+    if (Painting::absolute_rect(*unsafe_layout_node()).intersects(viewport_rect)) {
         ensure_element_rare_data().proximity_to_the_viewport = ProximityToTheViewport::CloseToTheViewport;
         return;
     }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1797,14 +1797,15 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
 
 void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
-    if (invalidation.needs_layout_tree_rebuild() || !unsafe_layout_node())
+    auto* layout_node = unsafe_layout_node();
+    if (invalidation.needs_layout_tree_rebuild() || !layout_node)
         return;
 
     // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
     VERIFY(has_style());
-    unsafe_layout_node()->apply_style(style_record_identity());
-    if (auto paintable = unsafe_layout_node()->paintable())
-        paintable->repaint_after_style_change(invalidation);
+    layout_node->apply_style(style_record_identity());
+    if (Painting::has_committed_box(*layout_node))
+        Painting::repaint_after_style_change(*layout_node, invalidation);
 
     apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation);
 }
@@ -1820,8 +1821,8 @@ void Element::apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS
 
         if (auto node_with_style = pseudo_element.unsafe_layout_node()) {
             node_with_style->apply_style(style_record_identity(pseudo_element_type));
-            if (auto paintable = node_with_style->paintable())
-                paintable->repaint_after_style_change(invalidation);
+            if (Painting::has_committed_box(*node_with_style))
+                Painting::repaint_after_style_change(*node_with_style, invalidation);
         }
     });
 }
@@ -3972,7 +3973,9 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, CS
         current_scroll_position = document.navigable()->viewport_scroll_offset() + visual_viewport.offset();
     } else if (auto paintable_box = scrolling_box.paintable_box()) {
         current_scroll_position = paintable_box->scroll_offset();
-        scrolling_box_rect = paintable_box->transform_rect_to_viewport(paintable_box->scroll_snapport_rect(), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+        auto const* layout_node = scrolling_box.layout_node();
+        VERIFY(layout_node);
+        scrolling_box_rect = Painting::transform_rect_to_viewport(*layout_node, paintable_box->scroll_snapport_rect(), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
     } else {
         return {};
     }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -85,6 +85,7 @@
 #include <LibWeb/MathML/MathMLElement.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
@@ -2462,15 +2463,16 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<Utf16StringBuilder>& obje
             }
         }
 
-        if (paintable_box()) {
-            MUST(object.add("display"sv, paintable_box()->layout_node().display().to_string()));
+        auto const* layout_node = this->layout_node();
+        if (layout_node && Painting::has_committed_box(*layout_node)) {
+            MUST(object.add("display"sv, Painting::display(*layout_node).to_string()));
             if (paintable_box()->could_be_scrolled_by_wheel_event()) {
                 MUST(object.add("scrollable"sv, true));
             }
-            if (!paintable_box()->is_visible()) {
+            if (!Painting::is_visible(*layout_node)) {
                 MUST(object.add("invisible"sv, true));
             }
-            if (paintable_box()->has_stacking_context()) {
+            if (Painting::has_stacking_context(*layout_node)) {
                 MUST(object.add("stackingContext"sv, true));
             }
         }
@@ -3105,8 +3107,8 @@ void Node::set_needs_repaint(InvalidateDisplayList should_invalidate_display_lis
             text_node->set_needs_repaint(should_invalidate_display_list);
             return;
         }
-        if (auto paintable = layout_node->paintable())
-            paintable->set_needs_repaint(should_invalidate_display_list);
+        if (Painting::has_committed_box(*layout_node))
+            Painting::set_needs_repaint(*layout_node, should_invalidate_display_list);
     }
 }
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1220,16 +1220,16 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             return Geometry::DOMRectList::create({});
     }
     for (GC::Ptr<Node> node = start_node; node && node.ptr() != end_node->next_in_pre_order(); node = node->next_in_pre_order()) {
-        auto selection_state = Painting::Paintable::SelectionState::Full;
+        auto selection_state = Painting::SelectionState::Full;
         if (node == start_node && node == end_node) {
             if (m_start_offset == m_end_offset)
-                selection_state = Painting::Paintable::SelectionState::None;
+                selection_state = Painting::SelectionState::None;
             else
-                selection_state = Painting::Paintable::SelectionState::StartAndEnd;
+                selection_state = Painting::SelectionState::StartAndEnd;
         } else if (node == start_node) {
-            selection_state = Painting::Paintable::SelectionState::Start;
+            selection_state = Painting::SelectionState::Start;
         } else if (node == end_node) {
-            selection_state = Painting::Paintable::SelectionState::End;
+            selection_state = Painting::SelectionState::End;
         }
 
         auto node_type = static_cast<NodeType>(node->node_type());
@@ -1247,7 +1247,7 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             // 2. For each Text node selected or partially selected by the range (including when the boundary-points
             // are identical), include scaled DOMRect object (for the part that is selected, not the whole line box).
             auto const& text = static_cast<DOM::Text const&>(*node);
-            if (selection_state == Painting::Paintable::SelectionState::None)
+            if (selection_state == Painting::SelectionState::None)
                 continue;
 
             Layout::TextOffsetMapping mapping { text };
@@ -1258,19 +1258,19 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             size_t filter_dom_start = 0;
             size_t filter_dom_end = NumericLimits<size_t>::max();
             switch (selection_state) {
-            case Painting::Paintable::SelectionState::Full:
+            case Painting::SelectionState::Full:
                 break;
-            case Painting::Paintable::SelectionState::StartAndEnd:
+            case Painting::SelectionState::StartAndEnd:
                 filter_dom_start = start_offset();
                 filter_dom_end = end_offset();
                 break;
-            case Painting::Paintable::SelectionState::Start:
+            case Painting::SelectionState::Start:
                 filter_dom_start = start_offset();
                 break;
-            case Painting::Paintable::SelectionState::End:
+            case Painting::SelectionState::End:
                 filter_dom_end = end_offset();
                 break;
-            case Painting::Paintable::SelectionState::None:
+            case Painting::SelectionState::None:
                 VERIFY_NOT_REACHED();
             }
             auto text_slots = mapping.slot_ids();

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -30,7 +30,9 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TextOffsetMapping.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Namespace.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/TrustedTypes/RequireTrustedTypesForDirective.h>
@@ -100,7 +102,8 @@ void Range::set_associated_selection(Badge<Selection::Selection>, GC::Ptr<Select
         auto& document = m_start_container->document();
         if (auto viewport = document.unsafe_paintable()) {
             viewport->reset_selection_states();
-            viewport->set_needs_repaint();
+            if (auto const* layout_node = document.unsafe_layout_node())
+                Painting::set_needs_repaint(*layout_node);
         }
 
         // https://w3c.github.io/selection-api/#selectionchange-event
@@ -122,7 +125,8 @@ void Range::update_associated_selection()
     // NB: Called during selection update after range change.
     if (auto viewport = document.unsafe_paintable()) {
         viewport->recompute_selection_states(*this);
-        viewport->set_needs_repaint();
+        if (auto const* layout_node = document.unsafe_layout_node())
+            Painting::set_needs_repaint(*layout_node);
     }
 
     document.reset_cursor_blink_cycle();

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -50,8 +50,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Namespace.h>
-#include <LibWeb/Painting/InlinePaintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 
 namespace Web {
@@ -208,20 +207,20 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     }
 
     auto dump_position = [&] {
-        if (auto paintable = layout_node.paintable(); auto const* paintable_box = paintable.ptr())
-            builder.appendff("at {}", paintable_box->absolute_rect().location());
+        if (Painting::has_committed_box(layout_node))
+            builder.appendff("at {}", Painting::absolute_rect(layout_node).location());
         else
             builder.appendff("(not painted)");
     };
     auto dump_box_model = [&] {
-        if (auto paintable = layout_node.paintable(); auto const* paintable_box = paintable.ptr()) {
-            auto const& box_model = paintable_box->box_model();
+        if (Painting::has_committed_box(layout_node)) {
+            auto const box_model = Painting::box_model(layout_node);
             // Dump the horizontal box properties
             builder.appendff(" [{}+{}+{} {} {}+{}+{}]",
                 box_model.margin.left,
                 box_model.border.left,
                 box_model.padding.left,
-                paintable_box->content_width(),
+                Painting::content_width(layout_node),
                 box_model.padding.right,
                 box_model.border.right,
                 box_model.margin.right);
@@ -231,7 +230,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
                 box_model.margin.top,
                 box_model.border.top,
                 box_model.padding.top,
-                paintable_box->content_height(),
+                Painting::content_height(layout_node),
                 box_model.padding.bottom,
                 box_model.border.bottom,
                 box_model.margin.bottom);
@@ -312,8 +311,8 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
 
         // SVG content geometry below is in this viewport's user units; the transform shown here is
         // what maps it into the viewport's content box.
-        if (auto const* box_paintable = box.paintable_box().ptr()) {
-            if (auto viewport_transform = box_paintable->svg_viewport_transform(); viewport_transform.has_value())
+        if (Painting::has_committed_box(box)) {
+            if (auto viewport_transform = Painting::svg_viewport_transform(box); viewport_transform.has_value())
                 builder.appendff(" viewport-transform={}", *viewport_transform);
         }
 
@@ -371,21 +370,24 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     };
 
     if (auto const* block_container = as_if<Layout::BlockContainer>(layout_node);
-        block_container && block_container->children_are_inline() && block_container->paintable_with_lines()) {
-        auto paintable_with_lines = block_container->paintable_with_lines();
+        block_container && block_container->children_are_inline() && Painting::is_paintable_with_lines(layout_node)) {
+        auto paintable = layout_node.paintable();
+        VERIFY(paintable);
         Layout::RustFFI::layout_arena_paintable_dump_block_fragments(
-            paintable_with_lines->rust_arena().handle(),
-            paintable_with_lines->rust_slot(),
+            layout_node.arena_handle(),
+            paintable->rust_slot(),
             indent,
             interactive,
             &builder,
             append_dumped_fragments);
     }
 
-    if (auto const* inline_paintable = as_if<Painting::InlinePaintable>(layout_node.paintable().ptr())) {
+    if (Painting::is_inline_paintable(layout_node)) {
+        auto paintable = layout_node.paintable();
+        VERIFY(paintable);
         Layout::RustFFI::layout_arena_paintable_dump_inline_piece_fragments(
-            inline_paintable->rust_arena().handle(),
-            inline_paintable->rust_slot(),
+            layout_node.arena_handle(),
+            paintable->rust_slot(),
             indent,
             interactive,
             &builder,
@@ -526,17 +528,17 @@ void dump_tree(StringBuilder& builder, Painting::Paintable const& paintable, boo
         for (int i = 0; i < entry_indent; ++i)
             builder.append("  "sv);
 
-        if (is<Painting::PaintableWithLines>(*entry_paintable))
+        if (Painting::is_paintable_with_lines(layout_node))
             builder.append(paintable_with_lines_color_on);
         else
             builder.append(paintable_box_color_on);
 
-        builder.appendff("{}{} ({})", entry_paintable->class_name(), color_off, layout_node.debug_description());
+        builder.appendff("{}{} ({})", Painting::class_name(layout_node), color_off, layout_node.debug_description());
 
-        builder.appendff(" {}", entry_paintable->absolute_border_box_rect());
+        builder.appendff(" {}", Painting::absolute_border_box_rect(layout_node));
 
-        if (entry_paintable->has_scrollable_overflow())
-            builder.appendff(" overflow: {}", entry_paintable->scrollable_overflow_rect());
+        if (Painting::has_scrollable_overflow(layout_node))
+            builder.appendff(" overflow: {}", Painting::scrollable_overflow_rect(layout_node));
 
         if (!entry_paintable->scroll_offset().is_zero())
             builder.appendff(" scroll-offset: {}", entry_paintable->scroll_offset());

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -1067,6 +1067,7 @@ class Notification;
 namespace Web::Painting {
 
 class AudioPaintable;
+class BoxViewRepaintAccess;
 class MediaPaintable;
 class Paintable;
 class PaintableWithLines;

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -15,7 +15,8 @@
 #include <LibWeb/HTML/CanvasRenderingContext2D.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/HTML/Window.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::HTML {
 
@@ -59,8 +60,8 @@ void CanvasRenderingContext2D::did_draw_hook()
     // NB: Invalidate the cached DrawCanvas command so that if another change causes the display list to be recorded, it
     // contains the new content generation and damages the canvas. Don't request a display list recording here: the new
     // content reaches the compositor through the canvas surface registry when the canvas is presented.
-    if (auto paintable = m_element->unsafe_paintable())
-        paintable->invalidate_paint_cache();
+    if (auto const* layout_node = m_element->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        Painting::invalidate_paint_cache(*layout_node);
     m_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -54,7 +54,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TextOffsetMapping.h>
 #include <LibWeb/Namespace.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/PointerEvent.h>
@@ -719,17 +719,19 @@ int HTMLElement::offset_top() const
     // NOTE: Ensure that layout is up-to-date before looking at metrics.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLElementOffsetTop);
 
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
-    CSSPixels top_border_edge_of_element = paintable_box()->absolute_border_box_rect().y();
+    CSSPixels top_border_edge_of_element = Painting::absolute_border_box_rect(*layout_node).y();
 
     // 2. If the offsetParent of the element is null
     //    return the y-coordinate of the top border edge of the first CSS layout box associated with the element,
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
-    if (!offset_parent || !offset_parent->paintable_box()) {
+    auto const* offset_parent_layout_node = offset_parent ? offset_parent->layout_node() : nullptr;
+    if (!offset_parent_layout_node || !Painting::has_committed_box(*offset_parent_layout_node)) {
         return top_border_edge_of_element.to_int();
     }
 
@@ -743,10 +745,10 @@ int HTMLElement::offset_top() const
     //       Spec bug: https://github.com/w3c/csswg-drafts/issues/10549
 
     CSSPixels top_padding_edge_of_offset_parent;
-    if (offset_parent->is_html_body_element() && !offset_parent->paintable_box()->is_positioned()) {
+    if (offset_parent->is_html_body_element() && !Painting::is_positioned(*offset_parent_layout_node)) {
         top_padding_edge_of_offset_parent = 0;
     } else {
-        top_padding_edge_of_offset_parent = offset_parent->paintable_box()->absolute_padding_box_rect().y();
+        top_padding_edge_of_offset_parent = Painting::absolute_padding_box_rect(*offset_parent_layout_node).y();
     }
     return (top_border_edge_of_element - top_padding_edge_of_offset_parent).to_int();
 }
@@ -761,17 +763,19 @@ int HTMLElement::offset_left() const
     // NOTE: Ensure that layout is up-to-date before looking at metrics.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLElementOffsetLeft);
 
-    if (!paintable_box())
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
-    CSSPixels left_border_edge_of_element = paintable_box()->absolute_border_box_rect().x();
+    CSSPixels left_border_edge_of_element = Painting::absolute_border_box_rect(*layout_node).x();
 
     // 2. If the offsetParent of the element is null
     //    return the x-coordinate of the left border edge of the first CSS layout box associated with the element,
     //    relative to the initial containing block origin,
     //    ignoring any transforms that apply to the element and its ancestors, and terminate this algorithm.
     auto offset_parent = this->offset_parent();
-    if (!offset_parent || !offset_parent->paintable_box()) {
+    auto const* offset_parent_layout_node = offset_parent ? offset_parent->layout_node() : nullptr;
+    if (!offset_parent_layout_node || !Painting::has_committed_box(*offset_parent_layout_node)) {
         return left_border_edge_of_element.to_int();
     }
 
@@ -785,10 +789,10 @@ int HTMLElement::offset_left() const
     //       Spec bug: https://github.com/w3c/csswg-drafts/issues/10549
 
     CSSPixels left_padding_edge_of_offset_parent;
-    if (offset_parent->is_html_body_element() && !offset_parent->paintable_box()->is_positioned()) {
+    if (offset_parent->is_html_body_element() && !Painting::is_positioned(*offset_parent_layout_node)) {
         left_padding_edge_of_offset_parent = 0;
     } else {
-        left_padding_edge_of_offset_parent = offset_parent->paintable_box()->absolute_padding_box_rect().x();
+        left_padding_edge_of_offset_parent = Painting::absolute_padding_box_rect(*offset_parent_layout_node).x();
     }
     return (left_border_edge_of_element - left_padding_edge_of_offset_parent).to_int();
 }
@@ -800,8 +804,8 @@ int HTMLElement::offset_width() const
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLElementOffsetWidth);
 
     // 1. If the element does not have any associated box return zero and terminate this algorithm.
-    auto box = paintable_box();
-    if (!box)
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 2. Return the unscaled width of the axis-aligned bounding box of the border boxes of all fragments generated by
@@ -809,7 +813,7 @@ int HTMLElement::offset_width() const
     //
     //    If the element’s principal box is an inline-level box which was "split" by a block-level descendant, also
     //    include fragments generated by the block-level descendants, unless they are zero width or height.
-    return round(box->absolute_border_box_rect().width()).to_int();
+    return round(Painting::absolute_border_box_rect(*layout_node).width()).to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetheight
@@ -819,8 +823,8 @@ int HTMLElement::offset_height() const
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLElementOffsetHeight);
 
     // 1. If the element does not have any associated box return zero and terminate this algorithm.
-    auto box = paintable_box();
-    if (!box)
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
     // 2. Return the unscaled height of the axis-aligned bounding box of the border boxes of all fragments generated by
@@ -828,7 +832,7 @@ int HTMLElement::offset_height() const
     //
     //    If the element’s principal box is an inline-level box which was "split" by a block-level descendant, also
     //    include fragments generated by the block-level descendants, unless they are zero width or height.
-    return round(box->absolute_border_box_rect().height()).to_int();
+    return round(Painting::absolute_border_box_rect(*layout_node).height()).to_int();
 }
 
 void HTMLElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -47,8 +47,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Namespace.h>
-#include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/ViewportPaintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
@@ -373,8 +372,8 @@ WebIDL::UnsignedLong HTMLImageElement::width() const
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementWidth);
 
     // Return the rendered width of the image, in CSS pixels, if the image is being rendered.
-    if (auto paintable_box = this->paintable_box())
-        return paintable_box->content_width().to_int();
+    if (auto const* layout_node = this->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        return Painting::content_width(*layout_node).to_int();
 
     // On setting [the width or height IDL attribute], they must act as if they reflected the respective content attributes of the same name.
     if (auto width_attr = get_attribute(HTML::AttributeNames::width); width_attr.has_value()) {
@@ -404,8 +403,8 @@ WebIDL::UnsignedLong HTMLImageElement::height() const
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementHeight);
 
     // Return the rendered height of the image, in CSS pixels, if the image is being rendered.
-    if (auto paintable_box = this->paintable_box())
-        return paintable_box->content_height().to_int();
+    if (auto const* layout_node = this->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        return Painting::content_height(*layout_node).to_int();
 
     // On setting [the width or height IDL attribute], they must act as if they reflected the respective content attributes of the same name.
     if (auto height_attr = get_attribute(HTML::AttributeNames::height); height_attr.has_value()) {
@@ -482,15 +481,11 @@ int HTMLImageElement::x() const
     // so resolve it before reading the enclosing scroll node below.
     const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
-    auto paintable_box = this->paintable_box();
-    if (!paintable_box)
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
-    CSSPixels scroll_offset_x = 0;
-    if (auto idx = paintable_box->enclosing_scroll_node_index(); idx.value())
-        scroll_offset_x = paintable_box->document().paintable()->cumulative_scroll_offset_for_node(idx).x();
-
-    return (paintable_box->absolute_border_box_rect().x() - scroll_offset_x).to_int();
+    return (Painting::absolute_border_box_rect(*layout_node).x() - Painting::cumulative_scroll_compensation(*layout_node).x()).to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-htmlimageelement-y
@@ -504,15 +499,11 @@ int HTMLImageElement::y() const
     // so resolve it before reading the enclosing scroll node below.
     const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
-    auto paintable_box = this->paintable_box();
-    if (!paintable_box)
+    auto const* layout_node = this->layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
 
-    CSSPixels scroll_offset_y = 0;
-    if (auto idx = paintable_box->enclosing_scroll_node_index(); idx.value())
-        scroll_offset_y = paintable_box->document().paintable()->cumulative_scroll_offset_for_node(idx).y();
-
-    return (paintable_box->absolute_border_box_rect().y() - scroll_offset_y).to_int();
+    return (Painting::absolute_border_box_rect(*layout_node).y() - Painting::cumulative_scroll_compensation(*layout_node).y()).to_int();
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-complete

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -59,7 +59,7 @@
 #include <LibWeb/MimeSniff/Resource.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/InputEvent.h>
@@ -2465,8 +2465,8 @@ WebIDL::UnsignedLong HTMLInputElement::height() const
         return 0;
 
     // Return the rendered height of the image, in CSS pixels, if the image is being rendered.
-    if (auto paintable_box = this->paintable_box())
-        return paintable_box->content_height().to_int();
+    if (auto const* layout_node = this->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        return Painting::content_height(*layout_node).to_int();
 
     // On setting [the width or height IDL attribute], they must act as if they reflected the respective content attributes of the same name.
     if (auto height_string = get_attribute(HTML::AttributeNames::height); height_string.has_value()) {
@@ -2500,8 +2500,8 @@ WebIDL::UnsignedLong HTMLInputElement::width() const
         return 0;
 
     // Return the rendered width of the image, in CSS pixels, if the image is being rendered.
-    if (auto paintable_box = this->paintable_box())
-        return paintable_box->content_width().to_int();
+    if (auto const* layout_node = this->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        return Painting::content_width(*layout_node).to_int();
 
     // On setting [the width or height IDL attribute], they must act as if they reflected the respective content attributes of the same name.
     if (auto width_string = get_attribute(HTML::AttributeNames::width); width_string.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -12,7 +12,8 @@
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 
@@ -77,17 +78,18 @@ void HTMLLabelElement::activation_behavior(DOM::Event const& event)
         auto const& mouse_event = as<UIEvents::MouseEvent>(event);
         auto click_event = UIEvents::MouseEvent::create_from_mouse_event(mouse_event, HighResolutionTime::current_high_resolution_time(relevant_global_object(*this)));
 
-        // NB: Ensure layout is up to date before accessing the control's paintable.
+        // NB: Ensure layout is up to date before accessing the control's committed box.
         document().update_layout(DOM::UpdateLayoutReason::HTMLLabelElementActivationBehavior);
 
         // Recompute offsetX/offsetY relative to the control element, since the original values are relative to the label.
-        if (auto paintable = control_element->paintable(); paintable && document().navigable()) {
+        auto const* layout_node = control_element->layout_node();
+        if (layout_node && Painting::has_committed_box(*layout_node) && document().navigable()) {
             auto scroll_offset = document().navigable()->viewport_scroll_offset();
             auto page_position = CSSPixelPoint {
                 CSSPixels::nearest_value_for(mouse_event.client_x() + scroll_offset.x().to_double()),
                 CSSPixels::nearest_value_for(mouse_event.client_y() + scroll_offset.y().to_double())
             };
-            auto box_position = paintable->box_type_agnostic_position();
+            auto box_position = Painting::box_type_agnostic_position(*layout_node);
             click_event->set_offset_x(AK::round((page_position.x() - box_position.x()).to_double()));
             click_event->set_offset_y(AK::round((page_position.y() - box_position.y()).to_double()));
         }

--- a/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -7,7 +7,8 @@
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLMapElement.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 
 namespace Web::HTML {
 
@@ -63,7 +64,8 @@ GC::Ptr<HTMLImageElement> HTMLMapElement::first_image_with_focusable_shapes() co
 GC::Ptr<HTMLImageElement> HTMLMapElement::first_painted_image_with_focusable_shapes() const
 {
     return first_associated_image_matching([](HTMLImageElement& image_element) {
-        return image_element.paintable_box() && !image_element.is_inert();
+        auto const* layout_node = image_element.layout_node();
+        return layout_node && Painting::has_committed_box(*layout_node) && !image_element.is_inert();
     });
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -58,7 +58,7 @@
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Page/ScreenWakeLockHandle.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -2566,8 +2566,8 @@ bool HTMLMediaElement::video_sink_should_tick() const
         return true;
     if (document().visibility_state_value() != VisibilityState::Visible)
         return false;
-    auto paintable = this->paintable();
-    return paintable && paintable->is_visible();
+    auto const* layout_node = this->layout_node();
+    return layout_node && Painting::has_committed_box(*layout_node) && Painting::is_visible(*layout_node);
 }
 
 void HTMLMediaElement::sync_video_sink_ticking() const

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3721,12 +3721,13 @@ void LocalNavigable::clamp_viewport_scroll_offset()
     auto document = active_document();
     if (!document || !document->layout_is_up_to_date())
         return;
-    if (!document->paintable_box())
+    auto paintable_box = document->paintable_box();
+    if (!paintable_box)
         return;
-    if (!document->paintable_box()->scrollable_overflow_rect().has_value())
+    if (!Painting::scrollable_overflow_rect(paintable_box->layout_node()).has_value())
         return;
-    auto minimum_scroll_offset = document->paintable_box()->minimum_scroll_offset();
-    auto maximum_scroll_offset = document->paintable_box()->maximum_scroll_offset();
+    auto minimum_scroll_offset = paintable_box->minimum_scroll_offset();
+    auto maximum_scroll_offset = paintable_box->maximum_scroll_offset();
     CSSPixelPoint clamped = {
         clamp(m_viewport_scroll_offset.x(), minimum_scroll_offset.x(), maximum_scroll_offset.x()),
         clamp(m_viewport_scroll_offset.y(), minimum_scroll_offset.y(), maximum_scroll_offset.y()),

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -76,6 +76,7 @@
 #include <LibWeb/Loader/DownloadFilename.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/DisplayListDamage.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableTypes.h>
@@ -3668,13 +3669,13 @@ CSSPixelPoint LocalNavigable::to_top_level_position(CSSPixelPoint a_position)
             break;
         if (!ancestor->container())
             return {};
-        auto paintable = ancestor->container()->paintable();
-        if (!paintable)
+        auto const* layout_node = ancestor->container()->layout_node();
+        if (!layout_node || !Painting::has_committed_box(*layout_node))
             return {};
 
-        auto point = paintable->absolute_position();
+        auto point = Painting::absolute_position(*layout_node);
         point.translate_by(position);
-        position = paintable->transform_rect_to_viewport({ point, { 0, 0 } }).location();
+        position = Painting::transform_rect_to_viewport(*layout_node, { point, { 0, 0 } }).location();
 
         auto parent = ancestor->parent();
         ancestor = parent ? &as<LocalNavigable>(*parent) : nullptr;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -32,7 +32,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
@@ -1905,11 +1905,12 @@ void LocalTraversableNavigable::process_screenshot_requests()
             auto* dom_node = DOM::Node::from_unique_id(*task.node_id);
             if (dom_node)
                 dom_node->document().update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
-            if (!dom_node || !dom_node->paintable_box()) {
+            auto const* layout_node = dom_node ? dom_node->layout_node() : nullptr;
+            if (!layout_node || !Painting::has_committed_box(*layout_node)) {
                 client.page_did_take_screenshot({});
                 continue;
             }
-            auto rect = page().enclosing_device_rect(dom_node->paintable_box()->absolute_border_box_rect());
+            auto rect = page().enclosing_device_rect(Painting::absolute_border_box_rect(*layout_node));
             auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
             if (bitmap_or_error.is_error()) {
                 client.page_did_take_screenshot({});
@@ -1923,7 +1924,9 @@ void LocalTraversableNavigable::process_screenshot_requests()
             });
         } else {
             active_document()->update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
-            auto scrollable_overflow_rect = active_document()->layout_node()->paintable_box()->scrollable_overflow_rect();
+            auto const* layout_node = active_document()->layout_node();
+            VERIFY(layout_node && Painting::has_committed_box(*layout_node));
+            auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(*layout_node);
             auto rect = page().enclosing_device_rect(scrollable_overflow_rect.value());
             auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>());
             if (bitmap_or_error.is_error()) {

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -83,6 +83,7 @@
 #include <LibWeb/Internals/Internals.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/RequestIdleCallback/IdleDeadline.h>
@@ -1778,8 +1779,9 @@ void Window::scroll(ScrollToOptions const& options, GC::Ptr<WebIDL::Promise> pro
         // NB: Make sure layout is up-to-date before looking at scrollable overflow metrics.
         document->update_layout(DOM::UpdateLayoutReason::WindowScroll);
 
-        VERIFY(document->paintable_box());
-        auto scrolling_area = document->paintable_box()->scrollable_overflow_rect()->to_type<float>();
+        auto const* layout_node = document->layout_node();
+        VERIFY(layout_node && Painting::has_committed_box(*layout_node));
+        auto scrolling_area = Painting::scrollable_overflow_rect(*layout_node).value().to_type<float>();
         auto overflow_directions = Painting::rust_physical_overflow_directions(*document->paintable_box());
 
         // 7. -> If the viewport has rightward overflow direction

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -83,6 +83,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/HitTestResult.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -1227,10 +1228,9 @@ u64 Internals::paint_style_record_identity(DOM::Element& element)
 {
     element.document().update_layout(DOM::UpdateLayoutReason::Debugging);
     auto const* layout_node = element.unsafe_layout_node();
-    if (!layout_node)
+    if (!layout_node || !Painting::has_committed_box(*layout_node))
         return 0;
-    auto paintable = layout_node->paintable();
-    return paintable ? paintable->style_record_identity().value() : 0;
+    return Painting::style_record_identity(*layout_node).value();
 }
 
 u64 Internals::layout_node_identity(DOM::Node& node)

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/CallbackType.h>
 
@@ -362,8 +363,8 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
         // Otherwise,
         //    it’s the result of getting the bounding box for the intersection root.
         rect = element->bounding_client_rect_assuming_layout_clean();
-        if (auto paintable_box = element->paintable_box())
-            intersection_root_is_scrollable = paintable_box->layout_node().is_scroll_container();
+        if (auto const* layout_node = element->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+            intersection_root_is_scrollable = layout_node->is_scroll_container();
     }
 
     // When calculating the root intersection rectangle for a same-origin-domain target, the rectangle is then

--- a/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibWeb/Layout/BlockContainer.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 
 namespace Web::Layout {
 
@@ -16,11 +15,5 @@ BlockContainer::BlockContainer(DOM::Document& document, GC::Ptr<DOM::Node> node,
 }
 
 BlockContainer::~BlockContainer() = default;
-
-RefPtr<Painting::PaintableWithLines const> BlockContainer::paintable_with_lines() const
-{
-    auto paintable_box = Box::paintable_box();
-    return as_if<Painting::PaintableWithLines>(paintable_box.ptr());
-}
 
 }

--- a/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Libraries/LibWeb/Layout/BlockContainer.h
@@ -16,8 +16,6 @@ public:
     BlockContainer(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::BlockContainer);
     virtual ~BlockContainer() override;
 
-    RefPtr<Painting::PaintableWithLines const> paintable_with_lines() const;
-
 private:
     virtual bool is_block_container() const final { return true; }
 };

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 
@@ -307,9 +308,9 @@ RustFFI::FfiReplacedContentFacts Box::build_replaced_content_facts_for_arena() c
 void Box::notify_content_navigable_of_committed_viewport()
 {
     if (auto content_navigable = as<HTML::NavigableContainer>(*dom_node()).content_navigable()) {
-        auto content_size = paintable_box()->content_size();
+        auto content_size = Painting::content_size(*this);
         as<HTML::LocalNavigable>(*content_navigable).set_viewport_size(content_size);
-        document().page().client().page_did_update_child_frame_viewport(content_navigable->id(), paintable_box()->absolute_rect());
+        document().page().client().page_did_update_child_frame_viewport(content_navigable->id(), Painting::absolute_rect(*this));
     }
 }
 

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -538,7 +538,7 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
         .content_size_changed = [](void*, void* paintable_pointer, RustFFI::FfiCssPixelSize old_size, RustFFI::FfiCssPixelSize new_size) {
             auto& paintable = *static_cast<Painting::Paintable*>(paintable_pointer);
             Painting::invalidate_descendant_styles_for_container_query_size_change(
-                paintable,
+                paintable.dom_node(),
                 { CSSPixels::from_raw(old_size.width), CSSPixels::from_raw(old_size.height) },
                 { CSSPixels::from_raw(new_size.width), CSSPixels::from_raw(new_size.height) }); },
         .finish_node = [](void*, void* node_pointer, void* paintable_pointer) {

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -38,7 +38,6 @@
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 #include <LibWeb/SVG/SVGImageElement.h>

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -192,8 +192,8 @@ void Node::bump_fragment_cache_epoch_of_self_and_ancestors()
     for (auto* node = this; node; node = node->parent_ptr()) {
         if (fragment_cache_epochs_enabled())
             ++node->node_data().fragment_cache_epoch;
-        if (auto* box = as_if<Box>(*node); box && box->paintable_box())
-            const_cast<Painting::Paintable&>(*box->paintable_box()).clear_cached_overflow_data();
+        if (auto* box = as_if<Box>(*node))
+            Painting::clear_cached_overflow_data(*box);
     }
 }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -30,6 +30,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
@@ -255,8 +256,8 @@ Box* Node::containing_block()
 
 static void invalidate_paint_caches(Node& node)
 {
-    if (auto paintable = node.paintable())
-        paintable->invalidate_paint_cache();
+    if (Painting::has_committed_box(node))
+        Painting::invalidate_paint_cache(node);
 }
 
 void Node::pin_style_record_for_detachment()
@@ -620,8 +621,8 @@ void NodeWithStyle::ImageObserver::image_style_value_did_update(CSS::ImageStyleV
 {
     VERIFY(m_owner);
 
-    if (auto paintable = m_owner->paintable())
-        paintable->set_needs_repaint();
+    if (Painting::has_committed_box(*m_owner))
+        Painting::set_needs_repaint(*m_owner);
 }
 
 NodeWithStyle::~NodeWithStyle()

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/Paintable.h>
 
@@ -790,13 +791,13 @@ Gfx::GlyphRun::TextType text_type_for_code_point(u32 code_point)
 void TextNode::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list) const
 {
     if (auto* containing_block = this->containing_block()) {
-        if (auto paintable_box = const_cast<Box&>(*containing_block).paintable_box())
-            paintable_box->set_needs_repaint(should_invalidate_display_list);
+        if (Painting::has_committed_box(*containing_block))
+            Painting::set_needs_repaint(*containing_block, should_invalidate_display_list);
     }
 
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
         if (auto const* self_painting_ancestor = Painting::nearest_self_painting_inline_box(*this))
-            self_painting_ancestor->invalidate_paint_cache();
+            Painting::invalidate_paint_cache(self_painting_ancestor->layout_node());
     }
 }
 

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -21,8 +21,6 @@
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Painting/BoxViews.h>
-#include <LibWeb/Painting/InlinePaintable.h>
-#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Layout {
 
@@ -797,7 +795,7 @@ void TextNode::set_needs_repaint(InvalidateDisplayList should_invalidate_display
 
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
         if (auto const* self_painting_ancestor = Painting::nearest_self_painting_inline_box(*this))
-            Painting::invalidate_paint_cache(self_painting_ancestor->layout_node());
+            Painting::invalidate_paint_cache(*self_painting_ancestor);
     }
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -42,7 +42,7 @@
 #include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/Layout/TreeBuilderRustFFI.h>
 #include <LibWeb/Layout/Viewport.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGMaskElement.h>
 #include <LibWeb/SVG/SVGPatternElement.h>
@@ -724,10 +724,8 @@ static bool is_svg_resource_box(Node const& layout_node)
 // rebuilds them.
 static void transfer_saved_layout_state_to_replacement_box(Layout::Node& old_layout_node, Layout::Node& new_layout_node)
 {
-    if (auto* containing_block = old_layout_node.containing_block()) {
-        if (auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(containing_block->paintable().ptr()))
-            RustFFI::layout_arena_paintable_transfer_fragments_to_replacement_node(paintable_with_lines->rust_arena().handle(), paintable_with_lines->rust_slot(), Node::slot_id(&old_layout_node), Node::slot_id(&new_layout_node));
-    }
+    if (auto* containing_block = old_layout_node.containing_block())
+        Painting::transfer_fragments_to_replacement_node(*containing_block, old_layout_node, new_layout_node);
 }
 
 TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Page/AutoScrollHandler.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
@@ -38,13 +39,13 @@ static CSSPixelRect compute_effective_auto_scroll_edge(CSSPixelRect const& scrol
 
 static Optional<CSSPixelRect> scrollport_rect_in_viewport(Painting::Paintable const& paintable_box)
 {
-    auto scrollport = paintable_box.absolute_padding_box_rect();
+    auto scrollport = Painting::absolute_padding_box_rect(paintable_box.layout_node());
 
     // The viewport's scrollport is already in viewport coordinates.
-    if (paintable_box.is_viewport_paintable())
+    if (Painting::is_viewport_paintable(paintable_box.layout_node()))
         return scrollport;
 
-    return paintable_box.transform_rect_to_viewport(scrollport);
+    return Painting::transform_rect_to_viewport(paintable_box.layout_node(), scrollport);
 }
 
 // Returns scroll speed in CSS pixels per second for each axis, based on how far the mouse is past the auto scroll edge.
@@ -123,7 +124,7 @@ GC::Ptr<DOM::Element> AutoScrollHandler::find_scrollable_ancestor(Painting::Pain
 
         // The viewport is always a potential scroll container, but may not report has_scrollable_overflow() and its DOM
         // node is Document (not Element).
-        if (paintable_box->is_viewport_paintable() && paintable_box->could_be_scrolled_by_wheel_event()) {
+        if (Painting::is_viewport_paintable(paintable_box->layout_node()) && paintable_box->could_be_scrolled_by_wheel_event()) {
             if (auto scrolling_element = paintable_box->document().scrolling_element())
                 return const_cast<DOM::Element*>(scrolling_element.ptr());
         }

--- a/Libraries/LibWeb/Page/ElementResizeAction.cpp
+++ b/Libraries/LibWeb/Page/ElementResizeAction.cpp
@@ -9,8 +9,8 @@
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Page/ElementResizeAction.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ChromeMetrics.h>
-#include <LibWeb/Painting/Paintable.h>
 
 // https://drafts.csswg.org/css-ui#resize
 
@@ -21,8 +21,8 @@ static Optional<CSSPixelSize> containing_block_padding_box_size(Layout::Node con
     auto parent_box = layout_node.containing_block();
     if (!parent_box)
         return {};
-    if (auto paintable = parent_box->paintable(); auto const* paintable_box = paintable.ptr())
-        return paintable_box->absolute_padding_box_rect().size();
+    if (Painting::has_committed_box(*parent_box))
+        return Painting::absolute_padding_box_rect(*parent_box).size();
     return {};
 }
 
@@ -30,9 +30,9 @@ ElementResizeAction::ElementResizeAction(GC::Ref<DOM::Element> element, CSSPixel
     : m_element(element)
     , m_pointer_down_origin(pointer_down_origin)
 {
-    auto paintable_box = element->paintable_box();
-    if (paintable_box)
-        m_initial_border_box_size = paintable_box->absolute_border_box_rect().size();
+    auto const* layout_node = element->layout_node();
+    if (layout_node && Painting::has_committed_box(*layout_node))
+        m_initial_border_box_size = Painting::absolute_border_box_rect(*layout_node).size();
 }
 
 void ElementResizeAction::handle_pointer_move(CSSPixelPoint pointer_position)
@@ -41,10 +41,10 @@ void ElementResizeAction::handle_pointer_move(CSSPixelPoint pointer_position)
     if (!element || !element->is_connected())
         return;
 
-    auto paintable_box = element->paintable_box();
-    if (!paintable_box)
+    auto const* layout_node_pointer = element->layout_node();
+    if (!layout_node_pointer || !Painting::has_committed_box(*layout_node_pointer))
         return;
-    auto const& layout_node = paintable_box->layout_node();
+    auto const& layout_node = *layout_node_pointer;
     auto resize = layout_node.resize();
     if (resize == CSS::Resize::None)
         return;
@@ -88,7 +88,7 @@ void ElementResizeAction::handle_pointer_move(CSSPixelPoint pointer_position)
         }
     }
     if (layout_node.box_sizing() == CSS::BoxSizing::ContentBox) {
-        auto const& metrics = paintable_box->box_model();
+        auto const metrics = Painting::box_model(layout_node);
         css_width -= metrics.padding.left + metrics.padding.right + layout_node.border_left().width + layout_node.border_right().width;
         css_height -= metrics.padding.top + metrics.padding.bottom + layout_node.border_top().width + layout_node.border_bottom().width;
     }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -57,6 +57,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/MiddleButtonScrollHandler.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ChromeWidget.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
@@ -92,8 +93,8 @@ static GC::Ptr<DOM::Node> associated_descendant_editing_host(DOM::Node& node)
     }
 
     Optional<CSSPixelRect> hit_node_rect;
-    if (auto paintable = node.paintable())
-        hit_node_rect = paintable->absolute_rect();
+    if (auto const* layout_node = node.layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        hit_node_rect = Painting::absolute_rect(*layout_node);
 
     for (auto* ancestor = &node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
         GC::Ptr<DOM::Node> editing_host;
@@ -112,9 +113,9 @@ static GC::Ptr<DOM::Node> associated_descendant_editing_host(DOM::Node& node)
         if (editing_host && !has_multiple_editing_hosts) {
             if (ancestor == &node)
                 return editing_host;
-            auto editing_host_paintable = editing_host->paintable();
-            if (hit_node_rect.has_value() && editing_host_paintable
-                && hit_node_rect->intersects(editing_host_paintable->absolute_rect()))
+            auto const* editing_host_layout_node = editing_host->layout_node();
+            if (hit_node_rect.has_value() && editing_host_layout_node && Painting::has_committed_box(*editing_host_layout_node)
+                && hit_node_rect->intersects(Painting::absolute_rect(*editing_host_layout_node)))
                 return editing_host;
         }
 
@@ -201,6 +202,16 @@ EventHandler::EventHandler(Badge<HTML::LocalNavigable>, HTML::LocalNavigable& na
 
 EventHandler::~EventHandler() = default;
 
+static Layout::Node* layout_node_for_box(void* arena_handle, Layout::RustFFI::PaintableSlotId box)
+{
+    return static_cast<Layout::Node*>(Layout::RustFFI::layout_arena_paintable_layout_node_shell(arena_handle, box));
+}
+
+static Layout::Node* layout_node_for_target(DOM::Document& document, Layout::RustFFI::PaintableSlotId box)
+{
+    return layout_node_for_box(document.layout_node_arena().handle(), box);
+}
+
 void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
 {
     if (m_mouse_selection_target)
@@ -214,28 +225,22 @@ void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
         m_middle_button_scroll_handler->visit_edges(visitor);
 }
 
-static GC::Ptr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable& paintable)
-{
-    return event_dispatch_dom_node_for(paintable);
-}
-
 static CSS::UserSelect user_select_used_value_for_caret_position(Painting::CaretPosition const& caret_position)
 {
     if (auto* layout_node = caret_position.boundary.node->layout_node())
         return layout_node->user_select_used_value();
-    if (auto caret_paintable = caret_position.paintable(); caret_paintable && caret_paintable->has_layout_node())
-        return caret_paintable->layout_node().user_select_used_value();
+    if (auto* layout_node = layout_node_for_box(caret_position.arena->handle(), caret_position.box))
+        return layout_node->user_select_used_value();
     return CSS::UserSelect::Auto;
 }
 
-static Optional<EventResult> dispatch_event_to_nested_navigable(Painting::Paintable& paintable, CSSPixelPoint viewport_position, Function<EventResult(EventHandler&, CSSPixelPoint)> dispatch)
+static Optional<EventResult> dispatch_event_to_nested_navigable(Layout::Node const& layout_node, GC::Ptr<DOM::Node> node, CSSPixelPoint viewport_position, Function<EventResult(EventHandler&, CSSPixelPoint)> dispatch)
 {
-    auto node = dom_node_for_event_dispatch(paintable);
     if (!node)
         return {};
 
-    if (paintable.is_navigable_container_viewport_paintable()) {
-        auto position = paintable.transform_to_local_coordinates(viewport_position) - paintable.absolute_rect().location();
+    if (Painting::is_navigable_container_viewport_paintable(layout_node)) {
+        auto position = Painting::transform_to_local_coordinates(layout_node, viewport_position) - Painting::absolute_rect(layout_node).location();
         if (auto content_navigable = as_if<HTML::NavigableContainer>(*node)->content_navigable()) {
             return dispatch(as<HTML::LocalNavigable>(*content_navigable).event_handler(), position);
         }
@@ -245,14 +250,13 @@ static Optional<EventResult> dispatch_event_to_nested_navigable(Painting::Painta
     return {};
 }
 
-static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, GC::Ptr<DOM::Node>& node, Layout::Node*& layout_node)
+static bool parent_element_for_event_dispatch(Layout::Node& target_layout_node, GC::Ptr<DOM::Node>& node, Layout::Node*& layout_node)
 {
-    auto* paintable_layout_node = &paintable.layout_node();
-    layout_node = node && node->layout_node() ? node->layout_node() : paintable_layout_node;
-    if (paintable_layout_node->is_generated_for_backdrop_pseudo_element()
-        || paintable_layout_node->is_generated_for_after_pseudo_element()
-        || paintable_layout_node->is_generated_for_before_pseudo_element()) {
-        node = paintable_layout_node->pseudo_element_generator();
+    layout_node = node && node->layout_node() ? node->layout_node() : &target_layout_node;
+    if (target_layout_node.is_generated_for_backdrop_pseudo_element()
+        || target_layout_node.is_generated_for_after_pseudo_element()
+        || target_layout_node.is_generated_for_before_pseudo_element()) {
+        node = target_layout_node.pseudo_element_generator();
         if (auto* generator_layout_node = node->layout_node())
             layout_node = generator_layout_node;
     }
@@ -303,18 +307,22 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     if (!paint_root())
         return EventResult::Dropped;
 
-    RefPtr<Painting::Paintable> paintable;
+    Optional<Target> target;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
-        paintable = result->paintable;
-        chrome_widget = result->chrome_widget;
-        node = result->dom_node;
+        target = move(*result);
+        chrome_widget = target->chrome_widget;
+        node = target->dom_node;
     } else {
         return EventResult::Dropped;
     }
 
-    auto pointer_events = paintable->layout_node().pointer_events();
+    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    if (!target_layout_node)
+        return EventResult::Dropped;
+
+    auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
     // FIXME: Handle other values for pointer-events.
     VERIFY(pointer_events != CSS::PointerEvents::None);
 
@@ -328,7 +336,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
 
     m_mousedown_click_count = click_count;
 
-    auto dispath_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [=](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+    auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [=](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
         return event_handler.handle_mousedown(position, screen_position, button, buttons, modifiers, click_count);
     });
     if (dispath_result.has_value())
@@ -345,14 +353,14 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     // The topmost event target MUST be the element highest in the rendering order which is capable of being an
     // event target.
     Layout::Node* layout_node = nullptr;
-    if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
+    if (!parent_element_for_event_dispatch(*target_layout_node, node, layout_node))
         return EventResult::Dropped;
 
     m_mousedown_target = node;
     m_last_mousedown_target = node;
     m_mousedown_visual_viewport_position = visual_viewport_position;
 
-    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
+    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *layout_node);
     auto dispatch_result = dispatch_a_pointer_event_for_a_device_that_supports_hover(PointerEventType::PointerDown, *node, chrome_widget, coordinates, screen_position, {}, button, buttons, modifiers, click_count);
 
     bool is_context_menu_trigger = button == UIEvents::MouseButton::Secondary;
@@ -366,7 +374,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     //     matching other engines. The page can still suppress the native context menu by cancelling the
     //     contextmenu event itself.
     if (is_context_menu_trigger && dispatch_result != PointerEventDispatchResult::SwallowedByChromeWidget)
-        maybe_show_context_menu(*node, *paintable, coordinates, screen_position, viewport_position, buttons, modifiers);
+        maybe_show_context_menu(*node, target->box, coordinates, screen_position, viewport_position, buttons, modifiers);
 
     if (dispatch_result != PointerEventDispatchResult::RunDefaultActions)
         return EventResult::Cancelled;
@@ -425,8 +433,8 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         if (caret_position.has_value()) {
             document->set_caret_hit_test_debug_rect(caret_position->debug_rect);
             auto paintable_description = "(gone)"_string;
-            if (auto caret_paintable = caret_position->paintable())
-                paintable_description = caret_paintable->debug_description();
+            if (auto const* layout_node = layout_node_for_box(caret_position->arena->handle(), caret_position->box))
+                paintable_description = Painting::debug_description(*layout_node);
             dbgln("Caret hit test: point=({}, {}) boundary=({}, {}) paintable={} debug_rect={}",
                 visual_viewport_position.x(),
                 visual_viewport_position.y(),
@@ -474,29 +482,33 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         }
     }
 
-    RefPtr<Painting::Paintable> paintable;
+    Optional<Target> target;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     Optional<int> start_index;
     bool hit_text_fragment = false;
 
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
-        paintable = result->paintable;
-        chrome_widget = result->chrome_widget;
-        node = result->dom_node;
-        start_index = result->index_in_node;
-        hit_text_fragment = result->is_text_fragment;
+        target = move(*result);
+        chrome_widget = target->chrome_widget;
+        node = target->dom_node;
+        start_index = target->index_in_node;
+        hit_text_fragment = target->is_text_fragment;
     }
 
     ArmedScopeGuard clear_cursor = [&] {
         update_cursor(nullptr, nullptr, nullptr);
     };
 
-    if (paintable) {
+    if (target.has_value()) {
         if (!node)
             return EventResult::Dropped;
 
-        auto dispath_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
+        auto* target_layout_node = layout_node_for_target(*document, target->box);
+        if (!target_layout_node)
+            return EventResult::Dropped;
+
+        auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
             return event_handler.handle_mousemove(position, screen_position, buttons, modifiers);
         });
         if (dispath_result.has_value()) {
@@ -504,7 +516,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
             return *dispath_result;
         }
 
-        auto pointer_events = paintable->layout_node().pointer_events();
+        auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
         // FIXME: Handle other values for pointer-events.
         VERIFY(pointer_events != CSS::PointerEvents::None);
 
@@ -517,13 +529,13 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         // The topmost event target MUST be the element highest in the rendering order which is capable of being an
         // event target.
         Layout::Node* layout_node = nullptr;
-        bool found_parent_element = parent_element_for_event_dispatch(*paintable, node, layout_node);
+        bool found_parent_element = parent_element_for_event_dispatch(*target_layout_node, node, layout_node);
 
         if (found_parent_element) {
-            update_cursor(*paintable, *node, chrome_widget, hit_text_fragment);
+            update_cursor(target_layout_node, *node, chrome_widget, hit_text_fragment);
             clear_cursor.disarm();
 
-            auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
+            auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *layout_node);
             auto movement = compute_mouse_event_movement(screen_position);
             m_mousemove_previous_screen_position = screen_position;
 
@@ -534,7 +546,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         // NOTE: In some implementation environments, such as a browser, mousemove events can continue to fire if the
         //       user began a drag operation (e.g., a mouse button is pressed) and the pointing device has left the
         //       boundary of the user agent.
-        auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *document->paintable(), *document->layout_node());
+        auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *document->layout_node());
         auto movement = compute_mouse_event_movement(screen_position);
         m_mousemove_previous_screen_position = screen_position;
 
@@ -596,26 +608,26 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     if (!paint_root())
         return EventResult::Dropped;
 
-    RefPtr<Painting::Paintable> paintable;
+    Optional<Target> target;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
-        paintable = result->paintable;
-        chrome_widget = result->chrome_widget;
-        node = result->dom_node;
+        target = move(*result);
+        chrome_widget = target->chrome_widget;
+        node = target->dom_node;
     }
 
     auto click_count = m_mousedown_click_count;
     if (click_count <= 0)
         return EventResult::Dropped;
 
-    if (!paintable) {
+    if (!target.has_value()) {
         VERIFY(!chrome_widget);
 
         // NB: Always fire a mouseup event if we've fired a mousedown event. Otherwise, web pages will not have a
         //     chance to end a drag that went outside the window.
         if (m_mousedown_target) {
-            auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *document->paintable(), *document->layout_node());
+            auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *document->layout_node());
             dispatch_a_pointer_event_for_a_device_that_supports_hover(PointerEventType::PointerUp, document->html_element(), nullptr, coordinates, screen_position, {}, button, buttons, modifiers, click_count);
             return EventResult::Handled;
         }
@@ -623,14 +635,18 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
         return EventResult::Dropped;
     }
 
-    auto pointer_events = paintable->layout_node().pointer_events();
+    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    if (!target_layout_node)
+        return EventResult::Dropped;
+
+    auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
     if (pointer_events == CSS::PointerEvents::None)
         return EventResult::Cancelled;
 
     if (!node)
         return EventResult::Dropped;
 
-    auto dispath_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
+    auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
         return event_handler.handle_mouseup(position, screen_position, button, buttons, modifiers);
     });
     if (dispath_result.has_value())
@@ -645,10 +661,10 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     // The topmost event target MUST be the element highest in the rendering order which is capable of being an
     // event target.
     Layout::Node* layout_node = nullptr;
-    if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
+    if (!parent_element_for_event_dispatch(*target_layout_node, node, layout_node))
         return EventResult::Dropped;
 
-    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
+    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *layout_node);
     [[maybe_unused]] auto dispatch_result = dispatch_a_pointer_event_for_a_device_that_supports_hover(PointerEventType::PointerUp, *node, chrome_widget, coordinates, screen_position, {}, button, buttons, modifiers, click_count);
 
 #if defined(AK_OS_MACOS)
@@ -683,7 +699,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx
-static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting::Paintable const& paintable)
+static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Layout::Node const& layout_node)
 {
     // If the event’s dispatch flag is set,
     // FIXME: Is this guaranteed to be dispatched?
@@ -691,10 +707,10 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
     // return the x-coordinate of the position where the event occurred,
     // ignoring the transforms that apply to the element and its ancestors,
     CSSPixelPoint offset_position = position;
-    offset_position = paintable.inverse_transform_point(position);
+    offset_position = Painting::inverse_transform_point(layout_node, position);
 
     // relative to the origin of the padding edge of the target node
-    auto const top_left_of_layout_node = paintable.box_type_agnostic_position();
+    auto const top_left_of_layout_node = Painting::box_type_agnostic_position(layout_node);
     auto offset = offset_position - top_left_of_layout_node;
 
     // and terminate these steps.
@@ -727,9 +743,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     if (modifiers & UIEvents::KeyModifier::Mod_Shift)
         swap(wheel_delta_x, wheel_delta_y);
 
-    RefPtr<Painting::Paintable> paintable;
-    if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
-        paintable = result->paintable;
+    auto target = target_for_mouse_position(visual_viewport_position);
 
     auto can_attempt_async_scroll = m_navigable->page().async_scrolling_enabled() && m_navigable->has_compositor_context();
     if (can_attempt_async_scroll && async_scroll_performed_default_action) {
@@ -737,7 +751,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     } else if (can_attempt_async_scroll && visual_viewport->scale() != 1.0) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: visual viewport is scaled");
     } else if (can_attempt_async_scroll) {
-        if (paintable) {
+        if (target.has_value()) {
             auto viewport_rect = m_navigable->page().css_to_device_rect(m_navigable->viewport_rect()).to_type<int>();
             auto async_scroll_delta = Gfx::FloatPoint { static_cast<float>(wheel_delta_x), static_cast<float>(wheel_delta_y) };
             auto device_position = m_navigable->page().css_to_device_point(visual_viewport_position);
@@ -756,14 +770,19 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 async_scroll_performed_default_action ? "Enqueued"sv : "Could not enqueue"sv,
                 async_scroll_position.x(), async_scroll_position.y(),
                 async_scroll_delta_in_device_pixels.x(), async_scroll_delta_in_device_pixels.y());
-        } else if (!paintable) {
+        } else {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: no paintable target");
         }
     }
 
     auto handled_event = EventResult::Dropped;
 
-    if (paintable) {
+    if (target.has_value()) {
+        auto paintable = Painting::paintable_for_slot(document->layout_node_arena().handle(), target->box);
+        auto* target_layout_node = layout_node_for_target(*document, target->box);
+        if (!paintable || !target_layout_node)
+            return EventResult::Dropped;
+
         auto resolve_wheel_default_action_target = [&]() -> RefPtr<Painting::Paintable> {
             auto document = m_navigable->active_document();
             if (!document || !document->is_fully_active())
@@ -774,7 +793,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 return nullptr;
 
             if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
-                return result->paintable;
+                return Painting::paintable_for_slot(document->layout_node_arena().handle(), result->box);
             return nullptr;
         };
 
@@ -813,8 +832,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             return EventResult::Accepted;
         };
 
-        if (auto node = dom_node_for_event_dispatch(*paintable)) {
-            if (auto result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+        if (auto node = target->dom_node) {
+            if (auto result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
                     return event_handler.handle_mousewheel(position, screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation);
                 });
                 result.has_value()) {
@@ -836,7 +855,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             } else
                 handled_event = dispatch_result;
         } else if (!async_scroll_performed_default_action) {
-            handled_event = perform_wheel_default_action(paintable);
+            handled_event = perform_wheel_default_action(move(paintable));
         }
     }
 
@@ -849,22 +868,20 @@ EventResult EventHandler::dispatch_wheel_event(Painting::Paintable& paintable, C
     if (!document || !document->is_fully_active())
         return EventResult::Dropped;
 
-    auto node = dom_node_for_event_dispatch(paintable);
+    auto node = event_dispatch_dom_node_for(paintable);
     if (!node)
         return EventResult::Dropped;
 
     // NB: Search for the first parent of the hit target that's an element.
     Layout::Node* layout_node = nullptr;
-    if (!parent_element_for_event_dispatch(paintable, node, layout_node))
+    if (!parent_element_for_event_dispatch(paintable.layout_node(), node, layout_node))
         return EventResult::Dropped;
 
     auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
     auto page_offset = compute_mouse_event_page_offset(viewport_position);
-    RefPtr<Painting::Paintable> offset_paintable = layout_node->paintable();
-    if (!offset_paintable)
-        offset_paintable = &paintable;
+    auto const* offset_layout_node = Painting::has_committed_box(*layout_node) ? layout_node : &paintable.layout_node();
     auto scroll_offset = document->navigable()->viewport_scroll_offset();
-    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), *offset_paintable);
+    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), *offset_layout_node);
     auto cancelability = is_cancelable ? UIEvents::WheelEventIsCancelable::Yes : UIEvents::WheelEventIsCancelable::No;
     auto event = UIEvents::WheelEvent::create_from_platform_event(HTML::relevant_global_object(*node), m_navigable->active_window_proxy(), UIEvents::EventNames::wheel, screen_position, page_offset, viewport_position, offset, wheel_delta_x, wheel_delta_y, button, buttons, modifiers, cancelability).release_value_but_fixme_should_propagate_errors();
     return node->dispatch_event(event) ? EventResult::Accepted : EventResult::Cancelled;
@@ -881,17 +898,15 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
     if (!paint_root())
         return EventResult::Dropped;
 
-    RefPtr<Painting::Paintable> paintable;
-    if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
-        paintable = result->paintable;
-
-    if (!paintable)
+    auto target = target_for_mouse_position(visual_viewport_position);
+    if (!target.has_value())
         return EventResult::Dropped;
 
-    if (!dom_node_for_event_dispatch(*paintable))
+    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    if (!target_layout_node || !target->dom_node)
         return EventResult::Dropped;
 
-    if (auto result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [screen_position, modifiers, wheel_delta_y](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+    if (auto result = dispatch_event_to_nested_navigable(*target_layout_node, target->dom_node, visual_viewport_position, [screen_position, modifiers, wheel_delta_y](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
             return event_handler.dispatch_synthetic_pinch_wheel_event(position, screen_position, modifiers, wheel_delta_y);
         });
         result.has_value()) {
@@ -900,6 +915,9 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
     }
 
     modifiers |= UIEvents::KeyModifier::Mod_Ctrl;
+    auto paintable = Painting::paintable_for_slot(document->layout_node_arena().handle(), target->box);
+    if (!paintable)
+        return EventResult::Dropped;
     return dispatch_wheel_event(*paintable, visual_viewport_position, screen_position, UIEvents::MouseButton::None, UIEvents::MouseButton::None, modifiers, 0, wheel_delta_y, true);
 }
 
@@ -954,15 +972,15 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     if (!paint_root())
         return;
 
-    RefPtr<Painting::Paintable> paintable;
+    Optional<Target> target;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     bool hit_text_fragment = false;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
-        paintable = result->paintable;
-        chrome_widget = result->chrome_widget;
-        node = result->dom_node;
-        hit_text_fragment = result->is_text_fragment;
+        target = move(*result);
+        chrome_widget = target->chrome_widget;
+        node = target->dom_node;
+        hit_text_fragment = target->is_text_fragment;
     }
 
     ArmedScopeGuard clear_hover = [&] {
@@ -971,13 +989,17 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
         track_the_effective_position_of_the_legacy_mouse_pointer(nullptr);
     };
 
-    if (!paintable)
+    if (!target.has_value())
         return;
 
     if (!node)
         return;
 
-    auto dispatch_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
+    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    if (!target_layout_node)
+        return;
+
+    auto dispatch_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
         event_handler.update_hover_after_scroll(position, screen_position, button, buttons, modifiers);
         return EventResult::Handled;
     });
@@ -987,13 +1009,13 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     }
 
     Layout::Node* layout_node = nullptr;
-    if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
+    if (!parent_element_for_event_dispatch(*target_layout_node, node, layout_node))
         return;
 
     update_hovered_chrome_widget(chrome_widget);
-    update_cursor(*paintable, *node, chrome_widget, hit_text_fragment);
+    update_cursor(target_layout_node, *node, chrome_widget, hit_text_fragment);
 
-    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
+    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *layout_node);
     track_the_effective_position_of_the_legacy_mouse_pointer(node, DOM::HoverEventData {
                                                                        .screen_position = screen_position,
                                                                        .page_offset = coordinates.page_offset,
@@ -1440,11 +1462,11 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
     if (!paint_root())
         return EventResult::Dropped;
 
-    RefPtr<Painting::Paintable> paintable;
+    Optional<Target> target;
     GC::Ptr<DOM::Node> node;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
-        paintable = result->paintable;
-        node = result->dom_node;
+        target = move(*result);
+        node = target->dom_node;
     } else {
         return EventResult::Dropped;
     }
@@ -1452,7 +1474,11 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
     if (!node)
         return EventResult::Dropped;
 
-    auto dispath_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
+    auto* target_layout_node = layout_node_for_target(document, target->box);
+    if (!target_layout_node)
+        return EventResult::Dropped;
+
+    auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
         return event_handler.handle_drag_and_drop_event(type, position, screen_position, button, buttons, modifiers, move(files));
     });
     if (dispath_result.has_value())
@@ -1460,7 +1486,7 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
 
     auto page_offset = compute_mouse_event_page_offset(viewport_position);
     auto scroll_offset = document.navigable()->viewport_scroll_offset();
-    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), *paintable);
+    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), *target_layout_node);
 
     switch (type) {
     case DragEvent::Type::DragStart:
@@ -2071,14 +2097,11 @@ bool EventHandler::fire_click_events(GC::Ref<DOM::Node> node, MouseEventCoordina
     return run_activation_behavior;
 }
 
-EventHandler::MouseEventCoordinates EventHandler::compute_mouse_event_coordinates(CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, Painting::Paintable const& paintable, Layout::Node const& layout_node) const
+EventHandler::MouseEventCoordinates EventHandler::compute_mouse_event_coordinates(CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, Layout::Node const& layout_node) const
 {
     auto page_offset = compute_mouse_event_page_offset(viewport_position);
-    RefPtr<Painting::Paintable const> offset_paintable = layout_node.paintable();
-    if (!offset_paintable)
-        offset_paintable = paintable;
     auto scroll_offset = m_navigable->active_document()->navigable()->viewport_scroll_offset();
-    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), *offset_paintable);
+    auto offset = compute_mouse_event_offset(visual_viewport_position.translated(scroll_offset), layout_node);
     return { page_offset, visual_viewport_position, viewport_position, offset };
 }
 
@@ -2120,11 +2143,10 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
         return {};
 
     if (auto result = document->hit_test(position); result.has_value()) {
-        auto paintable = result->paintable();
-        if (!paintable)
+        if (!layout_node_for_target(*document, result->box))
             return {};
         return Target {
-            .paintable = move(paintable),
+            .box = result->box,
             .chrome_widget = result->chrome_widget,
             .dom_node = result->dom_node(),
             .index_in_node = result->index_in_node,
@@ -2137,7 +2159,7 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
 GC::Ptr<DOM::Node> EventHandler::target_node_for_mouse_position(CSSPixelPoint position)
 {
     auto target = target_for_mouse_position(position);
-    if (!target.has_value() || !target->paintable)
+    if (!target.has_value())
         return {};
 
     return target->dom_node;
@@ -2307,7 +2329,11 @@ bool EventHandler::select_word_for_dictionary_lookup(CSSPixelPoint visual_viewpo
     if (!result.has_value())
         return false;
 
-    if (auto dispatch_result = dispatch_event_to_nested_navigable(*result->paintable, visual_viewport_position, [](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+    auto* target_layout_node = layout_node_for_target(*document, result->box);
+    if (!target_layout_node)
+        return false;
+
+    if (auto dispatch_result = dispatch_event_to_nested_navigable(*target_layout_node, result->dom_node, visual_viewport_position, [](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
             return event_handler.select_word_for_dictionary_lookup(position) ? EventResult::Handled : EventResult::Dropped;
         });
         dispatch_result.has_value()) {
@@ -2444,7 +2470,7 @@ void EventHandler::run_activation_behavior(GC::Ref<DOM::Node> node, unsigned but
 }
 
 // https://w3c.github.io/uievents/#maybe-show-context-menu
-void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Painting::Paintable& paintable, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
+void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::RustFFI::PaintableSlotId box, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
 {
     // AD-HOC: Allow the user to bypass custom context menus by holding shift, like Firefox.
     if ((modifiers & UIEvents::Mod_Shift) == 0) {
@@ -2491,8 +2517,10 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Painting::Pa
         // AD-HOC: Area elements are never rendered, so use the image over which the context menu was requested
         //         instead. This keeps the image context menu available over image maps.
         if (is<HTML::HTMLAreaElement>(*context_menu_node)) {
-            if (auto* image_element = as_if<HTML::HTMLImageElement>(paintable.dom_node().ptr()))
-                context_menu_node = *image_element;
+            if (auto* layout_node = layout_node_for_target(*document, box)) {
+                if (auto* image_element = as_if<HTML::HTMLImageElement>(layout_node->dom_node()))
+                    context_menu_node = *image_element;
+            }
         }
 
         if (is<HTML::HTMLImageElement>(*context_menu_node)) {
@@ -3433,7 +3461,7 @@ static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Read
     return Gfx::StandardCursor::None;
 }
 
-void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element,
+void EventHandler::update_cursor(Layout::Node const* layout_node, GC::Ptr<DOM::Node> host_element,
     RefPtr<Painting::ChromeWidget> chrome_widget, bool hit_text_fragment)
 {
     // AD-HOC: Update the cursor image based on the CSS rules before the steps terminate if the target hasn't changed.
@@ -3443,10 +3471,11 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
                 return css_to_gfx_cursor(cursor_override.value());
         }
 
-        if (paintable) {
+        if (layout_node) {
             auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
-            auto cursor_data = paintable->layout_node().cursor();
-            auto cursor_style_values = paintable->layout_node().cursor_style_values();
+            auto const& node_with_style = as<Layout::NodeWithStyle>(*layout_node);
+            auto cursor_data = node_with_style.cursor();
+            auto cursor_style_values = node_with_style.cursor_style_values();
             if (hit_text_fragment && host_layout_node)
                 cursor_data = as<Layout::NodeWithStyle>(*host_layout_node).cursor();
             if (hit_text_fragment && host_layout_node)
@@ -3460,7 +3489,7 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
             if (is_selectable_text_fragment || host_element->is_editable_or_editing_host()) {
                 if (host_node_with_style)
                     return resolve_cursor(*host_node_with_style, cursor_data, cursor_style_values, Gfx::StandardCursor::IBeam);
-                return resolve_cursor(*paintable->layout_node().parent(), cursor_data, cursor_style_values, Gfx::StandardCursor::IBeam);
+                return resolve_cursor(*node_with_style.parent(), cursor_data, cursor_style_values, Gfx::StandardCursor::IBeam);
             }
             if (host_element && host_element->is_element() && host_node_with_style)
                 return resolve_cursor(*host_node_with_style, cursor_data, cursor_style_values, Gfx::StandardCursor::Arrow);
@@ -3470,7 +3499,7 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
             //         node of the image that renders the area's image map for image cursors.
             if (auto const* area_element = as_if<HTML::HTMLAreaElement>(host_element.ptr())) {
                 if (auto area_computed_values = area_element->computed_style(); area_computed_values)
-                    return resolve_cursor(paintable->layout_node(), area_computed_values->cursor(), {}, Gfx::StandardCursor::Arrow);
+                    return resolve_cursor(node_with_style, area_computed_values->cursor(), {}, Gfx::StandardCursor::Arrow);
             }
         }
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -21,6 +21,7 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Gamepad/SDLGamepadForward.h>
+#include <LibWeb/Layout/LayoutRustFFI.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/Forward.h>
@@ -105,12 +106,12 @@ private:
     };
     bool fire_click_events(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
 
-    MouseEventCoordinates compute_mouse_event_coordinates(CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, Painting::Paintable const& paintable, Layout::Node const& layout_node) const;
+    MouseEventCoordinates compute_mouse_event_coordinates(CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, Layout::Node const& layout_node) const;
     CSSPixelPoint compute_mouse_event_page_offset(CSSPixelPoint event_client_offset) const;
     CSSPixelPoint compute_mouse_event_movement(CSSPixelPoint screen_position) const;
 
     struct Target {
-        RefPtr<Painting::Paintable> paintable;
+        Layout::RustFFI::PaintableSlotId box;
         RefPtr<Painting::ChromeWidget> chrome_widget;
         GC::Ptr<DOM::Node> dom_node;
         Optional<int> index_in_node;
@@ -122,7 +123,7 @@ private:
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
 
-    void maybe_show_context_menu(GC::Ref<DOM::Node>, Painting::Paintable&, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    void maybe_show_context_menu(GC::Ref<DOM::Node>, Layout::RustFFI::PaintableSlotId, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
@@ -164,7 +165,7 @@ private:
     bool dispatch_chrome_widget_pointer_event(RefPtr<Painting::ChromeWidget>, Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position);
     void update_hovered_chrome_widget(RefPtr<Painting::ChromeWidget>);
 
-    void update_cursor(RefPtr<Painting::Paintable>, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget>, bool hit_text_fragment = false);
+    void update_cursor(Layout::Node const*, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget>, bool hit_text_fragment = false);
     void record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult cancel_drag_and_drop_event(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 

--- a/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
@@ -7,8 +7,10 @@
 #include <AK/Math.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/AutoScrollHandler.h>
 #include <LibWeb/Page/MiddleButtonScrollHandler.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
@@ -24,16 +26,18 @@ MiddleButtonScrollHandler::MiddleButtonScrollHandler(DOM::Element& container, CS
     , m_origin(origin)
     , m_mouse_position(origin)
 {
-    if (auto paintable = m_container_element->document().paintable())
-        paintable->set_needs_repaint();
+    auto const* layout_node = m_container_element->document().layout_node();
+    if (layout_node && Painting::has_committed_box(*layout_node))
+        Painting::set_needs_repaint(*layout_node);
 }
 
 MiddleButtonScrollHandler::~MiddleButtonScrollHandler()
 {
     if (!m_container_element->document().layout_is_up_to_date())
         return;
-    if (auto paintable = m_container_element->document().paintable())
-        paintable->set_needs_repaint();
+    auto const* layout_node = m_container_element->document().layout_node();
+    if (layout_node && Painting::has_committed_box(*layout_node))
+        Painting::set_needs_repaint(*layout_node);
 }
 
 void MiddleButtonScrollHandler::visit_edges(JS::Cell::Visitor& visitor) const

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -5,8 +5,15 @@
  */
 
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Position.h>
+#include <LibWeb/DOM/Text.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLBRElement.h>
+#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Layout/TextOffsetMapping.h>
 #include <LibWeb/Painting/BoxViews.h>
+#include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::Painting {
@@ -86,12 +93,220 @@ FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_colu
 FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_rows, {})
 
 FORWARD_BOX_VIEW(CSSPixelPoint, box_type_agnostic_position, {})
-FORWARD_BOX_VIEW(bool, should_paint_cursor, false)
 FORWARD_BOX_VIEW(Paintable::SelectionStyle, selection_style, {})
 FORWARD_BOX_VIEW(StickyInsets, sticky_insets, {})
 FORWARD_BOX_VIEW(bool, has_sticky_insets, false)
 
 #undef FORWARD_BOX_VIEW
+
+bool should_paint_cursor(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return false;
+
+    auto const& document = node.document();
+    if (!document.cursor_blink_state() || !document.navigable()->is_focused())
+        return false;
+
+    auto cursor_position = document.cursor_position();
+    if (!cursor_position)
+        return false;
+
+    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document.focused_area().ptr());
+        text_control && text_control->text_control_to_html_element().is_mutable()) {
+        return true;
+    }
+
+    // The editable element may sit anywhere between the cursor and this box (e.g. a
+    // contenteditable inline box), so editability is the cursor node's, not this box's.
+    auto const* editable_node = cursor_position->node().ptr();
+    return editable_node && editable_node->is_editable_or_editing_host();
+}
+
+Layout::Node const* nearest_self_painting_inline_box(Layout::Node const& node)
+{
+    for (auto const* ancestor = node.nearest_fragmented_inline_ancestor(); ancestor; ancestor = ancestor->nearest_fragmented_inline_ancestor()) {
+        if (is_inline_paintable(*ancestor) && (has_stacking_context(*ancestor) || is_positioned(*ancestor)))
+            return ancestor;
+    }
+    return nullptr;
+}
+
+bool has_content(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return false;
+
+    // Interrupting block-in-inline children produce only placeholder pieces, so any child
+    // paintable also counts as content.
+    return Layout::RustFFI::layout_arena_inline_paintable_has_content_pieces(paintable->rust_arena().handle(), paintable->rust_slot())
+        || Layout::RustFFI::layout_arena_paintable_has_child_paintables(paintable->rust_arena().handle(), paintable->rust_slot());
+}
+
+// Caret rect for a cursor parked on this paintable's DOM node at the given child offset, e.g. on an empty line
+// rendered by a <br> child or in an empty editable element.
+CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offset)
+{
+    auto const* paintable = block.paintable_ptr();
+    if (!paintable)
+        return {};
+    auto const& styled_block = as<Layout::NodeWithStyle>(block);
+
+    auto content_box = absolute_padding_box_rect(block);
+    auto line_height = styled_block.line_height();
+    CSSPixelRect rect { content_box.x(), content_box.y(), 1, line_height };
+
+    auto dom_node = block.dom_node();
+    if (!dom_node)
+        return rect;
+
+    // A boundary immediately after an atomic inline element paints after that element. Atomic inline elements have
+    if (offset > 0) {
+        auto* previous_child = dom_node->child_at_index(offset - 1);
+        auto const* previous_layout_node = previous_child ? previous_child->unsafe_layout_node() : nullptr;
+        if (previous_layout_node && previous_layout_node->is_atomic_inline()) {
+            auto result = Layout::RustFFI::layout_arena_paintable_first_fragment_rect_for_node(paintable->rust_arena().handle(), paintable->rust_slot(), Layout::Node::slot_id(previous_layout_node));
+            if (result.has_value) {
+                auto fragment_rect = from_ffi_css_pixel_rect(result.rect);
+                if (styled_block.writing_mode() == CSS::WritingMode::HorizontalTb)
+                    rect.set_x(styled_block.inline_axis_is_reverse() ? fragment_rect.left() : fragment_rect.right());
+                else
+                    rect.set_y(styled_block.inline_axis_is_reverse() ? fragment_rect.top() : fragment_rect.bottom());
+                return rect;
+            }
+        }
+    }
+
+    auto* child = dom_node->child_at_index(offset);
+    if (!child || !is<HTML::HTMLBRElement>(*child))
+        return rect;
+
+    // A caret parked before a <br> sits on the line below the content preceding the <br>. Layout produces no
+    // fragments for <br>, so start below the fragments of any preceding content, and add one line height for each
+    // empty line rendered by earlier <br>s.
+    struct PrecedingContentContext {
+        GC::Ref<DOM::Node> child;
+        Optional<CSSPixels> preceding_content_bottom;
+    } preceding_context { const_cast<DOM::Node&>(*child), {} };
+    Layout::RustFFI::layout_arena_for_each_subtree_fragment_rect(
+        paintable->rust_arena().handle(), paintable->rust_slot(), &preceding_context,
+        [](void* context_pointer, void* fragment_layout_node_shell, Layout::RustFFI::FfiCssPixelRect rect) {
+            auto& context = *static_cast<PrecedingContentContext*>(context_pointer);
+            auto const* fragment_layout_node = static_cast<Layout::Node const*>(fragment_layout_node_shell);
+            auto* fragment_dom_node = fragment_layout_node ? const_cast<DOM::Node*>(fragment_layout_node->dom_node()) : nullptr;
+            if (!fragment_dom_node || !(context.child->compare_document_position(fragment_dom_node) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
+                return;
+            auto bottom = CSSPixels::from_raw(rect.y) + CSSPixels::from_raw(rect.height);
+            if (!context.preceding_content_bottom.has_value() || bottom > *context.preceding_content_bottom)
+                context.preceding_content_bottom = bottom;
+        });
+    auto& preceding_content_bottom = preceding_context.preceding_content_bottom;
+
+    size_t preceding_empty_lines = 0;
+    dom_node->for_each_in_subtree_of_type<HTML::HTMLBRElement>([&](auto& br) {
+        if (&br == child)
+            return TraversalDecision::Break;
+        if (br.represents_empty_line())
+            ++preceding_empty_lines;
+        return TraversalDecision::Continue;
+    });
+
+    rect.set_y(preceding_content_bottom.value_or(content_box.y()) + line_height * preceding_empty_lines);
+    return rect;
+}
+
+static bool layout_node_is_visible(Layout::NodeWithStyle const& layout_node)
+{
+    return layout_node.visibility() == CSS::Visibility::Visible && layout_node.opacity() != 0;
+}
+
+Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node const* owner_inline)
+{
+    auto const* paintable = block.paintable_ptr();
+    if (!paintable || !should_paint_cursor(block))
+        return {};
+    auto const& styled_block = as<Layout::NodeWithStyle>(block);
+
+    auto cursor_position = block.document().cursor_position();
+    VERIFY(cursor_position);
+
+    auto const* dom_node = block.dom_node();
+
+    Vector<Layout::RustFFI::NodeSlotId, 2> text_slots;
+    if (auto const* text = as_if<DOM::Text>(cursor_position->node().ptr()))
+        text_slots = Layout::TextOffsetMapping { *text }.slot_ids();
+
+    if (!text_slots.is_empty()) {
+        auto result = Layout::RustFFI::layout_arena_text_caret_rect_for_position(
+            paintable->rust_arena().handle(), text_slots.data(), text_slots.size(), cursor_position->offset(),
+            cursor_position->affinity() == TextAffinity::Downstream);
+        if (result.found && result.owner_paintable.index == paintable->rust_slot().index) {
+            auto const* owner_paintable = owner_inline ? owner_inline->paintable_ptr() : nullptr;
+            auto owner_slot = owner_paintable ? owner_paintable->rust_slot()
+                                              : Layout::RustFFI::PaintableSlotId { Layout::RustFFI::INVALID_PAINTABLE_SLOT_INDEX };
+            if (result.nearest_self_painting_inline.index != owner_slot.index)
+                return {};
+            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(result.style_source);
+            if (!style_source || !layout_node_is_visible(*style_source))
+                return {};
+            return CaretPaint { from_ffi_css_pixel_rect(result.rect), style_source->caret_color() };
+        }
+        if (result.found) {
+            return {};
+        }
+    }
+
+    if (owner_inline) {
+        // Blank lines and empty editable elements are handled by the block / the box itself.
+        return {};
+    }
+    if (!is_visible(block)) {
+        // Blank-line and empty-element carets belong to this block itself.
+        return {};
+    }
+
+    if (!text_slots.is_empty()) {
+        auto empty_line = Layout::RustFFI::layout_arena_paintable_empty_line_caret_rect(
+            paintable->rust_arena().handle(), paintable->rust_slot(), text_slots.data(), text_slots.size(), cursor_position->offset());
+        if (empty_line.has_value) {
+            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(empty_line.style_source);
+            if (!style_source)
+                return {};
+            auto empty_line_rect = from_ffi_css_pixel_rect(empty_line.rect);
+            CSSPixelRect cursor_rect { empty_line_rect.x(), empty_line_rect.y(), 1, empty_line_rect.height() };
+            return CaretPaint { cursor_rect, style_source->caret_color() };
+        }
+    }
+
+    if (cursor_position->node() != GC::Ptr { dom_node })
+        return {};
+
+    return CaretPaint { caret_rect_for_child_offset(block, cursor_position->offset()), styled_block.caret_color() };
+}
+
+Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const& node)
+{
+    if (!node.paintable_ptr() || has_content(node))
+        return {};
+    auto const& styled_node = as<Layout::NodeWithStyle>(node);
+
+    if (!should_paint_cursor(node))
+        return {};
+
+    auto cursor_position = node.document().cursor_position();
+    VERIFY(cursor_position);
+
+    auto const* dom_node = node.dom_node();
+    if (!dom_node || cursor_position->node() != GC::Ptr { dom_node })
+        return {};
+
+    auto position = box_type_agnostic_position(node);
+    return CaretPaint {
+        .rect = { position.x(), position.y(), 1, styled_node.line_height() },
+        .color = styled_node.caret_color(),
+    };
+}
 
 Optional<CSS::BorderData> outline_data(Layout::Node const& node, CSS::ComputedValues const& computed_values)
 {

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -4,14 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/StyleInvalidation.h>
+#include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
+#include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Position.h>
+#include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextOffsetMapping.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
@@ -23,81 +31,514 @@ bool has_committed_box(Layout::Node const& node)
     return node.paintable_ptr();
 }
 
-#define FORWARD_BOX_VIEW(return_type, name, zero_value) \
-    return_type name(Layout::Node const& node)          \
-    {                                                   \
-        auto const* paintable = node.paintable_ptr();   \
-        if (!paintable)                                 \
-            return zero_value;                          \
-        return paintable->name();                       \
+static bool has_flag(Paintable const& paintable, Layout::RustFFI::PaintableFlag flag)
+{
+    return (paintable.rust_data().flags & to_underlying(flag)) != 0;
+}
+
+static PixelBox pixel_box_from_ffi(Layout::RustFFI::FfiPixelBox const& box)
+{
+    return { CSSPixels::from_raw(box.top), CSSPixels::from_raw(box.right), CSSPixels::from_raw(box.bottom), CSSPixels::from_raw(box.left) };
+}
+
+CSSPixelRect absolute_rect(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_rect(paintable->rust_arena().handle(), paintable->rust_slot()));
+}
+
+CSSPixelRect absolute_padding_box_rect(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_padding_box_rect(paintable->rust_arena().handle(), paintable->rust_slot()));
+}
+
+CSSPixelRect absolute_border_box_rect(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_border_box_rect(paintable->rust_arena().handle(), paintable->rust_slot()));
+}
+
+CSSPixelPoint absolute_position(Layout::Node const& node)
+{
+    return absolute_rect(node).location();
+}
+
+CSSPixels absolute_x(Layout::Node const& node)
+{
+    return absolute_rect(node).x();
+}
+
+CSSPixels absolute_y(Layout::Node const& node)
+{
+    return absolute_rect(node).y();
+}
+
+CSSPixelPoint offset(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return { CSSPixels::from_raw(paintable->rust_data().offset.x), CSSPixels::from_raw(paintable->rust_data().offset.y) };
+}
+
+CSSPixelSize content_size(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return { CSSPixels::from_raw(paintable->rust_data().content_size.width), CSSPixels::from_raw(paintable->rust_data().content_size.height) };
+}
+
+CSSPixels content_width(Layout::Node const& node)
+{
+    return content_size(node).width();
+}
+
+CSSPixels content_height(Layout::Node const& node)
+{
+    return content_size(node).height();
+}
+
+BoxModelMetrics box_model(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return {
+        .margin = pixel_box_from_ffi(paintable->rust_data().margin),
+        .padding = pixel_box_from_ffi(paintable->rust_data().padding),
+        .border = pixel_box_from_ffi(paintable->rust_data().border),
+        .inset = pixel_box_from_ffi(paintable->rust_data().inset),
+    };
+}
+
+CSSPixels border_box_width(Layout::Node const& node)
+{
+    auto border_box = box_model(node).border_box();
+    return content_width(node) + border_box.left + border_box.right;
+}
+
+CSSPixels border_box_height(Layout::Node const& node)
+{
+    auto border_box = box_model(node).border_box();
+    return content_height(node) + border_box.top + border_box.bottom;
+}
+
+Optional<OverflowData> overflow_data(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable || !paintable->rust_data().has_overflow)
+        return {};
+    return OverflowData { from_ffi_css_pixel_rect(paintable->rust_data().overflow.rect), paintable->rust_data().overflow.has_scrollable_overflow };
+}
+
+Optional<CachedOverflowData> cached_overflow_data(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable || !paintable->rust_data().has_cached_overflow)
+        return {};
+    return CachedOverflowData { from_ffi_css_pixel_rect(paintable->rust_data().cached_overflow.rect), paintable->rust_data().cached_overflow.has_scrollable_overflow };
+}
+
+bool has_scrollable_overflow(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return false;
+    if (auto const* box = as_if<Layout::Box>(node))
+        node.document().ensure_scrollable_overflow_is_measured(*box);
+    if (paintable->rust_data().has_overflow)
+        return paintable->rust_data().overflow.has_scrollable_overflow;
+    return paintable->rust_data().has_cached_overflow && paintable->rust_data().cached_overflow.has_scrollable_overflow;
+}
+
+Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    if (auto const* box = as_if<Layout::Box>(node))
+        node.document().ensure_scrollable_overflow_is_measured(*box);
+    if (paintable->rust_data().has_overflow)
+        return from_ffi_css_pixel_rect(paintable->rust_data().overflow.rect);
+    if (!paintable->rust_data().has_cached_overflow)
+        return {};
+    auto rect = from_ffi_css_pixel_rect(paintable->rust_data().cached_overflow.rect);
+    rect.translate_by(absolute_padding_box_rect(node).location());
+    return rect;
+}
+
+bool is_visible(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return false;
+    auto const& styled_node = as<Layout::NodeWithStyle>(node);
+    return styled_node.visibility() == CSS::Visibility::Visible && styled_node.opacity() != 0;
+}
+
+bool visible_for_hit_testing(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return false;
+    if (auto dom_node = paintable->dom_node(); dom_node && dom_node->is_inert())
+        return false;
+    return as<Layout::NodeWithStyle>(node).pointer_events() != CSS::PointerEvents::None;
+}
+
+bool has_stacking_context(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->rust_data().stacking_context != Layout::RustFFI::NO_STACKING_CONTEXT;
+}
+
+CSS::Display display(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return CSS::display_from_ffi_display(CSS::decode_ffi_display(paintable->rust_data().display));
+}
+
+bool is_positioned(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::Positioned);
+}
+
+bool is_fixed_position(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::FixedPosition);
+}
+
+bool is_sticky_position(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::StickyPosition);
+}
+
+bool is_absolutely_positioned(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::AbsolutelyPositioned);
+}
+
+bool is_floating(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::Floating);
+}
+
+bool is_inline(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::Inline);
+}
+
+bool has_css_transform(Layout::Node const& node)
+{
+    return node.paintable_ptr() && as<Layout::NodeWithStyle>(node).has_css_transform();
+}
+
+bool has_non_invertible_css_transform(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && has_flag(*paintable, Layout::RustFFI::PaintableFlag::HasNonInvertibleCssTransform);
+}
+
+bool uses_collapsing_borders_model(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->rust_data().uses_collapsing_borders_model;
+}
+
+SelectionState selection_state(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return static_cast<SelectionState>(paintable->rust_data().selection_state);
+}
+
+CSS::StyleRecordID style_record_identity(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return {};
+    return as<Layout::NodeWithStyle>(node).style_record_identity();
+}
+
+static StringView class_name_for_kind(Layout::RustFFI::PaintableKind kind)
+{
+    switch (kind) {
+    case Layout::RustFFI::PaintableKind::None:
+    case Layout::RustFFI::PaintableKind::Paintable:
+        return "Paintable"sv;
+    case Layout::RustFFI::PaintableKind::PaintableWithLines:
+        return "PaintableWithLines"sv;
+    case Layout::RustFFI::PaintableKind::InlinePaintable:
+        return "InlinePaintable"sv;
+    case Layout::RustFFI::PaintableKind::ViewportPaintable:
+        return "ViewportPaintable"sv;
+    case Layout::RustFFI::PaintableKind::ImagePaintable:
+        return "ImagePaintable"sv;
+    case Layout::RustFFI::PaintableKind::CanvasPaintable:
+        return "CanvasPaintable"sv;
+    case Layout::RustFFI::PaintableKind::VideoPaintable:
+        return "VideoPaintable"sv;
+    case Layout::RustFFI::PaintableKind::CheckBoxPaintable:
+        return "CheckBoxPaintable"sv;
+    case Layout::RustFFI::PaintableKind::RadioButtonPaintable:
+        return "RadioButtonPaintable"sv;
+    case Layout::RustFFI::PaintableKind::FieldSetPaintable:
+        return "FieldSetPaintable"sv;
+    case Layout::RustFFI::PaintableKind::NavigableContainerViewportPaintable:
+        return "NavigableContainerViewportPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGSVGPaintable:
+        return "SVGSVGPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGPathPaintable:
+        return "SVGPathPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGGraphicsPaintable:
+        return "SVGGraphicsPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGImagePaintable:
+        return "SVGImagePaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGMaskPaintable:
+        return "SVGMaskPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGClipPaintable:
+        return "SVGClipPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGPatternPaintable:
+        return "SVGPatternPaintable"sv;
+    case Layout::RustFFI::PaintableKind::SVGForeignObjectPaintable:
+        return "SVGForeignObjectPaintable"sv;
     }
+    VERIFY_NOT_REACHED();
+}
 
-FORWARD_BOX_VIEW(CSSPixelRect, absolute_rect, {})
-FORWARD_BOX_VIEW(CSSPixelRect, absolute_padding_box_rect, {})
-FORWARD_BOX_VIEW(CSSPixelRect, absolute_border_box_rect, {})
-FORWARD_BOX_VIEW(CSSPixelPoint, absolute_position, {})
-FORWARD_BOX_VIEW(CSSPixels, absolute_x, {})
-FORWARD_BOX_VIEW(CSSPixels, absolute_y, {})
-FORWARD_BOX_VIEW(CSSPixelPoint, offset, {})
-FORWARD_BOX_VIEW(CSSPixelSize, content_size, {})
-FORWARD_BOX_VIEW(CSSPixels, content_width, {})
-FORWARD_BOX_VIEW(CSSPixels, content_height, {})
-FORWARD_BOX_VIEW(CSSPixels, border_box_width, {})
-FORWARD_BOX_VIEW(CSSPixels, border_box_height, {})
-FORWARD_BOX_VIEW(BoxModelMetrics, box_model, {})
-FORWARD_BOX_VIEW(CSSPixels, outline_offset, {})
-FORWARD_BOX_VIEW(CSSPixelRect, transform_reference_box, {})
-FORWARD_BOX_VIEW(Optional<CSSPixelRect>, scrollable_overflow_rect, {})
-FORWARD_BOX_VIEW(bool, has_scrollable_overflow, false)
-FORWARD_BOX_VIEW(Optional<Paintable::OverflowData>, overflow_data, {})
-FORWARD_BOX_VIEW(Optional<Paintable::CachedOverflowData>, cached_overflow_data, {})
+StringView class_name(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? class_name_for_kind(paintable->kind()) : StringView {};
+}
 
-FORWARD_BOX_VIEW(bool, is_visible, false)
-FORWARD_BOX_VIEW(bool, visible_for_hit_testing, false)
-FORWARD_BOX_VIEW(bool, has_stacking_context, false)
-FORWARD_BOX_VIEW(Optional<int>, effective_z_index, {})
-FORWARD_BOX_VIEW(CSS::Display, display, {})
-FORWARD_BOX_VIEW(bool, is_positioned, false)
-FORWARD_BOX_VIEW(bool, is_fixed_position, false)
-FORWARD_BOX_VIEW(bool, is_sticky_position, false)
-FORWARD_BOX_VIEW(bool, is_absolutely_positioned, false)
-FORWARD_BOX_VIEW(bool, is_floating, false)
-FORWARD_BOX_VIEW(bool, is_inline, false)
-FORWARD_BOX_VIEW(bool, has_css_transform, false)
-FORWARD_BOX_VIEW(bool, has_non_invertible_css_transform, false)
-FORWARD_BOX_VIEW(bool, uses_collapsing_borders_model, false)
-FORWARD_BOX_VIEW(SelectionState, selection_state, {})
-FORWARD_BOX_VIEW(CSS::StyleRecordID, style_record_identity, {})
-FORWARD_BOX_VIEW(StringView, class_name, {})
-FORWARD_BOX_VIEW(String, debug_description, {})
-FORWARD_BOX_VIEW(bool, is_navigable_container_viewport_paintable, false)
-FORWARD_BOX_VIEW(bool, is_viewport_paintable, false)
-FORWARD_BOX_VIEW(bool, is_paintable_with_lines, false)
-FORWARD_BOX_VIEW(bool, is_inline_paintable, false)
-FORWARD_BOX_VIEW(bool, is_svg_paintable, false)
-FORWARD_BOX_VIEW(bool, is_svg_svg_paintable, false)
-FORWARD_BOX_VIEW(bool, is_svg_path_paintable, false)
-FORWARD_BOX_VIEW(bool, is_svg_foreign_object_paintable, false)
+String debug_description(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return {};
+    return MUST(String::formatted("{}({})", class_name(node), node.debug_description()));
+}
 
-FORWARD_BOX_VIEW(bool, has_accumulated_visual_context, false)
-FORWARD_BOX_VIEW(VisualContextIndex, accumulated_visual_context_index, {})
-FORWARD_BOX_VIEW(VisualContextIndex, accumulated_visual_context_for_descendants_index, {})
-FORWARD_BOX_VIEW(Optional<VisualContextIndex>, fixed_background_visual_context, {})
-FORWARD_BOX_VIEW(VisualContextIndex, enclosing_scroll_node_index, {})
-FORWARD_BOX_VIEW(VisualContextIndex, own_scroll_node_index, {})
+bool is_navigable_container_viewport_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::NavigableContainerViewportPaintable;
+}
 
-FORWARD_BOX_VIEW(Gfx::Path const*, committed_svg_path, nullptr)
-FORWARD_BOX_VIEW(CSSPixelSize, svg_viewport_size, {})
-FORWARD_BOX_VIEW(Optional<Gfx::AffineTransform>, svg_viewport_transform, {})
-FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_columns, {})
-FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_rows, {})
+bool is_viewport_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::ViewportPaintable;
+}
 
-FORWARD_BOX_VIEW(CSSPixelPoint, box_type_agnostic_position, {})
-FORWARD_BOX_VIEW(Paintable::SelectionStyle, selection_style, {})
-FORWARD_BOX_VIEW(StickyInsets, sticky_insets, {})
-FORWARD_BOX_VIEW(bool, has_sticky_insets, false)
+bool is_paintable_with_lines(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return false;
+    auto kind = paintable->kind();
+    return kind == Layout::RustFFI::PaintableKind::PaintableWithLines
+        || kind == Layout::RustFFI::PaintableKind::ViewportPaintable
+        || kind == Layout::RustFFI::PaintableKind::SVGForeignObjectPaintable;
+}
 
-#undef FORWARD_BOX_VIEW
+bool is_inline_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::InlinePaintable;
+}
+
+bool is_svg_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return false;
+    switch (paintable->kind()) {
+    case Layout::RustFFI::PaintableKind::SVGGraphicsPaintable:
+    case Layout::RustFFI::PaintableKind::SVGPathPaintable:
+    case Layout::RustFFI::PaintableKind::SVGImagePaintable:
+    case Layout::RustFFI::PaintableKind::SVGMaskPaintable:
+    case Layout::RustFFI::PaintableKind::SVGClipPaintable:
+    case Layout::RustFFI::PaintableKind::SVGPatternPaintable:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool is_svg_svg_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::SVGSVGPaintable;
+}
+
+bool is_svg_path_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::SVGPathPaintable;
+}
+
+bool is_svg_foreign_object_paintable(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->kind() == Layout::RustFFI::PaintableKind::SVGForeignObjectPaintable;
+}
+
+Optional<int> effective_z_index(Layout::Node const& node)
+{
+    if (!node.paintable_ptr() || !is_positioned(node))
+        return {};
+    return as<Layout::NodeWithStyle>(node).z_index();
+}
+
+bool has_accumulated_visual_context(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->rust_data().has_accumulated_visual_context;
+}
+
+VisualContextIndex accumulated_visual_context_index(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? VisualContextIndex { paintable->rust_data().accumulated_visual_context_index } : VisualContextIndex {};
+}
+
+VisualContextIndex accumulated_visual_context_for_descendants_index(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? VisualContextIndex { paintable->rust_data().accumulated_visual_context_for_descendants_index } : VisualContextIndex {};
+}
+
+Optional<VisualContextIndex> fixed_background_visual_context(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable || !paintable->rust_data().has_fixed_background_visual_context)
+        return {};
+    return VisualContextIndex { paintable->rust_data().fixed_background_visual_context };
+}
+
+VisualContextIndex enclosing_scroll_node_index(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? VisualContextIndex { paintable->rust_data().enclosing_scroll_node_index } : VisualContextIndex {};
+}
+
+VisualContextIndex own_scroll_node_index(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? VisualContextIndex { paintable->rust_data().own_scroll_node_index } : VisualContextIndex {};
+}
+
+Gfx::Path const* committed_svg_path(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return nullptr;
+    return static_cast<Gfx::Path const*>(Layout::RustFFI::layout_arena_paintable_computed_svg_path(paintable->rust_arena().handle(), paintable->rust_slot()));
+}
+
+CSSPixelSize svg_viewport_size(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return {
+        CSSPixels::from_raw(paintable->rust_data().svg_viewport_size.width),
+        CSSPixels::from_raw(paintable->rust_data().svg_viewport_size.height),
+    };
+}
+
+Optional<Gfx::AffineTransform> svg_viewport_transform(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable || !paintable->rust_data().has_svg_viewport_transform)
+        return {};
+    auto const& transform = paintable->rust_data().svg_viewport_transform;
+    return Gfx::AffineTransform { transform.a, transform.b, transform.c, transform.d, transform.e, transform.f };
+}
+
+Optional<UsedGridTrackList> used_values_for_grid_template_columns(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    Optional<UsedGridTrackList> result;
+    Layout::RustFFI::layout_arena_paintable_used_grid_tracks(paintable->rust_arena().handle(), paintable->rust_slot(), &result,
+        [](void* context, Layout::RustFFI::FfiUsedGridTrackList const* columns, Layout::RustFFI::FfiUsedGridTrackList const*) {
+            *static_cast<Optional<UsedGridTrackList>*>(context) = Layout::build_used_grid_track_list(*columns);
+        });
+    return result;
+}
+
+Optional<UsedGridTrackList> used_values_for_grid_template_rows(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    Optional<UsedGridTrackList> result;
+    Layout::RustFFI::layout_arena_paintable_used_grid_tracks(paintable->rust_arena().handle(), paintable->rust_slot(), &result,
+        [](void* context, Layout::RustFFI::FfiUsedGridTrackList const*, Layout::RustFFI::FfiUsedGridTrackList const* rows) {
+            *static_cast<Optional<UsedGridTrackList>*>(context) = Layout::build_used_grid_track_list(*rows);
+        });
+    return result;
+}
+
+CSSPixelPoint box_type_agnostic_position(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    if (paintable->kind() == Layout::RustFFI::PaintableKind::InlinePaintable) {
+        auto result = Layout::RustFFI::layout_arena_inline_paintable_first_piece_position(paintable->rust_arena().handle(), paintable->rust_slot());
+        if (result.has_value)
+            return { CSSPixels::from_raw(result.x), CSSPixels::from_raw(result.y) };
+    }
+    return absolute_position(node);
+}
+
+SelectionStyle selection_style(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    return selection_style_for_node(node, paintable->dom_node());
+}
+
+bool has_sticky_insets(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable && paintable->rust_data().has_sticky_insets;
+}
+
+StickyInsets sticky_insets(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    VERIFY(has_sticky_insets(node));
+    auto const& insets = paintable->rust_data().sticky_insets;
+    auto side = [](i32 raw, bool present) -> Optional<CSSPixels> {
+        if (!present)
+            return {};
+        return CSSPixels::from_raw(raw);
+    };
+    return { side(insets.top, insets.has_top), side(insets.right, insets.has_right), side(insets.bottom, insets.has_bottom), side(insets.left, insets.has_left) };
+}
 
 bool should_paint_cursor(Layout::Node const& node)
 {
@@ -308,99 +749,395 @@ Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const& node
     };
 }
 
+static Optional<CSS::BorderData> border_data_for_outline(Layout::Node const& layout_node, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width)
+{
+    CSS::LineStyle line_style;
+    if (outline_style == CSS::OutlineStyle::Auto) {
+        line_style = CSS::LineStyle::Solid;
+        outline_color = CSS::KeywordStyleValue::create(CSS::Keyword::Accentcolor)->to_color(CSS::ColorResolutionContext::for_layout_node_with_style(*static_cast<Layout::NodeWithStyle const*>(&layout_node))).value();
+        outline_width = 2;
+    } else {
+        line_style = CSS::keyword_to_line_style(CSS::to_keyword(outline_style)).value_or(CSS::LineStyle::None);
+    }
+
+    if (outline_color.alpha() == 0 || line_style == CSS::LineStyle::None || outline_width == 0)
+        return {};
+
+    return CSS::BorderData {
+        .color = outline_color,
+        .line_style = line_style,
+        .width = outline_width,
+    };
+}
+
 Optional<CSS::BorderData> outline_data(Layout::Node const& node, CSS::ComputedValues const& computed_values)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->outline_data(computed_values) : Optional<CSS::BorderData> {};
+    if (!node.paintable_ptr())
+        return {};
+
+    // The `auto` outline is the UA focus ring; like native controls, it is only shown while the window has focus.
+    auto navigable = node.document().navigable();
+    if (computed_values.outline_style() == CSS::OutlineStyle::Auto && (!navigable || !navigable->is_focused()))
+        return {};
+
+    return border_data_for_outline(node, computed_values.outline_color(), computed_values.outline_style(), computed_values.outline_width());
+}
+
+CSSPixels outline_offset(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return {};
+    return as<Layout::NodeWithStyle>(node).outline_offset();
+}
+
+CSSPixelRect transform_reference_box(Layout::Node const& node)
+{
+    if (!node.paintable_ptr())
+        return {};
+
+    auto transform_box = as<Layout::NodeWithStyle>(node).transform_box();
+    // For SVG elements without associated CSS layout box, the used value for content-box is fill-box and for
+    // border-box is stroke-box.
+    // FIXME: This currently detects any SVG element except the <svg> one. Is that correct?
+    //        And is it correct to use `else` below?
+    if (is_svg_paintable(node)) {
+        switch (transform_box) {
+        case CSS::TransformBox::ContentBox:
+            transform_box = CSS::TransformBox::FillBox;
+            break;
+        case CSS::TransformBox::BorderBox:
+            transform_box = CSS::TransformBox::StrokeBox;
+            break;
+        default:
+            break;
+        }
+    }
+    // For elements with associated CSS layout box, the used value for fill-box is content-box and for
+    // stroke-box and view-box is border-box.
+    else {
+        switch (transform_box) {
+        case CSS::TransformBox::FillBox:
+            transform_box = CSS::TransformBox::ContentBox;
+            break;
+        case CSS::TransformBox::StrokeBox:
+        case CSS::TransformBox::ViewBox:
+            transform_box = CSS::TransformBox::BorderBox;
+            break;
+        default:
+            break;
+        }
+    }
+
+    switch (transform_box) {
+    case CSS::TransformBox::ContentBox:
+        // Uses the content box as reference box.
+        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
+        return absolute_rect(node);
+    case CSS::TransformBox::BorderBox:
+        // Uses the border box as reference box.
+        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
+        return absolute_border_box_rect(node);
+    case CSS::TransformBox::FillBox:
+        // Uses the object bounding box as reference box.
+        // FIXME: For now we're using the content rect as an approximation.
+        return absolute_rect(node);
+    case CSS::TransformBox::StrokeBox:
+        // Uses the stroke bounding box as reference box.
+        // FIXME: For now we're using the border rect as an approximation.
+        return absolute_border_box_rect(node);
+    case CSS::TransformBox::ViewBox: {
+        // Uses the nearest SVG viewport as reference box.
+        // FIXME: If a viewBox attribute is specified for the SVG viewport creating element:
+        //  - The reference box is positioned at the origin of the coordinate system established by the viewBox attribute.
+        //  - The dimension of the reference box is set to the width and height values of the viewBox attribute.
+        auto const* viewport_paintable = nearest_svg_viewport_paintable_of(node);
+        if (!viewport_paintable)
+            return absolute_border_box_rect(node);
+        return svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
+    }
+    }
+    VERIFY_NOT_REACHED();
 }
 
 CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->transform_rect_to_viewport(rect, include_visual_viewport_transform) : CSSPixelRect {};
+    if (!node.paintable_ptr())
+        return {};
+    auto const& document = node.document();
+    if (!document.paintable())
+        return rect;
+    auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
+    auto result = document.visual_context_tree().transform_rect_to_viewport(
+        accumulated_visual_context_index(node), rect.to_type<float>() * pixel_ratio,
+        document.scroll_state_snapshot(), include_visual_viewport_transform);
+    return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();
 }
 
 Optional<CSSPixelPoint> transform_point_to_local(Layout::Node const& node, CSSPixelPoint position)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->transform_point_to_local(position) : Optional<CSSPixelPoint> {};
+    if (!node.paintable_ptr())
+        return {};
+    auto const& document = node.document();
+    if (!document.paintable())
+        return position;
+    auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
+    auto result = document.visual_context_tree().transform_point_for_hit_test(
+        accumulated_visual_context_index(node), position.to_type<float>() * pixel_ratio,
+        document.scroll_state_snapshot());
+    if (!result.has_value())
+        return {};
+    return (*result / pixel_ratio).to_type<CSSPixels>();
 }
 
 Optional<CSSPixelPoint> transform_point_to_local_for_descendants(Layout::Node const& node, CSSPixelPoint position)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->transform_point_to_local_for_descendants(position) : Optional<CSSPixelPoint> {};
+    if (!node.paintable_ptr())
+        return {};
+    auto const& document = node.document();
+    if (!document.paintable())
+        return position;
+    auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
+    auto result = document.visual_context_tree().transform_point_for_hit_test(
+        accumulated_visual_context_for_descendants_index(node), position.to_type<float>() * pixel_ratio,
+        document.scroll_state_snapshot());
+    if (!result.has_value())
+        return {};
+    return (*result / pixel_ratio).to_type<CSSPixels>();
 }
 
 CSSPixelPoint inverse_transform_point(Layout::Node const& node, CSSPixelPoint position)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->inverse_transform_point(position) : CSSPixelPoint {};
+    if (!node.paintable_ptr())
+        return {};
+    auto const& document = node.document();
+    if (!document.paintable())
+        return position;
+    auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
+    auto result = document.visual_context_tree().inverse_transform_point(accumulated_visual_context_index(node), position.to_type<float>() * pixel_ratio);
+    return (result / pixel_ratio).to_type<CSSPixels>();
 }
 
 CSSPixelPoint transform_to_local_coordinates(Layout::Node const& node, CSSPixelPoint position)
 {
-    auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->transform_to_local_coordinates(position) : CSSPixelPoint {};
+    if (!node.paintable_ptr())
+        return {};
+    return transform_point_to_local(node, position).value_or(position);
 }
 
 Optional<String> grid_layout_json(Layout::Node const& node, UniqueNodeID container_node_id)
 {
     auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->grid_layout_json(container_node_id) : Optional<String> {};
+    if (!paintable)
+        return {};
+    Optional<String> result;
+    Layout::RustFFI::layout_arena_paintable_grid_layout_json(paintable->rust_arena().handle(), paintable->rust_slot(), container_node_id.value(), &result,
+        [](void* context, u8 const* bytes, size_t length) {
+            *static_cast<Optional<String>*>(context) = MUST(String::from_utf8(StringView { bytes, length }));
+        });
+    return result;
 }
 
 Optional<String> flex_layout_json(Layout::Node const& node, UniqueNodeID container_node_id)
 {
     auto const* paintable = node.paintable_ptr();
-    return paintable ? paintable->flex_layout_json(container_node_id) : Optional<String> {};
+    if (!paintable)
+        return {};
+    Optional<String> result;
+    Layout::RustFFI::layout_arena_paintable_flex_layout_json(paintable->rust_arena().handle(), paintable->rust_slot(), container_node_id.value(), &result,
+        [](void* context, u8 const* bytes, size_t length) {
+            *static_cast<Optional<String>*>(context) = MUST(String::from_utf8(StringView { bytes, length }));
+        });
+    return result;
 }
 
-Paintable::SelectionStyle selection_style_for_node(Layout::Node const& node, GC::Ptr<DOM::Node const> dom_node)
+SelectionStyle selection_style_for_node(Layout::Node const& layout_node, GC::Ptr<DOM::Node const> node)
 {
-    return Paintable::selection_style_for_node(node, dom_node);
+    // Selections render in a muted color while the window does not have focus.
+    auto navigable = layout_node.document().navigable();
+    auto window_is_active = navigable && navigable->is_focused();
+    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(layout_node);
+    auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
+
+    auto default_style_for_color_scheme = [&](CSS::PreferredColorScheme color_scheme, bool use_palette_for_normal_color_scheme = true) {
+        auto palette = layout_node.document().page().palette();
+        auto palette_color_scheme = palette.is_dark() ? CSS::PreferredColorScheme::Dark : CSS::PreferredColorScheme::Light;
+        if (color_scheme == palette_color_scheme || use_palette_for_normal_color_scheme) {
+            auto background = window_is_active ? palette.selection() : palette.inactive_selection();
+            return SelectionStyle { CSS::SystemColor::transform_selection_background_color(background) };
+        }
+
+        auto background = window_is_active ? CSS::SystemColor::highlight(color_scheme) : CSS::SystemColor::inactive_highlight(color_scheme);
+        return SelectionStyle { CSS::SystemColor::transform_selection_background_color(background) };
+    };
+
+    // For text nodes, check the parent element since text nodes don't have computed properties.
+    if (!node)
+        return default_style_for_color_scheme(style_source.color_scheme());
+
+    DOM::Element const* element = as_if<DOM::Element>(*node);
+    if (!element)
+        element = node->parent_element().ptr();
+    if (!element)
+        return default_style_for_color_scheme(style_source.color_scheme());
+
+    auto color_scheme_is_normal = style_source.color_schemes().is_empty();
+    auto use_palette_for_normal_color_scheme = color_scheme_is_normal && !layout_node.document().supported_color_schemes().has_value();
+    auto default_style = default_style_for_color_scheme(style_source.color_scheme(), use_palette_for_normal_color_scheme);
+
+    auto style_from_element = [&](DOM::Element const& element) -> Optional<SelectionStyle> {
+        auto computed_selection_style = element.computed_style(CSS::PseudoElement::Selection);
+        if (!computed_selection_style)
+            return {};
+
+        SelectionStyle style;
+        style.background_color = computed_selection_style->background_color();
+
+        // Only use text color if it was explicitly set in the ::selection rule, not inherited.
+        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::Color))
+            style.text_color = computed_selection_style->color();
+
+        // Only use text-shadow if it was explicitly set in the ::selection rule, not inherited.
+        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::TextShadow)) {
+            auto const& css_shadows = computed_selection_style->text_shadow();
+            Vector<ShadowData> shadows;
+            shadows.ensure_capacity(css_shadows.size());
+            for (auto const& shadow : css_shadows)
+                shadows.unchecked_append(ShadowData::from_css(shadow));
+            style.text_shadow = move(shadows);
+        }
+
+        // Only use text-decoration if it was explicitly set in the ::selection rule, not inherited.
+        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::TextDecorationLine)) {
+            style.text_decoration = TextDecorationStyle {
+                .line = Vector<CSS::TextDecorationLine> { computed_selection_style->text_decoration_line() },
+                .style = computed_selection_style->text_decoration_style(),
+                .color = computed_selection_style->text_decoration_color(),
+            };
+        }
+
+        // Only return a style if there's a meaningful customization. This allows us to continue checking shadow hosts
+        // when the current element only has UA default styles.
+        if (!style.has_styling())
+            return {};
+
+        return style;
+    };
+
+    // Check the element itself.
+    if (auto style = style_from_element(*element); style.has_value())
+        return style.release_value();
+
+    // If inside a shadow tree, check the shadow host. This enables ::selection styling on elements like <input> to
+    // apply to text rendered inside their shadow DOM.
+    if (auto shadow_root = element->containing_shadow_root(); shadow_root && shadow_root->is_user_agent_internal()) {
+        if (auto const* host = shadow_root->host()) {
+            if (auto style = style_from_element(*host); style.has_value())
+                return style.release_value();
+        }
+    }
+
+    return default_style;
 }
+
+class BoxViewRepaintAccess {
+public:
+    static void set_document_needs_repaint(DOM::Document& document, InvalidateDisplayList should_invalidate_display_list)
+    {
+        document.set_needs_repaint(Badge<BoxViewRepaintAccess> {}, should_invalidate_display_list);
+    }
+};
 
 void set_needs_repaint(Layout::Node const& node, InvalidateDisplayList should_invalidate_display_list)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->set_needs_repaint(should_invalidate_display_list);
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return;
+
+    auto& document = const_cast<DOM::Document&>(node.document());
+    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
+        Layout::RustFFI::layout_arena_paintable_invalidate_for_repaint(paintable->rust_arena().handle(), paintable->rust_slot());
+
+        // The root element paints the body's propagated background, so a body repaint must also refresh the
+        // root's cached background. A root repaint can conversely flip whether propagation applies, changing
+        // what the body itself paints.
+        if (body_background_is_propagated_to_root(as<Layout::NodeWithStyle>(node))) {
+            if (auto const* document_element = document.document_element()) {
+                if (auto const* document_element_layout_node = document_element->unsafe_layout_node())
+                    invalidate_paint_cache(*document_element_layout_node);
+            }
+        } else if (node.is_root_element()) {
+            if (auto const* body = document.body()) {
+                if (auto const* body_layout_node = body->unsafe_layout_node())
+                    invalidate_paint_cache(*body_layout_node);
+            }
+        }
+    }
+    BoxViewRepaintAccess::set_document_needs_repaint(document, should_invalidate_display_list);
 }
 
 void invalidate_paint_cache(Layout::Node const& node)
 {
     if (auto const* paintable = node.paintable_ptr())
-        paintable->invalidate_paint_cache();
+        mirror_rust_invalidate_paint_cache(*paintable);
 }
 
 void repaint_after_style_change(Layout::Node const& node, CSS::RequiredInvalidationAfterStyleChange const& invalidation)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->repaint_after_style_change(invalidation);
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return;
+    if (invalidation.needs_repaint())
+        set_needs_repaint(node);
+    if (invalidation.repaint_propagated_text_decorations)
+        rust_invalidate_propagated_text_decoration_caches(*paintable);
 }
 
 void invalidate_stacking_context(Layout::Node const& node)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->invalidate_stacking_context();
+    if (!node.paintable_ptr())
+        return;
+    if (auto viewport_paintable = node.document().unsafe_paintable())
+        const_cast<ViewportPaintable&>(*viewport_paintable).invalidate_stacking_context_tree();
 }
 
 void clear_overflow_data(Layout::Node const& node)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->clear_overflow_data();
+    if (auto const* paintable = node.paintable_ptr())
+        Layout::RustFFI::layout_arena_paintable_clear_overflow_data(paintable->rust_arena().handle(), paintable->rust_slot());
 }
 
 void clear_cached_overflow_data(Layout::Node const& node)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->clear_cached_overflow_data();
+    if (auto const* paintable = node.paintable_ptr())
+        Layout::RustFFI::layout_arena_paintable_clear_cached_overflow_data(paintable->rust_arena().handle(), paintable->rust_slot());
 }
 
 void set_sticky_insets(Layout::Node const& node, OwnPtr<StickyInsets> sticky_insets)
 {
-    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
-        paintable->set_sticky_insets(move(sticky_insets));
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return;
+    Layout::RustFFI::FfiStickyInsets ffi_insets {};
+    if (sticky_insets) {
+        auto pack = [](Optional<CSSPixels> const& value, i32& raw, bool& present) {
+            present = value.has_value();
+            raw = value.has_value() ? value->raw_value() : 0;
+        };
+        pack(sticky_insets->top, ffi_insets.top, ffi_insets.has_top);
+        pack(sticky_insets->right, ffi_insets.right, ffi_insets.has_right);
+        pack(sticky_insets->bottom, ffi_insets.bottom, ffi_insets.has_bottom);
+        pack(sticky_insets->left, ffi_insets.left, ffi_insets.has_left);
+    }
+    Layout::RustFFI::layout_arena_paintable_set_sticky_insets(paintable->rust_arena().handle(), paintable->rust_slot(), ffi_insets, !!sticky_insets);
+}
+
+void transfer_fragments_to_replacement_node(Layout::Node const& containing_block, Layout::Node const& old_node, Layout::Node const& new_node)
+{
+    auto const* paintable = containing_block.paintable_ptr();
+    if (!paintable || !is_paintable_with_lines(containing_block))
+        return;
+    Layout::RustFFI::layout_arena_paintable_transfer_fragments_to_replacement_node(
+        paintable->rust_arena().handle(), paintable->rust_slot(), Layout::Node::slot_id(&old_node), Layout::Node::slot_id(&new_node));
 }
 
 void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect>& rects)
@@ -422,13 +1159,12 @@ void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect
 
 CSSPixelPoint cumulative_scroll_compensation(Layout::Node const& node)
 {
-    auto const* paintable = node.paintable_ptr();
-    if (!paintable)
+    if (!node.paintable_ptr())
         return {};
-    auto index = paintable->enclosing_scroll_node_index();
+    auto index = enclosing_scroll_node_index(node);
     if (!index.value())
         return {};
-    return paintable->document().paintable()->cumulative_scroll_offset_for_node(index);
+    return node.document().paintable()->cumulative_scroll_offset_for_node(index);
 }
 
 }

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
+
+namespace Web::Painting {
+
+bool has_committed_box(Layout::Node const& node)
+{
+    return node.paintable_ptr();
+}
+
+#define FORWARD_BOX_VIEW(return_type, name, zero_value) \
+    return_type name(Layout::Node const& node)          \
+    {                                                   \
+        auto const* paintable = node.paintable_ptr();   \
+        if (!paintable)                                 \
+            return zero_value;                          \
+        return paintable->name();                       \
+    }
+
+FORWARD_BOX_VIEW(CSSPixelRect, absolute_rect, {})
+FORWARD_BOX_VIEW(CSSPixelRect, absolute_padding_box_rect, {})
+FORWARD_BOX_VIEW(CSSPixelRect, absolute_border_box_rect, {})
+FORWARD_BOX_VIEW(CSSPixelPoint, absolute_position, {})
+FORWARD_BOX_VIEW(CSSPixels, absolute_x, {})
+FORWARD_BOX_VIEW(CSSPixels, absolute_y, {})
+FORWARD_BOX_VIEW(CSSPixelPoint, offset, {})
+FORWARD_BOX_VIEW(CSSPixelSize, content_size, {})
+FORWARD_BOX_VIEW(CSSPixels, content_width, {})
+FORWARD_BOX_VIEW(CSSPixels, content_height, {})
+FORWARD_BOX_VIEW(CSSPixels, border_box_width, {})
+FORWARD_BOX_VIEW(CSSPixels, border_box_height, {})
+FORWARD_BOX_VIEW(BoxModelMetrics, box_model, {})
+FORWARD_BOX_VIEW(CSSPixels, outline_offset, {})
+FORWARD_BOX_VIEW(CSSPixelRect, transform_reference_box, {})
+FORWARD_BOX_VIEW(Optional<CSSPixelRect>, scrollable_overflow_rect, {})
+FORWARD_BOX_VIEW(bool, has_scrollable_overflow, false)
+FORWARD_BOX_VIEW(Optional<Paintable::OverflowData>, overflow_data, {})
+FORWARD_BOX_VIEW(Optional<Paintable::CachedOverflowData>, cached_overflow_data, {})
+
+FORWARD_BOX_VIEW(bool, is_visible, false)
+FORWARD_BOX_VIEW(bool, visible_for_hit_testing, false)
+FORWARD_BOX_VIEW(bool, has_stacking_context, false)
+FORWARD_BOX_VIEW(Optional<int>, effective_z_index, {})
+FORWARD_BOX_VIEW(CSS::Display, display, {})
+FORWARD_BOX_VIEW(bool, is_positioned, false)
+FORWARD_BOX_VIEW(bool, is_fixed_position, false)
+FORWARD_BOX_VIEW(bool, is_sticky_position, false)
+FORWARD_BOX_VIEW(bool, is_absolutely_positioned, false)
+FORWARD_BOX_VIEW(bool, is_floating, false)
+FORWARD_BOX_VIEW(bool, is_inline, false)
+FORWARD_BOX_VIEW(bool, has_css_transform, false)
+FORWARD_BOX_VIEW(bool, has_non_invertible_css_transform, false)
+FORWARD_BOX_VIEW(bool, uses_collapsing_borders_model, false)
+FORWARD_BOX_VIEW(SelectionState, selection_state, {})
+FORWARD_BOX_VIEW(CSS::StyleRecordID, style_record_identity, {})
+FORWARD_BOX_VIEW(StringView, class_name, {})
+FORWARD_BOX_VIEW(String, debug_description, {})
+FORWARD_BOX_VIEW(bool, is_navigable_container_viewport_paintable, false)
+FORWARD_BOX_VIEW(bool, is_viewport_paintable, false)
+FORWARD_BOX_VIEW(bool, is_paintable_with_lines, false)
+FORWARD_BOX_VIEW(bool, is_inline_paintable, false)
+FORWARD_BOX_VIEW(bool, is_svg_paintable, false)
+FORWARD_BOX_VIEW(bool, is_svg_svg_paintable, false)
+FORWARD_BOX_VIEW(bool, is_svg_path_paintable, false)
+FORWARD_BOX_VIEW(bool, is_svg_foreign_object_paintable, false)
+
+FORWARD_BOX_VIEW(bool, has_accumulated_visual_context, false)
+FORWARD_BOX_VIEW(VisualContextIndex, accumulated_visual_context_index, {})
+FORWARD_BOX_VIEW(VisualContextIndex, accumulated_visual_context_for_descendants_index, {})
+FORWARD_BOX_VIEW(Optional<VisualContextIndex>, fixed_background_visual_context, {})
+FORWARD_BOX_VIEW(VisualContextIndex, enclosing_scroll_node_index, {})
+FORWARD_BOX_VIEW(VisualContextIndex, own_scroll_node_index, {})
+
+FORWARD_BOX_VIEW(Gfx::Path const*, committed_svg_path, nullptr)
+FORWARD_BOX_VIEW(CSSPixelSize, svg_viewport_size, {})
+FORWARD_BOX_VIEW(Optional<Gfx::AffineTransform>, svg_viewport_transform, {})
+FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_columns, {})
+FORWARD_BOX_VIEW(Optional<UsedGridTrackList>, used_values_for_grid_template_rows, {})
+
+FORWARD_BOX_VIEW(CSSPixelPoint, box_type_agnostic_position, {})
+FORWARD_BOX_VIEW(bool, should_paint_cursor, false)
+FORWARD_BOX_VIEW(Paintable::SelectionStyle, selection_style, {})
+FORWARD_BOX_VIEW(StickyInsets, sticky_insets, {})
+FORWARD_BOX_VIEW(bool, has_sticky_insets, false)
+
+#undef FORWARD_BOX_VIEW
+
+Optional<CSS::BorderData> outline_data(Layout::Node const& node, CSS::ComputedValues const& computed_values)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->outline_data(computed_values) : Optional<CSS::BorderData> {};
+}
+
+CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->transform_rect_to_viewport(rect, include_visual_viewport_transform) : CSSPixelRect {};
+}
+
+Optional<CSSPixelPoint> transform_point_to_local(Layout::Node const& node, CSSPixelPoint position)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->transform_point_to_local(position) : Optional<CSSPixelPoint> {};
+}
+
+Optional<CSSPixelPoint> transform_point_to_local_for_descendants(Layout::Node const& node, CSSPixelPoint position)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->transform_point_to_local_for_descendants(position) : Optional<CSSPixelPoint> {};
+}
+
+CSSPixelPoint inverse_transform_point(Layout::Node const& node, CSSPixelPoint position)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->inverse_transform_point(position) : CSSPixelPoint {};
+}
+
+CSSPixelPoint transform_to_local_coordinates(Layout::Node const& node, CSSPixelPoint position)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->transform_to_local_coordinates(position) : CSSPixelPoint {};
+}
+
+Optional<String> grid_layout_json(Layout::Node const& node, UniqueNodeID container_node_id)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->grid_layout_json(container_node_id) : Optional<String> {};
+}
+
+Optional<String> flex_layout_json(Layout::Node const& node, UniqueNodeID container_node_id)
+{
+    auto const* paintable = node.paintable_ptr();
+    return paintable ? paintable->flex_layout_json(container_node_id) : Optional<String> {};
+}
+
+Paintable::SelectionStyle selection_style_for_node(Layout::Node const& node, GC::Ptr<DOM::Node const> dom_node)
+{
+    return Paintable::selection_style_for_node(node, dom_node);
+}
+
+void set_needs_repaint(Layout::Node const& node, InvalidateDisplayList should_invalidate_display_list)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->set_needs_repaint(should_invalidate_display_list);
+}
+
+void invalidate_paint_cache(Layout::Node const& node)
+{
+    if (auto const* paintable = node.paintable_ptr())
+        paintable->invalidate_paint_cache();
+}
+
+void repaint_after_style_change(Layout::Node const& node, CSS::RequiredInvalidationAfterStyleChange const& invalidation)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->repaint_after_style_change(invalidation);
+}
+
+void invalidate_stacking_context(Layout::Node const& node)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->invalidate_stacking_context();
+}
+
+void clear_overflow_data(Layout::Node const& node)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->clear_overflow_data();
+}
+
+void clear_cached_overflow_data(Layout::Node const& node)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->clear_cached_overflow_data();
+}
+
+void set_sticky_insets(Layout::Node const& node, OwnPtr<StickyInsets> sticky_insets)
+{
+    if (auto* paintable = const_cast<Paintable*>(node.paintable_ptr()))
+        paintable->set_sticky_insets(move(sticky_insets));
+}
+
+void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect>& rects)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return;
+    Layout::RustFFI::layout_arena_inline_paintable_piece_border_box_rects(
+        paintable->rust_arena().handle(), paintable->rust_slot(), &rects,
+        [](void* context, Layout::RustFFI::FfiCssPixelRect rect) {
+            static_cast<Vector<CSSPixelRect>*>(context)->append({
+                CSSPixels::from_raw(rect.x),
+                CSSPixels::from_raw(rect.y),
+                CSSPixels::from_raw(rect.width),
+                CSSPixels::from_raw(rect.height),
+            });
+        });
+}
+
+CSSPixelPoint cumulative_scroll_compensation(Layout::Node const& node)
+{
+    auto const* paintable = node.paintable_ptr();
+    if (!paintable)
+        return {};
+    auto index = paintable->enclosing_scroll_node_index();
+    if (!index.value())
+        return {};
+    return paintable->document().paintable()->cumulative_scroll_offset_for_node(index);
+}
+
+}

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -35,8 +35,8 @@ WEB_API CSSPixels outline_offset(Layout::Node const&);
 WEB_API CSSPixelRect transform_reference_box(Layout::Node const&);
 WEB_API Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const&);
 WEB_API bool has_scrollable_overflow(Layout::Node const&);
-WEB_API Optional<Paintable::OverflowData> overflow_data(Layout::Node const&);
-WEB_API Optional<Paintable::CachedOverflowData> cached_overflow_data(Layout::Node const&);
+WEB_API Optional<OverflowData> overflow_data(Layout::Node const&);
+WEB_API Optional<CachedOverflowData> cached_overflow_data(Layout::Node const&);
 
 WEB_API bool is_visible(Layout::Node const&);
 WEB_API bool visible_for_hit_testing(Layout::Node const&);
@@ -93,8 +93,8 @@ WEB_API bool has_content(Layout::Node const&);
 WEB_API CSSPixelRect caret_rect_for_child_offset(Layout::Node const&, size_t offset);
 WEB_API Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node const* owner_inline);
 WEB_API Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const&);
-WEB_API Paintable::SelectionStyle selection_style(Layout::Node const&);
-WEB_API Paintable::SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
+WEB_API SelectionStyle selection_style(Layout::Node const&);
+WEB_API SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
 
 WEB_API void set_needs_repaint(Layout::Node const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
 WEB_API void invalidate_paint_cache(Layout::Node const&);
@@ -105,6 +105,7 @@ WEB_API void clear_cached_overflow_data(Layout::Node const&);
 WEB_API void set_sticky_insets(Layout::Node const&, OwnPtr<StickyInsets>);
 WEB_API StickyInsets sticky_insets(Layout::Node const&);
 WEB_API bool has_sticky_insets(Layout::Node const&);
+WEB_API void transfer_fragments_to_replacement_node(Layout::Node const& containing_block, Layout::Node const& old_node, Layout::Node const& new_node);
 
 WEB_API void inline_piece_border_box_rects(Layout::Node const&, Vector<CSSPixelRect>&);
 WEB_API CSSPixelPoint cumulative_scroll_compensation(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -10,6 +10,11 @@
 
 namespace Web::Painting {
 
+struct CaretPaint {
+    CSSPixelRect rect;
+    Color color;
+};
+
 WEB_API bool has_committed_box(Layout::Node const&);
 
 WEB_API CSSPixelRect absolute_rect(Layout::Node const&);
@@ -83,6 +88,11 @@ WEB_API Optional<String> flex_layout_json(Layout::Node const&, UniqueNodeID);
 
 WEB_API CSSPixelPoint box_type_agnostic_position(Layout::Node const&);
 WEB_API bool should_paint_cursor(Layout::Node const&);
+WEB_API Layout::Node const* nearest_self_painting_inline_box(Layout::Node const&);
+WEB_API bool has_content(Layout::Node const&);
+WEB_API CSSPixelRect caret_rect_for_child_offset(Layout::Node const&, size_t offset);
+WEB_API Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node const* owner_inline);
+WEB_API Optional<CaretPaint> resolve_empty_editable_caret_paint(Layout::Node const&);
 WEB_API Paintable::SelectionStyle selection_style(Layout::Node const&);
 WEB_API Paintable::SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
 

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Painting/Paintable.h>
+
+namespace Web::Painting {
+
+WEB_API bool has_committed_box(Layout::Node const&);
+
+WEB_API CSSPixelRect absolute_rect(Layout::Node const&);
+WEB_API CSSPixelRect absolute_padding_box_rect(Layout::Node const&);
+WEB_API CSSPixelRect absolute_border_box_rect(Layout::Node const&);
+WEB_API CSSPixelPoint absolute_position(Layout::Node const&);
+WEB_API CSSPixels absolute_x(Layout::Node const&);
+WEB_API CSSPixels absolute_y(Layout::Node const&);
+WEB_API CSSPixelPoint offset(Layout::Node const&);
+WEB_API CSSPixelSize content_size(Layout::Node const&);
+WEB_API CSSPixels content_width(Layout::Node const&);
+WEB_API CSSPixels content_height(Layout::Node const&);
+WEB_API CSSPixels border_box_width(Layout::Node const&);
+WEB_API CSSPixels border_box_height(Layout::Node const&);
+WEB_API BoxModelMetrics box_model(Layout::Node const&);
+WEB_API Optional<CSS::BorderData> outline_data(Layout::Node const&, CSS::ComputedValues const&);
+WEB_API CSSPixels outline_offset(Layout::Node const&);
+WEB_API CSSPixelRect transform_reference_box(Layout::Node const&);
+WEB_API Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const&);
+WEB_API bool has_scrollable_overflow(Layout::Node const&);
+WEB_API Optional<Paintable::OverflowData> overflow_data(Layout::Node const&);
+WEB_API Optional<Paintable::CachedOverflowData> cached_overflow_data(Layout::Node const&);
+
+WEB_API bool is_visible(Layout::Node const&);
+WEB_API bool visible_for_hit_testing(Layout::Node const&);
+WEB_API bool has_stacking_context(Layout::Node const&);
+WEB_API Optional<int> effective_z_index(Layout::Node const&);
+WEB_API CSS::Display display(Layout::Node const&);
+WEB_API bool is_positioned(Layout::Node const&);
+WEB_API bool is_fixed_position(Layout::Node const&);
+WEB_API bool is_sticky_position(Layout::Node const&);
+WEB_API bool is_absolutely_positioned(Layout::Node const&);
+WEB_API bool is_floating(Layout::Node const&);
+WEB_API bool is_inline(Layout::Node const&);
+WEB_API bool has_css_transform(Layout::Node const&);
+WEB_API bool has_non_invertible_css_transform(Layout::Node const&);
+WEB_API bool uses_collapsing_borders_model(Layout::Node const&);
+WEB_API SelectionState selection_state(Layout::Node const&);
+WEB_API CSS::StyleRecordID style_record_identity(Layout::Node const&);
+WEB_API StringView class_name(Layout::Node const&);
+WEB_API String debug_description(Layout::Node const&);
+WEB_API bool is_navigable_container_viewport_paintable(Layout::Node const&);
+WEB_API bool is_viewport_paintable(Layout::Node const&);
+WEB_API bool is_paintable_with_lines(Layout::Node const&);
+WEB_API bool is_inline_paintable(Layout::Node const&);
+WEB_API bool is_svg_paintable(Layout::Node const&);
+WEB_API bool is_svg_svg_paintable(Layout::Node const&);
+WEB_API bool is_svg_path_paintable(Layout::Node const&);
+WEB_API bool is_svg_foreign_object_paintable(Layout::Node const&);
+
+WEB_API CSSPixelRect transform_rect_to_viewport(Layout::Node const&, CSSPixelRect const&, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
+WEB_API Optional<CSSPixelPoint> transform_point_to_local(Layout::Node const&, CSSPixelPoint);
+WEB_API Optional<CSSPixelPoint> transform_point_to_local_for_descendants(Layout::Node const&, CSSPixelPoint);
+WEB_API CSSPixelPoint inverse_transform_point(Layout::Node const&, CSSPixelPoint);
+WEB_API CSSPixelPoint transform_to_local_coordinates(Layout::Node const&, CSSPixelPoint);
+
+WEB_API bool has_accumulated_visual_context(Layout::Node const&);
+WEB_API VisualContextIndex accumulated_visual_context_index(Layout::Node const&);
+WEB_API VisualContextIndex accumulated_visual_context_for_descendants_index(Layout::Node const&);
+WEB_API Optional<VisualContextIndex> fixed_background_visual_context(Layout::Node const&);
+WEB_API VisualContextIndex enclosing_scroll_node_index(Layout::Node const&);
+WEB_API VisualContextIndex own_scroll_node_index(Layout::Node const&);
+
+WEB_API Gfx::Path const* committed_svg_path(Layout::Node const&);
+WEB_API CSSPixelSize svg_viewport_size(Layout::Node const&);
+WEB_API Optional<Gfx::AffineTransform> svg_viewport_transform(Layout::Node const&);
+WEB_API Optional<UsedGridTrackList> used_values_for_grid_template_columns(Layout::Node const&);
+WEB_API Optional<UsedGridTrackList> used_values_for_grid_template_rows(Layout::Node const&);
+WEB_API Optional<String> grid_layout_json(Layout::Node const&, UniqueNodeID);
+WEB_API Optional<String> flex_layout_json(Layout::Node const&, UniqueNodeID);
+
+WEB_API CSSPixelPoint box_type_agnostic_position(Layout::Node const&);
+WEB_API bool should_paint_cursor(Layout::Node const&);
+WEB_API Paintable::SelectionStyle selection_style(Layout::Node const&);
+WEB_API Paintable::SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
+
+WEB_API void set_needs_repaint(Layout::Node const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
+WEB_API void invalidate_paint_cache(Layout::Node const&);
+WEB_API void repaint_after_style_change(Layout::Node const&, CSS::RequiredInvalidationAfterStyleChange const&);
+WEB_API void invalidate_stacking_context(Layout::Node const&);
+WEB_API void clear_overflow_data(Layout::Node const&);
+WEB_API void clear_cached_overflow_data(Layout::Node const&);
+WEB_API void set_sticky_insets(Layout::Node const&, OwnPtr<StickyInsets>);
+WEB_API StickyInsets sticky_insets(Layout::Node const&);
+WEB_API bool has_sticky_insets(Layout::Node const&);
+
+WEB_API void inline_piece_border_box_rects(Layout::Node const&, Vector<CSSPixelRect>&);
+WEB_API CSSPixelPoint cumulative_scroll_compensation(Layout::Node const&);
+
+}

--- a/Libraries/LibWeb/Painting/Forward.h
+++ b/Libraries/LibWeb/Painting/Forward.h
@@ -10,7 +10,9 @@
 
 namespace Web::Painting {
 
+class AccumulatedVisualContextTree;
 class HitTestDisplayList;
+class ScrollStateSnapshot;
 enum class CaretLineDirection : u8;
 enum class CaretLineEdge : u8;
 enum class CaretPositionMode : u8;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/HTMLMapElement.h>
 #include <LibWeb/Layout/LayoutRustFFI.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ChromeWidget.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -393,7 +394,7 @@ bool HitTestDisplayList::item_can_produce_caret_position(Item const& item) const
         auto paintable_box = paintable_for_item(item);
         if (!paintable_box)
             return false;
-        if (paintable_box->effective_z_index().value_or(0) < 0)
+        if (Painting::effective_z_index(paintable_box->layout_node()).value_or(0) < 0)
             return false;
         return paintable_box->dom_node()
             && paintable_box->dom_node()->parent()
@@ -465,7 +466,7 @@ static GC::Ptr<DOM::Node> image_map_area_for_point(Paintable& paintable, CSSPixe
 
     // For historical reasons, the coordinates must be interpreted relative to the displayed image after any stretching
     // caused by the CSS 'width' and 'height' properties.
-    auto image_rect = paintable.absolute_rect();
+    auto image_rect = Painting::absolute_rect(paintable.layout_node());
     return map_element->area_for_point(local_point - image_rect.location(), image_rect.size());
 }
 

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/BinarySearch.h>
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Position.h>
-#include <LibWeb/HTML/HTMLHtmlElement.h>
-#include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/InlinePaintable.h>
 
 namespace Web::Painting {
@@ -27,46 +21,12 @@ InlinePaintable::InlinePaintable(Layout::NodeWithStyle const& layout_node)
 
 InlinePaintable::~InlinePaintable() = default;
 
-bool InlinePaintable::has_content_pieces() const
-{
-    return Layout::RustFFI::layout_arena_inline_paintable_has_content_pieces(rust_arena().handle(), rust_slot());
-}
-
 CSSPixelPoint InlinePaintable::box_type_agnostic_position() const
 {
     auto result = Layout::RustFFI::layout_arena_inline_paintable_first_piece_position(rust_arena().handle(), rust_slot());
     if (!result.has_value)
         return absolute_position();
     return { CSSPixels::from_raw(result.x), CSSPixels::from_raw(result.y) };
-}
-
-bool InlinePaintable::has_content() const
-{
-    // Interrupting block-in-inline children produce only placeholder pieces, so any child
-    // paintable also counts as content.
-    return has_content_pieces() || Layout::RustFFI::layout_arena_paintable_has_child_paintables(rust_arena().handle(), rust_slot());
-}
-
-Optional<PaintableWithLines::CaretPaint> InlinePaintable::resolve_empty_editable_caret_paint() const
-{
-    if (has_content())
-        return {};
-
-    if (!should_paint_cursor())
-        return {};
-
-    auto cursor_position = document().cursor_position();
-    VERIFY(cursor_position);
-
-    auto const* dom_node = layout_node().dom_node();
-    if (!dom_node || cursor_position->node() != GC::Ptr { dom_node })
-        return {};
-
-    auto position = box_type_agnostic_position();
-    return PaintableWithLines::CaretPaint {
-        .rect = { position.x(), position.y(), 1, layout_node().line_height() },
-        .color = layout_node().caret_color(),
-    };
 }
 
 }

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -21,12 +21,4 @@ InlinePaintable::InlinePaintable(Layout::NodeWithStyle const& layout_node)
 
 InlinePaintable::~InlinePaintable() = default;
 
-CSSPixelPoint InlinePaintable::box_type_agnostic_position() const
-{
-    auto result = Layout::RustFFI::layout_arena_inline_paintable_first_piece_position(rust_arena().handle(), rust_slot());
-    if (!result.has_value)
-        return absolute_position();
-    return { CSSPixels::from_raw(result.x), CSSPixels::from_raw(result.y) };
-}
-
 }

--- a/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -19,8 +19,6 @@ public:
     static NonnullRefPtr<InlinePaintable> create(Layout::NodeWithStyle const&);
     virtual ~InlinePaintable() override;
 
-    virtual CSSPixelPoint box_type_agnostic_position() const override;
-
 private:
     explicit InlinePaintable(Layout::NodeWithStyle const&);
 };

--- a/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Painting {
 
@@ -19,21 +19,10 @@ public:
     static NonnullRefPtr<InlinePaintable> create(Layout::NodeWithStyle const&);
     virtual ~InlinePaintable() override;
 
-    // Whether this box paints its own foreground (fragments and caret) instead of the
-    // containing block: it forms a group that content must be recorded inside.
-    bool is_self_painting() const { return has_stacking_context() || is_positioned(); }
-
     virtual CSSPixelPoint box_type_agnostic_position() const override;
-
-    bool has_content() const;
 
 private:
     explicit InlinePaintable(Layout::NodeWithStyle const&);
-
-    bool has_content_pieces() const;
-
-public:
-    Optional<PaintableWithLines::CaretPaint> resolve_empty_editable_caret_paint() const;
 };
 
 template<>

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -31,7 +31,6 @@
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
-#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
@@ -323,26 +322,6 @@ void Paintable::set_sticky_insets(OwnPtr<StickyInsets> sticky_insets)
         pack(sticky_insets->left, ffi_insets.left, ffi_insets.has_left);
     }
     Layout::RustFFI::layout_arena_paintable_set_sticky_insets(m_rust_arena->handle(), m_rust_slot, ffi_insets, !!sticky_insets);
-}
-
-bool Paintable::should_paint_cursor() const
-{
-    if (!document().cursor_blink_state() || !document().navigable()->is_focused())
-        return false;
-
-    auto cursor_position = document().cursor_position();
-    if (!cursor_position)
-        return false;
-
-    if (auto const* text_control = as_if<HTML::FormAssociatedTextControlElement>(document().focused_area().ptr());
-        text_control && text_control->text_control_to_html_element().is_mutable()) {
-        return true;
-    }
-
-    // The editable element may sit anywhere between the cursor and this box (e.g. a
-    // contenteditable inline box), so editability is the cursor node's, not this box's.
-    auto const* editable_node = cursor_position->node().ptr();
-    return editable_node && editable_node->is_editable_or_editing_host();
 }
 
 void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offset, TextAffinity affinity, ScrollBlockDirection scroll_block_direction)

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -401,28 +401,32 @@ void Paintable::scroll_ancestor_to_offset_into_view(size_t offset)
 
 static bool g_paint_viewport_scrollbars = true;
 
-static bool content_size_change_affects_container_queries(Paintable const& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
+static bool content_size_change_affects_container_queries(Layout::NodeWithStyle const& layout_node, CSSPixelSize old_size, CSSPixelSize new_size)
 {
-    auto container_type = paintable_box.layout_node().container_type();
+    auto container_type = layout_node.container_type();
     if (container_type.is_size_container)
         return old_size != new_size;
 
     if (!container_type.is_inline_size_container)
         return false;
 
-    if (paintable_box.layout_node().writing_mode() == CSS::WritingMode::HorizontalTb)
+    if (layout_node.writing_mode() == CSS::WritingMode::HorizontalTb)
         return old_size.width() != new_size.width();
 
     return old_size.height() != new_size.height();
 }
 
-void invalidate_descendant_styles_for_container_query_size_change(Paintable& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
+void invalidate_descendant_styles_for_container_query_size_change(GC::Ptr<DOM::Node> node, CSSPixelSize old_size, CSSPixelSize new_size)
 {
-    if (!content_size_change_affects_container_queries(paintable_box, old_size, new_size))
+    auto* element = as_if<DOM::Element>(node.ptr());
+    if (!element)
         return;
 
-    if (auto* element = as_if<DOM::Element>(paintable_box.dom_node().ptr()))
-        CSS::Invalidation::invalidate_descendant_styles_depending_on_size_container_query(*element);
+    auto const* layout_node = element->unsafe_layout_node();
+    if (!layout_node || !content_size_change_affects_container_queries(*layout_node, old_size, new_size))
+        return;
+
+    CSS::Invalidation::invalidate_descendant_styles_depending_on_size_container_query(*element);
 }
 
 void set_paint_viewport_scrollbars(bool const enabled)

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -46,12 +46,12 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/MiddleButtonScrollHandler.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/Painting/FlexboxInspectorOverlay.h>
 #include <LibWeb/Painting/GridInspectorOverlay.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ResizeHandle.h>
 #include <LibWeb/Painting/Scrollbar.h>
@@ -62,62 +62,6 @@
 
 namespace Web::Painting {
 
-static PixelBox pixel_box_from_ffi(Layout::RustFFI::FfiPixelBox const& box)
-{
-    return { CSSPixels::from_raw(box.top), CSSPixels::from_raw(box.right), CSSPixels::from_raw(box.bottom), CSSPixels::from_raw(box.left) };
-}
-
-BoxModelMetrics Paintable::box_model() const
-{
-    return {
-        .margin = pixel_box_from_ffi(rust_data().margin),
-        .padding = pixel_box_from_ffi(rust_data().padding),
-        .border = pixel_box_from_ffi(rust_data().border),
-        .inset = pixel_box_from_ffi(rust_data().inset),
-    };
-}
-
-CSS::Display Paintable::display() const
-{
-    return CSS::display_from_ffi_display(CSS::decode_ffi_display(rust_data().display));
-}
-
-CSSPixelSize Paintable::content_size() const
-{
-    return { CSSPixels::from_raw(rust_data().content_size.width), CSSPixels::from_raw(rust_data().content_size.height) };
-}
-
-Optional<Paintable::OverflowData> Paintable::overflow_data() const
-{
-    if (!rust_data().has_overflow)
-        return {};
-    return OverflowData { from_ffi_css_pixel_rect(rust_data().overflow.rect), rust_data().overflow.has_scrollable_overflow };
-}
-
-Optional<Paintable::CachedOverflowData> Paintable::cached_overflow_data() const
-{
-    if (!rust_data().has_cached_overflow)
-        return {};
-    return CachedOverflowData { from_ffi_css_pixel_rect(rust_data().cached_overflow.rect), rust_data().cached_overflow.has_scrollable_overflow };
-}
-
-Paintable::StickyInsets Paintable::sticky_insets() const
-{
-    VERIFY(has_sticky_insets());
-    auto const& insets = rust_data().sticky_insets;
-    auto side = [](i32 raw, bool present) -> Optional<CSSPixels> {
-        if (!present)
-            return {};
-        return CSSPixels::from_raw(raw);
-    };
-    return { side(insets.top, insets.has_top), side(insets.right, insets.has_right), side(insets.bottom, insets.has_bottom), side(insets.left, insets.has_left) };
-}
-
-String Paintable::debug_description() const
-{
-    return MUST(String::formatted("{}({})", class_name(), layout_node().debug_description()));
-}
-
 DOM::Document const& Paintable::document() const
 {
     return layout_node().document();
@@ -126,23 +70,6 @@ DOM::Document const& Paintable::document() const
 DOM::Document& Paintable::document()
 {
     return layout_node().document();
-}
-
-bool Paintable::is_visible() const
-{
-    return layout_node().visibility() == CSS::Visibility::Visible && layout_node().opacity() != 0;
-}
-
-CSS::StyleRecordID Paintable::style_record_identity() const
-{
-    return layout_node().style_record_identity();
-}
-
-bool Paintable::visible_for_hit_testing() const
-{
-    if (auto node = dom_node(); node && node->is_inert())
-        return false;
-    return layout_node().pointer_events() != CSS::PointerEvents::None;
 }
 
 void Paintable::set_dom_node(GC::Ptr<DOM::Node> dom_node)
@@ -163,11 +90,6 @@ GC::Ptr<DOM::Node const> Paintable::dom_node() const
 GC::Ptr<HTML::LocalNavigable> Paintable::navigable() const
 {
     return document().navigable();
-}
-
-bool Paintable::has_stacking_context() const
-{
-    return rust_data().stacking_context != Layout::RustFFI::NO_STACKING_CONTEXT;
 }
 
 GC::Ptr<DOM::Node> event_dispatch_dom_node_for(Paintable const& paintable)
@@ -194,134 +116,6 @@ RefPtr<Paintable> HitTestResult::paintable() const
 RefPtr<Paintable> CaretPosition::paintable() const
 {
     return paintable_for_slot(arena->handle(), box);
-}
-
-CSSPixelPoint Paintable::box_type_agnostic_position() const
-{
-    return absolute_position();
-}
-
-// https://drafts.csswg.org/css-pseudo-4/#highlight-styling
-// FIXME: Support additional ::selection properties: text-underline-offset, text-underline-position, stroke-color,
-//        fill-color, stroke-width, and CSS custom properties.
-Paintable::SelectionStyle Paintable::selection_style() const
-{
-    return selection_style_for_node(layout_node(), dom_node());
-}
-
-Paintable::SelectionStyle Paintable::selection_style_for_node(Layout::Node const& layout_node, GC::Ptr<DOM::Node const> node)
-{
-    // Selections render in a muted color while the window does not have focus.
-    auto navigable = layout_node.document().navigable();
-    auto window_is_active = navigable && navigable->is_focused();
-    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(layout_node);
-    auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
-
-    auto default_style_for_color_scheme = [&](CSS::PreferredColorScheme color_scheme, bool use_palette_for_normal_color_scheme = true) {
-        auto palette = layout_node.document().page().palette();
-        auto palette_color_scheme = palette.is_dark() ? CSS::PreferredColorScheme::Dark : CSS::PreferredColorScheme::Light;
-        if (color_scheme == palette_color_scheme || use_palette_for_normal_color_scheme) {
-            auto background = window_is_active ? palette.selection() : palette.inactive_selection();
-            return SelectionStyle { CSS::SystemColor::transform_selection_background_color(background) };
-        }
-
-        auto background = window_is_active ? CSS::SystemColor::highlight(color_scheme) : CSS::SystemColor::inactive_highlight(color_scheme);
-        return SelectionStyle { CSS::SystemColor::transform_selection_background_color(background) };
-    };
-
-    // For text nodes, check the parent element since text nodes don't have computed properties.
-    if (!node)
-        return default_style_for_color_scheme(style_source.color_scheme());
-
-    DOM::Element const* element = as_if<DOM::Element>(*node);
-    if (!element)
-        element = node->parent_element().ptr();
-    if (!element)
-        return default_style_for_color_scheme(style_source.color_scheme());
-
-    auto color_scheme_is_normal = style_source.color_schemes().is_empty();
-    auto use_palette_for_normal_color_scheme = color_scheme_is_normal && !layout_node.document().supported_color_schemes().has_value();
-    auto default_style = default_style_for_color_scheme(style_source.color_scheme(), use_palette_for_normal_color_scheme);
-
-    auto style_from_element = [&](DOM::Element const& element) -> Optional<SelectionStyle> {
-        auto computed_selection_style = element.computed_style(CSS::PseudoElement::Selection);
-        if (!computed_selection_style)
-            return {};
-
-        SelectionStyle style;
-        style.background_color = computed_selection_style->background_color();
-
-        // Only use text color if it was explicitly set in the ::selection rule, not inherited.
-        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::Color))
-            style.text_color = computed_selection_style->color();
-
-        // Only use text-shadow if it was explicitly set in the ::selection rule, not inherited.
-        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::TextShadow)) {
-            auto const& css_shadows = computed_selection_style->text_shadow();
-            Vector<ShadowData> shadows;
-            shadows.ensure_capacity(css_shadows.size());
-            for (auto const& shadow : css_shadows)
-                shadows.unchecked_append(ShadowData::from_css(shadow));
-            style.text_shadow = move(shadows);
-        }
-
-        // Only use text-decoration if it was explicitly set in the ::selection rule, not inherited.
-        if (!computed_selection_style->is_property_inherited(CSS::PropertyID::TextDecorationLine)) {
-            style.text_decoration = TextDecorationStyle {
-                .line = Vector<CSS::TextDecorationLine> { computed_selection_style->text_decoration_line() },
-                .style = computed_selection_style->text_decoration_style(),
-                .color = computed_selection_style->text_decoration_color(),
-            };
-        }
-
-        // Only return a style if there's a meaningful customization. This allows us to continue checking shadow hosts
-        // when the current element only has UA default styles.
-        if (!style.has_styling())
-            return {};
-
-        return style;
-    };
-
-    // Check the element itself.
-    if (auto style = style_from_element(*element); style.has_value())
-        return style.release_value();
-
-    // If inside a shadow tree, check the shadow host. This enables ::selection styling on elements like <input> to
-    // apply to text rendered inside their shadow DOM.
-    if (auto shadow_root = element->containing_shadow_root(); shadow_root && shadow_root->is_user_agent_internal()) {
-        if (auto const* host = shadow_root->host()) {
-            if (auto style = style_from_element(*host); style.has_value())
-                return style.release_value();
-        }
-    }
-
-    return default_style;
-}
-
-void Paintable::clear_overflow_data()
-{
-    Layout::RustFFI::layout_arena_paintable_clear_overflow_data(m_rust_arena->handle(), m_rust_slot);
-}
-
-void Paintable::clear_cached_overflow_data()
-{
-    Layout::RustFFI::layout_arena_paintable_clear_cached_overflow_data(m_rust_arena->handle(), m_rust_slot);
-}
-
-void Paintable::set_sticky_insets(OwnPtr<StickyInsets> sticky_insets)
-{
-    Layout::RustFFI::FfiStickyInsets ffi_insets {};
-    if (sticky_insets) {
-        auto pack = [](Optional<CSSPixels> const& value, i32& raw, bool& present) {
-            present = value.has_value();
-            raw = value.has_value() ? value->raw_value() : 0;
-        };
-        pack(sticky_insets->top, ffi_insets.top, ffi_insets.has_top);
-        pack(sticky_insets->right, ffi_insets.right, ffi_insets.has_right);
-        pack(sticky_insets->bottom, ffi_insets.bottom, ffi_insets.has_bottom);
-        pack(sticky_insets->left, ffi_insets.left, ffi_insets.has_left);
-    }
-    Layout::RustFFI::layout_arena_paintable_set_sticky_insets(m_rust_arena->handle(), m_rust_slot, ffi_insets, !!sticky_insets);
 }
 
 void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offset, TextAffinity affinity, ScrollBlockDirection scroll_block_direction)
@@ -353,7 +147,7 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
     }
     auto owner = paintable_for_slot(layout_node->arena_handle(), result.owner_paintable);
     for (auto* ancestor = owner.ptr(); ancestor;) {
-        if (ancestor->has_scrollable_overflow()) {
+        if (Painting::has_scrollable_overflow(ancestor->layout_node())) {
             if (scroll_block_direction == ScrollBlockDirection::No) {
                 auto snapport = ancestor->scroll_snapport_rect();
                 if (style_source.writing_mode() == CSS::WritingMode::HorizontalTb) {
@@ -484,7 +278,7 @@ CSS::ScrollbarColorData scrollbar_colors_for_paint(Paintable const& paintable_bo
 Paintable const* nearest_svg_viewport_paintable_of(Layout::Node const& layout_node)
 {
     for (auto const* ancestor = layout_node.parent(); ancestor; ancestor = ancestor->parent()) {
-        if (auto paintable = ancestor->paintable(); paintable && paintable->svg_viewport_transform().has_value())
+        if (auto paintable = ancestor->paintable(); paintable && Painting::svg_viewport_transform(*ancestor).has_value())
             return paintable.ptr();
     }
     return nullptr;
@@ -496,8 +290,10 @@ static Gfx::FloatRect svg_svg_box_view_box_or_viewport_rect(Layout::Box const& s
 {
     if (auto view_box = as<SVG::SVGSVGElement>(*svg_svg_box.dom_node()).active_view_box(); view_box.has_value())
         return { view_box->min_x, view_box->min_y, view_box->width, view_box->height };
-    if (auto const* paintable = svg_svg_box.paintable_box().ptr())
-        return { {}, { paintable->svg_viewport_size().width().to_float(), paintable->svg_viewport_size().height().to_float() } };
+    if (svg_svg_box.paintable_box()) {
+        auto viewport_size = Painting::svg_viewport_size(svg_svg_box);
+        return { {}, { viewport_size.width().to_float(), viewport_size.height().to_float() } };
+    }
     return {};
 }
 
@@ -511,7 +307,7 @@ Gfx::FloatRect svg_viewport_user_rect(Paintable const& viewport_paintable)
                 return { static_cast<float>(view_box->min_x), static_cast<float>(view_box->min_y), static_cast<float>(view_box->width), static_cast<float>(view_box->height) };
         }
     }
-    return { {}, viewport_paintable.absolute_rect().size().to_type<float>() };
+    return { {}, Painting::absolute_rect(viewport_paintable.layout_node()).size().to_type<float>() };
 }
 
 ResolvedCSSFilter resolve_css_filter(CSS::ComputedFilterView computed_filter, Paintable const& paintable_box)
@@ -545,7 +341,7 @@ ResolvedCSSFilter resolve_css_filter(CSS::ComputedFilterView computed_filter, Pa
                 result.svg_filter = filter_element->gfx_filter(layout_node, filter_scale);
                 // The bounds live in the filtered element's user space; an element without
                 // geometry of its own falls back to the whole enclosing viewport rect there.
-                auto bounds = paintable_box.absolute_border_box_rect();
+                auto bounds = Painting::absolute_border_box_rect(layout_node);
                 if (bounds.is_empty()) {
                     if (auto const* viewport_paintable = nearest_svg_viewport_paintable_of(paintable_box.layout_node()))
                         result.svg_filter_bounds = svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
@@ -637,91 +433,13 @@ void Paintable::detach_chrome_widgets()
     }
 }
 
-bool Paintable::has_css_transform() const
-{
-    return layout_node().has_css_transform();
-}
-
-StringView Paintable::class_name() const
-{
-    switch (kind()) {
-    case Layout::RustFFI::PaintableKind::None:
-        return "Paintable"sv;
-    case Layout::RustFFI::PaintableKind::Paintable:
-        return "Paintable"sv;
-    case Layout::RustFFI::PaintableKind::PaintableWithLines:
-        return "PaintableWithLines"sv;
-    case Layout::RustFFI::PaintableKind::InlinePaintable:
-        return "InlinePaintable"sv;
-    case Layout::RustFFI::PaintableKind::ViewportPaintable:
-        return "ViewportPaintable"sv;
-    case Layout::RustFFI::PaintableKind::ImagePaintable:
-        return "ImagePaintable"sv;
-    case Layout::RustFFI::PaintableKind::CanvasPaintable:
-        return "CanvasPaintable"sv;
-    case Layout::RustFFI::PaintableKind::VideoPaintable:
-        return "VideoPaintable"sv;
-    case Layout::RustFFI::PaintableKind::CheckBoxPaintable:
-        return "CheckBoxPaintable"sv;
-    case Layout::RustFFI::PaintableKind::RadioButtonPaintable:
-        return "RadioButtonPaintable"sv;
-    case Layout::RustFFI::PaintableKind::FieldSetPaintable:
-        return "FieldSetPaintable"sv;
-    case Layout::RustFFI::PaintableKind::NavigableContainerViewportPaintable:
-        return "NavigableContainerViewportPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGSVGPaintable:
-        return "SVGSVGPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGPathPaintable:
-        return "SVGPathPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGGraphicsPaintable:
-        return "SVGGraphicsPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGImagePaintable:
-        return "SVGImagePaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGMaskPaintable:
-        return "SVGMaskPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGClipPaintable:
-        return "SVGClipPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGPatternPaintable:
-        return "SVGPatternPaintable"sv;
-    case Layout::RustFFI::PaintableKind::SVGForeignObjectPaintable:
-        return "SVGForeignObjectPaintable"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-Optional<Gfx::AffineTransform> Paintable::svg_viewport_transform() const
-{
-    if (!rust_data().has_svg_viewport_transform)
-        return {};
-    auto const& transform = rust_data().svg_viewport_transform;
-    return Gfx::AffineTransform { transform.a, transform.b, transform.c, transform.d, transform.e, transform.f };
-}
-
-Gfx::Path const* Paintable::committed_svg_path() const
-{
-    return static_cast<Gfx::Path const*>(Layout::RustFFI::layout_arena_paintable_computed_svg_path(m_rust_arena->handle(), m_rust_slot));
-}
-
-void Paintable::invalidate_paint_cache() const
-{
-    mirror_rust_invalidate_paint_cache(*this);
-}
-
-void Paintable::repaint_after_style_change(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
-{
-    if (invalidation.needs_repaint())
-        set_needs_repaint();
-    if (invalidation.repaint_propagated_text_decorations)
-        rust_invalidate_propagated_text_decoration_caches(*this);
-}
-
 void Paintable::reset_for_relayout()
 {
     // A reused paintable must shed its chrome widgets: whether the box still warrants them
     // (e.g. scrollbars on a scroll container) is only known after the new layout is painted.
     detach_chrome_widgets();
 
-    invalidate_stacking_context();
+    Painting::invalidate_stacking_context(layout_node());
 }
 
 CSSPixelPoint Paintable::scroll_offset() const
@@ -743,46 +461,24 @@ CSSPixelPoint Paintable::scroll_offset() const
 
 CSSPixelPoint Paintable::minimum_scroll_offset() const
 {
-    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(layout_node());
     if (!scrollable_overflow_rect.has_value())
         return {};
 
-    auto scrollport_rect = absolute_padding_box_rect();
+    auto scrollport_rect = Painting::absolute_padding_box_rect(layout_node());
     return {
         min(scrollable_overflow_rect->left() - scrollport_rect.left(), CSSPixels(0)),
         min(scrollable_overflow_rect->top() - scrollport_rect.top(), CSSPixels(0)),
     };
 }
 
-bool Paintable::has_scrollable_overflow() const
-{
-    if (auto const* box = as_if<Layout::Box>(layout_node()))
-        document().ensure_scrollable_overflow_is_measured(*box);
-    if (rust_data().has_overflow)
-        return rust_data().overflow.has_scrollable_overflow;
-    return rust_data().has_cached_overflow && rust_data().cached_overflow.has_scrollable_overflow;
-}
-
-Optional<CSSPixelRect> Paintable::scrollable_overflow_rect() const
-{
-    if (auto const* box = as_if<Layout::Box>(layout_node()))
-        document().ensure_scrollable_overflow_is_measured(*box);
-    if (rust_data().has_overflow)
-        return from_ffi_css_pixel_rect(rust_data().overflow.rect);
-    if (!rust_data().has_cached_overflow)
-        return {};
-    auto scrollable_overflow_rect = from_ffi_css_pixel_rect(rust_data().cached_overflow.rect);
-    scrollable_overflow_rect.translate_by(absolute_padding_box_rect().location());
-    return scrollable_overflow_rect;
-}
-
 CSSPixelPoint Paintable::maximum_scroll_offset() const
 {
-    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(layout_node());
     if (!scrollable_overflow_rect.has_value())
         return {};
 
-    auto scrollport_rect = absolute_padding_box_rect();
+    auto scrollport_rect = Painting::absolute_padding_box_rect(layout_node());
     return {
         max(scrollable_overflow_rect->right() - scrollport_rect.right(), CSSPixels(0)),
         max(scrollable_overflow_rect->bottom() - scrollport_rect.bottom(), CSSPixels(0)),
@@ -791,7 +487,7 @@ CSSPixelPoint Paintable::maximum_scroll_offset() const
 
 CSSPixelPoint Paintable::clamp_scroll_offset(CSSPixelPoint offset) const
 {
-    if (!scrollable_overflow_rect().has_value())
+    if (!Painting::scrollable_overflow_rect(layout_node()).has_value())
         return offset;
 
     auto minimum_offset = minimum_scroll_offset();
@@ -804,7 +500,7 @@ CSSPixelPoint Paintable::clamp_scroll_offset(CSSPixelPoint offset) const
 
 Paintable::ScrollHandled Paintable::set_scroll_offset(CSSPixelPoint offset)
 {
-    if (!scrollable_overflow_rect().has_value())
+    if (!Painting::scrollable_overflow_rect(layout_node()).has_value())
         return ScrollHandled::No;
 
     offset = clamp_scroll_offset(offset);
@@ -850,7 +546,7 @@ Paintable::ScrollHandled Paintable::set_scroll_offset(CSSPixelPoint offset)
     if (!document.append_pending_scroll_event({ *event_target, HTML::EventNames::scroll }))
         return ScrollHandled::Yes;
 
-    set_needs_repaint(InvalidateDisplayList::No);
+    Painting::set_needs_repaint(layout_node(), InvalidateDisplayList::No);
     return ScrollHandled::Yes;
 }
 
@@ -886,7 +582,7 @@ GC::Ptr<DOM::EventTarget> Paintable::scroll_event_target()
 
 CSSPixelRect Paintable::scroll_snapport_rect() const
 {
-    return scroll_snapport_rect(absolute_padding_box_rect());
+    return scroll_snapport_rect(Painting::absolute_padding_box_rect(layout_node()));
 }
 
 CSSPixelRect Paintable::scroll_snapport_rect(CSSPixelRect scrollport) const
@@ -933,34 +629,14 @@ void Paintable::scroll_into_view(CSSPixelRect rect)
     set_scroll_offset(new_offset);
 }
 
-CSSPixelPoint Paintable::offset() const
-{
-    return { CSSPixels::from_raw(rust_data().offset.x), CSSPixels::from_raw(rust_data().offset.y) };
-}
-
-CSSPixelRect Paintable::absolute_rect() const
-{
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_rect(m_rust_arena->handle(), m_rust_slot));
-}
-
-CSSPixelRect Paintable::absolute_padding_box_rect() const
-{
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_padding_box_rect(m_rust_arena->handle(), m_rust_slot));
-}
-
 Optional<CSSPixelRect> Paintable::absolute_resizer_rect(ChromeMetrics const& metrics) const
 {
     if (!has_resizer())
         return {};
-    auto padding_rect = absolute_padding_box_rect();
+    auto padding_rect = Painting::absolute_padding_box_rect(layout_node());
     CSSPixels x = is_chrome_mirrored() ? padding_rect.x() : padding_rect.right() - metrics.resize_gripper_size;
     CSSPixels y = padding_rect.bottom() - metrics.resize_gripper_size;
     return CSSPixelRect { x, y, metrics.resize_gripper_size, metrics.resize_gripper_size };
-}
-
-CSSPixelRect Paintable::absolute_border_box_rect() const
-{
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_border_box_rect(m_rust_arena->handle(), m_rust_slot));
 }
 
 RefPtr<Scrollbar> Paintable::scrollbar(ScrollDirection direction) const
@@ -1023,12 +699,12 @@ bool Paintable::could_be_scrolled_by_wheel_event(ScrollDirection direction) cons
     if (overflow != CSS::Overflow::Auto && overflow != CSS::Overflow::Scroll)
         return false;
 
-    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(layout_node());
     if (!scrollable_overflow_rect.has_value())
         return false;
 
     CSSPixels scrollable_overflow_size = scrollable_overflow_rect->primary_size_for_orientation(orientation);
-    CSSPixels scrollport_size = absolute_padding_box_rect().primary_size_for_orientation(orientation);
+    CSSPixels scrollport_size = Painting::absolute_padding_box_rect(layout_node()).primary_size_for_orientation(orientation);
 
     return scrollable_overflow_size > scrollport_size;
 }
@@ -1041,7 +717,7 @@ bool Paintable::could_be_scrolled_by_wheel_event() const
 CSSPixels Paintable::available_scrollbar_length(ScrollDirection direction, ChromeMetrics const& metrics) const
 {
     bool is_horizontal = direction == ScrollDirection::Horizontal;
-    auto padding_rect = absolute_padding_box_rect();
+    auto padding_rect = Painting::absolute_padding_box_rect(layout_node());
     CSSPixels full_scrollport_length = is_horizontal ? padding_rect.width() : padding_rect.height();
     if (has_resizer())
         full_scrollport_length -= metrics.resize_gripper_size;
@@ -1068,7 +744,7 @@ Optional<CSSPixelRect> Paintable::absolute_scrollbar_rect(ScrollDirection direct
     CSSPixels rect_thickness = with_gutter
         ? metrics.scroll_gutter_thickness
         : metrics.scroll_thumb_thickness_thin + metrics.scroll_thumb_padding_thin;
-    CSSPixelRect scrollbar_rect = absolute_padding_box_rect();
+    CSSPixelRect scrollbar_rect = Painting::absolute_padding_box_rect(layout_node());
 
     if (is_horizontal) {
         if (!adjusting_for_resizer && could_be_scrolled_by_wheel_event(ScrollDirection::Vertical)) {
@@ -1101,10 +777,10 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
     if (overflow != CSS::Overflow::Scroll && !could_be_scrolled_by_wheel_event(direction))
         return {};
 
-    if (!own_scroll_node_index().value())
+    if (!Painting::own_scroll_node_index(layout_node()).value())
         return {};
 
-    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(layout_node());
     if (!scrollable_overflow_rect.has_value())
         return {};
 
@@ -1136,7 +812,7 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
     }
     CSSPixels scrollbar_length = scrollbar_rect->primary_size_for_orientation(orientation);
     CSSPixels usable_scrollbar_length = max(CSSPixels { 0 }, scrollbar_length - (2 * thumb_margin));
-    CSSPixels scrollport_size = absolute_padding_box_rect().primary_size_for_orientation(orientation);
+    CSSPixels scrollport_size = Painting::absolute_padding_box_rect(layout_node()).primary_size_for_orientation(orientation);
     CSSPixels min_thumb_length = min(usable_scrollbar_length, metrics.scroll_thumb_min_length);
     CSSPixels thumb_length = max(usable_scrollbar_length * (scrollport_size / scrollable_overflow_length), min_thumb_length);
 
@@ -1155,7 +831,7 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
         scrollbar_data.gutter_rect = scrollbar_rect.value();
 
     if (scroll_state_snapshot) {
-        auto own_offset = scroll_state_snapshot->device_offset_for_index(own_scroll_node_index());
+        auto own_offset = scroll_state_snapshot->device_offset_for_index(Painting::own_scroll_node_index(layout_node()));
         auto device_scroll_offset = is_horizontal ? -own_offset.x() : -own_offset.y();
         auto device_pixels_per_css_pixel = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
         CSSPixels thumb_offset = CSSPixels::nearest_value_for(device_scroll_offset / device_pixels_per_css_pixel) * scrollbar_data.thumb_travel_to_scroll_ratio;
@@ -1163,120 +839,6 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
     }
 
     return scrollbar_data;
-}
-
-Optional<UsedGridTrackList> Paintable::used_values_for_grid_template_columns() const
-{
-    Optional<UsedGridTrackList> result;
-    Layout::RustFFI::layout_arena_paintable_used_grid_tracks(rust_arena().handle(), rust_slot(), &result,
-        [](void* context, Layout::RustFFI::FfiUsedGridTrackList const* columns, Layout::RustFFI::FfiUsedGridTrackList const*) {
-            *static_cast<Optional<UsedGridTrackList>*>(context) = Layout::build_used_grid_track_list(*columns);
-        });
-    return result;
-}
-
-Optional<UsedGridTrackList> Paintable::used_values_for_grid_template_rows() const
-{
-    Optional<UsedGridTrackList> result;
-    Layout::RustFFI::layout_arena_paintable_used_grid_tracks(rust_arena().handle(), rust_slot(), &result,
-        [](void* context, Layout::RustFFI::FfiUsedGridTrackList const*, Layout::RustFFI::FfiUsedGridTrackList const* rows) {
-            *static_cast<Optional<UsedGridTrackList>*>(context) = Layout::build_used_grid_track_list(*rows);
-        });
-    return result;
-}
-
-Optional<String> Paintable::grid_layout_json(UniqueNodeID container_node_id) const
-{
-    Optional<String> result;
-    Layout::RustFFI::layout_arena_paintable_grid_layout_json(rust_arena().handle(), rust_slot(), container_node_id.value(), &result,
-        [](void* context, u8 const* bytes, size_t length) {
-            *static_cast<Optional<String>*>(context) = MUST(String::from_utf8(StringView { bytes, length }));
-        });
-    return result;
-}
-
-Optional<String> Paintable::flex_layout_json(UniqueNodeID container_node_id) const
-{
-    Optional<String> result;
-    Layout::RustFFI::layout_arena_paintable_flex_layout_json(rust_arena().handle(), rust_slot(), container_node_id.value(), &result,
-        [](void* context, u8 const* bytes, size_t length) {
-            *static_cast<Optional<String>*>(context) = MUST(String::from_utf8(StringView { bytes, length }));
-        });
-    return result;
-}
-
-void Paintable::invalidate_stacking_context()
-{
-    if (!has_layout_node())
-        return;
-    if (auto viewport_paintable = document().unsafe_paintable())
-        viewport_paintable->invalidate_stacking_context_tree();
-}
-
-Optional<int> Paintable::effective_z_index() const
-{
-    // https://drafts.csswg.org/css2/#z-index
-    // Applies to: positioned elements
-    if (is_positioned())
-        return layout_node().z_index();
-
-    return {};
-}
-
-Optional<CSSPixelPoint> Paintable::transform_point_to_local(CSSPixelPoint screen_position) const
-{
-    auto viewport_paintable = document().paintable();
-    if (!viewport_paintable)
-        return screen_position;
-    auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
-    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
-    auto result = visual_context_tree.transform_point_for_hit_test(accumulated_visual_context_index(), screen_position.to_type<float>() * pixel_ratio, scroll_state);
-    if (!result.has_value())
-        return {};
-    return (*result / pixel_ratio).to_type<CSSPixels>();
-}
-
-Optional<CSSPixelPoint> Paintable::transform_point_to_local_for_descendants(CSSPixelPoint screen_position) const
-{
-    auto viewport_paintable = document().paintable();
-    if (!viewport_paintable)
-        return screen_position;
-    auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
-    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
-    auto result = visual_context_tree.transform_point_for_hit_test(accumulated_visual_context_for_descendants_index(), screen_position.to_type<float>() * pixel_ratio, scroll_state);
-    if (!result.has_value())
-        return {};
-    return (*result / pixel_ratio).to_type<CSSPixels>();
-}
-
-CSSPixelRect Paintable::transform_rect_to_viewport(CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform) const
-{
-    auto viewport_paintable = document().paintable();
-    if (!viewport_paintable)
-        return rect;
-    auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
-    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
-    auto result = visual_context_tree.transform_rect_to_viewport(accumulated_visual_context_index(), rect.to_type<float>() * pixel_ratio, scroll_state, include_visual_viewport_transform);
-    return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();
-}
-
-CSSPixelPoint Paintable::inverse_transform_point(CSSPixelPoint screen_position) const
-{
-    auto viewport_paintable = document().paintable();
-    if (!viewport_paintable)
-        return screen_position;
-    auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
-    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
-    auto result = visual_context_tree.inverse_transform_point(accumulated_visual_context_index(), screen_position.to_type<float>() * pixel_ratio);
-    return (result / pixel_ratio).to_type<CSSPixels>();
-}
-
-CSSPixelPoint Paintable::transform_to_local_coordinates(CSSPixelPoint screen_position) const
-{
-    return transform_point_to_local(screen_position).value_or(screen_position);
 }
 
 bool Paintable::has_resizer() const
@@ -1337,134 +899,10 @@ bool Paintable::resizer_contains(CSSPixelPoint adjusted_position, ChromeMetrics 
     if (!handle_rect.has_value())
         return false;
     bool bottom_left_resizer = is_chrome_mirrored();
-    handle_rect->inflate(0, bottom_left_resizer ? 0 : box_model().border.right, box_model().border.bottom, bottom_left_resizer ? box_model().border.left : 0);
+    auto box_model = Painting::box_model(layout_node());
+    handle_rect->inflate(0, bottom_left_resizer ? 0 : box_model.border.right, box_model.border.bottom, bottom_left_resizer ? box_model.border.left : 0);
 
     return handle_rect->contains(adjusted_position);
-}
-
-void Paintable::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
-{
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
-        Layout::RustFFI::layout_arena_paintable_invalidate_for_repaint(rust_arena().handle(), rust_slot());
-
-        // The root element paints the body's propagated background, so a body repaint must also refresh the
-        // root's cached background. A root repaint can conversely flip whether propagation applies, changing
-        // what the body itself paints.
-        if (body_background_is_propagated_to_root(layout_node())) {
-            if (auto const* document_element = document().document_element()) {
-                if (auto document_element_paintable = document_element->unsafe_paintable())
-                    document_element_paintable->invalidate_paint_cache();
-            }
-        } else if (layout_node().is_root_element()) {
-            if (auto const* body = document().body()) {
-                if (auto body_paintable = body->unsafe_paintable())
-                    body_paintable->invalidate_paint_cache();
-            }
-        }
-    }
-    document().set_needs_repaint(Badge<Painting::Paintable> {}, should_invalidate_display_list);
-}
-
-// https://www.w3.org/TR/css-transforms-1/#reference-box
-CSSPixelRect Paintable::transform_reference_box() const
-{
-    auto transform_box = layout_node().transform_box();
-    // For SVG elements without associated CSS layout box, the used value for content-box is fill-box and for
-    // border-box is stroke-box.
-    // FIXME: This currently detects any SVG element except the <svg> one. Is that correct?
-    //        And is it correct to use `else` below?
-    if (is_svg_paintable()) {
-        switch (transform_box) {
-        case CSS::TransformBox::ContentBox:
-            transform_box = CSS::TransformBox::FillBox;
-            break;
-        case CSS::TransformBox::BorderBox:
-            transform_box = CSS::TransformBox::StrokeBox;
-            break;
-        default:
-            break;
-        }
-    }
-    // For elements with associated CSS layout box, the used value for fill-box is content-box and for
-    // stroke-box and view-box is border-box.
-    else {
-        switch (transform_box) {
-        case CSS::TransformBox::FillBox:
-            transform_box = CSS::TransformBox::ContentBox;
-            break;
-        case CSS::TransformBox::StrokeBox:
-        case CSS::TransformBox::ViewBox:
-            transform_box = CSS::TransformBox::BorderBox;
-            break;
-        default:
-            break;
-        }
-    }
-
-    switch (transform_box) {
-    case CSS::TransformBox::ContentBox:
-        // Uses the content box as reference box.
-        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
-        return absolute_rect();
-    case CSS::TransformBox::BorderBox:
-        // Uses the border box as reference box.
-        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
-        return absolute_border_box_rect();
-    case CSS::TransformBox::FillBox:
-        // Uses the object bounding box as reference box.
-        // FIXME: For now we're using the content rect as an approximation.
-        return absolute_rect();
-    case CSS::TransformBox::StrokeBox:
-        // Uses the stroke bounding box as reference box.
-        // FIXME: For now we're using the border rect as an approximation.
-        return absolute_border_box_rect();
-    case CSS::TransformBox::ViewBox: {
-        // Uses the nearest SVG viewport as reference box.
-        // FIXME: If a viewBox attribute is specified for the SVG viewport creating element:
-        //  - The reference box is positioned at the origin of the coordinate system established by the viewBox attribute.
-        //  - The dimension of the reference box is set to the width and height values of the viewBox attribute.
-        auto const* viewport_paintable = nearest_svg_viewport_paintable_of(layout_node());
-        if (!viewport_paintable)
-            return absolute_border_box_rect();
-        return svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
-    }
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static Optional<CSS::BorderData> border_data_for_outline(Layout::Node const& layout_node, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width)
-{
-    CSS::LineStyle line_style;
-    if (outline_style == CSS::OutlineStyle::Auto) {
-        line_style = CSS::LineStyle::Solid;
-        outline_color = CSS::KeywordStyleValue::create(CSS::Keyword::Accentcolor)->to_color(CSS::ColorResolutionContext::for_layout_node_with_style(*static_cast<Layout::NodeWithStyle const*>(&layout_node))).value();
-        outline_width = 2;
-    } else {
-        line_style = CSS::keyword_to_line_style(CSS::to_keyword(outline_style)).value_or(CSS::LineStyle::None);
-    }
-
-    if (outline_color.alpha() == 0 || line_style == CSS::LineStyle::None || outline_width == 0)
-        return {};
-
-    return CSS::BorderData {
-        .color = outline_color,
-        .line_style = line_style,
-        .width = outline_width,
-    };
-}
-
-Optional<CSS::BorderData> Paintable::outline_data(CSS::ComputedValues const& computed_values) const
-{
-    // The `auto` outline is the UA focus ring; like native controls, it is only shown while the window has focus.
-    if (computed_values.outline_style() == CSS::OutlineStyle::Auto && (!navigable() || !navigable()->is_focused()))
-        return {};
-
-    return border_data_for_outline(layout_node(), computed_values.outline_color(), computed_values.outline_style(), computed_values.outline_width());
-}
-
-CSSPixels Paintable::outline_offset() const
-{
-    return layout_node().outline_offset();
 }
 
 RefPtr<Paintable const> Paintable::nearest_scrollable_ancestor() const
@@ -1477,7 +915,7 @@ RefPtr<Paintable const> Paintable::nearest_scrollable_ancestor() const
             return nullptr;
         if (paintable->could_be_scrolled_by_wheel_event())
             return paintable;
-        if (paintable->is_fixed_position())
+        if (Painting::is_fixed_position(*box))
             return nullptr;
     }
     return nullptr;

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -63,7 +63,7 @@ RefPtr<Paintable> paintable_for_slot(void* arena_handle, Layout::RustFFI::Painta
 
 bool body_background_is_propagated_to_root(Layout::NodeWithStyle const&);
 
-void invalidate_descendant_styles_for_container_query_size_change(Paintable&, CSSPixelSize old_content_size, CSSPixelSize new_content_size);
+void invalidate_descendant_styles_for_container_query_size_change(GC::Ptr<DOM::Node>, CSSPixelSize old_content_size, CSSPixelSize new_content_size);
 
 // Used grid track data captured at layout time as plain values; getComputedStyle
 // reflection mints style values from it on demand.

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -45,6 +45,7 @@ struct FlexboxInspectorOverlayOptions;
 struct GridInspectorOverlayOptions;
 class HitTestDisplayList;
 class Paintable;
+class PaintableWithLines;
 class ResizeHandle;
 class Scrollbar;
 
@@ -75,6 +76,34 @@ struct UsedGridTrackList {
     Vector<CSSPixels> track_sizes;
 };
 
+struct TextDecorationStyle {
+    Vector<CSS::TextDecorationLine> line;
+    CSS::TextDecorationStyle style;
+    Color color;
+};
+
+struct SelectionStyle {
+    Color background_color;
+    Optional<Color> text_color {};
+    Optional<Vector<ShadowData>> text_shadow {};
+    Optional<TextDecorationStyle> text_decoration {};
+
+    bool has_styling() const
+    {
+        return background_color.alpha() > 0 || text_color.has_value() || text_shadow.has_value() || text_decoration.has_value();
+    }
+};
+
+struct OverflowData {
+    CSSPixelRect scrollable_overflow_rect;
+    bool has_scrollable_overflow { false };
+};
+
+struct CachedOverflowData {
+    CSSPixelRect rect_relative_to_padding_box;
+    bool has_scrollable_overflow { false };
+};
+
 class WEB_API Paintable
     : public RefCounted<Paintable>
     , public Weakable<Paintable> {
@@ -85,18 +114,6 @@ public:
     virtual ~Paintable();
 
     Layout::RustFFI::PaintableKind kind() const { return rust_data().kind; }
-    StringView class_name() const;
-
-    [[nodiscard]] bool is_visible() const;
-    [[nodiscard]] bool is_positioned() const { return has_flag(Layout::RustFFI::PaintableFlag::Positioned); }
-    [[nodiscard]] bool is_fixed_position() const { return has_flag(Layout::RustFFI::PaintableFlag::FixedPosition); }
-    [[nodiscard]] bool is_sticky_position() const { return has_flag(Layout::RustFFI::PaintableFlag::StickyPosition); }
-    [[nodiscard]] bool is_absolutely_positioned() const { return has_flag(Layout::RustFFI::PaintableFlag::AbsolutelyPositioned); }
-    [[nodiscard]] bool is_floating() const { return has_flag(Layout::RustFFI::PaintableFlag::Floating); }
-    [[nodiscard]] bool is_inline() const { return has_flag(Layout::RustFFI::PaintableFlag::Inline); }
-    [[nodiscard]] CSS::Display display() const;
-
-    bool has_stacking_context() const;
 
     bool has_layout_node() const { return m_layout_node; }
     Layout::NodeWithStyle const& layout_node() const
@@ -109,10 +126,6 @@ public:
     [[nodiscard]] GC::Ptr<DOM::Node> dom_node();
     [[nodiscard]] GC::Ptr<DOM::Node const> dom_node() const;
     void set_dom_node(GC::Ptr<DOM::Node>);
-
-    CSS::StyleRecordID style_record_identity() const;
-
-    bool visible_for_hit_testing() const;
 
     GC::Ptr<HTML::LocalNavigable> navigable() const;
 
@@ -150,8 +163,6 @@ public:
     DOM::Document const& document() const;
     DOM::Document& document();
 
-    virtual CSSPixelPoint box_type_agnostic_position() const;
-
     enum class ScrollBlockDirection {
         No,
         Yes,
@@ -159,30 +170,6 @@ public:
 
     static void scroll_text_offset_into_view(DOM::Text const&, size_t offset, TextAffinity = TextAffinity::Downstream, ScrollBlockDirection = ScrollBlockDirection::Yes);
     void scroll_ancestor_to_offset_into_view(size_t offset);
-
-    using SelectionState = Painting::SelectionState;
-    SelectionState selection_state() const { return static_cast<SelectionState>(rust_data().selection_state); }
-
-    struct TextDecorationStyle {
-        Vector<CSS::TextDecorationLine> line;
-        CSS::TextDecorationStyle style;
-        Color color;
-    };
-    struct SelectionStyle {
-        Color background_color;
-        Optional<Color> text_color {};
-        Optional<Vector<ShadowData>> text_shadow {};
-        Optional<TextDecorationStyle> text_decoration {};
-
-        bool has_styling() const
-        {
-            return background_color.alpha() > 0 || text_color.has_value() || text_shadow.has_value() || text_decoration.has_value();
-        }
-    };
-    [[nodiscard]] SelectionStyle selection_style() const;
-    [[nodiscard]] static SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM::Node const>);
-
-    [[nodiscard]] String debug_description() const;
 
     friend class Layout::Node;
 
@@ -192,44 +179,9 @@ public:
     Layout::NodeArena& rust_arena() const { return *m_rust_arena; }
     Layout::RustFFI::PaintableData const& rust_data() const { return *m_rust_data; }
 
-    // The viewBox/preserveAspectRatio transform a viewport-establishing box applies to its
-    // content, in content-box-local user coordinates. Presence marks the paintable as
-    // viewport-establishing for the accumulated visual context tree.
-    Optional<Gfx::AffineTransform> svg_viewport_transform() const;
-
-    Gfx::Path const* committed_svg_path() const;
-
-    // Callers are responsible for checking that the element is empty and visible.
-
-    void invalidate_stacking_context();
-    Optional<int> effective_z_index() const;
-
     Optional<CSSPixelRect> get_mask_area() const;
     Optional<Gfx::MaskKind> get_mask_type() const;
     Optional<CSSPixelRect> get_clip_area() const;
-
-    CSSPixelSize svg_viewport_size() const
-    {
-        return {
-            CSSPixels::from_raw(rust_data().svg_viewport_size.width),
-            CSSPixels::from_raw(rust_data().svg_viewport_size.height),
-        };
-    }
-
-    BoxModelMetrics box_model() const;
-
-    struct OverflowData {
-        CSSPixelRect scrollable_overflow_rect;
-        bool has_scrollable_overflow { false };
-    };
-
-    struct CachedOverflowData {
-        CSSPixelRect rect_relative_to_padding_box;
-        bool has_scrollable_overflow { false };
-    };
-
-    // Offset from the top left of the containing block's content edge.
-    [[nodiscard]] CSSPixelPoint offset() const;
 
     enum class ScrollHandled {
         No,
@@ -246,48 +198,6 @@ public:
     ScrollHandled set_scroll_offset_from_user_input(CSSPixelPoint);
     ScrollHandled scroll_by(double delta_x, double delta_y);
     void scroll_into_view(CSSPixelRect);
-
-    CSSPixelSize content_size() const;
-    CSSPixels content_width() const { return content_size().width(); }
-    CSSPixels content_height() const { return content_size().height(); }
-
-    CSSPixelRect absolute_rect() const;
-    CSSPixelRect absolute_padding_box_rect() const;
-    CSSPixelRect absolute_border_box_rect() const;
-
-    CSSPixels border_box_width() const
-    {
-        auto border_box = box_model().border_box();
-        return content_width() + border_box.left + border_box.right;
-    }
-
-    CSSPixels border_box_height() const
-    {
-        auto border_box = box_model().border_box();
-        return content_height() + border_box.top + border_box.bottom;
-    }
-
-    CSSPixels absolute_x() const { return absolute_rect().x(); }
-    CSSPixels absolute_y() const { return absolute_rect().y(); }
-    CSSPixelPoint absolute_position() const { return absolute_rect().location(); }
-
-    CSSPixelPoint transform_to_local_coordinates(CSSPixelPoint position) const;
-
-    [[nodiscard]] bool has_scrollable_overflow() const;
-
-    [[nodiscard]] bool has_css_transform() const;
-
-    [[nodiscard]] bool has_non_invertible_css_transform() const { return has_flag(Layout::RustFFI::PaintableFlag::HasNonInvertibleCssTransform); }
-
-    [[nodiscard]] Optional<CSSPixelRect> scrollable_overflow_rect() const;
-
-    [[nodiscard]] Optional<OverflowData> overflow_data() const;
-    void clear_overflow_data();
-
-    Optional<CachedOverflowData> cached_overflow_data() const;
-    void clear_cached_overflow_data();
-
-    void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
 
     virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y);
 
@@ -317,11 +227,6 @@ public:
     RefPtr<Scrollbar> scrollbar(ScrollDirection) const;
     NonnullRefPtr<Scrollbar> ensure_scrollbar(ScrollDirection);
 
-    bool uses_collapsing_borders_model() const { return rust_data().uses_collapsing_borders_model; }
-
-    Optional<CSS::BorderData> outline_data(CSS::ComputedValues const&) const;
-    CSSPixels outline_offset() const;
-
     void set_filter(ResolvedCSSFilter filter) { m_filter = move(filter); }
     ResolvedCSSFilter const& filter() const { return m_filter; }
 
@@ -338,48 +243,13 @@ public:
     RefPtr<ResizeHandle> resize_handle() const;
     NonnullRefPtr<ResizeHandle> ensure_resize_handle();
 
-    CSSPixelRect transform_reference_box() const;
-
     RefPtr<Paintable const> nearest_scrollable_ancestor() const;
-
-    using StickyInsets = Painting::StickyInsets;
-    bool has_sticky_insets() const { return rust_data().has_sticky_insets; }
-    StickyInsets sticky_insets() const;
-    void set_sticky_insets(OwnPtr<StickyInsets>);
 
     [[nodiscard]] bool could_be_scrolled_by_wheel_event() const;
     [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection direction) const;
 
-    Optional<UsedGridTrackList> used_values_for_grid_template_columns() const;
-    Optional<UsedGridTrackList> used_values_for_grid_template_rows() const;
-    Optional<String> grid_layout_json(UniqueNodeID container_node_id) const;
-    Optional<String> flex_layout_json(UniqueNodeID container_node_id) const;
-
-    [[nodiscard]] bool has_accumulated_visual_context() const { return rust_data().has_accumulated_visual_context; }
-    [[nodiscard]] VisualContextIndex accumulated_visual_context_index() const { return VisualContextIndex { rust_data().accumulated_visual_context_index }; }
-    [[nodiscard]] VisualContextIndex accumulated_visual_context_for_descendants_index() const { return VisualContextIndex { rust_data().accumulated_visual_context_for_descendants_index }; }
-
-    Optional<CSSPixelPoint> transform_point_to_local(CSSPixelPoint screen_position) const;
-    Optional<CSSPixelPoint> transform_point_to_local_for_descendants(CSSPixelPoint screen_position) const;
-    CSSPixelRect transform_rect_to_viewport(CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes) const;
-    CSSPixelPoint inverse_transform_point(CSSPixelPoint screen_position) const;
-
-    void invalidate_paint_cache() const;
-    void repaint_after_style_change(CSS::RequiredInvalidationAfterStyleChange const&);
-
-    [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const
-    {
-        if (!rust_data().has_fixed_background_visual_context)
-            return {};
-        return VisualContextIndex { rust_data().fixed_background_visual_context };
-    }
-
     [[nodiscard]] size_t visual_context_nodes_begin() const { return rust_data().visual_context_nodes_begin; }
     [[nodiscard]] size_t visual_context_nodes_end() const { return rust_data().visual_context_nodes_end; }
-
-    [[nodiscard]] VisualContextIndex enclosing_scroll_node_index() const { return VisualContextIndex { rust_data().enclosing_scroll_node_index }; }
-
-    [[nodiscard]] VisualContextIndex own_scroll_node_index() const { return VisualContextIndex { rust_data().own_scroll_node_index }; }
 
 protected:
     explicit Paintable(Layout::NodeWithStyle const&);

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -199,8 +199,6 @@ public:
 
     Gfx::Path const* committed_svg_path() const;
 
-    bool should_paint_cursor() const;
-
     // Callers are responsible for checking that the element is empty and visible.
 
     void invalidate_stacking_context();

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -7,23 +7,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Position.h>
-#include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
-#include <LibWeb/Layout/Node.h>
-#include <LibWeb/Layout/TextNode.h>
-#include <LibWeb/Layout/TextOffsetMapping.h>
-#include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
-#include <LibWeb/Painting/PaintingRustBridge.h>
 
 namespace Web::Painting {
 
-static bool layout_node_is_visible(Layout::NodeWithStyle const& layout_node)
-{
-    return layout_node.visibility() == CSS::Visibility::Visible && layout_node.opacity() != 0;
-}
 NonnullRefPtr<PaintableWithLines> PaintableWithLines::create(Layout::BlockContainer const& block_container)
 {
     return adopt_ref(*new PaintableWithLines(block_container));
@@ -36,142 +24,6 @@ PaintableWithLines::PaintableWithLines(Layout::BlockContainer const& layout_box)
 
 PaintableWithLines::~PaintableWithLines()
 {
-}
-
-InlinePaintable const* nearest_self_painting_inline_box(Layout::Node const& node)
-{
-    for (auto const* ancestor = node.nearest_fragmented_inline_ancestor(); ancestor; ancestor = ancestor->nearest_fragmented_inline_ancestor()) {
-        auto const* proxy = as_if<InlinePaintable>(ancestor->paintable().ptr());
-        if (proxy && proxy->is_self_painting())
-            return proxy;
-    }
-    return nullptr;
-}
-
-CSSPixelRect PaintableWithLines::caret_rect_for_child_offset(size_t offset) const
-{
-    auto content_box = absolute_padding_box_rect();
-    auto line_height = layout_node().line_height();
-    CSSPixelRect rect { content_box.x(), content_box.y(), 1, line_height };
-
-    auto dom_node = layout_node().dom_node();
-    if (!dom_node)
-        return rect;
-
-    // A boundary immediately after an atomic inline element paints after that element. Atomic inline elements have
-    if (offset > 0) {
-        auto* previous_child = dom_node->child_at_index(offset - 1);
-        auto const* previous_layout_node = previous_child ? previous_child->unsafe_layout_node() : nullptr;
-        if (previous_layout_node && previous_layout_node->is_atomic_inline()) {
-            auto result = Layout::RustFFI::layout_arena_paintable_first_fragment_rect_for_node(rust_arena().handle(), rust_slot(), Layout::Node::slot_id(previous_layout_node));
-            if (result.has_value) {
-                auto fragment_rect = from_ffi_css_pixel_rect(result.rect);
-                if (layout_node().writing_mode() == CSS::WritingMode::HorizontalTb)
-                    rect.set_x(layout_node().inline_axis_is_reverse() ? fragment_rect.left() : fragment_rect.right());
-                else
-                    rect.set_y(layout_node().inline_axis_is_reverse() ? fragment_rect.top() : fragment_rect.bottom());
-                return rect;
-            }
-        }
-    }
-
-    auto* child = dom_node->child_at_index(offset);
-    if (!child || !is<HTML::HTMLBRElement>(*child))
-        return rect;
-
-    // A caret parked before a <br> sits on the line below the content preceding the <br>. Layout produces no
-    // fragments for <br>, so start below the fragments of any preceding content, and add one line height for each
-    // empty line rendered by earlier <br>s.
-    struct PrecedingContentContext {
-        GC::Ref<DOM::Node> child;
-        Optional<CSSPixels> preceding_content_bottom;
-    } preceding_context { const_cast<DOM::Node&>(*child), {} };
-    Layout::RustFFI::layout_arena_for_each_subtree_fragment_rect(
-        rust_arena().handle(), rust_slot(), &preceding_context,
-        [](void* context_pointer, void* fragment_layout_node_shell, Layout::RustFFI::FfiCssPixelRect rect) {
-            auto& context = *static_cast<PrecedingContentContext*>(context_pointer);
-            auto const* fragment_layout_node = static_cast<Layout::Node const*>(fragment_layout_node_shell);
-            auto* fragment_dom_node = fragment_layout_node ? const_cast<DOM::Node*>(fragment_layout_node->dom_node()) : nullptr;
-            if (!fragment_dom_node || !(context.child->compare_document_position(fragment_dom_node) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
-                return;
-            auto bottom = CSSPixels::from_raw(rect.y) + CSSPixels::from_raw(rect.height);
-            if (!context.preceding_content_bottom.has_value() || bottom > *context.preceding_content_bottom)
-                context.preceding_content_bottom = bottom;
-        });
-    auto& preceding_content_bottom = preceding_context.preceding_content_bottom;
-
-    size_t preceding_empty_lines = 0;
-    dom_node->for_each_in_subtree_of_type<HTML::HTMLBRElement>([&](auto& br) {
-        if (&br == child)
-            return TraversalDecision::Break;
-        if (br.represents_empty_line())
-            ++preceding_empty_lines;
-        return TraversalDecision::Continue;
-    });
-
-    rect.set_y(preceding_content_bottom.value_or(content_box.y()) + line_height * preceding_empty_lines);
-    return rect;
-}
-
-Optional<PaintableWithLines::CaretPaint> PaintableWithLines::resolve_caret_paint(InlinePaintable const* owner) const
-{
-    if (!should_paint_cursor())
-        return {};
-
-    auto cursor_position = document().cursor_position();
-    VERIFY(cursor_position);
-
-    auto const* dom_node = layout_node().dom_node();
-
-    Vector<Layout::RustFFI::NodeSlotId, 2> text_slots;
-    if (auto const* text = as_if<DOM::Text>(cursor_position->node().ptr()))
-        text_slots = Layout::TextOffsetMapping { *text }.slot_ids();
-
-    if (!text_slots.is_empty()) {
-        auto result = Layout::RustFFI::layout_arena_text_caret_rect_for_position(
-            rust_arena().handle(), text_slots.data(), text_slots.size(), cursor_position->offset(),
-            cursor_position->affinity() == TextAffinity::Downstream);
-        if (result.found && result.owner_paintable.index == rust_slot().index) {
-            auto owner_slot = owner ? owner->rust_slot()
-                                    : Layout::RustFFI::PaintableSlotId { Layout::RustFFI::INVALID_PAINTABLE_SLOT_INDEX };
-            if (result.nearest_self_painting_inline.index != owner_slot.index)
-                return {};
-            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(result.style_source);
-            if (!style_source || !layout_node_is_visible(*style_source))
-                return {};
-            return CaretPaint { from_ffi_css_pixel_rect(result.rect), style_source->caret_color() };
-        }
-        if (result.found) {
-            return {};
-        }
-    }
-
-    if (owner) {
-        // Blank lines and empty editable elements are handled by the block / the box itself.
-        return {};
-    }
-    if (!is_visible()) {
-        // Blank-line and empty-element carets belong to this block itself.
-        return {};
-    }
-
-    if (!text_slots.is_empty()) {
-        auto empty_line = Layout::RustFFI::layout_arena_paintable_empty_line_caret_rect(
-            rust_arena().handle(), rust_slot(), text_slots.data(), text_slots.size(), cursor_position->offset());
-        if (empty_line.has_value) {
-            auto const* style_source = static_cast<Layout::NodeWithStyle const*>(empty_line.style_source);
-            if (!style_source)
-                return {};
-            auto empty_line_rect = from_ffi_css_pixel_rect(empty_line.rect);
-            CSSPixelRect cursor_rect { empty_line_rect.x(), empty_line_rect.y(), 1, empty_line_rect.height() };
-            return CaretPaint { cursor_rect, style_source->caret_color() };
-        }
-    }
-
-    if (cursor_position->node() != GC::Ptr { dom_node })
-        return {};
-
-    return CaretPaint { caret_rect_for_child_offset(cursor_position->offset()), layout_node().caret_color() };
 }
 
 } // namespace Web::Painting

--- a/Libraries/LibWeb/Painting/PaintableWithLines.h
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.h
@@ -7,30 +7,14 @@
 
 #pragma once
 
-#include <AK/Function.h>
-#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Painting {
-
-class InlinePaintable;
-
-InlinePaintable const* nearest_self_painting_inline_box(Layout::Node const&);
 
 class PaintableWithLines : public Paintable {
 public:
     static NonnullRefPtr<PaintableWithLines> create(Layout::BlockContainer const&);
     virtual ~PaintableWithLines() override;
-
-    struct CaretPaint {
-        CSSPixelRect rect;
-        Color color;
-    };
-    Optional<CaretPaint> resolve_caret_paint(InlinePaintable const* owner) const;
-
-    // Caret rect for a cursor parked on this paintable's DOM node at the given child offset, e.g. on an empty line
-    // rendered by a <br> child or in an empty editable element.
-    CSSPixelRect caret_rect_for_child_offset(size_t offset) const;
 
 protected:
     PaintableWithLines(Layout::BlockContainer const&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -43,15 +43,14 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/Blending.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/ChromeWidget.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ImagePaint.h>
-#include <LibWeb/Painting/InlinePaintable.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/PaintingRustFFI.h>
 #include <LibWeb/Painting/ResizeHandle.h>
@@ -716,8 +715,9 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
             };
         },
         .line_break_caret_targets = [](void*, void* paintable_shell, void* sink) {
-            auto const& paintable = as<PaintableWithLines>(*static_cast<Paintable const*>(paintable_shell));
-            auto* dom_node = paintable.layout_node().dom_node();
+            auto const& layout_node = static_cast<Paintable const*>(paintable_shell)->layout_node();
+            VERIFY(is_paintable_with_lines(layout_node));
+            auto* dom_node = layout_node.dom_node();
             if (!dom_node)
                 return;
             for (auto* child = dom_node->first_child(); child; child = child->next_sibling()) {
@@ -726,7 +726,7 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
                     continue;
                 Layout::RustFFI::FfiLineBreakCaretTarget target {};
                 target.caret_offset = br->index();
-                target.rect = to_ffi_css_pixel_rect(paintable.caret_rect_for_child_offset(br->index()));
+                target.rect = to_ffi_css_pixel_rect(caret_rect_for_child_offset(layout_node, br->index()));
                 Layout::RustFFI::layout_arena_hit_test_push_line_break_caret_target(sink, target);
             } },
     };
@@ -960,13 +960,18 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             return context.resource_storage.add_font(*static_cast<Gfx::Font const*>(font)).value();
         },
         .cursor_facts = [](void*, void* paintable_shell, void* owner_shell) -> Layout::RustFFI::FfiCursorFacts {
-            auto const& paintable = *static_cast<Paintable const*>(paintable_shell);
+            auto const& layout_node = static_cast<Paintable const*>(paintable_shell)->layout_node();
             Layout::RustFFI::FfiCursorFacts facts {};
-            if (!paintable.document().cursor_position())
+            if (!layout_node.document().cursor_position())
                 return facts;
-            auto caret = is<InlinePaintable>(paintable)
-                ? static_cast<InlinePaintable const&>(paintable).resolve_empty_editable_caret_paint()
-                : as<PaintableWithLines>(paintable).resolve_caret_paint(static_cast<InlinePaintable const*>(owner_shell));
+            auto const* owner_layout_node = owner_shell ? &static_cast<Paintable const*>(owner_shell)->layout_node() : nullptr;
+            Optional<CaretPaint> caret;
+            if (is_inline_paintable(layout_node)) {
+                caret = resolve_empty_editable_caret_paint(layout_node);
+            } else {
+                VERIFY(is_paintable_with_lines(layout_node));
+                caret = resolve_caret_paint(layout_node, owner_layout_node);
+            }
             if (!caret.has_value())
                 return facts;
             facts.paints = true;

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -641,13 +641,13 @@ static void dump_stacking_context_node(StringBuilder& builder, void* arena, size
     for (int i = 0; i < indent; ++i)
         builder.append(' ');
     if (auto const* paintable = static_cast<Paintable const*>(node.paintable_shell)) {
-        builder.appendff("SC for {} {} (z-index: ", paintable->layout_node().debug_description(), paintable->absolute_rect());
+        builder.appendff("SC for {} {} (z-index: ", paintable->layout_node().debug_description(), absolute_rect(paintable->layout_node()));
         if (node.has_effective_z_index)
             builder.appendff("{}", node.effective_z_index);
         else
             builder.append("auto"sv);
         builder.append(')');
-        if (paintable->has_css_transform())
+        if (has_css_transform(paintable->layout_node()))
             builder.append(", has_transform"sv);
     } else {
         builder.append("SC for (gone)"sv);
@@ -676,7 +676,7 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
             auto const& layout_node = paintable.layout_node();
             Layout::RustFFI::FfiHitTestPaintableFacts facts {};
             facts.opacity_is_zero = layout_node.opacity() == 0;
-            facts.visible_for_hit_testing = paintable.visible_for_hit_testing();
+            facts.visible_for_hit_testing = visible_for_hit_testing(layout_node);
             auto dom_node = paintable.dom_node();
             facts.dom_node_has_parent = dom_node && dom_node->parent();
             facts.is_editable_or_editing_host = dom_node && dom_node->is_editable_or_editing_host();
@@ -864,8 +864,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 auto const* image_element = as_if<HTML::HTMLImageElement>(paintable.dom_node().ptr());
                 if (map_element && image_element && map_element->first_painted_image_with_focusable_shapes().ptr() == image_element) {
                     if (auto area_computed_values = area_element->computed_style(); area_computed_values && area_computed_values->outline_style() == CSS::OutlineStyle::Auto) {
-                        if (auto outline_data = paintable.outline_data(*area_computed_values); outline_data.has_value()) {
-                            if (auto path = area_element->shape_path(paintable.absolute_rect().size()); path.has_value()) {
+                        if (auto outline_data = Painting::outline_data(paintable.layout_node(), *area_computed_values); outline_data.has_value()) {
+                            if (auto path = area_element->shape_path(absolute_rect(paintable.layout_node()).size()); path.has_value()) {
                                 facts.paints_focused_area_outline = true;
                                 facts.focused_area_path = new Gfx::Path(path.release_value());
                                 facts.focused_area_color = outline_data->color.value();
@@ -934,7 +934,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto const* text_node = as_if<Layout::TextNode>(static_cast<Layout::Node const*>(layout_node_shell));
             if (!text_node)
                 return facts;
-            auto style = Paintable::selection_style_for_node(*text_node, text_node->dom_text());
+            auto style = selection_style_for_node(*text_node, text_node->dom_text());
             facts.background_color = style.background_color.value();
             if (style.text_color.has_value()) {
                 facts.has_text_color = true;
@@ -1069,8 +1069,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                     facts.natural_aspect_ratio_numerator = aspect_ratio->numerator().raw_value();
                     facts.natural_aspect_ratio_denominator = aspect_ratio->denominator().raw_value();
                 }
-                if (paintable.selection_state() != Paintable::SelectionState::None)
-                    facts.selection_background_color = paintable.selection_style().background_color.value();
+                if (selection_state(paintable.layout_node()) != SelectionState::None)
+                    facts.selection_background_color = selection_style(layout_node).background_color.value();
             } else if (paintable.kind() == Layout::RustFFI::PaintableKind::CanvasPaintable) {
                 auto& canvas_element = as<HTML::HTMLCanvasElement>(*paintable.dom_node());
                 if (auto content_size = canvas_element.canvas_surface_content_size(); content_size.has_value()) {
@@ -1322,9 +1322,9 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             Utf16String text;
             if (paintable_shell) {
                 auto const& paintable = *static_cast<Paintable const*>(paintable_shell);
-                auto border_rect = paintable.absolute_border_box_rect();
+                auto border_rect = absolute_border_box_rect(paintable.layout_node());
                 Utf16StringBuilder builder;
-                builder.appendff("{}", paintable.debug_description());
+                builder.appendff("{}", debug_description(paintable.layout_node()));
                 builder.appendff(" {}x{} @ {},{}", border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
                 text = builder.to_string();
             } else if (utf16_fly_string_raw) {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -1278,7 +1278,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 },
                 [&](SVG::SVGGraphicsElement::PatternPaintServer const& pattern) {
                     style.kind = Layout::RustFFI::FfiSvgPaintStyleKind::Pattern;
-                    style.pattern_paintable = pattern.pattern_paintable->rust_slot();
+                    style.pattern_paintable = pattern.pattern_paintable->paintable_ptr()->rust_slot();
                     write_matrix(pattern.tile_content_transform.matrix, style.tile_content_transform);
                     style.tile_rect[0] = pattern.tile_rect.x();
                     style.tile_rect[1] = pattern.tile_rect.y();

--- a/Libraries/LibWeb/Painting/SVGMasking.cpp
+++ b/Libraries/LibWeb/Painting/SVGMasking.cpp
@@ -7,6 +7,7 @@
 #include <LibGfx/BoundingBox.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
@@ -58,16 +59,16 @@ static Layout::Box const* get_clip_box(SVG::SVGGraphicsElement const& graphics_e
 //         box for it — so its border box still stands in there.
 static CSSPixelRect target_user_space_object_bounding_box(Paintable const& target_paintable)
 {
-    if (auto const* committed_path = target_paintable.committed_svg_path())
+    if (auto const* committed_path = Painting::committed_svg_path(target_paintable.layout_node()))
         return committed_path->bounding_box().to_type<CSSPixels>();
-    return target_paintable.absolute_border_box_rect();
+    return Painting::absolute_border_box_rect(target_paintable.layout_node());
 }
 
 // https://drafts.csswg.org/css-masking-1/#ClipPathElement
 static bool contributes_to_clip_path(Paintable const& paintable)
 {
     // If a child element is made invisible by display or visibility it does not contribute to the clipping path.
-    return paintable.layout_node().visibility() == CSS::Visibility::Visible && !paintable.display().is_none();
+    return paintable.layout_node().visibility() == CSS::Visibility::Visible && !Painting::display(paintable.layout_node()).is_none();
 }
 
 // https://drafts.csswg.org/css-masking-1/#ClipPathElement
@@ -77,7 +78,7 @@ static Optional<CSSPixelRect> svg_clip_path_geometry_bounds(Paintable const& pai
         return {};
 
     if (paintable.is_svg_path_paintable()) {
-        auto const* committed_path = paintable.committed_svg_path();
+        auto const* committed_path = Painting::committed_svg_path(paintable.layout_node());
         if (!committed_path)
             return {};
         auto path = committed_path->copy_transformed(additional_transform);

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -6,7 +6,9 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Scrollbar.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/UIEvents/EventNames.h>
@@ -54,7 +56,7 @@ MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned
     auto position = paintable_box->transform_to_local_coordinates(visual_viewport_position);
     if (!scroll_to_mouse_position(position) && !m_thumb_grab_position.has_value())
         return MouseAction::None;
-    paintable_box->set_needs_repaint();
+    Painting::set_needs_repaint(paintable_box->layout_node());
 
     if (type == UIEvents::EventNames::pointerup) {
         release_thumb_grab();
@@ -81,7 +83,7 @@ MouseAction Scrollbar::mouse_up(CSSPixelPoint, unsigned)
 {
     release_thumb_grab();
     if (auto paintable_box = paintable())
-        paintable_box->set_needs_repaint();
+        Painting::set_needs_repaint(paintable_box->layout_node());
     return MouseAction::None;
 }
 
@@ -97,7 +99,7 @@ void Scrollbar::mouse_enter()
         return;
     m_hovered = true;
     if (auto paintable_box = paintable())
-        paintable_box->set_needs_repaint();
+        Painting::set_needs_repaint(paintable_box->layout_node());
 }
 
 void Scrollbar::mouse_leave()
@@ -106,7 +108,7 @@ void Scrollbar::mouse_leave()
         return;
     m_hovered = false;
     if (auto paintable_box = paintable())
-        paintable_box->set_needs_repaint();
+        Painting::set_needs_repaint(paintable_box->layout_node());
 }
 
 bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -53,7 +53,7 @@ MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned
         return MouseAction::None;
     }
 
-    auto position = paintable_box->transform_to_local_coordinates(visual_viewport_position);
+    auto position = Painting::transform_to_local_coordinates(paintable_box->layout_node(), visual_viewport_position);
     if (!scroll_to_mouse_position(position) && !m_thumb_grab_position.has_value())
         return MouseAction::None;
     Painting::set_needs_repaint(paintable_box->layout_node());
@@ -72,7 +72,7 @@ MouseAction Scrollbar::mouse_move(CSSPixelPoint position)
         auto paintable_box = paintable();
         if (!paintable_box)
             return MouseAction::None;
-        position = paintable_box->transform_to_local_coordinates(position);
+        position = Painting::transform_to_local_coordinates(paintable_box->layout_node(), position);
         scroll_to_mouse_position(position);
         return MouseAction::SwallowEvent;
     }
@@ -143,8 +143,8 @@ bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
     auto constrained_offset = AK::clamp(offset_relative_to_gutter - m_thumb_grab_position.value(), 0, gutter_size - thumb_size);
     auto scroll_position = constrained_offset.to_double() / (gutter_size - thumb_size).to_double();
 
-    auto scrollable_overflow_size = paintable_box->scrollable_overflow_rect()->primary_size_for_orientation(orientation);
-    auto padding_size = paintable_box->absolute_padding_box_rect().primary_size_for_orientation(orientation);
+    auto scrollable_overflow_size = Painting::scrollable_overflow_rect(paintable_box->layout_node())->primary_size_for_orientation(orientation);
+    auto padding_size = Painting::absolute_padding_box_rect(paintable_box->layout_node()).primary_size_for_orientation(orientation);
     auto minimum_scroll_offset = paintable_box->minimum_scroll_offset().primary_offset_for_orientation(orientation);
     auto scroll_position_in_pixels = minimum_scroll_offset + CSSPixels::nearest_value_for(scroll_position * (scrollable_overflow_size - padding_size));
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ScrollState.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
@@ -170,7 +171,7 @@ void ViewportPaintable::append_paint_command_cache_source_resources(DisplayListR
 void ViewportPaintable::invalidate_all_cached_paint()
 {
     Layout::RustFFI::layout_arena_invalidate_all_paint_caches(rust_arena().handle());
-    set_needs_repaint();
+    Painting::set_needs_repaint(layout_node());
 }
 
 void ViewportPaintable::refresh_scroll_state()

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserverEntry.cpp
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserverEntry.cpp
@@ -6,7 +6,8 @@
 
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Element.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/ResizeObserver/ResizeObserverEntry.h>
 
 namespace Web::ResizeObserver {
@@ -42,14 +43,14 @@ WebIDL::ExceptionOr<GC::Ref<ResizeObserverEntry>> ResizeObserverEntry::create_an
     // NB: Layout was up to date when observations were gathered, but a previous
     //     observer's callback may have invalidated it before we get here.
     //     This matches the behavior of all major browsers.
-    if (!target.is_svg_element() && target.unsafe_paintable_box()) {
-        auto const& paintable_box = *target.unsafe_paintable_box();
-        auto absolute_padding_rect = paintable_box.absolute_padding_box_rect();
+    auto const* layout_node = target.unsafe_layout_node();
+    if (!target.is_svg_element() && layout_node && Painting::has_committed_box(*layout_node)) {
+        auto absolute_padding_rect = Painting::absolute_padding_box_rect(*layout_node);
         // Set this.contentRect.top to target.padding top.
         y = absolute_padding_rect.y().to_double();
         // Set this.contentRect.left to target.padding left.
         x = absolute_padding_rect.x().to_double();
-    } else if (target.is_svg_element() && target.unsafe_paintable_box()) {
+    } else if (target.is_svg_element() && layout_node && Painting::has_committed_box(*layout_node)) {
         // 8. If target is an SVG element without an associated CSS layout box do these steps:
         // Set this.contentRect.top and this.contentRect.left to 0.
         // NOTE: This is already done by the default constructor.

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserverSize.cpp
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserverSize.cpp
@@ -7,7 +7,8 @@
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Window.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/ResizeObserver/ResizeObserverSize.h>
 
 namespace Web::ResizeObserver {
@@ -24,21 +25,21 @@ ResizeObserverSize::RawSize ResizeObserverSize::compute_box_size(DOM::Element& t
     // NB: Layout was up to date when observations were gathered, but a previous
     //     observer's callback may have invalidated it before we get here.
     //     This matches the behavior of all major browsers.
-    if (target.unsafe_paintable_box()) {
-        auto const& paintable_box = *target.unsafe_paintable_box();
+    auto const* layout_node = target.unsafe_layout_node();
+    if (layout_node && Painting::has_committed_box(*layout_node)) {
         switch (observed_box) {
         case ObservedBox::BorderBox:
-            size.inline_size = paintable_box.border_box_width().to_double();
-            size.block_size = paintable_box.border_box_height().to_double();
+            size.inline_size = Painting::border_box_width(*layout_node).to_double();
+            size.block_size = Painting::border_box_height(*layout_node).to_double();
             break;
         case ObservedBox::ContentBox:
-            size.inline_size = paintable_box.content_width().to_double();
-            size.block_size = paintable_box.content_height().to_double();
+            size.inline_size = Painting::content_width(*layout_node).to_double();
+            size.block_size = Painting::content_height(*layout_node).to_double();
             break;
         case ObservedBox::DevicePixelContentBox: {
             auto device_pixel_ratio = target.document().window()->device_pixel_ratio();
-            size.inline_size = paintable_box.border_box_width().to_double() * device_pixel_ratio;
-            size.block_size = paintable_box.border_box_height().to_double() * device_pixel_ratio;
+            size.inline_size = Painting::border_box_width(*layout_node).to_double() * device_pixel_ratio;
+            size.block_size = Painting::border_box_height(*layout_node).to_double() * device_pixel_ratio;
             break;
         }
         }

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
 #include <LibWeb/SVG/SVGDescElement.h>
@@ -407,8 +408,9 @@ Gfx::Size<double> SVGElement::viewport_size_for_percentage_resolution()
         if (!viewport_element.is_connected())
             return {};
 
-        if (auto const* svg_paintable = viewport_element.paintable().ptr(); svg_paintable && svg_paintable->is_svg_svg_paintable())
-            return svg_paintable->svg_viewport_size().to_type<double>();
+        auto const* layout_node = viewport_element.layout_node();
+        if (layout_node && Painting::has_committed_box(*layout_node) && Painting::is_svg_svg_paintable(*layout_node))
+            return Painting::svg_viewport_size(*layout_node).to_type<double>();
 
         return {};
     };

--- a/Libraries/LibWeb/SVG/SVGFilterElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.cpp
@@ -14,7 +14,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/SVG/SVGComponentTransferFunctionElement.h>
 #include <LibWeb/SVG/SVGFEBlendElement.h>
 #include <LibWeb/SVG/SVGFEColorMatrixElement.h>
@@ -301,14 +301,14 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter(Layout::NodeWithStyle const& 
 
             // NB: We use the unsafe accessor here because this may be called
             //     during layout update, before the layout-is-up-to-date flag
-            //     has been set. The paintable is valid since layout has already
-            //     been performed at this point.
-            auto paintable_box = dom_node->unsafe_paintable_box();
-            if (!paintable_box)
+            //     has been set. The committed box is valid since layout has
+            //     already been performed at this point.
+            auto const* layout_node = dom_node->unsafe_layout_node();
+            if (!layout_node || !Painting::has_committed_box(*layout_node))
                 return IterationDecision::Continue;
 
-            auto dest_rect = Gfx::enclosing_int_rect(paintable_box->absolute_rect().to_type<float>());
-            auto scaling_mode = CSS::to_gfx_scaling_mode(paintable_box->layout_node().image_rendering(), src_rect->size(), dest_rect.size());
+            auto dest_rect = Gfx::enclosing_int_rect(Painting::absolute_rect(*layout_node).to_type<float>());
+            auto scaling_mode = CSS::to_gfx_scaling_mode(as<Layout::NodeWithStyle>(*layout_node).image_rendering(), src_rect->size(), dest_rect.size());
             root = { Gfx::Filter::image(*frame, *src_rect, dest_rect, scaling_mode), Gfx::InterpolationColorSpace::SRGB };
             update_result_map(*image_primitive);
         } else if (auto* merge_primitive = as_if<SVGFEMergeElement>(node)) {

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -17,8 +17,8 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/PaintStyle.h>
-#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
@@ -382,7 +382,8 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
     //        calculate this from SVG geometry without a full layout tree (at least for simple cases).
     //        See: https://svgwg.org/svg2-draft/coords.html#BoundingBoxes
     document().update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::SVGGraphicsElementGetBBox);
-    if (!layout_node())
+    auto const* self_layout_node = layout_node();
+    if (!self_layout_node)
         return Geometry::DOMRect::create();
     auto owner_svg_element = this->owner_svg_element();
 
@@ -392,11 +393,10 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
     if (!owner_svg_element) {
         if (!is<SVGSVGElement>(*this))
             return Geometry::DOMRect::create();
-        auto self_paintable = paintable_box();
-        if (!self_paintable)
+        if (!Painting::has_committed_box(*self_layout_node))
             return Geometry::DOMRect::create();
         Gfx::FloatRect united_rect;
-        for (auto const* child = self_paintable->layout_node().first_child_ptr(); child; child = child->next_sibling_ptr()) {
+        for (auto const* child = self_layout_node->first_child_ptr(); child; child = child->next_sibling_ptr()) {
             switch (child->kind()) {
             case Layout::RustFFI::NodeKind::SVGMaskBox:
             case Layout::RustFFI::NodeKind::SVGClipBox:
@@ -405,10 +405,9 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
             default:
                 break;
             }
-            auto const* child_paintable = child->paintable_ptr();
-            if (!child_paintable)
+            if (!Painting::has_committed_box(*child))
                 continue;
-            auto child_rect = child_paintable->layout_node().used_svg_element_transform().map(child_paintable->absolute_rect().to_type<float>());
+            auto child_rect = as<Layout::NodeWithStyle>(*child).used_svg_element_transform().map(Painting::absolute_rect(*child).to_type<float>());
             united_rect.unite(child_rect);
         }
         if (united_rect.is_empty())
@@ -416,8 +415,8 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
         return Geometry::DOMRect::create(united_rect);
     }
 
-    auto self_paintable = paintable_box();
-    if (!owner_svg_element->paintable_box() || !self_paintable) {
+    auto const* owner_layout_node = owner_svg_element->layout_node();
+    if (!owner_layout_node || !Painting::has_committed_box(*owner_layout_node) || !Painting::has_committed_box(*self_layout_node)) {
         // Throw only for non-rendered *graphics* elements where geometry isn't computable
         // (e.g. elements inside <marker>, <pattern>, etc.).
         if (is<SVGSVGElement>(*this))
@@ -429,10 +428,10 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Bi
 
     // A path-like element's bounding box covers its geometry alone; the committed content rect is
     // inflated by the visible stroke width, so take the unstroked path bounds directly.
-    if (auto const* committed_path = self_paintable->committed_svg_path())
+    if (auto const* committed_path = Painting::committed_svg_path(*self_layout_node))
         return Geometry::DOMRect::create(committed_path->bounding_box());
 
-    auto rect = self_paintable->absolute_rect().to_type<float>();
+    auto rect = Painting::absolute_rect(*self_layout_node).to_type<float>();
     // An element with a non-positive geometry dimension is not rendered and
     // therefore contributes an empty bounding box, regardless of its
     // positioning rectangle's origin.
@@ -461,11 +460,11 @@ GC::Ptr<Geometry::DOMMatrix> SVGGraphicsElement::get_screen_ctm()
     // 2. If the current element is a non-rendered element, and the UA is not able to resolve the style of the element,
     //    then return null.
     //
-    // NB: We currently require a paintable connected to the document's visual-context tree to compute this matrix.
+    // NB: We currently require committed box data connected to the document's visual-context tree to compute this matrix.
     //     This also excludes geometry in resource-only subtrees such as masks, clip paths, and patterns.
-    auto paintable = this->paintable();
+    auto const* layout_node = this->layout_node();
     auto viewport_paintable = document().paintable();
-    if (!paintable || !viewport_paintable)
+    if (!layout_node || !Painting::has_committed_box(*layout_node) || !viewport_paintable)
         return {};
 
     // 3. Let ctm be a matrix that transforms the coordinate space of the current element (including its transform
@@ -474,16 +473,16 @@ GC::Ptr<Geometry::DOMMatrix> SVGGraphicsElement::get_screen_ctm()
     // NB: An SVG viewport's current user coordinate system is the space produced by its viewBox transform, which is the
     //     coordinate system recorded for its descendants. Other graphics elements use their own accumulated context so
     //     their transform property is included exactly once.
-    auto const& visual_context_tree = viewport_paintable->visual_context_tree();
-    if (!paintable->has_accumulated_visual_context())
+    auto const& visual_context_tree = document().visual_context_tree();
+    if (!Painting::has_accumulated_visual_context(*layout_node))
         return {};
 
-    auto visual_context_index = paintable->svg_viewport_transform().has_value()
-        ? paintable->accumulated_visual_context_for_descendants_index()
-        : paintable->accumulated_visual_context_index();
+    auto visual_context_index = Painting::svg_viewport_transform(*layout_node).has_value()
+        ? Painting::accumulated_visual_context_for_descendants_index(*layout_node)
+        : Painting::accumulated_visual_context_index(*layout_node);
     auto ctm = visual_context_tree.accumulated_matrix(
         visual_context_index,
-        viewport_paintable->scroll_state_snapshot(),
+        document().scroll_state_snapshot(),
         Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
 
     // NB: Accumulated visual-context matrices operate in device-pixel space. Conjugate the matrix by the device scale

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -80,7 +80,7 @@ public:
     }
 
     struct PatternPaintServer {
-        Painting::Paintable const* pattern_paintable;
+        Layout::NodeWithStyle const* pattern_paintable;
         Gfx::FloatRect tile_rect;
         Gfx::FloatSize content_scale;
         Painting::TransformData tile_content_transform;

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -306,7 +306,7 @@ Optional<SVGPatternElement::PaintGeometry> SVGPatternElement::resolve_paint_geom
     if (style->has_transformations()) {
         auto matrix = Gfx::FloatMatrix4x4::identity();
         style->for_each_transformation([&](auto const& css_transform) {
-            matrix = matrix * css_transform.to_matrix(*pattern_paintable);
+            matrix = matrix * css_transform.to_matrix(pattern_box);
         });
 
         user_space_pattern_transform = extract_2d_affine_transform(matrix);

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeNames.h>
@@ -241,8 +242,7 @@ Optional<SVGPatternElement::PaintGeometry> SVGPatternElement::resolve_paint_geom
     if (!pattern_box)
         return {};
 
-    auto pattern_paintable = pattern_box->paintable_box();
-    if (!pattern_paintable)
+    if (!Painting::has_committed_box(*pattern_box))
         return {};
 
     float tile_x = 0;
@@ -327,7 +327,7 @@ Optional<SVGPatternElement::PaintGeometry> SVGPatternElement::resolve_paint_geom
     }
 
     return PaintGeometry {
-        .pattern_paintable = pattern_paintable,
+        .pattern_paintable = pattern_box,
         .tile_rect = tile_rect,
         .content_scale = content_scale,
         .tile_content_transform = tile_content_transform,

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -54,7 +54,7 @@ public:
     GC::Ptr<SVGPatternElement const> pattern_content_element() const;
 
     struct PaintGeometry {
-        Painting::Paintable const* pattern_paintable;
+        Layout::NodeWithStyle const* pattern_paintable;
         Gfx::FloatRect tile_rect;
         Gfx::FloatSize content_scale;
         Painting::TransformData tile_content_transform;

--- a/Libraries/LibWeb/Selection/CaretNavigation.cpp
+++ b/Libraries/LibWeb/Selection/CaretNavigation.cpp
@@ -18,9 +18,8 @@
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
-#include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/CaretNavigation.h>
 #include <LibWeb/VisualLines.h>
 
@@ -66,9 +65,8 @@ static bool is_empty_line_host(DOM::Node& node)
     auto* element = as_if<DOM::Element>(node);
     if (!element || !element->is_editable())
         return false;
-    auto element_paintable = element->unsafe_paintable();
-    auto* paintable = as_if<Painting::PaintableWithLines>(element_paintable.ptr());
-    if (!paintable || paintable->layout_node().display().is_inline_outside())
+    auto const* layout_node = element->unsafe_layout_node();
+    if (!layout_node || !Painting::is_paintable_with_lines(*layout_node) || Painting::display(*layout_node).is_inline_outside())
         return false;
 
     bool has_rendered_content = false;
@@ -183,9 +181,9 @@ Optional<CSSPixels> CaretNavigator::inline_coordinate(CaretLocation const& locat
         }
     }
 
-    auto paintable = location.node->paintable();
+    auto const* layout_node = location.node->layout_node();
     return m_document->current_caret_rect().map([&](auto const& rect) {
-        if (paintable && paintable->layout_node().writing_mode() != CSS::WritingMode::HorizontalTb)
+        if (layout_node && Painting::has_committed_box(*layout_node) && as<Layout::NodeWithStyle>(*layout_node).writing_mode() != CSS::WritingMode::HorizontalTb)
             return rect.y();
         return rect.x();
     });
@@ -566,8 +564,8 @@ Optional<CaretLocation> CaretNavigator::move_by_page(CaretLocation const& locati
         return {};
 
     m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
-    auto editing_host_paintable = editing_host->paintable();
-    if (!editing_host_paintable)
+    auto const* editing_host_layout_node = editing_host->layout_node();
+    if (!editing_host_layout_node || !Painting::has_committed_box(*editing_host_layout_node))
         return {};
     auto window = m_document->window();
     if (!window)
@@ -576,7 +574,7 @@ Optional<CaretLocation> CaretNavigator::move_by_page(CaretLocation const& locati
     // INTEROP: Chromium defines a page as the smaller of the editing host and viewport heights, then leaves either
     // 12.5% or (on macOS) at least 40 CSS pixels of overlap. It walks visual lines until the next line would exceed
     // that distance, rather than mapping the target coordinate directly back into the DOM.
-    auto page_height = min(editing_host_paintable->absolute_padding_box_rect().height().to_int(), window->inner_height());
+    auto page_height = min(Painting::absolute_padding_box_rect(*editing_host_layout_node).height().to_int(), window->inner_height());
     if (page_height <= 0)
         return {};
     auto page_distance = static_cast<i32>(page_height * 0.875);

--- a/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
+++ b/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
@@ -20,7 +20,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/ViewTransition/ViewTransition.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -313,7 +313,9 @@ ErrorOr<void> ViewTransition::capture_the_old_state()
 
         // 3. Let originalRect be snapshot containing block if element is the document element, otherwise, the
         //    element's border box.
-        auto original_rect = element.is_document_element() ? snapshot_containing_block : element.paintable_box()->absolute_border_box_rect();
+        auto const* layout_node = element.layout_node();
+        VERIFY(element.is_document_element() || (layout_node && Painting::has_committed_box(*layout_node)));
+        auto original_rect = element.is_document_element() ? snapshot_containing_block : Painting::absolute_border_box_rect(*layout_node);
 
         // 4. Set capture’s old width to originalRect’s width.
         capture->old_width = original_rect.width();
@@ -892,7 +894,9 @@ ErrorOr<void> ViewTransition::update_pseudo_element_styles()
 
             // 2. Let newRect be the snapshot containing block if capturedElement’s new element is the
             //    document element, otherwise, capturedElement’s border box.
-            auto new_rect = captured_element->new_element->is_document_element() ? captured_element->new_element->navigable()->snapshot_containing_block() : captured_element->new_element->paintable_box()->absolute_border_box_rect();
+            auto const* layout_node = captured_element->new_element->layout_node();
+            VERIFY(captured_element->new_element->is_document_element() || (layout_node && Painting::has_committed_box(*layout_node)));
+            auto new_rect = captured_element->new_element->is_document_element() ? captured_element->new_element->navigable()->snapshot_containing_block() : Painting::absolute_border_box_rect(*layout_node);
 
             // 3. Set width to the current width of newRect.
             width = new_rect.width();

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -22,7 +22,7 @@
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/WebDriver/Actions.h>
 #include <LibWeb/WebDriver/Contexts.h>
 #include <LibWeb/WebDriver/ElementReference.h>
@@ -158,12 +158,15 @@ static CSSPixelPoint get_parent_offset(HTML::BrowsingContext const& browsing_con
         CSSPixels border_left_width = 0;
         CSSPixels border_top_width = 0;
 
-        if (auto paintable_box = container_element->paintable_box()) {
+        auto const* layout_node = container_element->layout_node();
+        if (layout_node && Painting::has_committed_box(*layout_node)) {
+            auto const box_model = Painting::box_model(*layout_node);
+
             // 7. Let borderLeftWidth be the computed border-left-width of containerElement in CSS pixels.
-            border_left_width = paintable_box->layout_node().border_left().width;
+            border_left_width = box_model.border.left;
 
             // 8. Let borderTopWidth be the computed border-top-width of containerElement in CSS pixels.
-            border_top_width = paintable_box->layout_node().border_top().width;
+            border_top_width = box_model.border.top;
         }
 
         // 9. Add containerRect.left + borderLeftWidth to offsetLeft.

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -19,7 +19,9 @@
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebDriver/ElementReference.h>
 
@@ -380,7 +382,8 @@ bool is_element_in_view(ReadonlySpan<GC::Ref<Web::DOM::Element>> paint_tree, Web
 {
     // An element is in view if it is a member of its own pointer-interactable paint tree, given the pretense that its
     // pointer events are not disabled.
-    if (!element.paintable() || !element.paintable()->is_visible() || !element.paintable()->visible_for_hit_testing())
+    auto const* layout_node = element.layout_node();
+    if (!layout_node || !Painting::has_committed_box(*layout_node) || !Painting::is_visible(*layout_node) || !Painting::visible_for_hit_testing(*layout_node))
         return false;
 
     return paint_tree.contains_slow(GC::Ref { element });

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -20,9 +20,9 @@
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BoxViews.h>
-#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebDriver/ElementReference.h>
 
 namespace Web::WebDriver {
@@ -268,8 +268,8 @@ bool is_element_pointer_interactable(Web::HTML::BrowsingContext const& browsing_
     if (!document)
         return false;
 
-    auto paint_root = document->paintable_box();
-    if (!paint_root)
+    auto const* layout_root = document->layout_node();
+    if (!layout_root || !Painting::has_committed_box(*layout_root))
         return false;
 
     auto viewport = browsing_context.page().top_level_traversable()->viewport_rect();

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -12,7 +12,8 @@
 #include <LibWeb/Bindings/WebGL2RenderingContext.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/Infra/Strings.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/WebGL/EventNames.h>
 #include <LibWeb/WebGL/WebGL2RenderingContext.h>
 #include <LibWeb/WebGL/WebGLContextEvent.h>
@@ -82,8 +83,8 @@ void WebGL2RenderingContext::did_update_canvas_content()
     //     recorded, it contains the new content generation and damages the canvas. Don't request a display list
     //     recording here: the new content reaches the compositor through the canvas surface registry when the
     //     canvas is presented.
-    if (auto paintable = m_canvas_element->unsafe_paintable())
-        paintable->invalidate_paint_cache();
+    if (auto const* layout_node = m_canvas_element->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        Painting::invalidate_paint_cache(*layout_node);
     m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -15,8 +15,9 @@
 #include <LibWeb/HTML/HTMLCanvasElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/WebGL/EventNames.h>
 #include <LibWeb/WebGL/RemoteWebGLTransport.h>
 #include <LibWeb/WebGL/WebGLContextEvent.h>
@@ -170,8 +171,8 @@ void WebGLRenderingContext::did_update_canvas_content()
     //     recorded, it contains the new content generation and damages the canvas. Don't request a display list
     //     recording here: the new content reaches the compositor through the canvas surface registry when the
     //     canvas is presented.
-    if (auto paintable = m_canvas_element->unsafe_paintable())
-        paintable->invalidate_paint_cache();
+    if (auto const* layout_node = m_canvas_element->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node))
+        Painting::invalidate_paint_cache(*layout_node);
     m_canvas_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -74,6 +74,7 @@
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Namespace.h>
+#include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Painting/FlexboxInspectorOverlay.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
@@ -928,17 +929,16 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
     };
 
     auto serialize_layout = [&](Web::Layout::Node const* layout_node) {
-        auto paintable = layout_node ? layout_node->paintable() : nullptr;
-        if (!layout_node || !layout_node->is_box() || !paintable) {
+        if (!layout_node || !layout_node->is_box() || !Web::Painting::has_committed_box(*layout_node)) {
             return JsonObject {};
         }
 
-        auto const& box_model = paintable->box_model();
+        auto const box_model = Web::Painting::box_model(*layout_node);
 
         JsonObject serialized;
 
-        serialized.set("width"sv, paintable->content_width().to_double());
-        serialized.set("height"sv, paintable->content_height().to_double());
+        serialized.set("width"sv, Web::Painting::content_width(*layout_node).to_double());
+        serialized.set("height"sv, Web::Painting::content_height(*layout_node).to_double());
 
         serialized.set("padding-top"sv, box_model.padding.top.to_double());
         serialized.set("padding-right"sv, box_model.padding.right.to_double());
@@ -1014,11 +1014,11 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
 
 static Optional<JsonObject> flex_layout_for_node(Web::DOM::Node const& node)
 {
-    auto paintable_box = node.paintable_box();
-    if (!paintable_box)
+    auto const* layout_node = node.layout_node();
+    if (!layout_node || !Web::Painting::has_committed_box(*layout_node))
         return {};
 
-    auto serialized_layout = paintable_box->flex_layout_json(node.unique_id());
+    auto serialized_layout = Web::Painting::flex_layout_json(*layout_node, node.unique_id());
     if (!serialized_layout.has_value())
         return {};
 
@@ -1029,11 +1029,11 @@ static Optional<JsonObject> flex_layout_for_node(Web::DOM::Node const& node)
 
 static Optional<JsonObject> grid_layout_for_node(Web::DOM::Node const& node)
 {
-    auto paintable_box = node.paintable_box();
-    if (!paintable_box)
+    auto const* layout_node = node.layout_node();
+    if (!layout_node || !Web::Painting::has_committed_box(*layout_node))
         return {};
 
-    auto serialized_layout = paintable_box->grid_layout_json(node.unique_id());
+    auto serialized_layout = Web::Painting::grid_layout_json(*layout_node, node.unique_id());
     if (!serialized_layout.has_value())
         return {};
 


### PR DESCRIPTION
Part of removing paintables completely. After this PR, C++ code outside Painting/ no longer reads geometry, status, transforms, or per-box data through a Paintable object. Every such read goes through a Painting:: free function keyed by Layout::Node (Painting/BoxViews.h). Callers that checked for a paintable now check for a layout node with a committed box.

The flip was done in two steps to keep every commit small: first the views were added as thin forwarders to the existing methods, then caller families were flipped one by one (CSSOM geometry, observers and style, SVG, event handling, tools and repaint entries, caret helpers), and finally the method bodies moved into the views and the methods were deleted. EventHandler's hit-test target now carries an arena slot instead of a Paintable reference.

Two areas stay on Paintable on purpose and are the next steps: the scroll API (wheel handling still needs it, bridged explicitly in EventHandler) and the scrollbar/resize-handle widgets. Everything else that remains on the class is lifecycle and arena plumbing.