### PR TITLE
LibWeb: Eliminate redundant StyleBench style work

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -596,6 +596,12 @@ bool StyleEngine::has_pending_transaction() const
     return has_recorded_input() || StyleEngineFFI::style_engine_has_pending_transaction(m_impl);
 }
 
+bool StyleEngine::pending_transaction_may_affect_layout_geometry()
+{
+    submit_recorded_input();
+    return StyleEngineFFI::style_engine_pending_transaction_may_affect_layout_geometry(m_impl);
+}
+
 bool StyleEngine::read_matches(StyleNodeID node, Vector<RuleMatch>& matches, Optional<MatchPurpose> purpose)
 {
     matches.resize(max(m_element_match_capacity, 16u));

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -555,10 +555,10 @@ bool StyleEngine::take_diagnostic_style_transaction(StyleNodeID root, Function<v
     return true;
 }
 
-StyleEngine::PublishedStyleTransaction StyleEngine::take_style_transaction(StyleNodeID root)
+StyleEngine::PublishedStyleTransaction StyleEngine::take_style_transaction(StyleNodeID root, TransactionMode mode)
 {
     submit_recorded_input();
-    auto view = StyleEngineFFI::style_engine_take_style_transaction(m_impl, root.value());
+    auto view = StyleEngineFFI::style_engine_take_style_transaction(m_impl, root.value(), mode == TransactionMode::LayoutGeometry);
     if (view.reclaimed_style_atom_count != 0) {
         HashTable<StyleAtomID> reclaimed_atoms;
         reclaimed_atoms.ensure_capacity(view.reclaimed_style_atom_count);
@@ -594,6 +594,11 @@ StyleEngine::PublishedStyleTransaction StyleEngine::take_style_transaction(Style
 bool StyleEngine::has_pending_transaction() const
 {
     return has_recorded_input() || StyleEngineFFI::style_engine_has_pending_transaction(m_impl);
+}
+
+bool StyleEngine::has_immediate_pending_transaction() const
+{
+    return has_recorded_input() || StyleEngineFFI::style_engine_has_immediate_pending_transaction(m_impl);
 }
 
 bool StyleEngine::pending_transaction_may_affect_layout_geometry()

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -189,6 +189,7 @@ public:
     void record_benchmark_marker(Utf16View);
     [[nodiscard]] bool has_recorded_input() const;
     [[nodiscard]] bool has_pending_transaction() const;
+    [[nodiscard]] bool has_immediate_pending_transaction() const;
     [[nodiscard]] bool pending_transaction_may_affect_layout_geometry();
 
     // Submits everything recorded since the last flush as one transaction and normalizes it.
@@ -205,6 +206,10 @@ public:
         ReadonlySpan<PublishedStyleDelta> reactions;
         bool is_scoped;
     };
+    enum class TransactionMode : u8 {
+        AllStyle,
+        LayoutGeometry,
+    };
 
     // Takes pending inputs. The diagnostic transaction reports reaction nodes and then discards
     // its matching outputs. The style transaction publishes versioned match-answer records. False
@@ -212,7 +217,7 @@ public:
     // NB: The returned reactions borrow Rust storage until the next mutable engine call or an
     //     explicit discard. Consume them synchronously before asking the engine anything else.
     bool take_diagnostic_style_transaction(StyleNodeID root, Function<void(ReadonlySpan<StyleNodeID>)>&&);
-    PublishedStyleTransaction take_style_transaction(StyleNodeID root);
+    PublishedStyleTransaction take_style_transaction(StyleNodeID root, TransactionMode = TransactionMode::AllStyle);
 
     using RuleMatch = StyleEngineFFI::FfiRuleMatch;
 

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -189,6 +189,7 @@ public:
     void record_benchmark_marker(Utf16View);
     [[nodiscard]] bool has_recorded_input() const;
     [[nodiscard]] bool has_pending_transaction() const;
+    [[nodiscard]] bool pending_transaction_may_affect_layout_geometry();
 
     // Submits everything recorded since the last flush as one transaction and normalizes it.
     void flush();

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -43,7 +43,7 @@ static void finish_complete_style_update()
         ladybird_animated_properties_unref(releases.animated_properties[i]);
 }
 
-static void update_style(DOM::Document&);
+static void update_style(DOM::Document&, StyleEngine::TransactionMode);
 static bool update_style_for_element(DOM::Document&, DOM::AbstractElement const&, StyleUpdateMode);
 
 static void apply_element_style_invalidation_after_style_change(DOM::Element& element, RequiredInvalidationAfterStyleChange const& invalidation)
@@ -148,7 +148,7 @@ static void sort_style_engine_reactions_for_direct_application(StyleComputer& st
     });
 }
 
-static StyleEngineTransaction take_style_engine_transaction(DOM::Document& document)
+static StyleEngineTransaction take_style_engine_transaction(DOM::Document& document, StyleEngine::TransactionMode mode)
 {
     StyleEngineTransaction transaction;
     auto& style_computer = document.style_computer();
@@ -166,7 +166,7 @@ static StyleEngineTransaction take_style_engine_transaction(DOM::Document& docum
     }
 
     auto planning_started_at = MonotonicTime::now();
-    auto published_transaction = style_computer.style_engine().take_style_transaction(root->style_node_id());
+    auto published_transaction = style_computer.style_engine().take_style_transaction(root->style_node_id(), mode);
     if (!published_transaction.reactions.is_empty())
         transaction.published_version = published_transaction.version;
     for (auto const& answer : published_transaction.reactions) {
@@ -425,7 +425,7 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
     return transaction_invalidation;
 }
 
-static void update_style(DOM::Document& document)
+static void update_style(DOM::Document& document, StyleEngine::TransactionMode mode)
 {
     StyleValueFFI::rust_style_ffi_complete_style_update_begin();
     ScopeGuard leave_complete_style_update = finish_complete_style_update;
@@ -473,10 +473,16 @@ static void update_style(DOM::Document& document)
     // change selector or cascade inputs. Apply an animation-only update first, then take a
     // transaction only if the resulting inherited-style feedback requires one.
     record_non_author_stylesheets(document);
+    auto has_pending_transaction = [&] {
+        if (mode == StyleEngine::TransactionMode::LayoutGeometry)
+            return document.style_computer().style_engine().has_immediate_pending_transaction();
+        return document.style_computer().style_engine().has_pending_transaction();
+    };
+
     if (document.has_completed_style_update()
-        && !document.style_computer().style_engine().has_pending_transaction()) {
+        && !has_pending_transaction()) {
         document.update_animated_style_if_needed();
-        if (!document.style_computer().style_engine().has_pending_transaction())
+        if (!has_pending_transaction())
             return;
     }
 
@@ -485,7 +491,7 @@ static void update_style(DOM::Document& document)
     // transpose programs reach. A transaction that could not be proven narrower publishes a
     // complete document reaction batch. Only a transaction that cannot complete its answers falls
     // back to document invalidation.
-    auto style_engine_transaction = take_style_engine_transaction(document);
+    auto style_engine_transaction = take_style_engine_transaction(document, mode);
 
     if (!style_engine_transaction.reactions.is_empty())
         document.note_style_stabilization_has_style_reactions();
@@ -494,8 +500,8 @@ static void update_style(DOM::Document& document)
     auto style_engine_reactions = move(style_engine_transaction.reactions);
     auto prefers_broad_matching_batch = style_engine_transaction.prefers_broad_matching_batch;
     if (style_engine_reactions.is_empty()
-        && document.style_computer().style_engine().has_pending_transaction()) {
-        auto feedback_transaction = take_style_engine_transaction(document);
+        && has_pending_transaction()) {
+        auto feedback_transaction = take_style_engine_transaction(document, mode);
         style_engine_reactions = move(feedback_transaction.reactions);
         prefers_broad_matching_batch = feedback_transaction.prefers_broad_matching_batch;
     }
@@ -637,8 +643,8 @@ static void update_style(DOM::Document& document)
         // Exact consequences produced while recomputing become the next transaction in this
         // stabilization epoch. Take it only after consuming the current published answers, since
         // a new transaction retires their scratch.
-        if (document.style_computer().style_engine().has_pending_transaction()) {
-            auto next_transaction = take_style_engine_transaction(document);
+        if (has_pending_transaction()) {
+            auto next_transaction = take_style_engine_transaction(document, mode);
             style_engine_reactions = move(next_transaction.reactions);
         }
         if (style_engine_reactions.is_empty())
@@ -739,13 +745,13 @@ static bool update_style_for_element(DOM::Document& document, DOM::AbstractEleme
             && (!document.has_completed_style_update()
                 || document.style_computer().style_engine().has_pending_transaction());
         if (can_run_regular_style_update) {
-            update_style(document);
+            update_style(document, StyleEngine::TransactionMode::AllStyle);
             ran_regular_style_update = true;
         } else {
             document.update_animated_style_if_needed();
             if (!document.is_running_update_layout()
                 && document.style_computer().style_engine().has_pending_transaction()) {
-                update_style(document);
+                update_style(document, StyleEngine::TransactionMode::AllStyle);
                 ran_regular_style_update = true;
             }
         }
@@ -843,7 +849,12 @@ namespace Web::DOM {
 
 void Document::update_style()
 {
-    CSS::update_style(*this);
+    CSS::update_style(*this, CSS::StyleEngine::TransactionMode::AllStyle);
+}
+
+void Document::update_style_for_layout_geometry()
+{
+    CSS::update_style(*this, CSS::StyleEngine::TransactionMode::LayoutGeometry);
 }
 
 bool Document::update_style_for_element(AbstractElement const& abstract_element)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2049,16 +2049,21 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
     }
 }
 
+static bool update_layout_reason_reads_element_geometry(UpdateLayoutReason reason)
+{
+    return reason == UpdateLayoutReason::ElementGetClientRects
+        || reason == UpdateLayoutReason::ElementClientWidth
+        || reason == UpdateLayoutReason::ElementClientHeight
+        || reason == UpdateLayoutReason::HTMLElementOffsetWidth
+        || reason == UpdateLayoutReason::HTMLElementOffsetHeight;
+}
+
 void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutReason reason)
 {
     if (!node.is_connected())
         return;
 
-    auto const reads_layout_geometry = reason == UpdateLayoutReason::ElementGetClientRects
-        || reason == UpdateLayoutReason::ElementClientWidth
-        || reason == UpdateLayoutReason::ElementClientHeight
-        || reason == UpdateLayoutReason::HTMLElementOffsetWidth
-        || reason == UpdateLayoutReason::HTMLElementOffsetHeight;
+    auto const reads_layout_geometry = update_layout_reason_reads_element_geometry(reason);
     if (reads_layout_geometry
         && m_has_completed_style_update
         && layout_is_up_to_date()
@@ -2244,7 +2249,10 @@ void Document::update_layout(UpdateLayoutReason reason)
     // Recompute it after each pass because an initial style update can enroll the elements of a
     // freshly parsed document after update_layout() has already started.
     for (u64 layout_pass = 0; layout_pass < ordinary_stabilization_round_limit + static_cast<u64>(style_computer().style_engine().connected_element_count()) + 1; ++layout_pass) {
-        update_style();
+        if (update_layout_reason_reads_element_geometry(reason))
+            update_style_for_layout_geometry();
+        else
+            update_style();
         process_pending_top_layer_layout_changes();
 
         auto const should_collect_devtools_layout_data = page().client().has_active_devtools_client();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2051,8 +2051,45 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
 
 void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutReason reason)
 {
-    if (node.is_connected())
-        update_layout(reason);
+    if (!node.is_connected())
+        return;
+
+    auto const reads_layout_geometry = reason == UpdateLayoutReason::ElementGetClientRects
+        || reason == UpdateLayoutReason::ElementClientWidth
+        || reason == UpdateLayoutReason::ElementClientHeight
+        || reason == UpdateLayoutReason::HTMLElementOffsetWidth
+        || reason == UpdateLayoutReason::HTMLElementOffsetHeight;
+    if (reads_layout_geometry
+        && m_has_completed_style_update
+        && layout_is_up_to_date()
+        && !m_needs_media_rule_evaluation
+        && !m_needs_animated_style_update
+        && m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
+        && m_elements_with_pending_top_layer_membership_change.is_empty()
+        && !m_top_layer_needs_layout_zone_rebuild) {
+        auto navigable = this->navigable();
+        auto container = navigable ? navigable->container() : nullptr;
+        auto embedding_document_is_clean = [&] {
+            if (!container || &container->document() == this)
+                return true;
+            auto& embedding_document = container->document();
+            return embedding_document.layout_is_up_to_date()
+                && !embedding_document.m_has_dirty_style_attributes
+                && !embedding_document.style_computer().style_engine().has_pending_transaction()
+                && !embedding_document.m_needs_media_rule_evaluation
+                && !embedding_document.m_needs_animated_style_update
+                && embedding_document.m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
+                && embedding_document.m_elements_with_pending_top_layer_membership_change.is_empty()
+                && !embedding_document.m_top_layer_needs_layout_zone_rebuild;
+        };
+        if (embedding_document_is_clean()) {
+            synchronize_dirty_style_attributes();
+            if (!style_computer().style_engine().pending_transaction_may_affect_layout_geometry())
+                return;
+        }
+    }
+
+    update_layout(reason);
 }
 
 bool Document::needs_style_update_after_layout()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -468,6 +468,7 @@ public:
     void obtain_theme_color();
 
     void update_style();
+    void update_style_for_layout_geometry();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }
     void set_suppresses_attribute_style_invalidation(bool suppresses) { m_suppresses_attribute_style_invalidation = suppresses; }

--- a/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -81,9 +81,8 @@ double Performance::now() const
 // https://w3c.github.io/user-timing/#mark-method
 WebIDL::ExceptionOr<GC::Ref<UserTiming::PerformanceMark>> Performance::mark(Utf16String const& mark_name, Bindings::PerformanceMarkOptions const& mark_options)
 {
-    auto& realm = relevant_global_object().shape().realm();
-    if (is<HTML::Window>(realm.global_object()))
-        as<HTML::Window>(realm.global_object()).associated_document().style_computer().style_engine().record_benchmark_marker(mark_name);
+    if (auto* window = HTML::window_from_global_object(relevant_global_object()))
+        window->associated_document().style_computer().style_engine().record_benchmark_marker(mark_name);
 
     // 1. Run the PerformanceMark constructor and let entry be the newly created object.
     auto entry = TRY(UserTiming::PerformanceMark::create_for_constructor(relevant_global_object(), mark_name, mark_options));

--- a/Libraries/LibWeb/Rust/StyleEngineBoundary.json
+++ b/Libraries/LibWeb/Rust/StyleEngineBoundary.json
@@ -82,7 +82,8 @@
     [79, "PrepareSelectorQuery"],
     [80, "AddCounterStyleRule"],
     [81, "AttributeValueTextRequirementsVersion"],
-    [82, "AttributeNameRequiresValueText"]
+    [82, "AttributeNameRequiresValueText"],
+    [83, "PendingTransactionMayAffectLayoutGeometry"]
   ],
   "operations": [
     { "event": "SetFoldIdAndClassNameCase", "ffi": "style_engine_set_fold_id_and_class_name_case", "cpp": "set_fold_id_and_class_name_case", "return": "void", "args": [["fold", "bool"]], "body": "engine.set_fold_id_and_class_name_case(fold);" },
@@ -104,6 +105,7 @@
     { "event": "SetElementCustomStates", "ffi": "style_engine_set_element_custom_states", "cpp": "set_element_custom_states", "return": "void", "args": [["node", "style_node"], ["states", "style_atom_slice"]], "body": "let Some(node) = StyleNodeID::from_raw(node) else { return; }; let states = states.iter().copied().map(StyleAtomID).collect::<Vec<_>>(); engine.set_element_custom_states(node, &states);" },
     { "event": "ConnectedElementCount", "ffi": "style_engine_connected_element_count", "cpp": "connected_element_count", "return": "u32", "receiver": "const", "args": [], "body": "let result = engine.connected_element_count();" },
     { "event": "HasPendingTransaction", "ffi": "style_engine_has_pending_transaction", "return": "bool", "receiver": "const", "args": [], "body": "let result = engine.has_pending_transaction();" },
+    { "event": "PendingTransactionMayAffectLayoutGeometry", "ffi": "style_engine_pending_transaction_may_affect_layout_geometry", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.pending_transaction_may_affect_layout_geometry();" },
     { "event": "MatchDocument", "ffi": "style_engine_match_document", "cpp": "match_document", "return": "usize_u64", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return usize::MAX; }; let result = engine.match_document(root).unwrap_or(usize::MAX);" },
     { "event": "BeginColdMatchingBatch", "ffi": "style_engine_begin_cold_matching_batch", "cpp": "begin_cold_matching_batch", "return": "bool", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return false; }; let result = engine.begin_cold_matching_batch(root);" },
     { "event": "BeginAdaptiveColdMatchingBatch", "ffi": "style_engine_begin_adaptive_cold_matching_batch", "cpp": "begin_adaptive_cold_matching_batch", "return": "void", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return; }; engine.begin_adaptive_cold_matching_batch(root);" },

--- a/Libraries/LibWeb/Rust/StyleEngineBoundary.json
+++ b/Libraries/LibWeb/Rust/StyleEngineBoundary.json
@@ -83,7 +83,8 @@
     [80, "AddCounterStyleRule"],
     [81, "AttributeValueTextRequirementsVersion"],
     [82, "AttributeNameRequiresValueText"],
-    [83, "PendingTransactionMayAffectLayoutGeometry"]
+    [83, "PendingTransactionMayAffectLayoutGeometry"],
+    [84, "HasImmediatePendingTransaction"]
   ],
   "operations": [
     { "event": "SetFoldIdAndClassNameCase", "ffi": "style_engine_set_fold_id_and_class_name_case", "cpp": "set_fold_id_and_class_name_case", "return": "void", "args": [["fold", "bool"]], "body": "engine.set_fold_id_and_class_name_case(fold);" },
@@ -105,6 +106,7 @@
     { "event": "SetElementCustomStates", "ffi": "style_engine_set_element_custom_states", "cpp": "set_element_custom_states", "return": "void", "args": [["node", "style_node"], ["states", "style_atom_slice"]], "body": "let Some(node) = StyleNodeID::from_raw(node) else { return; }; let states = states.iter().copied().map(StyleAtomID).collect::<Vec<_>>(); engine.set_element_custom_states(node, &states);" },
     { "event": "ConnectedElementCount", "ffi": "style_engine_connected_element_count", "cpp": "connected_element_count", "return": "u32", "receiver": "const", "args": [], "body": "let result = engine.connected_element_count();" },
     { "event": "HasPendingTransaction", "ffi": "style_engine_has_pending_transaction", "return": "bool", "receiver": "const", "args": [], "body": "let result = engine.has_pending_transaction();" },
+    { "event": "HasImmediatePendingTransaction", "ffi": "style_engine_has_immediate_pending_transaction", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.has_immediate_pending_transaction();" },
     { "event": "PendingTransactionMayAffectLayoutGeometry", "ffi": "style_engine_pending_transaction_may_affect_layout_geometry", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.pending_transaction_may_affect_layout_geometry();" },
     { "event": "MatchDocument", "ffi": "style_engine_match_document", "cpp": "match_document", "return": "usize_u64", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return usize::MAX; }; let result = engine.match_document(root).unwrap_or(usize::MAX);" },
     { "event": "BeginColdMatchingBatch", "ffi": "style_engine_begin_cold_matching_batch", "cpp": "begin_cold_matching_batch", "return": "bool", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return false; }; let result = engine.begin_cold_matching_batch(root);" },

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -953,6 +953,7 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
 
     let mut levels = vec![0u8; (last_longhand - first_longhand + 1) as usize];
     let mut animation_types = vec![0u8; levels.len()];
+    let mut layout_geometry_effects = vec![false; levels.len()];
     let mut numeric_range_rows = vec![String::new(); levels.len()];
     let value_types = [
         "anchor",
@@ -1021,6 +1022,16 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
             "none" => 4,
             other => return Err(format!("unknown animation-type '{other}' for {name}").into()),
         };
+
+        let metadata_flag = |field: &str, default| {
+            property_field(name, field)
+                .and_then(|value| value.as_bool())
+                .unwrap_or(default)
+        };
+        layout_geometry_effects[index] = metadata_flag("affects-layout", true)
+            || metadata_flag("affects-accumulated-visual-contexts", false)
+            || metadata_flag("affects-scrollable-overflow", false)
+            || metadata_flag("affects-stacking-context", false);
 
         let mut ranges = Vec::new();
         if let Some(valid_types) = property_field(name, "valid-types").and_then(|value| value.as_array().cloned()) {
@@ -1222,6 +1233,11 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
         "pub(crate) static PROPERTY_ANIMATION_TYPES: [u8; {}] = {:?};\n",
         animation_types.len(),
         animation_types
+    ));
+    output.push_str(&format!(
+        "pub(crate) static PROPERTY_MAY_AFFECT_LAYOUT_GEOMETRY: [bool; {}] = {:?};\n",
+        layout_geometry_effects.len(),
+        layout_geometry_effects
     ));
     output.push_str(&format!(
         "pub(crate) static PROPERTY_NUMERIC_RANGES: [&[FfiPropertyNumericRange]; {}] = [\n{}\n];\n",

--- a/Libraries/LibWeb/Rust/src/bin/style_replay.rs
+++ b/Libraries/LibWeb/Rust/src/bin/style_replay.rs
@@ -1852,18 +1852,13 @@ struct ReplayStyleTransactionContext {
 #[derive(Default)]
 struct MatchAnswerIdentityMapping {
     actual_by_expected: Vec<Option<u32>>,
-    expected_by_actual: Vec<Option<u32>>,
 }
 
 impl MatchAnswerIdentityMapping {
     fn record(&mut self, expected: u32, actual: u32) -> Result<(), String> {
         let expected_index = expected as usize;
-        let actual_index = actual as usize;
         if self.actual_by_expected.len() <= expected_index {
             self.actual_by_expected.resize(expected_index + 1, None);
-        }
-        if self.expected_by_actual.len() <= actual_index {
-            self.expected_by_actual.resize(actual_index + 1, None);
         }
         match self.actual_by_expected[expected_index] {
             Some(mapped) if mapped != actual => {
@@ -1872,14 +1867,6 @@ impl MatchAnswerIdentityMapping {
                 ));
             }
             Some(_) | None => self.actual_by_expected[expected_index] = Some(actual),
-        }
-        match self.expected_by_actual[actual_index] {
-            Some(mapped) if mapped != expected => {
-                return Err(format!(
-                    "identity alias: replayed {actual} previously mapped from {mapped}, got {expected}"
-                ));
-            }
-            Some(_) | None => self.expected_by_actual[actual_index] = Some(expected),
         }
         Ok(())
     }
@@ -1926,14 +1913,29 @@ fn replay_style_transaction_output(
         })
     {
         context.error.get_or_insert_with(|| {
+            let first_difference = actual.answers.iter().zip(&expected.answers).position(|(actual, expected)| {
+                actual.style_node != expected.style_node
+                    || actual.reaction != expected.reaction
+                    || actual.inherited_style_groups != expected.inherited_style_groups
+                    || actual.old_style_record != expected.old_style_record
+                    || actual.new_style_record != expected.new_style_record
+                    || actual.damage != expected.damage
+                    || actual.pseudo_kind != expected.pseudo_kind
+                    || actual.gap != expected.gap
+            });
+            let expected_answer = first_difference.and_then(|index| expected.answers.get(index));
+            let actual_answer = first_difference.and_then(|index| actual.answers.get(index));
             format!(
-                "style transaction output diverged: expected versions {}/{} and {:?}, got versions {}/{} and {:?}",
+                "style transaction output diverged: expected versions {}/{} and {} answers, got versions {}/{} and {} answers; first difference at {:?}: expected {:?}, got {:?}",
                 expected.transaction_version,
                 expected.program_version,
-                expected.answers,
+                expected.answers.len(),
                 actual.transaction_version,
                 actual.program_version,
-                actual.answers
+                actual.answers.len(),
+                first_difference,
+                expected_answer,
+                actual_answer
             )
         });
     }

--- a/Libraries/LibWeb/Rust/src/bin/style_replay.rs
+++ b/Libraries/LibWeb/Rust/src/bin/style_replay.rs
@@ -350,6 +350,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 EventKind::StyleDeltaBatch => {
                     let (engine_index, engine) = read_engine_indexed(&mut event.payload, &live_engines)?;
                     let root = event.payload.read_u32()?;
+                    let defer_non_geometry_style = event.payload.read_bool()?;
                     let output_bytes = event.payload.read_bytes()?;
                     let expected_digest = event.payload.read_u64()?;
                     let expected = read_style_transaction_outputs(PayloadReader::new(output_bytes))?;
@@ -380,7 +381,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     let start = Instant::now();
-                    let actual_view = unsafe { bridge::style_engine_take_style_transaction(engine, root) };
+                    let actual_view =
+                        unsafe { bridge::style_engine_take_style_transaction(engine, root, defer_non_geometry_style) };
                     let actual_reclaimed_atoms = if actual_view.reclaimed_style_atom_count == 0 {
                         Vec::new()
                     } else {

--- a/Libraries/LibWeb/Rust/src/css/property_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/css/property_metadata.rs
@@ -44,6 +44,18 @@ pub fn property_animation_type(property_id: u16) -> u8 {
     PROPERTY_ANIMATION_TYPES[longhand_index(property_id)]
 }
 
+/// Whether changing a property may invalidate geometry exposed by synchronous layout APIs.
+///
+/// Besides properties which directly affect layout, this includes properties which can change the
+/// accumulated visual context, scrollable overflow, or stacking-context structure. Value-aware
+/// callers can refine this conservative property-level answer when both sides are available.
+pub fn property_may_affect_layout_geometry(property_id: u16) -> bool {
+    if !(FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&property_id) {
+        return true;
+    }
+    PROPERTY_MAY_AFFECT_LAYOUT_GEOMETRY[longhand_index(property_id)]
+}
+
 pub(crate) fn pseudo_element_supports_property(pseudo_element: u8, property_id: u16) -> bool {
     if PSEUDO_ELEMENT_ALWAYS_ALLOWED_PROPERTIES
         .binary_search(&property_id)
@@ -97,6 +109,21 @@ pub extern "C" fn rust_property_metadata_requires_computation_level(property_id:
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_property_metadata_animation_type(property_id: u16) -> u8 {
     property_animation_type(property_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_geometry_effects_include_visual_geometry_metadata() {
+        assert!(!property_may_affect_layout_geometry(property_id::BACKGROUND_COLOR));
+        assert!(!property_may_affect_layout_geometry(property_id::COLOR));
+        assert!(property_may_affect_layout_geometry(property_id::WIDTH));
+        assert!(property_may_affect_layout_geometry(property_id::TRANSFORM));
+        assert!(property_may_affect_layout_geometry(property_id::OPACITY));
+        assert!(property_may_affect_layout_geometry(property_id::CUSTOM));
+    }
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/batch_matcher.rs
@@ -721,6 +721,7 @@ pub struct BatchMatcher<'a> {
     /// node about exactly the rules a transaction reached, through the same machinery a full
     /// match uses.
     rule_filter: Option<&'a [(RuleID, SelectorProgramID)]>,
+    direct_rule_filter: bool,
     cascade_only: bool,
     witnesses: Option<&'a std::cell::RefCell<RelationalWitnesses>>,
 }
@@ -938,6 +939,7 @@ impl<'a> BatchMatcher<'a> {
             ancestor_requirements: None,
             match_workspace: None,
             rule_filter: None,
+            direct_rule_filter: false,
             cascade_only: false,
             witnesses: None,
         }
@@ -1014,6 +1016,12 @@ impl<'a> BatchMatcher<'a> {
     #[must_use]
     pub(super) fn with_rule_filter(mut self, rules: &'a [(RuleID, SelectorProgramID)]) -> Self {
         self.rule_filter = Some(rules);
+        self
+    }
+
+    #[must_use]
+    pub(super) fn with_direct_rule_filter(mut self) -> Self {
+        self.direct_rule_filter = true;
         self
     }
 
@@ -1247,7 +1255,10 @@ impl<'a> BatchMatcher<'a> {
         if let Some(witnesses) = self.witnesses {
             evaluator = evaluator.observing_witnesses(witnesses);
         }
-        if let Some(rules) = self.rule_filter.filter(|rules| self.filtered_rules_are_narrow(rules)) {
+        if let Some(rules) = self
+            .rule_filter
+            .filter(|rules| self.direct_rule_filter || self.filtered_rules_are_narrow(rules))
+        {
             return self.match_filtered_rules_directly(node, row, rules, &evaluator, out, counters);
         }
         let start = out.matches.len();

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -2523,6 +2523,7 @@ pub unsafe extern "C" fn style_engine_intern_atom(engine: *mut c_void, raw: usiz
 pub unsafe extern "C" fn style_engine_take_style_transaction(
     engine: *mut c_void,
     root: u32,
+    defer_non_geometry_style: bool,
 ) -> FfiStyleTransactionView {
     abort_on_panic(|| {
         let Some(root) = StyleNodeID::from_raw(root) else {
@@ -2531,7 +2532,9 @@ pub unsafe extern "C" fn style_engine_take_style_transaction(
         let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
         engine.clear_ffi_style_transaction_output();
         let mut output = FfiStyleTransactionOutput::default();
-        output.scoped = engine.take_style_transaction(root, |transaction_version, program_version, answers| {
+        let mut emit = |transaction_version: super::StyleTransactionVersion,
+                        program_version: super::ProgramVersion,
+                        answers: &[super::PublishedStyleDeltaRecord]| {
             assert!(
                 output.answers.is_empty(),
                 "a style transaction emitted more than one batch"
@@ -2539,7 +2542,11 @@ pub unsafe extern "C" fn style_engine_take_style_transaction(
             output.transaction_version = transaction_version.0;
             output.program_version = program_version.0;
             output.answers.extend_from_slice(answers);
-        });
+        };
+        output.scoped = match defer_non_geometry_style {
+            true => engine.take_style_transaction_for_layout_geometry(root, &mut emit),
+            false => engine.take_style_transaction(root, &mut emit),
+        };
         output.reclaimed_style_atoms = std::mem::take(&mut engine.reclaimed_style_atoms)
             .into_iter()
             .map(|reclaimed| FfiReclaimedStyleAtom {
@@ -2551,6 +2558,7 @@ pub unsafe extern "C" fn style_engine_take_style_transaction(
         if engine.recording_id().is_some() {
             engine.record_boundary_call(EventKind::StyleDeltaBatch, |payload| {
                 payload.write_u32(root.raw());
+                payload.write_bool(defer_non_geometry_style);
                 let mut outputs = super::record_replay::PayloadWriter::default();
                 write_style_transaction_outputs(&output, &mut outputs);
                 payload.write_bytes(outputs.as_bytes());

--- a/Libraries/LibWeb/Rust/src/css/style/catalog.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/catalog.rs
@@ -1292,6 +1292,7 @@ pub(super) struct BatchMatchingTraversal {
     pub(super) dispatch_workspace_bytes: u64,
     pub(super) cascade_compaction_workspace: ordering::CascadeCompactionWorkspace,
     pub(super) cascade_compaction_workspace_bytes: u64,
+    pub(super) rule_filter: Option<Rc<[(RuleID, SelectorProgramID)]>>,
 }
 
 /// Current-side matching scratch produced by the transaction immediately before a style

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -14,6 +14,23 @@ impl StyleEngine {
         root: StyleNodeID,
         mut emit: impl FnMut(StyleTransactionVersion, ProgramVersion, &[PublishedStyleDeltaRecord]),
     ) -> bool {
+        self.take_style_transaction_impl(root, false, &mut emit)
+    }
+
+    pub fn take_style_transaction_for_layout_geometry(
+        &mut self,
+        root: StyleNodeID,
+        mut emit: impl FnMut(StyleTransactionVersion, ProgramVersion, &[PublishedStyleDeltaRecord]),
+    ) -> bool {
+        self.take_style_transaction_impl(root, true, &mut emit)
+    }
+
+    fn take_style_transaction_impl(
+        &mut self,
+        root: StyleNodeID,
+        defer_non_geometry_style: bool,
+        emit: &mut impl FnMut(StyleTransactionVersion, ProgramVersion, &[PublishedStyleDeltaRecord]),
+    ) -> bool {
         self.reclaim_computed_memory_if_needed();
         self.sync_tier3_benefit_observations();
         let tier3_evictions = self.memory.finish_tier3_quota_period();
@@ -45,7 +62,25 @@ impl StyleEngine {
 
         let mut transaction = self.drain_transaction();
         self.apply_staged_transaction(&mut transaction);
-        if transaction.is_empty() {
+        let force_deferred_resident_non_geometry_style =
+            !defer_non_geometry_style && self.deferred_resident_non_geometry_style;
+        if force_deferred_resident_non_geometry_style {
+            self.deferred_resident_non_geometry_style = false;
+        }
+        let mut layout_geometry_rule_filter =
+            (defer_non_geometry_style && !initial_tree_was_bulk_loaded && !publish_document_root_arrival)
+                .then(|| self.layout_geometry_rule_filter_for_deferred_resident_non_geometry_style(&transaction))
+                .flatten();
+        let defer_resident_non_geometry_style = layout_geometry_rule_filter.is_some();
+        if defer_resident_non_geometry_style {
+            self.deferred_resident_non_geometry_style = true;
+            self.discard_retained_prefix_caches();
+            self.retained_match_answers.evict(&mut self.match_answers);
+            let workspace_bytes = self.match_workspace.capacity_bytes();
+            self.match_workspace = MatchEvaluationWorkspace::default();
+            self.memory.release(MemoryCategory::BatchScratch, workspace_bytes);
+        }
+        if transaction.is_empty() && !force_deferred_resident_non_geometry_style {
             self.release_transaction_and_sweep_atoms(transaction);
             return true;
         }
@@ -84,7 +119,9 @@ impl StyleEngine {
         // retain it across the same boundary. Other selector-affecting transactions retire the
         // answers they name: a planned element may not be recomputed by the traversal that
         // immediately follows, and stale state must not survive into a later reuse.
-        let transaction_reaches_no_selector = !transaction.has_coarsened_markers()
+        let transaction_reaches_no_selector = !force_deferred_resident_non_geometry_style
+            && !defer_resident_non_geometry_style
+            && !transaction.has_coarsened_markers()
             && transaction.inputs.iter().all(|input| {
                 matches!(
                     input.key,
@@ -103,7 +140,10 @@ impl StyleEngine {
                         | InputKey::CascadeTopology(_)
                 )
             });
-        let retained_answer_patch_selection = self.rules_for_retained_answer_patch(&transaction);
+        let retained_answer_patch_selection = (!force_deferred_resident_non_geometry_style
+            && !defer_resident_non_geometry_style)
+            .then(|| self.rules_for_retained_answer_patch(&transaction))
+            .flatten();
         let transaction_supports_global_exact_cascade_stops =
             retained_answer_patch_selection.as_ref().is_some_and(|selection| {
                 let changed_nodes_have_selector_only_identity_inputs = transaction.inputs.iter().all(|input| {
@@ -310,7 +350,8 @@ impl StyleEngine {
                 )
             })
             .count();
-        let use_exact_tree_routing = !transaction.has_coarsened_markers()
+        let use_exact_tree_routing = !defer_resident_non_geometry_style
+            && !transaction.has_coarsened_markers()
             && exact_tree_routing_is_selective(arriving_nodes.len() + departing_nodes, connected_element_count);
         let mut transaction_fact_view = self.transaction_fact_view_for(&mut transaction, root, &regions);
         if use_exact_tree_routing {
@@ -326,7 +367,10 @@ impl StyleEngine {
         self.memory
             .reserve_required(MemoryCategory::BatchScratch, fact_view_bytes);
         let mut sequences = SequenceChanges::new();
-        if !transaction.has_coarsened_markers() {
+        if !transaction.has_coarsened_markers()
+            && !defer_resident_non_geometry_style
+            && !force_deferred_resident_non_geometry_style
+        {
             // Routing reads the program as it stands now, but the inputs happened before it did.
             // A sheet that went away in this same transaction was still deciding when the mutations
             // ahead of it in the journal were recorded, so its rules cannot be skipped as inactive.
@@ -620,7 +664,7 @@ impl StyleEngine {
                     InputKey::RuleField(_, RuleField::Activation) | InputKey::SheetActivation(_)
                 )
             });
-        if !transaction.markers.is_empty() {
+        if !transaction.markers.is_empty() || force_deferred_resident_non_geometry_style {
             // A complete-scope action or coarsened journal proves no narrower output region, so the
             // plan is the document. An environment action still preserves the exact selector state
             // maintained above because it changed no selector input.
@@ -1014,6 +1058,10 @@ impl StyleEngine {
                 if !reuse_active_batch_matching_traversal {
                     self.begin_published_match_answer_completion_batch(root, prefer_complete_batch);
                 }
+                if let Some(rule_filter) = layout_geometry_rule_filter.take() {
+                    debug_assert!(!reuse_active_batch_matching_traversal);
+                    self.set_published_match_answer_rule_filter(rule_filter);
+                }
                 let retained_answer_dispatch = retained_answer_patch
                     .as_ref()
                     .map(|patch| patch.dispatch.as_ref())
@@ -1370,6 +1418,127 @@ impl StyleEngine {
             }
         }
         !publish_document_root_arrival && !plan_is_broad
+    }
+
+    /// A leaf-only tree transaction can be split at a geometry observation when every rule which
+    /// may affect geometry is insensitive to unrelated leaves. Arrivals receive a complete
+    /// geometry-affecting style projection; resident non-geometry style and the rest of each
+    /// arrival's style are observed by the next ordinary cold transaction.
+    fn layout_geometry_rule_filter_for_deferred_resident_non_geometry_style(
+        &self,
+        transaction: &StyleTransaction,
+    ) -> Option<Vec<(RuleID, SelectorProgramID)>> {
+        if transaction.has_coarsened_markers() {
+            return None;
+        }
+
+        let mut has_tree_change = false;
+        let mut nonresident_nodes = Vec::new();
+        let route_liveness = self.routing.route_liveness(&self.program, &self.programs);
+        for input in &transaction.inputs {
+            match (input.key, input.old, input.new) {
+                (
+                    InputKey::TreeRelations(node),
+                    InputValue::TreeRelations(None),
+                    InputValue::TreeRelations(Some(relations)),
+                ) => {
+                    has_tree_change = true;
+                    nonresident_nodes.push(node);
+                    if relations.parent.is_none()
+                        || relations.assigned_slot.is_some()
+                        || self.tree.first_element_child(node).is_some()
+                    {
+                        return None;
+                    }
+                }
+                (
+                    InputKey::TreeRelations(node),
+                    InputValue::TreeRelations(Some(relations)),
+                    InputValue::TreeRelations(None),
+                ) => {
+                    has_tree_change = true;
+                    nonresident_nodes.push(node);
+                    if relations.parent.is_none()
+                        || relations.assigned_slot.is_some()
+                        || self.tree.first_element_child(node).is_some()
+                    {
+                        return None;
+                    }
+                }
+                (
+                    InputKey::TreeRelations(_),
+                    InputValue::TreeRelations(Some(old)),
+                    InputValue::TreeRelations(Some(new)),
+                ) if old.parent.is_some()
+                    && old.parent == new.parent
+                    && old.tree_scope == new.tree_scope
+                    && old.assigned_slot == new.assigned_slot =>
+                {
+                    has_tree_change = true;
+                }
+                (
+                    InputKey::LocalFeature(_, LocalFeatureKey::ArrivingFacts),
+                    InputValue::Feature(FeatureValue::Absent),
+                    InputValue::Feature(FeatureValue::Present),
+                ) => {}
+                (InputKey::LocalFeature(_, LocalFeatureKey::PartExposure), _, _) => return None,
+                (InputKey::LocalFeature(..) | InputKey::State(..), _, _) => {
+                    if self.input_routes_may_affect_layout_geometry(input, &route_liveness) {
+                        return None;
+                    }
+                }
+                _ => return None,
+            }
+        }
+        if !has_tree_change {
+            return None;
+        }
+
+        let mut geometry_rules = Vec::new();
+        for raw_rule in 0..self.program.rule_count() {
+            let rule = RuleID(raw_rule);
+            if !self.program.rule_can_decide(rule) {
+                continue;
+            }
+            let version = self.program.rule_version(rule);
+            if !version.kind.matches_elements() {
+                continue;
+            }
+            if !self.program.declarations_are_complete_for(rule) {
+                return None;
+            }
+            let affects_geometry =
+                self.program.declared_properties_of(rule).iter().any(|declared| {
+                    crate::css::property_metadata::property_may_affect_layout_geometry(declared.property)
+                });
+            if !affects_geometry {
+                continue;
+            }
+            let program_id = version.selector_program?;
+            let program = self.programs.get(program_id);
+            let resident_answers_are_stable = program.resident_answers_are_stable_under_leaf_changes()
+                || program.entries().iter().enumerate().all(|(entry, _)| {
+                    program.entry_resident_answer_is_stable_under_leaf_changes(entry)
+                        || (!program.subject_dispatch_keys(entry).is_empty()
+                            && !program.subject_dispatch_keys(entry).iter().any(|&key| {
+                                if !key.has_selector_posting() {
+                                    return true;
+                                }
+                                match self.facts.postings().lookup(key) {
+                                    Lookup::Known(posting) => posting
+                                        .candidates()
+                                        .any(|candidate| !nonresident_nodes.contains(&candidate)),
+                                    Lookup::KnownAbsent => false,
+                                    Lookup::Missing(_) => true,
+                                }
+                            }))
+                });
+            if !resident_answers_are_stable {
+                return None;
+            }
+            geometry_rules.push((rule, program_id));
+        }
+        Some(geometry_rules)
     }
 
     pub(super) fn prepare_topology_for_matching(&mut self, root: StyleNodeID, regions: &mut ImpactRegions) -> bool {

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -705,6 +705,63 @@ impl StyleEngine {
             || self.sheet_rule_replacement.is_some()
     }
 
+    /// Whether settling the pending selector inputs can change geometry derived from the committed
+    /// layout. This is deliberately a proof of independence rather than a list of properties which
+    /// usually avoid layout: anything not explicitly known to preserve geometry remains observable.
+    #[must_use]
+    pub fn pending_transaction_may_affect_layout_geometry(&self) -> bool {
+        if self.journal.is_empty() {
+            return !self.tree_staging.is_empty()
+                || self.program_staging.is_dirty()
+                || self.sheet_rule_replacement.is_some()
+                || !self.deferred_element_style_inputs.is_empty()
+                || self.initial_tree_bulk_load_is_pending;
+        }
+        if !self.journal.markers().is_empty()
+            || !self.tree_staging.is_empty()
+            || self.program_staging.is_dirty()
+            || self.sheet_rule_replacement.is_some()
+            || !self.deferred_element_style_inputs.is_empty()
+            || self.initial_tree_bulk_load_is_pending
+        {
+            return true;
+        }
+
+        let route_liveness = self.routing.route_liveness(&self.program, &self.programs);
+        self.journal.inputs().any(|input| {
+            let mut keys = match input.key {
+                InputKey::LocalFeature(_, LocalFeatureKey::PartExposure | LocalFeatureKey::ArrivingFacts) => {
+                    return true;
+                }
+                InputKey::LocalFeature(_, LocalFeatureKey::Attribute(name)) => {
+                    let mut keys = routing_keys_for_input(&input);
+                    for other in self.facts.attribute_name_keys(name) {
+                        if other != name {
+                            keys.push(RoutingKey::AttributeName(other));
+                        }
+                    }
+                    keys
+                }
+                InputKey::LocalFeature(..) | InputKey::State(..) => routing_keys_for_input(&input),
+                _ => return true,
+            };
+            keys.sort_unstable();
+            keys.dedup();
+            keys.into_iter().any(|key| {
+                self.routing.routes_for(key).iter().copied().any(|route| {
+                    if !route_liveness.contains(route.index()) {
+                        return false;
+                    }
+                    let rule = self.routing.rule_of(route);
+                    !self.program.declarations_are_complete_for(rule)
+                        || self.program.declared_properties_of(rule).iter().any(|declared| {
+                            crate::css::property_metadata::property_may_affect_layout_geometry(declared.property)
+                        })
+                })
+            })
+        })
+    }
+
     /// Record one member of a flat FFI batch without repeatedly settling the fact-store capacity.
     ///
     /// The bridge has already applied every tree delta before it publishes facts. It can therefore

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -50,6 +50,7 @@ impl StyleEngine {
             deferred_element_style_input_memory: MemoryLease::new(MemoryCategory::NormalizationJournal),
             initial_tree_batch_applied: false,
             initial_tree_bulk_load_is_pending: false,
+            deferred_resident_non_geometry_style: false,
             tree_staging: TreeRelationStaging::default(),
             tree_staging_memory: MemoryLease::new(MemoryCategory::NormalizationJournal),
             program_staging: ProgramStaging::default(),
@@ -703,6 +704,48 @@ impl StyleEngine {
             || !self.tree_staging.is_empty()
             || self.program_staging.is_dirty()
             || self.sheet_rule_replacement.is_some()
+            || self.deferred_resident_non_geometry_style
+    }
+
+    #[must_use]
+    pub fn has_immediate_pending_transaction(&self) -> bool {
+        !self.journal.is_empty()
+            || !self.tree_staging.is_empty()
+            || self.program_staging.is_dirty()
+            || self.sheet_rule_replacement.is_some()
+    }
+
+    pub(super) fn input_routes_may_affect_layout_geometry(
+        &self,
+        input: &NormalizedInput,
+        route_liveness: &BitColumn,
+    ) -> bool {
+        let mut keys = match input.key {
+            InputKey::LocalFeature(_, LocalFeatureKey::Attribute(name)) => {
+                let mut keys = routing_keys_for_input(input);
+                for other in self.facts.attribute_name_keys(name) {
+                    if other != name {
+                        keys.push(RoutingKey::AttributeName(other));
+                    }
+                }
+                keys
+            }
+            _ => routing_keys_for_input(input),
+        };
+        keys.sort_unstable();
+        keys.dedup();
+        keys.into_iter().any(|key| {
+            self.routing.routes_for(key).iter().copied().any(|route| {
+                if !route_liveness.contains(route.index()) {
+                    return false;
+                }
+                let rule = self.routing.rule_of(route);
+                !self.program.declarations_are_complete_for(rule)
+                    || self.program.declared_properties_of(rule).iter().any(|declared| {
+                        crate::css::property_metadata::property_may_affect_layout_geometry(declared.property)
+                    })
+            })
+        })
     }
 
     /// Whether settling the pending selector inputs can change geometry derived from the committed
@@ -728,37 +771,12 @@ impl StyleEngine {
         }
 
         let route_liveness = self.routing.route_liveness(&self.program, &self.programs);
-        self.journal.inputs().any(|input| {
-            let mut keys = match input.key {
-                InputKey::LocalFeature(_, LocalFeatureKey::PartExposure | LocalFeatureKey::ArrivingFacts) => {
-                    return true;
-                }
-                InputKey::LocalFeature(_, LocalFeatureKey::Attribute(name)) => {
-                    let mut keys = routing_keys_for_input(&input);
-                    for other in self.facts.attribute_name_keys(name) {
-                        if other != name {
-                            keys.push(RoutingKey::AttributeName(other));
-                        }
-                    }
-                    keys
-                }
-                InputKey::LocalFeature(..) | InputKey::State(..) => routing_keys_for_input(&input),
-                _ => return true,
-            };
-            keys.sort_unstable();
-            keys.dedup();
-            keys.into_iter().any(|key| {
-                self.routing.routes_for(key).iter().copied().any(|route| {
-                    if !route_liveness.contains(route.index()) {
-                        return false;
-                    }
-                    let rule = self.routing.rule_of(route);
-                    !self.program.declarations_are_complete_for(rule)
-                        || self.program.declared_properties_of(rule).iter().any(|declared| {
-                            crate::css::property_metadata::property_may_affect_layout_geometry(declared.property)
-                        })
-                })
-            })
+        self.journal.inputs().any(|input| match input.key {
+            InputKey::LocalFeature(_, LocalFeatureKey::PartExposure | LocalFeatureKey::ArrivingFacts) => true,
+            InputKey::LocalFeature(..) | InputKey::State(..) => {
+                self.input_routes_may_affect_layout_geometry(&input, &route_liveness)
+            }
+            _ => true,
         })
     }
 

--- a/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
@@ -101,6 +101,8 @@ define_counters! {
     PrefixTransitionCacheMatchMisses => "prefixTransitionCacheMatchMisses",
     PrefixTransitionMemoHits => "prefixTransitionMemoHits",
     PrefixTransitionMemoMisses => "prefixTransitionMemoMisses",
+    PrefixTransitionDeltaAttempts => "prefixTransitionDeltaAttempts",
+    PrefixTransitionDeltaHits => "prefixTransitionDeltaHits",
     PrefixLocalFactIdentityHits => "prefixLocalFactIdentityHits",
     PrefixLocalFactIdentityMisses => "prefixLocalFactIdentityMisses",
     PrefixAnswerCacheHits => "prefixAnswerCacheHits",

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -477,11 +477,12 @@ impl StyleEngine {
                     // The batch just matched every node it iterates here, so completing the
                     // transitions matching did not touch is the cheap tail of work already paid
                     // for: each one is a chain walk over memoized dependencies. A complete cache
-                    // is what lets a sibling-bearing automaton's convergence maintain itself
-                    // through later flushes instead of upquerying its way back to the planner:
-                    // the rightward walk cannot seed missing left context the way the downward
-                    // walk seeds through ancestors, so only sibling automata earn the uncapped
-                    // walk, and only when the pool can plausibly retain what the walk builds.
+                    // is what lets a sibling-bearing or positional automaton's convergence
+                    // maintain itself through later flushes instead of upquerying its way back to
+                    // the planner: a rightward walk cannot seed missing left context, and a
+                    // positional walk needs each affected sibling's old positional truth. These
+                    // automata earn the uncapped walk only when the pool can plausibly retain what
+                    // the walk builds.
                     // Completing a cache with no available Tier-3 headroom is work paid and thrown
                     // away after admission has already closed.
                     let headroom = self
@@ -493,7 +494,8 @@ impl StyleEngine {
                     #[cfg(not(test))]
                     let force_bounded = false;
                     let completion_budget = match !force_bounded
-                        && dispatch.prefixes().has_sibling_steps()
+                        && (dispatch.prefixes().has_sibling_steps()
+                            || !dispatch.prefixes().positional_tests().is_empty())
                         && headroom >= states.capacity_bytes()
                     {
                         true => usize::MAX,

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -269,7 +269,22 @@ impl StyleEngine {
             dispatch_workspace_bytes: 0,
             cascade_compaction_workspace: ordering::CascadeCompactionWorkspace::default(),
             cascade_compaction_workspace_bytes: 0,
+            rule_filter: None,
         }));
+    }
+
+    pub(super) fn set_published_match_answer_rule_filter(&mut self, rules: Vec<(RuleID, SelectorProgramID)>) {
+        let traversal = self
+            .batch_matching_traversal
+            .as_mut()
+            .expect("a published answer rule filter requires a completion batch");
+        debug_assert!(traversal.rule_filter.is_none());
+        let rules: Rc<[(RuleID, SelectorProgramID)]> = rules.into_boxed_slice().into();
+        self.memory.reserve_required(
+            MemoryCategory::BatchScratch,
+            (rules.len() * size_of::<(RuleID, SelectorProgramID)>()) as u64,
+        );
+        traversal.rule_filter = Some(rules);
     }
 
     pub(super) fn end_published_match_answer_completion_batch(&mut self) {
@@ -302,6 +317,12 @@ impl StyleEngine {
         self.memory.release(
             MemoryCategory::BatchScratch,
             traversal.cascade_compaction_workspace_bytes,
+        );
+        self.memory.release(
+            MemoryCategory::BatchScratch,
+            traversal.rule_filter.as_ref().map_or(0, |rules| {
+                (rules.len() * size_of::<(RuleID, SelectorProgramID)>()) as u64
+            }),
         );
         let released_cascade_payload_bytes = self.match_answers.sweep_unreferenced();
         self.retained_match_answers
@@ -351,6 +372,7 @@ impl StyleEngine {
             dispatch_workspace_bytes: 0,
             cascade_compaction_workspace: ordering::CascadeCompactionWorkspace::default(),
             cascade_compaction_workspace_bytes: 0,
+            rule_filter: None,
         })
     }
 
@@ -447,6 +469,7 @@ impl StyleEngine {
             dispatch_workspace_bytes: 0,
             cascade_compaction_workspace: ordering::CascadeCompactionWorkspace::default(),
             cascade_compaction_workspace_bytes: 0,
+            rule_filter: None,
         }));
     }
 
@@ -921,6 +944,7 @@ impl StyleEngine {
                 deferred_prefix_matches: retry.deferred_prefix_matches,
                 answer_is_exact: retry.answer_is_exact,
                 cascade_only: retry.cascade_only,
+                rule_filter: retry.rule_filter,
             },
         );
         let _ = shared_prefix_states;
@@ -959,6 +983,9 @@ impl StyleEngine {
             .observing_witnesses(&self.relational_witnesses);
         if attempt.cascade_only {
             interpreter = interpreter.for_cascade();
+        }
+        if let Some(rule_filter) = attempt.rule_filter {
+            interpreter = interpreter.with_rule_filter(rule_filter).with_direct_rule_filter();
         }
         if self.tree.tree_scope(node) == scope
             && let Some(requirements) = ancestor_requirements
@@ -3579,10 +3606,14 @@ impl StyleEngine {
             }
             // OPTIMIZATION: Identical sheet sets share a scope program, so the prefix automaton's
             // answer can be reused across otherwise independent shadow trees.
-            let can_defer_prefix_matches =
-                compact_for_cascade && inner_scope.is_none() && slotted_scopes.is_empty() && part_scopes.is_empty();
+            let rule_filter = traversal.rule_filter.as_deref();
+            let can_defer_prefix_matches = compact_for_cascade
+                && rule_filter.is_none()
+                && inner_scope.is_none()
+                && slotted_scopes.is_empty()
+                && part_scopes.is_empty();
             let mut deferred_prefix_matches = None;
-            let mut retained_match_answer_is_exact = compact_for_cascade;
+            let mut retained_match_answer_is_exact = compact_for_cascade && rule_filter.is_none();
             let result = for_each_matching_scope(
                 scope,
                 inner_scope,
@@ -3606,6 +3637,7 @@ impl StyleEngine {
                                 .then_some(&mut deferred_prefix_matches),
                             answer_is_exact: Some(&mut retained_match_answer_is_exact),
                             cascade_only: is_primary && can_defer_prefix_matches && !self.complete_answers_exactly,
+                            rule_filter,
                         },
                     )
                 },
@@ -4051,7 +4083,12 @@ impl StyleEngine {
             .map(|traversal| Rc::clone(&traversal.prefix_caches))
             .unwrap_or_else(|| Rc::new(RefCell::new(PrefixCaches::default())));
         let mut completion_scratch_bytes = 0;
-        let mut retained_match_answer_is_exact = compact_for_cascade;
+        let rule_filter = self
+            .batch_matching_traversal
+            .as_ref()
+            .and_then(|traversal| traversal.rule_filter.as_ref())
+            .map(Rc::clone);
+        let mut retained_match_answer_is_exact = compact_for_cascade && rule_filter.is_none();
         let mut facts = StyleNodeFacts::new();
         let mut requests = Vec::new();
         loop {
@@ -4085,6 +4122,7 @@ impl StyleEngine {
                                 && inner_scope.is_none()
                                 && slotted_scopes.is_empty()
                                 && part_scopes.is_empty(),
+                            rule_filter: rule_filter.as_deref(),
                         },
                     )
                 },

--- a/Libraries/LibWeb/Rust/src/css/style/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/mod.rs
@@ -777,6 +777,10 @@ pub struct StyleEngine {
     initial_tree_batch_applied: bool,
     /// Whether that bulk load is still part of the transaction awaiting first observation.
     initial_tree_bulk_load_is_pending: bool,
+    /// A geometry-only observation committed structural inputs while leaving resident
+    /// non-geometry style at its previous snapshot. The next ordinary style observation
+    /// cold-matches the document.
+    deferred_resident_non_geometry_style: bool,
     /// Final relation rows staged until the next observation boundary. Moving one node updates its
     /// affected neighbours here, so those derived changes need no separate journal ingress.
     tree_staging: TreeRelationStaging,

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -979,6 +979,7 @@ impl StyleEngine {
                         deferred_prefix_matches: None,
                         answer_is_exact: None,
                         cascade_only: false,
+                        rule_filter: None,
                     },
                 ) {
                     result = Err(incomplete);

--- a/Libraries/LibWeb/Rust/src/css/style/planning.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/planning.rs
@@ -1413,6 +1413,7 @@ pub(super) struct BatchMatchAttempt<'a> {
     pub(super) deferred_prefix_matches: Option<&'a mut Option<PrefixMatchSetID>>,
     pub(super) answer_is_exact: Option<&'a mut bool>,
     pub(super) cascade_only: bool,
+    pub(super) rule_filter: Option<&'a [(RuleID, SelectorProgramID)]>,
 }
 
 pub(super) struct BatchMatchRetry<'a> {
@@ -1421,6 +1422,7 @@ pub(super) struct BatchMatchRetry<'a> {
     pub(super) deferred_prefix_matches: Option<&'a mut Option<PrefixMatchSetID>>,
     pub(super) answer_is_exact: Option<&'a mut bool>,
     pub(super) cascade_only: bool,
+    pub(super) rule_filter: Option<&'a [(RuleID, SelectorProgramID)]>,
 }
 
 #[derive(Clone, Copy)]

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -1275,7 +1275,7 @@ impl PrefixDeltaArena {
     ///
     /// A step can occur in both delta partitions while moving between them, so test its combined
     /// state sign instead of treating every non-empty span as a semantic change.
-    fn changes_selected_state(&self, id: PrefixStateDeltaID, selection: &PrefixSelection) -> bool {
+    fn changes_selected_state(&self, id: PrefixStateDeltaID, selection: Option<&PrefixSelection>) -> bool {
         let delta = self.delta(id);
         [
             delta.persisting_additions,
@@ -1285,7 +1285,9 @@ impl PrefixDeltaArena {
         ]
         .into_iter()
         .flat_map(|span| self.get(span))
-        .any(|&step| selection.contains_step(step) && self.state_sign(Some(id), step) != 0)
+        .any(|&step| {
+            selection.is_none_or(|selection| selection.contains_step(step)) && self.state_sign(Some(id), step) != 0
+        })
     }
 
     fn persisting_only(&mut self, id: Option<PrefixStateDeltaID>) -> PrefixStateDeltaID {
@@ -2287,7 +2289,7 @@ impl PrefixStates {
         if entering_deltas.parent.is_none() && entering_deltas.previous.is_none() {
             return None;
         }
-        if self.local_facts_of(node) != Some(local_facts) || self.positional_bits_of(node) != positional_bits {
+        if self.local_facts_of(node) != Some(local_facts) {
             return None;
         }
         if local_output_deltas.result_changed && !local_output_deltas.result_delta_complete {
@@ -2356,6 +2358,7 @@ impl PrefixStates {
         evaluation: &PrefixEvaluation<'_, '_>,
         old_evaluation: &PrefixEvaluation<'_, '_>,
         selection: Option<&PrefixSelection>,
+        derive_unselected_deltas: bool,
         node: StyleNodeID,
         local_facts_changed: bool,
         local_affected_candidates: Option<&[PrefixProducer]>,
@@ -2412,84 +2415,108 @@ impl PrefixStates {
             Ok(bits) => bits,
             Err(incomplete) => return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete)),
         };
+        let old_positional_bits = self.positional_bits_of(node);
+        let positional_bits_changed = old.is_some() && old_positional_bits != positional_bits;
         let entering = EnteringStates {
             parent: parent_state,
             previous: previous_state,
         };
+        let transition_is_memoized = selection.is_none()
+            && derive_unselected_deltas
+            && self.transitions.contains_key(&PrefixTransitionKey {
+                parent: entering.parent,
+                previous: entering.previous,
+                local_facts,
+                is_document_root: evaluation.tree.parent(node).is_none(),
+                positional_bits,
+            });
         let old_entering = self.entering_of(node);
         // Interner give-back can strand a node with a remapped transition but no surviving
         // entering states: the entering names the parent's old state, which dies with a forgotten
         // parent transition. Local output deltas replay from the old entering, so without one the
         // difference has to come from comparing the interned state chains instead.
-        let can_derive_delta = selection.is_some()
+        let can_derive_delta = (selection.is_some() || derive_unselected_deltas)
+            && !transition_is_memoized
             && (entering_deltas.parent.is_some()
                 || entering_deltas.previous.is_some()
-                || local_affected_candidates.is_some())
+                || local_affected_candidates.is_some()
+                || positional_bits_changed)
             && (!local_facts_changed || local_affected_candidates.is_some())
             && old_entering.is_some();
         let mut affected_candidates = std::mem::take(&mut self.candidates);
         affected_candidates.clear();
-        for delta in [entering_deltas.parent, entering_deltas.previous].into_iter().flatten() {
-            self.collect_delta_steps(delta, delta_arena, &mut affected_candidates);
-        }
-        for delta in [entering_deltas.parent, entering_deltas.previous].into_iter().flatten() {
-            let delta = delta_arena.delta(delta);
-            for span in [delta.persisting_additions, delta.persisting_removals] {
-                for &step in delta_arena.get(span) {
-                    if let Some(predecessor) = evaluation.automaton.predecessor_of(step) {
-                        affected_candidates.push(predecessor);
+        if can_derive_delta {
+            for delta in [entering_deltas.parent, entering_deltas.previous].into_iter().flatten() {
+                self.collect_delta_steps(delta, delta_arena, &mut affected_candidates);
+            }
+            for delta in [entering_deltas.parent, entering_deltas.previous].into_iter().flatten() {
+                let delta = delta_arena.delta(delta);
+                for span in [delta.persisting_additions, delta.persisting_removals] {
+                    for &step in delta_arena.get(span) {
+                        if let Some(predecessor) = evaluation.automaton.predecessor_of(step) {
+                            affected_candidates.push(predecessor);
+                        }
                     }
                 }
             }
-        }
-        if local_facts_changed && let Some(local_affected_candidates) = local_affected_candidates {
-            let mut active_candidates = std::mem::take(&mut self.compare_left);
-            active_candidates.clear();
-            for active in [
-                old_entering.map(|entering| entering.parent),
-                old_entering.map(|entering| entering.previous),
-                Some(entering.parent),
-                Some(entering.previous),
-            ]
-            .into_iter()
-            .flatten()
-            {
-                self.collect_active(active, &mut active_candidates);
-            }
-            let mut append_roots = |evaluation: &PrefixEvaluation<'_, '_>| {
-                let Ok(row) = evaluation.row_of(node) else {
-                    return;
+            if (local_facts_changed && local_affected_candidates.is_some()) || positional_bits_changed {
+                let mut active_candidates = std::mem::take(&mut self.compare_left);
+                active_candidates.clear();
+                for active in [
+                    old_entering.map(|entering| entering.parent),
+                    old_entering.map(|entering| entering.previous),
+                    Some(entering.parent),
+                    Some(entering.previous),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    self.collect_active(active, &mut active_candidates);
+                }
+                let mut append_roots = |evaluation: &PrefixEvaluation<'_, '_>| {
+                    let Ok(row) = evaluation.row_of(node) else {
+                        return;
+                    };
+                    row.facts
+                        .for_each_dispatch_probe(row.row, evaluation.tree.parent(node).is_none(), |key, _| {
+                            if let Some(bucket) = evaluation.automaton.bucket(key) {
+                                active_candidates.extend_from_slice(&bucket.root_steps);
+                            }
+                        });
                 };
-                row.facts
-                    .for_each_dispatch_probe(row.row, evaluation.tree.parent(node).is_none(), |key, _| {
-                        if let Some(bucket) = evaluation.automaton.bucket(key) {
-                            active_candidates.extend_from_slice(&bucket.root_steps);
+                append_roots(old_evaluation);
+                append_roots(evaluation);
+                active_candidates.retain(|step| {
+                    local_affected_candidates
+                        .is_some_and(|producers| producers.binary_search_by_key(step, |producer| producer.step).is_ok())
+                        || match &evaluation.automaton.compounds
+                            [evaluation.automaton.steps[step.0 as usize].compound.0 as usize]
+                            .predicate
+                        {
+                            PrefixPredicate::Features {
+                                required_positional_bits,
+                                ..
+                            } => required_positional_bits & (old_positional_bits ^ positional_bits) != 0,
+                            PrefixPredicate::Program { .. } => false,
                         }
-                    });
-            };
-            append_roots(old_evaluation);
-            append_roots(evaluation);
-            active_candidates.retain(|step| {
+                });
+                affected_candidates.extend_from_slice(&active_candidates);
+                self.compare_left = active_candidates;
+            }
+            affected_candidates.sort_unstable();
+            affected_candidates.dedup();
+            let is_document_root = evaluation.tree.parent(node).is_none();
+            affected_candidates.retain(|&step| {
                 local_affected_candidates
-                    .binary_search_by_key(step, |producer| producer.step)
-                    .is_ok()
+                    .is_some_and(|producers| producers.binary_search_by_key(&step, |producer| producer.step).is_ok())
+                    || row.facts.carries_dispatch_key(
+                        row.row,
+                        evaluation.automaton.compounds[evaluation.automaton.steps[step.0 as usize].compound.0 as usize]
+                            .dispatch_key,
+                        is_document_root,
+                    )
             });
-            affected_candidates.extend_from_slice(&active_candidates);
-            self.compare_left = active_candidates;
         }
-        affected_candidates.sort_unstable();
-        affected_candidates.dedup();
-        let is_document_root = evaluation.tree.parent(node).is_none();
-        affected_candidates.retain(|&step| {
-            local_affected_candidates
-                .is_some_and(|producers| producers.binary_search_by_key(&step, |producer| producer.step).is_ok())
-                || row.facts.carries_dispatch_key(
-                    row.row,
-                    evaluation.automaton.compounds[evaluation.automaton.steps[step.0 as usize].compound.0 as usize]
-                        .dispatch_key,
-                    is_document_root,
-                )
-        });
         let local_output_deltas = if can_derive_delta && !local_facts_changed {
             old.zip(old_entering).map(|(old, old_entering)| {
                 self.emit_local_output_deltas(
@@ -2518,7 +2545,10 @@ impl PrefixStates {
                 return PrefixTransitionLookup::Missing(PrefixTransitionGap::Incomplete(incomplete));
             }
         };
-        let sparse = if !local_facts_changed && selection.is_some() {
+        if can_derive_delta {
+            counters.bump(Counter::PrefixTransitionDeltaAttempts);
+        }
+        let sparse = if !local_facts_changed && can_derive_delta {
             match (old, local_output_deltas) {
                 (Some(old), Some(local_output_deltas)) => self.try_sparse_retained_local_transition(
                     evaluation,
@@ -2538,6 +2568,9 @@ impl PrefixStates {
         } else {
             None
         };
+        if sparse.is_some() {
+            counters.bump(Counter::PrefixTransitionDeltaHits);
+        }
         let used_sparse_transition = sparse.is_some();
         let (new, use_admitted_new_truth) = if let Some(transition) = sparse {
             (transition, false)
@@ -2616,7 +2649,7 @@ impl PrefixStates {
             } else {
                 delta_arena.combine(entering_deltas.parent, local_output_deltas.unwrap().continuation)
             };
-            let changed = delta_arena.changes_selected_state(delta, selection.unwrap());
+            let changed = delta_arena.changes_selected_state(delta, selection);
             (changed, changed.then_some(delta))
         } else {
             (!self.selected_states_equal(old.state, new.state, selection), None)
@@ -2629,7 +2662,7 @@ impl PrefixStates {
             } else {
                 delta_arena.combine(entering_deltas.previous, local_output_deltas.unwrap().right)
             };
-            let changed = delta_arena.changes_selected_state(delta, selection.unwrap());
+            let changed = delta_arena.changes_selected_state(delta, selection);
             (changed, changed.then_some(delta))
         } else {
             (!self.selected_states_equal(old.right, new.right, selection), None)
@@ -4368,8 +4401,8 @@ mod tests {
             terminals: Box::new([]),
         };
 
-        assert!(!arena.changes_selected_state(delta, &cancelled_selection));
-        assert!(arena.changes_selected_state(delta, &changed_selection));
+        assert!(!arena.changes_selected_state(delta, Some(&cancelled_selection)));
+        assert!(arena.changes_selected_state(delta, Some(&changed_selection)));
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -895,6 +895,41 @@ fn step_hash(step: PrefixStepID) -> u64 {
     (u64::from(step.0) ^ 0x9E37_79B9_7F4A_7C15).wrapping_mul(0x2545_F491_4F6C_DD1D)
 }
 
+fn apply_sorted_step_delta(
+    source: &[PrefixStepID],
+    additions: &[PrefixStepID],
+    removals: &[PrefixStepID],
+    result: &mut Vec<PrefixStepID>,
+) {
+    result.clear();
+    result.reserve(source.len() + additions.len());
+    let mut source_index = 0;
+    let mut addition_index = 0;
+    let mut removal_index = 0;
+    while source_index < source.len() || addition_index < additions.len() {
+        let step = match (source.get(source_index), additions.get(addition_index)) {
+            (Some(&source), Some(&addition)) => source.min(addition),
+            (Some(&source), None) => source,
+            (None, Some(&addition)) => addition,
+            (None, None) => unreachable!(),
+        };
+        while source.get(source_index) == Some(&step) {
+            source_index += 1;
+        }
+        while additions.get(addition_index) == Some(&step) {
+            addition_index += 1;
+        }
+        while removals.get(removal_index).is_some_and(|&removal| removal < step) {
+            removal_index += 1;
+        }
+        if removals.get(removal_index) == Some(&step) {
+            removal_index += 1;
+        } else {
+            result.push(step);
+        }
+    }
+}
+
 /// Content identity of a prefix state. The two digests are fast lookup keys only; interning still
 /// compares the complete persisting and expiring sets on a hit.
 fn state_content_key(
@@ -1047,6 +1082,7 @@ pub(super) struct PrefixStates {
     local_fact_interner: LocalFactInterner,
     transition_by_row: Vec<PrefixTransition>,
     transition_by_element: Column<PrefixTransition>,
+    transition_fully_evaluated_by_element: Column<bool>,
     entering_by_element: Column<EnteringStates>,
     local_facts_by_element: Column<u32>,
     /// Per-element positional truth retained only for automata that test it.
@@ -1529,6 +1565,7 @@ impl PrefixStates {
             local_fact_interner: LocalFactInterner::new(),
             transition_by_row: vec![UNKNOWN_TRANSITION; row_count],
             transition_by_element: Column::new(|| UNKNOWN_TRANSITION),
+            transition_fully_evaluated_by_element: Column::default(),
             entering_by_element: Column::new(|| UNKNOWN_ENTERING_STATES),
             local_facts_by_element: Column::default(),
             positional_bits_by_element: Column::default(),
@@ -1811,6 +1848,24 @@ impl PrefixStates {
         self.transition_by_element.insert(index, transition);
     }
 
+    fn transition_is_fully_evaluated(&self, node: StyleNodeID) -> bool {
+        let Some(index) = node.element_index().map(|index| index as usize) else {
+            return false;
+        };
+        self.transition_fully_evaluated_by_element
+            .get(index)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    fn set_transition_fully_evaluated(&mut self, node: StyleNodeID, fully_evaluated: bool) {
+        let Some(index) = node.element_index().map(|index| index as usize) else {
+            return;
+        };
+        self.transition_fully_evaluated_by_element
+            .insert(index, fully_evaluated);
+    }
+
     fn set_entering(&mut self, node: StyleNodeID, entering: EnteringStates) {
         let Some(index) = node.element_index().map(|index| index as usize) else {
             return;
@@ -1863,6 +1918,9 @@ impl PrefixStates {
             return;
         };
         *transition = UNKNOWN_TRANSITION;
+        if let Some(fully_evaluated) = self.transition_fully_evaluated_by_element.get_mut(index) {
+            *fully_evaluated = false;
+        }
         if let Some(entering) = self.entering_by_element.get_mut(index) {
             *entering = UNKNOWN_ENTERING_STATES;
         }
@@ -2246,6 +2304,88 @@ impl PrefixStates {
         Some(state)
     }
 
+    fn apply_delta_to_unchanged_base_state(
+        &mut self,
+        source_state: u32,
+        base_state: u32,
+        delta: PrefixStateDeltaID,
+        arena: &PrefixDeltaArena,
+        downward: bool,
+        counters: &mut Counters,
+    ) -> u32 {
+        let mut additions = match downward {
+            true => std::mem::take(&mut self.new_descendant),
+            false => std::mem::take(&mut self.new_following),
+        };
+        let mut expiring = match downward {
+            true => std::mem::take(&mut self.new_child),
+            false => std::mem::take(&mut self.new_adjacent),
+        };
+        additions.clear();
+        expiring.clear();
+        let source_uses_base = source_state == base_state || self.states[source_state as usize].base == base_state;
+        let delta = arena.delta(delta);
+        let persisting_additions = arena.get(delta.persisting_additions);
+        let persisting_removals = arena.get(delta.persisting_removals);
+        if source_uses_base {
+            let source_additions = match source_state == base_state {
+                true => &[][..],
+                false => self.additions_in(source_state),
+            };
+            apply_sorted_step_delta(
+                source_additions,
+                persisting_additions,
+                persisting_removals,
+                &mut additions,
+            );
+        } else {
+            self.collect_persisting(source_state, &mut additions);
+            additions.retain(|&step| !self.persisting_state_contains_step(base_state, step));
+            if !persisting_removals.is_empty() {
+                additions.retain(|step| persisting_removals.binary_search(step).is_err());
+            }
+            additions.extend(
+                persisting_additions
+                    .iter()
+                    .copied()
+                    .filter(|&step| !self.persisting_state_contains_step(base_state, step)),
+            );
+            additions.sort_unstable();
+            additions.dedup();
+        }
+        apply_sorted_step_delta(
+            self.expiring_in(source_state),
+            arena.get(delta.expiring_additions),
+            arena.get(delta.expiring_removals),
+            &mut expiring,
+        );
+        let additions_hash = additions
+            .iter()
+            .fold(0_u64, |hash, &step| hash.wrapping_add(step_hash(step)));
+        let expiring_hash = expiring
+            .iter()
+            .fold(0_u32, |hash, &step| hash.wrapping_add(step_hash(step) as u32));
+        let state = self.intern_extended_state(
+            base_state,
+            &additions,
+            additions_hash,
+            &expiring,
+            expiring_hash,
+            counters,
+        );
+        match downward {
+            true => {
+                self.new_descendant = additions;
+                self.new_child = expiring;
+            }
+            false => {
+                self.new_following = additions;
+                self.new_adjacent = expiring;
+            }
+        }
+        state
+    }
+
     fn apply_local_match_delta(
         &mut self,
         old_result: PrefixResultID,
@@ -2282,11 +2422,16 @@ impl PrefixStates {
         local_facts: u32,
         positional_bits: u32,
         local_output_deltas: PrefixLocalOutputDeltas,
+        fully_evaluated_update: bool,
         delta_arena: &PrefixDeltaArena,
         counters: &mut Counters,
     ) -> Option<PrefixTransition> {
         let old_entering = self.entering_of(node)?;
-        if entering_deltas.parent.is_none() && entering_deltas.previous.is_none() {
+        let entering_unchanged = old_entering.parent == entering.parent && old_entering.previous == entering.previous;
+        if entering_deltas.parent.is_none()
+            && entering_deltas.previous.is_none()
+            && (!entering_unchanged || !self.transition_is_fully_evaluated(node))
+        {
             return None;
         }
         if self.local_facts_of(node) != Some(local_facts) {
@@ -2295,32 +2440,57 @@ impl PrefixStates {
         if local_output_deltas.result_changed && !local_output_deltas.result_delta_complete {
             return None;
         }
-        let (state, right) = if local_output_deltas.outputs_changed {
-            (
-                self.rebase_payload_with_local_delta(
-                    old.state,
-                    old_entering.parent,
-                    entering.parent,
-                    local_output_deltas.continuation,
-                    delta_arena,
-                    true,
-                    counters,
-                )?,
-                self.rebase_payload_with_local_delta(
-                    old.right,
-                    old_entering.previous,
-                    entering.previous,
-                    local_output_deltas.right,
-                    delta_arena,
-                    false,
-                    counters,
-                )?,
-            )
+        let (state, right) = if entering_deltas.parent.is_none() && entering_deltas.previous.is_none() {
+            if local_output_deltas.outputs_changed {
+                (
+                    self.apply_delta_to_unchanged_base_state(
+                        old.state,
+                        entering.parent,
+                        local_output_deltas.continuation,
+                        delta_arena,
+                        true,
+                        counters,
+                    ),
+                    self.apply_delta_to_unchanged_base_state(
+                        old.right,
+                        entering.previous,
+                        local_output_deltas.right,
+                        delta_arena,
+                        false,
+                        counters,
+                    ),
+                )
+            } else {
+                (old.state, old.right)
+            }
         } else {
-            (
-                self.rebase_unchanged_local_payload(old.state, old_entering.parent, entering.parent, counters)?,
-                self.rebase_unchanged_local_payload(old.right, old_entering.previous, entering.previous, counters)?,
-            )
+            if local_output_deltas.outputs_changed {
+                (
+                    self.rebase_payload_with_local_delta(
+                        old.state,
+                        old_entering.parent,
+                        entering.parent,
+                        local_output_deltas.continuation,
+                        delta_arena,
+                        true,
+                        counters,
+                    )?,
+                    self.rebase_payload_with_local_delta(
+                        old.right,
+                        old_entering.previous,
+                        entering.previous,
+                        local_output_deltas.right,
+                        delta_arena,
+                        false,
+                        counters,
+                    )?,
+                )
+            } else {
+                (
+                    self.rebase_unchanged_local_payload(old.state, old_entering.parent, entering.parent, counters)?,
+                    self.rebase_unchanged_local_payload(old.right, old_entering.previous, entering.previous, counters)?,
+                )
+            }
         };
         let result = match local_output_deltas.result_changed {
             true => self.apply_local_match_delta(old.result, local_output_deltas.matches, delta_arena, counters),
@@ -2345,6 +2515,7 @@ impl PrefixStates {
             self.transition_by_row[row.row as usize] = transition;
         }
         self.set_transition(node, transition);
+        self.set_transition_fully_evaluated(node, fully_evaluated_update);
         Some(transition)
     }
 
@@ -2560,6 +2731,7 @@ impl PrefixStates {
                     local_facts,
                     positional_bits,
                     local_output_deltas,
+                    selection.is_none(),
                     delta_arena,
                     counters,
                 ),
@@ -3532,6 +3704,7 @@ impl PrefixStates {
                 self.transitions,
                 self.transition_by_row,
                 self.transition_by_element,
+                self.transition_fully_evaluated_by_element,
                 self.entering_by_element,
                 self.local_facts_by_element,
                 self.positional_bits_by_element,
@@ -3683,6 +3856,7 @@ impl PrefixTransitionSurface<'_> {
                 // Retained coverage is ancestor-closed: a missing parent therefore proves that no
                 // descendant below it can hold a transition that this update would leave stale.
                 states.set_transition(node, transition);
+                states.set_transition_fully_evaluated(node, true);
             }
         }
     }
@@ -4229,6 +4403,7 @@ mod tests {
         );
         states.set_entering(node, EnteringStates { parent: 0, previous: 0 });
         states.set_positional_bits(node, 0b11);
+        states.set_transition_fully_evaluated(node, true);
         assert!(matches!(states.transition_of(node), PrefixTransitionLookup::Known(_)));
         states.forget_transition(node);
         assert_eq!(
@@ -4239,6 +4414,7 @@ mod tests {
             states.positional_bits_by_element[node.element_index().unwrap() as usize],
             0
         );
+        assert!(!states.transition_is_fully_evaluated(node));
         assert!(matches!(
             states.transition_of(node),
             PrefixTransitionLookup::Missing(PrefixTransitionGap::MissingTransition(gap)) if gap == node
@@ -4442,6 +4618,57 @@ mod tests {
         assert_eq!(states.states[rebased as usize].base, new_base);
         assert_eq!(states.additions_in(rebased), [retained_step, added_step]);
         assert_eq!(states.expiring_in(rebased), [added_expiring_step]);
+    }
+
+    #[test]
+    fn unchanged_base_delta_recovers_semantic_local_payload() {
+        let inherited_step = PrefixStepID(0);
+        let local_step = PrefixStepID(1);
+        let added_step = PrefixStepID(2);
+        let old_expiring_step = PrefixStepID(3);
+        let new_expiring_step = PrefixStepID(4);
+        let mut states = PrefixStates::new(0);
+        states.automaton_step_count = 5;
+        let mut counters = Counters::new();
+        let unrelated_base =
+            states.intern_extended_state(0, &[local_step], step_hash(local_step), &[], 0, &mut counters);
+        let canonical = states.intern_extended_state(
+            unrelated_base,
+            &[inherited_step],
+            step_hash(inherited_step),
+            &[old_expiring_step],
+            step_hash(old_expiring_step) as u32,
+            &mut counters,
+        );
+        let base = states.intern_extended_state(0, &[inherited_step], step_hash(inherited_step), &[], 0, &mut counters);
+        let source = states.intern_extended_state(
+            base,
+            &[local_step],
+            step_hash(local_step),
+            &[old_expiring_step],
+            step_hash(old_expiring_step) as u32,
+            &mut counters,
+        );
+        assert_eq!(source, canonical);
+        assert_ne!(states.states[source as usize].base, base);
+
+        let mut arena = PrefixDeltaArena::default();
+        arena.scratch[0].push(added_step);
+        arena.scratch[1].push(local_step);
+        arena.scratch[2].push(new_expiring_step);
+        arena.scratch[3].push(old_expiring_step);
+        let delta = arena.append_scratch_delta(0);
+        let updated = states.apply_delta_to_unchanged_base_state(source, base, delta, &arena, true, &mut counters);
+        let expected = states.intern_extended_state(
+            base,
+            &[added_step],
+            step_hash(added_step),
+            &[new_expiring_step],
+            step_hash(new_expiring_step) as u32,
+            &mut counters,
+        );
+
+        assert!(states.states_have_equal_contents(updated, expected));
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/record_replay.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/record_replay.rs
@@ -30,7 +30,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 const MAGIC: [u8; 8] = *b"SGREPLAY";
-const FORMAT_VERSION: u64 = 9;
+const FORMAT_VERSION: u64 = 10;
 const EVENT_HEADER_SIZE: usize = 3 * size_of::<u64>();
 const PAYLOAD_ALIGNMENT: usize = 8;
 

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2871,6 +2871,7 @@ impl StyleEngine {
                 }
                 let mut visited = Vec::new();
                 let mut changed_nodes = Vec::new();
+                let mut retained_prefix_matches = Vec::new();
                 let mut prefix_delta_arena = PrefixDeltaArena::default();
                 let old_evaluator = MatchEvaluator::new(&self.tree, resident_facts)
                     .with_transaction_fact_view(view, TransactionFactSide::Before);
@@ -2897,11 +2898,13 @@ impl StyleEngine {
                 let workspace_bytes = |pending_node_capacity: usize,
                                        visited_capacity: usize,
                                        changed_node_capacity: usize,
+                                       retained_prefix_match_capacity: usize,
                                        delta_capacity_bytes: u64| {
                     (pending_node_capacity * size_of::<PendingPrefixNode>()) as u64
                         + (local_fact_changes.capacity() * size_of::<StyleNodeID>()) as u64
                         + visited_capacity.div_ceil(8) as u64
                         + (changed_node_capacity * size_of::<StyleNodeID>()) as u64
+                        + (retained_prefix_match_capacity * size_of::<EntryID>()) as u64
                         + selection_bytes
                         + delta_capacity_bytes
                 };
@@ -2909,6 +2912,7 @@ impl StyleEngine {
                     pending_nodes.capacity(),
                     visited.capacity(),
                     changed_nodes.capacity(),
+                    retained_prefix_matches.capacity(),
                     prefix_delta_arena.capacity_bytes(),
                 );
                 self.memory
@@ -3001,19 +3005,34 @@ impl StyleEngine {
                         };
                         self.counters.bump(Counter::PrefixConvergenceNodes);
                         if difference.arrived {
-                            self.counters.bump(Counter::PrefixConvergenceUpqueries);
-                            // NB: An arrival has no old state to diff against, so the retained
-                            //     answer must be re-derived cold. An exact node region alone does
-                            //     not force that once attributed regions cover the node, so poison
-                            //     its patch explicitly.
+                            let mut needs_region = true;
                             if self.selector_truth_changes_active
-                                && !regions.is_covered_by_full_subtree(ImpactRegion::Node(node), &self.tree)
+                                && let Lookup::Known(retained) = self.retained_match_answer(node)
+                                && matches!(self.retained_match_answers.cascade_input_lookup(node), Lookup::Known(_))
                             {
-                                self.selector_truth_changes
-                                    .refreshes
-                                    .push(SelectorTruthRefresh { node, rule: None });
+                                retained_prefix_matches.clear();
+                                retained_prefix_matches.extend(retained.iter().filter_map(|matched| {
+                                    let entry = self.programs.entry_id(matched.program, matched.entry);
+                                    dispatch.prefixes().contains_entry(entry).then_some(entry)
+                                }));
+                                retained_prefix_matches.sort_unstable();
+                                retained_prefix_matches.dedup();
+                                let new_matches = states.matches_in(difference.new_matches);
+                                needs_region = retained_prefix_matches.as_slice() != new_matches;
+                                record_match_set_difference(
+                                    &mut self.selector_truth_changes,
+                                    true,
+                                    node,
+                                    &retained_prefix_matches,
+                                    new_matches,
+                                    &dispatch,
+                                );
+                            } else {
+                                self.counters.bump(Counter::PrefixConvergenceUpqueries);
                             }
-                            regions.add(ImpactRegion::Node(node), &mut self.counters);
+                            if needs_region {
+                                regions.add(ImpactRegion::Node(node), &mut self.counters);
+                            }
                         } else if difference.matches_changed {
                             changed_nodes.push((node, difference.old_matches, difference.new_matches));
                         }
@@ -3081,6 +3100,7 @@ impl StyleEngine {
                             pending_prefix_nodes.capacity(),
                             visited.capacity(),
                             changed_nodes.capacity(),
+                            retained_prefix_matches.capacity(),
                             prefix_delta_arena.capacity_bytes(),
                         );
                         if current_bytes > charged_bytes {

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2920,6 +2920,10 @@ impl StyleEngine {
                 let mut complete = true;
                 let mut prefix_completion_budget = PREFIX_TRANSITION_CACHE_COMPLETION_BUDGET;
                 let mut sibling_walk_abandoned = false;
+                // An arrival commonly creates transition keys this cache has never seen. Derive
+                // their exact signed changes from the retained states; departure-only edits tend
+                // to revisit memoized keys, where direct transition lookup is cheaper.
+                let derive_unselected_deltas = tree_relations_changed && departures.is_empty();
                 {
                     let states = match retained.lookup_mut(scope_program) {
                         Lookup::Known(states) => states,
@@ -2989,6 +2993,7 @@ impl StyleEngine {
                             &new_evaluation,
                             &old_evaluation,
                             difference_selection,
+                            derive_unselected_deltas,
                             node,
                             local_facts_changed,
                             local_prefix_candidates,

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -761,6 +761,55 @@ impl SelectorProgram {
             .any(|node| matches!(node, SelectorOp::RelativeExists(_)))
     }
 
+    /// Whether inserting or removing an unrelated element leaf can leave every resident element's
+    /// answer unchanged. The arriving element itself is outside this proof and must be matched in
+    /// full. Parent and ancestor constraints are stable because no resident ancestry changes;
+    /// sibling, positional, relational, scoped, and shadow-crossing constraints can observe the
+    /// leaf from another subject and therefore refuse the proof.
+    #[must_use]
+    pub(super) fn resident_answers_are_stable_under_leaf_changes(&self) -> bool {
+        (0..self.entries.len()).all(|entry| self.entry_resident_answer_is_stable_under_leaf_changes(entry))
+    }
+
+    #[must_use]
+    pub(super) fn entry_resident_answer_is_stable_under_leaf_changes(&self, entry: usize) -> bool {
+        self.node_is_resident_stable_under_leaf_changes(self.entries[entry].root)
+    }
+
+    fn node_is_resident_stable_under_leaf_changes(&self, id: SelectorNodeID) -> bool {
+        match self.node(id) {
+            SelectorOp::And { first, count } | SelectorOp::Or { first, count } => self
+                .operands(first, count)
+                .iter()
+                .all(|&operand| self.node_is_resident_stable_under_leaf_changes(operand)),
+            SelectorOp::Where(inner)
+            | SelectorOp::Not(inner)
+            | SelectorOp::Parent(inner)
+            | SelectorOp::Ancestor(inner) => self.node_is_resident_stable_under_leaf_changes(inner),
+            SelectorOp::Feature(_)
+            | SelectorOp::State(_)
+            | SelectorOp::Root
+            | SelectorOp::IsNode(_)
+            | SelectorOp::ValueState { .. }
+            | SelectorOp::Language { .. }
+            | SelectorOp::Heading(_) => true,
+            SelectorOp::PreviousSibling(_)
+            | SelectorOp::PrecedingSibling(_)
+            | SelectorOp::NthPosition(_)
+            | SelectorOp::RelativeExists(_)
+            | SelectorOp::Host(_)
+            | SelectorOp::Slotted(_)
+            | SelectorOp::Part(_)
+            | SelectorOp::ExposedToHost { .. }
+            | SelectorOp::Empty
+            | SelectorOp::Scope
+            | SelectorOp::AssignedSlot(_)
+            | SelectorOp::ScopeRootInstance
+            | SelectorOp::RelativeAnchorInstance
+            | SelectorOp::InScope { .. } => false,
+        }
+    }
+
     /// Whether any node in this subtree tests sibling position. A retained witness for a
     /// query containing one can go stale from a sibling mutation that never touches the
     /// witness itself, so such witnesses cannot prove an anchor unchanged.

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -1306,13 +1306,7 @@ impl SelectorProgram {
             SelectorOp::Where(inner) => {
                 return self.visit_canonical_prefix_operand(inner, visit_feature, visit_structural_test);
             }
-            // Only step-free an+b tests are canonical: their truth flips at a bounded number
-            // of positions per mutation, so the convergence walk maintains them cheaply. A
-            // step-bearing test flips truth across a whole moved side at once, which
-            // fragments transition states per index and displaces retained answers out of
-            // Tier 3; it stays with the sequence router's moved-position narrowing until
-            // transitions are flat-priced.
-            SelectorOp::NthPosition(nth) if nth.of_selector.is_none() && nth.step == 0 => {
+            SelectorOp::NthPosition(nth) if nth.of_selector.is_none() => {
                 visit_structural_test(PrefixStructuralTest::Nth(nth));
                 return Some(());
             }

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4836,6 +4836,90 @@ fn selective_matching_completes_a_bounded_prefix_transition_window() {
 }
 
 #[test]
+fn positional_matching_completes_the_prefix_transition_cache() {
+    let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+    let mut raw = vec![0_u32; 2 * PREFIX_TRANSITION_CACHE_COMPLETION_BUDGET + 4];
+    engine.allocate_style_nodes(&mut raw);
+    let nodes: Vec<StyleNodeID> = raw.iter().map(|&raw| StyleNodeID::from_raw(raw).unwrap()).collect();
+    engine.record_tree_delta(nodes[0], None, Some(relations(None, None, None)));
+    for index in 1..nodes.len() {
+        engine.record_tree_delta(
+            nodes[index],
+            None,
+            Some(relations(
+                Some(nodes[0].raw()),
+                (index > 1).then(|| nodes[index - 1].raw()),
+                None,
+            )),
+        );
+        set_atom_feature(&mut engine, nodes[index], LocalFeatureKey::TagName, StyleAtomID(100));
+        add_feature(&mut engine, nodes[index], LocalFeatureKey::Class(StyleAtomID(200)));
+    }
+    add_nth_target_rule(&mut engine, StyleAtomID(200), 2, 1);
+    discard_transaction(&mut engine);
+
+    assert!(engine.begin_cold_matching_batch(nodes[0]));
+    assert_eq!(engine.match_element(nodes[1]).unwrap().len(), 1);
+    engine.end_cold_matching_batch();
+
+    let (scope_program, dispatch) = engine.ranked_scope_program(TreeScopeID::DOCUMENT);
+    assert_eq!(dispatch.prefixes().positional_tests().len(), 1);
+    let caches = engine.prefix_caches.borrow();
+    let states = match caches.states.lookup(scope_program) {
+        Lookup::Known(states) => states,
+        Lookup::KnownAbsent | Lookup::Missing(_) => panic!("expected retained prefix states"),
+    };
+    assert!(
+        nodes.iter().all(|&node| states.has_transition(node)),
+        "a periodic positional automaton needs the old truth of every sibling"
+    );
+}
+
+#[test]
+fn a_prefix_arrival_diffs_against_the_retained_match_answer() {
+    let (mut engine, nodes) = linear_document();
+    let target = StyleAtomID(200);
+    add_nth_target_rule(&mut engine, target, 2, 1);
+    for &node in &nodes {
+        set_atom_feature(&mut engine, node, LocalFeatureKey::TagName, StyleAtomID(100));
+    }
+    for &node in &nodes[1..] {
+        add_feature(&mut engine, node, LocalFeatureKey::Class(target));
+    }
+    discard_transaction(&mut engine);
+
+    assert!(engine.begin_cold_matching_batch(nodes[0]));
+    for &node in &nodes[1..] {
+        let _ = engine.match_element(node).unwrap();
+    }
+    engine.end_cold_matching_batch();
+
+    let (scope_program, _) = engine.ranked_scope_program(TreeScopeID::DOCUMENT);
+    engine
+        .prefix_caches
+        .borrow_mut()
+        .states
+        .forget_transition(scope_program, nodes[3]);
+    remove_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+
+    let upqueries_before = engine.counters().get(Counter::PrefixConvergenceUpqueries);
+    let poisoned_before = engine.counters().get(Counter::RetainedPatchesPoisoned);
+    let signed_before = engine.counters().get(Counter::PlannedNodesWithSignedDelta);
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction_nodes(nodes[0], |nodes| planned.extend_from_slice(nodes)));
+    assert_eq!(planned, vec![nodes[3].raw()]);
+    assert_eq!(
+        engine.counters().get(Counter::PrefixConvergenceUpqueries),
+        upqueries_before
+    );
+    assert_eq!(engine.counters().get(Counter::RetainedPatchesPoisoned), poisoned_before);
+    assert_eq!(
+        engine.counters().get(Counter::PlannedNodesWithSignedDelta) - signed_before,
+        1
+    );
+}
+
+#[test]
 fn a_prefix_upquery_retains_every_transition_on_its_ancestor_chain() {
     let (mut engine, nodes) = nested_document();
     let guard = StyleAtomID(200);
@@ -5802,8 +5886,8 @@ fn positional_answers_stay_cold_equivalent_across_sequence_mutations() {
     let (_, dispatch) = engine.ranked_scope_program(TreeScopeID::DOCUMENT);
     assert_eq!(
         dispatch.prefixes().positional_tests().len(),
-        4,
-        "the step-free structural tests are admitted while the step-bearing rules stay routed"
+        6,
+        "plain step-bearing and step-free structural tests are admitted"
     );
 
     // A trailing arrival: the previously last child keeps its facts but loses

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -16,6 +16,7 @@ use super::transaction::InputKind;
 use super::tree::PseudoElementKind;
 use super::tree::PseudoElementTarget;
 use super::*;
+use crate::css::property_metadata::property_id;
 
 #[test]
 fn dense_program_staging_freezes_before_until_release() {
@@ -40,6 +41,39 @@ fn dense_program_staging_freezes_before_until_release() {
     assert_eq!(staged.current(rule, || 50), 50);
     assert_eq!(staged.rows.capacity(), 0);
     assert_eq!(staged.touched.capacity(), 0);
+}
+
+#[test]
+fn pending_paint_only_local_inputs_preserve_layout_geometry() {
+    for property in [property_id::BACKGROUND_COLOR, property_id::COLOR] {
+        let (mut engine, nodes) = linear_document();
+        let paint_only = StyleAtomID(200);
+        let rule = add_target_rule(&mut engine, StyleSheetObjectID(1), paint_only);
+        engine.set_rule_declared_properties(rule, &[(property, false)], true);
+        discard_transaction(&mut engine);
+
+        add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(paint_only));
+        assert!(!engine.pending_transaction_may_affect_layout_geometry());
+        assert!(engine.has_pending_transaction());
+    }
+}
+
+#[test]
+fn pending_layout_and_incomplete_local_inputs_may_change_geometry() {
+    for (property, declarations_are_complete) in [
+        (property_id::WIDTH, true),
+        (property_id::TRANSFORM, true),
+        (property_id::BACKGROUND_COLOR, false),
+    ] {
+        let (mut engine, nodes) = linear_document();
+        let target = StyleAtomID(200);
+        let rule = add_target_rule(&mut engine, StyleSheetObjectID(1), target);
+        engine.set_rule_declared_properties(rule, &[(property, false)], declarations_are_complete);
+        discard_transaction(&mut engine);
+
+        add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(target));
+        assert!(engine.pending_transaction_may_affect_layout_geometry());
+    }
 }
 
 fn test_nth_position(argument: &str, of_type: bool) -> selector::NthPosition {

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -5892,6 +5892,7 @@ fn positional_answers_stay_cold_equivalent_across_sequence_mutations() {
 
     // A trailing arrival: the previously last child keeps its facts but loses
     // `:last-child`, and the previous `:nth-last-child(2)` holder loses that too.
+    let delta_hits_before = engine.counters().get(Counter::PrefixTransitionDeltaHits);
     let trailing = nodes[8];
     let old_last = *model.last().unwrap();
     model.push(trailing);
@@ -5902,6 +5903,10 @@ fn positional_answers_stay_cold_equivalent_across_sequence_mutations() {
     );
     record_facts(&mut engine, trailing, class_item);
     flush_and_check(&mut engine, &model, "a trailing arrival");
+    assert!(
+        engine.counters().get(Counter::PrefixTransitionDeltaHits) > delta_hits_before,
+        "an arrival derives retained transition deltas for stationary siblings"
+    );
 
     // A middle removal: forward parity flips for every following sibling.
     let removed_index = 2;

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -271,6 +271,26 @@ fn test_selector_parser_builds_class_descendant_selectors() {
     assert!(parsed == builder.finish());
 }
 
+#[test]
+fn selector_leaf_stability_distinguishes_ancestry_from_sibling_position() {
+    let guard = StyleAtomID(1);
+    let target = StyleAtomID(2);
+    let stable_atoms = [("guard", guard), ("target", target)];
+
+    for selector in [".guard .target", ".guard > .target"] {
+        assert!(
+            test_selector_program(selector, &stable_atoms).resident_answers_are_stable_under_leaf_changes(),
+            "{selector} cannot observe an unrelated leaf through a resident subject"
+        );
+    }
+    for selector in [".guard + .target", ".guard ~ .target", ".target:nth-child(2n+1)"] {
+        assert!(
+            !test_selector_program(selector, &stable_atoms).resident_answers_are_stable_under_leaf_changes(),
+            "{selector} can observe an unrelated leaf through a resident subject"
+        );
+    }
+}
+
 fn prepare_empty_transaction_fact_view(engine: &mut StyleEngine, root: StyleNodeID) {
     let mut transaction = engine.take_transaction();
     assert!(transaction.is_empty(), "test setup left a transaction pending");
@@ -8795,7 +8815,7 @@ fn replay_ffi_reclaims_the_non_empty_recorded_atom_set() {
         bridge::style_engine_set_replay_reclaimed_style_atoms(engine_pointer, recorded.as_ptr(), recorded.len());
     }
 
-    let output = unsafe { bridge::style_engine_take_style_transaction(engine_pointer, nodes[0].raw()) };
+    let output = unsafe { bridge::style_engine_take_style_transaction(engine_pointer, nodes[0].raw(), false) };
 
     assert!(output.style_atoms_swept);
     assert_eq!(output.reclaimed_style_atom_count, 1);

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -469,6 +469,13 @@ impl NormalizationJournal {
         &self.markers
     }
 
+    /// The normalized view of the fine-grained inputs which are still pending.
+    pub(super) fn inputs(&self) -> impl Iterator<Item = NormalizedInput> + '_ {
+        self.entries
+            .iter()
+            .map(|(&key, &(old, new))| NormalizedInput { key, old, new })
+    }
+
     #[must_use]
     pub fn contains_only_element_style_inputs(&self) -> bool {
         self.markers.is_empty()

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
@@ -1,0 +1,9 @@
+paint-only geometry: 100
+paint-only offset width: 100
+paint-only client height: 10
+paint-only style deferred: true
+deferred style is observable: rgb(255, 0, 0)
+layout offset size: 200x20
+layout style settled: true
+transformed geometry: 18
+visual geometry style settled: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-resident-leaf-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-resident-leaf-effects.txt
@@ -1,0 +1,5 @@
+arriving leaf geometry: 37
+first resident geometry settled: 44
+second resident geometry settled: 37
+first resident style settled: true
+second resident style settled: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-styles-only-arriving-leaf.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-styles-only-arriving-leaf.txt
@@ -1,0 +1,7 @@
+arriving leaf geometry: 37
+only arriving leaf invalidated: true
+first resident style deferred: true
+second resident style deferred: true
+deferred first style is observable: rgb(255, 0, 0)
+deferred second style is observable: rgb(0, 0, 255)
+deferred resident class style is observable: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/style-engine/converging-style-input-shares-style.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/converging-style-input-shares-style.html
@@ -21,12 +21,12 @@
 <script>
     test(() => {
         const items = document.querySelectorAll("span");
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         internals.resetStyleInvalidationCounters();
         for (const item of items)
             item.className = "new";
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         const counters = internals.getStyleInvalidationCounters();
         println(`shared converging style: ${counters.elementStyleSharedComputations >= 1}`);

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 10px;
+    }
+    #target.paint-only {
+        color: green;
+        background-color: red;
+    }
+    #target.layout {
+        width: 200px;
+        height: 20px;
+    }
+    #target.transformed {
+        transform: translateX(10px);
+    }
+</style>
+<div id="target"></div>
+<script>
+    test(() => {
+        target.getBoundingClientRect();
+
+        internals.resetStyleInvalidationCounters();
+        target.className = "paint-only";
+        const paintOnlyRect = target.getBoundingClientRect();
+        const paintOnlyOffsetWidth = target.offsetWidth;
+        const paintOnlyClientHeight = target.clientHeight;
+        let counters = internals.getStyleInvalidationCounters();
+        println(`paint-only geometry: ${paintOnlyRect.width}`);
+        println(`paint-only offset width: ${paintOnlyOffsetWidth}`);
+        println(`paint-only client height: ${paintOnlyClientHeight}`);
+        println(`paint-only style deferred: ${counters.styleStabilizationEpochs === 0}`);
+        println(`deferred style is observable: ${getComputedStyle(target).backgroundColor}`);
+
+        target.className = "";
+        target.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        target.className = "layout";
+        const layoutOffsetWidth = target.offsetWidth;
+        const layoutOffsetHeight = target.offsetHeight;
+        counters = internals.getStyleInvalidationCounters();
+        println(`layout offset size: ${layoutOffsetWidth}x${layoutOffsetHeight}`);
+        println(`layout style settled: ${counters.styleStabilizationEpochs === 1}`);
+
+        target.className = "";
+        target.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        target.className = "transformed";
+        const transformedRect = target.getBoundingClientRect();
+        counters = internals.getStyleInvalidationCounters();
+        println(`transformed geometry: ${transformedRect.x}`);
+        println(`visual geometry style settled: ${counters.styleStabilizationEpochs === 1}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-resident-leaf-effects.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-resident-leaf-effects.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .item {
+        width: 37px;
+        height: 10px;
+    }
+    .item:nth-child(even) {
+        width: 44px;
+    }
+</style>
+<div id="container"><div class="item" id="first"></div><div class="item" id="second"></div></div>
+<script>
+    test(() => {
+        container.getBoundingClientRect();
+        const firstIdentity = internals.styleRecordIdentity(first);
+        const secondIdentity = internals.styleRecordIdentity(second);
+
+        const arriving = document.createElement("div");
+        arriving.className = "item";
+        container.prepend(arriving);
+
+        println(`arriving leaf geometry: ${arriving.offsetWidth}`);
+        println(`first resident geometry settled: ${first.offsetWidth}`);
+        println(`second resident geometry settled: ${second.offsetWidth}`);
+        println(`first resident style settled: ${internals.styleRecordIdentity(first) !== firstIdentity}`);
+        println(`second resident style settled: ${internals.styleRecordIdentity(second) !== secondIdentity}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-styles-only-arriving-leaf.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-styles-only-arriving-leaf.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .item {
+        width: 37px;
+        height: 10px;
+    }
+    .item:nth-child(even) {
+        background-color: red;
+    }
+    .item.pending-paint {
+        color: green;
+    }
+    .item[data-paint] {
+        background-color: blue;
+    }
+</style>
+<div id="container"><div class="item" id="first"></div><div class="item" id="second"></div></div>
+<script>
+    test(() => {
+        container.getBoundingClientRect();
+        const firstIdentity = internals.styleRecordIdentity(first);
+        const secondIdentity = internals.styleRecordIdentity(second);
+
+        first.classList.add("pending-paint");
+        second.setAttribute("data-paint", "");
+
+        const arriving = document.createElement("div");
+        arriving.className = "item";
+        container.prepend(arriving);
+
+        const beforeGeometry = internals.styleEngineCounters();
+        const width = arriving.offsetWidth;
+        const afterGeometry = internals.styleEngineCounters();
+
+        println(`arriving leaf geometry: ${width}`);
+        println(`only arriving leaf invalidated: ${afterGeometry.invalidatedStyleNodes - beforeGeometry.invalidatedStyleNodes === 1}`);
+        println(`first resident style deferred: ${internals.styleRecordIdentity(first) === firstIdentity}`);
+        println(`second resident style deferred: ${internals.styleRecordIdentity(second) === secondIdentity}`);
+        println(`deferred first style is observable: ${getComputedStyle(first).backgroundColor}`);
+        println(`deferred second style is observable: ${getComputedStyle(second).backgroundColor}`);
+        println(`deferred resident class style is observable: ${getComputedStyle(first).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
@@ -12,7 +12,7 @@
             document.body.appendChild(makeElement("a", { attributes: { href: `https://example.com/page${i}` } }));
         }
         document.body.appendChild(makeElement("a", { id: "same-doc", attributes: { href: "#target" } }));
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         const printCounters = label => {
             const counters = internals.getStyleInvalidationCounters();
@@ -22,17 +22,17 @@
         // Without any :local-link rule, a URL change should produce no invalidation work at all.
         resetStyleCounters();
         history.pushState({}, "", "#initial");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters("no :local-link rule");
 
         const documentStyle = addStyle(document.head, `a:local-link { color: rgb(0, 128, 0); }`);
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         // With a :local-link rule, navigating to the targeted fragment must restyle only the matching anchor, the
         // other 50 anchors and the rest of the document are untouched.
         resetStyleCounters();
         history.pushState({}, "", "#target");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters(":local-link rule, anchor flips");
 
         // A :local-link rule that lives only inside a shadow root must still trigger invalidation for shadow
@@ -43,11 +43,11 @@
         const shadowRoot = host.attachShadow({ mode: "open" });
         addStyle(shadowRoot, `a:local-link { color: rgb(0, 0, 128); }`);
         shadowRoot.appendChild(makeElement("a", { id: "shadow-anchor", attributes: { href: "#shadow-target" } }));
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         resetStyleCounters();
         history.pushState({}, "", "#shadow-target");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters("shadow-only :local-link rule, shadow anchor flips");
     });
 </script>


### PR DESCRIPTION
StyleBench spends much of its time repeatedly deriving selector and style
answers that are either already known or irrelevant to a synchronous
geometry observation. This series removes those work classes while keeping
the conservative fallbacks explicit.

- Admit periodic positional selectors to prefix convergence and replay exact
  signed transition deltas from retained answers.
- Repair Performance mark dispatch and style-replay validation so captured
  StyleBench transactions remain useful exact oracles.
- Generate conservative property geometry metadata and defer paint-only
  selector inputs across client rectangle, client dimension, and offset
  dimension reads.
- Split safe leaf-only transactions at geometry observations, preserve
  resident geometry style, and match only geometry-affecting rules for new
  leaves. Positional, sibling, relational, shadow-crossing, incomplete, and
  geometry-affecting cases retain the full transaction path.

On the same machine, the official one-iteration StyleBench score rises from
about 77 to 104-105, roughly a 36% improvement. A direct dirty sibling leaf
insertion sequence falls from about 1,225,667 us of style work to about
12,000 us because it no longer cold-matches 20,000 resident elements.

Regression coverage exercises positional convergence, exact replay,
paint-only local inputs, accumulated class and attribute changes around leaf
insertions, arriving-leaf geometry, and conservative positional geometry
fallbacks.