### PR TITLE
LibWeb: Only record transition baselines within a stabilization epoch

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -910,6 +910,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
             return target->document().style_computer().build_computed_values(*style, element, element.style_scope());
         }();
         if (animated_properties_after_update && !animated_properties_after_update->values().is_empty()
+            && target->document().is_in_style_stabilization_epoch()
             && (target->document().style_stabilization_has_style_reactions() || animated_property_invalidation.requires_base_style_recomputation)) {
             target->document().style_computer().record_transition_stabilization_baseline(element);
         }

--- a/Tests/LibWeb/Crash/Animations/replace-animation-effect-outside-style-update.html
+++ b/Tests/LibWeb/Crash/Animations/replace-animation-effect-outside-style-update.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script>
+    window.onload = () => {
+        const animation = video.animate({}, 400);
+        animation.effect = null;
+        document.body.offsetHeight;
+    };
+</script>


### PR DESCRIPTION
Previously, replacing the effect of an animation from a script ran an animated style update outside of any style stabilization epoch. The update recorded a transition stabilization baseline, which only a stabilization epoch can consume and release. The stale entry hit an assertion when the next epoch began.

Found with Domato.

Fixes #11275