### PR TITLE
LibCore+LibWebView: Preserve Mach task ports for child processes

### DIFF
--- a/Libraries/LibCore/Platform/ProcessInfo.h
+++ b/Libraries/LibCore/Platform/ProcessInfo.h
@@ -20,6 +20,14 @@ struct ProcessInfo {
     {
     }
 
+    void reset_cpu_time()
+    {
+        cpu_percent = 0.0f;
+#if defined(AK_OS_MACH)
+        has_cpu_time_baseline = false;
+#endif
+    }
+
     pid_t pid { 0 };
 
     u64 memory_usage_bytes { 0 };
@@ -29,6 +37,7 @@ struct ProcessInfo {
 
 #if defined(AK_OS_MACH)
     Core::MachPort child_task_port;
+    bool has_cpu_time_baseline { false };
 #endif
 };
 

--- a/Libraries/LibCore/Platform/ProcessStatisticsMach.cpp
+++ b/Libraries/LibCore/Platform/ProcessStatisticsMach.cpp
@@ -17,6 +17,13 @@ namespace Core::Platform {
 
 static auto user_hz = sysconf(_SC_CLK_TCK);
 
+static constexpr bool task_is_unavailable(kern_return_t result)
+{
+    // A dead task port fails in the MIG client. If task termination races the request, task_info() instead sees an
+    // inactive task and returns KERN_INVALID_ARGUMENT.
+    return result == MACH_SEND_INVALID_DEST || result == KERN_INVALID_ARGUMENT;
+}
+
 ErrorOr<void> update_process_statistics(ProcessStatistics& statistics)
 {
     host_cpu_load_info_data_t cpu_info {};
@@ -39,10 +46,22 @@ ErrorOr<void> update_process_statistics(ProcessStatistics& statistics)
     statistics.total_time_scheduled = total_cpu_ticks;
 
     for (auto& process : statistics.processes) {
+        // A newly spawned process may be added to the process manager before its task port is delivered to the browser
+        // event loop. Skip it for this sample; the port will be available on the next update.
+        if (!MACH_PORT_VALID(process->child_task_port.port())) {
+            process->reset_cpu_time();
+            continue;
+        }
+
         mach_task_basic_info_data_t basic_info {};
         count = MACH_TASK_BASIC_INFO_COUNT;
         res = task_info(process->child_task_port.port(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&basic_info), &count);
         if (res != KERN_SUCCESS) {
+            if (task_is_unavailable(res)) {
+                process->reset_cpu_time();
+                continue;
+            }
+
             dbgln("Failed to get task info for pid {}: {}", process->pid, mach_error_string(res));
             return Core::mach_error_to_error(res);
         }
@@ -53,6 +72,11 @@ ErrorOr<void> update_process_statistics(ProcessStatistics& statistics)
         count = TASK_THREAD_TIMES_INFO_COUNT;
         res = task_info(process->child_task_port.port(), TASK_THREAD_TIMES_INFO, reinterpret_cast<task_info_t>(&time_info), &count);
         if (res != KERN_SUCCESS) {
+            if (task_is_unavailable(res)) {
+                process->reset_cpu_time();
+                continue;
+            }
+
             dbgln("Failed to get thread times info for pid {}: {}", process->pid, mach_error_string(res));
             return Core::mach_error_to_error(res);
         }
@@ -66,8 +90,9 @@ ErrorOr<void> update_process_statistics(ProcessStatistics& statistics)
         process->time_spent_in_process = time_in_process.to_microseconds();
 
         process->cpu_percent = 0.0f;
-        if (time_diff_process > AK::Duration::zero())
+        if (process->has_cpu_time_baseline && time_diff_process > AK::Duration::zero())
             process->cpu_percent = 100.0f * static_cast<float>(time_diff_process.to_microseconds()) / total_cpu_micro_diff;
+        process->has_cpu_time_baseline = true;
     }
 
     return {};

--- a/Libraries/LibCore/Platform/ProcessStatisticsMach.cpp
+++ b/Libraries/LibCore/Platform/ProcessStatisticsMach.cpp
@@ -90,7 +90,7 @@ ErrorOr<void> update_process_statistics(ProcessStatistics& statistics)
         process->time_spent_in_process = time_in_process.to_microseconds();
 
         process->cpu_percent = 0.0f;
-        if (process->has_cpu_time_baseline && time_diff_process > AK::Duration::zero())
+        if (process->has_cpu_time_baseline && time_diff_process > AK::Duration::zero() && total_cpu_micro_diff > 0.0f)
             process->cpu_percent = 100.0f * static_cast<float>(time_diff_process.to_microseconds()) / total_cpu_micro_diff;
         process->has_cpu_time_baseline = true;
     }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -488,10 +488,15 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     set_mach_server_name(m_mach_port_server->server_port_name());
 
     m_mach_port_server->on_bootstrap_request = [this](IPC::MachBootstrapListener::BootstrapRequest request) {
-        set_process_mach_port(request.pid, move(request.task_port));
         auto result = MUST(m_transport_bootstrap_server.handle_bootstrap_request(request.pid, move(request.reply_port)));
         result.visit(
-            [](IPC::TransportBootstrapMachServer::ChildTransportHandled) {
+            [this, pid = request.pid, task_port = move(request.task_port)](IPC::TransportBootstrapMachServer::ChildTransportHandled) mutable {
+                // The child sends its task port before Process::spawn() returns, so it cannot be added to the process
+                // manager yet. Install the port once control returns to the browser event loop.
+                VERIFY(m_event_loop);
+                m_event_loop->deferred_invoke([this, pid, task_port = move(task_port)]() mutable {
+                    set_process_mach_port(pid, move(task_port));
+                });
             },
             [this](IPC::TransportBootstrapMachServer::OnDemandTransport& transport) {
                 if (!m_on_browser_process_transport)


### PR DESCRIPTION
`about:processes` was failing to retrieve statistics for child processes on macOS with the error:
```
Failed to get task info for pid 7227: (ipc/send) invalid destination port
```