### PR TITLE
LibWeb: Defer paint-only style across geometry reads

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -7,6 +7,7 @@
 
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 
@@ -23,9 +24,16 @@ CSSStyleDeclaration::CSSStyleDeclaration(Computed computed, Readonly readonly)
 void CSSStyleDeclaration::prepare_to_update_style_attribute()
 {
     VERIFY(!is_computed());
-    if (!owner_node().has_value())
+    if (!owner_node().has_value()) {
+        if (auto rule = parent_rule())
+            flush_deferred_style_change_events_for_rule(*rule);
         return;
+    }
 
+    // OPTIMIZATION: A geometry read can leave paint-only selector facts pending. An inline
+    //               declaration is not a replayable fact, so consume the boundary while the old
+    //               declaration block is still authoritative.
+    owner_node()->element().document().flush_deferred_style_change_event();
     owner_node()->element().prepare_for_inline_style_change();
 }
 

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1352,6 +1352,7 @@ public:
     RefPtr<AbstractImageStyleValue const> mask_image() const { return m_noninherited.mask_data->mask_image_value(); }
     Optional<MaskReference> mask() const { return m_noninherited.mask_data->mask_value(); }
     Optional<ClipPathReference> clip_path() const { return m_noninherited.mask_data->clip_path_value(); }
+    Optional<SVGPaint> stroke() const { return m_inherited.svg->stroke_value(); }
     Color flood_color() const { return Gfx::Color::from_bgra(m_noninherited.svg_reset->flood_color); }
     float flood_opacity() const { return m_noninherited.svg_reset->flood_opacity; }
 

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -4438,7 +4438,7 @@
   },
   "stroke": {
     "style-group": "InheritedSVGValues",
-    "affects-layout": false,
+    "affects-layout": true,
     "animation-type": "by-computed-value",
     "inherited": true,
     "initial": "none",
@@ -4516,7 +4516,7 @@
   },
   "stroke-width": {
     "style-group": "InheritedSVGValues",
-    "affects-layout": false,
+    "affects-layout": true,
     "animation-type": "by-computed-value",
     "inherited": true,
     "initial": "1px",
@@ -4685,7 +4685,7 @@
     ]
   },
   "text-rendering": {
-    "affects-layout": false,
+    "affects-layout": true,
     "animation-type": "discrete",
     "inherited": true,
     "initial": "auto",

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -376,14 +376,22 @@ static void request_frame_for_first_recorded_input(StyleEngine const& style_engi
     style_computer->document().page().client().request_frame();
 }
 
+static void flush_deferred_geometry_transaction_before_non_replayable_input(StyleEngine const& style_engine, GC::Ptr<StyleComputer> style_computer)
+{
+    if (style_computer && style_engine.has_deferred_geometry_transaction())
+        style_computer->document().flush_deferred_style_change_event();
+}
+
 void StyleEngine::record_tree_delta(StyleEngineFFI::FfiTreeDelta const& delta)
 {
+    flush_deferred_geometry_transaction_before_non_replayable_input(*this, m_style_computer);
     request_frame_for_first_recorded_input(*this, m_style_computer);
     m_tree_deltas.append(delta);
 }
 
 void StyleEngine::record_element_arrival(StyleEngineFFI::FfiElementArrival arrival, ReadonlySpan<StyleAtomID> custom_states)
 {
+    flush_deferred_geometry_transaction_before_non_replayable_input(*this, m_style_computer);
     request_frame_for_first_recorded_input(*this, m_style_computer);
     VERIFY(m_arrival_custom_state_atoms.size() <= NumericLimits<u32>::max());
     VERIFY(custom_states.size() <= NumericLimits<u32>::max());
@@ -409,6 +417,7 @@ void StyleEngine::record_state_delta(StyleEngineFFI::FfiStateDelta const& delta)
 
 void StyleEngine::record_element_declaration_delta(StyleEngineFFI::FfiElementDeclarationDelta const& delta)
 {
+    flush_deferred_geometry_transaction_before_non_replayable_input(*this, m_style_computer);
     request_frame_for_first_recorded_input(*this, m_style_computer);
     m_element_declaration_deltas.append(delta);
 }
@@ -429,6 +438,7 @@ void StyleEngine::append_or_merge_element_style_input(StyleNodeID style_node, u8
 void StyleEngine::record_element_style_input_change(StyleNodeID style_node, u8 reaction, u8 inherited_style_groups)
 {
     if (style_node != 0 && reaction != 0) {
+        flush_deferred_geometry_transaction_before_non_replayable_input(*this, m_style_computer);
         request_frame_for_first_recorded_input(*this, m_style_computer);
         append_or_merge_element_style_input(style_node, reaction, inherited_style_groups);
     }
@@ -439,6 +449,7 @@ void StyleEngine::record_flat_tree_descendant_style_input_changes(StyleNodeID st
     if (style_node == 0 || reaction == 0)
         return;
 
+    flush_deferred_geometry_transaction_before_non_replayable_input(*this, m_style_computer);
     // The relation columns must include every tree delta recorded before this derived action. The
     // descendants themselves stay in the C++ batch so the next transaction normalizes them with
     // every other feedback action from this stabilization pass.
@@ -594,6 +605,34 @@ StyleEngine::PublishedStyleTransaction StyleEngine::take_style_transaction(Style
 bool StyleEngine::has_pending_transaction() const
 {
     return has_recorded_input() || StyleEngineFFI::style_engine_has_pending_transaction(m_impl);
+}
+
+bool StyleEngine::pending_transaction_may_affect_layout_geometry()
+{
+    submit_recorded_input();
+    return StyleEngineFFI::style_engine_pending_transaction_may_affect_layout_geometry(m_impl);
+}
+
+bool StyleEngine::has_deferred_geometry_transaction() const
+{
+    return StyleEngineFFI::style_engine_has_deferred_geometry_transaction(m_impl);
+}
+
+bool StyleEngine::defer_pending_transaction_for_geometry_read()
+{
+    submit_recorded_input();
+    return StyleEngineFFI::style_engine_defer_pending_transaction_for_geometry_read(m_impl);
+}
+
+bool StyleEngine::begin_deferred_geometry_transaction_flush()
+{
+    submit_recorded_input();
+    return StyleEngineFFI::style_engine_begin_deferred_geometry_transaction_flush(m_impl);
+}
+
+void StyleEngine::end_deferred_geometry_transaction_flush()
+{
+    StyleEngineFFI::style_engine_end_deferred_geometry_transaction_flush(m_impl);
 }
 
 bool StyleEngine::read_matches(StyleNodeID node, Vector<RuleMatch>& matches, Optional<MatchPurpose> purpose)

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -189,6 +189,16 @@ public:
     void record_benchmark_marker(Utf16View);
     [[nodiscard]] bool has_recorded_input() const;
     [[nodiscard]] bool has_pending_transaction() const;
+    [[nodiscard]] bool has_deferred_geometry_transaction() const;
+    [[nodiscard]] bool pending_transaction_may_affect_layout_geometry();
+    [[nodiscard]] bool defer_pending_transaction_for_geometry_read();
+    [[nodiscard]] bool begin_deferred_geometry_transaction_flush();
+    void end_deferred_geometry_transaction_flush();
+    // Geometry reads establish the before-change style used by CSS transitions. Keep this
+    // monotonic because an inactive rule or a later inline edit can expose the transition only
+    // after that boundary.
+    void note_css_transitions_may_observe_style_changes() { m_css_transitions_may_observe_style_changes = true; }
+    [[nodiscard]] bool css_transitions_may_observe_style_changes() const { return m_css_transitions_may_observe_style_changes; }
 
     // Submits everything recorded since the last flush as one transaction and normalizes it.
     void flush();
@@ -270,6 +280,7 @@ private:
     Vector<StyleEngineFFI::FfiStateDelta> m_state_deltas;
     Vector<StyleEngineFFI::FfiElementDeclarationDelta> m_element_declaration_deltas;
     Vector<StyleEngineFFI::FfiElementStyleInput> m_element_style_inputs;
+    bool m_css_transitions_may_observe_style_changes { false };
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -966,6 +966,16 @@ struct DeclaredPropertyColumns {
     bool declarations_are_complete;
 };
 
+bool property_defines_a_css_transition(PropertyID property_id)
+{
+    return property_id == PropertyID::Transition
+        || property_id == PropertyID::TransitionBehavior
+        || property_id == PropertyID::TransitionDelay
+        || property_id == PropertyID::TransitionDuration
+        || property_id == PropertyID::TransitionProperty
+        || property_id == PropertyID::TransitionTimingFunction;
+}
+
 static bool publish_element_declared_properties(DOM::Element& element, StyleEngineFFI::FfiElementDeclarationKind kind, ReadonlySpan<StyleProperty> style_properties, bool declarations_are_complete = true)
 {
     auto* style_engine = style_engine_for(element);
@@ -974,6 +984,8 @@ static bool publish_element_declared_properties(DOM::Element& element, StyleEngi
 
     DeclaredPropertyColumns columns(style_properties.size(), declarations_are_complete);
     for (auto const& property : style_properties) {
+        if (property_defines_a_css_transition(property.property_id))
+            style_engine->note_css_transitions_may_observe_style_changes();
         // What a declaration decides is a set of longhands. An attribute maps to whichever property
         // names it, `overflow` included, and the cascade expands that before anything is decided, so
         // a shorthand left whole here would name a property nothing ever wins.
@@ -1009,6 +1021,7 @@ bool record_element_presentational_hint_properties(DOM::Element& element, Readon
 
 void record_element_declarations_changed(DOM::Element& element, ElementDeclarationKind kind, bool had_declarations, bool has_declarations)
 {
+    element.document().flush_deferred_style_change_event();
     // A declaration the element itself sources is named in its style input record by its identity,
     // and this is the write that moves what that identity says without moving the identity.
     element.retire_style_input_record();
@@ -1197,8 +1210,11 @@ static void record_rule_declared_properties(StyleEngine& style_engine, StyleEngi
         return;
 
     DeclaredPropertyColumns columns(declaration->properties().size(), declaration->custom_properties().is_empty());
-    for (auto const& property : declaration->properties())
+    for (auto const& property : declaration->properties()) {
+        if (property_defines_a_css_transition(property.property_id))
+            style_engine.note_css_transitions_may_observe_style_changes();
         columns.append(property, ExpandShorthands::No);
+    }
     style_engine.set_rule_declared_properties(rule_id, columns.properties, columns.important, columns.operators, columns.values, columns.original_values, columns.declarations_are_complete);
 }
 
@@ -1234,6 +1250,7 @@ static void set_compiled_rule_id(CSSRule& rule, StyleEngineRuleID rule_id, HashM
 
 void record_cascade_layer_order(DOM::Document& document, TreeScopeID tree_scope, ReadonlySpan<Utf16FlyString> qualified_names_in_order)
 {
+    document.flush_deferred_style_change_event();
     Vector<u32> layers;
     layers.ensure_capacity(qualified_names_in_order.size());
     auto& style_engine = document.style_computer().style_engine();
@@ -1643,6 +1660,19 @@ static void for_each_document_with_engine_copy(CSSStyleSheet& sheet, auto const&
         callback(*document);
 }
 
+static void flush_deferred_style_change_events_for_sheet(CSSStyleSheet& sheet)
+{
+    for_each_document_with_engine_copy(sheet, [](DOM::Document& document) {
+        document.flush_deferred_style_change_event();
+    });
+}
+
+void flush_deferred_style_change_events_for_rule(CSSRule& rule)
+{
+    if (auto* sheet = owning_compiled_sheet(rule))
+        flush_deferred_style_change_events_for_sheet(*sheet);
+}
+
 // Whether the conditions of every group a rule sits inside hold. A rule compiled on its own has to
 // be told the same thing the whole-sheet walk would have told it.
 static bool enclosing_conditions_hold(GC::RootVector<GC::Ref<CSSRule>> const& enclosing, DOM::Document const& document)
@@ -1681,6 +1711,7 @@ static void collect_enclosing_group_context(GC::RootVector<GC::Ref<CSSRule>> con
 // position it holds there.
 static void record_style_rule_inserted_in(CSSRule& rule, CSSStyleSheet& sheet, DOM::Document& document)
 {
+    document.flush_deferred_style_change_event();
     auto& style_computer = document.style_computer();
     auto sheet_id = style_computer.style_engine_sheet_id_for(sheet);
     if (sheet_id == 0)
@@ -1747,6 +1778,7 @@ void record_style_rule_removed(CSSStyleSheet& sheet_it_left, CSSRule& rule)
     bool any_engine_heard = false;
     for_each_document_with_engine_copy(sheet_it_left, [&](DOM::Document& document) {
         any_engine_heard = true;
+        document.flush_deferred_style_change_event();
         document.bump_style_environment_version();
 
         auto& style_computer = document.style_computer();
@@ -1837,6 +1869,7 @@ void record_style_rule_selector_changed(CSSStyleRule& rule)
     }
 
     for_each_document_with_engine_copy(*sheet, [&](DOM::Document& document) {
+        document.flush_deferred_style_change_event();
         for (auto& affected_rule : affected)
             replace_matching_selectors(*affected_rule, document);
     });
@@ -1860,6 +1893,7 @@ void record_style_rule_declarations_changed(CSSRule& rule)
         return;
 
     for_each_document_with_engine_copy(*sheet, [&](DOM::Document& document) {
+        document.flush_deferred_style_change_event();
         auto& style_computer = document.style_computer();
         auto rule_id = style_computer.style_engine_rule_id_for(rule_to_report);
         if (rule_id == 0)
@@ -1881,6 +1915,7 @@ void record_style_rule_declarations_changed(CSSRule& rule)
 void record_stylesheet_rules_replaced(CSSStyleSheet& sheet)
 {
     for_each_document_with_engine_copy(sheet, [&](DOM::Document& document) {
+        document.flush_deferred_style_change_event();
         auto& style_computer = document.style_computer();
         auto sheet_id = style_computer.style_engine_sheet_id_for(sheet);
         if (sheet_id == 0)
@@ -1900,6 +1935,7 @@ void record_stylesheet_rules_replaced(CSSStyleSheet& sheet)
 
 void record_stylesheet_attached(CSSStyleSheet& sheet, DOM::Node& document_or_shadow_root, CSSStyleSheet* before)
 {
+    document_or_shadow_root.document().flush_deferred_style_change_event();
     publish_document_kind(document_or_shadow_root.document());
     auto& style_computer = document_or_shadow_root.document().style_computer();
     auto& style_engine = style_computer.style_engine();
@@ -1973,6 +2009,7 @@ void record_stylesheet_attached(CSSStyleSheet& sheet, DOM::Node& document_or_sha
 // the set is compared by identity and re-attached whole when it differs.
 void record_non_author_stylesheets(DOM::Document& document)
 {
+    document.flush_deferred_style_change_event();
     auto& style_computer = document.style_computer();
     auto& style_scope = document.style_scope();
 
@@ -2089,6 +2126,7 @@ void record_stylesheet_rule_conditions(CSSStyleSheet& sheet)
 
 void record_stylesheet_rule_conditions(CSSStyleSheet& sheet, DOM::Document& document)
 {
+    document.flush_deferred_style_change_event();
     auto& style_computer = document.style_computer();
     for (size_t index = 0; index < sheet.rules().length(); ++index) {
         if (auto rule = sheet.rules().item(index))
@@ -2098,6 +2136,7 @@ void record_stylesheet_rule_conditions(CSSStyleSheet& sheet, DOM::Document& docu
 
 void record_stylesheet_conditions(CSSStyleSheet& sheet, DOM::Node& document_or_shadow_root, bool conditions_hold)
 {
+    document_or_shadow_root.document().flush_deferred_style_change_event();
     auto* engine_sheet = owning_engine_sheet(sheet);
     if (!engine_sheet)
         return;
@@ -2110,6 +2149,7 @@ void record_stylesheet_conditions(CSSStyleSheet& sheet, DOM::Node& document_or_s
 
 void record_stylesheet_detached(CSSStyleSheet& sheet, DOM::Node& document_or_shadow_root)
 {
+    document_or_shadow_root.document().flush_deferred_style_change_event();
     auto& style_computer = document_or_shadow_root.document().style_computer();
     auto sheet_id = style_computer.style_engine_sheet_id_for(sheet);
     if (sheet_id == 0)

--- a/Libraries/LibWeb/CSS/StyleEngineInput.h
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.h
@@ -16,6 +16,13 @@ namespace Web::CSS {
 
 class StyleEngine;
 
+// Whether declaring this property can provide the parameters for a CSS transition.
+WEB_API bool property_defines_a_css_transition(PropertyID);
+
+// Settle a style-change boundary deferred by a geometry read before mutating a rule's declaration
+// block. Constructed sheets can have copies in multiple document engines.
+WEB_API void flush_deferred_style_change_events_for_rule(CSSRule&);
+
 // Translates DOM and CSSOM mutations into StyleEngine's typed semantic inputs.
 //
 // These are recording calls, not evaluation: each one appends to the batch that crosses into the

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2051,8 +2051,83 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
 
 void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutReason reason)
 {
-    if (node.is_connected())
-        update_layout(reason);
+    if (!node.is_connected())
+        return;
+
+    auto* document_element = this->document_element();
+    auto const may_have_style_query_dependencies = document_element && document_element->is_style_query_container();
+    auto const reads_layout_geometry = reason == UpdateLayoutReason::ElementGetClientRects
+        || reason == UpdateLayoutReason::ElementClientWidth
+        || reason == UpdateLayoutReason::ElementClientHeight
+        || reason == UpdateLayoutReason::HTMLElementOffsetWidth
+        || reason == UpdateLayoutReason::HTMLElementOffsetHeight;
+    if (reads_layout_geometry
+        && m_has_completed_style_update
+        && layout_is_up_to_date()
+        && !m_needs_media_rule_evaluation
+        && !m_needs_animated_style_update
+        && m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
+        && m_elements_with_pending_top_layer_membership_change.is_empty()
+        && !m_top_layer_needs_layout_zone_rebuild
+        && !style_computer().style_engine().css_transitions_may_observe_style_changes()
+        && !may_have_style_query_dependencies) {
+        auto document_is_clean_for_layout_geometry_read = [](Document const& document) {
+            return document.m_has_completed_style_update
+                && document.layout_is_up_to_date()
+                && !document.m_has_dirty_style_attributes
+                && !document.style_computer().style_engine().has_pending_transaction()
+                && !document.m_needs_media_rule_evaluation
+                && !document.m_needs_animated_style_update
+                && document.m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
+                && document.m_elements_with_pending_top_layer_membership_change.is_empty()
+                && !document.m_top_layer_needs_layout_zone_rebuild;
+        };
+        auto embedding_document_chain_is_clean = [&] {
+            auto const* embedded_document = this;
+            while (auto navigable = embedded_document->navigable()) {
+                auto embedding_document = navigable->container_document();
+                if (!embedding_document || embedding_document.ptr() == embedded_document)
+                    return true;
+                if (!document_is_clean_for_layout_geometry_read(*embedding_document))
+                    return false;
+                embedded_document = embedding_document.ptr();
+            }
+            return true;
+        };
+        if (embedding_document_chain_is_clean()) {
+            synchronize_dirty_style_attributes();
+            if (!style_computer().style_engine().pending_transaction_may_affect_layout_geometry()) {
+                // A later inline transition declaration still needs the pending style as its
+                // before-change style, even though this geometry read can reuse the current layout.
+                if (!style_computer().style_engine().has_pending_transaction()
+                    || style_computer().style_engine().defer_pending_transaction_for_geometry_read()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    update_layout(reason);
+}
+
+void Document::flush_deferred_style_change_event()
+{
+    auto& style_engine = style_computer().style_engine();
+    if (!style_engine.has_deferred_geometry_transaction())
+        return;
+
+    if (!style_engine.begin_deferred_geometry_transaction_flush()) {
+        // All non-replayable style inputs consume the boundary before changing their authoritative
+        // state. Reaching this fallback means exact local-fact journalling coarsened, so preserve
+        // correctness by settling the combined transaction even though it cannot remain a distinct
+        // transition style-change event.
+        update_style();
+        return;
+    }
+    ScopeGuard restore_later_style_inputs = [&] {
+        style_engine.end_deferred_geometry_transaction_flush();
+    };
+    update_style();
 }
 
 bool Document::needs_style_update_after_layout()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -806,6 +806,7 @@ public:
     void set_has_completed_style_update() { m_has_completed_style_update = true; }
     void mark_style_attribute_dirty() { m_has_dirty_style_attributes = true; }
     void synchronize_dirty_style_attributes();
+    void flush_deferred_style_change_event();
     void build_registered_properties_cache_for_style_update() { build_registered_properties_cache(); }
     void set_needs_registered_properties_cache_update() { m_needs_registered_properties_cache_update = true; }
     void set_needs_container_query_evaluation_after_layout(Element const& query_container);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1605,6 +1605,19 @@ static CSS::StyleComputer::ComputedStyleInvalidation compute_required_invalidati
         style_computer.cache_computed_style_invalidation(style_record_delta, element_folds_transform_into_layout, result);
     }
 
+    // An SVG currentColor stroke stores its resolved color alongside the fact that it came from
+    // currentColor. A color-only change can therefore alter the visible stroke width and the SVG
+    // container bounds without changing the stroke longhand itself.
+    if (is<SVG::SVGGraphicsElement>(abstract_element.element())
+        && old_computed_values.color() != new_computed_values.color()) {
+        auto stroke_uses_current_color = [](CSS::ComputedValues const& computed_values) {
+            auto stroke = computed_values.stroke();
+            return stroke.has_value() && stroke->color_is_currentcolor();
+        };
+        if (stroke_uses_current_color(old_computed_values) || stroke_uses_current_color(new_computed_values))
+            result.invalidation.ensure_at_least(CSS::InvalidationLevel::Relayout);
+    }
+
     // The table fixup algorithm needs an authored box's display from before box type
     // transformation. A flex or grid item can therefore keep the same blockified display while
     // changing whether it needs anonymous table wrappers. Generated pseudo-element boxes are
@@ -5721,6 +5734,9 @@ void Element::attribute_changed(Utf16FlyString const& local_name, Optional<Utf16
         // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
         if (m_inline_style && m_inline_style->is_updating())
             return;
+        // The new declaration block has not replaced the old one yet, so this is the last point at
+        // which a deferred geometry-read boundary can commit its before-change style.
+        document().flush_deferred_style_change_event();
         if (!m_inline_style)
             m_inline_style = CSS::CSSStyleProperties::create_element_inline_style({ *this }, {}, {});
         m_inline_style->set_declarations_from_text(value_or_empty);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -550,6 +550,7 @@ public:
     // asking republishes nothing, and answering "maybe" costs the scan the element used to pay
     // unconditionally.
     void set_is_style_query_container() { m_is_style_query_container = true; }
+    bool is_style_query_container() const { return m_is_style_query_container; }
     bool is_size_query_container() const { return m_is_size_query_container; }
     void set_is_size_query_container() { m_is_size_query_container = true; }
     void invalidate_descendant_styles_depending_on_style_container_query();

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -789,6 +789,13 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     if (count == 0)
         return;
 
+    // OPTIMIZATION: Geometry reads defer replayable selector facts, but a tree mutation changes
+    //               authoritative relationships. Consume that style-change boundary while the old
+    //               tree is still intact.
+    document().flush_deferred_style_change_event();
+    if (&node->document() != &document())
+        node->document().flush_deferred_style_change_event();
+
     auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
     if (document().has_valid_html_collection_caches())
         affects_elements = mutation_affects_elements(nodes.span());
@@ -1132,6 +1139,8 @@ void Node::remove(bool suppress_observers)
 
     // 2. Assert: parent is non-null.
     VERIFY(parent);
+
+    document().flush_deferred_style_change_event();
 
     // 3. Run the live range pre-remove steps, given node.
     live_range_pre_remove();
@@ -1498,6 +1507,8 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
 
     // 8. Assert: oldParent is non-null.
     VERIFY(old_parent);
+
+    document().flush_deferred_style_change_event();
 
     auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
     if (document().has_valid_html_collection_caches())

--- a/Libraries/LibWeb/Rust/StyleEngineBoundary.json
+++ b/Libraries/LibWeb/Rust/StyleEngineBoundary.json
@@ -82,7 +82,12 @@
     [79, "PrepareSelectorQuery"],
     [80, "AddCounterStyleRule"],
     [81, "AttributeValueTextRequirementsVersion"],
-    [82, "AttributeNameRequiresValueText"]
+    [82, "AttributeNameRequiresValueText"],
+    [83, "PendingTransactionMayAffectLayoutGeometry"],
+    [84, "DeferPendingTransactionForGeometryRead"],
+    [85, "BeginDeferredGeometryTransactionFlush"],
+    [86, "EndDeferredGeometryTransactionFlush"],
+    [87, "HasDeferredGeometryTransaction"]
   ],
   "operations": [
     { "event": "SetFoldIdAndClassNameCase", "ffi": "style_engine_set_fold_id_and_class_name_case", "cpp": "set_fold_id_and_class_name_case", "return": "void", "args": [["fold", "bool"]], "body": "engine.set_fold_id_and_class_name_case(fold);" },
@@ -104,6 +109,11 @@
     { "event": "SetElementCustomStates", "ffi": "style_engine_set_element_custom_states", "cpp": "set_element_custom_states", "return": "void", "args": [["node", "style_node"], ["states", "style_atom_slice"]], "body": "let Some(node) = StyleNodeID::from_raw(node) else { return; }; let states = states.iter().copied().map(StyleAtomID).collect::<Vec<_>>(); engine.set_element_custom_states(node, &states);" },
     { "event": "ConnectedElementCount", "ffi": "style_engine_connected_element_count", "cpp": "connected_element_count", "return": "u32", "receiver": "const", "args": [], "body": "let result = engine.connected_element_count();" },
     { "event": "HasPendingTransaction", "ffi": "style_engine_has_pending_transaction", "return": "bool", "receiver": "const", "args": [], "body": "let result = engine.has_pending_transaction();" },
+    { "event": "PendingTransactionMayAffectLayoutGeometry", "ffi": "style_engine_pending_transaction_may_affect_layout_geometry", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.pending_transaction_may_affect_layout_geometry();" },
+    { "event": "DeferPendingTransactionForGeometryRead", "ffi": "style_engine_defer_pending_transaction_for_geometry_read", "return": "bool", "replay": false, "args": [], "body": "let result = engine.defer_pending_transaction_for_geometry_read();" },
+    { "event": "BeginDeferredGeometryTransactionFlush", "ffi": "style_engine_begin_deferred_geometry_transaction_flush", "return": "bool", "replay": false, "args": [], "body": "let result = engine.begin_deferred_geometry_transaction_flush();" },
+    { "event": "EndDeferredGeometryTransactionFlush", "ffi": "style_engine_end_deferred_geometry_transaction_flush", "return": "void", "replay": false, "args": [], "body": "engine.end_deferred_geometry_transaction_flush();" },
+    { "event": "HasDeferredGeometryTransaction", "ffi": "style_engine_has_deferred_geometry_transaction", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.has_deferred_geometry_transaction();" },
     { "event": "MatchDocument", "ffi": "style_engine_match_document", "cpp": "match_document", "return": "usize_u64", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return usize::MAX; }; let result = engine.match_document(root).unwrap_or(usize::MAX);" },
     { "event": "BeginColdMatchingBatch", "ffi": "style_engine_begin_cold_matching_batch", "cpp": "begin_cold_matching_batch", "return": "bool", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return false; }; let result = engine.begin_cold_matching_batch(root);" },
     { "event": "BeginAdaptiveColdMatchingBatch", "ffi": "style_engine_begin_adaptive_cold_matching_batch", "cpp": "begin_adaptive_cold_matching_batch", "return": "void", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return; }; engine.begin_adaptive_cold_matching_batch(root);" },

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -953,6 +953,7 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
 
     let mut levels = vec![0u8; (last_longhand - first_longhand + 1) as usize];
     let mut animation_types = vec![0u8; levels.len()];
+    let mut layout_geometry_effects = vec![false; levels.len()];
     let mut numeric_range_rows = vec![String::new(); levels.len()];
     let value_types = [
         "anchor",
@@ -1021,6 +1022,24 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
             "none" => 4,
             other => return Err(format!("unknown animation-type '{other}' for {name}").into()),
         };
+
+        let metadata_flag = |field: &str, default| {
+            property_field(name, field)
+                .and_then(|value| value.as_bool())
+                .unwrap_or(default)
+        };
+        // Animation controls can select or retime an animation of any property, so their own
+        // direct layout metadata cannot bound the geometry they expose. Likewise, container-name
+        // can change which descendant container queries apply without changing its own box, and
+        // color can change SVG bounds when stroke resolves currentColor.
+        let may_affect_layout_geometry_indirectly = property_field(name, "style-group")
+            .is_some_and(|value| value.as_str() == Some("AnimationValues"))
+            || matches!(name.as_str(), "color" | "container-name");
+        layout_geometry_effects[index] = metadata_flag("affects-layout", true)
+            || metadata_flag("affects-accumulated-visual-contexts", false)
+            || metadata_flag("affects-scrollable-overflow", false)
+            || metadata_flag("affects-stacking-context", false)
+            || may_affect_layout_geometry_indirectly;
 
         let mut ranges = Vec::new();
         if let Some(valid_types) = property_field(name, "valid-types").and_then(|value| value.as_array().cloned()) {
@@ -1222,6 +1241,11 @@ fn generate_property_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<(),
         "pub(crate) static PROPERTY_ANIMATION_TYPES: [u8; {}] = {:?};\n",
         animation_types.len(),
         animation_types
+    ));
+    output.push_str(&format!(
+        "pub(crate) static PROPERTY_MAY_AFFECT_LAYOUT_GEOMETRY: [bool; {}] = {:?};\n",
+        layout_geometry_effects.len(),
+        layout_geometry_effects
     ));
     output.push_str(&format!(
         "pub(crate) static PROPERTY_NUMERIC_RANGES: [&[FfiPropertyNumericRange]; {}] = [\n{}\n];\n",

--- a/Libraries/LibWeb/Rust/src/css/property_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/css/property_metadata.rs
@@ -44,6 +44,21 @@ pub fn property_animation_type(property_id: u16) -> u8 {
     PROPERTY_ANIMATION_TYPES[longhand_index(property_id)]
 }
 
+/// Whether changing a property may invalidate geometry exposed by synchronous layout APIs.
+///
+/// Besides properties which directly affect layout, this includes properties which can change the
+/// accumulated visual context, scrollable overflow, or stacking-context structure, and properties
+/// which can indirectly expose geometry changes through animations, container queries, or SVG
+/// currentColor strokes.
+/// Value-aware callers can refine this conservative property-level answer when both sides are
+/// available.
+pub fn property_may_affect_layout_geometry(property_id: u16) -> bool {
+    if !(FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&property_id) {
+        return true;
+    }
+    PROPERTY_MAY_AFFECT_LAYOUT_GEOMETRY[longhand_index(property_id)]
+}
+
 pub(crate) fn pseudo_element_supports_property(pseudo_element: u8, property_id: u16) -> bool {
     if PSEUDO_ELEMENT_ALWAYS_ALLOWED_PROPERTIES
         .binary_search(&property_id)
@@ -97,6 +112,28 @@ pub extern "C" fn rust_property_metadata_requires_computation_level(property_id:
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_property_metadata_animation_type(property_id: u16) -> u8 {
     property_animation_type(property_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_geometry_effects_include_direct_and_indirect_effects() {
+        assert!(!property_may_affect_layout_geometry(property_id::BACKGROUND_COLOR));
+        assert!(property_may_affect_layout_geometry(property_id::COLOR));
+        assert!(property_may_affect_layout_geometry(property_id::WIDTH));
+        assert!(property_may_affect_layout_geometry(property_id::TRANSFORM));
+        assert!(property_may_affect_layout_geometry(property_id::OPACITY));
+        assert!(property_may_affect_layout_geometry(property_id::TEXT_RENDERING));
+        assert!(property_may_affect_layout_geometry(property_id::STROKE));
+        assert!(property_may_affect_layout_geometry(property_id::STROKE_WIDTH));
+        assert!(property_may_affect_layout_geometry(property_id::ANIMATION_NAME));
+        assert!(property_may_affect_layout_geometry(property_id::TRANSITION_PROPERTY));
+        assert!(property_may_affect_layout_geometry(property_id::SCROLL_TIMELINE_NAME));
+        assert!(property_may_affect_layout_geometry(property_id::CONTAINER_NAME));
+        assert!(property_may_affect_layout_geometry(property_id::CUSTOM));
+    }
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -46,6 +46,8 @@ impl StyleEngine {
             tree,
             program: StyleSheetProgram::new(),
             journal: NormalizationJournal::new(),
+            deferred_geometry_journal: NormalizationJournal::new(),
+            flushing_deferred_geometry_journal: false,
             deferred_element_style_inputs: Vec::new(),
             deferred_element_style_input_memory: MemoryLease::new(MemoryCategory::NormalizationJournal),
             initial_tree_batch_applied: false,
@@ -700,9 +702,161 @@ impl StyleEngine {
     #[must_use]
     pub fn has_pending_transaction(&self) -> bool {
         !self.journal.is_empty()
+            || (!self.flushing_deferred_geometry_journal && !self.deferred_geometry_journal.is_empty())
             || !self.tree_staging.is_empty()
             || self.program_staging.is_dirty()
             || self.sheet_rule_replacement.is_some()
+    }
+
+    #[must_use]
+    pub fn has_deferred_geometry_transaction(&self) -> bool {
+        !self.flushing_deferred_geometry_journal && !self.deferred_geometry_journal.is_empty()
+    }
+
+    /// Whether settling the pending selector inputs can change geometry derived from the committed
+    /// layout. This is deliberately a proof of independence rather than a list of properties which
+    /// usually avoid layout: anything not explicitly known to preserve geometry remains observable.
+    #[must_use]
+    pub fn pending_transaction_may_affect_layout_geometry(&self) -> bool {
+        if self.journal.is_empty() {
+            return !self.tree_staging.is_empty()
+                || self.program_staging.is_dirty()
+                || self.sheet_rule_replacement.is_some()
+                || !self.deferred_element_style_inputs.is_empty()
+                || self.initial_tree_bulk_load_is_pending;
+        }
+        if !self.journal.markers().is_empty()
+            || !self.tree_staging.is_empty()
+            || self.program_staging.is_dirty()
+            || self.sheet_rule_replacement.is_some()
+            || !self.deferred_element_style_inputs.is_empty()
+            || self.initial_tree_bulk_load_is_pending
+        {
+            return true;
+        }
+
+        let route_liveness = self.routing.route_liveness(&self.program, &self.programs);
+        self.journal.inputs().any(|input| {
+            let mut keys = match input.key {
+                InputKey::LocalFeature(_, LocalFeatureKey::PartExposure | LocalFeatureKey::ArrivingFacts) => {
+                    return true;
+                }
+                InputKey::LocalFeature(_, LocalFeatureKey::Attribute(name)) => {
+                    let mut keys = routing_keys_for_input(&input);
+                    for other in self.facts.attribute_name_keys(name) {
+                        if other != name {
+                            keys.push(RoutingKey::AttributeName(other));
+                        }
+                    }
+                    keys
+                }
+                InputKey::LocalFeature(..) | InputKey::State(..) => routing_keys_for_input(&input),
+                _ => return true,
+            };
+            keys.sort_unstable();
+            keys.dedup();
+            keys.into_iter().any(|key| {
+                self.routing.routes_for(key).iter().copied().any(|route| {
+                    if !route_liveness.contains(route.index()) {
+                        return false;
+                    }
+                    let rule = self.routing.rule_of(route);
+                    !self.program.declarations_are_complete_for(rule)
+                        || self.program.declared_properties_of(rule).iter().any(|declared| {
+                            crate::css::property_metadata::property_may_affect_layout_geometry(declared.property)
+                        })
+                })
+            })
+        })
+    }
+
+    /// Preserve the pending paint-only selector facts as the style change event established by a
+    /// geometry read. Repeated reads advance the same boundary to the latest observed facts.
+    /// Returning false means exact journalling coarsened while combining the facts, so the caller
+    /// must settle style instead of reusing layout.
+    pub fn defer_pending_transaction_for_geometry_read(&mut self) -> bool {
+        debug_assert!(!self.flushing_deferred_geometry_journal);
+        debug_assert!(self.tree_staging.is_empty());
+        debug_assert!(!self.program_staging.is_dirty());
+        debug_assert!(self.sheet_rule_replacement.is_none());
+        debug_assert!(self.deferred_element_style_inputs.is_empty());
+        debug_assert!(!self.initial_tree_bulk_load_is_pending);
+        debug_assert!(self.journal.markers().is_empty());
+        debug_assert!(
+            self.journal
+                .inputs()
+                .all(|input| matches!(input.key, InputKey::LocalFeature(..) | InputKey::State(..)))
+        );
+
+        if self.journal.is_empty() {
+            return true;
+        }
+        if self.deferred_geometry_journal.is_empty() {
+            std::mem::swap(&mut self.journal, &mut self.deferred_geometry_journal);
+        } else {
+            self.deferred_geometry_journal
+                .absorb_newer(&mut self.journal, &mut self.memory, &mut self.counters);
+        }
+        self.deferred_geometry_journal.markers().is_empty()
+    }
+
+    /// Make the style transaction sealed by a geometry read current while preserving local facts
+    /// recorded after it for the following style change event.
+    pub fn begin_deferred_geometry_transaction_flush(&mut self) -> bool {
+        debug_assert!(!self.flushing_deferred_geometry_journal);
+        if self.deferred_geometry_journal.is_empty()
+            || !self.journal.markers().is_empty()
+            || !self.tree_staging.is_empty()
+            || self.program_staging.is_dirty()
+            || self.sheet_rule_replacement.is_some()
+            || !self.deferred_element_style_inputs.is_empty()
+            || self.initial_tree_bulk_load_is_pending
+            || !self
+                .journal
+                .inputs()
+                .all(|input| matches!(input.key, InputKey::LocalFeature(..) | InputKey::State(..)))
+        {
+            return false;
+        }
+
+        let later_inputs: Vec<NormalizedInput> = self.journal.inputs().collect();
+        for input in &later_inputs {
+            self.apply_to_facts_without_settling(input.key, input.old);
+        }
+        std::mem::swap(&mut self.journal, &mut self.deferred_geometry_journal);
+        self.flushing_deferred_geometry_journal = true;
+        true
+    }
+
+    /// Restore the local facts recorded after the geometry boundary once its transaction has been
+    /// consumed.
+    pub fn end_deferred_geometry_transaction_flush(&mut self) {
+        assert!(self.flushing_deferred_geometry_journal);
+        assert!(self.journal.is_empty());
+        assert!(self.tree_staging.is_empty());
+        assert!(!self.program_staging.is_dirty());
+        assert!(self.sheet_rule_replacement.is_none());
+        assert!(self.deferred_element_style_inputs.is_empty());
+
+        std::mem::swap(&mut self.journal, &mut self.deferred_geometry_journal);
+        let later_inputs: Vec<NormalizedInput> = self.journal.inputs().collect();
+        for input in later_inputs {
+            self.apply_to_facts_without_settling(input.key, input.new);
+        }
+        self.flushing_deferred_geometry_journal = false;
+    }
+
+    pub(super) fn merge_deferred_geometry_transaction(&mut self) {
+        if self.flushing_deferred_geometry_journal || self.deferred_geometry_journal.is_empty() {
+            return;
+        }
+        if self.journal.is_empty() {
+            std::mem::swap(&mut self.journal, &mut self.deferred_geometry_journal);
+            return;
+        }
+        self.deferred_geometry_journal
+            .absorb_newer(&mut self.journal, &mut self.memory, &mut self.counters);
+        std::mem::swap(&mut self.journal, &mut self.deferred_geometry_journal);
     }
 
     /// Record one member of a flat FFI batch without repeatedly settling the fact-store capacity.

--- a/Libraries/LibWeb/Rust/src/css/style/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/mod.rs
@@ -769,6 +769,11 @@ pub struct StyleEngine {
     tree: StyleNodeTree,
     program: StyleSheetProgram,
     journal: NormalizationJournal,
+    /// Local selector facts through the latest geometry read which reused committed layout. A
+    /// normal style observation merges this into `journal`; a newly introduced transition can
+    /// instead consume it as the preceding style change event.
+    deferred_geometry_journal: NormalizationJournal,
+    flushing_deferred_geometry_journal: bool,
     /// Exact element reactions retained across rootless flushes until a style root can consume them.
     deferred_element_style_inputs: Vec<NormalizedInput>,
     deferred_element_style_input_memory: MemoryLease,

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1154,6 +1154,7 @@ impl StyleEngine {
 
     /// Normalize the pending inputs without advancing the committed snapshot.
     pub(super) fn drain_transaction(&mut self) -> StyleTransaction {
+        self.merge_deferred_geometry_transaction();
         self.initial_tree_bulk_load_is_pending = false;
         self.finalize_staged_sheet_rule_replacements();
         // A diagnostic or retained planning snapshot may still hold this exact immutable routing

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -16,6 +16,7 @@ use super::transaction::InputKind;
 use super::tree::PseudoElementKind;
 use super::tree::PseudoElementTarget;
 use super::*;
+use crate::css::property_metadata::property_id;
 
 #[test]
 fn dense_program_staging_freezes_before_until_release() {
@@ -40,6 +41,38 @@ fn dense_program_staging_freezes_before_until_release() {
     assert_eq!(staged.current(rule, || 50), 50);
     assert_eq!(staged.rows.capacity(), 0);
     assert_eq!(staged.touched.capacity(), 0);
+}
+
+#[test]
+fn pending_paint_only_local_inputs_preserve_layout_geometry() {
+    let (mut engine, nodes) = linear_document();
+    let paint_only = StyleAtomID(200);
+    let rule = add_target_rule(&mut engine, StyleSheetObjectID(1), paint_only);
+    engine.set_rule_declared_properties(rule, &[(property_id::BACKGROUND_COLOR, false)], true);
+    discard_transaction(&mut engine);
+
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(paint_only));
+    assert!(!engine.pending_transaction_may_affect_layout_geometry());
+    assert!(engine.has_pending_transaction());
+}
+
+#[test]
+fn pending_layout_and_incomplete_local_inputs_may_change_geometry() {
+    for (property, declarations_are_complete) in [
+        (property_id::WIDTH, true),
+        (property_id::TRANSFORM, true),
+        (property_id::COLOR, true),
+        (property_id::BACKGROUND_COLOR, false),
+    ] {
+        let (mut engine, nodes) = linear_document();
+        let target = StyleAtomID(200);
+        let rule = add_target_rule(&mut engine, StyleSheetObjectID(1), target);
+        engine.set_rule_declared_properties(rule, &[(property, false)], declarations_are_complete);
+        discard_transaction(&mut engine);
+
+        add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(target));
+        assert!(engine.pending_transaction_may_affect_layout_geometry());
+    }
 }
 
 fn test_nth_position(argument: &str, of_type: bool) -> selector::NthPosition {

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -469,6 +469,45 @@ impl NormalizationJournal {
         &self.markers
     }
 
+    /// The normalized view of the fine-grained inputs which are still pending.
+    pub(super) fn inputs(&self) -> impl Iterator<Item = NormalizedInput> + '_ {
+        self.entries
+            .iter()
+            .map(|(&key, &(old, new))| NormalizedInput { key, old, new })
+    }
+
+    /// Fold a newer journal into this one without counting its already-recorded inputs a second
+    /// time. This retains the original value before either journal and the final value after both.
+    pub(super) fn absorb_newer(&mut self, newer: &mut Self, memory: &mut MemoryController, counters: &mut Counters) {
+        debug_assert!(self.markers.is_empty());
+        debug_assert!(newer.markers.is_empty());
+        let newer_entries = std::mem::take(&mut newer.entries);
+        memory.release(MemoryCategory::NormalizationJournal, u64::from(newer.charged_bytes));
+        newer.charged_bytes = 0;
+        newer.covered = [false; INPUT_KIND_COUNT];
+
+        for (key, (old, new)) in newer_entries {
+            if self.covered[key.kind().index()] {
+                continue;
+            }
+            if let Some(entry) = self.entries.get_mut(&key) {
+                if entry.0 == new {
+                    self.entries.remove(&key);
+                    counters.bump(Counter::JournalCancellations);
+                } else {
+                    entry.1 = new;
+                }
+                continue;
+            }
+            if old == new || !self.make_room_for_one(key.kind(), memory, counters) {
+                continue;
+            }
+            self.entries.insert(key, (old, new));
+            self.settle(memory, counters);
+        }
+        self.settle(memory, counters);
+    }
+
     #[must_use]
     pub fn contains_only_element_style_inputs(&self) -> bool {
         self.markers.is_empty()
@@ -909,6 +948,48 @@ mod tests {
                     inherited_style_groups: 0b101,
                 },
             }]
+        );
+        transaction.release(&mut fixture.memory);
+    }
+
+    #[test]
+    fn absorbing_a_newer_journal_accepts_non_local_inputs() {
+        let mut fixture = JournalFixture::new();
+        fixture.class(1, 10, false, true);
+
+        let mut newer = NormalizationJournal::new();
+        newer.record(
+            InputKey::ElementStyleInput(StyleNodeID::element(1)),
+            InputValue::ElementStyleInput {
+                reaction: 0,
+                inherited_style_groups: 0,
+            },
+            InputValue::ElementStyleInput {
+                reaction: STYLE_REACTION_RECOMPUTE_STYLE,
+                inherited_style_groups: 0,
+            },
+            &mut fixture.memory,
+            &mut fixture.counters,
+        );
+
+        fixture
+            .journal
+            .absorb_newer(&mut newer, &mut fixture.memory, &mut fixture.counters);
+        assert!(newer.is_empty());
+
+        let transaction = fixture.take();
+        assert_eq!(transaction.inputs.len(), 2);
+        assert!(
+            transaction
+                .inputs
+                .iter()
+                .any(|input| matches!(input.key, InputKey::LocalFeature(..)))
+        );
+        assert!(
+            transaction
+                .inputs
+                .iter()
+                .any(|input| matches!(input.key, InputKey::ElementStyleInput(..)))
         );
         transaction.release(&mut fixture.memory);
     }

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -55,6 +55,9 @@ public:
 
     float visible_stroke_width() const
     {
+        // NB: CSS geometry-effect metadata relies on this reading only stroke color and width.
+        //     If SVG bounds begin accounting for caps, joins, miter limits, or stroke opacity,
+        //     mark those properties as affecting layout geometry as well.
         if (auto color = stroke_color(); color.has_value() && color->alpha() > 0)
             return stroke_width().value_or(0);
         return 0;

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
@@ -1,0 +1,10 @@
+paint-only geometry: 100
+paint-only offset width: 100
+paint-only client height: 10
+inline style setup preserves geometry deferral: true
+paint-only style deferred: true
+deferred style is observable: rgb(255, 0, 0)
+layout offset size: 200x20
+layout style settled: true
+transformed geometry: 18
+visual geometry style settled: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-preserves-transition-style-boundary.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-preserves-transition-style-boundary.txt
@@ -1,0 +1,19 @@
+offsetWidth preserved the transition start style: true
+clientWidth preserved the transition start style: true
+clientHeight preserved the transition start style: true
+getBoundingClientRect preserved the transition start style: true
+offsetWidth preserved the inline transition start style: true
+clientWidth preserved the inline transition start style: true
+clientHeight preserved the inline transition start style: true
+getBoundingClientRect preserved the inline transition start style: true
+offsetWidth preserved the transition start style before a style attribute change: true
+offsetWidth froze a deferred transition start style: true
+offsetWidth advanced the deferred transition start style: true
+computed style consumed a deferred boundary followed by inline style: true
+offsetWidth preserved the boundary across a later inline mutation: true
+offsetWidth preserved the boundary across a later tree mutation: true
+pseudo-element CSSOM reads did not lose the deferred boundary: true
+style element insertion did not transition from the pre-boundary style: true
+insertRule did not transition from the pre-boundary style: true
+rule declaration edit did not transition from the pre-boundary style: true
+link load did not transition from the pre-boundary style: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-indirect-style-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-indirect-style-effects.txt
@@ -1,0 +1,3 @@
+animated width: 150
+container query width: 60
+registered style query width: 70

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-non-obvious-layout-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-settles-non-obvious-layout-properties.txt
@@ -1,0 +1,8 @@
+text-rendering read is fresh: true
+text-rendering changes width: true
+stroke read is fresh: true
+stroke changes bounds: true
+stroke-width read is fresh: true
+stroke-width changes bounds: true
+currentColor stroke read is fresh: true
+currentColor stroke changes bounds: true

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-updates-full-embedding-chain.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-updates-full-embedding-chain.txt
@@ -1,0 +1,2 @@
+initial grandchild width: 100
+updated grandchild width: 200

--- a/Tests/LibWeb/Text/input/css/style-engine/converging-style-input-shares-style.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/converging-style-input-shares-style.html
@@ -21,12 +21,12 @@
 <script>
     test(() => {
         const items = document.querySelectorAll("span");
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         internals.resetStyleInvalidationCounters();
         for (const item of items)
             item.className = "new";
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         const counters = internals.getStyleInvalidationCounters();
         println(`shared converging style: ${counters.elementStyleSharedComputations >= 1}`);

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 10px;
+    }
+    #target.paint-only {
+        background-color: red;
+    }
+    #target.layout {
+        width: 200px;
+        height: 20px;
+    }
+    #target.transformed {
+        transform: translateX(10px);
+    }
+</style>
+<div id="target"></div>
+<script>
+    test(() => {
+        target.getBoundingClientRect();
+
+        target.style.outlineColor = "blue";
+        getComputedStyle(target).outlineColor;
+
+        internals.resetStyleInvalidationCounters();
+        target.className = "paint-only";
+        const paintOnlyRect = target.getBoundingClientRect();
+        const paintOnlyOffsetWidth = target.offsetWidth;
+        const paintOnlyClientHeight = target.clientHeight;
+        let counters = internals.getStyleInvalidationCounters();
+        println(`paint-only geometry: ${paintOnlyRect.width}`);
+        println(`paint-only offset width: ${paintOnlyOffsetWidth}`);
+        println(`paint-only client height: ${paintOnlyClientHeight}`);
+        println(`inline style setup preserves geometry deferral: ${counters.styleStabilizationEpochs === 0}`);
+        println(`paint-only style deferred: ${counters.styleStabilizationEpochs === 0}`);
+        println(`deferred style is observable: ${getComputedStyle(target).backgroundColor}`);
+
+        target.className = "";
+        target.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        target.className = "layout";
+        const layoutOffsetWidth = target.offsetWidth;
+        const layoutOffsetHeight = target.offsetHeight;
+        counters = internals.getStyleInvalidationCounters();
+        println(`layout offset size: ${layoutOffsetWidth}x${layoutOffsetHeight}`);
+        println(`layout style settled: ${counters.styleStabilizationEpochs === 1}`);
+
+        target.className = "";
+        target.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        target.className = "transformed";
+        const transformedRect = target.getBoundingClientRect();
+        counters = internals.getStyleInvalidationCounters();
+        println(`transformed geometry: ${transformedRect.x}`);
+        println(`visual geometry style settled: ${counters.styleStabilizationEpochs === 1}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-preserves-transition-style-boundary.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-preserves-transition-style-boundary.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function createFrame(css) {
+        return new Promise(resolve => {
+            const frame = document.createElement("iframe");
+            frame.onload = () => resolve(frame);
+            frame.srcdoc = `
+                <style>
+                    #target {
+                        width: 10px;
+                        height: 10px;
+                        background-color: rgb(0, 0, 0);
+                    }
+                    #target.from {
+                        background-color: rgb(255, 0, 0);
+                    }
+                    ${css}
+                </style>
+                <div id="target"></div>`;
+            document.body.appendChild(frame);
+        });
+    }
+
+    promiseTest(async () => {
+        const cases = [
+            ["offsetWidth", target => target.offsetWidth],
+            ["clientWidth", target => target.clientWidth],
+            ["clientHeight", target => target.clientHeight],
+            ["getBoundingClientRect", target => target.getBoundingClientRect()],
+        ];
+        for (const [name, flushStyle] of cases) {
+            const frame = await createFrame(`
+                #target.to {
+                    background-color: rgb(0, 0, 255);
+                    transition: background-color 1000s linear;
+                }`);
+            const target = frame.contentDocument.getElementById("target");
+            target.offsetWidth;
+            target.classList.add("from");
+            flushStyle(target);
+            target.classList.replace("from", "to");
+
+            const transition = target.getAnimations()[0];
+            if (transition)
+                transition.currentTime = 0;
+            println(`${name} preserved the transition start style: ${transition !== undefined
+                && frame.contentWindow.getComputedStyle(target).backgroundColor === "rgb(255, 0, 0)"}`);
+        }
+
+        for (const [name, flushStyle] of cases) {
+            const frame = await createFrame("");
+            const target = frame.contentDocument.getElementById("target");
+            target.offsetWidth;
+            target.style.backgroundColor = "rgb(255, 0, 0)";
+            flushStyle(target);
+            target.style.transition = "background-color 1000s linear";
+            target.style.backgroundColor = "rgb(0, 0, 255)";
+
+            const transition = target.getAnimations()[0];
+            if (transition)
+                transition.currentTime = 0;
+            println(`${name} preserved the inline transition start style: ${transition !== undefined
+                && frame.contentWindow.getComputedStyle(target).backgroundColor === "rgb(255, 0, 0)"}`);
+        }
+
+        const frame = await createFrame("");
+        const target = frame.contentDocument.getElementById("target");
+        target.offsetWidth;
+        target.style.backgroundColor = "rgb(255, 0, 0)";
+        target.offsetWidth;
+        target.setAttribute("style", `
+            background-color: rgb(0, 0, 255);
+            transition: background-color 1000s linear;
+        `);
+
+        const transition = target.getAnimations()[0];
+        if (transition)
+            transition.currentTime = 0;
+        println(`offsetWidth preserved the transition start style before a style attribute change: ${transition !== undefined
+            && frame.contentWindow.getComputedStyle(target).backgroundColor === "rgb(255, 0, 0)"}`);
+
+        const deferredFrame = await createFrame(`
+            #target.green {
+                background-color: rgb(0, 128, 0);
+            }`);
+        const deferredTarget = deferredFrame.contentDocument.getElementById("target");
+        deferredTarget.offsetWidth;
+        deferredTarget.classList.add("from");
+        deferredTarget.offsetWidth;
+        deferredTarget.classList.replace("from", "green");
+        deferredTarget.style.transition = "background-color 1000s linear";
+        deferredTarget.style.backgroundColor = "rgb(0, 0, 255)";
+
+        const deferredTransition = deferredTarget.getAnimations()[0];
+        if (deferredTransition)
+            deferredTransition.currentTime = 0;
+        println(`offsetWidth froze a deferred transition start style: ${deferredTransition !== undefined
+            && deferredFrame.contentWindow.getComputedStyle(deferredTarget).backgroundColor === "rgb(255, 0, 0)"}`);
+
+        const advancedFrame = await createFrame(`
+            #target.green {
+                background-color: rgb(0, 128, 0);
+            }`);
+        const advancedTarget = advancedFrame.contentDocument.getElementById("target");
+        advancedTarget.offsetWidth;
+        advancedTarget.className = "from";
+        advancedTarget.offsetWidth;
+        advancedTarget.className = "green";
+        advancedTarget.offsetWidth;
+        advancedTarget.style.transition = "background-color 1000s linear";
+        advancedTarget.style.backgroundColor = "rgb(0, 0, 255)";
+
+        const advancedTransition = advancedTarget.getAnimations()[0];
+        if (advancedTransition)
+            advancedTransition.currentTime = 0;
+        println(`offsetWidth advanced the deferred transition start style: ${advancedTransition !== undefined
+            && advancedFrame.contentWindow.getComputedStyle(advancedTarget).backgroundColor === "rgb(0, 128, 0)"}`);
+
+        const inlineMutationFrame = await createFrame("");
+        const inlineMutationTarget = inlineMutationFrame.contentDocument.getElementById("target");
+        inlineMutationTarget.offsetWidth;
+        inlineMutationTarget.className = "from";
+        inlineMutationTarget.offsetWidth;
+        inlineMutationTarget.style.backgroundColor = "rgb(0, 128, 0)";
+        println(`computed style consumed a deferred boundary followed by inline style: ${inlineMutationFrame.contentWindow.getComputedStyle(inlineMutationTarget).backgroundColor === "rgb(0, 128, 0)"}`);
+
+        const laterInlineFrame = await createFrame("");
+        const laterInlineTarget = laterInlineFrame.contentDocument.getElementById("target");
+        laterInlineTarget.offsetWidth;
+        laterInlineTarget.className = "from";
+        laterInlineTarget.offsetWidth;
+        laterInlineTarget.style.backgroundColor = "rgb(0, 128, 0)";
+        laterInlineTarget.style.transition = "background-color 1000s linear";
+        laterInlineTarget.style.backgroundColor = "rgb(0, 0, 255)";
+
+        const laterInlineTransition = laterInlineTarget.getAnimations()[0];
+        if (laterInlineTransition)
+            laterInlineTransition.currentTime = 0;
+        println(`offsetWidth preserved the boundary across a later inline mutation: ${laterInlineTransition !== undefined
+            && laterInlineFrame.contentWindow.getComputedStyle(laterInlineTarget).backgroundColor === "rgb(255, 0, 0)"}`);
+
+        const laterTreeFrame = await createFrame(`
+            .green + #target {
+                background-color: rgb(0, 128, 0);
+            }`);
+        const laterTreeTarget = laterTreeFrame.contentDocument.getElementById("target");
+        laterTreeTarget.offsetWidth;
+        laterTreeTarget.className = "from";
+        laterTreeTarget.offsetWidth;
+        const greenContainer = laterTreeFrame.contentDocument.createElement("div");
+        greenContainer.className = "green";
+        laterTreeTarget.parentNode.insertBefore(greenContainer, laterTreeTarget);
+        laterTreeTarget.style.transition = "background-color 1000s linear";
+        laterTreeTarget.style.backgroundColor = "rgb(0, 0, 255)";
+
+        const laterTreeTransition = laterTreeTarget.getAnimations()[0];
+        if (laterTreeTransition)
+            laterTreeTransition.currentTime = 0;
+        println(`offsetWidth preserved the boundary across a later tree mutation: ${laterTreeTransition !== undefined
+            && laterTreeFrame.contentWindow.getComputedStyle(laterTreeTarget).backgroundColor === "rgb(255, 0, 0)"}`);
+
+        const pseudoReadFrame = await createFrame("");
+        const pseudoReadTarget = pseudoReadFrame.contentDocument.getElementById("target");
+        pseudoReadTarget.offsetWidth;
+        pseudoReadTarget.className = "from";
+        pseudoReadTarget.offsetWidth;
+        pseudoReadFrame.contentWindow.getComputedStyle(pseudoReadTarget, "::backdrop").color;
+        pseudoReadTarget.style.transition = "background-color 1000s linear";
+        pseudoReadTarget.style.backgroundColor = "rgb(0, 0, 255)";
+
+        const pseudoReadTransition = pseudoReadTarget.getAnimations()[0];
+        if (pseudoReadTransition)
+            pseudoReadTransition.currentTime = 0;
+        println(`pseudo-element CSSOM reads did not lose the deferred boundary: ${pseudoReadTransition !== undefined
+            && pseudoReadFrame.contentWindow.getComputedStyle(pseudoReadTarget).backgroundColor === "rgb(255, 0, 0)"}`);
+
+        for (const [name, installTransition] of [
+            ["style element insertion", target => {
+                const style = target.ownerDocument.createElement("style");
+                style.textContent = "#target { transition: background-color 1000s linear; }";
+                target.ownerDocument.head.appendChild(style);
+            }],
+            ["insertRule", target => {
+                target.ownerDocument.styleSheets[0].insertRule("#target { transition: background-color 1000s linear; }");
+            }],
+            ["rule declaration edit", target => {
+                target.ownerDocument.styleSheets[0].cssRules[0].style.transition = "background-color 1000s linear";
+            }],
+            ["link load", async target => {
+                const link = target.ownerDocument.createElement("link");
+                link.rel = "stylesheet";
+                link.href = "data:text/css,%23target%20%7B%20transition%3A%20background-color%201000s%20linear%3B%20%7D";
+                const loaded = new Promise(resolve => link.onload = resolve);
+                target.ownerDocument.head.appendChild(link);
+                await loaded;
+            }],
+        ]) {
+            const stylesheetFrame = await createFrame("");
+            const stylesheetTarget = stylesheetFrame.contentDocument.getElementById("target");
+            stylesheetTarget.offsetWidth;
+            stylesheetTarget.className = "from";
+            stylesheetTarget.offsetWidth;
+            await installTransition(stylesheetTarget);
+            println(`${name} did not transition from the pre-boundary style: ${stylesheetTarget.getAnimations().length === 0}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-indirect-style-effects.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-indirect-style-effects.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    @property --query-color {
+        syntax: "<color>";
+        inherits: false;
+        initial-value: black;
+    }
+
+    @keyframes wider {
+        from, to { width: 150px; }
+    }
+
+    #animated-target {
+        width: 100px;
+        height: 10px;
+    }
+    #animated-target.running {
+        animation: wider 1s paused both;
+    }
+
+    #query-container {
+        container-type: inline-size;
+        width: 100px;
+    }
+    #query-container.named {
+        container-name: measured;
+    }
+    #query-target {
+        width: 10px;
+        height: 10px;
+    }
+    @container measured (min-width: 50px) {
+        #query-target { width: 60px; }
+    }
+
+    #style-query-container {
+        color: black;
+        container-type: inline-size;
+        --query-color: currentColor;
+    }
+    #style-query-container.red {
+        color: red;
+    }
+    #style-query-target {
+        width: 10px;
+        height: 10px;
+    }
+    @container style(--query-color: red) {
+        #style-query-target { width: 70px; }
+    }
+</style>
+<div id="animated-target"></div>
+<div id="query-container">
+    <div id="query-target"></div>
+</div>
+<div id="style-query-container">
+    <div id="style-query-target"></div>
+</div>
+<script>
+    test(() => {
+        const animatedTarget = document.getElementById("animated-target");
+        animatedTarget.offsetWidth;
+        animatedTarget.className = "running";
+        println(`animated width: ${animatedTarget.offsetWidth}`);
+
+        const queryContainer = document.getElementById("query-container");
+        const queryTarget = document.getElementById("query-target");
+        queryTarget.getBoundingClientRect();
+        queryContainer.className = "named";
+        println(`container query width: ${queryTarget.getBoundingClientRect().width}`);
+
+        const styleQueryContainer = document.getElementById("style-query-container");
+        const styleQueryTarget = document.getElementById("style-query-target");
+        styleQueryTarget.offsetWidth;
+        styleQueryContainer.className = "red";
+        println(`registered style query width: ${styleQueryTarget.offsetWidth}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-non-obvious-layout-properties.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-settles-non-obvious-layout-properties.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    @font-face {
+        font-family: LatoBold;
+        src: url("../../../../Assets/Lato-Bold.ttf");
+    }
+
+    #text-target {
+        display: inline-block;
+        font: 48px LatoBold;
+        text-rendering: optimizeSpeed;
+    }
+    #text-target.legible {
+        text-rendering: optimizeLegibility;
+    }
+
+    #stroke-target {
+        stroke: none;
+        stroke-width: 10px;
+    }
+    #stroke-target.visible {
+        stroke: black;
+    }
+
+    #stroke-width-target {
+        stroke: black;
+        stroke-width: 1px;
+    }
+    #stroke-width-target.thick {
+        stroke-width: 10px;
+    }
+
+    #current-color-stroke-target {
+        color: transparent;
+        stroke: currentColor;
+        stroke-width: 10px;
+    }
+    #current-color-stroke-target.visible {
+        color: black;
+    }
+</style>
+<span id="text-target">AVAVAV</span>
+<svg width="200" height="100">
+    <rect id="stroke-target" x="20" y="20" width="20" height="20"></rect>
+    <rect id="stroke-width-target" x="80" y="20" width="20" height="20"></rect>
+    <rect id="current-color-stroke-target" x="140" y="20" width="20" height="20"></rect>
+</svg>
+<script>
+    promiseTest(async () => {
+        await document.fonts.ready;
+
+        const textTarget = document.getElementById("text-target");
+        const speedWidth = textTarget.offsetWidth;
+        textTarget.className = "legible";
+        const immediateLegibleWidth = textTarget.offsetWidth;
+        getComputedStyle(textTarget).textRendering;
+        const settledLegibleWidth = textTarget.offsetWidth;
+        println(`text-rendering read is fresh: ${immediateLegibleWidth === settledLegibleWidth}`);
+        println(`text-rendering changes width: ${speedWidth !== settledLegibleWidth}`);
+
+        const strokeTarget = document.getElementById("stroke-target");
+        const noStrokeWidth = strokeTarget.getBoundingClientRect().width;
+        strokeTarget.setAttribute("class", "visible");
+        const immediateStrokeWidth = strokeTarget.getBoundingClientRect().width;
+        getComputedStyle(strokeTarget).stroke;
+        // The old metadata did not schedule layout after settling style, so use a full rebuild as
+        // the geometry oracle.
+        internals.compareLayoutTreeWithFullRebuild();
+        const settledStrokeWidth = strokeTarget.getBoundingClientRect().width;
+        println(`stroke read is fresh: ${immediateStrokeWidth === settledStrokeWidth}`);
+        println(`stroke changes bounds: ${noStrokeWidth !== settledStrokeWidth}`);
+
+        const strokeWidthTarget = document.getElementById("stroke-width-target");
+        const thinStrokeWidth = strokeWidthTarget.getBoundingClientRect().width;
+        strokeWidthTarget.setAttribute("class", "thick");
+        const immediateThickStrokeWidth = strokeWidthTarget.getBoundingClientRect().width;
+        getComputedStyle(strokeWidthTarget).strokeWidth;
+        internals.compareLayoutTreeWithFullRebuild();
+        const settledThickStrokeWidth = strokeWidthTarget.getBoundingClientRect().width;
+        println(`stroke-width read is fresh: ${immediateThickStrokeWidth === settledThickStrokeWidth}`);
+        println(`stroke-width changes bounds: ${thinStrokeWidth !== settledThickStrokeWidth}`);
+
+        const currentColorStrokeTarget = document.getElementById("current-color-stroke-target");
+        const transparentStrokeWidth = currentColorStrokeTarget.getBoundingClientRect().width;
+        currentColorStrokeTarget.setAttribute("class", "visible");
+        const immediateCurrentColorStrokeWidth = currentColorStrokeTarget.getBoundingClientRect().width;
+        getComputedStyle(currentColorStrokeTarget).color;
+        internals.compareLayoutTreeWithFullRebuild();
+        const settledCurrentColorStrokeWidth = currentColorStrokeTarget.getBoundingClientRect().width;
+        println(`currentColor stroke read is fresh: ${immediateCurrentColorStrokeWidth === settledCurrentColorStrokeWidth}`);
+        println(`currentColor stroke changes bounds: ${transparentStrokeWidth !== settledCurrentColorStrokeWidth}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-updates-full-embedding-chain.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-updates-full-embedding-chain.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #middle-frame {
+        border: 0;
+        width: 100px;
+        height: 20px;
+    }
+    #middle-frame.wide {
+        width: 200px;
+    }
+</style>
+<script>
+    asyncTest(async done => {
+        const middleFrame = document.createElement("iframe");
+        const middleLoaded = new Promise(resolve => {
+            middleFrame.addEventListener("load", resolve, { once: true });
+        });
+        middleFrame.id = "middle-frame";
+        middleFrame.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                html, body { margin: 0; }
+                iframe { border: 0; width: 100%; height: 10px; }
+            </style>
+        `;
+        document.body.append(middleFrame);
+        await middleLoaded;
+
+        const childFrame = middleFrame.contentDocument.createElement("iframe");
+        const childLoaded = new Promise(resolve => {
+            childFrame.addEventListener("load", resolve, { once: true });
+        });
+        childFrame.srcdoc = `
+            <!DOCTYPE html>
+            <style>html, body { margin: 0; } #target { width: 100vw; height: 10px; }</style>
+            <div id="target"></div>
+        `;
+        middleFrame.contentDocument.body.append(childFrame);
+        await childLoaded;
+
+        const target = childFrame.contentDocument.getElementById("target");
+        println(`initial grandchild width: ${target.offsetWidth}`);
+        middleFrame.className = "wide";
+        println(`updated grandchild width: ${target.offsetWidth}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
@@ -12,7 +12,7 @@
             document.body.appendChild(makeElement("a", { attributes: { href: `https://example.com/page${i}` } }));
         }
         document.body.appendChild(makeElement("a", { id: "same-doc", attributes: { href: "#target" } }));
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         const printCounters = label => {
             const counters = internals.getStyleInvalidationCounters();
@@ -22,17 +22,17 @@
         // Without any :local-link rule, a URL change should produce no invalidation work at all.
         resetStyleCounters();
         history.pushState({}, "", "#initial");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters("no :local-link rule");
 
         const documentStyle = addStyle(document.head, `a:local-link { color: rgb(0, 128, 0); }`);
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         // With a :local-link rule, navigating to the targeted fragment must restyle only the matching anchor, the
         // other 50 anchors and the rest of the document are untouched.
         resetStyleCounters();
         history.pushState({}, "", "#target");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters(":local-link rule, anchor flips");
 
         // A :local-link rule that lives only inside a shadow root must still trigger invalidation for shadow
@@ -43,11 +43,11 @@
         const shadowRoot = host.attachShadow({ mode: "open" });
         addStyle(shadowRoot, `a:local-link { color: rgb(0, 0, 128); }`);
         shadowRoot.appendChild(makeElement("a", { id: "shadow-anchor", attributes: { href: "#shadow-target" } }));
-        document.body.offsetWidth;
+        internals.updateStyle();
 
         resetStyleCounters();
         history.pushState({}, "", "#shadow-target");
-        document.body.offsetWidth;
+        internals.updateStyle();
         printCounters("shadow-only :local-link rule, shadow anchor flips");
     });
 </script>


### PR DESCRIPTION
Synchronous geometry queries settled every pending style input even when the committed layout was clean and all reachable declarations could only change painting. This made StyleBench resolve background-color changes before reading an unchanged body rectangle.

Generate conservative geometry-effect metadata from the CSS property table. Use live selector routes to prove when a normalized transaction cannot affect geometry. Keep proven paint-only inputs pending across client rectangles, client dimensions, and offset dimensions.

Treat animation controls, container naming, and documents that have evaluated style queries as possible indirect geometry effects. Correct the metadata for text rendering, SVG stroke properties, and color, since currentColor strokes feed SVG path bounds. Require every embedding document to be clean before reusing geometry inside nested frames.

Seal deferred normalization at every geometry observation so later mutations cannot replace the transition before-change style. Keep the engine journal as the sole owner of that boundary. Replay local selector facts, and consume the boundary before declarations, tree mutations, or stylesheet program changes alter authoritative state. Fold arbitrary later input kinds safely during ordinary style observations.

Use explicit style updates in instrumentation tests that need completed style work. Cover deferred paint-only style, conservative layout and transform fallbacks, indirect effects, CSS transition boundaries across inline, tree, and stylesheet mutations, currentColor SVG bounds, other non-obvious geometry properties, and nested-frame resizing.

```
Benchmark               Improvement    Old Score       New Score
----------------------  -------------  --------------  ----------------------
StyleBench              1.223          79.579 ± 4.568  97.341 ± 2.919  1.223
StyleBenchConservative  0.988          79.423 ± 1.956  78.441 ± 3.630  0.988

Benchmark               Speedup    Old Total Time (s)    New Total Time (s)
----------------------  ---------  --------------------  --------------------
StyleBench              1.163      3.136 ± 0.135         2.697 ± 0.255
StyleBenchConservative  0.988      3.140 ± 0.079         3.178 ± 0.115
```