### PR TITLE
LibWeb: Scope HTMLCollection cache invalidation to affected roots

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -246,6 +246,53 @@
 
 namespace Web::DOM {
 
+void Document::register_valid_html_collection_cache(HTMLCollectionAttributeInvalidationType type) const
+{
+    VERIFY(type != HTMLCollectionAttributeInvalidationType::Count);
+    auto index = to_underlying(type);
+    ++m_html_collection_attribute_invalidation_type_counts[index];
+    m_html_collection_attribute_invalidation_types |= HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(type);
+}
+
+void Document::unregister_valid_html_collection_cache(HTMLCollectionAttributeInvalidationType type) const
+{
+    VERIFY(type != HTMLCollectionAttributeInvalidationType::Count);
+    auto index = to_underlying(type);
+    VERIFY(m_html_collection_attribute_invalidation_type_counts[index] > 0);
+    if (--m_html_collection_attribute_invalidation_type_counts[index] == 0)
+        m_html_collection_attribute_invalidation_types &= ~HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(type);
+}
+
+Document::HTMLCollectionAttributeInvalidationTypes Document::html_collection_attribute_invalidation_types_for_attribute(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& namespace_) const
+{
+    constexpr auto none = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::None);
+    constexpr auto class_ = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::Class);
+    constexpr auto name = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::Name);
+    constexpr auto id_or_name = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::IdOrName);
+    constexpr auto href = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::Href);
+    constexpr auto form_controls = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(HTMLCollectionAttributeInvalidationType::FormControls);
+
+    auto registered_types = m_html_collection_attribute_invalidation_types;
+    auto attribute_sensitive_types = registered_types & ~none;
+    if (attribute_sensitive_types == 0)
+        return 0;
+
+    HTMLCollectionAttributeInvalidationTypes types = 0;
+    if (!namespace_.has_value()) {
+        if ((attribute_sensitive_types & class_) && local_name == HTML::AttributeNames::class_)
+            types |= class_;
+        if ((attribute_sensitive_types & name) && local_name == HTML::AttributeNames::name)
+            types |= name;
+        if ((attribute_sensitive_types & id_or_name) && local_name.is_one_of(HTML::AttributeNames::id, HTML::AttributeNames::name))
+            types |= id_or_name;
+        if ((attribute_sensitive_types & href) && local_name == HTML::AttributeNames::href)
+            types |= href;
+        if ((attribute_sensitive_types & form_controls) && local_name == HTML::AttributeNames::type)
+            types |= form_controls;
+    }
+    return types;
+}
+
 GC_DEFINE_ALLOCATOR(Document);
 
 // https://html.spec.whatwg.org/multipage/origin.html#obtain-browsing-context-navigation
@@ -3257,7 +3304,7 @@ GC::Ref<NodeList> Document::get_elements_by_name(Utf16View name)
 GC::Ref<HTMLCollection> Document::applets()
 {
     if (!m_applets)
-        m_applets = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](auto&) { return false; });
+        m_applets = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](auto&) { return false; }, HTMLCollection::AttributeInvalidationType::None);
     return *m_applets;
 }
 
@@ -3265,9 +3312,7 @@ GC::Ref<HTMLCollection> Document::applets()
 GC::Ref<HTMLCollection> Document::anchors()
 {
     if (!m_anchors) {
-        m_anchors = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLAnchorElement>(element) && element.name().has_value();
-        });
+        m_anchors = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLAnchorElement>(element) && element.name().has_value(); }, HTMLCollection::AttributeInvalidationType::Name);
     }
     return *m_anchors;
 }
@@ -3276,9 +3321,7 @@ GC::Ref<HTMLCollection> Document::anchors()
 GC::Ref<HTMLCollection> Document::images()
 {
     if (!m_images) {
-        m_images = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLImageElement>(element);
-        });
+        m_images = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLImageElement>(element); }, HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_images;
 }
@@ -3287,9 +3330,7 @@ GC::Ref<HTMLCollection> Document::images()
 GC::Ref<HTMLCollection> Document::embeds()
 {
     if (!m_embeds) {
-        m_embeds = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLEmbedElement>(element);
-        });
+        m_embeds = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLEmbedElement>(element); }, HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_embeds;
 }
@@ -3304,9 +3345,7 @@ GC::Ref<HTMLCollection> Document::plugins()
 GC::Ref<HTMLCollection> Document::links()
 {
     if (!m_links) {
-        m_links = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return (is<HTML::HTMLAnchorElement>(element) || is<HTML::HTMLAreaElement>(element)) && element.has_attribute(HTML::AttributeNames::href);
-        });
+        m_links = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return (is<HTML::HTMLAnchorElement>(element) || is<HTML::HTMLAreaElement>(element)) && element.has_attribute(HTML::AttributeNames::href); }, HTMLCollection::AttributeInvalidationType::Href);
     }
     return *m_links;
 }
@@ -3315,9 +3354,7 @@ GC::Ref<HTMLCollection> Document::links()
 GC::Ref<HTMLCollection> Document::forms()
 {
     if (!m_forms) {
-        m_forms = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLFormElement>(element);
-        });
+        m_forms = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLFormElement>(element); }, HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_forms;
 }
@@ -3326,9 +3363,7 @@ GC::Ref<HTMLCollection> Document::forms()
 GC::Ref<HTMLCollection> Document::scripts()
 {
     if (!m_scripts) {
-        m_scripts = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLScriptElement>(element);
-        });
+        m_scripts = HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLScriptElement>(element); }, HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_scripts;
 }
@@ -5277,8 +5312,7 @@ void Document::check_favicon_after_loading_link_resource()
     auto favicon_link_elements = HTMLCollection::create(*head_element, HTMLCollection::Scope::Descendants, [](Element const& element) {
         if (auto const* link_element = as_if<HTML::HTMLLinkElement>(element))
             return link_element->has_loaded_icon();
-        return false;
-    });
+        return false; }, HTMLCollection::AttributeInvalidationType::None);
 
     if (favicon_link_elements->length() == 0) {
         dbgln_if(SPAM_DEBUG, "No favicon found to be used");
@@ -10190,9 +10224,7 @@ JS::Value document_named_item_value(WrapperWorld& wrapper_world, JS::Realm& real
         return wrap(wrapper_world, realm, elements.first()).ptr();
 
     // 4. Otherwise return an HTMLCollection rooted at the Document node, whose filter matches only named elements with the name name.
-    auto collection = DOM::HTMLCollection::create(*const_cast<DOM::Document*>(&document), DOM::HTMLCollection::Scope::Descendants, [name](auto& element) {
-        return DOM::Document::is_named_element_with_name(element, name);
-    });
+    auto collection = DOM::HTMLCollection::create(*const_cast<DOM::Document*>(&document), DOM::HTMLCollection::Scope::Descendants, [name](auto& element) { return DOM::Document::is_named_element_with_name(element, name); }, DOM::HTMLCollection::AttributeInvalidationType::IdOrName);
     return wrap(wrapper_world, realm, collection);
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
@@ -277,11 +278,19 @@ public:
     u64 dom_tree_version() const { return m_dom_tree_version; }
     void bump_dom_tree_version() { ++m_dom_tree_version; }
 
-    u64 form_associated_custom_element_version() const { return m_form_associated_custom_element_version; }
-    void bump_form_associated_custom_element_version() { ++m_form_associated_custom_element_version; }
+    u64 form_controls_version() const { return m_form_controls_version; }
+    void bump_form_controls_version() { ++m_form_controls_version; }
 
     u64 option_selectedness_version() const { return m_option_selectedness_version; }
     void bump_option_selectedness_version() { ++m_option_selectedness_version; }
+
+    using HTMLCollectionAttributeInvalidationType = HTMLCollectionCacheRegistration::AttributeInvalidationType;
+    using HTMLCollectionAttributeInvalidationTypes = HTMLCollectionCacheRegistration::AttributeInvalidationTypes;
+
+    void register_valid_html_collection_cache(HTMLCollectionAttributeInvalidationType) const;
+    void unregister_valid_html_collection_cache(HTMLCollectionAttributeInvalidationType) const;
+    bool has_valid_html_collection_caches() const { return m_html_collection_attribute_invalidation_types != 0; }
+    HTMLCollectionAttributeInvalidationTypes html_collection_attribute_invalidation_types_for_attribute(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& namespace_) const;
 
     // Everything a style input record cannot name by an identity of its own: a stylesheet rule's
     // declarations changing under a block that has not moved, a font finishing loading, the
@@ -1845,8 +1854,10 @@ private:
     Optional<AK::UnixDateTime> m_last_modified;
 
     u64 m_dom_tree_version { 0 };
-    u64 m_form_associated_custom_element_version { 0 };
+    u64 m_form_controls_version { 0 };
     u64 m_option_selectedness_version { 0 };
+    mutable Array<u64, to_underlying(HTMLCollectionAttributeInvalidationType::Count)> m_html_collection_attribute_invalidation_type_counts {};
+    mutable HTMLCollectionAttributeInvalidationTypes m_html_collection_attribute_invalidation_types { 0 };
     u64 m_style_environment_version { 0 };
     u64 m_next_counter_style_environment_identity { 1 };
     u64 m_character_data_version { 0 };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1379,6 +1379,9 @@ void Element::run_attribute_change_steps(Utf16FlyString const& local_name, Optio
             if (local_name == HTML::AttributeNames::id || local_name == HTML::AttributeNames::class_)
                 invalidate_content_blocker_style_if_needed(*this);
         }
+        auto html_collection_invalidation_types = document().html_collection_attribute_invalidation_types_for_attribute(local_name, namespace_);
+        if (html_collection_invalidation_types != 0)
+            invalidate_html_collection_caches_in_ancestors_for_attribute_change(html_collection_invalidation_types);
         document().bump_dom_tree_version();
     }
 }
@@ -4494,7 +4497,7 @@ void Element::set_custom_element_definition(GC::Ptr<HTML::CustomElementDefinitio
     }
 
     if (was_form_associated != is_form_associated)
-        document().bump_form_associated_custom_element_version();
+        document().bump_form_controls_version();
 }
 
 GC::Ptr<HTML::CustomElementRegistry> Element::custom_element_registry() const

--- a/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -19,22 +19,30 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(HTMLCollection);
 
-GC::Ref<HTMLCollection> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort, Kind kind)
+GC::Ref<HTMLCollection> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, AttributeInvalidationType attribute_invalidation_type, Function<bool(Element const&, Element const&)> sort, Kind kind)
 {
-    return GC::Heap::the().allocate<HTMLCollection>(root, scope, move(filter), move(sort), kind);
+    return GC::Heap::the().allocate<HTMLCollection>(root, scope, move(filter), attribute_invalidation_type, move(sort), kind);
 }
 
-HTMLCollection::HTMLCollection(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, Function<bool(Element const&, Element const&)> sort, Kind kind)
+HTMLCollection::HTMLCollection(ParentNode& root, Scope scope, Function<bool(Element const&)> filter, AttributeInvalidationType attribute_invalidation_type, Function<bool(Element const&, Element const&)> sort, Kind kind)
     : GC::WeakContainer(heap())
     , m_root(root)
     , m_filter(move(filter))
     , m_sort(move(sort))
+    , m_cache_registration(*this)
     , m_scope(scope)
     , m_kind(kind)
+    , m_attribute_invalidation_type(attribute_invalidation_type)
 {
 }
 
 HTMLCollection::~HTMLCollection() = default;
+
+void HTMLCollection::finalize()
+{
+    Base::finalize();
+    invalidate_cache();
+}
 
 void HTMLCollection::visit_edges(GC::Cell::Visitor& visitor)
 {
@@ -83,6 +91,7 @@ void HTMLCollection::update_name_to_element_mappings_if_needed() const
                 m_cached_name_to_element_mappings->set(move(element_name), element);
         }
     }
+    m_cached_document->register_valid_html_collection_cache(AttributeInvalidationType::IdOrName);
 }
 
 void HTMLCollection::update_cache_if_needed() const
@@ -90,12 +99,13 @@ void HTMLCollection::update_cache_if_needed() const
     auto& document = root()->document();
     auto invalidation_version = this->invalidation_version(document);
 
-    // Nothing to do, the DOM hasn't updated since we last built the cache.
-    if (m_cached_document.ptr().ptr() == &document
-        && m_cached_dom_tree_version == document.dom_tree_version()
+    if (m_cache_registration.list_node.is_in_list()
+        && m_cached_document.ptr().ptr() == &document
         && m_cached_invalidation_version == invalidation_version) {
         return;
     }
+
+    invalidate_cache();
 
     m_cached_elements.clear();
     m_cached_name_to_element_mappings = nullptr;
@@ -120,8 +130,68 @@ void HTMLCollection::update_cache_if_needed() const
     }
 
     m_cached_document = document;
-    m_cached_dom_tree_version = document.dom_tree_version();
     m_cached_invalidation_version = invalidation_version;
+    ++m_cache_generation;
+    document.register_valid_html_collection_cache(m_attribute_invalidation_type);
+    m_root->register_html_collection_with_valid_cache(const_cast<HTMLCollection&>(*this));
+}
+
+void HTMLCollection::invalidate_cache() const
+{
+    if (!m_cache_registration.list_node.is_in_list())
+        return;
+    invalidate_name_to_element_mappings();
+    if (auto cached_document = m_cached_document.ptr())
+        cached_document->unregister_valid_html_collection_cache(m_attribute_invalidation_type);
+    m_cache_registration.list_node.remove();
+    m_cached_elements.clear();
+}
+
+void HTMLCollection::invalidate_name_to_element_mappings() const
+{
+    if (!m_cached_name_to_element_mappings)
+        return;
+    if (auto cached_document = m_cached_document.ptr())
+        cached_document->unregister_valid_html_collection_cache(AttributeInvalidationType::IdOrName);
+    m_cached_name_to_element_mappings = nullptr;
+}
+
+void HTMLCollection::invalidate_cache_for_tree_mutation(Node const& mutation_parent) const
+{
+    if (m_scope == Scope::Children && m_root.ptr() != &mutation_parent)
+        return;
+    invalidate_cache();
+}
+
+void HTMLCollection::invalidate_cache_for_attribute_change(Element const& element, AttributeInvalidationTypes invalidation_types) const
+{
+    if (m_root.ptr() == &element)
+        return;
+    if (m_scope == Scope::Children && m_root.ptr() != element.parent())
+        return;
+
+    auto membership_invalidation_type = HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(m_attribute_invalidation_type);
+    if (!(invalidation_types & membership_invalidation_type)) {
+        if (invalidation_types & HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(AttributeInvalidationType::IdOrName))
+            invalidate_name_to_element_mappings();
+        return;
+    }
+
+    if (m_sort) {
+        invalidate_cache();
+        return;
+    }
+
+    // OPTIMIZATION: The cache still records whether the element matched before the attribute
+    // change. Keep the element vector when reevaluating the filter produces the same result.
+    bool was_matching = m_cached_elements.contains([&](auto const& cached_element) { return cached_element.ptr() == &element; });
+    if (was_matching != m_filter(element)) {
+        invalidate_cache();
+        return;
+    }
+
+    if (invalidation_types & HTMLCollectionCacheRegistration::attribute_invalidation_type_mask(AttributeInvalidationType::IdOrName))
+        invalidate_name_to_element_mappings();
 }
 
 u64 HTMLCollection::invalidation_version(Document const& document) const
@@ -130,7 +200,7 @@ u64 HTMLCollection::invalidation_version(Document const& document) const
     case Kind::Generic:
         return 0;
     case Kind::FormControls:
-        return document.form_associated_custom_element_version();
+        return document.form_controls_version();
     case Kind::SelectedOptions:
         return document.option_selectedness_version();
     }

--- a/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -12,7 +12,14 @@
 #include <LibGC/Weak.h>
 #include <LibGC/WeakContainer.h>
 #include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/DOM/HTMLCollectionCacheRegistration.h>
 #include <LibWeb/Forward.h>
+
+namespace Web::Internals {
+
+class Internals;
+
+}
 
 namespace Web::DOM {
 
@@ -30,6 +37,8 @@ class HTMLCollection
     GC_DECLARE_ALLOCATOR(HTMLCollection);
 
 public:
+    static constexpr bool OVERRIDES_FINALIZE = true;
+
     enum class Scope {
         Children,
         Descendants,
@@ -41,7 +50,10 @@ public:
         SelectedOptions,
     };
 
-    [[nodiscard]] static GC::Ref<HTMLCollection> create(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
+    using AttributeInvalidationType = HTMLCollectionCacheRegistration::AttributeInvalidationType;
+    using AttributeInvalidationTypes = HTMLCollectionCacheRegistration::AttributeInvalidationTypes;
+
+    [[nodiscard]] static GC::Ref<HTMLCollection> create(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, AttributeInvalidationType, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
 
     virtual ~HTMLCollection() override;
 
@@ -55,7 +67,7 @@ public:
     virtual bool is_supported_property_name(Utf16FlyString const&) const override;
 
 protected:
-    HTMLCollection(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
+    HTMLCollection(ParentNode& root, Scope, ESCAPING Function<bool(Element const&)> filter, AttributeInvalidationType, ESCAPING Function<bool(Element const&, Element const&)> sort = nullptr, Kind = Kind::Generic);
 
     GC::Ref<ParentNode> root() { return *m_root; }
     GC::Ref<ParentNode const> root() const { return *m_root; }
@@ -64,16 +76,26 @@ protected:
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
 private:
+    virtual void finalize() override;
     virtual void remove_dead_cells(Badge<GC::Heap>) override;
     virtual GC::Cell const& owner_cell(Badge<GC::Heap>) const override;
 
     void update_cache_if_needed() const;
     void update_name_to_element_mappings_if_needed() const;
     u64 invalidation_version(Document const&) const;
+    void invalidate_cache() const;
+    void invalidate_name_to_element_mappings() const;
+    void invalidate_cache_for_tree_mutation(Node const& mutation_parent) const;
+    void invalidate_cache_for_attribute_change(Element const&, AttributeInvalidationTypes) const;
+
+    friend class Node;
+    friend class Web::Internals::Internals;
+
+    u64 cache_generation_for_testing() const { return m_cache_generation; }
 
     mutable GC::Weak<Document const> m_cached_document;
-    mutable u64 m_cached_dom_tree_version { 0 };
     mutable u64 m_cached_invalidation_version { 0 };
+    mutable u64 m_cache_generation { 0 };
     mutable Vector<GC::RawPtr<Element>> m_cached_elements;
     mutable OwnPtr<OrderedHashMap<Utf16FlyString, GC::RawPtr<Element>>> m_cached_name_to_element_mappings;
 
@@ -81,8 +103,11 @@ private:
     Function<bool(Element const&)> m_filter;
     Function<bool(Element const&, Element const&)> m_sort;
 
+    mutable HTMLCollectionCacheRegistration m_cache_registration;
+
     Scope m_scope { Scope::Descendants };
     Kind m_kind { Kind::Generic };
+    AttributeInvalidationType m_attribute_invalidation_type { AttributeInvalidationType::None };
 };
 
 }

--- a/Libraries/LibWeb/DOM/HTMLCollectionCacheRegistration.h
+++ b/Libraries/LibWeb/DOM/HTMLCollectionCacheRegistration.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <AK/Types.h>
+#include <LibGC/Ptr.h>
+
+namespace Web::DOM {
+
+class HTMLCollection;
+
+class HTMLCollectionCacheRegistration {
+public:
+    enum class AttributeInvalidationType : u8 {
+        None,
+        Class,
+        Name,
+        IdOrName,
+        Href,
+        FormControls,
+        Count,
+    };
+
+    using AttributeInvalidationTypes = u32;
+
+    static constexpr AttributeInvalidationTypes attribute_invalidation_type_mask(AttributeInvalidationType type)
+    {
+        return 1u << to_underlying(type);
+    }
+
+    explicit HTMLCollectionCacheRegistration(HTMLCollection& collection)
+        : m_collection(collection)
+    {
+    }
+
+    HTMLCollection& collection() { return m_collection; }
+
+    IntrusiveListNode<HTMLCollectionCacheRegistration> list_node;
+    using List = IntrusiveList<&HTMLCollectionCacheRegistration::list_node>;
+
+private:
+    GC::RawRef<HTMLCollection> m_collection;
+};
+
+}

--- a/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -90,7 +90,7 @@ u64 LiveNodeList::invalidation_version(Document const& document) const
         return 0;
     case Kind::Labels:
     case Kind::FormControls:
-        return document.form_associated_custom_element_version();
+        return document.form_controls_version();
     }
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventDispatcher.h>
+#include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/LiveNodeList.h>
 #include <LibWeb/DOM/MutationObserver.h>
@@ -172,6 +173,60 @@ void Node::RareData::visit_edges(Cell::Visitor& visitor)
     visitor.visit(children);
     if (registered_observer_list)
         visitor.visit(*registered_observer_list);
+}
+
+void Node::register_html_collection_with_valid_cache(HTMLCollection& collection)
+{
+    auto& collections = ensure_rare_data().html_collections_with_valid_caches;
+    if (!collections)
+        collections = make<HTMLCollectionCacheRegistration::List>();
+    collections->append(collection.m_cache_registration);
+}
+
+void Node::invalidate_html_collection_caches_in_ancestors(ChildrenChangedMetadata::AffectsElements affects_elements)
+{
+    if (affects_elements == ChildrenChangedMetadata::AffectsElements::No || !document().has_valid_html_collection_caches())
+        return;
+
+    for (auto* ancestor = this; ancestor; ancestor = ancestor->parent()) {
+        if (!ancestor->m_rare_data || !ancestor->m_rare_data->html_collections_with_valid_caches)
+            continue;
+
+        GC::RootVector<GC::Ref<HTMLCollection>> collections;
+        for (auto& registration : *ancestor->m_rare_data->html_collections_with_valid_caches)
+            collections.append(registration.collection());
+        for (auto& collection : collections)
+            collection->invalidate_cache_for_tree_mutation(*this);
+    }
+}
+
+void Node::invalidate_html_collection_caches_in_ancestors_for_attribute_change(HTMLCollectionCacheRegistration::AttributeInvalidationTypes invalidation_types)
+{
+    auto& element = as<Element>(*this);
+    for (auto* ancestor = this; ancestor; ancestor = ancestor->parent()) {
+        if (!ancestor->m_rare_data || !ancestor->m_rare_data->html_collections_with_valid_caches)
+            continue;
+
+        GC::RootVector<GC::Ref<HTMLCollection>> collections;
+        for (auto& registration : *ancestor->m_rare_data->html_collections_with_valid_caches)
+            collections.append(registration.collection());
+        for (auto& collection : collections)
+            collection->invalidate_cache_for_attribute_change(element, invalidation_types);
+    }
+}
+
+static Node::ChildrenChangedMetadata::AffectsElements mutation_affects_elements(ReadonlySpan<GC::Root<Node>> nodes)
+{
+    for (auto const& node : nodes) {
+        if (is<Element>(*node))
+            return Node::ChildrenChangedMetadata::AffectsElements::Yes;
+    }
+    return Node::ChildrenChangedMetadata::AffectsElements::No;
+}
+
+static Node::ChildrenChangedMetadata::AffectsElements mutation_affects_elements(Node& node)
+{
+    return is<Element>(node) ? Node::ChildrenChangedMetadata::AffectsElements::Yes : Node::ChildrenChangedMetadata::AffectsElements::No;
 }
 
 size_t Node::RareData::external_memory_size() const
@@ -733,6 +788,10 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     if (count == 0)
         return;
 
+    auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
+    if (document().has_valid_html_collection_caches())
+        affects_elements = mutation_affects_elements(nodes.span());
+
     // 4. If node is a DocumentFragment node:
     if (is<DocumentFragment>(*node)) {
         // 1. Remove its children with suppressObservers set to true.
@@ -863,8 +922,9 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     }
 
     // 9. Run the children changed steps for parent.
-    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node };
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node, affects_elements };
     children_changed(metadata);
+    invalidate_html_collection_caches_in_ancestors(affects_elements);
 
     // 10. Let staticNodeList be a list of nodes, initially « ».
     // NOTE: We collect all nodes before calling the post-connection steps on any one of them, instead of calling the
@@ -1226,8 +1286,12 @@ void Node::remove(bool suppress_observers)
     }
 
     // 17. Run the children changed steps for parent.
-    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Removal, *this };
+    auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
+    if (document().has_valid_html_collection_caches())
+        affects_elements = mutation_affects_elements(*this);
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Removal, *this, affects_elements };
     parent->children_changed(metadata);
+    parent->invalidate_html_collection_caches_in_ancestors(affects_elements);
 
     document().bump_dom_tree_version();
 }
@@ -1434,6 +1498,10 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
     // 8. Assert: oldParent is non-null.
     VERIFY(old_parent);
 
+    auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
+    if (document().has_valid_html_collection_caches())
+        affects_elements = mutation_affects_elements(*this);
+
     struct PreviousReadWriteState {
         GC::Ptr<Element> element;
         bool value;
@@ -1628,6 +1696,9 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
 
     // 26. Queue a tree mutation record for newParent with « node », « », newPreviousSibling, and child.
     new_parent.queue_tree_mutation_record({ *this }, {}, new_previous_sibling, child);
+
+    old_parent->invalidate_html_collection_caches_in_ancestors(affects_elements);
+    new_parent.invalidate_html_collection_caches_in_ancestors(affects_elements);
 
     document().bump_dom_tree_version();
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -19,6 +19,7 @@
 #include <LibWeb/Bindings/Node.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/FragmentSerializationMode.h>
+#include <LibWeb/DOM/HTMLCollectionCacheRegistration.h>
 #include <LibWeb/DOM/NodeType.h>
 #include <LibWeb/DOM/Slottable.h>
 #include <LibWeb/Export.h>
@@ -361,8 +362,13 @@ public:
             Removal,
             Mutation,
         };
+        enum class AffectsElements {
+            No,
+            Yes,
+        };
         Type type {};
         GC::Ref<Node> node;
+        AffectsElements affects_elements { AffectsElements::No };
     };
     // FIXME: It would be good if we could always provide this metadata for use in optimizations.
     virtual void children_changed(ChildrenChangedMetadata const&) { }
@@ -542,6 +548,8 @@ public:
     }
 
 protected:
+    friend class HTMLCollection;
+
     struct RareData {
         virtual ~RareData();
         virtual void visit_edges(Cell::Visitor&);
@@ -555,7 +563,12 @@ protected:
 
         GC::Ptr<NodeList> child_nodes;
         GC::Ptr<HTMLCollection> children;
+        OwnPtr<HTMLCollectionCacheRegistration::List> html_collections_with_valid_caches;
     };
+
+    void register_html_collection_with_valid_cache(HTMLCollection&);
+    void invalidate_html_collection_caches_in_ancestors(ChildrenChangedMetadata::AffectsElements);
+    void invalidate_html_collection_caches_in_ancestors_for_attribute_change(HTMLCollectionCacheRegistration::AttributeInvalidationTypes);
 
     Node(Document&, NodeType);
 

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -83,9 +83,7 @@ GC::Ref<HTMLCollection> ParentNode::children()
     // The children getter steps are to return an HTMLCollection collection rooted at this matching only element children.
     auto& children = ensure_rare_data().children;
     if (!children) {
-        children = HTMLCollection::create(*this, HTMLCollection::Scope::Children, [](Element const&) {
-            return true;
-        });
+        children = HTMLCollection::create(*this, HTMLCollection::Scope::Children, [](Element const&) { return true; }, HTMLCollection::AttributeInvalidationType::None);
     }
     return *children;
 }
@@ -96,9 +94,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name(Utf16FlyString cons
 {
     // 1. If qualifiedName is "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches only descendant elements.
     if (qualified_name == u"*"sv) {
-        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) {
-            return true;
-        });
+        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) { return true; }, HTMLCollection::AttributeInvalidationType::None);
     }
 
     // 2. Otherwise, if root’s node document is an HTML document, return a HTMLCollection rooted at root, whose filter matches the following descendant elements:
@@ -110,14 +106,11 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name(Utf16FlyString cons
                 return element.qualified_name() == lowercase_qualified_name;
 
             // - Whose namespace is not the HTML namespace and whose qualified name is qualifiedName.
-            return element.qualified_name().view() == qualified_name.view();
-        });
+            return element.qualified_name() == qualified_name; }, HTMLCollection::AttributeInvalidationType::None);
     }
 
     // 3. Otherwise, return a HTMLCollection rooted at root, whose filter matches descendant elements whose qualified name is qualifiedName.
-    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [qualified_name](Element const& element) {
-        return element.qualified_name().view() == qualified_name.view();
-    });
+    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [qualified_name](Element const& element) { return element.qualified_name() == qualified_name; }, HTMLCollection::AttributeInvalidationType::None);
 }
 
 // https://dom.spec.whatwg.org/#concept-getelementsbytagnamens
@@ -130,16 +123,12 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Optional<Utf16Fl
 
     // 2. If both namespace and localName are "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches descendant elements.
     if (namespace_ == u"*"sv && local_name == u"*"sv) {
-        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) {
-            return true;
-        });
+        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) { return true; }, HTMLCollection::AttributeInvalidationType::None);
     }
 
     // 3. Otherwise, if namespace is "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches descendant elements whose local name is localName.
     if (namespace_ == u"*"sv) {
-        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [local_name](Element const& element) {
-            return element.local_name().view() == local_name.view();
-        });
+        return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [local_name](Element const& element) { return element.local_name().view() == local_name.view(); }, HTMLCollection::AttributeInvalidationType::None);
     }
 
     // 4. Otherwise, if localName is "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches descendant elements whose namespace is namespace.
@@ -148,8 +137,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Optional<Utf16Fl
             auto element_namespace = element.namespace_uri();
             if (element_namespace.has_value() != namespace_.has_value())
                 return false;
-            return !namespace_.has_value() || element_namespace->view() == namespace_->view();
-        });
+            return !namespace_.has_value() || element_namespace->view() == namespace_->view(); }, HTMLCollection::AttributeInvalidationType::None);
     }
 
     // 5. Otherwise, return a HTMLCollection rooted at root, whose filter matches descendant elements whose namespace is namespace and local name is localName.
@@ -158,8 +146,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Optional<Utf16Fl
         if (element_namespace.has_value() != namespace_.has_value())
             return false;
         return (!namespace_.has_value() || element_namespace->view() == namespace_->view())
-            && element.local_name().view() == local_name.view();
-    });
+            && element.local_name().view() == local_name.view(); }, HTMLCollection::AttributeInvalidationType::None);
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-prepend
@@ -247,8 +234,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_class_name(Utf16View class_n
             if (!element.has_class(name.utf16_view(), quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
                 return false;
         }
-        return !list_of_class_names.is_empty();
-    });
+        return !list_of_class_names.is_empty(); }, HTMLCollection::AttributeInvalidationType::Class);
 }
 
 GC::Ptr<Element> ParentNode::get_element_by_id(Utf16View id) const

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -173,14 +173,18 @@ void FormAssociatedElement::reset_algorithm()
 
 void FormAssociatedElement::set_form(HTMLFormElement* form)
 {
-    if (auto* old_form = this->form())
-        old_form->remove_associated_element({}, form_associated_element_to_html_element());
+    auto& element = form_associated_element_to_html_element();
+    GC::Ptr<HTMLFormElement> old_form { this->form() };
+    if (old_form)
+        old_form->remove_associated_element({}, element);
     if (form)
         ensure_form_associated_rare_data().form = form;
     else if (auto* rare_data = form_associated_rare_data())
         rare_data->form = nullptr;
     if (form)
-        form->add_associated_element({}, form_associated_element_to_html_element());
+        form->add_associated_element({}, element);
+    if (old_form.ptr() != form)
+        element.document().bump_form_controls_version();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity

--- a/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
@@ -125,9 +125,7 @@ static AllNamedElementsLookupResult find_all_named_elements(DOM::ParentNode& roo
 static GC::Ref<DOM::HTMLCollection> create_all_named_elements_sub_collection(DOM::ParentNode& root, Utf16String name)
 {
     // 2. Let subCollection be an HTMLCollection object rooted at the same Document as collection, whose filter matches only elements that are either:
-    return DOM::HTMLCollection::create(root, DOM::HTMLCollection::Scope::Descendants, [name = move(name)](DOM::Element const& element) {
-        return all_collection_element_matches_name(element, name);
-    });
+    return DOM::HTMLCollection::create(root, DOM::HTMLCollection::Scope::Descendants, [name = move(name)](DOM::Element const& element) { return all_collection_element_matches_name(element, name); }, DOM::HTMLCollection::AttributeInvalidationType::IdOrName);
 }
 
 static Variant<GC::Ref<DOM::HTMLCollection>, GC::Ref<DOM::Element>, Empty> get_the_all_named_elements(DOM::ParentNode& root, Utf16View name)

--- a/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDataListElement.cpp
@@ -29,9 +29,7 @@ GC::Ref<DOM::HTMLCollection> HTMLDataListElement::options()
 {
     // The options IDL attribute must return an HTMLCollection rooted at the datalist node, whose filter matches option elements.
     if (!m_options) {
-        m_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLOptionElement>(element);
-        });
+        m_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLOptionElement>(element); }, DOM::HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_options;
 }

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -76,7 +76,7 @@ GC::Ptr<DOM::HTMLCollection> const& HTMLFieldSetElement::elements()
 
             return false;
         };
-        m_elements = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), nullptr, DOM::HTMLCollection::Kind::FormControls);
+        m_elements = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), DOM::HTMLCollection::AttributeInvalidationType::FormControls, nullptr, DOM::HTMLCollection::Kind::FormControls);
     }
     return m_elements;
 }

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
@@ -33,7 +33,7 @@ GC::Ref<HTMLFormControlsCollection> HTMLFormControlsCollection::create(DOM::Pare
 }
 
 HTMLFormControlsCollection::HTMLFormControlsCollection(DOM::ParentNode& root, Scope scope, HTMLFormElement& form, Function<bool(DOM::Element const&)> filter)
-    : DOM::HTMLCollection(root, scope, move(filter), nullptr, Kind::FormControls)
+    : DOM::HTMLCollection(root, scope, move(filter), AttributeInvalidationType::FormControls, nullptr, Kind::FormControls)
     , m_form(form)
 {
 }

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -1039,8 +1039,7 @@ void HTMLLinkElement::load_fallback_favicon_if_needed(GC::Ref<DOM::Document> doc
         if (!is<HTMLLinkElement>(element))
             return false;
 
-        return static_cast<HTMLLinkElement const&>(element).has_icon_keyword();
-    });
+        return static_cast<HTMLLinkElement const&>(element).has_icon_keyword(); }, DOM::HTMLCollection::AttributeInvalidationType::None);
     if (icon_link_elements->length() != 0)
         return;
 

--- a/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -74,9 +74,7 @@ GC::Ref<DOM::HTMLCollection> HTMLMapElement::areas()
 {
     // The areas attribute must return an HTMLCollection rooted at the map element, whose filter matches only area elements.
     if (!m_areas) {
-        m_areas = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [](Element const& element) {
-            return is<HTML::HTMLAreaElement>(element);
-        });
+        m_areas = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, [](Element const& element) { return is<HTML::HTMLAreaElement>(element); }, DOM::HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_areas;
 }

--- a/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -23,7 +23,7 @@ GC::Ref<HTMLOptionsCollection> HTMLOptionsCollection::create(DOM::ParentNode& ro
 }
 
 HTMLOptionsCollection::HTMLOptionsCollection(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter)
-    : DOM::HTMLCollection(root, Scope::Descendants, move(filter))
+    : DOM::HTMLCollection(root, Scope::Descendants, move(filter), AttributeInvalidationType::None)
 {
 }
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -204,7 +204,7 @@ GC::Ref<DOM::HTMLCollection> HTMLSelectElement::selected_options()
             }
             return false;
         };
-        m_selected_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), nullptr, DOM::HTMLCollection::Kind::SelectedOptions);
+        m_selected_options = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Descendants, move(filter), DOM::HTMLCollection::AttributeInvalidationType::None, nullptr, DOM::HTMLCollection::Kind::SelectedOptions);
     }
     return *m_selected_options;
 }

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -356,9 +356,7 @@ GC::Ref<DOM::HTMLCollection> HTMLTableElement::t_bodies()
     // The tBodies attribute must return an HTMLCollection rooted at the table node,
     // whose filter matches only tbody elements that are children of the table element.
     if (!m_t_bodies) {
-        m_t_bodies = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Children, [](DOM::Element const& element) {
-            return element.local_name() == TagNames::tbody;
-        });
+        m_t_bodies = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Children, [](DOM::Element const& element) { return element.local_name() == TagNames::tbody; }, DOM::HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_t_bodies;
 }
@@ -412,6 +410,7 @@ GC::Ref<DOM::HTMLCollection> HTMLTableElement::rows()
                 return true;
 
             return false; },
+            DOM::HTMLCollection::AttributeInvalidationType::None,
             [](Element const& a, Element const& b) -> bool {
                 auto static sort_priority = [](Element const& element) {
                     auto const& parent_tag = element.parent_element()->local_name();

--- a/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -82,9 +82,7 @@ GC::Ref<DOM::HTMLCollection> HTMLTableRowElement::cells() const
     // The cells attribute must return an HTMLCollection rooted at this tr element,
     // whose filter matches only td and th elements that are children of the tr element.
     if (!m_cells) {
-        m_cells = DOM::HTMLCollection::create(const_cast<HTMLTableRowElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) {
-            return is<HTMLTableCellElement>(element);
-        });
+        m_cells = DOM::HTMLCollection::create(const_cast<HTMLTableRowElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) { return is<HTMLTableCellElement>(element); }, DOM::HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_cells;
 }

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -40,9 +40,7 @@ GC::Ref<DOM::HTMLCollection> HTMLTableSectionElement::rows() const
     // The rows attribute must return an HTMLCollection rooted at this element,
     // whose filter matches only tr elements that are children of this element.
     if (!m_rows) {
-        m_rows = DOM::HTMLCollection::create(const_cast<HTMLTableSectionElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) {
-            return is<HTMLTableRowElement>(element);
-        });
+        m_rows = DOM::HTMLCollection::create(const_cast<HTMLTableSectionElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) { return is<HTMLTableRowElement>(element); }, DOM::HTMLCollection::AttributeInvalidationType::None);
     }
     return *m_rows;
 }

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -2213,8 +2213,7 @@ Variant<Empty, GC::Ref<WindowProxy>, GC::Ref<DOM::Element>, GC::Ref<DOM::HTMLCol
         if ((is<HTMLEmbedElement>(element) || is<HTMLFormElement>(element) || is<HTMLImageElement>(element) || is<HTMLObjectElement>(element))
             && (element.name() == name))
             return true;
-        return element.id() == name;
-    });
+        return element.id() == name; }, DOM::HTMLCollection::AttributeInvalidationType::IdOrName);
     return collection;
 }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -48,6 +48,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOMURL/DOMURL.h>
@@ -293,6 +294,11 @@ bool Internals::has_activity_root(JS::Object& object)
 WebIDL::UnsignedLongLong Internals::message_port_pending_outgoing_message_count(HTML::MessagePort& port)
 {
     return port.pending_outgoing_message_count();
+}
+
+WebIDL::UnsignedLongLong Internals::html_collection_cache_generation(DOM::HTMLCollection& collection)
+{
+    return collection.cache_generation_for_testing();
 }
 
 void Internals::fail_next_message_port_transfer(HTML::MessagePort& port)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -59,6 +59,7 @@ public:
     bool wrapper_is_preserved(JS::Object&);
     bool has_activity_root(JS::Object&);
     WebIDL::UnsignedLongLong message_port_pending_outgoing_message_count(HTML::MessagePort&);
+    WebIDL::UnsignedLongLong html_collection_cache_generation(DOM::HTMLCollection&);
     void fail_next_message_port_transfer(HTML::MessagePort&);
     bool message_ports_are_directly_entangled(HTML::MessagePort&, HTML::MessagePort&);
     GC::Ref<XHR::XMLHttpRequest> create_xml_http_request_for_document(DOM::Document&);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -18,6 +18,7 @@ interface Internals {
     boolean wrapperIsPreserved(object object);
     boolean hasActivityRoot(object object);
     unsigned long long messagePortPendingOutgoingMessageCount(MessagePort port);
+    unsigned long long htmlCollectionCacheGeneration(HTMLCollection collection);
     undefined failNextMessagePortTransfer(MessagePort port);
     boolean messagePortsAreDirectlyEntangled(MessagePort first, MessagePort second);
     XMLHttpRequest createXMLHttpRequestForDocument(Document document);

--- a/Tests/LibWeb/Text/expected/DOM/HTMLCollection-live-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/HTMLCollection-live-mutations.txt
@@ -1,0 +1,26 @@
+initial descendants: section,span
+after fragment insertion: section,span,p,em
+after subtree removal: p,em
+initial children: first,second
+after descendant insertion: first,second, cache preserved: true
+after child insertion: first,second,third, cache rebuilt: true
+after atomic move: third,first,second
+rows after text move: 2, same first row: true, cache preserved: true
+cells after text move: 2, same first cell: true, cache preserved: true
+rows after attribute change: cache preserved: true
+before adoption: before, named=true
+after adoption and insertion: before,after, named=true
+after subsequent insertion: before,after,final
+after cross-root move: source=source, destination=destination,moved
+cross-root caches rebuilt: source=true, destination=true
+initial attribute collections: class=1, link=0
+after irrelevant attribute: cache preserved=true
+after matching attributes: class=2, link=1, anchor=1
+named candidate: true
+after id change: old=null, new=true, cache preserved=true
+after name change: old=null, new=true, anchor=1
+after removing matching attributes: class=1, link=0, anchor=0
+initial scoped names: direct=true, nested=null
+after nested ID change: nested=null, cache preserved=true
+after direct ID change: old=null, new=true, cache preserved=true
+mutations after named collection GC: 2, id=after

--- a/Tests/LibWeb/Text/expected/HTML/HTMLFormControlsCollection-live-mutations.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLFormControlsCollection-live-mutations.txt
@@ -1,0 +1,8 @@
+initial: first=1, second=0, owner=first
+after form ID change: first=0, owner=null, cache rebuilt=true
+after restoring form ID: first=1, owner=first
+after introducing earlier matching ID: first=0, owner=null, cache rebuilt=true
+after removing earlier matching ID: first=1, owner=first
+after changing form attribute: first=0, second=1, owner=second
+after changing type to image: second=0, cache rebuilt=true
+after restoring type: second=1

--- a/Tests/LibWeb/Text/input/DOM/HTMLCollection-live-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/HTMLCollection-live-mutations.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const root = document.createElement("div");
+        root.innerHTML = "<section><span id='first'></span></section>";
+        const descendants = root.getElementsByTagName("*");
+
+        println(`initial descendants: ${Array.from(descendants, element => element.localName)}`);
+
+        const fragment = document.createDocumentFragment();
+        const paragraph = document.createElement("p");
+        paragraph.innerHTML = "<em></em>";
+        fragment.append(paragraph);
+        root.append(fragment);
+        println(`after fragment insertion: ${Array.from(descendants, element => element.localName)}`);
+
+        root.firstChild.remove();
+        println(`after subtree removal: ${Array.from(descendants, element => element.localName)}`);
+        {
+            const root = document.createElement("div");
+            const first = document.createElement("div");
+            const second = document.createElement("div");
+            first.id = "first";
+            second.id = "second";
+            root.append(first, second);
+
+            const children = root.children;
+            println(`initial children: ${Array.from(children, element => element.id)}`);
+            const initialGeneration = internals.htmlCollectionCacheGeneration(children);
+
+            first.append(document.createTextNode("text"), document.createElement("span"));
+            println(`after descendant insertion: ${Array.from(children, element => element.id)}, cache preserved: ${internals.htmlCollectionCacheGeneration(children) === initialGeneration}`);
+
+            const third = document.createElement("div");
+            third.id = "third";
+            root.append(third);
+            println(`after child insertion: ${Array.from(children, element => element.id)}, cache rebuilt: ${internals.htmlCollectionCacheGeneration(children) > initialGeneration}`);
+
+            root.moveBefore(third, first);
+            println(`after atomic move: ${Array.from(children, element => element.id)}`);
+        }
+
+        {
+            const table = document.createElement("table");
+            table.innerHTML = "<tbody><tr><td>first</td><td>second</td></tr><tr><td>third</td><td>fourth</td></tr></tbody>";
+            const rows = table.rows;
+            const firstRow = rows[0];
+            const cells = firstRow.cells;
+            const firstText = cells[0].firstChild;
+            const rowsGeneration = internals.htmlCollectionCacheGeneration(rows);
+            const cellsGeneration = internals.htmlCollectionCacheGeneration(cells);
+
+            cells[0].removeChild(firstText);
+            cells[1].appendChild(firstText);
+
+            println(`rows after text move: ${rows.length}, same first row: ${rows[0] === firstRow}, cache preserved: ${internals.htmlCollectionCacheGeneration(rows) === rowsGeneration}`);
+            println(`cells after text move: ${cells.length}, same first cell: ${cells[0] === firstRow.firstElementChild}, cache preserved: ${internals.htmlCollectionCacheGeneration(cells) === cellsGeneration}`);
+
+            firstRow.id = "first-row";
+            rows.length;
+            println(`rows after attribute change: cache preserved: ${internals.htmlCollectionCacheGeneration(rows) === rowsGeneration}`);
+        }
+
+        {
+            const otherDocument = document.implementation.createHTMLDocument();
+            const root = otherDocument.createElement("div");
+            root.innerHTML = "<span id='before'></span>";
+            const children = root.children;
+            const before = children[0];
+            println(`before adoption: ${before.id}, named=${children.namedItem("before") === before}`);
+
+            document.adoptNode(root);
+            const after = document.createElement("span");
+            after.id = "after";
+            root.append(after);
+            println(`after adoption and insertion: ${Array.from(children, element => element.id)}, named=${children.namedItem("before") === before && children.namedItem("after") === after}`);
+
+            const final = document.createElement("span");
+            final.id = "final";
+            root.append(final);
+            println(`after subsequent insertion: ${Array.from(children, element => element.id)}`);
+        }
+
+        {
+            const host = document.createElement("div");
+            const source = document.createElement("div");
+            const destination = document.createElement("div");
+            host.append(source, destination);
+            source.innerHTML = "<span id='moved'></span><span id='source'></span>";
+            destination.innerHTML = "<span id='destination'></span>";
+            const moved = source.firstElementChild;
+            const sourceChildren = source.children;
+            const destinationChildren = destination.children;
+            const sourceGeneration = internals.htmlCollectionCacheGeneration(sourceChildren);
+            const destinationGeneration = internals.htmlCollectionCacheGeneration(destinationChildren);
+
+            destination.moveBefore(moved, null);
+            println(`after cross-root move: source=${Array.from(sourceChildren, element => element.id)}, destination=${Array.from(destinationChildren, element => element.id)}`);
+            println(`cross-root caches rebuilt: source=${internals.htmlCollectionCacheGeneration(sourceChildren) > sourceGeneration}, destination=${internals.htmlCollectionCacheGeneration(destinationChildren) > destinationGeneration}`);
+        }
+
+        {
+            const root = document.createElement("div");
+            root.innerHTML = "<a id='candidate'></a><span class='wanted'></span>";
+            const candidate = root.firstElementChild;
+            const byClass = root.getElementsByClassName("wanted");
+            const links = root.getElementsByTagName("a");
+            document.body.append(root);
+
+            println(`initial attribute collections: class=${byClass.length}, link=${document.links.length}`);
+            const initialClassGeneration = internals.htmlCollectionCacheGeneration(byClass);
+            candidate.title = "irrelevant";
+            byClass.length;
+            println(`after irrelevant attribute: cache preserved=${internals.htmlCollectionCacheGeneration(byClass) === initialClassGeneration}`);
+            candidate.className = "wanted";
+            candidate.href = "https://example.com/";
+            candidate.name = "named";
+            println(`after matching attributes: class=${byClass.length}, link=${document.links.length}, anchor=${document.anchors.length}`);
+
+            println(`named candidate: ${links.namedItem("candidate") === candidate}`);
+            const linksGeneration = internals.htmlCollectionCacheGeneration(links);
+            candidate.id = "renamed";
+            println(`after id change: old=${links.namedItem("candidate")}, new=${links.namedItem("renamed") === candidate}, cache preserved=${internals.htmlCollectionCacheGeneration(links) === linksGeneration}`);
+
+            candidate.name = "aliased";
+            println(`after name change: old=${links.namedItem("named")}, new=${links.namedItem("aliased") === candidate}, anchor=${document.anchors.length}`);
+
+            candidate.className = "";
+            candidate.removeAttribute("href");
+            candidate.removeAttribute("name");
+            println(`after removing matching attributes: class=${byClass.length}, link=${document.links.length}, anchor=${document.anchors.length}`);
+            root.remove();
+        }
+
+        {
+            const root = document.createElement("div");
+            root.innerHTML = "<div id='direct'><span id='nested'></span></div>";
+            const children = root.children;
+            const direct = root.firstElementChild;
+            const nested = direct.firstElementChild;
+            println(`initial scoped names: direct=${children.namedItem("direct") === direct}, nested=${children.namedItem("nested")}`);
+            const generation = internals.htmlCollectionCacheGeneration(children);
+
+            nested.id = "nested-renamed";
+            println(`after nested ID change: nested=${children.namedItem("nested-renamed")}, cache preserved=${internals.htmlCollectionCacheGeneration(children) === generation}`);
+
+            direct.id = "direct-renamed";
+            println(`after direct ID change: old=${children.namedItem("direct")}, new=${children.namedItem("direct-renamed") === direct}, cache preserved=${internals.htmlCollectionCacheGeneration(children) === generation}`);
+        }
+
+        {
+            const root = document.createElement("div");
+            root.innerHTML = "<span id='before'></span>";
+            (() => root.getElementsByTagName("*").namedItem("before"))();
+            internals.gc();
+            root.firstElementChild.id = "after";
+            root.append(document.createElement("span"));
+            println(`mutations after named collection GC: ${root.childElementCount}, id=${root.firstElementChild.id}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLFormControlsCollection-live-mutations.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLFormControlsCollection-live-mutations.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const host = document.createElement("div");
+        host.innerHTML = `
+            <div id="blocker"></div>
+            <form id="first"></form>
+            <input id="control" form="first">
+            <form id="second"></form>
+        `;
+        document.body.append(host);
+
+        const blocker = host.querySelector("#blocker");
+        const firstForm = host.querySelector("#first");
+        const secondForm = host.querySelector("#second");
+        const control = host.querySelector("#control");
+        const firstControls = firstForm.elements;
+        const secondControls = secondForm.elements;
+
+        println(`initial: first=${firstControls.length}, second=${secondControls.length}, owner=${control.form.id}`);
+        let generation = internals.htmlCollectionCacheGeneration(firstControls);
+
+        firstForm.id = "renamed";
+        println(`after form ID change: first=${firstControls.length}, owner=${control.form}, cache rebuilt=${internals.htmlCollectionCacheGeneration(firstControls) > generation}`);
+
+        firstForm.id = "first";
+        println(`after restoring form ID: first=${firstControls.length}, owner=${control.form.id}`);
+        generation = internals.htmlCollectionCacheGeneration(firstControls);
+
+        blocker.id = "first";
+        println(`after introducing earlier matching ID: first=${firstControls.length}, owner=${control.form}, cache rebuilt=${internals.htmlCollectionCacheGeneration(firstControls) > generation}`);
+
+        blocker.id = "blocker";
+        println(`after removing earlier matching ID: first=${firstControls.length}, owner=${control.form.id}`);
+
+        control.setAttribute("form", "second");
+        println(`after changing form attribute: first=${firstControls.length}, second=${secondControls.length}, owner=${control.form.id}`);
+
+        generation = internals.htmlCollectionCacheGeneration(secondControls);
+        control.type = "image";
+        println(`after changing type to image: second=${secondControls.length}, cache rebuilt=${internals.htmlCollectionCacheGeneration(secondControls) > generation}`);
+
+        control.type = "text";
+        println(`after restoring type: second=${secondControls.length}`);
+
+        host.remove();
+    });
+</script>


### PR DESCRIPTION
Track valid HTMLCollection caches on their root nodes and invalidate only collections whose scope and membership can be affected by a mutation. Keep document-level counts of active attribute dependencies so irrelevant attribute and tree changes return before walking ancestors.

Separate named-property map invalidation from element-vector invalidation. Use form-control versions for association changes outside a collection's root, and remove registrations during GC finalization.

Avoid scanning inserted and removed subtrees after document fragments have been flattened. Add deterministic coverage for structural, attribute, adoption, form-owner, atomic-move, sorting, and garbage collection cases.

```
Benchmark     Old Score       New Score         Improvement
------------  --------------  --------------  -------------
Speedometer2  79.817 ± 5.906  78.463 ± 5.285          0.983
Speedometer3  4.461 ± 0.223   4.431 ± 0.222           0.993
StyleBench    78.159 ± 2.735  77.826 ± 1.556          0.996

Benchmark         Speedup  Old Total Time (s)    New Total Time (s)
--------------  ---------  --------------------  --------------------
Speedometer2        0.988  6.328 ± 0.288         6.407 ± 0.372
Speedometer3        0.993  5.886 ± 0.036         5.929 ± 0.165
StyleBench          0.995  3.190 ± 0.098         3.205 ± 0.046
WebKitBindings      0.998  2.440 ± 0.823         2.445 ± 0.893
WebKitCSS           0.997  0.555 ± 0.030         0.557 ± 0.050
WebKitDOM           1.055  3.141 ± 0.141         2.976 ± 0.515
WebKitParser        0.987  1.844 ± 0.718         1.868 ± 0.673
WebKitSVG           0.999  4.508 ± 0.048         4.514 ± 0.027
```