### PR TITLE
AK+LibWeb: Mixed bag of optimizations for WebKit performance tests

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -666,8 +666,12 @@ struct SentinelOptionalTraits;
 
 template<typename T, typename Traits = SentinelOptionalTraits<T>>
 class SentinelOptional : public OptionalBase<T> {
+    AK_MAKE_DEFAULT_MOVABLE(SentinelOptional);
+    AK_MAKE_DEFAULT_COPYABLE(SentinelOptional);
+
 public:
     SentinelOptional() = default;
+    ALWAYS_INLINE constexpr ~SentinelOptional() = default;
 
     template<SameAs<OptionalNone> V>
     constexpr SentinelOptional(V) { }

--- a/AK/Utf16FlyString.h
+++ b/AK/Utf16FlyString.h
@@ -19,6 +19,7 @@ class [[nodiscard]] Utf16FlyString {
 
 public:
     constexpr Utf16FlyString() = default;
+    ALWAYS_INLINE ~Utf16FlyString() = default;
 
     static Utf16FlyString from_utf8(StringView);
     static Utf16FlyString from_utf8(String const& string) { return from_utf8_without_validation(string); }

--- a/AK/Utf16FlyString.h
+++ b/AK/Utf16FlyString.h
@@ -243,8 +243,12 @@ struct SentinelOptionalTraits<Utf16FlyString> {
 
 template<>
 class Optional<Utf16FlyString> : public SentinelOptional<Utf16FlyString> {
+    AK_MAKE_DEFAULT_MOVABLE(Optional);
+    AK_MAKE_DEFAULT_COPYABLE(Optional);
+
 public:
     using SentinelOptional::SentinelOptional;
+    ALWAYS_INLINE ~Optional() = default;
 };
 
 template<>

--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -28,8 +28,12 @@ namespace AK {
 // The data may or may not be heap-allocated, and may or may not be reference counted. As a memory optimization, if the
 // UTF-16 string is entirely ASCII, the string is stored as 8-bit bytes.
 class [[nodiscard]] Utf16String : public Detail::Utf16StringBase {
+    AK_MAKE_DEFAULT_COPYABLE(Utf16String);
+    AK_MAKE_DEFAULT_MOVABLE(Utf16String);
+
 public:
     using Utf16StringBase::Utf16StringBase;
+    ALWAYS_INLINE ~Utf16String() = default;
 
     explicit constexpr Utf16String(Utf16StringBase&& base)
         : Utf16StringBase(move(base))

--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -47,7 +47,7 @@ public:
         other.m_value = { .short_ascii_string = ShortString::create_empty() };
     }
 
-    constexpr ~Utf16StringBase()
+    ALWAYS_INLINE constexpr ~Utf16StringBase()
     {
         if !consteval {
             destroy_string();

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -77,6 +77,12 @@ static auto& main_thread_vm_ptr()
     return *vm;
 }
 
+static HTML::SimilarOriginWindowAgent*& main_thread_similar_origin_window_agent_ptr()
+{
+    static HTML::SimilarOriginWindowAgent* agent;
+    return agent;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#active-script
 HTML::Script* active_script()
 {
@@ -97,11 +103,14 @@ HTML::Script* active_script()
         });
 }
 
-static NonnullOwnPtr<JS::Agent> create_agent(GC::Heap& heap, HTML::AgentType type)
+static NonnullOwnPtr<HTML::Agent> create_agent(GC::Heap& heap, HTML::AgentType type)
 {
     switch (type) {
-    case HTML::AgentType::SimilarOriginWindow:
-        return HTML::SimilarOriginWindowAgent::create(heap);
+    case HTML::AgentType::SimilarOriginWindow: {
+        auto agent = HTML::SimilarOriginWindowAgent::create(heap);
+        main_thread_similar_origin_window_agent_ptr() = agent.ptr();
+        return agent;
+    }
     case HTML::AgentType::DedicatedWorker:
     case HTML::AgentType::SharedWorker:
         return HTML::WorkerAgent::create(heap, JS::Agent::CanBlock::Yes);
@@ -111,6 +120,12 @@ static NonnullOwnPtr<JS::Agent> create_agent(GC::Heap& heap, HTML::AgentType typ
         break;
     }
     VERIFY_NOT_REACHED();
+}
+
+HTML::SimilarOriginWindowAgent& main_thread_similar_origin_window_agent()
+{
+    VERIFY(main_thread_similar_origin_window_agent_ptr());
+    return *main_thread_similar_origin_window_agent_ptr();
 }
 
 void initialize_main_thread_vm(HTML::AgentType type)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3697,7 +3697,7 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Document::import_node(GC::Ref<Node> node, Imp
 
     // 5. If registry is null, then set registry to the result of looking up a custom element registry given this.
     if (!registry)
-        registry = HTML::look_up_a_custom_element_registry(*this);
+        registry = custom_element_registry();
 
     // 6. Return the result of cloning a node given node with document set to this, subtree set to subtree, and
     //   fallbackRegistry set to registry.
@@ -9311,7 +9311,7 @@ void Document::run_csp_initialization() const
 WebIDL::ExceptionOr<Document::RegistryAndIs> Document::flatten_element_creation_options(ElementCreationOptions const& options) const
 {
     // 1. Let registry be the result of looking up a custom element registry given document.
-    GC::Ptr<HTML::CustomElementRegistry> registry = HTML::look_up_a_custom_element_registry(*this);
+    GC::Ptr<HTML::CustomElementRegistry> registry = custom_element_registry();
 
     // 2. Let is be null.
     Optional<Utf16FlyString> is;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3440,11 +3440,11 @@ HTML::EnvironmentSettingsObject& Document::relevant_settings_object() const
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createelement
-WebIDL::ExceptionOr<GC::Ref<Element>> Document::create_element(Utf16String const& local_name, ElementCreationOptions const& options)
+WebIDL::ExceptionOr<GC::Ref<Element>> Document::create_element(Utf16FlyString const& local_name, ElementCreationOptions const& options)
 {
     auto normalized_local_name = local_name;
     // 1. If localName is not a valid element local name, then throw an "InvalidCharacterError" DOMException.
-    if (!is_valid_element_local_name(local_name.utf16_view()))
+    if (!is_valid_element_local_name(local_name.view()))
         return WebIDL::InvalidCharacterError::create("Invalid character in tag name."_utf16);
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
@@ -3461,10 +3461,10 @@ WebIDL::ExceptionOr<GC::Ref<Element>> Document::create_element(Utf16String const
         namespace_ = Namespace::HTML;
 
     // 5. Return the result of creating an element given this, localName, namespace, null, is, true, and registry.
-    return TRY(DOM::create_element(*this, Utf16FlyString::from_utf16(normalized_local_name.utf16_view()), move(namespace_), {}, move(is_value), true, registry));
+    return TRY(DOM::create_element(*this, move(normalized_local_name), move(namespace_), {}, move(is_value), true, registry));
 }
 
-WebIDL::ExceptionOr<GC::Ref<Element>> Document::create_element(Utf16String const& local_name, Variant<Utf16String, ElementCreationOptions> const& options)
+WebIDL::ExceptionOr<GC::Ref<Element>> Document::create_element(Utf16FlyString const& local_name, Variant<Utf16String, ElementCreationOptions> const& options)
 {
     ElementCreationOptions element_creation_options;
     options.visit(

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -549,8 +549,8 @@ public:
     HTML::EnvironmentSettingsObject& relevant_settings_object() const;
 
     using ElementCreationOptions = Bindings::ElementCreationOptions;
-    WebIDL::ExceptionOr<GC::Ref<Element>> create_element(Utf16String const& local_name, ElementCreationOptions const& options);
-    WebIDL::ExceptionOr<GC::Ref<Element>> create_element(Utf16String const& local_name, Variant<Utf16String, ElementCreationOptions> const& options);
+    WebIDL::ExceptionOr<GC::Ref<Element>> create_element(Utf16FlyString const& local_name, ElementCreationOptions const& options);
+    WebIDL::ExceptionOr<GC::Ref<Element>> create_element(Utf16FlyString const& local_name, Variant<Utf16String, ElementCreationOptions> const& options);
     WebIDL::ExceptionOr<GC::Ref<Element>> create_element_ns(Optional<Utf16String> const& namespace_, Utf16String const& qualified_name, ElementCreationOptions const& options);
     WebIDL::ExceptionOr<GC::Ref<Element>> create_element_ns(Optional<Utf16String> const& namespace_, Utf16String const& qualified_name, Variant<Utf16String, ElementCreationOptions> const& options);
     WebIDL::ExceptionOr<GC::Ref<Element>> create_element_ns(Optional<Utf16FlyString> const& namespace_, Utf16String const& qualified_name, Variant<Utf16String, ElementCreationOptions> const& options);

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -65,7 +65,7 @@ interface Document : Node {
     undefined captureEvents();
     undefined releaseEvents();
 
-    [CEReactions, NewObject] Element createElement(DOMString tagName, optional (DOMString or ElementCreationOptions) options = {});
+    [CEReactions, NewObject] Element createElement([Utf16FlyString] DOMString tagName, optional (DOMString or ElementCreationOptions) options = {});
     [CEReactions, NewObject] Element createElementNS([FlyString] DOMString? namespace, DOMString qualifiedName, optional (DOMString or ElementCreationOptions) options = {});
     DocumentFragment createDocumentFragment();
     Text createTextNode(Utf16DOMString data);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -826,9 +826,10 @@ bool is_valid_element_local_name(Utf16View const& name)
     auto first_code_point = *name.begin();
     if (is_ascii_alpha(first_code_point)) {
         // 1. If name contains ASCII whitespace, U+0000 NULL, U+002F (/), or U+003E (>), then return false.
-        constexpr Array<u32, 8> INVALID_CHARACTERS { '\t', '\n', '\f', '\r', ' ', '\0', '/', '>' };
-        if (name.contains_any_of(INVALID_CHARACTERS))
-            return false;
+        for (auto code_point : name) {
+            if (first_is_one_of(code_point, u'\t', u'\n', u'\f', u'\r', u' ', u'\0', u'/', u'>'))
+                return false;
+        }
 
         // 2. Return true.
         return true;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5668,12 +5668,11 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
 
     auto value_or_empty = value.has_value() ? value->utf16_view() : u""sv;
 
-    // StyleEngine keys local features by interned atom, so the old and new sides are captured here,
-    // before the element's own copies are replaced.
-    auto old_style_engine_id = m_id;
-    auto old_style_engine_classes = m_classes;
-
     if (local_name == HTML::AttributeNames::id) {
+        // StyleEngine keys local features by interned atom, so capture the old side before the
+        // element's own copy is replaced.
+        auto old_style_engine_id = m_id;
+
         if (value_or_empty.is_empty())
             m_id = {};
         else
@@ -5685,6 +5684,8 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
                 old_id = Utf16FlyString::from_utf16(old_value->utf16_view());
             document().element_id_changed({}, *this, old_id);
         }
+
+        CSS::record_element_id_changed(*this, old_style_engine_id, m_id);
     } else if (local_name == HTML::AttributeNames::name) {
         m_has_name = !value_or_empty.is_empty();
         if (m_has_name) {
@@ -5696,6 +5697,12 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         if (is_connected())
             document().element_name_changed({}, *this);
     } else if (local_name == HTML::AttributeNames::class_) {
+        // Elements without a StyleEngine identity have no feature state to update. Avoid copying
+        // their class list just for record_element_class_list_changed() to reject the update.
+        Optional<Vector<Utf16FlyString>> old_style_engine_classes;
+        if (style_node_id().value() != 0)
+            old_style_engine_classes = m_classes;
+
         if (value_or_empty.is_empty()) {
             m_classes.clear();
         } else {
@@ -5707,6 +5714,9 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         }
         if (auto* rare_data = element_rare_data(); rare_data && rare_data->class_list)
             rare_data->class_list->associated_attribute_changed(value_or_empty);
+
+        if (old_style_engine_classes.has_value())
+            CSS::record_element_class_list_changed(*this, *old_style_engine_classes, m_classes);
     } else if (local_name == HTML::AttributeNames::style) {
         // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
         if (m_inline_style && m_inline_style->is_updating())
@@ -5783,14 +5793,6 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
     }
-
-    // Every attribute mutation publishes its own typed effects: a selector feature always, and for
-    // some names an element declaration or an attr() input as well. Routing sends each to its own
-    // consumers, so handling one never stands in for the others.
-    if (local_name == HTML::AttributeNames::id)
-        CSS::record_element_id_changed(*this, old_style_engine_id, m_id);
-    else if (local_name == HTML::AttributeNames::class_)
-        CSS::record_element_class_list_changed(*this, old_style_engine_classes, m_classes);
 }
 
 Optional<Utf16FlyString> Element::name() const

--- a/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
+#include <AK/NeverDestroyed.h>
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
@@ -328,156 +330,175 @@ bool is_unknown_html_element(Utf16FlyString const& tag_name)
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom%3Aelement-interface
+using HTMLElementFactory = GC::Ref<Element> (*)(Document&, QualifiedName);
+
+template<typename ElementType>
+static GC::Ref<Element> create_html_element_on_heap(Document& document, QualifiedName qualified_name)
+{
+    return create_element_on_heap<ElementType>(document, move(qualified_name));
+}
+
+static HashMap<FlatPtr, HTMLElementFactory> const& html_element_factories()
+{
+    static NeverDestroyed<HashMap<FlatPtr, HTMLElementFactory>> factories = [] {
+        HashMap<FlatPtr, HTMLElementFactory> factories;
+
+#define __ENUMERATE_HTML_TAG(name, tag) factories.set(HTML::TagNames::name.raw_identity(), &create_html_element_on_heap<HTML::HTMLUnknownElement>);
+        ENUMERATE_HTML_TAGS
+#undef __ENUMERATE_HTML_TAG
+
+#define REGISTER_HTML_ELEMENT(tag_name, element_type) factories.set(HTML::TagNames::tag_name.raw_identity(), &create_html_element_on_heap<HTML::element_type>)
+        REGISTER_HTML_ELEMENT(a, HTMLAnchorElement);
+        REGISTER_HTML_ELEMENT(area, HTMLAreaElement);
+        REGISTER_HTML_ELEMENT(audio, HTMLAudioElement);
+        REGISTER_HTML_ELEMENT(base, HTMLBaseElement);
+        REGISTER_HTML_ELEMENT(body, HTMLBodyElement);
+        REGISTER_HTML_ELEMENT(br, HTMLBRElement);
+        REGISTER_HTML_ELEMENT(button, HTMLButtonElement);
+        REGISTER_HTML_ELEMENT(canvas, HTMLCanvasElement);
+        REGISTER_HTML_ELEMENT(data, HTMLDataElement);
+        REGISTER_HTML_ELEMENT(datalist, HTMLDataListElement);
+        REGISTER_HTML_ELEMENT(details, HTMLDetailsElement);
+        REGISTER_HTML_ELEMENT(dialog, HTMLDialogElement);
+        REGISTER_HTML_ELEMENT(dir, HTMLDirectoryElement);
+        REGISTER_HTML_ELEMENT(div, HTMLDivElement);
+        REGISTER_HTML_ELEMENT(dl, HTMLDListElement);
+        REGISTER_HTML_ELEMENT(embed, HTMLEmbedElement);
+        REGISTER_HTML_ELEMENT(fieldset, HTMLFieldSetElement);
+        REGISTER_HTML_ELEMENT(font, HTMLFontElement);
+        REGISTER_HTML_ELEMENT(form, HTMLFormElement);
+        REGISTER_HTML_ELEMENT(frame, HTMLFrameElement);
+        REGISTER_HTML_ELEMENT(frameset, HTMLFrameSetElement);
+        REGISTER_HTML_ELEMENT(head, HTMLHeadElement);
+        REGISTER_HTML_ELEMENT(h1, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(h2, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(h3, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(h4, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(h5, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(h6, HTMLHeadingElement);
+        REGISTER_HTML_ELEMENT(hr, HTMLHRElement);
+        REGISTER_HTML_ELEMENT(html, HTMLHtmlElement);
+        REGISTER_HTML_ELEMENT(iframe, HTMLIFrameElement);
+        REGISTER_HTML_ELEMENT(img, HTMLImageElement);
+        REGISTER_HTML_ELEMENT(input, HTMLInputElement);
+        REGISTER_HTML_ELEMENT(label, HTMLLabelElement);
+        REGISTER_HTML_ELEMENT(legend, HTMLLegendElement);
+        REGISTER_HTML_ELEMENT(li, HTMLLIElement);
+        REGISTER_HTML_ELEMENT(link, HTMLLinkElement);
+        REGISTER_HTML_ELEMENT(map, HTMLMapElement);
+        REGISTER_HTML_ELEMENT(marquee, HTMLMarqueeElement);
+        REGISTER_HTML_ELEMENT(menu, HTMLMenuElement);
+        REGISTER_HTML_ELEMENT(meta, HTMLMetaElement);
+        REGISTER_HTML_ELEMENT(meter, HTMLMeterElement);
+        REGISTER_HTML_ELEMENT(ins, HTMLModElement);
+        REGISTER_HTML_ELEMENT(del, HTMLModElement);
+        REGISTER_HTML_ELEMENT(object, HTMLObjectElement);
+        REGISTER_HTML_ELEMENT(ol, HTMLOListElement);
+        REGISTER_HTML_ELEMENT(optgroup, HTMLOptGroupElement);
+        REGISTER_HTML_ELEMENT(option, HTMLOptionElement);
+        REGISTER_HTML_ELEMENT(output, HTMLOutputElement);
+        REGISTER_HTML_ELEMENT(p, HTMLParagraphElement);
+        REGISTER_HTML_ELEMENT(param, HTMLParamElement);
+        REGISTER_HTML_ELEMENT(picture, HTMLPictureElement);
+        REGISTER_HTML_ELEMENT(pre, HTMLPreElement);
+        REGISTER_HTML_ELEMENT(listing, HTMLPreElement);
+        REGISTER_HTML_ELEMENT(xmp, HTMLPreElement);
+        REGISTER_HTML_ELEMENT(progress, HTMLProgressElement);
+        REGISTER_HTML_ELEMENT(blockquote, HTMLQuoteElement);
+        REGISTER_HTML_ELEMENT(q, HTMLQuoteElement);
+        REGISTER_HTML_ELEMENT(script, HTMLScriptElement);
+        REGISTER_HTML_ELEMENT(selectedcontent, HTMLSelectedContentElement);
+        REGISTER_HTML_ELEMENT(select, HTMLSelectElement);
+        REGISTER_HTML_ELEMENT(slot, HTMLSlotElement);
+        REGISTER_HTML_ELEMENT(source, HTMLSourceElement);
+        REGISTER_HTML_ELEMENT(span, HTMLSpanElement);
+        REGISTER_HTML_ELEMENT(style, HTMLStyleElement);
+        REGISTER_HTML_ELEMENT(summary, HTMLSummaryElement);
+        REGISTER_HTML_ELEMENT(caption, HTMLTableCaptionElement);
+        REGISTER_HTML_ELEMENT(td, HTMLTableCellElement);
+        REGISTER_HTML_ELEMENT(th, HTMLTableCellElement);
+        REGISTER_HTML_ELEMENT(colgroup, HTMLTableColElement);
+        REGISTER_HTML_ELEMENT(col, HTMLTableColElement);
+        REGISTER_HTML_ELEMENT(table, HTMLTableElement);
+        REGISTER_HTML_ELEMENT(tr, HTMLTableRowElement);
+        REGISTER_HTML_ELEMENT(tbody, HTMLTableSectionElement);
+        REGISTER_HTML_ELEMENT(thead, HTMLTableSectionElement);
+        REGISTER_HTML_ELEMENT(tfoot, HTMLTableSectionElement);
+        REGISTER_HTML_ELEMENT(template_, HTMLTemplateElement);
+        REGISTER_HTML_ELEMENT(textarea, HTMLTextAreaElement);
+        REGISTER_HTML_ELEMENT(time, HTMLTimeElement);
+        REGISTER_HTML_ELEMENT(title, HTMLTitleElement);
+        REGISTER_HTML_ELEMENT(track, HTMLTrackElement);
+        REGISTER_HTML_ELEMENT(ul, HTMLUListElement);
+        REGISTER_HTML_ELEMENT(video, HTMLVideoElement);
+
+#define REGISTER_GENERIC_HTML_ELEMENT(tag_name) REGISTER_HTML_ELEMENT(tag_name, HTMLElement)
+        REGISTER_GENERIC_HTML_ELEMENT(article);
+        REGISTER_GENERIC_HTML_ELEMENT(search);
+        REGISTER_GENERIC_HTML_ELEMENT(section);
+        REGISTER_GENERIC_HTML_ELEMENT(nav);
+        REGISTER_GENERIC_HTML_ELEMENT(aside);
+        REGISTER_GENERIC_HTML_ELEMENT(hgroup);
+        REGISTER_GENERIC_HTML_ELEMENT(header);
+        REGISTER_GENERIC_HTML_ELEMENT(footer);
+        REGISTER_GENERIC_HTML_ELEMENT(address);
+        REGISTER_GENERIC_HTML_ELEMENT(dt);
+        REGISTER_GENERIC_HTML_ELEMENT(dd);
+        REGISTER_GENERIC_HTML_ELEMENT(figure);
+        REGISTER_GENERIC_HTML_ELEMENT(figcaption);
+        REGISTER_GENERIC_HTML_ELEMENT(main);
+        REGISTER_GENERIC_HTML_ELEMENT(em);
+        REGISTER_GENERIC_HTML_ELEMENT(strong);
+        REGISTER_GENERIC_HTML_ELEMENT(small);
+        REGISTER_GENERIC_HTML_ELEMENT(s);
+        REGISTER_GENERIC_HTML_ELEMENT(cite);
+        REGISTER_GENERIC_HTML_ELEMENT(dfn);
+        REGISTER_GENERIC_HTML_ELEMENT(abbr);
+        REGISTER_GENERIC_HTML_ELEMENT(ruby);
+        REGISTER_GENERIC_HTML_ELEMENT(rt);
+        REGISTER_GENERIC_HTML_ELEMENT(rp);
+        REGISTER_GENERIC_HTML_ELEMENT(code);
+        REGISTER_GENERIC_HTML_ELEMENT(var);
+        REGISTER_GENERIC_HTML_ELEMENT(samp);
+        REGISTER_GENERIC_HTML_ELEMENT(kbd);
+        REGISTER_GENERIC_HTML_ELEMENT(sub);
+        REGISTER_GENERIC_HTML_ELEMENT(sup);
+        REGISTER_GENERIC_HTML_ELEMENT(i);
+        REGISTER_GENERIC_HTML_ELEMENT(b);
+        REGISTER_GENERIC_HTML_ELEMENT(u);
+        REGISTER_GENERIC_HTML_ELEMENT(mark);
+        REGISTER_GENERIC_HTML_ELEMENT(bdi);
+        REGISTER_GENERIC_HTML_ELEMENT(bdo);
+        REGISTER_GENERIC_HTML_ELEMENT(wbr);
+        REGISTER_GENERIC_HTML_ELEMENT(noscript);
+        REGISTER_GENERIC_HTML_ELEMENT(acronym);
+        REGISTER_GENERIC_HTML_ELEMENT(basefont);
+        REGISTER_GENERIC_HTML_ELEMENT(big);
+        REGISTER_GENERIC_HTML_ELEMENT(center);
+        REGISTER_GENERIC_HTML_ELEMENT(nobr);
+        REGISTER_GENERIC_HTML_ELEMENT(noembed);
+        REGISTER_GENERIC_HTML_ELEMENT(noframes);
+        REGISTER_GENERIC_HTML_ELEMENT(plaintext);
+        REGISTER_GENERIC_HTML_ELEMENT(rb);
+        REGISTER_GENERIC_HTML_ELEMENT(rtc);
+        REGISTER_GENERIC_HTML_ELEMENT(strike);
+        REGISTER_GENERIC_HTML_ELEMENT(tt);
+#undef REGISTER_GENERIC_HTML_ELEMENT
+#undef REGISTER_HTML_ELEMENT
+
+        return factories;
+    }();
+
+    return *factories;
+}
+
 static GC::Ref<Element> create_html_element(Document& document, QualifiedName qualified_name)
 {
     auto const& tag_name = qualified_name.local_name();
 
-    if (tag_name == HTML::TagNames::a)
-        return create_element_on_heap<HTML::HTMLAnchorElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::area)
-        return create_element_on_heap<HTML::HTMLAreaElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::audio)
-        return create_element_on_heap<HTML::HTMLAudioElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::base)
-        return create_element_on_heap<HTML::HTMLBaseElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::body)
-        return create_element_on_heap<HTML::HTMLBodyElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::br)
-        return create_element_on_heap<HTML::HTMLBRElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::button)
-        return create_element_on_heap<HTML::HTMLButtonElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::canvas)
-        return create_element_on_heap<HTML::HTMLCanvasElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::data)
-        return create_element_on_heap<HTML::HTMLDataElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::datalist)
-        return create_element_on_heap<HTML::HTMLDataListElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::details)
-        return create_element_on_heap<HTML::HTMLDetailsElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::dialog)
-        return create_element_on_heap<HTML::HTMLDialogElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::dir)
-        return create_element_on_heap<HTML::HTMLDirectoryElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::div)
-        return create_element_on_heap<HTML::HTMLDivElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::dl)
-        return create_element_on_heap<HTML::HTMLDListElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::embed)
-        return create_element_on_heap<HTML::HTMLEmbedElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::fieldset)
-        return create_element_on_heap<HTML::HTMLFieldSetElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::font)
-        return create_element_on_heap<HTML::HTMLFontElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::form)
-        return create_element_on_heap<HTML::HTMLFormElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::frame)
-        return create_element_on_heap<HTML::HTMLFrameElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::frameset)
-        return create_element_on_heap<HTML::HTMLFrameSetElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::head)
-        return create_element_on_heap<HTML::HTMLHeadElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6))
-        return create_element_on_heap<HTML::HTMLHeadingElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::hr)
-        return create_element_on_heap<HTML::HTMLHRElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::html)
-        return create_element_on_heap<HTML::HTMLHtmlElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::iframe)
-        return create_element_on_heap<HTML::HTMLIFrameElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::img)
-        return create_element_on_heap<HTML::HTMLImageElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::input)
-        return create_element_on_heap<HTML::HTMLInputElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::label)
-        return create_element_on_heap<HTML::HTMLLabelElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::legend)
-        return create_element_on_heap<HTML::HTMLLegendElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::li)
-        return create_element_on_heap<HTML::HTMLLIElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::link)
-        return create_element_on_heap<HTML::HTMLLinkElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::map)
-        return create_element_on_heap<HTML::HTMLMapElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::marquee)
-        return create_element_on_heap<HTML::HTMLMarqueeElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::menu)
-        return create_element_on_heap<HTML::HTMLMenuElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::meta)
-        return create_element_on_heap<HTML::HTMLMetaElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::meter)
-        return create_element_on_heap<HTML::HTMLMeterElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(HTML::TagNames::ins, HTML::TagNames::del))
-        return create_element_on_heap<HTML::HTMLModElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::object)
-        return create_element_on_heap<HTML::HTMLObjectElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::ol)
-        return create_element_on_heap<HTML::HTMLOListElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::optgroup)
-        return create_element_on_heap<HTML::HTMLOptGroupElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::option)
-        return create_element_on_heap<HTML::HTMLOptionElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::output)
-        return create_element_on_heap<HTML::HTMLOutputElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::p)
-        return create_element_on_heap<HTML::HTMLParagraphElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::param)
-        return create_element_on_heap<HTML::HTMLParamElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::picture)
-        return create_element_on_heap<HTML::HTMLPictureElement>(document, move(qualified_name));
-    // NOTE: The obsolete elements "listing" and "xmp" are explicitly mapped to HTMLPreElement in the specification.
-    if (tag_name.is_one_of(HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp))
-        return create_element_on_heap<HTML::HTMLPreElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::progress)
-        return create_element_on_heap<HTML::HTMLProgressElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(HTML::TagNames::blockquote, HTML::TagNames::q))
-        return create_element_on_heap<HTML::HTMLQuoteElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::script)
-        return create_element_on_heap<HTML::HTMLScriptElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::selectedcontent)
-        return create_element_on_heap<HTML::HTMLSelectedContentElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::select)
-        return create_element_on_heap<HTML::HTMLSelectElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::slot)
-        return create_element_on_heap<HTML::HTMLSlotElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::source)
-        return create_element_on_heap<HTML::HTMLSourceElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::span)
-        return create_element_on_heap<HTML::HTMLSpanElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::style)
-        return create_element_on_heap<HTML::HTMLStyleElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::summary)
-        return create_element_on_heap<HTML::HTMLSummaryElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::caption)
-        return create_element_on_heap<HTML::HTMLTableCaptionElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(Web::HTML::TagNames::td, Web::HTML::TagNames::th))
-        return create_element_on_heap<HTML::HTMLTableCellElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(HTML::TagNames::colgroup, HTML::TagNames::col))
-        return create_element_on_heap<HTML::HTMLTableColElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::table)
-        return create_element_on_heap<HTML::HTMLTableElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::tr)
-        return create_element_on_heap<HTML::HTMLTableRowElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot))
-        return create_element_on_heap<HTML::HTMLTableSectionElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::template_)
-        return create_element_on_heap<HTML::HTMLTemplateElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::textarea)
-        return create_element_on_heap<HTML::HTMLTextAreaElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::time)
-        return create_element_on_heap<HTML::HTMLTimeElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::title)
-        return create_element_on_heap<HTML::HTMLTitleElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::track)
-        return create_element_on_heap<HTML::HTMLTrackElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::ul)
-        return create_element_on_heap<HTML::HTMLUListElement>(document, move(qualified_name));
-    if (tag_name == HTML::TagNames::video)
-        return create_element_on_heap<HTML::HTMLVideoElement>(document, move(qualified_name));
-    if (tag_name.is_one_of(
-            HTML::TagNames::article, HTML::TagNames::search, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::noscript,
-            // Obsolete
-            HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt))
-        return create_element_on_heap<HTML::HTMLElement>(document, move(qualified_name));
+    if (auto factory = html_element_factories().get(tag_name.raw_identity()); factory.has_value())
+        return factory.value()(document, move(qualified_name));
+
     if (HTML::is_valid_custom_element_name(qualified_name.local_name()))
         return create_element_on_heap<HTML::HTMLElement>(document, move(qualified_name));
 

--- a/Libraries/LibWeb/DOM/QualifiedName.cpp
+++ b/Libraries/LibWeb/DOM/QualifiedName.cpp
@@ -13,11 +13,11 @@ namespace Web::DOM {
 
 static unsigned hash_impl(Utf16FlyString const& local_name, Optional<Utf16FlyString> const& prefix, Optional<Utf16FlyString> const& namespace_)
 {
-    unsigned hash = local_name.hash();
+    unsigned hash = ptr_hash(local_name.raw_identity());
     if (prefix.has_value())
-        hash = pair_int_hash(hash, prefix->hash());
+        hash = pair_int_hash(hash, ptr_hash(prefix->raw_identity()));
     if (namespace_.has_value())
-        hash = pair_int_hash(hash, namespace_->hash());
+        hash = pair_int_hash(hash, ptr_hash(namespace_->raw_identity()));
     return hash;
 }
 

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -3944,8 +3944,7 @@ GC::Ref<DOM::Element> set_the_tag_name(GC::Ref<DOM::Element> element, Utf16FlySt
         return element;
 
     // 3. Let replacement element be the result of calling createElement(new name) on the ownerDocument of element.
-    auto replacement_name = Utf16String::from_utf16(new_name.view());
-    auto replacement_element = MUST(element->owner_document()->create_element(replacement_name, DOM::Document::ElementCreationOptions {}));
+    auto replacement_element = MUST(element->owner_document()->create_element(new_name, DOM::Document::ElementCreationOptions {}));
 
     // 4. Insert replacement element into element's parent immediately before element.
     insert_node_before(replacement_element, *element->parent(), element);

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -35,7 +35,7 @@ void HTMLAnchorElement::attribute_changed(Utf16FlyString const& name, Optional<U
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::href) {
-        set_the_url();
+        href_content_attribute_changed();
     } else if (name == HTML::AttributeNames::rel) {
         if (m_rel_list)
             m_rel_list->associated_attribute_changed(value.has_value() ? value->utf16_view() : u""sv);

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -36,7 +36,7 @@ void HTMLAreaElement::attribute_changed(Utf16FlyString const& name, Optional<Utf
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::href) {
-        set_the_url();
+        href_content_attribute_changed();
     } else if (name == HTML::AttributeNames::rel) {
         if (m_rel_list)
             m_rel_list->associated_attribute_changed(value.has_value() ? value->utf16_view() : u""sv);

--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -18,8 +18,10 @@ HTMLHyperlinkElementUtils::~HTMLHyperlinkElementUtils() = default;
 // https://html.spec.whatwg.org/multipage/links.html#api-for-a-and-area-elements:concept-hyperlink-url-set-2
 void HTMLHyperlinkElementUtils::set_the_url()
 {
-    ScopeGuard invalidate_style_if_needed = [old_url = m_url, this] {
-        if (m_url != old_url)
+    auto should_invalidate_style = m_should_invalidate_style_after_url_change;
+    m_should_invalidate_style_after_url_change = true;
+    ScopeGuard invalidate_style_if_needed = [old_url = m_url, should_invalidate_style, this] {
+        if (should_invalidate_style && m_url != old_url)
             CSS::Invalidation::invalidate_style_after_hyperlink_state_change(hyperlink_element_utils_element());
     };
 

--- a/Libraries/LibWeb/HTML/HyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HyperlinkElementUtils.cpp
@@ -396,11 +396,20 @@ void HyperlinkElementUtils::reinitialize_url() const
     const_cast<HyperlinkElementUtils*>(this)->set_the_url();
 }
 
+void HyperlinkElementUtils::href_content_attribute_changed()
+{
+    m_url = {};
+    m_should_invalidate_style_after_url_change = false;
+    CSS::Invalidation::invalidate_style_after_hyperlink_state_change(hyperlink_element_utils_element());
+}
+
 // https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set
 void HyperlinkElementUtils::set_the_url()
 {
-    ScopeGuard invalidate_style_if_needed = [old_url = m_url, this] {
-        if (m_url != old_url)
+    auto should_invalidate_style = m_should_invalidate_style_after_url_change;
+    m_should_invalidate_style_after_url_change = true;
+    ScopeGuard invalidate_style_if_needed = [old_url = m_url, should_invalidate_style, this] {
+        if (should_invalidate_style && m_url != old_url)
             CSS::Invalidation::invalidate_style_after_hyperlink_state_change(hyperlink_element_utils_element());
     };
 
@@ -426,6 +435,8 @@ void HyperlinkElementUtils::set_the_url()
 // https://html.spec.whatwg.org/multipage/links.html#api-for-hyperlink-elements:extract-an-origin
 Optional<URL::Origin> HyperlinkElementUtils::hyperlink_element_utils_extract_an_origin() const
 {
+    reinitialize_url();
+
     // 1. If this's url is null, then return null.
     if (!m_url.has_value())
         return {};

--- a/Libraries/LibWeb/HTML/HyperlinkElementUtils.h
+++ b/Libraries/LibWeb/HTML/HyperlinkElementUtils.h
@@ -58,9 +58,11 @@ protected:
 
     Optional<URL::Origin> hyperlink_element_utils_extract_an_origin() const;
 
+    void href_content_attribute_changed();
     void reinitialize_url() const;
 
     Optional<URL::URL> m_url;
+    bool m_should_invalidate_style_after_url_change { true };
 };
 
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1089,7 +1089,7 @@ Utf16String const& LocalNavigable::target_name() const
 GC::Ptr<NavigableContainer> LocalNavigable::container() const
 {
     // The container of a navigable navigable is the navigable container whose nested navigable is navigable, or null if there is no such element.
-    return NavigableContainer::navigable_container_with_content_navigable(const_cast<LocalNavigable&>(*this));
+    return m_container;
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-container-document

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -130,6 +130,7 @@ public:
     virtual Utf16String const& target_name() const override;
 
     GC::Ptr<NavigableContainer> container() const;
+    void set_container(Badge<NavigableContainer>, GC::Ptr<NavigableContainer> container) { m_container = container; }
     GC::Ptr<DOM::Document> container_document() const;
 
     GC::Ptr<LocalTraversableNavigable> traversable_navigable() const;

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -105,6 +105,7 @@ void NavigableContainer::create_new_child_navigable()
 
     // 9. Set element's content navigable to navigable.
     m_content_navigable = navigable;
+    navigable->set_container({}, this);
 
     auto traversable = parent_navigable->traversable_navigable();
     (void)traversable->adopt_canonical_id_for_child_created_during_history_reconstruction(*parent_navigable, navigable);
@@ -337,6 +338,7 @@ void NavigableContainer::destroy_the_child_navigable()
 
     auto after_document_destruction = GC::create_function(GC::Heap::the(), [this, navigable] {
         // 3. Set container's content navigable to null.
+        as<LocalNavigable>(*navigable).set_container({}, nullptr);
         m_content_navigable = nullptr;
         document().schedule_html_parser_end_check();
 

--- a/Libraries/LibWeb/HTML/Scripting/SimilarOriginWindowAgent.h
+++ b/Libraries/LibWeb/HTML/Scripting/SimilarOriginWindowAgent.h
@@ -57,3 +57,9 @@ WEB_API SimilarOriginWindowAgent& relevant_similar_origin_window_agent(DOM::Node
 WEB_API SimilarOriginWindowAgent& relevant_similar_origin_window_agent(Window const&);
 
 }
+
+namespace Web::Bindings {
+
+WEB_API HTML::SimilarOriginWindowAgent& main_thread_similar_origin_window_agent();
+
+}

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -131,9 +131,13 @@ WebIDL::ExceptionOr<void> initialize_window_web_interfaces(HTML::Window& window,
 {
     auto& global_object = realm.global_object();
 
-    Bindings::add_window_exposed_interfaces(global_object);
-
     WEB_SET_PROTOTYPE_FOR_INTERFACE_ON(global_object, Window);
+
+    // OPTIMIZATION: The Window wrapper becomes the internal prototype of its WindowProxy. Mark it
+    // as a prototype before adding its many own properties so that attaching it does not copy them.
+    global_object.convert_to_prototype_if_needed();
+
+    Bindings::add_window_exposed_interfaces(global_object);
 
     Bindings::WindowGlobalMixin window_global_mixin;
     window_global_mixin.initialize(realm, global_object);

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1060,15 +1060,18 @@ Utf16String Window::name() const
 void Window::set_name(Utf16View name)
 {
     // 1. If this's navigable is null, then return.
-    if (!navigable())
+    auto navigable = this->navigable();
+    if (!navigable)
         return;
 
     // 2. Set this's navigable's active session history entry's document state's navigable target name to the given value.
+    if (navigable->target_name() == name)
+        return;
     auto navigable_target_name = Utf16String::from_utf16(name);
-    auto active_session_history_entry = navigable()->active_session_history_entry();
+    auto active_session_history_entry = navigable->active_session_history_entry();
     active_session_history_entry->document_state()->set_navigable_target_name(navigable_target_name);
-    navigable()->page().client().page_did_update_session_history_entry_document_state_navigable_target_name(
-        navigable()->id(), active_session_history_entry->navigation_api_key(), navigable_target_name);
+    navigable->page().client().page_did_update_session_history_entry_document_state_navigable_target_name(
+        navigable->id(), active_session_history_entry->navigation_api_key(), navigable_target_name);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status

--- a/Meta/Generators/generate_libweb_css_style_properties.py
+++ b/Meta/Generators/generate_libweb_css_style_properties.py
@@ -121,7 +121,7 @@ GC::Ref<JS::NativeFunction> create_setter(JS::Realm& realm, Utf16FlyString const
         // For [CEReactions]: https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
 
         // 1. Push a new element queue onto this object's relevant agent's custom element reactions stack.
-        auto& reactions_stack = HTML::relevant_similar_origin_window_agent(realm.global_object()).custom_element_reactions_stack;
+        auto& reactions_stack = Bindings::main_thread_similar_origin_window_agent().custom_element_reactions_stack;
         reactions_stack.element_queue_stack.append({});
 
         // 2. Run the originally-specified steps for this construct, catching any exceptions. If the steps return a value,

--- a/Meta/Generators/libweb_bindings/extended_attributes.py
+++ b/Meta/Generators/libweb_bindings/extended_attributes.py
@@ -39,7 +39,7 @@ def wrap_with_ce_reactions(includes: GeneratedIncludes, expression: str, this_ob
         // For [CEReactions]: https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
 
         // 1. Push a new element queue onto this object's relevant agent's custom element reactions stack.
-        auto& reactions_stack = HTML::relevant_similar_origin_window_agent({this_object_realm}.global_object()).custom_element_reactions_stack;
+        auto& reactions_stack = Bindings::main_thread_similar_origin_window_agent().custom_element_reactions_stack;
         reactions_stack.element_queue_stack.append({{}});
 
         // 2. Run the originally-specified steps for this construct, catching any exceptions. If the steps return a value, let value be the returned value. If they throw an exception, let exception be the thrown exception.


### PR DESCRIPTION
Reduce repeated work in bindings, element creation, navigable lookup, hyperlink handling, and Window setup.

Intern createElement() names earlier, use fly-string identity for qualified-name hashing and HTML element factory dispatch, and cache relationships and type information that are already known. Parse hyperlink URLs lazily, avoid redundant window.name propagation and detached class-list copies, and inline destruction for common AK string and optional types.

These changes improve common document construction paths while preserving custom element fallback behavior and connected-element style updates.

```
Benchmark     Old Score        New Score          Improvement
------------  ---------------  ---------------  -------------
Speedometer2  53.175 ± 38.720  52.469 ± 45.425          0.987
Speedometer3  2.999 ± 1.519    3.104 ± 0.978            1.035
StyleBench    63.429 ± 7.277   63.164 ± 6.356           0.996

Benchmark         Speedup  Old Total Time (s)    New Total Time (s)
--------------  ---------  --------------------  --------------------
Speedometer2        0.997  9.353 ± 6.411         9.381 ± 7.054
Speedometer3        1.035  8.722 ± 6.124         8.425 ± 3.027
StyleBench          0.996  3.923 ± 0.497         3.940 ± 0.435
WebKitBindings      1.106  4.156 ± 0.103         3.759 ± 0.259
WebKitCSS           0.914  0.646 ± 0.014         0.707 ± 0.006
WebKitDOM           1.222  3.871 ± 0.348         3.168 ± 0.949
WebKitParser        1.374  2.840 ± 0.623         2.068 ± 2.753
WebKitSVG           1.002  6.418 ± 0.004         6.406 ± 1.021
```