### PR TITLE
WebDriver: Keep connections alive after sending an error response

### DIFF
--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -186,6 +186,13 @@ static JsonValue make_success_response(JsonValue value)
     return result;
 }
 
+static bool is_keep_alive_request(HTTP::HttpRequest const& request)
+{
+    if (auto it = request.headers().headers().find_if([](auto& header) { return header.name.equals_ignoring_ascii_case("Connection"sv); }); !it.is_end())
+        return it->value.trim_whitespace().equals_ignoring_ascii_case("keep-alive"sv);
+    return false;
+}
+
 Client::Client(NonnullOwnPtr<Core::BufferedTCPSocket> socket)
     : m_socket(move(socket))
 {
@@ -205,6 +212,9 @@ void Client::die()
     if (m_is_dying)
         return;
     m_is_dying = true;
+
+    // A dying connection will never service its queued requests, so drop them.
+    m_pending_requests.clear();
 
     // We defer removing this connection to avoid closing its socket while we are inside the on_ready_to_read callback.
     deferred_invoke([this] {
@@ -346,25 +356,25 @@ ErrorOr<Client::ResponsePromise, Client::WrappedError> Client::handle_request(HT
 void Client::handle_error(HTTP::HttpRequest const& request, WrappedError const& error)
 {
     error.visit(
-        [](AK::Error const& error) {
+        [&](AK::Error const& error) {
             warnln("Internal error: {}", error);
+            die();
         },
-        [](HTTP::HttpRequest::ParseError const& error) {
+        [&](HTTP::HttpRequest::ParseError const& error) {
             warnln("HTTP request parsing error: {}", HTTP::HttpRequest::parse_error_to_string(error));
+            die();
         },
         [&](WebDriver::Error const& error) {
-            if (send_error_response(request, error).is_error())
+            if (send_error_response(request, error).is_error()) {
                 warnln("Could not send error response");
+                die();
+            }
         });
-
-    die();
 }
 
 ErrorOr<void, Client::WrappedError> Client::send_success_response(HTTP::HttpRequest const& request, JsonValue result)
 {
-    bool keep_alive = false;
-    if (auto it = request.headers().headers().find_if([](auto& header) { return header.name.equals_ignoring_ascii_case("Connection"sv); }); !it.is_end())
-        keep_alive = it->value.trim_whitespace().equals_ignoring_ascii_case("keep-alive"sv);
+    auto keep_alive = is_keep_alive_request(request);
 
     result = make_success_response(move(result));
     auto content = result.serialized();
@@ -396,6 +406,7 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     // FIXME: Implement to spec.
     dbgln_if(WEBDRIVER_DEBUG, "Sending error response: {} {}: {}", error.http_status, error.error, error.message);
     auto reason = HTTP::reason_phrase_for_code(error.http_status);
+    auto keep_alive = is_keep_alive_request(request);
 
     JsonObject error_response;
     error_response.set("error"sv, error.error);
@@ -411,6 +422,8 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
 
     StringBuilder builder;
     builder.appendff("HTTP/1.1 {} {}\r\n", error.http_status, reason);
+    if (keep_alive)
+        builder.append("Connection: keep-alive\r\n"sv);
     builder.append("Cache-Control: no-cache\r\n"sv);
     builder.append("Content-Type: application/json; charset=utf-8\r\n"sv);
     builder.appendff("Content-Length: {}\r\n", content.byte_count());
@@ -418,6 +431,9 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     builder.append(content);
 
     TRY(m_socket->write_until_depleted(builder.string_view()));
+
+    if (!keep_alive)
+        die();
 
     log_response(request, error.http_status);
     return {};

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -70,6 +70,12 @@ if (BUILD_TESTING AND NOT WIN32)
     )
     set_tests_properties(TestWebDriverSessionHistory PROPERTIES TIMEOUT 120)
 
+    add_test(
+        NAME TestWebDriverErrorKeepAlive
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-webdriver-error-keep-alive.py $<TARGET_FILE:WebDriver>
+    )
+    set_tests_properties(TestWebDriverErrorKeepAlive PROPERTIES TIMEOUT 120)
+
     add_test(NAME TestAutocomplete COMMAND $<TARGET_FILE:TestAutocomplete>)
     set_tests_properties(TestAutocomplete PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
 

--- a/Tests/LibWebView/test-webdriver-error-keep-alive.py
+++ b/Tests/LibWebView/test-webdriver-error-keep-alive.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026-present, the Ladybird developers.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+import http.client
+import json
+import socket
+import subprocess
+import time
+
+EVENT_TIMEOUT_SECONDS = 30
+WEBDRIVER_REQUEST_TIMEOUT_SECONDS = 30
+
+
+def unused_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for_port(port):
+    deadline = time.monotonic() + EVENT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"Timed out waiting for port {port}")
+
+
+def request(connection, method, path, body=None):
+    encoded_body = json.dumps(body).encode() if body is not None else None
+    headers = {"Connection": "keep-alive"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    connection.request(method, path, encoded_body, headers)
+    response = connection.getresponse()
+    response_body = response.read().decode()
+
+    payload = json.loads(response_body) if response_body else {}
+    return response.status, payload, response_body
+
+
+def run_test(webdriver_binary):
+    webdriver_port = unused_port()
+    webdriver = subprocess.Popen([webdriver_binary, "--headless", "-l", "127.0.0.1", "-p", str(webdriver_port)])
+    connection = None
+    try:
+        wait_for_port(webdriver_port)
+
+        # Every request in this test is sent over the same keep-alive connection, matching how the
+        # WPT wdspec harness drives WebDriver. An error response must leave the connection usable.
+        connection = http.client.HTTPConnection("127.0.0.1", webdriver_port, timeout=WEBDRIVER_REQUEST_TIMEOUT_SECONDS)
+
+        status, payload, response_body = request(
+            connection,
+            "POST",
+            "/session",
+            {"capabilities": {"alwaysMatch": {"ladybird:headless": True}}},
+        )
+        value = payload.get("value")
+        session_id = value.get("sessionId") if isinstance(value, dict) else None
+        if status != 200 or not session_id:
+            raise AssertionError(f"New Session failed with HTTP {status}: {response_body}")
+
+        status, payload, response_body = request(
+            connection, "POST", f"/session/{session_id}/window", {"handle": "does-not-exist"}
+        )
+        if status != 404 or payload.get("value", {}).get("error") != "no such window":
+            raise AssertionError(f"Switch To Window returned an unexpected response: HTTP {status}: {response_body}")
+
+        status, payload, response_body = request(connection, "GET", f"/session/{session_id}/title")
+        if status != 200:
+            raise AssertionError(f"Get Title after error failed with HTTP {status}: {response_body}")
+
+        status, payload, response_body = request(connection, "GET", f"/session/{session_id}/unknown-command")
+        if status != 404 or payload.get("value", {}).get("error") != "unknown command":
+            raise AssertionError(f"Unknown command returned an unexpected response: HTTP {status}: {response_body}")
+
+        status, payload, response_body = request(connection, "GET", f"/session/{session_id}/title")
+        if status != 200:
+            raise AssertionError(f"Get Title after unknown command failed with HTTP {status}: {response_body}")
+
+        status, payload, response_body = request(connection, "DELETE", f"/session/{session_id}")
+        if status != 200:
+            raise AssertionError(f"Delete Session failed with HTTP {status}: {response_body}")
+    finally:
+        if connection is not None:
+            connection.close()
+        webdriver.terminate()
+        try:
+            webdriver.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            webdriver.kill()
+            webdriver.wait()
+
+    if webdriver.returncode not in (0, -15):
+        raise RuntimeError(f"WebDriver exited with status {webdriver.returncode}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("webdriver_binary")
+    args = parser.parse_args()
+
+    run_test(args.webdriver_binary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Previously, a connection stopped servicing requests after any command completed with an error. Errors are ordinary protocol responses, so an error response now keeps the connection alive in the same way a success response does.

The WPT harness sends commands over a single keep-alive connection, so prior to this change hundreds of WebDriver WPT tests were timing out: https://wpt.fyi/results/webdriver/tests/classic?diff&filter=ADC&run_id=5202417204592640&run_id=5160952315248640

This fixes a regression introduced by b9fdfd20465 (#11220).