### PR TITLE
Read paint geometry from retained committed fragment links

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -665,7 +665,7 @@ Layout::NodeArena& Document::layout_node_arena()
             [](void* context, Layout::RustFFI::PaintableSlotId slot, Layout::RustFFI::PaintableRowResetKind kind) {
                 auto& document = *static_cast<Document*>(context);
                 document.chrome_widget_registry().drop_widgets_for_slot(slot);
-                if (kind == Layout::RustFFI::PaintableRowResetKind::RelayoutReuse && Painting::viewport_row_slot(document).index == slot.index)
+                if (kind == Layout::RustFFI::PaintableRowResetKind::Recommitted && Painting::viewport_row_slot(document).index == slot.index)
                     document.paint_state().viewport_row_was_reset(document);
             });
     }

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -104,7 +104,7 @@ bool Box::is_partial_relayout_boundary() const
     // outermost one. An absolutely positioned SVG root's placement is not frozen, so it must
     // qualify through the saved-inputs replay path below instead.
     if (is_svg_svg_box() && !is_absolutely_positioned())
-        return has_saved_committed_geometry();
+        return has_committed_fragment_link();
 
     if (!is_absolutely_positioned())
         return false;

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -56,7 +56,7 @@ public:
 
     void notify_content_navigable_of_committed_viewport();
     bool has_saved_abspos_layout_inputs() const { return has_flag(RustFFI::NodeFlag::HasSavedAbsposLayoutInputs); }
-    bool has_saved_committed_geometry() const { return has_flag(RustFFI::NodeFlag::HasSavedCommittedGeometry); }
+    bool has_committed_fragment_link() const { return has_flag(RustFFI::NodeFlag::HasCommittedFragmentLink); }
     bool saved_abspos_cb_derives_from_own_computed_values() const { return has_flag(RustFFI::NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues); }
     bool saved_abspos_alignment_derives_from_own_computed_values() const { return has_flag(RustFFI::NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues); }
 

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -254,14 +254,12 @@ CSSPixels content_height(Layout::Node const& node)
 
 BoxModelMetrics box_model(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
-        return {};
+    auto metrics = Layout::RustFFI::layout_arena_paintable_box_model(node.arena_handle(), committed_row_slot(node));
     return {
-        .margin = pixel_box_from_ffi(row->margin),
-        .padding = pixel_box_from_ffi(row->padding),
-        .border = pixel_box_from_ffi(row->border),
-        .inset = pixel_box_from_ffi(row->inset),
+        .margin = pixel_box_from_ffi(metrics.margin),
+        .padding = pixel_box_from_ffi(metrics.padding),
+        .border = pixel_box_from_ffi(metrics.border),
+        .inset = pixel_box_from_ffi(metrics.inset),
     };
 }
 
@@ -407,8 +405,7 @@ bool has_non_invertible_css_transform(Layout::Node const& node)
 
 bool uses_collapsing_borders_model(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    return row && row->uses_collapsing_borders_model;
+    return Layout::RustFFI::layout_arena_paintable_uses_collapsing_borders_model(node.arena_handle(), committed_row_slot(node));
 }
 
 SelectionState selection_state(Layout::Node const& node)

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -67,8 +67,10 @@ static Gfx::FloatRect svg_svg_box_view_box_or_viewport_rect(Layout::Box const& s
 {
     if (auto view_box = as<SVG::SVGSVGElement>(*svg_svg_box.dom_node()).active_view_box(); view_box.has_value())
         return { view_box->min_x, view_box->min_y, view_box->width, view_box->height };
-    if (auto const* row = committed_row(svg_svg_box))
-        return { {}, { CSSPixels::from_raw(row->svg_viewport_size.width).to_float(), CSSPixels::from_raw(row->svg_viewport_size.height).to_float() } };
+    if (has_committed_box(svg_svg_box)) {
+        auto size = svg_viewport_size(svg_svg_box);
+        return { {}, { size.width().to_float(), size.height().to_float() } };
+    }
     return {};
 }
 
@@ -596,21 +598,16 @@ Gfx::Path const* committed_svg_path(Layout::Node const& node)
 
 CSSPixelSize svg_viewport_size(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
-        return {};
-    return {
-        CSSPixels::from_raw(row->svg_viewport_size.width),
-        CSSPixels::from_raw(row->svg_viewport_size.height),
-    };
+    auto size = Layout::RustFFI::layout_arena_paintable_svg_viewport_size(node.arena_handle(), committed_row_slot(node));
+    return { CSSPixels::from_raw(size.width), CSSPixels::from_raw(size.height) };
 }
 
 Optional<Gfx::AffineTransform> svg_viewport_transform(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row || !row->has_svg_viewport_transform)
+    auto result = Layout::RustFFI::layout_arena_paintable_svg_viewport_transform(node.arena_handle(), committed_row_slot(node));
+    if (!result.has_value)
         return {};
-    auto const& transform = row->svg_viewport_transform;
+    auto const& transform = result.transform;
     return Gfx::AffineTransform { transform.a, transform.b, transform.c, transform.d, transform.e, transform.f };
 }
 

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -228,18 +228,14 @@ CSSPixels absolute_y(Layout::Node const& node)
 
 CSSPixelPoint offset(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
-        return {};
-    return { CSSPixels::from_raw(row->offset.x), CSSPixels::from_raw(row->offset.y) };
+    auto offset = Layout::RustFFI::layout_arena_paintable_offset(node.arena_handle(), committed_row_slot(node));
+    return { CSSPixels::from_raw(offset.x), CSSPixels::from_raw(offset.y) };
 }
 
 CSSPixelSize content_size(Layout::Node const& node)
 {
-    auto const* row = committed_row(node);
-    if (!row)
-        return {};
-    return { CSSPixels::from_raw(row->content_size.width), CSSPixels::from_raw(row->content_size.height) };
+    auto size = Layout::RustFFI::layout_arena_paintable_content_size(node.arena_handle(), committed_row_slot(node));
+    return { CSSPixels::from_raw(size.width), CSSPixels::from_raw(size.height) };
 }
 
 CSSPixels content_width(Layout::Node const& node)

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -22,11 +22,12 @@ fn commit_subtree(
     callbacks: &FfiLayoutFcCallbacks,
     sink: &FfiCommitSink,
     paintables: &crate::painting::paintable_build::PaintableCommit<'_>,
-    scopes: &mut crate::layout::CommitScopes<'_>,
+    links_by_slot: &std::collections::HashMap<u32, &crate::layout::FragmentLink>,
+    pass_fragments: &crate::layout::CompletedPassFragments,
 ) {
     let slot_index = callbacks.slot_index(node);
-    let entry = scopes.link_for_slot(slot_index);
-    let reuses_committed_subtree = scopes.subtree_was_reused(slot_index);
+    let entry = links_by_slot.get(&slot_index).copied();
+    let reuses_committed_subtree = pass_fragments.subtree_was_reused(slot_index);
     debug_assert!(!reuses_committed_subtree || entry.is_some());
     if let Some(link) = entry {
         callbacks.set_saved_abspos_layout_inputs(node, link.abspos_layout_inputs);
@@ -70,17 +71,11 @@ fn commit_subtree(
         return;
     }
 
-    if let Some(link) = entry {
-        scopes.open_scope(&link.fragment.children);
-    }
     let mut child = callbacks.first_child(node);
     while !child.is_invalid() {
         let next = callbacks.next_sibling(child);
-        commit_subtree(child, callbacks, sink, paintables, scopes);
+        commit_subtree(child, callbacks, sink, paintables, links_by_slot, pass_fragments);
         child = next;
-    }
-    if entry.is_some() {
-        scopes.close_scope();
     }
 
     if has_pending_inline_box_geometry {
@@ -97,10 +92,10 @@ pub(crate) fn commit_replacing(
     sink: &FfiCommitSink,
     pass_fragments: &crate::layout::CompletedPassFragments,
 ) {
-    let mut scopes = crate::layout::CommitScopes::for_pass(pass_fragments);
+    let links_by_slot = pass_fragments.links_by_slot();
     let paintables = crate::painting::paintable_build::PaintableCommit::new(callbacks);
     paintables.begin_commit(root);
-    commit_subtree(root, callbacks, sink, &paintables, &mut scopes);
+    commit_subtree(root, callbacks, sink, &paintables, &links_by_slot, pass_fragments);
     paintables.translate_reused_subtrees();
     paintables.discard_absolute_rects_memoized_during_commit();
     let viewport_shells = paintables.committed_navigable_container_viewport_shells();

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -30,11 +30,6 @@ fn commit_subtree(
     debug_assert!(!reuses_committed_subtree || entry.is_some());
     if let Some(link) = entry {
         callbacks.set_saved_abspos_layout_inputs(node, link.abspos_layout_inputs);
-        // SVG roots are the only non-abspos partial relayout boundaries; save their committed
-        // geometry so a later subtree pass can seed itself without reading the old paintable.
-        if callbacks.node_data(node).kind == NodeKind::SVGSVGBox {
-            callbacks.set_saved_committed_fragment(node, link.clone());
-        }
     }
     let prepared = paintables.prepare_node(node, entry.is_some(), reuses_committed_subtree);
     let paintable_slot = prepared.slot;
@@ -43,6 +38,7 @@ fn commit_subtree(
     if let Some(link) = entry
         && !paintable_slot.is_invalid()
     {
+        callbacks.set_committed_fragment_link(node, link.clone());
         let fragment = &link.fragment;
         let content_size_change = paintables.set_box_metrics(paintable_slot, link, reuses_committed_subtree);
         if prepared.row_existed_before_this_commit

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -38,9 +38,17 @@ fn commit_subtree(
     if let Some(link) = entry
         && !paintable_slot.is_invalid()
     {
-        callbacks.set_committed_fragment_link(node, link.clone());
         let fragment = &link.fragment;
-        let content_size_change = paintables.set_box_metrics(paintable_slot, link, reuses_committed_subtree);
+        debug_assert!(
+            fragment.computed_svg_path.is_some()
+                || !matches!(
+                    callbacks.node_data(node).kind,
+                    NodeKind::SVGGeometryBox | NodeKind::SVGTextBox | NodeKind::SVGTextPathBox
+                ),
+            "committed path-like fragment carries no computed SVG path"
+        );
+        let content_size_change =
+            paintables.replace_committed_fragment_link(node, paintable_slot, link, reuses_committed_subtree);
         if prepared.row_existed_before_this_commit
             && let Some((old_content_size, new_content_size)) = content_size_change
         {
@@ -53,41 +61,6 @@ fn commit_subtree(
 
         if !reuses_committed_subtree && let Some(line_data) = &fragment.line_data {
             has_pending_inline_box_geometry = paintables.set_line_data(paintable_slot, line_data, fragment.content_inline_size);
-        }
-
-        if !reuses_committed_subtree {
-            if let Some(transform) = fragment.svg_viewport_transform {
-                paintables.set_svg_viewport_transform(paintable_slot, transform);
-            }
-            if let Some(viewport_size) = fragment.svg_viewport_size {
-                paintables.set_svg_viewport_size(paintable_slot, viewport_size);
-            }
-            // The paintable keeps its committed path across relayout and only swaps it on an
-            // identity change, which is sound only while every committed path-like fragment
-            // carries a path.
-            debug_assert!(
-                fragment.computed_svg_path.is_some()
-                    || !matches!(
-                        callbacks.node_data(node).kind,
-                        NodeKind::SVGGeometryBox | NodeKind::SVGTextBox | NodeKind::SVGTextPathBox
-                    ),
-                "committed path-like fragment carries no computed SVG path"
-            );
-            if let Some(path) = &fragment.computed_svg_path {
-                paintables.set_computed_svg_path(paintable_slot, path);
-            }
-        }
-        if !reuses_committed_subtree && let Some(data) = &fragment.grid_layout_data {
-            paintables.set_grid_layout_data(paintable_slot, data);
-        }
-        if !reuses_committed_subtree && let Some(data) = &fragment.flex_layout_data {
-            paintables.set_flex_layout_data(paintable_slot, data);
-        }
-        if !reuses_committed_subtree && let Some(tracks) = &fragment.used_grid_tracks {
-            paintables.set_used_grid_tracks(paintable_slot, tracks);
-        }
-        if !reuses_committed_subtree && let Some(borders) = &fragment.collapsed_table_borders {
-            paintables.set_collapsed_table_borders(paintable_slot, borders);
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -4,30 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct FfiPaintableGeometry {
-    pub content_inline_size: crate::layout::CssPixels,
-    pub content_block_size: crate::layout::CssPixels,
-    pub content_offset: crate::layout::FfiCssPixelPoint,
-    pub svg_viewport_size: crate::layout::FfiCssPixelSize,
-    pub margin_left: crate::layout::CssPixels,
-    pub margin_right: crate::layout::CssPixels,
-    pub margin_top: crate::layout::CssPixels,
-    pub margin_bottom: crate::layout::CssPixels,
-    pub border_left: crate::layout::CssPixels,
-    pub border_right: crate::layout::CssPixels,
-    pub border_top: crate::layout::CssPixels,
-    pub border_bottom: crate::layout::CssPixels,
-    pub padding_left: crate::layout::CssPixels,
-    pub padding_right: crate::layout::CssPixels,
-    pub padding_top: crate::layout::CssPixels,
-    pub padding_bottom: crate::layout::CssPixels,
-    pub inset_left: crate::layout::CssPixels,
-    pub inset_right: crate::layout::CssPixels,
-    pub inset_top: crate::layout::CssPixels,
-    pub inset_bottom: crate::layout::CssPixels,
-}
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiCommitSink {
@@ -57,36 +33,7 @@ fn commit_subtree(
         // SVG roots are the only non-abspos partial relayout boundaries; save their committed
         // geometry so a later subtree pass can seed itself without reading the old paintable.
         if callbacks.node_data(node).kind == NodeKind::SVGSVGBox {
-            let fragment = &link.fragment;
-            debug_assert!(
-                fragment.svg_viewport_size.is_some(),
-                "committed SVG root fragment carries no viewport size"
-            );
-            callbacks.set_saved_committed_geometry(
-                node,
-                FfiPaintableGeometry {
-                    content_inline_size: fragment.content_inline_size,
-                    content_block_size: fragment.content_block_size,
-                    content_offset: link.committed_offset,
-                    svg_viewport_size: fragment.svg_viewport_size.unwrap_or_default(),
-                    margin_left: fragment.margin_left,
-                    margin_right: fragment.margin_right,
-                    margin_top: fragment.margin_top,
-                    margin_bottom: fragment.margin_bottom,
-                    border_left: fragment.border_left,
-                    border_right: fragment.border_right,
-                    border_top: fragment.border_top,
-                    border_bottom: fragment.border_bottom,
-                    padding_left: fragment.padding_left,
-                    padding_right: fragment.padding_right,
-                    padding_top: fragment.padding_top,
-                    padding_bottom: fragment.padding_bottom,
-                    inset_left: link.inset_left,
-                    inset_right: link.inset_right,
-                    inset_top: link.inset_top,
-                    inset_bottom: link.inset_bottom,
-                },
-            );
+            callbacks.set_saved_committed_fragment(node, link.clone());
         }
     }
     let prepared = paintables.prepare_node(node, entry.is_some(), reuses_committed_subtree);

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -5,36 +5,6 @@
  */
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
-pub struct FfiCommittedBoxMetrics {
-    pub fragment_identity: u64,
-    pub reuses_committed_subtree: bool,
-    pub content_offset: crate::layout::FfiCssPixelPoint,
-    pub content_inline_size: crate::layout::CssPixels,
-    pub content_block_size: crate::layout::CssPixels,
-    pub margin_left: crate::layout::CssPixels,
-    pub margin_right: crate::layout::CssPixels,
-    pub margin_top: crate::layout::CssPixels,
-    pub margin_bottom: crate::layout::CssPixels,
-    pub border_left: crate::layout::CssPixels,
-    pub border_right: crate::layout::CssPixels,
-    pub border_top: crate::layout::CssPixels,
-    pub border_bottom: crate::layout::CssPixels,
-    pub padding_left: crate::layout::CssPixels,
-    pub padding_right: crate::layout::CssPixels,
-    pub padding_top: crate::layout::CssPixels,
-    pub padding_bottom: crate::layout::CssPixels,
-    pub inset_left: crate::layout::CssPixels,
-    pub inset_right: crate::layout::CssPixels,
-    pub inset_top: crate::layout::CssPixels,
-    pub inset_bottom: crate::layout::CssPixels,
-    pub containing_line_box_index: usize,
-    pub has_containing_line_box_index: bool,
-    pub uses_collapsing_borders_model: bool,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
 pub struct FfiPaintableGeometry {
     pub content_inline_size: crate::layout::CssPixels,
     pub content_block_size: crate::layout::CssPixels,
@@ -127,33 +97,7 @@ fn commit_subtree(
         && !paintable_slot.is_invalid()
     {
         let fragment = &link.fragment;
-        let box_metrics = FfiCommittedBoxMetrics {
-            fragment_identity: fragment.identity,
-            reuses_committed_subtree,
-            content_offset: link.committed_offset,
-            content_inline_size: fragment.content_inline_size,
-            content_block_size: fragment.content_block_size,
-            margin_left: fragment.margin_left,
-            margin_right: fragment.margin_right,
-            margin_top: fragment.margin_top,
-            margin_bottom: fragment.margin_bottom,
-            border_left: fragment.border_left,
-            border_right: fragment.border_right,
-            border_top: fragment.border_top,
-            border_bottom: fragment.border_bottom,
-            padding_left: fragment.padding_left,
-            padding_right: fragment.padding_right,
-            padding_top: fragment.padding_top,
-            padding_bottom: fragment.padding_bottom,
-            inset_left: link.inset_left,
-            inset_right: link.inset_right,
-            inset_top: link.inset_top,
-            inset_bottom: link.inset_bottom,
-            containing_line_box_index: link.containing_line_box_index.unwrap_or(0),
-            has_containing_line_box_index: link.containing_line_box_index.is_some(),
-            uses_collapsing_borders_model: fragment.uses_collapsing_borders_model,
-        };
-        let content_size_change = paintables.set_box_metrics(paintable_slot, &box_metrics);
+        let content_size_change = paintables.set_box_metrics(paintable_slot, link, reuses_committed_subtree);
         if prepared.row_existed_before_this_commit
             && let Some((old_content_size, new_content_size)) = content_size_change
         {

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -995,12 +995,12 @@ impl FfiLayoutFcCallbacks {
         self.arena().saved_abspos_layout_inputs(data)
     }
 
-    pub(crate) fn saved_committed_geometry(&self, node: Node) -> Option<crate::layout::FfiPaintableGeometry> {
-        self.arena().saved_committed_geometry(self.arena().data(node))
+    pub(crate) fn saved_committed_fragment(&self, node: Node) -> Option<crate::layout::FragmentLink> {
+        self.arena().saved_committed_fragment(self.arena().data(node))
     }
 
-    pub(crate) fn set_saved_committed_geometry(&self, node: Node, geometry: crate::layout::FfiPaintableGeometry) {
-        self.arena().set_saved_committed_geometry(self.arena().data(node), geometry);
+    pub(crate) fn set_saved_committed_fragment(&self, node: Node, fragment: crate::layout::FragmentLink) {
+        self.arena().set_saved_committed_fragment(self.arena().data(node), fragment);
     }
 
     pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<crate::layout::AbsposLayoutInputs>) {
@@ -2156,7 +2156,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let sink = unsafe { &*sink };
 
         let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
-        let root_used = used_values_from_saved_committed_geometry(&callbacks, root)
+        let root_used = used_values_from_saved_committed_fragment(&callbacks, root)
             .expect("partial relayout root must have committed geometry");
         entry_records.register(root, root_used.clone());
         let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -995,12 +995,12 @@ impl FfiLayoutFcCallbacks {
         self.arena().saved_abspos_layout_inputs(data)
     }
 
-    pub(crate) fn saved_committed_fragment(&self, node: Node) -> Option<crate::layout::FragmentLink> {
-        self.arena().saved_committed_fragment(self.arena().data(node))
+    pub(crate) fn committed_fragment_link(&self, node: Node) -> Option<crate::layout::FragmentLink> {
+        self.arena().committed_fragment_link(self.arena().data(node))
     }
 
-    pub(crate) fn set_saved_committed_fragment(&self, node: Node, fragment: crate::layout::FragmentLink) {
-        self.arena().set_saved_committed_fragment(self.arena().data(node), fragment);
+    pub(crate) fn set_committed_fragment_link(&self, node: Node, link: crate::layout::FragmentLink) {
+        self.arena().set_committed_fragment_link(self.arena().data(node), link);
     }
 
     pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<crate::layout::AbsposLayoutInputs>) {
@@ -2156,7 +2156,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let sink = unsafe { &*sink };
 
         let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
-        let root_used = used_values_from_saved_committed_fragment(&callbacks, root)
+        let root_used = used_values_from_committed_fragment_link(&callbacks, root)
             .expect("partial relayout root must have committed geometry");
         entry_records.register(root, root_used.clone());
         let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -270,65 +270,29 @@ pub(crate) struct CompletedPassFragments {
     pub(crate) reused_subtree_roots: std::collections::HashSet<u32>,
 }
 
-pub(crate) struct CommitScopes<'tree> {
-    links_by_slot: std::collections::HashMap<u32, &'tree FragmentLink>,
-    open_scopes: Vec<&'tree [FragmentLink]>,
-    reused_subtree_roots: &'tree std::collections::HashSet<u32>,
-}
-
-impl<'tree> CommitScopes<'tree> {
-    pub(crate) fn for_pass(fragments: &'tree CompletedPassFragments) -> Self {
-        #[cfg(debug_assertions)]
-        assert_one_fragment_per_slot_in_whole_pass(&fragments.roots, &mut std::collections::HashSet::new());
-        let mut scopes = Self {
-            links_by_slot: std::collections::HashMap::new(),
-            open_scopes: Vec::new(),
-            reused_subtree_roots: &fragments.reused_subtree_roots,
-        };
-        scopes.open_scope(&fragments.roots);
-        scopes
-    }
-
-    pub(crate) fn link_for_slot(&self, slot: u32) -> Option<&'tree FragmentLink> {
-        self.links_by_slot.get(&slot).copied()
+impl CompletedPassFragments {
+    pub(crate) fn links_by_slot(&self) -> std::collections::HashMap<u32, &FragmentLink> {
+        fn insert_links<'tree>(
+            links: &'tree [FragmentLink],
+            links_by_slot: &mut std::collections::HashMap<u32, &'tree FragmentLink>,
+        ) {
+            for link in links {
+                let previous = links_by_slot.insert(link.fragment.node.slot_index(), link);
+                assert!(
+                    previous.is_none(),
+                    "two fragments claim slot {}",
+                    link.fragment.node.slot_index()
+                );
+                insert_links(&link.fragment.children, links_by_slot);
+            }
+        }
+        let mut links_by_slot = std::collections::HashMap::new();
+        insert_links(&self.roots, &mut links_by_slot);
+        links_by_slot
     }
 
     pub(crate) fn subtree_was_reused(&self, slot: u32) -> bool {
         self.reused_subtree_roots.contains(&slot)
-    }
-
-    pub(crate) fn open_scope(&mut self, links: &'tree [FragmentLink]) {
-        for link in links {
-            let previous = self.links_by_slot.insert(link.fragment.node.slot_index(), link);
-            assert!(
-                previous.is_none(),
-                "two open fragments claim slot {}",
-                link.fragment.node.slot_index()
-            );
-        }
-        self.open_scopes.push(links);
-    }
-
-    pub(crate) fn close_scope(&mut self) {
-        let links = self
-            .open_scopes
-            .pop()
-            .expect("a commit scope was closed without being opened");
-        for link in links {
-            self.links_by_slot.remove(&link.fragment.node.slot_index());
-        }
-    }
-}
-
-#[cfg(debug_assertions)]
-fn assert_one_fragment_per_slot_in_whole_pass(links: &[FragmentLink], seen: &mut std::collections::HashSet<u32>) {
-    for link in links {
-        assert!(
-            seen.insert(link.fragment.node.slot_index()),
-            "two fragments claim slot {}",
-            link.fragment.node.slot_index()
-        );
-        assert_one_fragment_per_slot_in_whole_pass(&link.fragment.children, seen);
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -159,9 +159,9 @@ struct SavedAbsposLayoutInputsSlot {
 }
 
 #[derive(Default)]
-struct SavedCommittedFragmentSlot {
+struct CommittedFragmentLinkSlot {
     generation: u8,
-    fragment: Option<Box<crate::layout::FragmentLink>>,
+    link: Option<Box<crate::layout::FragmentLink>>,
 }
 
 #[derive(Default)]
@@ -262,7 +262,7 @@ pub(crate) struct LayoutNodeArena {
     live_count: u32,
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
-    saved_committed_fragments: RefCell<Vec<SavedCommittedFragmentSlot>>,
+    committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
     replaced_content_facts: Vec<ReplacedContentFactsSlot>,
@@ -286,7 +286,7 @@ impl LayoutNodeArena {
             live_count: 0,
             intrinsic_size_caches: RefCell::new(Vec::new()),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
-            saved_committed_fragments: RefCell::new(Vec::new()),
+            committed_fragment_links: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
             replaced_content_facts: Vec::new(),
@@ -436,8 +436,8 @@ impl LayoutNodeArena {
         if let Some(slot) = self.saved_abspos_layout_inputs.get_mut().get_mut(index as usize) {
             *slot = SavedAbsposLayoutInputsSlot::default();
         }
-        if let Some(slot) = self.saved_committed_fragments.get_mut().get_mut(index as usize) {
-            *slot = SavedCommittedFragmentSlot::default();
+        if let Some(slot) = self.committed_fragment_links.get_mut().get_mut(index as usize) {
+            *slot = CommittedFragmentLinkSlot::default();
         }
         if let Some(slot) = self.text_contents.get_mut(index as usize) {
             *slot = TextContentSlot::default();
@@ -1074,41 +1074,41 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn saved_committed_fragment(&self, data: *const NodeData) -> Option<crate::layout::FragmentLink> {
+    pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<crate::layout::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
-        let slots = self.saved_committed_fragments.borrow();
-        let fragment = slots
+        let slots = self.committed_fragment_links.borrow();
+        let link = slots
             .get(index as usize)
             .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.fragment.as_deref().cloned());
+            .and_then(|slot| slot.link.as_deref().cloned());
 
         // SAFETY: slot_for_data() established that data points to a live slot
         // in this arena.
         let flags = unsafe { (&raw const (*data).flags).read() };
         assert_eq!(
-            flags & NodeFlag::HasSavedCommittedGeometry as u32 != 0,
-            fragment.is_some(),
-            "saved committed fragment presence flag disagrees with the arena side table"
+            flags & NodeFlag::HasCommittedFragmentLink as u32 != 0,
+            link.is_some(),
+            "committed fragment link presence flag disagrees with the arena side table"
         );
-        fragment
+        link
     }
 
-    pub(crate) fn set_saved_committed_fragment(&self, data: *mut NodeData, fragment: crate::layout::FragmentLink) {
+    pub(crate) fn set_committed_fragment_link(&self, data: *mut NodeData, link: crate::layout::FragmentLink) {
         let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.saved_committed_fragments.borrow_mut();
+        let mut slots = self.committed_fragment_links.borrow_mut();
         if slots.len() <= index as usize {
-            slots.resize_with(index as usize + 1, SavedCommittedFragmentSlot::default);
+            slots.resize_with(index as usize + 1, CommittedFragmentLinkSlot::default);
         }
         let slot = &mut slots[index as usize];
         if slot.generation != metadata.generation {
-            *slot = SavedCommittedFragmentSlot {
+            *slot = CommittedFragmentLinkSlot {
                 generation: metadata.generation,
-                fragment: Some(Box::new(fragment)),
+                link: Some(Box::new(link)),
             };
-        } else if let Some(saved_fragment) = &mut slot.fragment {
-            **saved_fragment = fragment;
+        } else if let Some(retained_link) = &mut slot.link {
+            **retained_link = link;
         } else {
-            slot.fragment = Some(Box::new(fragment));
+            slot.link = Some(Box::new(link));
         }
         drop(slots);
 
@@ -1117,18 +1117,18 @@ impl LayoutNodeArena {
         // arena's owner thread.
         unsafe {
             let flags = &raw mut (*data).flags;
-            flags.write(flags.read() | NodeFlag::HasSavedCommittedGeometry as u32);
+            flags.write(flags.read() | NodeFlag::HasCommittedFragmentLink as u32);
         }
     }
 
-    pub(crate) fn take_saved_committed_fragment(&self, data: *mut NodeData) -> Option<crate::layout::FragmentLink> {
+    pub(crate) fn take_committed_fragment_link(&self, data: *mut NodeData) -> Option<crate::layout::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.saved_committed_fragments.borrow_mut();
-        let fragment = slots
+        let mut slots = self.committed_fragment_links.borrow_mut();
+        let link = slots
             .get_mut(index as usize)
             .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.fragment.take())
-            .map(|fragment| *fragment);
+            .and_then(|slot| slot.link.take())
+            .map(|link| *link);
         drop(slots);
 
         // SAFETY: slot_for_data() established that data points to a live slot
@@ -1137,17 +1137,17 @@ impl LayoutNodeArena {
         unsafe {
             let flags = &raw mut (*data).flags;
             assert_eq!(
-                flags.read() & NodeFlag::HasSavedCommittedGeometry as u32 != 0,
-                fragment.is_some(),
-                "saved committed fragment presence flag disagrees with the arena side table"
+                flags.read() & NodeFlag::HasCommittedFragmentLink as u32 != 0,
+                link.is_some(),
+                "committed fragment link presence flag disagrees with the arena side table"
             );
-            flags.write(flags.read() & !(NodeFlag::HasSavedCommittedGeometry as u32));
+            flags.write(flags.read() & !(NodeFlag::HasCommittedFragmentLink as u32));
         }
-        fragment
+        link
     }
 
-    pub(crate) fn clear_saved_committed_fragment(&self, id: NodeSlotId) {
-        drop(self.take_saved_committed_fragment(self.data(id)));
+    pub(crate) fn clear_committed_fragment_link(&self, id: NodeSlotId) {
+        drop(self.take_committed_fragment_link(self.data(id)));
     }
 
     pub(crate) fn set_text_content(
@@ -2034,11 +2034,11 @@ mod tests {
     }
 
     #[test]
-    fn clearing_a_committed_box_evicts_its_saved_fragment() {
+    fn clearing_a_committed_box_evicts_its_fragment_link() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate();
-        arena.set_saved_committed_fragment(allocation.data, test_fragment_link(allocation.slot));
-        assert!(arena.saved_committed_fragment(allocation.data).is_some());
+        arena.set_committed_fragment_link(allocation.data, test_fragment_link(allocation.slot));
+        assert!(arena.committed_fragment_link(allocation.data).is_some());
 
         // SAFETY: arena is a live handle on this thread, and allocation names
         // a live slot in it.
@@ -2049,28 +2049,28 @@ mod tests {
             );
         }
 
-        assert!(arena.saved_committed_fragment(allocation.data).is_none());
+        assert!(arena.committed_fragment_link(allocation.data).is_none());
         arena.free(allocation.slot, allocation.generation);
     }
 
     #[test]
-    fn saved_committed_fragments_move_between_slots() {
+    fn committed_fragment_links_move_between_slots() {
         let mut arena = LayoutNodeArena::new();
         let old = arena.allocate();
         let new = arena.allocate();
         let link = test_fragment_link(old.slot);
         let retained_fragment = link.fragment.clone();
-        arena.set_saved_committed_fragment(old.data, link);
+        arena.set_committed_fragment_link(old.data, link);
 
         let moved = arena
-            .take_saved_committed_fragment(old.data)
+            .take_committed_fragment_link(old.data)
             .expect("old slot must retain its committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
-        arena.set_saved_committed_fragment(new.data, moved);
+        arena.set_committed_fragment_link(new.data, moved);
 
-        assert!(arena.saved_committed_fragment(old.data).is_none());
+        assert!(arena.committed_fragment_link(old.data).is_none());
         let moved = arena
-            .saved_committed_fragment(new.data)
+            .committed_fragment_link(new.data)
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
         arena.free(old.slot, old.generation);

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -159,12 +159,6 @@ struct SavedAbsposLayoutInputsSlot {
 }
 
 #[derive(Default)]
-struct CommittedFragmentLinkSlot {
-    generation: u8,
-    link: Option<Box<crate::layout::FragmentLink>>,
-}
-
-#[derive(Default)]
 pub(crate) struct TextContent {
     pub(crate) text: Vec<u16>,
     pub(crate) untransformed_text_is_ascii_whitespace: bool,
@@ -262,7 +256,6 @@ pub(crate) struct LayoutNodeArena {
     live_count: u32,
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
-    committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
     replaced_content_facts: Vec<ReplacedContentFactsSlot>,
@@ -286,7 +279,6 @@ impl LayoutNodeArena {
             live_count: 0,
             intrinsic_size_caches: RefCell::new(Vec::new()),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
-            committed_fragment_links: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
             replaced_content_facts: Vec::new(),
@@ -436,9 +428,7 @@ impl LayoutNodeArena {
         if let Some(slot) = self.saved_abspos_layout_inputs.get_mut().get_mut(index as usize) {
             *slot = SavedAbsposLayoutInputsSlot::default();
         }
-        if let Some(slot) = self.committed_fragment_links.get_mut().get_mut(index as usize) {
-            *slot = CommittedFragmentLinkSlot::default();
-        }
+        self.paintables.get_mut().reset_committed_fragment_link_slot(index);
         if let Some(slot) = self.text_contents.get_mut(index as usize) {
             *slot = TextContentSlot::default();
         }
@@ -1076,11 +1066,10 @@ impl LayoutNodeArena {
 
     pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<crate::layout::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
-        let slots = self.committed_fragment_links.borrow();
-        let link = slots
-            .get(index as usize)
-            .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.link.as_deref().cloned());
+        let link = self
+            .paintables
+            .borrow()
+            .committed_fragment_link_cloned(index, metadata.generation);
 
         // SAFETY: slot_for_data() established that data points to a live slot
         // in this arena.
@@ -1095,22 +1084,9 @@ impl LayoutNodeArena {
 
     pub(crate) fn set_committed_fragment_link(&self, data: *mut NodeData, link: crate::layout::FragmentLink) {
         let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.committed_fragment_links.borrow_mut();
-        if slots.len() <= index as usize {
-            slots.resize_with(index as usize + 1, CommittedFragmentLinkSlot::default);
-        }
-        let slot = &mut slots[index as usize];
-        if slot.generation != metadata.generation {
-            *slot = CommittedFragmentLinkSlot {
-                generation: metadata.generation,
-                link: Some(Box::new(link)),
-            };
-        } else if let Some(retained_link) = &mut slot.link {
-            **retained_link = link;
-        } else {
-            slot.link = Some(Box::new(link));
-        }
-        drop(slots);
+        self.paintables
+            .borrow()
+            .set_committed_fragment_link(index, metadata.generation, link);
 
         // SAFETY: slot_for_data() established that data points to a live slot
         // in this arena, and layout/tree building serialize mutation on the
@@ -1123,13 +1099,10 @@ impl LayoutNodeArena {
 
     pub(crate) fn take_committed_fragment_link(&self, data: *mut NodeData) -> Option<crate::layout::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.committed_fragment_links.borrow_mut();
-        let link = slots
-            .get_mut(index as usize)
-            .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.link.take())
-            .map(|link| *link);
-        drop(slots);
+        let link = self
+            .paintables
+            .borrow()
+            .take_committed_fragment_link(index, metadata.generation);
 
         // SAFETY: slot_for_data() established that data points to a live slot
         // in this arena, and layout/tree building serialize mutation on the

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -159,9 +159,9 @@ struct SavedAbsposLayoutInputsSlot {
 }
 
 #[derive(Default)]
-struct SavedCommittedGeometrySlot {
+struct SavedCommittedFragmentSlot {
     generation: u8,
-    geometry: Option<Box<crate::layout::FfiPaintableGeometry>>,
+    fragment: Option<Box<crate::layout::FragmentLink>>,
 }
 
 #[derive(Default)]
@@ -262,7 +262,7 @@ pub(crate) struct LayoutNodeArena {
     live_count: u32,
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
-    saved_committed_geometries: RefCell<Vec<SavedCommittedGeometrySlot>>,
+    saved_committed_fragments: RefCell<Vec<SavedCommittedFragmentSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
     replaced_content_facts: Vec<ReplacedContentFactsSlot>,
@@ -286,7 +286,7 @@ impl LayoutNodeArena {
             live_count: 0,
             intrinsic_size_caches: RefCell::new(Vec::new()),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
-            saved_committed_geometries: RefCell::new(Vec::new()),
+            saved_committed_fragments: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
             replaced_content_facts: Vec::new(),
@@ -436,8 +436,8 @@ impl LayoutNodeArena {
         if let Some(slot) = self.saved_abspos_layout_inputs.get_mut().get_mut(index as usize) {
             *slot = SavedAbsposLayoutInputsSlot::default();
         }
-        if let Some(slot) = self.saved_committed_geometries.get_mut().get_mut(index as usize) {
-            *slot = SavedCommittedGeometrySlot::default();
+        if let Some(slot) = self.saved_committed_fragments.get_mut().get_mut(index as usize) {
+            *slot = SavedCommittedFragmentSlot::default();
         }
         if let Some(slot) = self.text_contents.get_mut(index as usize) {
             *slot = TextContentSlot::default();
@@ -1074,48 +1074,41 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn saved_committed_geometry(
-        &self,
-        data: *const NodeData,
-    ) -> Option<crate::layout::FfiPaintableGeometry> {
+    pub(crate) fn saved_committed_fragment(&self, data: *const NodeData) -> Option<crate::layout::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
-        let slots = self.saved_committed_geometries.borrow();
-        let geometry = slots
+        let slots = self.saved_committed_fragments.borrow();
+        let fragment = slots
             .get(index as usize)
             .filter(|slot| slot.generation == metadata.generation)
-            .and_then(|slot| slot.geometry.as_deref().copied());
+            .and_then(|slot| slot.fragment.as_deref().cloned());
 
         // SAFETY: slot_for_data() established that data points to a live slot
         // in this arena.
         let flags = unsafe { (&raw const (*data).flags).read() };
         assert_eq!(
             flags & NodeFlag::HasSavedCommittedGeometry as u32 != 0,
-            geometry.is_some(),
-            "saved committed geometry presence flag disagrees with the arena side table"
+            fragment.is_some(),
+            "saved committed fragment presence flag disagrees with the arena side table"
         );
-        geometry
+        fragment
     }
 
-    pub(crate) fn set_saved_committed_geometry(
-        &self,
-        data: *mut NodeData,
-        geometry: crate::layout::FfiPaintableGeometry,
-    ) {
+    pub(crate) fn set_saved_committed_fragment(&self, data: *mut NodeData, fragment: crate::layout::FragmentLink) {
         let (index, metadata) = self.slot_for_data(data);
-        let mut slots = self.saved_committed_geometries.borrow_mut();
+        let mut slots = self.saved_committed_fragments.borrow_mut();
         if slots.len() <= index as usize {
-            slots.resize_with(index as usize + 1, SavedCommittedGeometrySlot::default);
+            slots.resize_with(index as usize + 1, SavedCommittedFragmentSlot::default);
         }
         let slot = &mut slots[index as usize];
         if slot.generation != metadata.generation {
-            *slot = SavedCommittedGeometrySlot {
+            *slot = SavedCommittedFragmentSlot {
                 generation: metadata.generation,
-                geometry: Some(Box::new(geometry)),
+                fragment: Some(Box::new(fragment)),
             };
-        } else if let Some(saved_geometry) = &mut slot.geometry {
-            **saved_geometry = geometry;
+        } else if let Some(saved_fragment) = &mut slot.fragment {
+            **saved_fragment = fragment;
         } else {
-            slot.geometry = Some(Box::new(geometry));
+            slot.fragment = Some(Box::new(fragment));
         }
         drop(slots);
 
@@ -1128,23 +1121,33 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn clear_saved_committed_geometry(&self, id: NodeSlotId) {
-        let data = self.data(id);
-        let index = id.slot_index() as usize;
-        let mut slots = self.saved_committed_geometries.borrow_mut();
-        if let Some(slot) = slots.get_mut(index)
-            && slot.generation == id.generation()
-        {
-            *slot = SavedCommittedGeometrySlot::default();
-        }
+    pub(crate) fn take_saved_committed_fragment(&self, data: *mut NodeData) -> Option<crate::layout::FragmentLink> {
+        let (index, metadata) = self.slot_for_data(data);
+        let mut slots = self.saved_committed_fragments.borrow_mut();
+        let fragment = slots
+            .get_mut(index as usize)
+            .filter(|slot| slot.generation == metadata.generation)
+            .and_then(|slot| slot.fragment.take())
+            .map(|fragment| *fragment);
         drop(slots);
 
-        // SAFETY: data() established that id names a live slot in this arena,
-        // and layout/tree building serialize mutation on the owner thread.
+        // SAFETY: slot_for_data() established that data points to a live slot
+        // in this arena, and layout/tree building serialize mutation on the
+        // owner thread.
         unsafe {
             let flags = &raw mut (*data).flags;
+            assert_eq!(
+                flags.read() & NodeFlag::HasSavedCommittedGeometry as u32 != 0,
+                fragment.is_some(),
+                "saved committed fragment presence flag disagrees with the arena side table"
+            );
             flags.write(flags.read() & !(NodeFlag::HasSavedCommittedGeometry as u32));
         }
+        fragment
+    }
+
+    pub(crate) fn clear_saved_committed_fragment(&self, id: NodeSlotId) {
+        drop(self.take_saved_committed_fragment(self.data(id)));
     }
 
     pub(crate) fn set_text_content(
@@ -1901,7 +1904,47 @@ mod tests {
         SLOTS_PER_CHUNK,
     };
     use crate::layout::node_data::{NodeFlag, NodeSlotId};
-    use crate::layout::{AvailableSize, CssPixels, FfiPaintableGeometry};
+    use crate::layout::{AvailableSize, CssPixels, Fragment, FragmentLink};
+
+    fn test_fragment_link(node: NodeSlotId) -> FragmentLink {
+        FragmentLink {
+            fragment: std::rc::Rc::new(Fragment {
+                identity: 1,
+                node,
+                content_inline_size: CssPixels::default(),
+                content_block_size: CssPixels::default(),
+                margin_left: CssPixels::default(),
+                margin_right: CssPixels::default(),
+                margin_top: CssPixels::default(),
+                margin_bottom: CssPixels::default(),
+                border_left: CssPixels::default(),
+                border_right: CssPixels::default(),
+                border_top: CssPixels::default(),
+                border_bottom: CssPixels::default(),
+                padding_left: CssPixels::default(),
+                padding_right: CssPixels::default(),
+                padding_top: CssPixels::default(),
+                padding_bottom: CssPixels::default(),
+                uses_collapsing_borders_model: false,
+                collapsed_table_borders: None,
+                line_data: None,
+                grid_layout_data: None,
+                flex_layout_data: None,
+                used_grid_tracks: None,
+                svg_viewport_transform: None,
+                svg_viewport_size: None,
+                computed_svg_path: None,
+                children: Vec::new(),
+            }),
+            committed_offset: Default::default(),
+            inset_left: CssPixels::default(),
+            inset_right: CssPixels::default(),
+            inset_top: CssPixels::default(),
+            inset_bottom: CssPixels::default(),
+            containing_line_box_index: None,
+            abspos_layout_inputs: None,
+        }
+    }
 
     #[test]
     fn node_data_addresses_remain_stable_when_chunks_are_added() {
@@ -1991,11 +2034,11 @@ mod tests {
     }
 
     #[test]
-    fn clearing_a_committed_box_evicts_its_saved_geometry() {
+    fn clearing_a_committed_box_evicts_its_saved_fragment() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate();
-        arena.set_saved_committed_geometry(allocation.data, FfiPaintableGeometry::default());
-        assert!(arena.saved_committed_geometry(allocation.data).is_some());
+        arena.set_saved_committed_fragment(allocation.data, test_fragment_link(allocation.slot));
+        assert!(arena.saved_committed_fragment(allocation.data).is_some());
 
         // SAFETY: arena is a live handle on this thread, and allocation names
         // a live slot in it.
@@ -2006,8 +2049,32 @@ mod tests {
             );
         }
 
-        assert!(arena.saved_committed_geometry(allocation.data).is_none());
+        assert!(arena.saved_committed_fragment(allocation.data).is_none());
         arena.free(allocation.slot, allocation.generation);
+    }
+
+    #[test]
+    fn saved_committed_fragments_move_between_slots() {
+        let mut arena = LayoutNodeArena::new();
+        let old = arena.allocate();
+        let new = arena.allocate();
+        let link = test_fragment_link(old.slot);
+        let retained_fragment = link.fragment.clone();
+        arena.set_saved_committed_fragment(old.data, link);
+
+        let moved = arena
+            .take_saved_committed_fragment(old.data)
+            .expect("old slot must retain its committed fragment");
+        assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
+        arena.set_saved_committed_fragment(new.data, moved);
+
+        assert!(arena.saved_committed_fragment(old.data).is_none());
+        let moved = arena
+            .saved_committed_fragment(new.data)
+            .expect("new slot must receive the committed fragment");
+        assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
+        arena.free(old.slot, old.generation);
+        arena.free(new.slot, new.generation);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1128,6 +1128,25 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn clear_saved_committed_geometry(&self, id: NodeSlotId) {
+        let data = self.data(id);
+        let index = id.slot_index() as usize;
+        let mut slots = self.saved_committed_geometries.borrow_mut();
+        if let Some(slot) = slots.get_mut(index)
+            && slot.generation == id.generation()
+        {
+            *slot = SavedCommittedGeometrySlot::default();
+        }
+        drop(slots);
+
+        // SAFETY: data() established that id names a live slot in this arena,
+        // and layout/tree building serialize mutation on the owner thread.
+        unsafe {
+            let flags = &raw mut (*data).flags;
+            flags.write(flags.read() & !(NodeFlag::HasSavedCommittedGeometry as u32));
+        }
+    }
+
     pub(crate) fn set_text_content(
         &mut self,
         id: NodeSlotId,
@@ -1882,7 +1901,7 @@ mod tests {
         SLOTS_PER_CHUNK,
     };
     use crate::layout::node_data::{NodeFlag, NodeSlotId};
-    use crate::layout::{AvailableSize, CssPixels};
+    use crate::layout::{AvailableSize, CssPixels, FfiPaintableGeometry};
 
     #[test]
     fn node_data_addresses_remain_stable_when_chunks_are_added() {
@@ -1969,6 +1988,26 @@ mod tests {
         let stale_read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| arena.data(first.slot)));
         assert!(stale_read.is_err());
         arena.free(second.slot, second.generation);
+    }
+
+    #[test]
+    fn clearing_a_committed_box_evicts_its_saved_geometry() {
+        let mut arena = LayoutNodeArena::new();
+        let allocation = arena.allocate();
+        arena.set_saved_committed_geometry(allocation.data, FfiPaintableGeometry::default());
+        assert!(arena.saved_committed_geometry(allocation.data).is_some());
+
+        // SAFETY: arena is a live handle on this thread, and allocation names
+        // a live slot in it.
+        unsafe {
+            crate::painting::ffi::layout_arena_paintable_cleared_from_node(
+                std::ptr::from_mut(&mut arena).cast(),
+                allocation.slot,
+            );
+        }
+
+        assert!(arena.saved_committed_geometry(allocation.data).is_none());
+        arena.free(allocation.slot, allocation.generation);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -160,7 +160,7 @@ pub enum NodeFlag {
     ListMarkerIsInside = 1 << 23,
     HasAnchorNames = 1 << 24,
     InsetsUseAnchorFunctions = 1 << 25,
-    HasSavedCommittedGeometry = 1 << 26,
+    HasCommittedFragmentLink = 1 << 26,
     HasPreserve3dTransformStyle = 1 << 27,
 }
 
@@ -263,8 +263,8 @@ mod tests {
     }
 
     #[test]
-    fn saved_committed_geometry_flag_uses_a_previously_unassigned_bit() {
-        assert_eq!(NodeFlag::HasSavedCommittedGeometry as u32, 1 << 26);
+    fn committed_fragment_link_flag_uses_a_previously_unassigned_bit() {
+        assert_eq!(NodeFlag::HasCommittedFragmentLink as u32, 1 << 26);
         assert_eq!(NodeFlag::HasPreserve3dTransformStyle as u32, 1 << 27);
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1526,10 +1526,10 @@ fn update_principal_node_after_entry(
                     arena.set_saved_abspos_layout_inputs(new_data, Some(inputs));
                 }
                 // SAFETY: data() returned pointers to live slots.
-                if unsafe { (*old_data).kind == NodeKind::SVGSVGBox && (*new_data).kind == NodeKind::SVGSVGBox }
-                    && let Some(fragment) = arena.take_saved_committed_fragment(old_data)
+                if unsafe { node_kind_is_box((*old_data).kind) && node_kind_is_box((*new_data).kind) }
+                    && let Some(link) = arena.take_committed_fragment_link(old_data)
                 {
-                    arena.set_saved_committed_fragment(new_data, fragment);
+                    arena.set_committed_fragment_link(new_data, link);
                 }
             }
             unsafe {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1527,9 +1527,9 @@ fn update_principal_node_after_entry(
                 }
                 // SAFETY: data() returned pointers to live slots.
                 if unsafe { (*old_data).kind == NodeKind::SVGSVGBox && (*new_data).kind == NodeKind::SVGSVGBox }
-                    && let Some(geometry) = arena.saved_committed_geometry(old_data)
+                    && let Some(fragment) = arena.take_saved_committed_fragment(old_data)
                 {
-                    arena.set_saved_committed_geometry(new_data, geometry);
+                    arena.set_saved_committed_fragment(new_data, fragment);
                 }
             }
             unsafe {

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -803,44 +803,42 @@ pub(crate) fn create_used_values(
     std::rc::Rc::new(used)
 }
 
-pub(crate) fn used_values_from_saved_committed_geometry(
+pub(crate) fn used_values_from_saved_committed_fragment(
     callbacks: &FfiLayoutFcCallbacks,
     node: Node,
 ) -> Option<std::rc::Rc<UsedValues>> {
-    let geometry = callbacks.saved_committed_geometry(node)?;
+    let link = callbacks.saved_committed_fragment(node)?;
+    let fragment = &link.fragment;
 
     // Skip normal node initialization: resolving computed sizes requires
     // percentage bases, and every resulting geometry field is replaced by
     // the previously committed value immediately.
     let used = UsedValues::default();
-    used.set_content_inline_size(geometry.content_inline_size);
-    used.set_content_block_size(geometry.content_block_size);
+    used.set_content_inline_size(fragment.content_inline_size);
+    used.set_content_block_size(fragment.content_block_size);
     used.has_definite_inline_size.set(true);
     used.has_definite_block_size.set(true);
-    used.content_offset.set(geometry.content_offset);
-    used.margin_left.set(geometry.margin_left);
-    used.margin_right.set(geometry.margin_right);
-    used.margin_top.set(geometry.margin_top);
-    used.margin_bottom.set(geometry.margin_bottom);
-    used.border_left.set(geometry.border_left);
-    used.border_right.set(geometry.border_right);
-    used.border_top.set(geometry.border_top);
-    used.border_bottom.set(geometry.border_bottom);
-    used.padding_left.set(geometry.padding_left);
-    used.padding_right.set(geometry.padding_right);
-    used.padding_top.set(geometry.padding_top);
-    used.padding_bottom.set(geometry.padding_bottom);
-    used.inset_left.set(geometry.inset_left);
-    used.inset_right.set(geometry.inset_right);
-    used.inset_top.set(geometry.inset_top);
-    used.inset_bottom.set(geometry.inset_bottom);
+    used.content_offset.set(link.committed_offset);
+    used.margin_left.set(fragment.margin_left);
+    used.margin_right.set(fragment.margin_right);
+    used.margin_top.set(fragment.margin_top);
+    used.margin_bottom.set(fragment.margin_bottom);
+    used.border_left.set(fragment.border_left);
+    used.border_right.set(fragment.border_right);
+    used.border_top.set(fragment.border_top);
+    used.border_bottom.set(fragment.border_bottom);
+    used.padding_left.set(fragment.padding_left);
+    used.padding_right.set(fragment.padding_right);
+    used.padding_top.set(fragment.padding_top);
+    used.padding_bottom.set(fragment.padding_bottom);
+    used.inset_left.set(link.inset_left);
+    used.inset_right.set(link.inset_right);
+    used.inset_top.set(link.inset_top);
+    used.inset_bottom.set(link.inset_bottom);
     // Materialization is this box's placement: the previously committed
     // geometry is final from the moment it is adopted.
     used.has_content_offset.set(true);
     used.seal_committed_box_metrics();
 
-    if NodeFacts::new(callbacks, node).is_svg_svg_box() {
-        used.rare_data_mut().svg_viewport_size = Some(geometry.svg_viewport_size);
-    }
     Some(std::rc::Rc::new(used))
 }

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -353,9 +353,9 @@ impl UsedValues {
         }
     }
 
-    /// Seals every field that commit emits as part of FfiCommittedBoxMetrics.
-    /// Called when the box is placed: after placement, none of these may
-    /// change again.
+    /// Seals every box metric that is copied from a committed fragment into
+    /// its paint record. Called when the box is placed: after placement, none
+    /// of these may change again.
     pub(crate) fn seal_committed_box_metrics(&self) {
         self.content_inline_size.seal();
         self.content_block_size.seal();

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -803,11 +803,11 @@ pub(crate) fn create_used_values(
     std::rc::Rc::new(used)
 }
 
-pub(crate) fn used_values_from_saved_committed_fragment(
+pub(crate) fn used_values_from_committed_fragment_link(
     callbacks: &FfiLayoutFcCallbacks,
     node: Node,
 ) -> Option<std::rc::Rc<UsedValues>> {
-    let link = callbacks.saved_committed_fragment(node)?;
+    let link = callbacks.committed_fragment_link(node)?;
     let fragment = &link.fragment;
 
     // Skip normal node initialization: resolving computed sizes requires

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: Pa
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        arena.clear_saved_committed_fragment(layout_node);
+        arena.clear_committed_fragment_link(layout_node);
         let reset = {
             let paintables = arena.paintables().borrow();
             let slot = paintables.paintable_of_node(layout_node);

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -364,6 +364,53 @@ pub unsafe extern "C" fn layout_arena_paintable_content_size(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_size(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiCssPixelSize {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelSize::default();
+        }
+        crate::painting::paintable_geometry::committed_svg_viewport_size(&paintables, slot)
+    })
+}
+
+#[repr(C)]
+pub struct FfiOptionalAffineTransform {
+    pub has_value: bool,
+    pub transform: crate::layout::FfiAffineTransform,
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_transform(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiOptionalAffineTransform {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        let transform = if paintables.is_live(slot) {
+            crate::painting::paintable_geometry::committed_svg_viewport_transform(&paintables, slot)
+        } else {
+            None
+        };
+        FfiOptionalAffineTransform {
+            has_value: transform.is_some(),
+            transform: transform.unwrap_or_default(),
+        }
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_box_model(
     arena: *mut c_void,
     slot: PaintableSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -8,6 +8,7 @@ use crate::abort_on_panic;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::FfiCssPixelPoint;
 use crate::layout::FfiCssPixelRect;
+use crate::layout::FfiCssPixelSize;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::*;
@@ -324,6 +325,39 @@ pub struct FfiBoxModelMetrics {
     pub padding: crate::painting::paintable_data::FfiPixelBox,
     pub border: crate::painting::paintable_data::FfiPixelBox,
     pub inset: crate::painting::paintable_data::FfiPixelBox,
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_offset(arena: *mut c_void, slot: PaintableSlotId) -> FfiCssPixelPoint {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelPoint::default();
+        }
+        crate::painting::paintable_geometry::committed_offset(&paintables, slot)
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_content_size(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiCssPixelSize {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiCssPixelSize::default();
+        }
+        crate::painting::paintable_geometry::committed_content_size(&paintables, slot)
+    })
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -70,6 +70,7 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: Pa
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        arena.clear_saved_committed_geometry(layout_node);
         let reset = {
             let paintables = arena.paintables().borrow();
             let slot = paintables.paintable_of_node(layout_node);

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1184,10 +1184,7 @@ pub unsafe extern "C" fn layout_arena_paintable_computed_svg_path(
         if !paintables.is_live(paintable) {
             return std::ptr::null();
         }
-        paintables
-            .side(paintable)
-            .computed_svg_path
-            .as_ref()
+        crate::painting::paintable_geometry::committed_svg_path(&paintables, paintable)
             .map_or(std::ptr::null(), |path| path.as_raw())
     })
 }
@@ -1946,8 +1943,8 @@ pub unsafe extern "C" fn layout_arena_paintable_grid_layout_json(
         if !paintables.is_live(paintable) {
             return;
         }
-        if let Some(data) = &paintables.side(paintable).grid_layout_data {
-            let json = crate::painting::devtools_layout::serialize_grid_layout(data, container_node_id);
+        if let Some(data) = crate::painting::paintable_geometry::committed_grid_layout_data(&paintables, paintable) {
+            let json = crate::painting::devtools_layout::serialize_grid_layout(&data, container_node_id);
             unsafe { consume(context, json.as_ptr(), json.len()) };
         }
     });
@@ -1970,8 +1967,8 @@ pub unsafe extern "C" fn layout_arena_paintable_flex_layout_json(
         if !paintables.is_live(paintable) {
             return;
         }
-        if let Some(data) = &paintables.side(paintable).flex_layout_data {
-            let json = crate::painting::devtools_layout::serialize_flex_layout(data, container_node_id);
+        if let Some(data) = crate::painting::paintable_geometry::committed_flex_layout_data(&paintables, paintable) {
+            let json = crate::painting::devtools_layout::serialize_flex_layout(&data, container_node_id);
             unsafe { consume(context, json.as_ptr(), json.len()) };
         }
     });
@@ -1997,7 +1994,7 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
         if !paintables.is_live(paintable) {
             return;
         }
-        if let Some(tracks) = &paintables.side(paintable).used_grid_tracks {
+        if let Some(tracks) = crate::painting::paintable_geometry::committed_used_grid_tracks(&paintables, paintable) {
             tracks.with_ffi_views(|columns, rows| unsafe { consume(context, columns, rows) });
         }
     });

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: Pa
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        arena.clear_saved_committed_geometry(layout_node);
+        arena.clear_saved_committed_fragment(layout_node);
         let reset = {
             let paintables = arena.paintables().borrow();
             let slot = paintables.paintable_of_node(layout_node);

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -317,6 +317,56 @@ pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
     });
 }
 
+#[repr(C)]
+#[derive(Default)]
+pub struct FfiBoxModelMetrics {
+    pub margin: crate::painting::paintable_data::FfiPixelBox,
+    pub padding: crate::painting::paintable_data::FfiPixelBox,
+    pub border: crate::painting::paintable_data::FfiPixelBox,
+    pub inset: crate::painting::paintable_data::FfiPixelBox,
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_box_model(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> FfiBoxModelMetrics {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return FfiBoxModelMetrics::default();
+        }
+        FfiBoxModelMetrics {
+            margin: crate::painting::paintable_geometry::committed_margin(&paintables, slot),
+            padding: crate::painting::paintable_geometry::committed_padding(&paintables, slot),
+            border: crate::painting::paintable_geometry::committed_border(&paintables, slot),
+            inset: crate::painting::paintable_geometry::committed_inset(&paintables, slot),
+        }
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_uses_collapsing_borders_model(
+    arena: *mut c_void,
+    slot: PaintableSlotId,
+) -> bool {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintables = arena.paintables().borrow();
+        if !paintables.is_live(slot) {
+            return false;
+        }
+        crate::painting::paintable_geometry::committed_uses_collapsing_borders_model(&paintables, slot)
+    })
+}
+
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
@@ -1292,13 +1342,15 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_first_piece_position(
             return result;
         };
         let root_position = crate::painting::paintable_geometry::absolute_position(&paintables, root);
-        with_inline_pieces(&paintables, inline_paintable, |piece, data| {
+        let border_widths = crate::painting::paintable_geometry::committed_border(&paintables, inline_paintable);
+        let padding_widths = crate::painting::paintable_geometry::committed_padding(&paintables, inline_paintable);
+        with_inline_pieces(&paintables, inline_paintable, |piece, _data| {
             let border_rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect);
             let rect = if piece.is_geometry_only_placeholder {
                 border_rect
             } else {
-                let padding_rect = piece.shrunken_by_present_edges(border_rect, data.border);
-                piece.shrunken_by_present_edges(padding_rect, data.padding)
+                let padding_rect = piece.shrunken_by_present_edges(border_rect, border_widths);
+                piece.shrunken_by_present_edges(padding_rect, padding_widths)
             };
             result.has_value = true;
             result.x = rect.x + root_position.x;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -528,15 +528,8 @@ impl PaintableArena {
             data.containing_block = PaintableSlotId::INVALID;
             data.offset = FfiCssPixelPoint::default();
             data.content_size = FfiCssPixelSize::default();
-            data.margin = FfiPixelBox::default();
-            data.border = FfiPixelBox::default();
-            data.padding = FfiPixelBox::default();
-            data.inset = FfiPixelBox::default();
             data.overflow = FfiOverflowData::default();
             data.has_overflow = false;
-            data.containing_line_box_index = 0;
-            data.has_containing_line_box_index = false;
-            data.uses_collapsing_borders_model = false;
             data.sticky_insets = FfiStickyInsets::default();
             data.has_sticky_insets = false;
             data.local_padding_box_union = FfiCssPixelRect::default();
@@ -549,8 +542,6 @@ impl PaintableArena {
             data.accumulated_visual_context_for_descendants_index = 0;
             data.fixed_background_visual_context = 0;
             data.has_fixed_background_visual_context = false;
-            data.svg_viewport_transform = crate::layout::FfiAffineTransform::default();
-            data.has_svg_viewport_transform = false;
         });
         self.paint_caches[id.slot_index() as usize].clear();
         self.side_mut(id).reset_for_relayout();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -51,9 +51,16 @@ impl PaintableRowReset {
 }
 
 #[derive(Default)]
+struct CommittedFragmentLinkSlot {
+    layout_slot_generation: u8,
+    link: Option<Box<crate::layout::FragmentLink>>,
+}
+
+#[derive(Default)]
 pub struct PaintableArena {
     chunks: Vec<Box<Chunk>>,
     side_data: Vec<PaintableSideData>,
+    committed_fragment_links: std::cell::RefCell<Vec<CommittedFragmentLinkSlot>>,
     pub(crate) stacking_context_tree: Option<crate::painting::stacking_context::StackingContextTree>,
     pub(crate) visual_context: crate::painting::visual_context::VisualContextState,
     pub(crate) hit_test_list: Option<crate::painting::hit_test::HitTestList>,
@@ -87,6 +94,64 @@ impl PaintableArena {
 
     pub(crate) fn clear_chrome_state_callback(&mut self) {
         self.chrome_state_callback = None;
+    }
+
+    pub(crate) fn committed_fragment_link_cloned(
+        &self,
+        layout_slot_index: u32,
+        layout_slot_generation: u8,
+    ) -> Option<crate::layout::FragmentLink> {
+        self.committed_fragment_links
+            .borrow()
+            .get(layout_slot_index as usize)
+            .filter(|slot| slot.layout_slot_generation == layout_slot_generation)
+            .and_then(|slot| slot.link.as_deref().cloned())
+    }
+
+    pub(crate) fn set_committed_fragment_link(
+        &self,
+        layout_slot_index: u32,
+        layout_slot_generation: u8,
+        link: crate::layout::FragmentLink,
+    ) {
+        let mut slots = self.committed_fragment_links.borrow_mut();
+        if slots.len() <= layout_slot_index as usize {
+            slots.resize_with(layout_slot_index as usize + 1, CommittedFragmentLinkSlot::default);
+        }
+        let slot = &mut slots[layout_slot_index as usize];
+        if slot.layout_slot_generation != layout_slot_generation {
+            *slot = CommittedFragmentLinkSlot {
+                layout_slot_generation,
+                link: Some(Box::new(link)),
+            };
+        } else if let Some(retained_link) = &mut slot.link {
+            **retained_link = link;
+        } else {
+            slot.link = Some(Box::new(link));
+        }
+    }
+
+    pub(crate) fn take_committed_fragment_link(
+        &self,
+        layout_slot_index: u32,
+        layout_slot_generation: u8,
+    ) -> Option<crate::layout::FragmentLink> {
+        self.committed_fragment_links
+            .borrow_mut()
+            .get_mut(layout_slot_index as usize)
+            .filter(|slot| slot.layout_slot_generation == layout_slot_generation)
+            .and_then(|slot| slot.link.take())
+            .map(|link| *link)
+    }
+
+    pub(crate) fn reset_committed_fragment_link_slot(&mut self, layout_slot_index: u32) {
+        if let Some(slot) = self
+            .committed_fragment_links
+            .get_mut()
+            .get_mut(layout_slot_index as usize)
+        {
+            *slot = CommittedFragmentLinkSlot::default();
+        }
     }
 
     pub(crate) fn reset_visual_context_state(&mut self) {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -516,16 +516,13 @@ impl PaintableArena {
         paintable
     }
 
-    pub(crate) fn prepare_reset_for_relayout(&self, id: PaintableSlotId) -> PaintableRowReset {
+    pub(crate) fn prepare_recommit_notification(&self, id: PaintableSlotId) -> PaintableRowReset {
         assert!(self.is_live(id));
-        self.prepare_row_reset(id, PaintableRowResetKind::RelayoutReuse)
+        self.prepare_row_reset(id, PaintableRowResetKind::Recommitted)
     }
 
-    pub(crate) fn reset_for_relayout(&mut self, reset: PaintableRowReset) {
-        let id = reset.slot;
-        self.clear_absolute_rect_memo();
+    pub(crate) fn begin_row_recommit(&mut self, id: PaintableSlotId) {
         self.update_data(id, |data| {
-            data.containing_block = PaintableSlotId::INVALID;
             data.offset = FfiCssPixelPoint::default();
             data.content_size = FfiCssPixelSize::default();
             data.overflow = FfiOverflowData::default();
@@ -535,15 +532,8 @@ impl PaintableArena {
             data.local_padding_box_union = FfiCssPixelRect::default();
             data.local_border_box_union = FfiCssPixelRect::default();
             data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;
-            data.enclosing_scroll_node_index = 0;
-            data.own_scroll_node_index = 0;
-            data.has_accumulated_visual_context = false;
-            data.accumulated_visual_context_index = 0;
-            data.accumulated_visual_context_for_descendants_index = 0;
-            data.fixed_background_visual_context = 0;
-            data.has_fixed_background_visual_context = false;
         });
         self.paint_caches[id.slot_index() as usize].clear();
-        self.side_mut(id).reset_for_relayout();
+        self.side_mut(id).clear_committed_records();
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_arena.rs
@@ -96,6 +96,20 @@ impl PaintableArena {
         self.chrome_state_callback = None;
     }
 
+    pub(crate) fn with_committed_fragment_link<R>(
+        &self,
+        slot: PaintableSlotId,
+        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+    ) -> R {
+        debug_assert!(self.is_live(slot));
+        let slots = self.committed_fragment_links.borrow();
+        read(
+            slots
+                .get(slot.slot_index() as usize)
+                .and_then(|entry| entry.link.as_deref()),
+        )
+    }
+
     pub(crate) fn committed_fragment_link_cloned(
         &self,
         layout_slot_index: u32,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -9,8 +9,7 @@ use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::{
-    FfiCommittedBoxMetrics, FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiLayoutFcCallbacks, LineData, Node,
-    NodeFacts,
+    FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiLayoutFcCallbacks, FragmentLink, LineData, Node, NodeFacts,
 };
 use crate::painting::paintable_arena::PaintableArena;
 use crate::painting::paintable_data::*;
@@ -295,7 +294,6 @@ impl<'a> PaintableCommit<'a> {
                 PaintableFlag::ReplacedBox,
                 crate::layout::kind_is_replaced_box(data.kind),
             );
-            paintable.set_flag(PaintableFlag::PreparedByCommit, true);
             paintable.display = display.encoded();
         });
         PreparedPaintable {
@@ -315,58 +313,60 @@ impl<'a> PaintableCommit<'a> {
     pub(crate) fn set_box_metrics(
         &self,
         slot: PaintableSlotId,
-        metrics: &FfiCommittedBoxMetrics,
+        link: &FragmentLink,
+        reuses_committed_subtree: bool,
     ) -> Option<(FfiCssPixelSize, FfiCssPixelSize)> {
         let arena = self.arena.borrow();
         let mut content_size_change = None;
+        let fragment = &link.fragment;
         arena.update_data(slot, |data| {
-            if data.layout_fragment_identity != metrics.fragment_identity {
-                data.layout_fragment_identity = metrics.fragment_identity;
+            if data.layout_fragment_identity != fragment.identity {
+                data.layout_fragment_identity = fragment.identity;
                 data.cached_overflow = FfiOverflowData::default();
                 data.has_cached_overflow = false;
             }
             data.inset = FfiPixelBox {
-                top: metrics.inset_top,
-                right: metrics.inset_right,
-                bottom: metrics.inset_bottom,
-                left: metrics.inset_left,
+                top: link.inset_top,
+                right: link.inset_right,
+                bottom: link.inset_bottom,
+                left: link.inset_left,
             };
             data.padding = FfiPixelBox {
-                top: metrics.padding_top,
-                right: metrics.padding_right,
-                bottom: metrics.padding_bottom,
-                left: metrics.padding_left,
+                top: fragment.padding_top,
+                right: fragment.padding_right,
+                bottom: fragment.padding_bottom,
+                left: fragment.padding_left,
             };
             data.border = FfiPixelBox {
-                top: metrics.border_top,
-                right: metrics.border_right,
-                bottom: metrics.border_bottom,
-                left: metrics.border_left,
+                top: fragment.border_top,
+                right: fragment.border_right,
+                bottom: fragment.border_bottom,
+                left: fragment.border_left,
             };
             data.margin = FfiPixelBox {
-                top: metrics.margin_top,
-                right: metrics.margin_right,
-                bottom: metrics.margin_bottom,
-                left: metrics.margin_left,
+                top: fragment.margin_top,
+                right: fragment.margin_right,
+                bottom: fragment.margin_bottom,
+                left: fragment.margin_left,
             };
             let new_content_size = FfiCssPixelSize {
-                width: metrics.content_inline_size,
-                height: metrics.content_block_size,
+                width: fragment.content_inline_size,
+                height: fragment.content_block_size,
             };
             if data.content_size != new_content_size {
                 assert!(
-                    !metrics.reuses_committed_subtree,
+                    !reuses_committed_subtree,
                     "a reused committed subtree changed its content size"
                 );
                 content_size_change = Some((data.content_size, new_content_size));
             }
             data.content_size = new_content_size;
-            data.offset = metrics.content_offset;
-            if metrics.has_containing_line_box_index {
-                data.containing_line_box_index = metrics.containing_line_box_index;
+            data.offset = link.committed_offset;
+            if let Some(containing_line_box_index) = link.containing_line_box_index {
+                data.containing_line_box_index = containing_line_box_index;
                 data.has_containing_line_box_index = true;
             }
-            data.uses_collapsing_borders_model = metrics.uses_collapsing_borders_model;
+            data.uses_collapsing_borders_model = fragment.uses_collapsing_borders_model;
         });
         content_size_change
     }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -178,7 +178,7 @@ impl<'a> PaintableCommit<'a> {
             && expected_kind != PaintableKind::None;
         let existing_slot = self.arena.borrow().paintable_of_node(node);
         if !wants_paintable {
-            self.callbacks.arena().clear_saved_committed_fragment(node);
+            self.callbacks.arena().clear_committed_fragment_link(node);
             if !existing_slot.is_invalid() {
                 let reset = {
                     let arena = self.arena.borrow();
@@ -214,6 +214,9 @@ impl<'a> PaintableCommit<'a> {
                 slot: existing_slot,
                 row_existed_before_this_commit: true,
             };
+        }
+        if !has_used_values {
+            self.callbacks.arena().clear_committed_fragment_link(node);
         }
         let style = self.callbacks.computed_values_view_if_styled(node);
         let (position, floating, has_z_index, display) = match style {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -314,64 +314,54 @@ impl<'a> PaintableCommit<'a> {
             .collect()
     }
 
-    pub(crate) fn set_box_metrics(
+    pub(crate) fn replace_committed_fragment_link(
         &self,
+        node: Node,
         slot: PaintableSlotId,
         link: &FragmentLink,
         reuses_committed_subtree: bool,
     ) -> Option<(FfiCssPixelSize, FfiCssPixelSize)> {
-        let arena = self.arena.borrow();
-        let mut content_size_change = None;
         let fragment = &link.fragment;
-        arena.update_data(slot, |data| {
-            if data.layout_fragment_identity != fragment.identity {
-                data.layout_fragment_identity = fragment.identity;
-                data.cached_overflow = FfiOverflowData::default();
-                data.has_cached_overflow = false;
-            }
-            data.inset = FfiPixelBox {
-                top: link.inset_top,
-                right: link.inset_right,
-                bottom: link.inset_bottom,
-                left: link.inset_left,
+        let new_content_size = FfiCssPixelSize {
+            width: fragment.content_inline_size,
+            height: fragment.content_block_size,
+        };
+        let mut content_size_change = None;
+        {
+            let arena = self.arena.borrow();
+            let (old_identity, old_content_size) = arena.with_committed_fragment_link(slot, |old_link| {
+                old_link.map_or((0, FfiCssPixelSize::default()), |old_link| {
+                    (
+                        old_link.fragment.identity,
+                        FfiCssPixelSize {
+                            width: old_link.fragment.content_inline_size,
+                            height: old_link.fragment.content_block_size,
+                        },
+                    )
+                })
+            });
+            let previous_content_size_for_diff = if reuses_committed_subtree {
+                old_content_size
+            } else {
+                FfiCssPixelSize::default()
             };
-            data.padding = FfiPixelBox {
-                top: fragment.padding_top,
-                right: fragment.padding_right,
-                bottom: fragment.padding_bottom,
-                left: fragment.padding_left,
-            };
-            data.border = FfiPixelBox {
-                top: fragment.border_top,
-                right: fragment.border_right,
-                bottom: fragment.border_bottom,
-                left: fragment.border_left,
-            };
-            data.margin = FfiPixelBox {
-                top: fragment.margin_top,
-                right: fragment.margin_right,
-                bottom: fragment.margin_bottom,
-                left: fragment.margin_left,
-            };
-            let new_content_size = FfiCssPixelSize {
-                width: fragment.content_inline_size,
-                height: fragment.content_block_size,
-            };
-            if data.content_size != new_content_size {
+            if previous_content_size_for_diff != new_content_size {
                 assert!(
                     !reuses_committed_subtree,
                     "a reused committed subtree changed its content size"
                 );
-                content_size_change = Some((data.content_size, new_content_size));
+                content_size_change = Some((previous_content_size_for_diff, new_content_size));
             }
-            data.content_size = new_content_size;
-            data.offset = link.committed_offset;
-            if let Some(containing_line_box_index) = link.containing_line_box_index {
-                data.containing_line_box_index = containing_line_box_index;
-                data.has_containing_line_box_index = true;
-            }
-            data.uses_collapsing_borders_model = fragment.uses_collapsing_borders_model;
-        });
+            arena.update_data(slot, |data| {
+                if old_identity != fragment.identity {
+                    data.cached_overflow = FfiOverflowData::default();
+                    data.has_cached_overflow = false;
+                }
+                data.content_size = new_content_size;
+                data.offset = link.committed_offset;
+            });
+        }
+        self.callbacks.set_committed_fragment_link(node, link.clone());
         content_size_change
     }
 
@@ -574,79 +564,6 @@ impl<'a> PaintableCommit<'a> {
             dom_end_offset_with_trailing_whitespace,
             trailing_whitespace_length,
         )
-    }
-
-    pub(crate) fn set_svg_viewport_transform(
-        &self,
-        slot: PaintableSlotId,
-        transform: crate::layout::FfiAffineTransform,
-    ) {
-        let arena = self.arena.borrow();
-        arena.update_data(slot, |data| {
-            data.svg_viewport_transform = transform;
-            data.has_svg_viewport_transform = true;
-        });
-    }
-
-    pub(crate) fn set_svg_viewport_size(&self, slot: PaintableSlotId, size: FfiCssPixelSize) {
-        let arena = self.arena.borrow();
-        arena.update_data(slot, |data| {
-            if data.kind == PaintableKind::SVGSVGPaintable {
-                data.svg_viewport_size = size;
-            }
-        });
-    }
-
-    pub(crate) fn set_computed_svg_path(
-        &self,
-        slot: PaintableSlotId,
-        path: &std::rc::Rc<libgfx_rust::path::OwnedPath>,
-    ) {
-        let mut arena = self.arena.borrow_mut();
-        if arena.data_ref(slot).kind != PaintableKind::SVGPathPaintable {
-            return;
-        }
-        let side = arena.side_mut(slot);
-        if path.identity() != 0
-            && path.identity() == side.computed_svg_path_identity
-            && side.computed_svg_path.is_some()
-        {
-            return;
-        }
-        side.computed_svg_path = Some(path.clone());
-        side.computed_svg_path_identity = path.identity();
-    }
-
-    pub(crate) fn set_grid_layout_data(
-        &self,
-        slot: PaintableSlotId,
-        data: &std::rc::Rc<crate::layout::GridLayoutData>,
-    ) {
-        self.arena.borrow_mut().side_mut(slot).grid_layout_data = Some(data.clone());
-    }
-
-    pub(crate) fn set_flex_layout_data(
-        &self,
-        slot: PaintableSlotId,
-        data: &std::rc::Rc<crate::layout::FlexLayoutData>,
-    ) {
-        self.arena.borrow_mut().side_mut(slot).flex_layout_data = Some(data.clone());
-    }
-
-    pub(crate) fn set_used_grid_tracks(
-        &self,
-        slot: PaintableSlotId,
-        tracks: &std::rc::Rc<crate::layout::OwnedUsedGridTracks>,
-    ) {
-        self.arena.borrow_mut().side_mut(slot).used_grid_tracks = Some(tracks.clone());
-    }
-
-    pub(crate) fn set_collapsed_table_borders(
-        &self,
-        slot: PaintableSlotId,
-        borders: &std::rc::Rc<crate::layout::OwnedCollapsedTableBorders>,
-    ) {
-        self.arena.borrow_mut().side_mut(slot).collapsed_table_borders = Some(borders.clone());
     }
 
     pub(crate) fn stamp_containing_block(&self, node: Node, slot: PaintableSlotId) {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -178,7 +178,7 @@ impl<'a> PaintableCommit<'a> {
             && expected_kind != PaintableKind::None;
         let existing_slot = self.arena.borrow().paintable_of_node(node);
         if !wants_paintable {
-            self.callbacks.arena().clear_saved_committed_geometry(node);
+            self.callbacks.arena().clear_saved_committed_fragment(node);
             if !existing_slot.is_invalid() {
                 let reset = {
                     let arena = self.arena.borrow();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -681,10 +681,8 @@ impl<'a> PaintableCommit<'a> {
             {
                 continue;
             }
-            let (padding_widths, border_widths) = {
-                let data = arena.data_ref(inline_paintable);
-                (data.padding, data.border)
-            };
+            let padding_widths = crate::painting::paintable_geometry::committed_padding(&arena, inline_paintable);
+            let border_widths = crate::painting::paintable_geometry::committed_border(&arena, inline_paintable);
             let mut content_union: Option<CssPixelRect> = None;
             let mut padding_union: Option<CssPixelRect> = None;
             let mut border_union: Option<CssPixelRect> = None;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -178,6 +178,7 @@ impl<'a> PaintableCommit<'a> {
             && expected_kind != PaintableKind::None;
         let existing_slot = self.arena.borrow().paintable_of_node(node);
         if !wants_paintable {
+            self.callbacks.arena().clear_saved_committed_geometry(node);
             if !existing_slot.is_invalid() {
                 let reset = {
                     let arena = self.arena.borrow();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -248,10 +248,10 @@ impl<'a> PaintableCommit<'a> {
             self.offsets_before_commit
                 .borrow_mut()
                 .insert(existing_slot, arena.data_ref(existing_slot).offset);
-            let reset = arena.prepare_reset_for_relayout(existing_slot);
+            let notification = arena.prepare_recommit_notification(existing_slot);
             drop(arena);
-            reset.invoke_callback();
-            self.arena.borrow_mut().reset_for_relayout(reset);
+            notification.invoke_callback();
+            self.arena.borrow_mut().begin_row_recommit(existing_slot);
             existing_slot
         } else {
             let mut arena = self.arena.borrow_mut();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -274,7 +274,7 @@ pub const SELECTION_STATE_FULL: u8 = 4;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum PaintableRowResetKind {
-    RelayoutReuse = 0,
+    Recommitted = 0,
     Cleared = 1,
     Freed = 2,
 }
@@ -358,7 +358,7 @@ pub struct PaintableSideData {
 }
 
 impl PaintableSideData {
-    pub(crate) fn reset_for_relayout(&mut self) {
+    pub(crate) fn clear_committed_records(&mut self) {
         self.lines.clear();
         self.fragments.clear();
         self.inline_box_pieces.clear();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -6,12 +6,8 @@
 
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::{
-    FfiAffineTransform, FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiDrawGlyph, FlexLayoutData,
-    GridLayoutData, OwnedUsedGridTracks,
-};
+use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiDrawGlyph};
 use std::cell::Cell;
-use std::rc::Rc;
 
 pub const INVALID_PAINTABLE_SLOT_INDEX: u32 = u32::MAX;
 pub const NO_STACKING_CONTEXT: u32 = u32::MAX;
@@ -189,17 +185,6 @@ pub struct PaintableData {
 
     pub offset: FfiCssPixelPoint,
     pub content_size: FfiCssPixelSize,
-    pub margin: FfiPixelBox,
-    pub padding: FfiPixelBox,
-    pub border: FfiPixelBox,
-    pub inset: FfiPixelBox,
-    pub layout_fragment_identity: u64,
-    pub containing_line_box_index: usize,
-    pub has_containing_line_box_index: bool,
-    pub uses_collapsing_borders_model: bool,
-    pub has_svg_viewport_transform: bool,
-    pub svg_viewport_transform: FfiAffineTransform,
-    pub svg_viewport_size: FfiCssPixelSize,
     pub local_padding_box_union: FfiCssPixelRect,
     pub local_border_box_union: FfiCssPixelRect,
 
@@ -236,17 +221,6 @@ impl Default for PaintableData {
             display: crate::css::display::FfiDisplay::none().encoded(),
             offset: FfiCssPixelPoint::default(),
             content_size: FfiCssPixelSize::default(),
-            margin: FfiPixelBox::default(),
-            border: FfiPixelBox::default(),
-            padding: FfiPixelBox::default(),
-            inset: FfiPixelBox::default(),
-            layout_fragment_identity: 0,
-            containing_line_box_index: 0,
-            has_containing_line_box_index: false,
-            uses_collapsing_borders_model: false,
-            has_svg_viewport_transform: false,
-            svg_viewport_transform: FfiAffineTransform::default(),
-            svg_viewport_size: FfiCssPixelSize::default(),
             local_padding_box_union: FfiCssPixelRect::default(),
             local_border_box_union: FfiCssPixelRect::default(),
             overflow: FfiOverflowData::default(),
@@ -377,16 +351,10 @@ pub struct PaintableSideData {
     pub(crate) fragments: Vec<FragmentRecord>,
     pub(crate) inline_box_pieces: Vec<InlineBoxPieceRecord>,
     pub(crate) piece_indices: Vec<u32>,
-    pub(crate) computed_svg_path: Option<Rc<libgfx_rust::path::OwnedPath>>,
-    pub(crate) computed_svg_path_identity: u64,
     pub(crate) svg_filter_bounds: Cell<Option<FfiCssPixelRect>>,
     // Only meaningful while is_self_painting(); assigned by the containing block's
     // assign_fragment_ownership().
     pub(crate) fragment_ownership: Option<crate::painting::fragment_ownership::FragmentOwnershipFilter>,
-    pub(crate) grid_layout_data: Option<Rc<GridLayoutData>>,
-    pub(crate) flex_layout_data: Option<Rc<FlexLayoutData>>,
-    pub(crate) used_grid_tracks: Option<Rc<OwnedUsedGridTracks>>,
-    pub(crate) collapsed_table_borders: Option<Rc<crate::layout::OwnedCollapsedTableBorders>>,
 }
 
 impl PaintableSideData {
@@ -396,9 +364,5 @@ impl PaintableSideData {
         self.inline_box_pieces.clear();
         self.piece_indices.clear();
         self.fragment_ownership = None;
-        self.grid_layout_data = None;
-        self.flex_layout_data = None;
-        self.used_grid_tracks = None;
-        self.collapsed_table_borders = None;
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -141,7 +141,6 @@ pub enum PaintableFlag {
     Floating = 1 << 4,
     Inline = 1 << 5,
     HasNonInvertibleCssTransform = 1 << 6,
-    PreparedByCommit = 1 << 7,
     Anonymous = 1 << 8,
     Replaced = 1 << 9,
     FlexOrGridItem = 1 << 10,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -96,6 +96,54 @@ pub(crate) fn committed_uses_collapsing_borders_model(arena: &PaintableArena, sl
     })
 }
 
+pub(crate) fn committed_grid_layout_data(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<std::rc::Rc<crate::layout::GridLayoutData>> {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.grid_layout_data.clone())
+    })
+}
+
+pub(crate) fn committed_flex_layout_data(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<std::rc::Rc<crate::layout::FlexLayoutData>> {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.flex_layout_data.clone())
+    })
+}
+
+pub(crate) fn committed_used_grid_tracks(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<std::rc::Rc<crate::layout::OwnedUsedGridTracks>> {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.used_grid_tracks.clone())
+    })
+}
+
+pub(crate) fn committed_collapsed_table_borders(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<std::rc::Rc<crate::layout::OwnedCollapsedTableBorders>> {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.collapsed_table_borders.clone())
+    })
+}
+
+pub(crate) fn committed_svg_path(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<std::rc::Rc<libgfx_rust::path::OwnedPath>> {
+    if arena.data_ref(slot).kind != PaintableKind::SVGPathPaintable {
+        return None;
+    }
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.computed_svg_path.clone())
+    })
+}
+
 pub(crate) fn committed_containing_line_box_index(arena: &PaintableArena, slot: PaintableSlotId) -> Option<usize> {
     arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.containing_line_box_index))
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -96,6 +96,30 @@ pub(crate) fn committed_uses_collapsing_borders_model(arena: &PaintableArena, sl
     })
 }
 
+pub(crate) fn committed_containing_line_box_index(arena: &PaintableArena, slot: PaintableSlotId) -> Option<usize> {
+    arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.containing_line_box_index))
+}
+
+pub(crate) fn committed_svg_viewport_transform(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<crate::layout::FfiAffineTransform> {
+    arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.fragment.svg_viewport_transform))
+}
+
+pub(crate) fn committed_svg_viewport_size(
+    arena: &PaintableArena,
+    slot: PaintableSlotId,
+) -> crate::layout::FfiCssPixelSize {
+    if arena.data_ref(slot).kind != PaintableKind::SVGSVGPaintable {
+        return crate::layout::FfiCssPixelSize::default();
+    }
+    arena.with_committed_fragment_link(slot, |link| {
+        link.and_then(|link| link.fragment.svg_viewport_size)
+            .unwrap_or_default()
+    })
+}
+
 pub fn absolute_rect(arena: &PaintableArena, slot: PaintableSlotId) -> CssPixelRect {
     if let Some(rect) = arena.memoized_absolute_rect(slot) {
         return rect;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::css::css_pixels::CssPixels;
-use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixelSize};
+use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
 use crate::painting::paintable_arena::PaintableArena;
 use crate::painting::paintable_data::*;
 
@@ -21,8 +21,29 @@ pub(crate) fn is_svg_paintable(kind: PaintableKind) -> bool {
     )
 }
 
-pub fn content_size(data: &PaintableData) -> CssPixelSize {
-    data.content_size.into()
+pub(crate) fn committed_offset(arena: &PaintableArena, slot: PaintableSlotId) -> crate::layout::FfiCssPixelPoint {
+    let data = arena.data_ref(slot);
+    if data.kind == PaintableKind::InlinePaintable {
+        return data.offset;
+    }
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(crate::layout::FfiCssPixelPoint::default, |link| link.committed_offset)
+    })
+}
+
+pub(crate) fn committed_content_size(arena: &PaintableArena, slot: PaintableSlotId) -> crate::layout::FfiCssPixelSize {
+    let data = arena.data_ref(slot);
+    if data.kind == PaintableKind::InlinePaintable {
+        return data.content_size;
+    }
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(crate::layout::FfiCssPixelSize::default, |link| {
+            crate::layout::FfiCssPixelSize {
+                width: link.fragment.content_inline_size,
+                height: link.fragment.content_block_size,
+            }
+        })
+    })
 }
 
 pub(crate) fn committed_margin(arena: &PaintableArena, slot: PaintableSlotId) -> FfiPixelBox {
@@ -80,7 +101,10 @@ pub fn absolute_rect(arena: &PaintableArena, slot: PaintableSlotId) -> CssPixelR
         return rect;
     }
     let data = arena.data_ref(slot);
-    let mut rect = CssPixelRect::from_location_and_size(data.offset.into(), data.content_size.into());
+    let mut rect = CssPixelRect::from_location_and_size(
+        committed_offset(arena, slot).into(),
+        committed_content_size(arena, slot).into(),
+    );
     if is_svg_paintable(data.kind) {
         arena.memoize_absolute_rect(slot, rect);
         return rect;
@@ -91,7 +115,7 @@ pub fn absolute_rect(arena: &PaintableArena, slot: PaintableSlotId) -> CssPixelR
         if block_data.kind == PaintableKind::SVGSVGPaintable || is_svg_paintable(block_data.kind) {
             break;
         }
-        rect = rect.translated_by(block_data.offset.into());
+        rect = rect.translated_by(committed_offset(arena, block).into());
         if block_data.kind == PaintableKind::SVGForeignObjectPaintable {
             break;
         }
@@ -112,11 +136,12 @@ pub fn absolute_padding_box_rect(arena: &PaintableArena, slot: PaintableSlotId) 
         return CssPixelRect::from(data.local_padding_box_union).translated_by(absolute.location());
     }
     let padding = committed_padding(arena, slot);
+    let content_size = committed_content_size(arena, slot);
     CssPixelRect::new(
         absolute.x - padding.left,
         absolute.y - padding.top,
-        data.content_size.width + padding.left + padding.right,
-        data.content_size.height + padding.top + padding.bottom,
+        content_size.width + padding.left + padding.right,
+        content_size.height + padding.top + padding.bottom,
     )
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -25,6 +25,56 @@ pub fn content_size(data: &PaintableData) -> CssPixelSize {
     data.content_size.into()
 }
 
+pub(crate) fn committed_margin(arena: &PaintableArena, slot: PaintableSlotId) -> FfiPixelBox {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(FfiPixelBox::default, |link| FfiPixelBox {
+            top: link.fragment.margin_top,
+            right: link.fragment.margin_right,
+            bottom: link.fragment.margin_bottom,
+            left: link.fragment.margin_left,
+        })
+    })
+}
+
+pub(crate) fn committed_border(arena: &PaintableArena, slot: PaintableSlotId) -> FfiPixelBox {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(FfiPixelBox::default, |link| FfiPixelBox {
+            top: link.fragment.border_top,
+            right: link.fragment.border_right,
+            bottom: link.fragment.border_bottom,
+            left: link.fragment.border_left,
+        })
+    })
+}
+
+pub(crate) fn committed_padding(arena: &PaintableArena, slot: PaintableSlotId) -> FfiPixelBox {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(FfiPixelBox::default, |link| FfiPixelBox {
+            top: link.fragment.padding_top,
+            right: link.fragment.padding_right,
+            bottom: link.fragment.padding_bottom,
+            left: link.fragment.padding_left,
+        })
+    })
+}
+
+pub(crate) fn committed_inset(arena: &PaintableArena, slot: PaintableSlotId) -> FfiPixelBox {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(FfiPixelBox::default, |link| FfiPixelBox {
+            top: link.inset_top,
+            right: link.inset_right,
+            bottom: link.inset_bottom,
+            left: link.inset_left,
+        })
+    })
+}
+
+pub(crate) fn committed_uses_collapsing_borders_model(arena: &PaintableArena, slot: PaintableSlotId) -> bool {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.is_some_and(|link| link.fragment.uses_collapsing_borders_model)
+    })
+}
+
 pub fn absolute_rect(arena: &PaintableArena, slot: PaintableSlotId) -> CssPixelRect {
     if let Some(rect) = arena.memoized_absolute_rect(slot) {
         return rect;
@@ -61,7 +111,7 @@ pub fn absolute_padding_box_rect(arena: &PaintableArena, slot: PaintableSlotId) 
     if data.kind == PaintableKind::InlinePaintable {
         return CssPixelRect::from(data.local_padding_box_union).translated_by(absolute.location());
     }
-    let padding = data.padding;
+    let padding = committed_padding(arena, slot);
     CssPixelRect::new(
         absolute.x - padding.left,
         absolute.y - padding.top,
@@ -76,11 +126,12 @@ pub fn absolute_border_box_rect(arena: &PaintableArena, slot: PaintableSlotId) -
         return CssPixelRect::from(data.local_border_box_union).translated_by(absolute_rect(arena, slot).location());
     }
     let padded = absolute_padding_box_rect(arena, slot);
-    let mut border_top = data.border.top;
-    let mut border_bottom = data.border.bottom;
-    let mut border_left = data.border.left;
-    let mut border_right = data.border.right;
-    if data.uses_collapsing_borders_model {
+    let border = committed_border(arena, slot);
+    let mut border_top = border.top;
+    let mut border_bottom = border.bottom;
+    let mut border_left = border.left;
+    let mut border_right = border.right;
+    if committed_uses_collapsing_borders_model(arena, slot) {
         let two = CssPixels::from_integer(2);
         border_top = border_top.div_as_fraction(two).round();
         border_bottom = border_bottom.div_as_fraction(two).round();

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -251,7 +251,7 @@ impl<'a> PaintRecorder<'a> {
         if phase != PaintPhase::Foreground {
             return;
         }
-        let Some(path) = self.paintables.side(paintable).computed_svg_path.clone() else {
+        let Some(path) = paintable_geometry::committed_svg_path(self.paintables, paintable) else {
             return;
         };
         if !self.visibility_is_visible(paintable) || !self.visible_for_hit_testing(paintable) {

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -333,11 +333,11 @@ impl<'a> PaintRecorder<'a> {
         if containing_block.is_invalid() || !self.paintables.is_live(containing_block) {
             return None;
         }
-        let block = self.data(containing_block);
         let absolute = paintable_geometry::absolute_rect(self.paintables, containing_block);
         let margin = paintable_geometry::committed_margin(self.paintables, containing_block);
         let border = paintable_geometry::committed_border(self.paintables, containing_block);
         let padding = paintable_geometry::committed_padding(self.paintables, containing_block);
+        let content_size = paintable_geometry::committed_content_size(self.paintables, containing_block);
         let top = margin.top + border.top + padding.top;
         let right = margin.right + border.right + padding.right;
         let bottom = margin.bottom + border.bottom + padding.bottom;
@@ -345,8 +345,8 @@ impl<'a> PaintRecorder<'a> {
         Some(CssPixelRect::new(
             absolute.x - left,
             absolute.y - top,
-            block.content_size.width + left + right,
-            block.content_size.height + top + bottom,
+            content_size.width + left + right,
+            content_size.height + top + bottom,
         ))
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -335,10 +335,13 @@ impl<'a> PaintRecorder<'a> {
         }
         let block = self.data(containing_block);
         let absolute = paintable_geometry::absolute_rect(self.paintables, containing_block);
-        let top = block.margin.top + block.border.top + block.padding.top;
-        let right = block.margin.right + block.border.right + block.padding.right;
-        let bottom = block.margin.bottom + block.border.bottom + block.padding.bottom;
-        let left = block.margin.left + block.border.left + block.padding.left;
+        let margin = paintable_geometry::committed_margin(self.paintables, containing_block);
+        let border = paintable_geometry::committed_border(self.paintables, containing_block);
+        let padding = paintable_geometry::committed_padding(self.paintables, containing_block);
+        let top = margin.top + border.top + padding.top;
+        let right = margin.right + border.right + padding.right;
+        let bottom = margin.bottom + border.bottom + padding.bottom;
+        let left = margin.left + border.left + padding.left;
         Some(CssPixelRect::new(
             absolute.x - left,
             absolute.y - top,

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -389,15 +389,13 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn absolute_containing_line_box_rect(&self, paintable: PaintableSlotId) -> Option<CssPixelRect> {
-        let data = self.data(paintable);
-        if !data.has_containing_line_box_index {
-            return None;
-        }
-        let block = data.containing_block;
+        let containing_line_box_index =
+            paintable_geometry::committed_containing_line_box_index(self.paintables, paintable)?;
+        let block = self.data(paintable).containing_block;
         if block.is_invalid() || !self.paintables.is_live(block) || !self.data(block).kind.has_lines() {
             return None;
         }
-        let line = self.paintables.side(block).lines.get(data.containing_line_box_index)?;
+        let line = self.paintables.side(block).lines.get(containing_line_box_index)?;
         Some(CssPixelRect::from(line.rect).translated_by(paintable_geometry::absolute_position(self.paintables, block)))
     }
 
@@ -409,15 +407,14 @@ impl<'a> PaintRecorder<'a> {
         context: usize,
         border_radii: BorderRadii,
     ) {
-        let data = self.data(paintable_box);
-        let (caret_line_index, caret_line_rect) = if data.has_containing_line_box_index {
-            (
-                Some(data.containing_line_box_index),
-                self.absolute_containing_line_box_rect(paintable_box),
-            )
-        } else {
-            (None, None)
-        };
+        let (caret_line_index, caret_line_rect) =
+            match paintable_geometry::committed_containing_line_box_index(self.paintables, paintable_box) {
+                Some(containing_line_box_index) => (
+                    Some(containing_line_box_index),
+                    self.absolute_containing_line_box_rect(paintable_box),
+                ),
+                None => (None, None),
+            };
         let can_produce_caret_position = (self.is_atomic_inline(target) || self.is_replaced_box(target)) && {
             let negative_z = crate::painting::style_queries::effective_z_index(self.layout_arena, &self.data(target))
                 .unwrap_or(0)

--- a/Libraries/LibWeb/Rust/src/painting/record/masks.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/masks.rs
@@ -245,7 +245,7 @@ impl PaintRecorder<'_> {
 
     fn target_user_space_object_bounding_box(&self, target: PaintableSlotId) -> CssPixelRect {
         if self.data(target).kind == PaintableKind::SVGPathPaintable
-            && let Some(path) = &self.paintables.side(target).computed_svg_path
+            && let Some(path) = crate::painting::paintable_geometry::committed_svg_path(self.paintables, target)
         {
             let [x, y, width, height] = path.bounding_box();
             return CssPixelRect::new(

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -269,14 +269,13 @@ pub(crate) fn background_box_for(
     recorder: &PaintRecorder<'_>,
     paintable: PaintableSlotId,
 ) -> BackgroundBox {
-    let data = recorder.data(paintable);
     let mut background_box = border_box;
     if box_clip == css_enums::background_box::CONTENT_BOX {
-        let padding = data.padding;
+        let padding = crate::painting::paintable_geometry::committed_padding(recorder.paintables, paintable);
         background_box.shrink(padding.top, padding.right, padding.bottom, padding.left);
     }
     if box_clip == css_enums::background_box::CONTENT_BOX || box_clip == css_enums::background_box::PADDING_BOX {
-        let border = data.border;
+        let border = crate::painting::paintable_geometry::committed_border(recorder.paintables, paintable);
         background_box.shrink(border.top, border.right, border.bottom, border.left);
     }
     background_box

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/border.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/border.rs
@@ -1140,8 +1140,9 @@ pub(crate) fn paint_box_borders_from_style(
         return;
     };
     let zero = CssPixels::from_raw(0);
+    let border = crate::painting::paintable_geometry::committed_border(recorder.paintables, paintable);
     let borders_data = BordersDataDevicePixels {
-        top: if data.border.top == zero {
+        top: if border.top == zero {
             default_side
         } else {
             device_side(
@@ -1150,7 +1151,7 @@ pub(crate) fn paint_box_borders_from_style(
                 style.border_top_width(),
             )
         },
-        right: if data.border.right == zero {
+        right: if border.right == zero {
             default_side
         } else {
             device_side(
@@ -1159,7 +1160,7 @@ pub(crate) fn paint_box_borders_from_style(
                 style.border_right_width(),
             )
         },
-        bottom: if data.border.bottom == zero {
+        bottom: if border.bottom == zero {
             default_side
         } else {
             device_side(
@@ -1168,7 +1169,7 @@ pub(crate) fn paint_box_borders_from_style(
                 style.border_bottom_width(),
             )
         },
-        left: if data.border.left == zero {
+        left: if border.left == zero {
             default_side
         } else {
             device_side(
@@ -1179,22 +1180,22 @@ pub(crate) fn paint_box_borders_from_style(
         },
     };
     let css_border_widths = [
-        if data.border.top == zero {
+        if border.top == zero {
             zero
         } else {
             style.border_top_width()
         },
-        if data.border.right == zero {
+        if border.right == zero {
             zero
         } else {
             style.border_right_width()
         },
-        if data.border.bottom == zero {
+        if border.bottom == zero {
             zero
         } else {
             style.border_bottom_width()
         },
-        if data.border.left == zero {
+        if border.left == zero {
             zero
         } else {
             style.border_left_width()

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/fieldset.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/fieldset.rs
@@ -43,10 +43,9 @@ fn css_border_top_width(recorder: &PaintRecorder<'_>, fieldset: PaintableSlotId)
 fn effective_border_top(recorder: &PaintRecorder<'_>, fieldset: PaintableSlotId) -> CssPixels {
     let css_border_top = css_border_top_width(recorder, fieldset);
     if let Some(legend) = legend_paintable(recorder, fieldset) {
-        let legend_data = recorder.data(legend);
-        let legend_margin_box_height = legend_data.margin.top
-            + absolute_border_box_rect(recorder.paintables, legend).height
-            + legend_data.margin.bottom;
+        let legend_margin = crate::painting::paintable_geometry::committed_margin(recorder.paintables, legend);
+        let legend_margin_box_height =
+            legend_margin.top + absolute_border_box_rect(recorder.paintables, legend).height + legend_margin.bottom;
         return css_border_top.max(legend_margin_box_height);
     }
     css_border_top

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -55,7 +55,10 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId
                 continue;
             }
             let border_box_rect = CssPixelRect::from(piece.border_box_rect).translated_by(root_position);
-            let padding_box_rect = piece.shrunken_by_present_edges(border_box_rect, data.border);
+            let padding_box_rect = piece.shrunken_by_present_edges(
+                border_box_rect,
+                crate::painting::paintable_geometry::committed_border(recorder.paintables, paintable),
+            );
             let border_radii = recorder.piece_border_radii(paintable, piece);
             if !background_is_propagated_to_root {
                 background::paint_background_within(
@@ -99,7 +102,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId
                 },
             )
         };
-        let border = data.border;
+        let border = crate::painting::paintable_geometry::committed_border(recorder.paintables, paintable);
         for piece_index in piece_indices {
             let piece = &root_pieces[*piece_index as usize];
             if piece.is_geometry_only_placeholder {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -75,12 +75,14 @@ fn with_highlight_context(
 
 fn paint_box_model_highlight(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId) {
     let content_rect = paintable_geometry::absolute_rect(recorder.paintables, paintable);
-    let data = recorder.data(paintable);
+    let margin = paintable_geometry::committed_margin(recorder.paintables, paintable);
+    let border = paintable_geometry::committed_border(recorder.paintables, paintable);
+    let padding = paintable_geometry::committed_padding(recorder.paintables, paintable);
     let margin_rect = content_rect.inflated(
-        data.margin.top + data.border.top + data.padding.top,
-        data.margin.right + data.border.right + data.padding.right,
-        data.margin.bottom + data.border.bottom + data.padding.bottom,
-        data.margin.left + data.border.left + data.padding.left,
+        margin.top + border.top + padding.top,
+        margin.right + border.right + padding.right,
+        margin.bottom + border.bottom + padding.bottom,
+        margin.left + border.left + padding.left,
     );
     let border_rect = paintable_geometry::absolute_border_box_rect(recorder.paintables, paintable);
     let padding_rect = paintable_geometry::absolute_padding_box_rect(recorder.paintables, paintable);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -115,7 +115,9 @@ fn paint_box_model_highlight(recorder: &mut PaintRecorder<'_>, paintable: Painta
 }
 
 fn paint_flex_overlay(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId, input: &FfiFlexOverlayInput) {
-    let Some(flex_layout_data) = recorder.paintables.side(paintable).flex_layout_data.clone() else {
+    let Some(flex_layout_data) =
+        crate::painting::paintable_geometry::committed_flex_layout_data(recorder.paintables, paintable)
+    else {
         return;
     };
     let content_rect = paintable_geometry::absolute_rect(recorder.paintables, paintable);
@@ -245,7 +247,9 @@ fn paint_flex_overlay(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlot
 }
 
 fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId, input: &FfiGridOverlayInput) {
-    let Some(grid_layout_data) = recorder.paintables.side(paintable).grid_layout_data.clone() else {
+    let Some(grid_layout_data) =
+        crate::painting::paintable_geometry::committed_grid_layout_data(recorder.paintables, paintable)
+    else {
         return;
     };
     let content_rect = paintable_geometry::absolute_rect(recorder.paintables, paintable);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
@@ -158,7 +158,7 @@ pub(crate) fn paint_base_with(
         shadow::paint_box_shadow(recorder, paintable, border_box_rect, padding_box_rect, border_radii);
     }
     if phase == PaintPhase::Border
-        && !recorder.data(paintable).uses_collapsing_borders_model
+        && !crate::painting::paintable_geometry::committed_uses_collapsing_borders_model(recorder.paintables, paintable)
         && !facts.empty_cells_property_applies
     {
         border::paint_box_borders_from_style(recorder, paintable, &facts);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
@@ -230,7 +230,8 @@ pub(crate) fn record_pattern_paint_styles(recorder: &mut PaintRecorder<'_>, pain
     if recorder.draw_svg_geometry_for_clip_path {
         return;
     }
-    let Some(computed_path) = recorder.paintables.side(paintable).computed_svg_path.clone() else {
+    let Some(computed_path) = crate::painting::paintable_geometry::committed_svg_path(recorder.paintables, paintable)
+    else {
         return;
     };
     if !recorder.is_visible(paintable) {
@@ -302,7 +303,8 @@ fn record_pattern_paint_style(recorder: &mut PaintRecorder<'_>, style: &FfiSvgPa
 }
 
 pub(crate) fn paint_path(recorder: &mut PaintRecorder<'_>, paintable: PaintableSlotId, phase: PaintPhase) {
-    let Some(computed_path) = recorder.paintables.side(paintable).computed_svg_path.clone() else {
+    let Some(computed_path) = crate::painting::paintable_geometry::committed_svg_path(recorder.paintables, paintable)
+    else {
         return;
     };
     let (facts, dash_array) = svg_paint_facts(recorder, paintable);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/table_borders.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/table_borders.rs
@@ -157,11 +157,8 @@ fn to_device_edge(recorder: &PaintRecorder<'_>, edge: CollapsedBorderEdge) -> De
 pub(crate) fn paint_table_borders(recorder: &mut PaintRecorder<'_>, table_paintable: PaintableSlotId) {
     // Painting according to the collapsing border model:
     // https://www.w3.org/TR/CSS22/tables.html#collapsing-borders
-    let Some(borders) = recorder
-        .paintables
-        .side(table_paintable)
-        .collapsed_table_borders
-        .clone()
+    let Some(borders) =
+        crate::painting::paintable_geometry::committed_collapsed_table_borders(recorder.paintables, table_paintable)
     else {
         return;
     };

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -262,7 +262,8 @@ impl PaintRecorder<'_> {
 
         // Draw the background and borders for block-level children (step 4)
         self.paint_descendants(paintable, StackingContextPaintPhase::BackgroundAndBorders);
-        if self.paintables.side(paintable).collapsed_table_borders.is_some() {
+        if crate::painting::paintable_geometry::committed_collapsed_table_borders(self.paintables, paintable).is_some()
+        {
             self.paint_node(paintable, PaintPhase::TableCollapsedBorder);
         }
         // Draw the non-positioned floats (step 5)
@@ -330,7 +331,8 @@ impl PaintRecorder<'_> {
         if !self.is_pure_inline_box(paintable) {
             self.paint_descendants(paintable, StackingContextPaintPhase::BackgroundAndBorders);
         }
-        if self.paintables.side(paintable).collapsed_table_borders.is_some() {
+        if crate::painting::paintable_geometry::committed_collapsed_table_borders(self.paintables, paintable).is_some()
+        {
             self.paint_node(paintable, PaintPhase::TableCollapsedBorder);
         }
     }

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -410,12 +410,10 @@ pub(crate) fn measure_scrollable_overflow(
                     border.top != zero || border.right != zero || border.bottom != zero || border.left != zero;
                 if !has_border {
                     let padding = crate::painting::paintable_geometry::committed_padding(paintables, child_paintable);
-                    let content_box_relative_to_padding_box = CssPixelRect::new(
-                        padding.left,
-                        padding.top,
-                        child_data.content_size.width,
-                        child_data.content_size.height,
-                    );
+                    let content_size =
+                        crate::painting::paintable_geometry::committed_content_size(paintables, child_paintable);
+                    let content_box_relative_to_padding_box =
+                        CssPixelRect::new(padding.left, padding.top, content_size.width, content_size.height);
                     // The committed line fragment already contributes this content box. A box with no border whose
                     // cached overflow fits inside the content box cannot expand its containing block's overflow.
                     if content_box_relative_to_padding_box.contains_rect(child_data.cached_overflow.rect.into()) {

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -404,12 +404,12 @@ pub(crate) fn measure_scrollable_overflow(
                 && !child_has_css_transform
                 && child_data.has_cached_overflow
             {
-                let border = child_data.border;
+                let border = crate::painting::paintable_geometry::committed_border(paintables, child_paintable);
                 let zero = CssPixels::from_raw(0);
                 let has_border =
                     border.top != zero || border.right != zero || border.bottom != zero || border.left != zero;
                 if !has_border {
-                    let padding = child_data.padding;
+                    let padding = crate::painting::paintable_geometry::committed_padding(paintables, child_paintable);
                     let content_box_relative_to_padding_box = CssPixelRect::new(
                         padding.left,
                         padding.top,

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -231,7 +231,7 @@ fn padding_inflated_scrollable_overflow(
 ) -> CssPixelRect {
     let content_box = paintable_geometry::absolute_rect(paintables, box_paintable);
     let padding_box = paintable_geometry::absolute_padding_box_rect(paintables, box_paintable);
-    let padding = paintables.data_ref(box_paintable).padding;
+    let padding = paintable_geometry::committed_padding(paintables, box_paintable);
     let overflow_directions = physical_overflow_directions(layout_arena, box_node);
 
     let mut left = in_flow_and_floated_content_bounds.left();

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -302,6 +302,8 @@ impl Builder<'_> {
         self.paintables.update_data(slot, |data| {
             data.enclosing_scroll_node_index = 0;
             data.own_scroll_node_index = 0;
+            data.fixed_background_visual_context = 0;
+            data.has_fixed_background_visual_context = false;
         });
 
         let mut nearest_scroll_nodes_for_descendants = if is_fixed {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -46,11 +46,11 @@ pub fn compute_svg_viewport_transform_data(
     }
 }
 
-pub(crate) fn svg_viewport_transform_of(data: &PaintableData) -> Option<AffineTransform> {
-    if !data.has_svg_viewport_transform {
-        return None;
-    }
-    let t = data.svg_viewport_transform;
+pub(crate) fn svg_viewport_transform_of(
+    paintables: &crate::painting::paintable_arena::PaintableArena,
+    slot: PaintableSlotId,
+) -> Option<AffineTransform> {
+    let t = crate::painting::paintable_geometry::committed_svg_viewport_transform(paintables, slot)?;
     Some(AffineTransform {
         values: [t.a, t.b, t.c, t.d, t.e, t.f],
     })
@@ -663,7 +663,7 @@ impl Builder<'_> {
         // out in the box's own coordinate space, not the viewport's user units, so they hang
         // above the viewport transform node.
         let state_for_positioned_descendants = state_for_descendants;
-        if let Some(svg_viewport_transform) = svg_viewport_transform_of(&self.paintables.data_ref(slot)) {
+        if let Some(svg_viewport_transform) = svg_viewport_transform_of(self.paintables, slot) {
             let mut viewport_transform_data =
                 compute_svg_viewport_transform_data(self.paintables, slot, svg_viewport_transform, self.pixel_ratio);
             viewport_transform_data.flattens_inherited_transform = descendants_flatten_inherited_transform;
@@ -914,7 +914,7 @@ pub(crate) fn update_visual_context_values(
     let effects = super::node_values::compute_effects_data(layout_arena, paintables, callbacks, slot);
     let perspective =
         super::node_values::compute_perspective_data(layout_arena, paintables, callbacks, slot, pixel_ratio);
-    let svg_viewport_transform_data = svg_viewport_transform_of(&paintables.data_ref(slot))
+    let svg_viewport_transform_data = svg_viewport_transform_of(paintables, slot)
         .map(|transform| compute_svg_viewport_transform_data(paintables, slot, transform, pixel_ratio));
 
     paintables.update_data(slot, |data| {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
@@ -32,7 +32,6 @@ struct NestedBuilder<'a> {
 
 impl NestedBuilder<'_> {
     fn build_subtree(&mut self, slot: PaintableSlotId, inherited_state: usize, include_element_transform: bool) {
-        let data = self.paintables.data_ref(slot);
         let facts = BoxFacts::gather(
             self.layout_arena,
             self.paintables,
@@ -71,7 +70,7 @@ impl NestedBuilder<'_> {
             state_for_descendants = self.tree.append(VisualContextData::Clip(clip), state_for_descendants);
         }
 
-        if let Some(svg_viewport_transform) = svg_viewport_transform_of(&data) {
+        if let Some(svg_viewport_transform) = svg_viewport_transform_of(self.paintables, slot) {
             let viewport_transform_data =
                 compute_svg_viewport_transform_data(self.paintables, slot, svg_viewport_transform, self.pixel_ratio);
             state_for_descendants = self.tree.append(

--- a/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
@@ -191,7 +191,7 @@ pub(crate) fn empty_line_caret_targets(
     }
 
     let content_position = paintable_geometry::absolute_position(paintables, block);
-    let content_width = paintables.data_ref(block).content_size.width;
+    let content_width = paintable_geometry::committed_content_size(paintables, block).width;
     let mut targets = Vec::new();
     for (i, line) in lines.iter().enumerate() {
         if line.has_fragments {


### PR DESCRIPTION
Paintable rows copied their geometry out of the committed fragment tree, and every recommit ran `reset_for_relayout()` — a blanket ~25-field zeroing that existed only to keep those copies from going stale.

This series retains each box's committed `FragmentLink` instead, reads all geometry through
the link — Rust paint, hit-test, and overflow plus the C++ accessors — and deletes the copies: eleven row fields, six side-table payload clones, and seven commit-time setters. Link replacement is the reset; what remains is a small clear of commit-owned state (inline-piece geometry, overflow, sticky insets, line records, paint cache).