### PR TITLE
LibWeb: Do not assume a required select element has a first option

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -843,9 +843,12 @@ HTMLOptionElement* HTMLSelectElement::placeholder_label_option() const
         // and if the value of the first option element in the select element's list of options (if any) is the empty
         // string, and that option element's parent node is the select element (and not an optgroup element), then that
         // option is the select element's placeholder label option.
-        auto first_option_element = list_of_options()[0];
-        if (first_option_element->value().is_empty() && first_option_element->parent() == this)
-            return first_option_element;
+        auto options = list_of_options();
+        if (!options.is_empty()) {
+            auto first_option_element = options[0];
+            if (first_option_element->value().is_empty() && first_option_element->parent() == this)
+                return first_option_element;
+        }
     }
     return {};
 }

--- a/Tests/LibWeb/Crash/HTML/select-placeholder-option-with-empty-option-list.html
+++ b/Tests/LibWeb/Crash/HTML/select-placeholder-option-with-empty-option-list.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<select id="select" required><option selected id="option"></option></select>
+<script>
+    const datalist = document.createElement("datalist");
+    select.appendChild(datalist);
+    datalist.moveBefore(option, null);
+</script>


### PR DESCRIPTION
Previously, finding the placeholder label option of a required select element attempted to access the first entry of its list of options without checking that the list was non-empty. A script leaving such an element with no options caused an out-of-bounds access.

Found with Domato.