### PR TITLE
LibWeb: Avoid permanent invalidation of nodes' intrinsic size caches

### DIFF
--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
+#include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
@@ -35,6 +36,11 @@ Box::Box(DOM::Document& document, GC::Ptr<DOM::Node> node, CSS::LayoutStyle styl
 
 Box::~Box()
 {
+}
+
+void Box::drop_cached_intrinsic_sizes()
+{
+    node_arena().drop_intrinsic_size_cache(node_data());
 }
 
 void Box::set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -73,14 +73,15 @@ public:
 
     void reset_cached_intrinsic_sizes()
     {
-        auto& epoch = node_data().intrinsic_cache_epoch;
-        if (epoch != NumericLimits<u16>::max())
-            ++epoch;
+        if (++node_data().intrinsic_cache_epoch == 0) [[unlikely]]
+            drop_cached_intrinsic_sizes();
     }
 
     Box(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::Box);
 
 private:
+    void drop_cached_intrinsic_sizes();
+
     CSS::SizeWithAspectRatio compute_auto_content_box_size() const;
 
     virtual bool is_box() const final { return true; }

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -40,6 +40,11 @@ u64 NodeArena::formatting_context_run_cache_hit_count() const
     return RustFFI::layout_arena_fc_run_cache_hit_count(m_handle);
 }
 
+void NodeArena::drop_intrinsic_size_cache(RustFFI::NodeData const& node_data) const
+{
+    RustFFI::layout_arena_drop_intrinsic_size_cache(m_handle, &node_data);
+}
+
 void NodeArena::enroll_text_node_for_content_sync(TextNode const& text_node)
 {
     m_text_nodes_enrolled_for_content_sync.append(text_node.make_weak_ptr<TextNode>());

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -36,6 +36,7 @@ public:
     void free(RustFFI::NodeSlotId, u32 generation);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
+    void drop_intrinsic_size_cache(RustFFI::NodeData const&) const;
 
     void enroll_text_node_for_content_sync(TextNode const&);
     void enroll_node_for_replaced_content_facts_sync(Node const&);

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -315,6 +315,16 @@ impl LayoutNodeArena {
         nodes.clone()
     }
 
+    /// Drops one node's cached intrinsic sizes outright, for the wrap of its epoch:
+    /// entries are stamped with the epoch they were measured under, so a stamp reused
+    /// after a full lap would match a pre-wrap entry.
+    pub(crate) fn drop_intrinsic_size_cache(&self, data: *const NodeData) {
+        let (index, _) = self.slot_for_data(data);
+        if let Some(slot) = self.intrinsic_size_caches.borrow_mut().get_mut(index as usize) {
+            *slot = IntrinsicSizeCacheSlot::default();
+        }
+    }
+
     pub(crate) fn fc_run_cache_store(&self) -> &crate::layout::FcRunCacheArenaStore {
         &self.fc_run_cache_store
     }
@@ -871,9 +881,6 @@ impl LayoutNodeArena {
             ),
             "block size cache kind must use the block axis"
         );
-        if data.intrinsic_cache_epoch == u16::MAX {
-            return None;
-        }
 
         let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
         let caches = self.intrinsic_size_caches.borrow();
@@ -890,10 +897,6 @@ impl LayoutNodeArena {
     }
 
     fn with_intrinsic_size_maps_mut(&self, data: &NodeData, callback: impl FnOnce(&mut IntrinsicSizeMaps)) {
-        if data.intrinsic_cache_epoch == u16::MAX {
-            return;
-        }
-
         let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
         let mut caches = self.intrinsic_size_caches.borrow_mut();
         if caches.len() <= index as usize {
@@ -937,9 +940,6 @@ impl LayoutNodeArena {
             ),
             "inline measurement cache kind must use the inline axis"
         );
-        if data.intrinsic_cache_epoch == u16::MAX {
-            return None;
-        }
 
         let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
         let caches = self.intrinsic_size_caches.borrow();
@@ -960,10 +960,6 @@ impl LayoutNodeArena {
         data: &NodeData,
         compute: impl FnOnce() -> bool,
     ) -> bool {
-        if data.intrinsic_cache_epoch == u16::MAX {
-            return compute();
-        }
-
         let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
         {
             let caches = self.intrinsic_size_caches.borrow();
@@ -1704,6 +1700,16 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, g
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_fc_run_cache_epochs_enabled() -> bool {
     crate::layout::fc_run_cache_mode_from_environment() != crate::layout::FcRunCacheMode::Disabled
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_drop_intrinsic_size_cache(arena: *mut c_void, data: *const NodeData) {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &*arena.cast::<LayoutNodeArena>() }.drop_intrinsic_size_cache(data);
+    });
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
On Twitch, we were hitting a severe performance cliff when the epoch of the intrinsic size cache hit u16::MAX. Instead of blocking it from wrapping, evict all the stale cache entries when it occurs so that the stale entries can never cause incorrect layout metrics.

Steady state would go from 12.3ms/pass to 906ms/pass the moment the epoch saturates, with intrinsic-size cache lookups jumping from 40,052 to 4,076,814, and measurement sub-layouts from 4,855 to 34,187. With this change, the same page stays around the baseline cost per pass.

Correctness was tested by increasing the increment to force frequent wrapping with and without the forced eviction. All tests passed with it, but a few showed failures without it.

CC @kalenikaliaksandr, since I believe this caching is something you introduced.

We _can_ add a test to prevent reintroduction of this particular performance cliff by exposing a cache hit count and an epoch setter, but I'm unsure if it's worth the complexity of storing, tracking and plumbing that to Internals.