### PR TITLE
LibWeb: Synchronize CSS-connected fonts after CSSOM mutations

### DIFF
--- a/Libraries/LibWeb/CSS/BindingsGlue.h
+++ b/Libraries/LibWeb/CSS/BindingsGlue.h
@@ -52,5 +52,6 @@ WEB_API GC::Ref<JS::Set> setlike_entries(JS::Realm&, WrapperWorld const&, CSS::F
 WEB_API bool setlike_has(CSS::FontFaceSet const&, JS::Value);
 WEB_API void did_add_font_face(CSS::FontFaceSet const&, GC::Ref<CSS::FontFace>);
 WEB_API void did_remove_font_face(CSS::FontFaceSet const&, GC::Ref<CSS::FontFace>);
+WEB_API void did_reorder_font_faces(CSS::FontFaceSet const&, Vector<GC::Ref<CSS::FontFace>> const&);
 
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/Font/FontStyleMapping.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/Serialize.h>
@@ -158,12 +159,31 @@ void CSSFontFaceRule::handle_descriptor_change(Utf16FlyString const& property)
         return;
     }
 
-    if (property.equals_ignoring_ascii_case("src"_utf16_fly_string))
+    if (property.equals_ignoring_ascii_case("src"_utf16_fly_string)) {
         handle_src_descriptor_change();
+        return;
+    }
+
+    auto descriptor_affects_font_matching = property.equals_ignoring_ascii_case("font-family"_utf16_fly_string)
+        || property.equals_ignoring_ascii_case("font-weight"_utf16_fly_string)
+        || property.equals_ignoring_ascii_case("font-style"_utf16_fly_string)
+        || property.equals_ignoring_ascii_case("font-width"_utf16_fly_string)
+        || property.equals_ignoring_ascii_case("font-stretch"_utf16_fly_string);
+
+    FontComputer* font_computer = nullptr;
+    if (descriptor_affects_font_matching) {
+        if (auto document = parent_style_sheet() ? parent_style_sheet()->owning_document() : nullptr) {
+            font_computer = &document->font_computer();
+            font_computer->unregister_font_face(*m_css_connected_font_face);
+        }
+    }
 
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // any change made to a @font-face descriptor is immediately reflected in the corresponding FontFace attribute
     m_css_connected_font_face->reparse_connected_css_font_face_rule_descriptors();
+
+    if (font_computer)
+        font_computer->register_font_face(*m_css_connected_font_face);
 }
 
 // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
@@ -190,6 +210,10 @@ void CSSFontFaceRule::handle_src_descriptor_change()
     document->fonts()->add_css_connected_font(new_font_face);
 }
 
+// https://drafts.csswg.org/css-font-loading/#font-face-css-connection
+// If a @font-face rule is removed from the document, its corresponding FontFace object is no longer CSS-connected.
+// The connection is not restorable by any means (but adding the @font-face back to the stylesheet will create a
+// brand new FontFace object which is CSS-connected).
 void CSSFontFaceRule::disconnect_font_face()
 {
     if (!m_css_connected_font_face)

--- a/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -50,6 +50,7 @@ WebIDL::ExceptionOr<u32> CSSGroupingRule::insert_rule(Utf16View rule, u32 index)
     if (auto* sheet = parent_style_sheet()) {
         record_style_rule_inserted(*m_rules->item(index));
         sheet->invalidate_owners();
+        sheet->synchronize_fonts_after_rule_change();
     }
     return index;
 }
@@ -62,6 +63,7 @@ WebIDL::ExceptionOr<void> CSSGroupingRule::delete_rule(u32 index)
         if (removed_rule)
             record_style_rule_removed(*sheet, *removed_rule);
         sheet->invalidate_owners();
+        sheet->synchronize_fonts_after_rule_change();
     }
     return {};
 }

--- a/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
 #include <LibWeb/CSS/CSSFunctionRule.h>
+#include <LibWeb/CSS/CSSGroupingRule.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSLayerBlockRule.h>
@@ -38,6 +39,31 @@ GC::Ref<CSSRuleList> CSSRuleList::create(ReadonlySpan<GC::Ref<CSSRule>> rules)
 
 CSSRuleList::CSSRuleList()
 {
+}
+
+static void disconnect_font_faces_in_rule(CSSRule& rule)
+{
+    if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule))
+        font_face_rule->disconnect_font_face();
+
+    if (auto* grouping_rule = as_if<CSSGroupingRule>(rule)) {
+        for (auto& child_rule : grouping_rule->css_rules())
+            disconnect_font_faces_in_rule(child_rule);
+    }
+}
+
+void CSSRuleList::set_rules(Badge<CSSStyleSheet>, Vector<GC::Ref<CSSRule>> rules)
+{
+    // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
+    // If a @font-face rule is removed from the document, its corresponding FontFace object is no longer CSS-connected.
+    // The connection is not restorable by any means (but adding the @font-face back to the stylesheet will create a
+    // brand new FontFace object which is CSS-connected).
+    for (auto& rule : m_rules) {
+        disconnect_font_faces_in_rule(rule);
+        rule->set_parent_style_sheet(nullptr);
+    }
+
+    m_rules = move(rules);
 }
 
 void CSSRuleList::visit_edges(GC::Cell::Visitor& visitor)
@@ -169,8 +195,6 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<Utf16View, 
     // 8. Insert new rule into list at the zero-indexed position index.
     m_rules.insert(index, *new_rule);
 
-    // FIXME: Load font faces for inserted @font-face rules
-
     // 9. Return index.
     if (on_change)
         on_change();
@@ -214,9 +238,10 @@ void CSSRuleList::remove_a_css_rule_without_validation(u32 index)
     CSSRule& old_rule = m_rules[index];
 
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
-    // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
-    if (auto* font_face_rule = as_if<CSSFontFaceRule>(old_rule))
-        font_face_rule->disconnect_font_face();
+    // If a @font-face rule is removed from the document, its corresponding FontFace object is no longer CSS-connected.
+    // The connection is not restorable by any means (but adding the @font-face back to the stylesheet will create a
+    // brand new FontFace object which is CSS-connected).
+    disconnect_font_faces_in_rule(old_rule);
 
     // 5. Remove rule old rule from list at the zero-indexed position index.
     m_rules.remove(index);

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -68,7 +68,7 @@ public:
     bool evaluate_media_queries(DOM::Document const&, Function<void(CSSRule const&)> const& changed_rule_callback);
 
     void set_owner_rule(GC::Ref<CSSRule> owner_rule) { m_owner_rule = owner_rule; }
-    void set_rules(Badge<CSSStyleSheet>, Vector<GC::Ref<CSSRule>> rules) { m_rules = move(rules); }
+    void set_rules(Badge<CSSStyleSheet>, Vector<GC::Ref<CSSRule>> rules);
 
     Function<void()> on_change;
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1872,6 +1872,8 @@ void CSSStyleProperties::invalidate_owners()
                 return;
 
             sheet->invalidate_owners();
+            if (rule->type() == CSSRule::Type::FontFace)
+                sheet->synchronize_fonts_after_rule_change();
         }
     }
 }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -218,6 +218,8 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(Utf16View rule, unsigne
             invalidate_rule_cache_for_style_sheet_owners(*this);
         else
             invalidate_owners();
+
+        synchronize_fonts_after_rule_change();
     }
 
     return result;
@@ -239,6 +241,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::delete_rule(unsigned index)
         if (removed_rule)
             record_style_rule_removed(*this, *removed_rule);
         invalidate_owners();
+        synchronize_fonts_after_rule_change();
     }
     return result;
 }
@@ -278,6 +281,7 @@ GC::Ref<WebIDL::Promise> CSSStyleSheet::replace(Utf16String text)
         m_rules->set_rules({}, rules_without_import);
         record_stylesheet_rules_replaced(*this);
         invalidate_owners();
+        synchronize_fonts_after_rule_change();
 
         // 4. Unset sheet’s disallow modification flag.
         set_disallow_modification(false);
@@ -314,6 +318,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::replace_sync(Utf16View text)
     m_rules->set_rules({}, rules_without_import);
     record_stylesheet_rules_replaced(*this);
     invalidate_owners();
+    synchronize_fonts_after_rule_change();
 
     return {};
 }
@@ -519,10 +524,20 @@ void CSSStyleSheet::invalidate_owners()
 
 void CSSStyleSheet::reload_fonts_after_media_query_change()
 {
-    if (auto document = owning_document(); document && has_document_owner()) {
-        document->font_computer().unload_fonts_from_sheet(*this);
+    synchronize_fonts_after_rule_change();
+}
+
+// https://drafts.csswg.org/css-font-loading/#document-font-face-set
+// As @font-face rules are added or removed from a stylesheet, or stylesheets containing @font-face rules are added or
+// removed, the corresponding CSS-connected FontFace objects must be added or removed from the document's font source,
+// and maintain this ordering.
+void CSSStyleSheet::synchronize_fonts_after_rule_change()
+{
+    if (!has_document_owner())
+        return;
+
+    if (auto document = owning_document())
         document->font_computer().load_fonts_from_sheet(*this);
-    }
 }
 
 bool CSSStyleSheet::has_document_owner() const

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -105,6 +105,7 @@ public:
     bool evaluate_media_queries(DOM::Document const&);
     bool evaluate_media_queries(DOM::Document const&, Function<void(CSSRule const&)> const& changed_rule_callback);
     void reload_fonts_after_media_query_change();
+    void synchronize_fonts_after_rule_change();
     void record_conditions_for_owners();
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
     void for_each_effective_counter_style_at_rule(Function<void(CSSCounterStyleRule const&)> const& callback) const;

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -907,6 +907,36 @@ void FontComputer::unregister_font_face(GC::Ref<FontFace> face)
     did_load_font(key.family_name);
 }
 
+void FontComputer::synchronize_font_face_order(Vector<GC::Ref<FontFace>> const& font_source_order)
+{
+    for (auto& entry : m_font_faces) {
+        Vector<GC::Ref<FontFace>> ordered_faces;
+        for (auto& font_face : font_source_order) {
+            if (entry.value.contains_slow(font_face))
+                ordered_faces.append(font_face);
+        }
+        for (auto& font_face : entry.value) {
+            if (!ordered_faces.contains_slow(font_face))
+                ordered_faces.append(font_face);
+        }
+
+        bool order_changed = ordered_faces.size() != entry.value.size();
+        if (!order_changed) {
+            for (size_t index = 0; index < entry.value.size(); ++index) {
+                if (ordered_faces[index] != entry.value[index]) {
+                    order_changed = true;
+                    break;
+                }
+            }
+        }
+        if (!order_changed)
+            continue;
+
+        entry.value = move(ordered_faces);
+        did_load_font(entry.key.family_name);
+    }
+}
+
 GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
 {
     if (font_face.sources().is_empty()) {
@@ -965,21 +995,6 @@ static void for_each_nested_font_rule(CSSRuleList& rules, Function<void(CSSRule&
     }
 }
 
-static void for_each_effective_font_rule(CSSStyleSheet& sheet, Function<void(CSSRule&)> const& callback)
-{
-    GC::RootHashTable<CSSRule const*> effective_font_rules;
-    sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
-        // Imported sheets are attached and load their fonts separately.
-        if (rule.parent_style_sheet() == &sheet && is_font_rule(rule))
-            effective_font_rules.set(&rule);
-    });
-
-    for_each_nested_font_rule(sheet.rules(), [&](CSSRule& rule) {
-        if (effective_font_rules.contains(&rule))
-            callback(rule);
-    });
-}
-
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
     begin_font_face_change_batch();
@@ -987,11 +1002,29 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
         end_font_face_change_batch();
     };
 
-    for_each_effective_font_rule(sheet, [&](auto& rule) {
+    GC::RootHashTable<CSSRule const*> effective_font_rules;
+    if (!sheet.disabled()) {
+        sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& effective_rule) {
+            // Imported sheets are attached and synchronize their fonts separately.
+            if (effective_rule.parent_style_sheet() == &sheet && is_font_rule(effective_rule))
+                effective_font_rules.set(&effective_rule);
+        });
+    }
+
+    for_each_nested_font_rule(sheet.rules(), [&](auto& rule) {
         if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
-            if (!font_face_rule->is_valid())
+            auto should_be_css_connected = effective_font_rules.contains(font_face_rule) && font_face_rule->is_valid();
+            if (!should_be_css_connected) {
+                font_face_rule->disconnect_font_face();
+                return;
+            }
+
+            if (font_face_rule->css_connected_font_face())
                 return;
 
+            // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
+            // A CSS @font-face rule automatically defines a corresponding FontFace object, which is automatically
+            // placed in the document's font source when the rule is parsed. This FontFace object is CSS-connected.
             auto font_face = FontFace::create_css_connected(HTML::relevant_realm(document()), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
         }
@@ -999,6 +1032,8 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();
     });
+
+    document().fonts()->synchronize_css_connected_font_order();
 }
 
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
@@ -1011,9 +1046,8 @@ void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
     for_each_nested_font_rule(sheet.rules(), [&](auto& rule) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule))
             font_face_rule->disconnect_font_face();
-        }
 
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -137,6 +137,7 @@ public:
 
     void register_font_face(GC::Ref<FontFace>);
     void unregister_font_face(GC::Ref<FontFace>);
+    void synchronize_font_face_order(Vector<GC::Ref<FontFace>> const&);
 
     GC::Ptr<FontLoader> load_font_face(ParsedFontFace const&, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
 

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -17,6 +17,8 @@
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
 #include <LibWeb/CSS/BindingsGlue.h>
+#include <LibWeb/CSS/CSSFontFaceRule.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
@@ -111,6 +113,61 @@ void FontFaceSet::add_css_connected_font(GC::Ref<FontFace> face)
         // 2. Append font to the FontFaceSet’s [[LoadingFonts]] list.
         m_loading_fonts.append(*face);
     }
+}
+
+// https://drafts.csswg.org/css-font-loading/#document-font-face-set
+// The FontFaceSet entries for a document's font source must be initially populated with all the CSS-connected FontFace
+// objects from all of the CSS @font-face rules in the document or shadow root CSS style sheets, in document order. As
+// @font-face rules are added or removed, the corresponding objects must be added or removed and maintain this ordering.
+// Any manually-added FontFace objects must be ordered after the CSS-connected ones.
+void FontFaceSet::synchronize_css_connected_font_order()
+{
+    auto* window = HTML::window_from_global_object(relevant_settings_object().global_object());
+    if (!window)
+        return;
+
+    Vector<GC::Ref<FontFace>> ordered_font_faces;
+    Function<void(CSSStyleSheet&)> append_fonts_from_sheet = [&](CSSStyleSheet& sheet) {
+        sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
+            auto const* font_face_rule = as_if<CSSFontFaceRule>(rule);
+            if (!font_face_rule)
+                return;
+            auto font_face = font_face_rule->css_connected_font_face();
+            if (!font_face)
+                return;
+            GC::Ref<FontFace> font_face_ref { *font_face };
+            if (!ordered_font_faces.contains_slow(font_face_ref))
+                ordered_font_faces.append(font_face_ref);
+        });
+    };
+
+    auto& document = window->associated_document();
+    document.for_each_active_css_style_sheet(append_fonts_from_sheet);
+
+    for (auto& font_face : m_font_faces) {
+        if (font_face->is_css_connected() && !ordered_font_faces.contains_slow(font_face))
+            ordered_font_faces.append(font_face);
+    }
+    for (auto& font_face : m_font_faces) {
+        if (!font_face->is_css_connected())
+            ordered_font_faces.append(font_face);
+    }
+
+    bool order_changed = ordered_font_faces.size() != m_font_faces.size();
+    if (!order_changed) {
+        for (size_t index = 0; index < m_font_faces.size(); ++index) {
+            if (ordered_font_faces[index] != m_font_faces[index]) {
+                order_changed = true;
+                break;
+            }
+        }
+    }
+    if (!order_changed)
+        return;
+
+    m_font_faces = move(ordered_font_faces);
+    Bindings::did_reorder_font_faces(*this, m_font_faces);
+    document.font_computer().synchronize_font_face_order(m_font_faces);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-delete
@@ -570,6 +627,15 @@ void did_remove_font_face(CSS::FontFaceSet const& font_face_set, GC::Ref<CSS::Fo
 {
     font_face_set_cache_for(font_face_set).for_each([&](auto& set_entries) {
         remove_font_face_from_set(set_entries, font_face);
+    });
+}
+
+void did_reorder_font_faces(CSS::FontFaceSet const& font_face_set, Vector<GC::Ref<CSS::FontFace>> const& font_faces)
+{
+    font_face_set_cache_for(font_face_set).for_each([&](auto& set_entries) {
+        set_entries.set_clear();
+        for (auto& font_face : font_faces)
+            add_font_face_to_set(set_entries, font_face);
     });
 }
 

--- a/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -43,6 +43,7 @@ public:
 
     void add_css_connected_font(GC::Ref<FontFace>);
     void remove_css_connected_font(GC::Ref<FontFace>);
+    void synchronize_css_connected_font_order();
 
     void set_onloading(WebIDL::CallbackType*);
     WebIDL::CallbackType* onloading();

--- a/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Libraries/LibWeb/CSS/MediaList.cpp
@@ -58,6 +58,7 @@ void MediaList::invalidate_owners_for_media_change()
     if (!sheet)
         return;
     sheet->invalidate_owners();
+    sheet->synchronize_fonts_after_rule_change();
 
     // Which of the sheet's rules are gated is published from here rather than from the transition
     // `evaluate_media_queries` reports, because a list that has just been reparsed has evaluated

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -843,7 +843,8 @@ GC::Ptr<CSSFontFaceRule> Parser::convert_to_font_face_rule(AtRule const& rule)
         }
     });
 
-    return CSSFontFaceRule::create(CSSFontFaceDescriptors::create(descriptors.release_descriptors()));
+    auto font_face_descriptors = CSSFontFaceDescriptors::create(descriptors.release_descriptors());
+    return CSSFontFaceRule::create(font_face_descriptors);
 }
 
 GC::Ptr<CSSFontFeatureValuesRule> Parser::convert_to_font_feature_values_rule(AtRule const& rule)

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/CSS/StyleSheetInvalidation.h>
@@ -93,6 +94,7 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet, StyleEngineUpdate style_eng
     sheet.load_pending_image_resources(document());
 
     insert_sheet_in_tree_order(sheet);
+    document().fonts()->synchronize_css_connected_font_order();
 
     if (style_engine_update == StyleEngineUpdate::Record)
         record_stylesheet_attached(sheet, document_or_shadow_root(), following_sheet(sheet));
@@ -178,6 +180,7 @@ void StyleSheetList::move_sheet(CSSStyleSheet& sheet, StyleSheetList& destinatio
     VERIFY(position.has_value());
     m_sheets.remove(*position);
     insert_sheet_in_tree_order(sheet);
+    document().fonts()->synchronize_css_connected_font_order();
     record_stylesheet_attached(sheet, document_or_shadow_root(), following_sheet(sheet));
     invalidate_rule_cache_after_style_sheet_change(document_or_shadow_root(), sheet);
 }

--- a/Tests/LibWeb/Ref/expected/font-feature-values-inactive-cache-invalidation-ref.html
+++ b/Tests/LibWeb/Ref/expected/font-feature-values-inactive-cache-invalidation-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: FeatureCacheFont;
+        src: url("../input/wpt-import/css/css-fonts/support/fonts/FontWithFancyFeatures.otf");
+    }
+
+    p {
+        font-family: FeatureCacheFont;
+        font-size: 2em;
+    }
+</style>
+<p>Xnophijklmqrstuvwxyz</p>

--- a/Tests/LibWeb/Ref/input/font-feature-values-inactive-cache-invalidation.html
+++ b/Tests/LibWeb/Ref/input/font-feature-values-inactive-cache-invalidation.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/font-feature-values-inactive-cache-invalidation-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-feature-values">
+<style>
+    @font-face {
+        font-family: FeatureCacheFont;
+        src: url("wpt-import/css/css-fonts/support/fonts/FontWithFancyFeatures.otf");
+    }
+
+    @media all {
+        @font-feature-values FeatureCacheFont {
+            @stylistic {
+                fancy: 1;
+            }
+        }
+    }
+
+    p {
+        font-family: FeatureCacheFont;
+        font-size: 2em;
+        font-variant-alternates: stylistic(fancy);
+    }
+</style>
+<p id="primer">Xnophijklmqrstuvwxyz</p>
+<script>
+    document.fonts.ready.then(() => {
+        primer.getBoundingClientRect();
+        document.styleSheets[0].cssRules[1].media.mediaText = "not all";
+
+        const result = document.createElement("p");
+        result.textContent = primer.textContent;
+        primer.replaceWith(result);
+        requestAnimationFrame(() => document.documentElement.classList.remove("reftest-wait"));
+    });
+</script>

--- a/Tests/LibWeb/Text/expected/css/font-face-cssom-mutations.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-cssom-mutations.txt
@@ -1,0 +1,24 @@
+insertRule adds a CSS-connected FontFace: true
+inserted faces follow stylesheet order: true
+CSS-connected faces precede manually-added faces: true
+unaffected rules retain their FontFace object: true
+deleteRule removes the corresponding FontFace: true
+deleteRule disconnects the FontFace before deletion: true
+deleteRule FontFace is absent after deletion: true
+insertRule connects a face in a matching group: true
+nested deleteRule removes the corresponding FontFace: true
+a face in a non-matching group is not connected: true
+a face is connected when its group starts matching: true
+a face is disconnected when its group stops matching: true
+replaceSync adds a CSS-connected FontFace: true
+replaceSync removes the old FontFace: true
+replaceSync creates a new FontFace: true
+replaceSync disconnects the old FontFace before deletion: true
+replaceSync old FontFace is absent after deletion: true
+replace removes the previous FontFace: true
+replace creates a new FontFace: true
+removing a stylesheet removes its FontFace: true
+face matches before a font-family descriptor change: true
+face matches after a font-family descriptor change: true
+old family stops matching after a descriptor change: true
+moving a stylesheet updates font source order: true

--- a/Tests/LibWeb/Text/input/css/font-face-cssom-mutations.html
+++ b/Tests/LibWeb/Text/input/css/font-face-cssom-mutations.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<style id="author-sheet"></style>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const sheet = document.getElementById("author-sheet").sheet;
+        const findFace = family => [...document.fonts].find(face => face.family === family);
+
+        const manualFace = new FontFace("ManualFace", "local(Arial)");
+        document.fonts.add(manualFace);
+
+        sheet.insertRule("@font-face { font-family: FirstInserted; src: local(Arial); }", 0);
+        const firstInserted = findFace("FirstInserted");
+        println(`insertRule adds a CSS-connected FontFace: ${!!firstInserted}`);
+
+        sheet.insertRule("@font-face { font-family: SecondInserted; src: local(Arial); }", 0);
+        const secondInserted = findFace("SecondInserted");
+        const orderedFaces = [...document.fonts];
+        println(`inserted faces follow stylesheet order: ${orderedFaces.indexOf(secondInserted) < orderedFaces.indexOf(firstInserted)}`);
+        println(`CSS-connected faces precede manually-added faces: ${orderedFaces.indexOf(firstInserted) < orderedFaces.indexOf(manualFace)}`);
+        println(`unaffected rules retain their FontFace object: ${findFace("FirstInserted") === firstInserted}`);
+
+        sheet.deleteRule(0);
+        println(`deleteRule removes the corresponding FontFace: ${!findFace("SecondInserted")}`);
+        document.fonts.add(secondInserted);
+        println(`deleteRule disconnects the FontFace before deletion: ${document.fonts.delete(secondInserted)}`);
+        println(`deleteRule FontFace is absent after deletion: ${!document.fonts.has(secondInserted)}`);
+
+        sheet.insertRule("@media all {}", sheet.cssRules.length);
+        const matchingGroup = sheet.cssRules[sheet.cssRules.length - 1];
+        matchingGroup.insertRule("@font-face { font-family: NestedMatching; src: local(Arial); }", 0);
+        println(`insertRule connects a face in a matching group: ${!!findFace("NestedMatching")}`);
+        matchingGroup.deleteRule(0);
+        println(`nested deleteRule removes the corresponding FontFace: ${!findFace("NestedMatching")}`);
+
+        sheet.insertRule("@media not all {}", sheet.cssRules.length);
+        const nonMatchingGroup = sheet.cssRules[sheet.cssRules.length - 1];
+        nonMatchingGroup.insertRule("@font-face { font-family: NestedNonMatching; src: local(Arial); }", 0);
+        println(`a face in a non-matching group is not connected: ${!findFace("NestedNonMatching")}`);
+        nonMatchingGroup.media.mediaText = "all";
+        println(`a face is connected when its group starts matching: ${!!findFace("NestedNonMatching")}`);
+        nonMatchingGroup.media.mediaText = "not all";
+        println(`a face is disconnected when its group stops matching: ${!findFace("NestedNonMatching")}`);
+
+        const constructedSheet = new CSSStyleSheet();
+        document.adoptedStyleSheets = [constructedSheet];
+        constructedSheet.replaceSync("@font-face { font-family: ReplacedSync; src: local(Arial); }");
+        const replacedSync = findFace("ReplacedSync");
+        println(`replaceSync adds a CSS-connected FontFace: ${!!replacedSync}`);
+
+        constructedSheet.replaceSync("@font-face { font-family: ReplacedSyncAgain; src: local(Arial); }");
+        println(`replaceSync removes the old FontFace: ${!findFace("ReplacedSync")}`);
+        println(`replaceSync creates a new FontFace: ${!!findFace("ReplacedSyncAgain")}`);
+        document.fonts.add(replacedSync);
+        println(`replaceSync disconnects the old FontFace before deletion: ${document.fonts.delete(replacedSync)}`);
+        println(`replaceSync old FontFace is absent after deletion: ${!document.fonts.has(replacedSync)}`);
+
+        await constructedSheet.replace("@font-face { font-family: ReplacedAsync; src: local(Arial); }");
+        println(`replace removes the previous FontFace: ${!findFace("ReplacedSyncAgain")}`);
+        println(`replace creates a new FontFace: ${!!findFace("ReplacedAsync")}`);
+
+        document.adoptedStyleSheets = [];
+        println(`removing a stylesheet removes its FontFace: ${!findFace("ReplacedAsync")}`);
+
+        sheet.insertRule('@font-face { font-family: BeforeDescriptorChange; src: url("../../../Assets/HashSans.woff"); }', sheet.cssRules.length);
+        const descriptorRuleIndex = sheet.cssRules.length - 1;
+        const descriptorRule = sheet.cssRules[descriptorRuleIndex];
+        const testString = "WWWWWWWWWWWWWWWWWWWW";
+        await document.fonts.load("20px BeforeDescriptorChange", testString);
+
+        const measureWidth = fontFamily => {
+            const span = document.createElement("span");
+            span.style.fontFamily = fontFamily;
+            span.style.fontSize = "20px";
+            span.textContent = testString;
+            document.body.appendChild(span);
+            const width = span.offsetWidth;
+            span.remove();
+            return width;
+        };
+
+        const fallbackWidth = measureWidth("serif");
+        println(`face matches before a font-family descriptor change: ${measureWidth("BeforeDescriptorChange, serif") !== fallbackWidth}`);
+        descriptorRule.style.fontFamily = "AfterDescriptorChange";
+        println(`face matches after a font-family descriptor change: ${measureWidth("AfterDescriptorChange, serif") !== fallbackWidth}`);
+        println(`old family stops matching after a descriptor change: ${measureWidth("BeforeDescriptorChange, serif") === fallbackWidth}`);
+        sheet.deleteRule(descriptorRuleIndex);
+
+        const firstStyle = document.createElement("style");
+        firstStyle.textContent = "@font-face { font-family: FirstMovedSheet; src: local(Arial); }";
+        const secondStyle = document.createElement("style");
+        secondStyle.textContent = "@font-face { font-family: SecondMovedSheet; src: local(Arial); }";
+        document.head.appendChild(firstStyle);
+        document.head.appendChild(secondStyle);
+
+        const firstMovedFace = findFace("FirstMovedSheet");
+        const secondMovedFace = findFace("SecondMovedSheet");
+        document.head.moveBefore(secondStyle, firstStyle);
+        const movedFaces = [...document.fonts];
+        println(`moving a stylesheet updates font source order: ${movedFaces.indexOf(secondMovedFace) < movedFaces.indexOf(firstMovedFace)}`);
+        firstStyle.remove();
+        secondStyle.remove();
+
+        document.fonts.delete(manualFace);
+    });
+</script>


### PR DESCRIPTION
This allows the fonts on Outlook to load.

Before:

<img width="146" height="146" alt="Screenshot 2026-08-22 at 18 26 54" src="https://github.com/user-attachments/assets/a38bae67-b9c1-4f3a-ac92-246cffbc8cbb" />

After:
<img width="136" height="146" alt="Screenshot 2026-08-22 at 18 07 28" src="https://github.com/user-attachments/assets/33ba0d07-5847-4fe0-bd72-fa707fef8223" />
