### PR TITLE
AK: Share UTF-16 string storage between C++ and Rust

### DIFF
--- a/AK/FFIHelpers.cpp
+++ b/AK/FFIHelpers.cpp
@@ -10,6 +10,9 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Try.h>
+#include <AK/Utf16FlyString.h>
+#include <AK/Utf16String.h>
+#include <AK/Utf16View.h>
 
 namespace AK {
 
@@ -31,4 +34,33 @@ StringView ffi_string_view(u8 const* ptr, size_t len)
     return { ptr, len };
 }
 
+}
+
+extern "C" FlatPtr ladybird_utf16_string_create_uninitialized(size_t length, bool has_ascii_storage)
+{
+    auto storage_type = has_ascii_storage
+        ? AK::Detail::Utf16StringData::StorageType::ASCII
+        : AK::Detail::Utf16StringData::StorageType::UTF16;
+    auto data = AK::Detail::Utf16StringData::create_uninitialized_for_ffi(storage_type, length);
+    return reinterpret_cast<FlatPtr>(&data.leak_ref());
+}
+
+extern "C" FlatPtr ladybird_utf16_fly_string_from_utf8(u8 const* data, size_t length)
+{
+    VERIFY(data != nullptr || length == 0);
+    return AK::Utf16FlyString::from_utf8(AK::ffi_string_view(data, length)).into_raw();
+}
+
+extern "C" FlatPtr ladybird_utf16_fly_string_from_utf16(u16 const* data, size_t length)
+{
+    if (data == nullptr) {
+        VERIFY(length == 0);
+        return AK::Utf16FlyString {}.into_raw();
+    }
+    return AK::Utf16FlyString::from_utf16({ reinterpret_cast<char16_t const*>(data), length }).into_raw();
+}
+
+extern "C" void ladybird_utf16_string_unref(FlatPtr raw)
+{
+    AK::Utf16String::unref_raw(raw);
 }

--- a/AK/FFIHelpers.h
+++ b/AK/FFIHelpers.h
@@ -18,6 +18,14 @@ StringView ffi_string_view(u8 const* ptr, size_t len);
 
 }
 
+extern "C" {
+
+FlatPtr ladybird_utf16_string_create_uninitialized(size_t, bool has_ascii_storage);
+FlatPtr ladybird_utf16_fly_string_from_utf8(u8 const*, size_t);
+FlatPtr ladybird_utf16_fly_string_from_utf16(u16 const*, size_t);
+void ladybird_utf16_string_unref(FlatPtr);
+}
+
 #ifdef USING_AK_GLOBALLY
 using AK::ffi_fly_string;
 using AK::ffi_string;

--- a/AK/Rust/Cargo.toml
+++ b/AK/Rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ak"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["rlib"]
+
+[lints]
+workspace = true

--- a/AK/Rust/src/lib.rs
+++ b/AK/Rust/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 const SHORT_STRING_FLAG: usize = 1;
 const SHORT_STRING_BYTE_COUNT_SHIFT: u32 = 2;
 const HAS_UTF16_STORAGE: u32 = 1;
+const UNKNOWN_CODE_POINT_LENGTH: u32 = u32::MAX;
 
 /// Mirrors `AK::Detail::Utf16StringDataHeader`.
 #[repr(C, align(8))]
@@ -34,6 +35,291 @@ const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, flags) == 16);
 pub enum Utf16StringUnits<'a> {
     Ascii(&'a [u8]),
     Utf16(&'a [u16]),
+}
+
+unsafe extern "C" {
+    fn ladybird_utf16_string_create_uninitialized(length: usize, has_ascii_storage: bool) -> usize;
+    fn ladybird_utf16_fly_string_from_utf8(data: *const u8, length: usize) -> usize;
+    fn ladybird_utf16_fly_string_from_utf16(data: *const u16, length: usize) -> usize;
+    fn ladybird_utf16_string_unref(raw: usize);
+}
+
+#[repr(transparent)]
+struct OwnedUtf16String {
+    raw: usize,
+    _not_send_or_sync: std::marker::PhantomData<*const ()>,
+}
+
+impl OwnedUtf16String {
+    const fn empty() -> Self {
+        Self {
+            raw: SHORT_STRING_FLAG,
+            _not_send_or_sync: std::marker::PhantomData,
+        }
+    }
+
+    unsafe fn from_raw(raw: usize) -> Self {
+        Self {
+            raw,
+            _not_send_or_sync: std::marker::PhantomData,
+        }
+    }
+
+    fn into_raw(self) -> usize {
+        let this = std::mem::ManuallyDrop::new(self);
+        this.raw
+    }
+
+    fn as_units(&self) -> Utf16StringUnits<'_> {
+        // SAFETY: This owner keeps the raw string alive for the returned lifetime.
+        unsafe { utf16_string_units(&self.raw) }
+    }
+}
+
+impl Clone for OwnedUtf16String {
+    fn clone(&self) -> Self {
+        // SAFETY: This owner keeps the raw string alive while adding a reference.
+        unsafe { reference_utf16_string(self.raw) };
+        // SAFETY: The new reference is transferred to the returned owner.
+        unsafe { Self::from_raw(self.raw) }
+    }
+}
+
+impl Drop for OwnedUtf16String {
+    fn drop(&mut self) {
+        // SAFETY: This object owns one reference to its raw string.
+        unsafe {
+            release_utf16_string_with(self.raw, |raw| ladybird_utf16_string_unref(raw));
+        }
+    }
+}
+
+/// A one-word Rust owner for the same storage as `AK::Utf16String`.
+#[repr(transparent)]
+pub struct Utf16String(OwnedUtf16String);
+
+/// A one-word Rust owner for the same interned storage as `AK::Utf16FlyString`.
+#[repr(transparent)]
+pub struct Utf16FlyString(OwnedUtf16String);
+
+const _: () = assert!(size_of::<OwnedUtf16String>() == size_of::<usize>());
+const _: () = assert!(align_of::<OwnedUtf16String>() == align_of::<usize>());
+const _: () = assert!(size_of::<Utf16String>() == size_of::<usize>());
+const _: () = assert!(align_of::<Utf16String>() == align_of::<usize>());
+const _: () = assert!(size_of::<Utf16FlyString>() == size_of::<usize>());
+const _: () = assert!(align_of::<Utf16FlyString>() == align_of::<usize>());
+
+macro_rules! impl_utf16_string_owner {
+    ($name:ident) => {
+        impl $name {
+            /// Adopts an existing C++ ownership reference without changing its count.
+            ///
+            /// # Safety
+            ///
+            /// `raw` must be a valid `AK::Utf16String` raw representation for which
+            /// the caller owns one reference. The reference must not be released
+            /// separately after this call.
+            pub unsafe fn from_raw_owned(raw: usize) -> Self {
+                // SAFETY: The caller transfers a valid ownership reference.
+                Self(unsafe { OwnedUtf16String::from_raw(raw) })
+            }
+
+            /// Transfers this owner's existing reference to the caller.
+            pub fn into_raw(self) -> usize {
+                self.0.into_raw()
+            }
+
+            /// Returns the shared one-word identity without transferring ownership.
+            pub fn raw_identity(&self) -> usize {
+                self.0.raw
+            }
+
+            /// Borrows the shared ASCII or UTF-16 character storage directly.
+            pub fn as_units(&self) -> Utf16StringUnits<'_> {
+                self.0.as_units()
+            }
+
+            /// Returns whether the string has no code units.
+            pub fn is_empty(&self) -> bool {
+                match self.as_units() {
+                    Utf16StringUnits::Ascii(units) => units.is_empty(),
+                    Utf16StringUnits::Utf16(units) => units.is_empty(),
+                }
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self(OwnedUtf16String::empty())
+            }
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                Self(self.0.clone())
+            }
+        }
+    };
+}
+
+impl_utf16_string_owner!(Utf16String);
+impl_utf16_string_owner!(Utf16FlyString);
+
+impl Utf16String {
+    /// Creates a string in AK's native representation and initializes its storage from UTF-8.
+    pub fn from_utf8(string: &str) -> Self {
+        if string.is_ascii() {
+            return Self::from_ascii(string.as_bytes());
+        }
+
+        let length = string.encode_utf16().count();
+        let result = Self::create_uninitialized(length, false);
+        let storage = result.long_storage().cast::<u16>();
+        for (index, code_unit) in string.encode_utf16().enumerate() {
+            // SAFETY: The allocation has space for exactly `length` UTF-16 code units.
+            unsafe { storage.add(index).write(code_unit) };
+        }
+        result
+    }
+
+    /// Creates a string in AK's native representation and initializes its storage from UTF-16.
+    pub fn from_utf16(string: &[u16]) -> Self {
+        if string.iter().all(|code_unit| *code_unit <= 0x7f) {
+            if string.len() < size_of::<usize>() {
+                let mut bytes = [0; size_of::<usize>() - 1];
+                for (index, code_unit) in string.iter().enumerate() {
+                    bytes[index] = *code_unit as u8;
+                }
+                return Self::from_short_ascii(&bytes[..string.len()]);
+            }
+
+            let result = Self::create_uninitialized(string.len(), true);
+            let storage = result.long_storage();
+            for (index, code_unit) in string.iter().enumerate() {
+                // SAFETY: The allocation has space for exactly `string.len()` ASCII bytes.
+                unsafe { storage.add(index).write(*code_unit as u8) };
+            }
+            return result;
+        }
+
+        let result = Self::create_uninitialized(string.len(), false);
+        // SAFETY: The source and destination are non-overlapping and the allocation has space for
+        // exactly `string.len()` UTF-16 code units.
+        unsafe { std::ptr::copy_nonoverlapping(string.as_ptr(), result.long_storage().cast(), string.len()) };
+        result
+    }
+
+    fn from_ascii(string: &[u8]) -> Self {
+        if string.len() < size_of::<usize>() {
+            return Self::from_short_ascii(string);
+        }
+
+        let result = Self::create_uninitialized(string.len(), true);
+        // SAFETY: The source and destination are non-overlapping and the allocation has space for
+        // exactly `string.len()` ASCII bytes.
+        unsafe { std::ptr::copy_nonoverlapping(string.as_ptr(), result.long_storage(), string.len()) };
+        result
+    }
+
+    fn from_short_ascii(string: &[u8]) -> Self {
+        assert!(string.len() < size_of::<usize>());
+        let mut bytes = [0; size_of::<usize>()];
+        let tag = ((string.len() as u8) << SHORT_STRING_BYTE_COUNT_SHIFT) | SHORT_STRING_FLAG as u8;
+        #[cfg(target_endian = "little")]
+        {
+            bytes[0] = tag;
+            bytes[1..][..string.len()].copy_from_slice(string);
+        }
+        #[cfg(target_endian = "big")]
+        {
+            bytes[size_of::<usize>() - 1] = tag;
+            bytes[..string.len()].copy_from_slice(string);
+        }
+        // SAFETY: The constructed word is AK's short-string representation and owns no allocation.
+        unsafe { Self::from_raw_owned(usize::from_ne_bytes(bytes)) }
+    }
+
+    fn create_uninitialized(length: usize, has_ascii_storage: bool) -> Self {
+        assert!(length < UNKNOWN_CODE_POINT_LENGTH as usize);
+        let unit_size = if has_ascii_storage { 1 } else { size_of::<u16>() };
+        assert!(
+            size_of::<Utf16StringDataHeader>()
+                .checked_add(
+                    length
+                        .checked_mul(unit_size)
+                        .expect("UTF-16 string allocation size overflow")
+                )
+                .is_some()
+        );
+        // SAFETY: C++ returns a fully initialized native string owner with trailing storage sized
+        // for `length` units. The caller initializes that storage before publishing the owner.
+        let raw = unsafe { ladybird_utf16_string_create_uninitialized(length, has_ascii_storage) };
+        // SAFETY: The allocator transfers one ownership reference.
+        unsafe { Self::from_raw_owned(raw) }
+    }
+
+    fn long_storage(&self) -> *mut u8 {
+        assert!(has_long_storage(self.raw_identity()));
+        std::ptr::with_exposed_provenance_mut::<u8>(self.raw_identity())
+            .wrapping_add(size_of::<Utf16StringDataHeader>())
+    }
+}
+
+impl Utf16FlyString {
+    /// Creates a string through AK's authoritative UTF-8 fly-string table.
+    pub fn from_utf8(string: &str) -> Self {
+        // SAFETY: The string's storage remains alive for the duration of the call.
+        let raw = unsafe { ladybird_utf16_fly_string_from_utf8(string.as_ptr(), string.len()) };
+        // SAFETY: The constructor transfers one ownership reference.
+        unsafe { Self::from_raw_owned(raw) }
+    }
+
+    /// Creates a string through AK's authoritative UTF-16 fly-string table.
+    pub fn from_utf16(string: &[u16]) -> Self {
+        // SAFETY: The slice remains alive for the duration of the call.
+        let raw = unsafe { ladybird_utf16_fly_string_from_utf16(string.as_ptr(), string.len()) };
+        // SAFETY: The constructor transfers one ownership reference.
+        unsafe { Self::from_raw_owned(raw) }
+    }
+}
+
+impl PartialEq for Utf16String {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.as_units(), other.as_units()) {
+            (Utf16StringUnits::Ascii(left), Utf16StringUnits::Ascii(right)) => left == right,
+            (Utf16StringUnits::Utf16(left), Utf16StringUnits::Utf16(right)) => left == right,
+            (Utf16StringUnits::Ascii(left), Utf16StringUnits::Utf16(right))
+            | (Utf16StringUnits::Utf16(right), Utf16StringUnits::Ascii(left)) => {
+                left.len() == right.len() && left.iter().zip(right).all(|(left, right)| u16::from(*left) == *right)
+            }
+        }
+    }
+}
+
+impl Eq for Utf16String {}
+
+impl PartialEq for Utf16FlyString {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw_identity() == other.raw_identity() || (self.is_empty() && other.is_empty())
+    }
+}
+
+impl Eq for Utf16FlyString {}
+
+impl From<Utf16FlyString> for Utf16String {
+    fn from(string: Utf16FlyString) -> Self {
+        // SAFETY: `into_raw` transfers the existing reference to this owner.
+        unsafe { Self::from_raw_owned(string.into_raw()) }
+    }
+}
+
+impl From<&Utf16FlyString> for Utf16String {
+    fn from(string: &Utf16FlyString) -> Self {
+        // SAFETY: The source owner keeps the raw string alive while adding a reference.
+        unsafe { reference_utf16_string(string.raw_identity()) };
+        // SAFETY: The new reference is transferred to this owner.
+        unsafe { Self::from_raw_owned(string.raw_identity()) }
+    }
 }
 
 #[inline]

--- a/AK/Rust/src/lib.rs
+++ b/AK/Rust/src/lib.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Rust views of shared AK data structures.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+const SHORT_STRING_FLAG: usize = 1;
+const SHORT_STRING_BYTE_COUNT_SHIFT: u32 = 2;
+const HAS_UTF16_STORAGE: u32 = 1;
+
+/// Mirrors `AK::Detail::Utf16StringDataHeader`.
+#[repr(C, align(8))]
+struct Utf16StringDataHeader {
+    reference_count: AtomicU32,
+    length_in_code_units: u32,
+    length_in_code_points: AtomicU32,
+    hash: AtomicU32,
+    flags: AtomicU32,
+}
+
+const _: () = assert!(size_of::<Utf16StringDataHeader>() == 24);
+const _: () = assert!(align_of::<Utf16StringDataHeader>() == 8);
+const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, reference_count) == 0);
+const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, length_in_code_units) == 4);
+const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, length_in_code_points) == 8);
+const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, hash) == 12);
+const _: () = assert!(std::mem::offset_of!(Utf16StringDataHeader, flags) == 16);
+
+/// A borrowed view of an `AK::Utf16String` or `AK::Utf16FlyString`.
+pub enum Utf16StringUnits<'a> {
+    Ascii(&'a [u8]),
+    Utf16(&'a [u16]),
+}
+
+#[inline]
+fn has_long_storage(raw: usize) -> bool {
+    raw != 0 && raw & SHORT_STRING_FLAG == 0
+}
+
+/// Adds an ownership reference to a raw `AK::Utf16String` representation.
+///
+/// # Safety
+///
+/// `raw` must be zero, a valid short string, or a live long string allocation.
+pub unsafe fn reference_utf16_string(raw: usize) {
+    if !has_long_storage(raw) {
+        return;
+    }
+
+    // SAFETY: The caller guarantees that `raw` points to a live long string allocation.
+    let header = unsafe { &*std::ptr::with_exposed_provenance::<Utf16StringDataHeader>(raw) };
+    let result = header
+        .reference_count
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+            (count != 0).then(|| count.checked_add(1)).flatten()
+        });
+    assert!(result.is_ok(), "invalid UTF-16 string reference count");
+}
+
+/// Releases an ownership reference to a raw `AK::Utf16String` representation.
+/// Calls `release_last` when C++ must perform the potentially final release.
+///
+/// # Safety
+///
+/// `raw` must be zero, a valid short string, or a live long string allocation
+/// for which the caller owns one reference. `release_last` must perform the
+/// release-ordered decrement and acquire fence required before destruction.
+pub unsafe fn release_utf16_string_with(raw: usize, release_last: impl FnOnce(usize)) {
+    if !has_long_storage(raw) {
+        return;
+    }
+
+    // SAFETY: The caller guarantees that `raw` points to a live long string allocation.
+    let header = unsafe { &*std::ptr::with_exposed_provenance::<Utf16StringDataHeader>(raw) };
+    loop {
+        let reference_count = header.reference_count.load(Ordering::Relaxed);
+        assert!(reference_count != 0, "invalid UTF-16 string reference count");
+        if reference_count == 1 {
+            // The callback performs the final release decrement and acquire fence.
+            release_last(raw);
+            return;
+        }
+        if header
+            .reference_count
+            .compare_exchange_weak(
+                reference_count,
+                reference_count - 1,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            return;
+        }
+    }
+}
+
+/// Decodes the storage referenced by a raw `AK::Utf16String` representation.
+///
+/// # Safety
+///
+/// `raw` must remain at a stable address for the returned lifetime. Its value
+/// must be zero, a valid short string, or a live long string allocation that
+/// remains alive for the returned lifetime.
+pub unsafe fn utf16_string_units(raw: &usize) -> Utf16StringUnits<'_> {
+    if *raw == 0 {
+        return Utf16StringUnits::Ascii(&[]);
+    }
+
+    if !has_long_storage(*raw) {
+        let bytes = raw.to_ne_bytes();
+        #[cfg(target_endian = "little")]
+        let tag = bytes[0];
+        #[cfg(target_endian = "big")]
+        let tag = bytes[size_of::<usize>() - 1];
+        let length = usize::from(tag >> SHORT_STRING_BYTE_COUNT_SHIFT);
+        assert!(length < size_of::<usize>());
+
+        let pointer = std::ptr::from_ref(raw).cast::<u8>();
+        #[cfg(target_endian = "little")]
+        // SAFETY: A short string stores its bytes after the tag byte.
+        let pointer = unsafe { pointer.add(1) };
+
+        // SAFETY: The short-string bytes are stored inline in `raw` and `length`
+        // is constrained to the remaining bytes in the word.
+        return Utf16StringUnits::Ascii(unsafe { std::slice::from_raw_parts(pointer, length) });
+    }
+
+    // SAFETY: The caller guarantees that `raw` points to a live long string allocation.
+    let header = unsafe { &*std::ptr::with_exposed_provenance::<Utf16StringDataHeader>(*raw) };
+    let length = header.length_in_code_units as usize;
+    let storage = std::ptr::from_ref(header)
+        .cast::<u8>()
+        .wrapping_add(size_of::<Utf16StringDataHeader>());
+    if header.flags.load(Ordering::Acquire) & HAS_UTF16_STORAGE == 0 {
+        // SAFETY: Long ASCII storage starts immediately after the header and contains `length` bytes.
+        Utf16StringUnits::Ascii(unsafe { std::slice::from_raw_parts(storage, length) })
+    } else {
+        // SAFETY: Long UTF-16 storage starts immediately after the aligned header and contains
+        // `length` u16 code units.
+        Utf16StringUnits::Utf16(unsafe { std::slice::from_raw_parts(storage.cast::<u16>(), length) })
+    }
+}

--- a/AK/Utf16FlyString.h
+++ b/AK/Utf16FlyString.h
@@ -41,11 +41,18 @@ public:
         return m_data.raw({});
     }
 
+    // Transfer this string's existing ownership reference to an FFI caller. The caller must
+    // eventually pass the raw value to adopt_raw() or unref_raw().
+    [[nodiscard]] FlatPtr into_raw() &&
+    {
+        return m_data.leak_raw(Badge<Utf16FlyString> {});
+    }
+
     [[nodiscard]] FlatPtr raw_identity() const { return m_data.raw({}); }
 
     [[nodiscard]] static Utf16FlyString from_raw(FlatPtr raw)
     {
-        auto base = Detail::Utf16StringBase::adopt_raw({}, raw);
+        auto base = Detail::Utf16StringBase::adopt_raw(Badge<Utf16FlyString> {}, raw);
         if (base.has_long_storage())
             base.data({})->ref();
 
@@ -54,10 +61,24 @@ public:
         return string;
     }
 
+    // Adopt a raw value produced by into_raw() without changing its reference count.
+    [[nodiscard]] static Utf16FlyString adopt_raw(FlatPtr raw)
+    {
+        return Utf16FlyString { Detail::Utf16StringBase::adopt_raw(Badge<Utf16FlyString> {}, raw) };
+    }
+
+    static void ref_raw(FlatPtr raw)
+    {
+        auto string = adopt_raw(raw);
+        if (string.m_data.has_long_storage())
+            string.m_data.data({})->ref();
+        (void)move(string).into_raw();
+    }
+
     static void unref_raw(FlatPtr raw)
     {
         // Adopt the bridge's reference and let it drop.
-        auto base = Detail::Utf16StringBase::adopt_raw({}, raw);
+        auto string = adopt_raw(raw);
     }
 
     template<typename T>

--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -80,6 +80,13 @@ public:
         return raw();
     }
 
+    // Transfer this string's existing ownership reference to an FFI caller. The caller must
+    // eventually pass the raw value to adopt_raw() or unref_raw().
+    [[nodiscard]] FlatPtr into_raw() &&
+    {
+        return leak_raw(Badge<Utf16String> {});
+    }
+
     [[nodiscard]] static Utf16String from_raw(FlatPtr raw)
     {
         Utf16String string;
@@ -88,6 +95,19 @@ public:
         if (string.has_long_storage())
             string.data_without_union_member_assertion()->ref();
         return string;
+    }
+
+    // Adopt a raw value produced by into_raw() without changing its reference count. This consumes
+    // the caller's reference. Use from_raw() when the caller keeps its own reference.
+    [[nodiscard]] static Utf16String adopt_raw(FlatPtr raw)
+    {
+        return Utf16String { Detail::Utf16StringBase::adopt_raw(Badge<Utf16String> {}, raw) };
+    }
+
+    static void unref_raw(FlatPtr raw)
+    {
+        // Adopt the bridge's reference and let it drop.
+        auto string = adopt_raw(raw);
     }
 
     template<typename T>

--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -341,10 +341,19 @@ public:
 
     [[nodiscard]] constexpr FlatPtr raw(Badge<Utf16FlyString>) const { return raw(); }
 
+    template<OneOf<Utf16String, Utf16FlyString> T>
+    [[nodiscard]] constexpr FlatPtr leak_raw(Badge<T>)
+    {
+        auto raw_value = raw();
+        m_value = { .short_ascii_string = ShortString::create_empty() };
+        return raw_value;
+    }
+
     // NB: Adopts a raw value previously produced by raw(), together with ownership of one
     //     reference to its data if it has long storage. For FFI bridges that retain the raw
     //     representation of a string.
-    [[nodiscard]] ALWAYS_INLINE static Utf16StringBase adopt_raw(Badge<Utf16FlyString>, FlatPtr raw)
+    template<OneOf<Utf16String, Utf16FlyString> T>
+    [[nodiscard]] ALWAYS_INLINE static Utf16StringBase adopt_raw(Badge<T>, FlatPtr raw)
     {
         Utf16StringBase string;
         auto const** data = __builtin_launder(&string.m_value.data);

--- a/AK/Utf16StringData.cpp
+++ b/AK/Utf16StringData.cpp
@@ -15,8 +15,8 @@
 
 namespace AK::Detail {
 
-// Due to internal optimizations, we have an explicit maximum string length of 2**63 - 1.
-#define VERIFY_UTF16_LENGTH(length) VERIFY(length >> Detail::UTF16_FLAG == 0);
+// The shared C++/Rust representation uses fixed-width lengths.
+#define VERIFY_UTF16_LENGTH(length) VERIFY(length < NumericLimits<u32>::max());
 
 NonnullRefPtr<Utf16StringData> Utf16StringData::create_uninitialized(StorageType storage_type, size_t code_unit_length)
 {
@@ -42,13 +42,13 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::create_from_code_point_iterable(
     VERIFY_UTF16_LENGTH(code_unit_length);
 
     auto string = create_uninitialized(StorageType::UTF16, code_unit_length);
-    string->m_length_in_code_points = code_point_length;
+    string->m_header.length_in_code_points = static_cast<u32>(code_point_length);
 
     size_t code_unit_index = 0;
 
     for (auto code_point : view) {
         (void)UnicodeUtils::code_point_to_utf16(code_point, [&](auto code_unit) {
-            string->m_utf16_data[code_unit_index++] = code_unit;
+            string->utf16_data()[code_unit_index++] = code_unit;
         });
     }
 
@@ -59,7 +59,7 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::from_ascii(ReadonlyBytes ascii_s
 {
     VERIFY_UTF16_LENGTH(ascii_string.size());
     auto string = create_uninitialized(StorageType::ASCII, ascii_string.size());
-    TypedTransfer<char>::copy(string->m_ascii_data, reinterpret_cast<char const*>(ascii_string.data()), ascii_string.size());
+    TypedTransfer<char>::copy(string->ascii_data(), reinterpret_cast<char const*>(ascii_string.data()), ascii_string.size());
     return string;
 }
 
@@ -68,7 +68,7 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::create_uninitialized_ascii(size_
     VERIFY_UTF16_LENGTH(length_in_code_units);
 
     auto string = create_uninitialized(StorageType::ASCII, length_in_code_units);
-    buffer = { string->m_ascii_data, length_in_code_units };
+    buffer = { string->ascii_data(), length_in_code_units };
     return string;
 }
 
@@ -80,14 +80,14 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::from_utf8(StringView utf8_string
         VERIFY_UTF16_LENGTH(utf8_string.length());
 
         string = create_uninitialized(StorageType::ASCII, utf8_string.length());
-        TypedTransfer<char>::copy(string->m_ascii_data, utf8_string.characters_without_null_termination(), utf8_string.length());
+        TypedTransfer<char>::copy(string->ascii_data(), utf8_string.characters_without_null_termination(), utf8_string.length());
     } else if (Utf8View view { utf8_string }; view.validate(AllowLonelySurrogates::No)) {
         auto code_unit_length = simdutf::utf16_length_from_utf8(utf8_string.characters_without_null_termination(), utf8_string.length());
         VERIFY_UTF16_LENGTH(code_unit_length);
 
         string = create_uninitialized(StorageType::UTF16, code_unit_length);
 
-        auto result = simdutf::convert_utf8_to_utf16(utf8_string.characters_without_null_termination(), utf8_string.length(), string->m_utf16_data);
+        auto result = simdutf::convert_utf8_to_utf16(utf8_string.characters_without_null_termination(), utf8_string.length(), string->utf16_data());
         VERIFY(result == code_unit_length);
     } else {
         string = create_from_code_point_iterable(view);
@@ -103,17 +103,18 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::from_utf16(Utf16View const& utf1
 
     if (utf16_string.has_ascii_storage()) {
         string = create_uninitialized(StorageType::ASCII, utf16_string.length_in_code_units());
-        TypedTransfer<char>::copy(string->m_ascii_data, utf16_string.ascii_span().data(), utf16_string.length_in_code_units());
+        TypedTransfer<char>::copy(string->ascii_data(), utf16_string.ascii_span().data(), utf16_string.length_in_code_units());
     } else if (utf16_string.is_ascii()) {
         string = create_uninitialized(StorageType::ASCII, utf16_string.length_in_code_units());
 
-        auto result = simdutf::convert_utf16_to_utf8(utf16_string.utf16_span().data(), utf16_string.length_in_code_units(), string->m_ascii_data);
+        auto result = simdutf::convert_utf16_to_utf8(utf16_string.utf16_span().data(), utf16_string.length_in_code_units(), string->ascii_data());
         VERIFY(result == utf16_string.length_in_code_units());
     } else {
         string = create_uninitialized(StorageType::UTF16, utf16_string.length_in_code_units());
-        TypedTransfer<char16_t>::copy(string->m_utf16_data, utf16_string.utf16_span().data(), utf16_string.length_in_code_units());
+        TypedTransfer<char16_t>::copy(string->utf16_data(), utf16_string.utf16_span().data(), utf16_string.length_in_code_units());
 
-        string->m_length_in_code_points = utf16_string.m_length_in_code_points;
+        if (utf16_string.m_length_in_code_points != NumericLimits<size_t>::max())
+            string->m_header.length_in_code_points = static_cast<u32>(utf16_string.m_length_in_code_points);
     }
 
     return string.release_nonnull();
@@ -134,12 +135,13 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::from_string_builder(Utf16StringB
     } else {
         if (view.has_ascii_storage()) {
             string = create_uninitialized(StorageType::ASCII, code_unit_length);
-            TypedTransfer<char>::copy(string->m_ascii_data, view.ascii_span().data(), code_unit_length);
+            TypedTransfer<char>::copy(string->ascii_data(), view.ascii_span().data(), code_unit_length);
         } else {
             string = create_uninitialized(StorageType::UTF16, code_unit_length);
-            TypedTransfer<char16_t>::copy(string->m_utf16_data, view.utf16_span().data(), code_unit_length);
+            TypedTransfer<char16_t>::copy(string->utf16_data(), view.utf16_span().data(), code_unit_length);
 
-            string->m_length_in_code_points = view.m_length_in_code_points;
+            if (view.m_length_in_code_points != NumericLimits<size_t>::max())
+                string->m_header.length_in_code_points = static_cast<u32>(view.m_length_in_code_points);
         }
     }
 
@@ -153,7 +155,7 @@ ErrorOr<NonnullRefPtr<Utf16StringData>> Utf16StringData::from_ipc_stream(Stream&
     if (is_ascii) {
         string = create_uninitialized(StorageType::ASCII, length_in_code_units);
 
-        Bytes bytes { string->m_ascii_data, length_in_code_units };
+        Bytes bytes { string->ascii_data(), length_in_code_units };
         TRY(stream.read_until_filled(bytes));
 
         if (!string->ascii_view().is_ascii())
@@ -161,7 +163,7 @@ ErrorOr<NonnullRefPtr<Utf16StringData>> Utf16StringData::from_ipc_stream(Stream&
     } else {
         string = create_uninitialized(StorageType::UTF16, length_in_code_units);
 
-        Bytes bytes { reinterpret_cast<u8*>(string->m_utf16_data), length_in_code_units * sizeof(char16_t) };
+        Bytes bytes { reinterpret_cast<u8*>(string->utf16_data()), length_in_code_units * sizeof(char16_t) };
         TRY(stream.read_until_filled(bytes));
     }
 
@@ -173,7 +175,7 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::to_well_formed(Utf16View const& 
     VERIFY(!utf16_string.has_ascii_storage());
 
     auto string = create_uninitialized(StorageType::UTF16, utf16_string.length_in_code_units());
-    simdutf::to_well_formed_utf16(utf16_string.utf16_span().data(), utf16_string.length_in_code_units(), string->m_utf16_data);
+    simdutf::to_well_formed_utf16(utf16_string.utf16_span().data(), utf16_string.length_in_code_units(), string->utf16_data());
 
     return string;
 }
@@ -182,8 +184,8 @@ size_t Utf16StringData::calculate_code_point_length() const
 {
     ASSERT(!has_ascii_storage());
 
-    if (simdutf::validate_utf16(m_utf16_data, length_in_code_units()))
-        return simdutf::count_utf16(m_utf16_data, length_in_code_units());
+    if (simdutf::validate_utf16(utf16_data(), length_in_code_units()))
+        return simdutf::count_utf16(utf16_data(), length_in_code_units());
 
     size_t code_points = 0;
     for ([[maybe_unused]] auto code_point : utf16_view())

--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -6,9 +6,10 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
+#include <AK/Checked.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/NumericLimits.h>
-#include <AK/RefCounted.h>
 #include <AK/Span.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -25,8 +26,32 @@ namespace AK::Detail {
 
 void did_destroy_utf16_fly_string_data(Badge<Detail::Utf16StringData>, Detail::Utf16StringData const&);
 
-class Utf16StringData final : public RefCounted<Utf16StringData> {
+// This is an intentionally stable representation shared with Rust. Keep all fields fixed-width,
+// and update the corresponding Rust layout assertions when changing it.
+struct alignas(8) Utf16StringDataHeader {
+    mutable u32 reference_count { 1 };
+    u32 length_in_code_units { 0 };
+    mutable u32 length_in_code_points { NumericLimits<u32>::max() };
+    mutable u32 hash { 0 };
+    mutable u32 flags { 0 };
+};
+
+static_assert(sizeof(Utf16StringDataHeader) == 24);
+static_assert(alignof(Utf16StringDataHeader) == 8);
+static_assert(offsetof(Utf16StringDataHeader, reference_count) == 0);
+static_assert(offsetof(Utf16StringDataHeader, length_in_code_units) == 4);
+static_assert(offsetof(Utf16StringDataHeader, length_in_code_points) == 8);
+static_assert(offsetof(Utf16StringDataHeader, hash) == 12);
+static_assert(offsetof(Utf16StringDataHeader, flags) == 16);
+
+class Utf16StringData final {
+    AK_MAKE_NONCOPYABLE(Utf16StringData);
+    AK_MAKE_NONMOVABLE(Utf16StringData);
+
 public:
+    using RefCountType = u32;
+    using AllowOwnPtr = FalseType;
+
     enum class StorageType : u8 {
         ASCII,
         UTF16,
@@ -36,6 +61,16 @@ public:
         No,
         Yes,
     };
+
+    enum Flag : u32 {
+        HasUtf16Storage = 1 << 0,
+        HasHash = 1 << 1,
+        IsFlyString = 1 << 2,
+    };
+
+    static_assert(HasUtf16Storage == 1);
+    static_assert(HasHash == 2);
+    static_assert(IsFlyString == 4);
 
     static NonnullRefPtr<Utf16StringData> from_utf8(StringView, AllowASCIIStorage);
     static NonnullRefPtr<Utf16StringData> from_ascii(ReadonlyBytes);
@@ -47,13 +82,47 @@ public:
 
     ~Utf16StringData()
     {
+        VERIFY(ref_count() == 0);
         if (is_fly_string())
             did_destroy_utf16_fly_string_data({}, *this);
     }
 
+    ALWAYS_INLINE void ref() const
+    {
+        auto old_reference_count = atomic_fetch_add(&m_header.reference_count, 1u, memory_order_relaxed);
+        VERIFY(old_reference_count > 0);
+        VERIFY(!Checked<RefCountType>::addition_would_overflow(old_reference_count, 1));
+    }
+
+    [[nodiscard]] bool try_ref() const
+    {
+        auto expected = atomic_load(&m_header.reference_count, memory_order_relaxed);
+        for (;;) {
+            if (expected == 0)
+                return false;
+            VERIFY(!Checked<RefCountType>::addition_would_overflow(expected, 1));
+            if (atomic_compare_exchange_strong(&m_header.reference_count, expected, expected + 1, memory_order_acquire))
+                return true;
+        }
+    }
+
+    ALWAYS_INLINE bool unref() const
+    {
+        auto old_reference_count = atomic_fetch_sub(&m_header.reference_count, 1u, memory_order_release);
+        VERIFY(old_reference_count > 0);
+        if (old_reference_count != 1)
+            return false;
+
+        atomic_thread_fence(memory_order_acquire);
+        delete this;
+        return true;
+    }
+
+    [[nodiscard]] RefCountType ref_count() const { return atomic_load(&m_header.reference_count, memory_order_relaxed); }
+
     [[nodiscard]] static constexpr size_t offset_of_string_storage()
     {
-        return offsetof(Utf16StringData, m_ascii_data);
+        return sizeof(Utf16StringDataHeader);
     }
 
     void operator delete(void* ptr)
@@ -80,57 +149,71 @@ public:
         return utf16_view() == Utf16View { other.characters_without_null_termination(), other.length() };
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_ascii_storage() const { return m_length_in_code_units >> Detail::UTF16_FLAG == 0; }
-    [[nodiscard]] ALWAYS_INLINE bool has_utf16_storage() const { return m_length_in_code_units >> Detail::UTF16_FLAG != 0; }
+    [[nodiscard]] ALWAYS_INLINE bool has_ascii_storage() const { return !has_flag(HasUtf16Storage); }
+    [[nodiscard]] ALWAYS_INLINE bool has_utf16_storage() const { return has_flag(HasUtf16Storage); }
 
     ALWAYS_INLINE u32 hash() const
     {
-        if (!m_has_hash) {
-            m_hash = utf16_view().hash();
-            m_has_hash = true;
+        if (!has_flag(HasHash)) {
+            auto hash = utf16_view().hash();
+            atomic_store(&m_header.hash, hash, memory_order_relaxed);
+            atomic_fetch_or(&m_header.flags, static_cast<u32>(HasHash), memory_order_release);
+            return hash;
         }
 
-        return m_hash;
+        return atomic_load(&m_header.hash, memory_order_relaxed);
     }
 
-    [[nodiscard]] ALWAYS_INLINE size_t length_in_code_units() const { return m_length_in_code_units & ~(1uz << Detail::UTF16_FLAG); }
+    [[nodiscard]] ALWAYS_INLINE size_t length_in_code_units() const { return m_header.length_in_code_units; }
     [[nodiscard]] ALWAYS_INLINE size_t length_in_code_points() const
     {
         if (has_ascii_storage())
             return length_in_code_units();
-        if (m_length_in_code_points == NumericLimits<size_t>::max())
-            m_length_in_code_points = calculate_code_point_length();
-        return m_length_in_code_points;
+
+        auto length_in_code_points = atomic_load(&m_header.length_in_code_points, memory_order_acquire);
+        if (length_in_code_points != NumericLimits<u32>::max())
+            return length_in_code_points;
+
+        auto calculated_length = calculate_code_point_length();
+        VERIFY(calculated_length < NumericLimits<u32>::max());
+
+        auto expected = NumericLimits<u32>::max();
+        if (atomic_compare_exchange_strong(&m_header.length_in_code_points, expected, static_cast<u32>(calculated_length), memory_order_acq_rel))
+            return calculated_length;
+        return expected;
     }
 
     [[nodiscard]] ALWAYS_INLINE StringView ascii_view() const LIFETIME_BOUND
     {
         ASSERT(has_ascii_storage());
-        return { m_ascii_data, length_in_code_units() };
+        return { ascii_data(), length_in_code_units() };
     }
 
     [[nodiscard]] ALWAYS_INLINE Utf16View utf16_view() const LIFETIME_BOUND
     {
         if (has_ascii_storage())
-            return { m_ascii_data, length_in_code_units() };
+            return { ascii_data(), length_in_code_units() };
 
-        Utf16View view { m_utf16_data, length_in_code_units() };
-        view.m_length_in_code_points = m_length_in_code_points;
+        Utf16View view { utf16_data(), length_in_code_units() };
+        auto length_in_code_points = atomic_load(&m_header.length_in_code_points, memory_order_acquire);
+        if (length_in_code_points != NumericLimits<u32>::max())
+            view.m_length_in_code_points = length_in_code_points;
 
         return view;
     }
 
-    ALWAYS_INLINE void mark_as_fly_string(Badge<Utf16FlyString>) const { m_is_fly_string = true; }
-    [[nodiscard]] ALWAYS_INLINE bool is_fly_string() const { return m_is_fly_string; }
+    ALWAYS_INLINE void mark_as_fly_string(Badge<Utf16FlyString>) const { atomic_fetch_or(&m_header.flags, static_cast<u32>(IsFlyString), memory_order_release); }
+    [[nodiscard]] ALWAYS_INLINE bool is_fly_string() const { return has_flag(IsFlyString); }
 
 private:
     friend class AK::Utf16String;
 
     ALWAYS_INLINE Utf16StringData(StorageType storage_type, size_t code_unit_length)
-        : m_length_in_code_units(code_unit_length)
     {
+        VERIFY(code_unit_length < NumericLimits<u32>::max());
+        m_header.length_in_code_units = static_cast<u32>(code_unit_length);
         if (storage_type == StorageType::UTF16)
-            m_length_in_code_units |= 1uz << Detail::UTF16_FLAG;
+            m_header.flags = HasUtf16Storage;
     }
 
     static NonnullRefPtr<Utf16StringData> create_uninitialized(StorageType storage_type, size_t code_unit_length);
@@ -148,21 +231,36 @@ private:
 
     [[nodiscard]] size_t calculate_code_point_length() const;
 
-    // We store whether this string has ASCII or UTF-16 storage by setting the most significant bit of m_length_in_code_units
-    // to 1 for UTF-16 storage. This shrinks the size of most UTF-16 string related classes, at the cost of not being
-    // allowed to create a string larger than 2**63 - 1.
-    size_t m_length_in_code_units { 0 };
-    mutable size_t m_length_in_code_points { NumericLimits<size_t>::max() };
+    [[nodiscard]] ALWAYS_INLINE bool has_flag(Flag flag) const
+    {
+        return atomic_load(&m_header.flags, memory_order_acquire) & static_cast<u32>(flag);
+    }
 
-    mutable u32 m_hash { 0 };
-    mutable bool m_has_hash { false };
+    [[nodiscard]] ALWAYS_INLINE char* ascii_data()
+    {
+        return reinterpret_cast<char*>(this) + offset_of_string_storage();
+    }
 
-    mutable bool m_is_fly_string { false };
+    [[nodiscard]] ALWAYS_INLINE char const* ascii_data() const
+    {
+        return reinterpret_cast<char const*>(this) + offset_of_string_storage();
+    }
 
-    union alignas(8) {
-        char m_ascii_data[0];
-        char16_t m_utf16_data[0];
-    };
+    [[nodiscard]] ALWAYS_INLINE char16_t* utf16_data()
+    {
+        return reinterpret_cast<char16_t*>(reinterpret_cast<char*>(this) + offset_of_string_storage());
+    }
+
+    [[nodiscard]] ALWAYS_INLINE char16_t const* utf16_data() const
+    {
+        return reinterpret_cast<char16_t const*>(reinterpret_cast<char const*>(this) + offset_of_string_storage());
+    }
+
+    Utf16StringDataHeader m_header;
 };
+
+static_assert(Utf16StringData::offset_of_string_storage() == sizeof(Utf16StringDataHeader));
+static_assert(sizeof(Utf16StringData) == sizeof(Utf16StringDataHeader));
+static_assert(alignof(Utf16StringData) == alignof(Utf16StringDataHeader));
 
 }

--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -78,6 +78,13 @@ public:
     static NonnullRefPtr<Utf16StringData> from_string_builder(Utf16StringBuilder&);
     static ErrorOr<NonnullRefPtr<Utf16StringData>> from_ipc_stream(Stream&, size_t length_in_code_units, bool is_ascii);
 
+    // Creates the stable shared header and reserves trailing character storage for an FFI caller
+    // to initialize before publishing the resulting string.
+    static NonnullRefPtr<Utf16StringData> create_uninitialized_for_ffi(StorageType storage_type, size_t code_unit_length)
+    {
+        return create_uninitialized(storage_type, code_unit_length);
+    }
+
     static NonnullRefPtr<Utf16StringData> to_well_formed(Utf16View const&);
 
     ~Utf16StringData()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
 name = "libjs_rust"
 version = "0.1.0"
 dependencies = [
+ "ak",
  "cbindgen",
  "fARM64",
  "flapc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ak"
+version = "0.1.0"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +829,7 @@ dependencies = [
 name = "libweb_rust"
 version = "0.1.0"
 dependencies = [
+ "ak",
  "cbindgen",
  "chardetng",
  "foldhash 0.1.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "AK/Rust",
     "Libraries/LibGfx/Rust",
     "Libraries/LibJS/Rust",
     "Libraries/LibRegex/Rust",

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/aarch64.S
@@ -5323,19 +5323,16 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt:
     cbz x1, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_2
     ldrb w3, [x2, #16]
     tbnz x3, #0, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_14
-    ldr x2, [x1, #8]
-    tbz x2, #63, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_17
-    lsl x2, x2, #1
-    lsr x2, x2, #1
+    ldr w2, [x1, #4]
     cmp x2, x0
     b.ls .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
-    add x1, x1, #32
+    ldr w2, [x1, #16]
+    tbz x2, #0, .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_19
+    add x1, x1, #24
     ldrh w0, [x1, x0, lsl #1]
     b .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_15
-.Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_17:
-    cmp x2, x0
-    b.ls .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
-    add x1, x1, #32
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_19:
+    add x1, x1, #24
     ldrb w0, [x1, x0]
     b .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_15
 .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_14:
@@ -5390,19 +5387,16 @@ asm_handler_CallBuiltinStringPrototypeCharAt:
     cbz x1, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_1
     ldrb w3, [x2, #16]
     tbnz x3, #0, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_14
-    ldr x2, [x1, #8]
-    tbz x2, #63, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_17
-    lsl x2, x2, #1
-    lsr x2, x2, #1
+    ldr w2, [x1, #4]
     cmp x2, x0
     b.ls .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
-    add x1, x1, #32
+    ldr w2, [x1, #16]
+    tbz x2, #0, .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_19
+    add x1, x1, #24
     ldrh w0, [x1, x0, lsl #1]
     b .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_15
-.Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_17:
-    cmp x2, x0
-    b.ls .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
-    add x1, x1, #32
+.Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_19:
+    add x1, x1, #24
     ldrb w0, [x1, x0]
     b .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_15
 .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_14:

--- a/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
+++ b/Libraries/LibJS/Flap/tests/interpreter-assembly/x86_64.S
@@ -5434,20 +5434,17 @@ asm_handler_CallBuiltinStringPrototypeCharCodeAt:
     movzx esi, BYTE PTR [rdx + 16]
     test esi, 1
     jnz .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_14
-    mov rdx, QWORD PTR [rcx + 8]
-    test rdx, rdx
-    jns .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_17
-    shl rdx, 1
-    shr rdx, 1
+    mov edx, DWORD PTR [rcx + 4]
     cmp rdx, rax
     jbe .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
-    lea rcx, [rcx + 32]
+    mov edx, DWORD PTR [rcx + 16]
+    test edx, 1
+    jz .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_19
+    lea rcx, [rcx + 24]
     movzx eax, WORD PTR [rcx + rax * 2]
     jmp .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_15
-.Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_17:
-    cmp rdx, rax
-    jbe .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_1
-    lea rcx, [rcx + 32]
+.Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_19:
+    lea rcx, [rcx + 24]
     movzx eax, BYTE PTR [rcx + rax]
     jmp .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_15
 .Lasm_CallBuiltinStringPrototypeCharCodeAt.ssa_block_14:
@@ -5507,20 +5504,17 @@ asm_handler_CallBuiltinStringPrototypeCharAt:
     movzx esi, BYTE PTR [rdx + 16]
     test esi, 1
     jnz .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_14
-    mov rdx, QWORD PTR [rcx + 8]
-    test rdx, rdx
-    jns .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_17
-    shl rdx, 1
-    shr rdx, 1
+    mov edx, DWORD PTR [rcx + 4]
     cmp rdx, rax
     jbe .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
-    lea rcx, [rcx + 32]
+    mov edx, DWORD PTR [rcx + 16]
+    test edx, 1
+    jz .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_19
+    lea rcx, [rcx + 24]
     movzx ecx, WORD PTR [rcx + rax * 2]
     jmp .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_15
-.Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_17:
-    cmp rdx, rax
-    jbe .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_2
-    lea rcx, [rcx + 32]
+.Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_19:
+    lea rcx, [rcx + 24]
     movzx ecx, BYTE PTR [rcx + rax]
     jmp .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_15
 .Lasm_CallBuiltinStringPrototypeCharAt.ssa_block_14:

--- a/Libraries/LibJS/Flap/tests/interpreter-layout.conf
+++ b/Libraries/LibJS/Flap/tests/interpreter-layout.conf
@@ -357,9 +357,12 @@ field PrimitiveString.utf16_short_string_byte_count_and_flag u8 PRIMITIVE_STRING
 field PrimitiveString.utf16_short_string_storage Sequence<u8> PRIMITIVE_STRING_UTF16_SHORT_STRING_STORAGE embedded scalar
 
 # Utf16StringData layout
-const UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS = 8
-const UTF16_STRING_DATA_STRING_STORAGE = 32
-field Utf16StringData.length_in_code_units u64 UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS nullable scalar
+const UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS = 4
+const UTF16_STRING_DATA_FLAGS = 16
+const UTF16_STRING_DATA_STRING_STORAGE = 24
+const UTF16_STRING_DATA_HAS_UTF16_STORAGE = 1
+field Utf16StringData.length_in_code_units u32 UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS nullable scalar
+field Utf16StringData.flags u32 UTF16_STRING_DATA_FLAGS nullable scalar
 field Utf16StringData.string_storage Sequence<u8> UTF16_STRING_DATA_STRING_STORAGE embedded scalar
 
 # Environment layout

--- a/Libraries/LibJS/Interpreter/GenerateLayout.cpp
+++ b/Libraries/LibJS/Interpreter/GenerateLayout.cpp
@@ -421,9 +421,12 @@ int main()
 
     // Utf16StringData layout
     outln("\n# Utf16StringData layout");
-    EMIT_OFFSET(UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS, AK::Detail::Utf16StringData, m_length_in_code_units);
+    EMIT_OFFSET(UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS, AK::Detail::Utf16StringData, m_header.length_in_code_units);
+    EMIT_OFFSET(UTF16_STRING_DATA_FLAGS, AK::Detail::Utf16StringData, m_header.flags);
     outln("const UTF16_STRING_DATA_STRING_STORAGE = {}", AK::Detail::Utf16StringData::offset_of_string_storage());
-    outln("field Utf16StringData.length_in_code_units u64 UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS nullable scalar");
+    outln("const UTF16_STRING_DATA_HAS_UTF16_STORAGE = {}", static_cast<u32>(AK::Detail::Utf16StringData::HasUtf16Storage));
+    outln("field Utf16StringData.length_in_code_units u32 UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS nullable scalar");
+    outln("field Utf16StringData.flags u32 UTF16_STRING_DATA_FLAGS nullable scalar");
     outln("field Utf16StringData.string_storage Sequence<u8> UTF16_STRING_DATA_STRING_STORAGE embedded scalar");
 
     // Environment layout

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -848,16 +848,13 @@ inline fn load_primitive_string_utf16_code_unit(
 
     let short_string_info = string.utf16_short_string_byte_count_and_flag;
     if short_string_info lacks UTF16_SHORT_STRING_FLAG {
-        let encoded_length = utf16_data.length_in_code_units;
-        let signed_length: i64 = alias(encoded_length);
-        if signed_length < 0 {
-            let length = encoded_length << 1 >> 1;
-            guard length > alias(index) else out_of_bounds;
+        let length = utf16_data.length_in_code_units;
+        guard length > index else out_of_bounds;
+        if utf16_data.flags has UTF16_STRING_DATA_HAS_UTF16_STORAGE {
             let utf16_storage: Sequence<u16> = alias(utf16_data.string_storage);
             let code_unit: u32 = alias(utf16_storage[index]);
             code_unit
         } else {
-            guard encoded_length > alias(index) else out_of_bounds;
             let code_unit: u32 = alias(utf16_data.string_storage[index]);
             code_unit
         }

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["staticlib"]
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
+ak = { path = "../../../AK/Rust" }
 libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false }
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -213,7 +213,8 @@ pub struct FFIExecutableData {
     pub identifier_count: usize,
     pub property_key_table: *const FFIUtf16Slice,
     pub property_key_count: usize,
-    pub string_table: *const FFIUtf16Slice,
+    /// Raw `AK::Utf16String` owners transferred to C++ by `rust_create_executable`.
+    pub owned_string_table: *const usize,
     pub string_count: usize,
     pub constants_data: *const u8,
     pub constants_data_length: usize,
@@ -783,6 +784,60 @@ pub struct ExecutableSlices<'a> {
     pub compiled_regexes: &'a [*mut c_void],
 }
 
+struct NativeUtf16StringTable {
+    strings: Vec<usize>,
+    transferred: bool,
+}
+
+impl NativeUtf16StringTable {
+    /// Creates native AK string owners from borrowed FFI slices.
+    ///
+    /// # Safety
+    /// Every slice must point to valid UTF-16 storage for the duration of this call.
+    unsafe fn new(slices: &[FFIUtf16Slice]) -> Self {
+        let mut table = Self {
+            strings: Vec::with_capacity(slices.len()),
+            transferred: false,
+        };
+        for slice in slices {
+            let units = if slice.length == 0 {
+                &[]
+            } else {
+                assert!(!slice.data.is_null());
+                // SAFETY: The caller guarantees that every FFI slice is valid for this call.
+                unsafe { std::slice::from_raw_parts(slice.data, slice.length) }
+            };
+            table.strings.push(ak::Utf16String::from_utf16(units).into_raw());
+        }
+        table
+    }
+
+    fn as_ptr(&self) -> *const usize {
+        self.strings.as_ptr()
+    }
+
+    fn len(&self) -> usize {
+        self.strings.len()
+    }
+
+    fn mark_transferred(&mut self) {
+        self.transferred = true;
+    }
+}
+
+impl Drop for NativeUtf16StringTable {
+    fn drop(&mut self) {
+        if self.transferred {
+            return;
+        }
+
+        for raw in self.strings.drain(..) {
+            // SAFETY: Until the table is marked transferred, it owns every raw reference.
+            drop(unsafe { ak::Utf16String::from_raw_owned(raw) });
+        }
+    }
+}
+
 /// Create a C++ Executable from borrowed FFI slices.
 ///
 /// This is the lowest-level executable constructor wrapper. It lets cache
@@ -824,6 +879,10 @@ pub unsafe fn create_executable_from_slices(
             })
             .collect();
 
+        // Materialize ordinary strings directly in AK's stable representation. C++ adopts these
+        // owners below without copying character data or changing their reference counts.
+        let mut native_string_table = NativeUtf16StringTable::new(slices.string_table);
+
         let ffi_data = FFIExecutableData {
             bytecode: parts.bytecode.as_ptr(),
             bytecode_length: parts.bytecode.len(),
@@ -832,8 +891,8 @@ pub unsafe fn create_executable_from_slices(
             identifier_count: slices.identifier_table.len(),
             property_key_table: slices.property_key_table.as_ptr(),
             property_key_count: slices.property_key_table.len(),
-            string_table: slices.string_table.as_ptr(),
-            string_count: slices.string_table.len(),
+            owned_string_table: native_string_table.as_ptr(),
+            string_count: native_string_table.len(),
             constants_data: slices.constants_data.as_ptr(),
             constants_data_length: slices.constants_data.len(),
             constants_count: slices.constants_count,
@@ -863,7 +922,10 @@ pub unsafe fn create_executable_from_slices(
             regex_count: slices.compiled_regexes.len(),
         };
 
-        rust_create_executable(vm_ptr, source_code_ptr, &raw const ffi_data)
+        let executable = rust_create_executable(vm_ptr, source_code_ptr, &raw const ffi_data);
+        // C++ adopts all string_count owners before returning, including on validation failure.
+        native_string_table.mark_transferred();
+        executable
     }
 }
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1176,11 +1176,6 @@ static Utf16View view_from_ffi(FFIUtf16Slice slice)
     return JS::RustIntegration::utf16_view_from_bytes(slice.data, slice.length);
 }
 
-static Utf16String utf16_from_ffi(FFIUtf16Slice slice)
-{
-    return Utf16String::from_utf16(view_from_ffi(slice));
-}
-
 static Utf16FlyString utf16_fly_from_ffi(FFIUtf16Slice slice)
 {
     return Utf16FlyString::from_utf16(view_from_ffi(slice));
@@ -1346,7 +1341,7 @@ extern "C" void* rust_create_executable(
     auto str_table = make<JS::Bytecode::StringTable>();
     str_table->ensure_capacity(data->string_count);
     for (size_t i = 0; i < data->string_count; ++i) {
-        str_table->insert(utf16_from_ffi(data->string_table[i]));
+        str_table->insert(Utf16String::adopt_raw(data->owned_string_table[i]));
     }
 
     // Build regex table from pre-compiled regex objects.

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -964,15 +964,9 @@ static bool property_computed_value_may_be_stored_as_style_value_handle(Property
 static Optional<Utf16String> serialize_style_value_handle(RustStyleValueHandle const& handle, SerializationMode mode)
 {
     auto text = StyleValueFFI::rust_style_value_serialize(handle.data(), to_underlying(mode));
-    if (!text.storage)
+    if (!text.has_value)
         return {};
-    Utf16StringBuilder builder;
-    if (text.ascii)
-        builder.append_ascii(StringView { reinterpret_cast<char const*>(text.ascii), text.length });
-    else
-        builder.append(Utf16View { reinterpret_cast<char16_t const*>(text.utf16), text.length });
-    StyleValueFFI::rust_serialized_text_release(text.storage);
-    return builder.to_string();
+    return Utf16String::adopt_raw(text.raw);
 }
 
 Optional<Utf16String> CSSStyleProperties::serialized_computed_value_from_stored_handle(PropertyID property_id) const

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1743,7 +1743,7 @@ public:
         {
             static_assert(sizeof(Utf16FlyString) == sizeof(size_t));
             static_assert(alignof(Utf16FlyString) == alignof(size_t));
-            return { reinterpret_cast<Utf16FlyString const*>(color_schemes.raw_pointer), color_schemes.length };
+            return { reinterpret_cast<Utf16FlyString const*>(color_schemes.pointer), color_schemes.length };
         }
 
         bool operator==(InheritedUIValues const& other) const
@@ -2022,7 +2022,7 @@ public:
         {
             static_assert(sizeof(Utf16FlyString) == sizeof(size_t));
             static_assert(alignof(Utf16FlyString) == alignof(size_t));
-            return { reinterpret_cast<Utf16FlyString const*>(values.raw_pointer), values.length };
+            return { reinterpret_cast<Utf16FlyString const*>(values.pointer), values.length };
         }
         static Vector<Utf16FlyString> materialize_fly_strings(ComputedValuesFFI::RetainedUtf16FlyStringList const& values)
         {

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -17,8 +17,7 @@ extern "C" void ladybird_animated_properties_ref(void const*);
 
 static void ladybird_utf16_fly_string_ref_raw(size_t raw)
 {
-    auto string = Utf16FlyString::from_raw(static_cast<FlatPtr>(raw));
-    (void)string.to_raw_leaked();
+    Utf16FlyString::ref_raw(static_cast<FlatPtr>(raw));
 }
 
 static void ladybird_utf16_fly_string_unref_raw(size_t raw)

--- a/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
@@ -49,7 +49,7 @@ private:
         ffi_definitions.ensure_capacity(counter_definitions.size());
         for (auto const& definition : counter_definitions) {
             auto const* value_data = definition.value ? StyleValueFFI::rust_style_value_retain(definition.value->rust_style_value_data()) : nullptr;
-            ffi_definitions.unchecked_append({ { definition.name.to_raw_leaked(), nullptr }, definition.is_reversed, { value_data } });
+            ffi_definitions.unchecked_append({ { definition.name.to_raw_leaked() }, definition.is_reversed, { value_data } });
         }
         return StyleValueFFI::rust_style_value_create_counter_definitions(ffi_definitions.data(), ffi_definitions.size());
     }

--- a/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
@@ -60,9 +60,9 @@ private:
             auto implicit_start_name = implicit_grid_line_name(name, "-start"sv);
             auto implicit_end_name = implicit_grid_line_name(name, "-end"sv);
             areas.unchecked_append({
-                { name.to_raw_leaked(), nullptr },
-                { implicit_start_name.to_raw_leaked(), nullptr },
-                { implicit_end_name.to_raw_leaked(), nullptr },
+                { name.to_raw_leaked() },
+                { implicit_start_name.to_raw_leaked() },
+                { implicit_end_name.to_raw_leaked() },
                 area.row_start,
                 area.row_end,
                 area.column_start,

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -29,7 +29,7 @@ StyleValueFFI::StyleValueData const* ImageSetStyleValue::make_image_set_data(Vec
             { StyleValueFFI::rust_style_value_retain(option.image->rust_style_value_data()) },
             { StyleValueFFI::rust_style_value_retain(option.resolution->rust_style_value_data()) },
             option.type.has_value(),
-            { option.type.has_value() ? option.type->to_raw_leaked() : 0, nullptr },
+            { option.type.has_value() ? option.type->to_raw_leaked() : 0 },
         });
     }
     return StyleValueFFI::rust_style_value_create_image_set(ffi_options.data(), ffi_options.size());

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -353,12 +353,12 @@ void StyleValue::serialize(StringBuilder& builder, SerializationMode mode) const
 {
     // The Rust serializer covers the ported types; everything else falls back to the
     // per-class C++ serializers until the port is complete.
-    if (auto text = StyleValueFFI::rust_style_value_serialize(m_value.operator->(), to_underlying(mode)); text.storage) {
-        if (text.ascii)
-            builder.append(StringView { reinterpret_cast<char const*>(text.ascii), text.length });
+    if (auto text = StyleValueFFI::rust_style_value_serialize(m_value.operator->(), to_underlying(mode)); text.has_value) {
+        auto string = Utf16String::adopt_raw(text.raw);
+        if (string.has_ascii_storage())
+            builder.append(string.ascii_view());
         else
-            builder.append(Utf16View { reinterpret_cast<char16_t const*>(text.utf16), text.length });
-        StyleValueFFI::rust_serialized_text_release(text.storage);
+            builder.append(string.utf16_view());
         return;
     }
 
@@ -446,12 +446,9 @@ void StyleValue::serialize(Utf16StringBuilder& builder, SerializationMode mode) 
 {
     // Rust serializes natively into ASCII-or-UTF-16, so ported types never round-trip
     // through UTF-8 here.
-    if (auto text = StyleValueFFI::rust_style_value_serialize(m_value.operator->(), to_underlying(mode)); text.storage) {
-        if (text.ascii)
-            builder.append_ascii(StringView { reinterpret_cast<char const*>(text.ascii), text.length });
-        else
-            builder.append(Utf16View { reinterpret_cast<char16_t const*>(text.utf16), text.length });
-        StyleValueFFI::rust_serialized_text_release(text.storage);
+    if (auto text = StyleValueFFI::rust_style_value_serialize(m_value.operator->(), to_underlying(mode)); text.has_value) {
+        auto string = Utf16String::adopt_raw(text.raw);
+        builder.append(string.utf16_view());
         return;
     }
 

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -99,8 +99,14 @@
 #include <LibWeb/Layout/Node.h>
 
 extern "C" void ladybird_utf16_fly_string_unref(size_t);
-extern "C" Web::CSS::StyleValueFFI::FfiFlyStringView ladybird_utf16_fly_string_view(size_t, u8*);
 extern "C" void ladybird_string_unref(size_t);
+
+static_assert(sizeof(Web::CSS::StyleValueFFI::RetainedUtf16FlyString) == sizeof(Utf16FlyString));
+static_assert(alignof(Web::CSS::StyleValueFFI::RetainedUtf16FlyString) == alignof(Utf16FlyString));
+static_assert(offsetof(Web::CSS::StyleValueFFI::RetainedUtf16FlyString, raw) == 0);
+static_assert(sizeof(Web::CSS::ComputedValuesFFI::RetainedUtf16FlyString) == sizeof(Utf16FlyString));
+static_assert(alignof(Web::CSS::ComputedValuesFFI::RetainedUtf16FlyString) == alignof(Utf16FlyString));
+static_assert(offsetof(Web::CSS::ComputedValuesFFI::RetainedUtf16FlyString, raw) == 0);
 
 namespace Web::CSS {
 
@@ -672,25 +678,6 @@ Keyword StyleValue::to_keyword() const
 extern "C" void ladybird_utf16_fly_string_unref(size_t raw)
 {
     Utf16FlyString::unref_raw(raw);
-}
-
-// Called when the Rust serializer reads a retained Utf16FlyString's contents. Short strings are
-// decoded into the caller-provided buffer (which must hold at least 16 bytes); long strings
-// return their heap storage, which the retained reference keeps alive across the call.
-extern "C" Web::CSS::StyleValueFFI::FfiFlyStringView ladybird_utf16_fly_string_view(size_t raw, u8* short_buffer)
-{
-    auto string = Utf16FlyString::from_raw(raw);
-    auto view = string.view();
-    if (view.has_ascii_storage()) {
-        auto span = view.ascii_span();
-        if (span.size() <= AK::Detail::MAX_SHORT_STRING_BYTE_COUNT) {
-            __builtin_memcpy(short_buffer, span.data(), span.size());
-            return { short_buffer, span.size(), true };
-        }
-        return { span.data(), span.size(), true };
-    }
-    auto span = view.utf16_span();
-    return { span.data(), span.size(), false };
 }
 
 // Called when Rust-owned style value data drops a retained String.

--- a/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -26,7 +26,7 @@ inline Vector<StyleValueFFI::RetainedRequestUrlModifier> retain_url_modifiers_fo
     Vector<StyleValueFFI::RetainedRequestUrlModifier> modifiers;
     modifiers.ensure_capacity(url.request_url_modifiers().size());
     for (auto const& modifier : url.request_url_modifiers()) {
-        StyleValueFFI::RetainedRequestUrlModifier ffi_modifier { to_underlying(modifier.type()), 0, { 0, nullptr } };
+        StyleValueFFI::RetainedRequestUrlModifier ffi_modifier { to_underlying(modifier.type()), 0, { 0 } };
         modifier.value().visit(
             [&](CrossOriginModifierValue value) { ffi_modifier.enum_value = to_underlying(value); },
             [&](ReferrerPolicyModifierValue value) { ffi_modifier.enum_value = to_underlying(value); },

--- a/Libraries/LibWeb/Rust/Cargo.toml
+++ b/Libraries/LibWeb/Rust/Cargo.toml
@@ -18,6 +18,7 @@ style-replay = ["style-recording"]
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
+ak = { path = "../../../AK/Rust" }
 chardetng = "1.0.0"
 foldhash = "0.1"
 hashbrown = "0.16.1"

--- a/Libraries/LibWeb/Rust/src/css/retained_fly_string.rs
+++ b/Libraries/LibWeb/Rust/src/css/retained_fly_string.rs
@@ -11,26 +11,15 @@
 //! the same arrangement `display.rs` uses for `FfiDisplay`.
 
 use crate::css::style_value::retained_list_partial_eq;
-use std::ffi::c_void;
-use std::sync::Arc;
-
-struct FlyStringStorage {
-    raw: usize,
-}
-
-impl Drop for FlyStringStorage {
-    fn drop(&mut self) {
-        crate::css::ffi_stats::release_utf16_fly_string(self.raw);
-    }
-}
-
-/// A retained AK::Utf16FlyString. Rust clones share one storage reference, so
-/// copying style values and computed payloads never crosses into C++.
+/// A retained `AK::Utf16FlyString` with the same one-word representation.
 #[repr(C)]
 pub struct RetainedUtf16FlyString {
     raw: usize,
-    storage: *const c_void,
+    _not_send_or_sync: std::marker::PhantomData<*const ()>,
 }
+
+const _: () = assert!(size_of::<RetainedUtf16FlyString>() == size_of::<usize>());
+const _: () = assert!(align_of::<RetainedUtf16FlyString>() == align_of::<usize>());
 
 impl RetainedUtf16FlyString {
     /// The raw one-word representation; fly strings are interned, so equal raw
@@ -39,12 +28,16 @@ impl RetainedUtf16FlyString {
         self.raw
     }
 
+    pub(crate) fn raw_word(&self) -> &usize {
+        &self.raw
+    }
+
     /// The no-string sentinel; holds no reference. No real fly string uses the
     /// zero raw representation.
     pub(crate) fn none() -> Self {
         Self {
             raw: 0,
-            storage: std::ptr::null(),
+            _not_send_or_sync: std::marker::PhantomData,
         }
     }
 
@@ -55,7 +48,7 @@ impl RetainedUtf16FlyString {
         }
         Self {
             raw,
-            storage: Arc::into_raw(Arc::new(FlyStringStorage { raw })).cast(),
+            _not_send_or_sync: std::marker::PhantomData,
         }
     }
 }
@@ -65,11 +58,11 @@ impl Clone for RetainedUtf16FlyString {
         if self.raw == 0 {
             return Self::none();
         }
-        // SAFETY: Every non-zero value owns one Arc strong reference.
-        unsafe { Arc::increment_strong_count(self.storage.cast::<FlyStringStorage>()) };
+        // SAFETY: Every non-zero value owns one reference to a valid fly string.
+        unsafe { ak::reference_utf16_string(self.raw) };
         Self {
             raw: self.raw,
-            storage: self.storage,
+            _not_send_or_sync: std::marker::PhantomData,
         }
     }
 }
@@ -79,8 +72,8 @@ impl Drop for RetainedUtf16FlyString {
         if self.raw == 0 {
             return;
         }
-        // SAFETY: Every non-zero value owns one Arc strong reference.
-        unsafe { Arc::decrement_strong_count(self.storage.cast::<FlyStringStorage>()) };
+        // SAFETY: Every non-zero value owns one reference to a valid fly string.
+        unsafe { ak::release_utf16_string_with(self.raw, crate::css::ffi_stats::release_utf16_fly_string) };
     }
 }
 
@@ -106,25 +99,14 @@ impl std::fmt::Debug for RetainedUtf16FlyString {
 pub struct RetainedUtf16FlyStringList {
     pointer: *mut RetainedUtf16FlyString,
     length: usize,
-    raw_pointer: *mut usize,
 }
 
 impl RetainedUtf16FlyStringList {
     pub(crate) fn from_retained_strings(strings: Vec<RetainedUtf16FlyString>) -> Self {
-        let raw_slice = strings
-            .iter()
-            .map(RetainedUtf16FlyString::raw)
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let raw_pointer = Box::into_raw(raw_slice) as *mut usize;
         let slice = strings.into_boxed_slice();
         let length = slice.len();
         let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
-        Self {
-            pointer,
-            length,
-            raw_pointer,
-        }
+        Self { pointer, length }
     }
 
     /// Takes ownership of one leaked reference to each string.
@@ -135,19 +117,9 @@ impl RetainedUtf16FlyStringList {
         let slice: Box<[RetainedUtf16FlyString]> = (0..length)
             .map(|i| unsafe { RetainedUtf16FlyString::from_leaked_raw(*strings.add(i)) })
             .collect();
-        let raw_slice = slice
-            .iter()
-            .map(RetainedUtf16FlyString::raw)
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let raw_pointer = Box::into_raw(raw_slice) as *mut usize;
         let length = slice.len();
         let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
-        Self {
-            pointer,
-            length,
-            raw_pointer,
-        }
+        Self { pointer, length }
     }
 
     pub(crate) fn clone_retained(&self) -> Self {
@@ -164,10 +136,11 @@ impl RetainedUtf16FlyStringList {
     /// The list viewed as raw fly-string words; fly strings are interned, so
     /// equal raws mean equal strings.
     pub(crate) fn raws(&self) -> &[usize] {
-        if self.raw_pointer.is_null() {
+        if self.pointer.is_null() {
             return &[];
         }
-        unsafe { std::slice::from_raw_parts(self.raw_pointer, self.length) }
+        // SAFETY: `RetainedUtf16FlyString` is represented by its single raw word.
+        unsafe { std::slice::from_raw_parts(self.pointer.cast::<usize>(), self.length) }
     }
 }
 
@@ -181,9 +154,6 @@ impl Drop for RetainedUtf16FlyStringList {
     fn drop(&mut self) {
         if !self.pointer.is_null() {
             drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(self.pointer, self.length)) });
-        }
-        if !self.raw_pointer.is_null() {
-            drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(self.raw_pointer, self.length)) });
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/css/serialize.rs
@@ -8,9 +8,9 @@
 //!
 //! Serializes Rust-owned [`StyleValueData`] into text without crossing the FFI per component.
 //! The output stays ASCII until the first non-ASCII code unit forces UTF-16 storage, matching
-//! AK::Utf16String's ASCII-or-UTF16 representation so C++ can adopt the buffer without
-//! transcoding. Value types whose serialization has not been ported yet return the null
-//! serialization, and the C++ dispatcher falls back to the legacy per-class serializer.
+//! AK::Utf16String's ASCII-or-UTF16 representation, then moves a native string owner to C++.
+//! Value types whose serialization has not been ported yet return no string, and the C++
+//! dispatcher falls back to the legacy per-class serializer.
 
 use std::ffi::c_void;
 
@@ -3441,55 +3441,33 @@ fn serialize_shorthand(
     default_serialize(sink)
 }
 
-/// A serialized text buffer handed to C++. Exactly one of `ascii` and `utf16` is set when
-/// `storage` is non-null; a null `storage` means the value's serialization is not ported.
+/// A native `AK::Utf16String` ownership reference handed to C++ without copying.
 #[repr(C)]
 pub struct FfiSerializedText {
-    pub ascii: *const u8,
-    pub utf16: *const u16,
-    pub length: usize,
-    pub storage: *mut c_void,
+    pub raw: usize,
+    pub has_value: bool,
 }
 
 impl FfiSerializedText {
     fn unported() -> Self {
         Self {
-            ascii: std::ptr::null(),
-            utf16: std::ptr::null(),
-            length: 0,
-            storage: std::ptr::null_mut(),
+            raw: 0,
+            has_value: false,
         }
     }
 }
 
-struct SerializedTextStorage {
-    ascii: Vec<u8>,
-    utf16: Vec<u16>,
-}
-
 pub(crate) fn sink_into_ffi(sink: TextSink) -> FfiSerializedText {
-    let storage = Box::new(SerializedTextStorage {
-        ascii: sink.ascii,
-        utf16: sink.utf16,
-    });
-    let result = if sink.is_ascii {
-        FfiSerializedText {
-            ascii: storage.ascii.as_ptr(),
-            utf16: std::ptr::null(),
-            length: storage.ascii.len(),
-            storage: std::ptr::null_mut(),
-        }
+    let string = if sink.is_ascii {
+        // SAFETY: The ASCII representation is valid UTF-8.
+        let text = unsafe { str::from_utf8_unchecked(&sink.ascii) };
+        ak::Utf16String::from_utf8(text)
     } else {
-        FfiSerializedText {
-            ascii: std::ptr::null(),
-            utf16: storage.utf16.as_ptr(),
-            length: storage.utf16.len(),
-            storage: std::ptr::null_mut(),
-        }
+        ak::Utf16String::from_utf16(&sink.utf16)
     };
     FfiSerializedText {
-        storage: Box::into_raw(storage).cast(),
-        ..result
+        raw: string.into_raw(),
+        has_value: true,
     }
 }
 
@@ -3509,14 +3487,6 @@ pub unsafe extern "C" fn rust_style_value_serialize(value: *const c_void, mode: 
         }
         sink_into_ffi(sink)
     })
-}
-
-/// # Safety
-/// `storage` must be a non-null storage returned by a serialization entry point that has not
-/// been released.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_serialized_text_release(storage: *mut c_void) {
-    drop(unsafe { Box::from_raw(storage.cast::<SerializedTextStorage>()) });
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/css/serialize.rs
@@ -36,32 +36,6 @@ impl SerializationMode {
     }
 }
 
-unsafe extern "C" {
-    /// Reads the contents of a retained Utf16FlyString. Short strings are decoded into
-    /// `short_buffer`, which must hold at least 16 bytes; long strings return a pointer into
-    /// the refcounted heap data the retained reference keeps alive.
-    fn ladybird_utf16_fly_string_view(raw: usize, short_buffer: *mut u8) -> FfiFlyStringView;
-}
-
-#[repr(C)]
-pub(crate) struct FfiFlyStringView {
-    data: *const c_void,
-    length: usize,
-    is_ascii: bool,
-}
-
-impl FfiFlyStringView {
-    /// The empty view, used by the cargo-test bridge stub.
-    #[cfg(test)]
-    pub(crate) fn empty() -> Self {
-        Self {
-            data: std::ptr::null(),
-            length: 0,
-            is_ascii: true,
-        }
-    }
-}
-
 /// The decoded storage of a fly string: ASCII bytes or UTF-16 code units.
 pub(crate) enum StringUnits<'a> {
     Ascii(&'a [u8]),
@@ -70,22 +44,10 @@ pub(crate) enum StringUnits<'a> {
 
 /// Calls `f` with a view of the fly string's contents.
 pub(crate) fn with_fly_string_units<R>(string: &RetainedUtf16FlyString, f: impl FnOnce(StringUnits) -> R) -> R {
-    if string.raw() == 0 {
-        return f(StringUnits::Ascii(&[]));
-    }
-    let mut short_buffer = [0u8; 16];
-    // SAFETY: The retained reference keeps the fly string alive; the buffer outlives the view.
-    let view = unsafe { ladybird_utf16_fly_string_view(string.raw(), short_buffer.as_mut_ptr()) };
-    if view.length == 0 {
-        return f(StringUnits::Ascii(&[]));
-    }
-    let units = if view.is_ascii {
-        // SAFETY: `data` points either at `short_buffer` or at heap storage kept alive by the
-        // retained reference for the duration of this call.
-        StringUnits::Ascii(unsafe { std::slice::from_raw_parts(view.data.cast::<u8>(), view.length) })
-    } else {
-        // SAFETY: Non-ASCII storage is never short, so `data` is stable heap storage.
-        StringUnits::Utf16(unsafe { std::slice::from_raw_parts(view.data.cast::<u16>(), view.length) })
+    // SAFETY: The retained owner remains borrowed for the returned view's lifetime.
+    let units = match unsafe { ak::utf16_string_units(string.raw_word()) } {
+        ak::Utf16StringUnits::Ascii(bytes) => StringUnits::Ascii(bytes),
+        ak::Utf16StringUnits::Utf16(units) => StringUnits::Utf16(units),
     };
     f(units)
 }
@@ -255,24 +217,13 @@ pub(crate) fn serialize_computed_size(size: &crate::css::computed_value_types::C
 }
 
 pub(crate) fn fly_string_raw_to_string(raw: usize) -> String {
-    if raw == 0 {
-        return String::new();
-    }
-    let mut short_buffer = [0u8; 16];
     // SAFETY: Callers hold a retained fly-string owner while converting the raw value.
-    let view = unsafe { ladybird_utf16_fly_string_view(raw, short_buffer.as_mut_ptr()) };
-    if view.length == 0 {
-        return String::new();
-    }
-    if view.is_ascii {
-        // SAFETY: The view points to ASCII bytes that remain live for this call.
-        let bytes = unsafe { std::slice::from_raw_parts(view.data.cast::<u8>(), view.length) };
-        // SAFETY: ASCII is valid UTF-8.
-        unsafe { String::from_utf8_unchecked(bytes.to_vec()) }
-    } else {
-        // SAFETY: The view points to UTF-16 units that remain live for this call.
-        let units = unsafe { std::slice::from_raw_parts(view.data.cast::<u16>(), view.length) };
-        String::from_utf16_lossy(units)
+    match unsafe { ak::utf16_string_units(&raw) } {
+        ak::Utf16StringUnits::Ascii(bytes) => {
+            // SAFETY: ASCII is valid UTF-8.
+            unsafe { String::from_utf8_unchecked(bytes.to_vec()) }
+        }
+        ak::Utf16StringUnits::Utf16(units) => String::from_utf16_lossy(units),
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5214,13 +5214,6 @@ mod ffi_test_stubs {
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_utf16_fly_string_unref(_raw: usize) {}
     #[unsafe(no_mangle)]
-    extern "C" fn ladybird_utf16_fly_string_view(
-        _raw: usize,
-        _short_buffer: *mut u8,
-    ) -> crate::css::serialize::FfiFlyStringView {
-        crate::css::serialize::FfiFlyStringView::empty()
-    }
-    #[unsafe(no_mangle)]
     extern "C" fn ladybird_string_unref(_raw: usize) {}
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_animated_properties_unref(_values: *const std::ffi::c_void) {}

--- a/Tests/AK/TestUtf16FlyString.cpp
+++ b/Tests/AK/TestUtf16FlyString.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/FFIHelpers.h>
 #include <AK/Utf16FlyString.h>
 
 static_assert(AK::Concepts::HashCompatible<Utf16String, Utf16FlyString>);
@@ -13,6 +14,32 @@ static_assert(AK::Concepts::HashCompatible<Utf16FlyString, Utf16String>);
 
 static_assert(AK::Concepts::HashCompatible<Utf16View, Utf16FlyString>);
 static_assert(AK::Concepts::HashCompatible<Utf16FlyString, Utf16View>);
+
+TEST_CASE(ffi_constructors_use_the_native_intern_table)
+{
+    auto first = Utf16FlyString::adopt_raw(ladybird_utf16_fly_string_from_utf8(
+        reinterpret_cast<u8 const*>("this is a shared fly string"), 27));
+    auto second = Utf16FlyString::adopt_raw(ladybird_utf16_fly_string_from_utf16(
+        reinterpret_cast<u16 const*>(u"this is a shared fly string"), 27));
+
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(first.raw_identity(), second.raw_identity());
+    EXPECT_EQ(Utf16FlyString::number_of_utf16_fly_strings(), 1u);
+
+    EXPECT_EQ(ladybird_utf16_fly_string_from_utf8(nullptr, 0), Utf16FlyString {}.raw_identity());
+    EXPECT_DEATH("Passing an invalid UTF-8 range", (void)ladybird_utf16_fly_string_from_utf8(nullptr, 1));
+
+    auto empty_raw = ladybird_utf16_fly_string_from_utf16(nullptr, 0);
+    EXPECT_EQ(empty_raw, Utf16FlyString {}.raw_identity());
+
+    auto empty = Utf16FlyString::adopt_raw(empty_raw);
+    EXPECT(empty.is_empty());
+    EXPECT(empty.to_utf16_string().has_short_ascii_storage());
+    EXPECT_EQ(empty.to_raw_leaked(), empty_raw);
+
+    Optional<Utf16FlyString> optional_empty { empty };
+    EXPECT(optional_empty.has_value());
+}
 
 TEST_CASE(short_ascii_literal_is_constexpr)
 {

--- a/Tests/AK/TestUtf16FlyString.cpp
+++ b/Tests/AK/TestUtf16FlyString.cpp
@@ -143,6 +143,48 @@ TEST_CASE(moved_fly_string_becomes_empty)
     EXPECT_EQ(Utf16FlyString::number_of_utf16_fly_strings(), 1u);
 }
 
+TEST_CASE(raw_ownership_transfer)
+{
+    {
+        auto string = "short"_utf16_fly_string;
+        auto raw = move(string).into_raw();
+
+        EXPECT(string.is_empty());
+
+        auto adopted_string = Utf16FlyString::adopt_raw(raw);
+        EXPECT_EQ(adopted_string, "short"sv);
+        EXPECT_EQ(adopted_string.raw_identity(), raw);
+    }
+
+    {
+        auto string = "this is a long fly string"_utf16_fly_string;
+        auto raw = string.raw_identity();
+        auto const* header = reinterpret_cast<AK::Detail::Utf16StringDataHeader const*>(raw);
+
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        EXPECT_EQ(move(string).into_raw(), raw);
+        EXPECT(string.is_empty());
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        auto adopted_string = Utf16FlyString::adopt_raw(raw);
+        EXPECT_EQ(adopted_string, "this is a long fly string"sv);
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        Utf16FlyString::ref_raw(raw);
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 2u);
+        Utf16FlyString::unref_raw(raw);
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        {
+            auto copied_string = Utf16FlyString::from_raw(raw);
+            EXPECT_EQ(copied_string, adopted_string);
+            EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 2u);
+        }
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+    }
+}
+
 TEST_CASE(is_one_of)
 {
     auto foo = Utf16FlyString::from_utf8("foo"sv);

--- a/Tests/AK/TestUtf16String.cpp
+++ b/Tests/AK/TestUtf16String.cpp
@@ -990,6 +990,44 @@ TEST_CASE(move_operations)
     test("hello 😀 there!"_utf16);
 }
 
+TEST_CASE(raw_ownership_transfer)
+{
+    {
+        auto string = "short"_utf16;
+        auto raw = move(string).into_raw();
+
+        EXPECT(string.is_empty());
+
+        auto adopted_string = Utf16String::adopt_raw(raw);
+        EXPECT_EQ(adopted_string, "short"sv);
+    }
+
+    {
+        auto string = "this is a long ASCII string"_utf16;
+        auto raw = move(string).into_raw();
+        auto const* header = reinterpret_cast<AK::Detail::Utf16StringDataHeader const*>(raw);
+
+        EXPECT(string.is_empty());
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        auto adopted_string = Utf16String::adopt_raw(raw);
+        EXPECT_EQ(adopted_string, "this is a long ASCII string"sv);
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        auto leaked_raw = adopted_string.to_raw_leaked();
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 2u);
+        Utf16String::unref_raw(leaked_raw);
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+
+        {
+            auto copied_string = Utf16String::from_raw(raw);
+            EXPECT_EQ(copied_string, adopted_string);
+            EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 2u);
+        }
+        EXPECT_EQ(AK::atomic_load(&header->reference_count, AK::memory_order_relaxed), 1u);
+    }
+}
+
 TEST_CASE(equals)
 {
     auto test = [](Utf16String const& string1, Utf16String const& inequal_string) {

--- a/Tests/LibWeb/TestStyleValueEquality.cpp
+++ b/Tests/LibWeb/TestStyleValueEquality.cpp
@@ -1026,7 +1026,7 @@ TEST_CASE(rust_counter_definition_handles_retain_value_data)
 {
     auto value = IntegerStyleValue::create(2);
     StyleValueFFI::RetainedCounterDefinition definition {
-        { Utf16FlyString::from_utf8("item"sv).to_raw_leaked(), nullptr },
+        { Utf16FlyString::from_utf8("item"sv).to_raw_leaked() },
         false,
         { StyleValueFFI::rust_style_value_retain(value->rust_style_value_data()) },
     };
@@ -1270,7 +1270,7 @@ TEST_CASE(rust_image_set_handles_retain_option_data)
         { create_test_image("candidate.png"sv) },
         { StyleValueFFI::rust_style_value_create_resolution(1, 0) },
         false,
-        { 0, nullptr },
+        { 0 },
     };
     auto image_set = StyleValue::adopt_rust_style_value_data(
         StyleValueFFI::rust_style_value_create_image_set(&option, 1));

--- a/Tests/LibWeb/TestStyleValueEquality.cpp
+++ b/Tests/LibWeb/TestStyleValueEquality.cpp
@@ -72,6 +72,27 @@ static StyleValueFFI::StyleValueData const* create_test_image(StringView url)
         0, nullptr, 0, false, false, false, false);
 }
 
+TEST_CASE(rust_serialization_transfers_a_native_utf16_string)
+{
+    auto value = StringStyleValue::create(Utf16FlyString::from_utf8("hello 😀"sv));
+    auto text = StyleValueFFI::rust_style_value_serialize(
+        value->rust_style_value_data(), to_underlying(SerializationMode::Normal));
+
+    EXPECT(text.has_value);
+    auto serialized = Utf16String::adopt_raw(text.raw);
+    EXPECT_EQ(serialized, u"\"hello 😀\""sv);
+    EXPECT(!serialized.has_ascii_storage());
+
+    auto ascii_value = StringStyleValue::create(Utf16FlyString::from_utf8("abc"sv));
+    auto ascii_text = StyleValueFFI::rust_style_value_serialize(
+        ascii_value->rust_style_value_data(), to_underlying(SerializationMode::Normal));
+
+    EXPECT(ascii_text.has_value);
+    auto ascii_serialized = Utf16String::adopt_raw(ascii_text.raw);
+    EXPECT_EQ(ascii_serialized, u"\"abc\""sv);
+    EXPECT(ascii_serialized.has_ascii_storage());
+}
+
 TEST_CASE(rust_composites_scalar_style_values)
 {
     auto underlying_number = NumberStyleValue::create(2);


### PR DESCRIPTION
Give Utf16String and Utf16FlyString a stable storage layout that Rust can understand directly. Rust owners now use the same one-word representation as C++, borrow the same character storage, and clone against the shared atomic reference count.

Ownership can move across FFI without copying characters or changing the reference count. Rust constructs short ASCII strings directly and fills native long-string allocations in place. Utf16FlyString continues using the authoritative C++ intern table, so both languages share identities without a second interning mechanism or side table.

Use these owners in LibWeb’s Rust CSS engine for retained fly strings and serialized UTF-16 output. This removes the separate Rust Arc, duplicated raw-word lists, boxed view descriptors, and release callbacks.

Also materialize LibJS bytecode string tables as native Utf16String owners in Rust and transfer them directly into C++ executables. Fly-string tables remain borrowed until materialization so interning stays on the VM thread and existing interned strings remain allocation-free.