### PR TITLE
UI: Make Duplicate Tab duplicate session history and add it to AppKit

### DIFF
--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -584,6 +584,29 @@ static char s_tab_group_observation_context;
     [current_window performClose:self];
 }
 
+- (void)duplicateCurrentTab:(id)sender
+{
+    auto* key_window = [NSApp keyWindow];
+    if (![key_window isKindOfClass:[Tab class]])
+        return;
+    auto* source_tab = (Tab*)key_window;
+
+    auto& source_view = [[source_tab web_view] view];
+    auto history = source_view.session_history_snapshot();
+    auto source_url = source_view.url();
+
+    auto* controller = [self createNewTab:Optional<URL::URL> { }
+                                  fromTab:source_tab
+                                isPrivate:[source_tab isPrivate]
+                              activateTab:Web::HTML::ActivateTab::Yes
+                              tabLocation:TabLocation::after_tab(source_tab)];
+    auto& duplicate_view = [[(Tab*)[controller window] web_view] view];
+
+    if (!history.has_value() || duplicate_view.restore_session_history_from_snapshot(history.release_value()).is_error())
+        [controller loadURL:source_url];
+    [controller focusWebView];
+}
+
 - (WebView::IsPrivate)keyWindowPrivacy
 {
     if (auto* key_window = [NSApp keyWindow]; [key_window isKindOfClass:[Tab class]])
@@ -697,6 +720,9 @@ static char s_tab_group_observation_context;
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"New Tab"
                                                 action:@selector(createNewTab:)
                                          keyEquivalent:@"t"]];
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Duplicate Tab"
+                                                action:@selector(duplicateCurrentTab:)
+                                         keyEquivalent:@""]];
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Reopen Closed Tab"
                                                 action:@selector(reopenClosedTab:)
                                          keyEquivalent:@"T"]];
@@ -856,7 +882,7 @@ static char s_tab_group_observation_context;
 {
     SEL action = [menu action];
 
-    if (action == @selector(closeCurrentTab:)) {
+    if (action == @selector(closeCurrentTab:) || action == @selector(duplicateCurrentTab:)) {
         return [[NSApp keyWindow] isKindOfClass:[Tab class]];
     }
     if (action == @selector(reopenClosedTab:)) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -566,6 +566,16 @@ Tab& BrowserWindow::new_tab_from_url(URL::URL const& url, Web::HTML::ActivateTab
     return tab;
 }
 
+void BrowserWindow::duplicate_tab(Tab& source_tab)
+{
+    auto history = source_tab.view().session_history_snapshot();
+    auto source_url = source_tab.view().url();
+    auto& duplicate = create_new_tab(Web::HTML::ActivateTab::Yes, TabLocation::after_tab(source_tab));
+
+    if (!history.has_value() || duplicate.view().restore_session_history_from_snapshot(history.release_value()).is_error())
+        duplicate.navigate(source_url);
+}
+
 Tab& BrowserWindow::new_child_tab(Web::HTML::ActivateTab activate_tab, Tab& parent, Optional<u64> page_index)
 {
     return create_new_tab(activate_tab, parent, page_index);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -139,6 +139,7 @@ public:
     int tab_index(Tab*);
 
     Tab& create_new_tab(Web::HTML::ActivateTab activate_tab, TabLocation);
+    void duplicate_tab(Tab&);
     Tab* current_tab() const { return m_current_tab; }
     bool activate_tab_with_url(URL::URL const&);
     FullscreenMode& fullscreen_mode();

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -1038,7 +1038,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     auto* duplicate_tab_action = new QAction("&Duplicate Tab", this);
     QObject::connect(duplicate_tab_action, &QAction::triggered, this, [this]() {
-        m_window->new_tab_from_url(view().url(), Web::HTML::ActivateTab::Yes, BrowserWindow::TabLocation::after_tab(*this));
+        m_window->duplicate_tab(*this);
     });
 
     auto* move_to_start_action = new QAction("Move to &Start", this);


### PR DESCRIPTION
Previously, it only opened a new tab with the current URL. Also adds the action to AppKit.