### PR TITLE
LibWebView: Make selection IPC asynchronous

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2104,16 +2104,18 @@ void Application::initialize_actions()
     });
     update_editing_history_actions();
     m_copy_selection_action = Action::create("Copy"sv, ActionID::CopySelection, [this]() {
-        if (auto view = active_web_view(); view.has_value()) {
-            if (auto text = view->selected_text(); !text.is_empty())
-                insert_clipboard_entry({ move(text), "text/plain"_string });
-        }
+        if (auto view = active_web_view(); view.has_value())
+            view->selected_text()->when_resolved([this](auto& text) {
+                if (!text.is_empty())
+                    insert_clipboard_entry({ text, "text/plain"_string });
+            });
     });
     m_cut_selection_action = Action::create("Cut"sv, ActionID::CutSelection, [this]() {
-        if (auto view = active_web_view(); view.has_value()) {
-            if (auto text = view->cut_selected_text(); !text.is_empty())
-                insert_clipboard_entry({ move(text), "text/plain"_string });
-        }
+        if (auto view = active_web_view(); view.has_value())
+            view->cut_selected_text()->when_resolved([this](auto& text) {
+                if (!text.is_empty())
+                    insert_clipboard_entry({ text, "text/plain"_string });
+            });
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {
         if (auto view = active_web_view(); view.has_value())

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1025,36 +1025,94 @@ Optional<Core::SharedVersion> ViewImplementation::document_cookie_version(URL::U
     return Core::get_shared_version(m_document_cookie_version_buffer, *document_index);
 }
 
-ByteString ViewImplementation::selected_text()
+NonnullRefPtr<Core::Promise<ByteString>> ViewImplementation::selected_text()
 {
-    return client().get_selected_text(page_id());
+    auto promise = Core::Promise<ByteString>::construct();
+    auto request_id = m_next_selection_request_id++;
+    m_pending_selected_text_requests.set(request_id, promise);
+    client().async_get_selected_text(page_id(), request_id);
+    return promise;
 }
 
-ByteString ViewImplementation::cut_selected_text()
+void ViewImplementation::did_receive_selected_text(Badge<WebContentClient>, u64 request_id, ByteString selection)
 {
-    return client().cut_selected_text(page_id());
+    auto promise = m_pending_selected_text_requests.take(request_id);
+    if (!promise.has_value())
+        return;
+    promise.value()->resolve(move(selection));
 }
 
-Optional<String> ViewImplementation::selected_text_with_whitespace_collapsed()
+NonnullRefPtr<Core::Promise<ByteString>> ViewImplementation::cut_selected_text()
 {
-    auto selected_text = MUST(Web::Infra::strip_and_collapse_whitespace(this->selected_text()));
-    if (selected_text.is_empty())
-        return OptionalNone {};
-    return selected_text;
+    auto promise = Core::Promise<ByteString>::construct();
+    auto request_id = m_next_selection_request_id++;
+    m_pending_cut_selected_text_requests.set(request_id, promise);
+    client().async_cut_selected_text(page_id(), request_id);
+    return promise;
 }
 
-Optional<DictionaryLookup> ViewImplementation::selected_text_for_dictionary_lookup()
+void ViewImplementation::did_cut_selected_text(Badge<WebContentClient>, u64 request_id, ByteString selection)
 {
-    auto lookup = client().get_selected_text_for_lookup(page_id());
-    if (!lookup.has_value())
-        return {};
+    auto promise = m_pending_cut_selected_text_requests.take(request_id);
+    if (!promise.has_value())
+        return;
+    promise.value()->resolve(move(selection));
+}
 
-    auto selected_text = MUST(Web::Infra::strip_and_collapse_whitespace(lookup->text));
-    if (selected_text.is_empty())
-        return {};
+NonnullRefPtr<Core::Promise<Optional<String>>> ViewImplementation::selected_text_with_whitespace_collapsed()
+{
+    return selected_text()->map<Optional<String>>([](auto& selection) -> Optional<String> {
+        auto collapsed_selection = MUST(Web::Infra::strip_and_collapse_whitespace(selection));
+        if (collapsed_selection.is_empty())
+            return {};
+        return collapsed_selection;
+    });
+}
 
-    lookup->text = move(selected_text);
-    return lookup;
+NonnullRefPtr<Core::Promise<Optional<DictionaryLookup>>> ViewImplementation::selected_text_for_dictionary_lookup()
+{
+    auto promise = Core::Promise<Optional<DictionaryLookup>>::construct();
+    auto request_id = m_next_selection_request_id++;
+    m_pending_selected_text_for_lookup_requests.set(request_id, promise);
+    client().async_get_selected_text_for_lookup(page_id(), request_id);
+
+    return promise->map<Optional<DictionaryLookup>>([](auto& lookup) -> Optional<DictionaryLookup> {
+        if (!lookup.has_value())
+            return {};
+
+        auto collapsed_selection = MUST(Web::Infra::strip_and_collapse_whitespace(lookup->text));
+        if (collapsed_selection.is_empty())
+            return {};
+
+        auto result = lookup;
+        result->text = move(collapsed_selection);
+        return result;
+    });
+}
+
+void ViewImplementation::did_receive_selected_text_for_lookup(Badge<WebContentClient>, u64 request_id, Optional<DictionaryLookup> lookup)
+{
+    auto promise = m_pending_selected_text_for_lookup_requests.take(request_id);
+    if (!promise.has_value())
+        return;
+    promise.value()->resolve(move(lookup));
+}
+
+NonnullRefPtr<Core::Promise<bool>> ViewImplementation::select_word_for_dictionary_lookup(Gfx::IntPoint widget_position)
+{
+    auto promise = Core::Promise<bool>::construct();
+    auto request_id = m_next_selection_request_id++;
+    m_pending_select_word_for_dictionary_lookup_requests.set(request_id, promise);
+    client().async_select_word_for_dictionary_lookup(page_id(), request_id, to_content_position(widget_position).to_type<Web::DevicePixels>());
+    return promise;
+}
+
+void ViewImplementation::did_select_word_for_dictionary_lookup(Badge<WebContentClient>, u64 request_id, bool selected)
+{
+    auto promise = m_pending_select_word_for_dictionary_lookup_requests.take(request_id);
+    if (!promise.has_value())
+        return;
+    promise.value()->resolve(selected);
 }
 
 bool ViewImplementation::look_up_selected_text_at(Gfx::IntPoint widget_position)
@@ -1062,18 +1120,30 @@ bool ViewImplementation::look_up_selected_text_at(Gfx::IntPoint widget_position)
     if (!on_request_dictionary_lookup)
         return false;
 
-    auto lookup = selected_text_for_dictionary_lookup();
-    if (!lookup.has_value()) {
-        if (!client().select_word_for_dictionary_lookup(page_id(), to_content_position(widget_position).to_type<Web::DevicePixels>()))
-            return false;
+    auto weak_this = make_weak_ptr();
+    selected_text_for_dictionary_lookup()->when_resolved([weak_this, widget_position](auto& lookup) {
+        if (!weak_this)
+            return;
 
-        lookup = selected_text_for_dictionary_lookup();
-    }
-    if (!lookup.has_value())
-        return false;
+        if (lookup.has_value()) {
+            auto lookup_position = lookup->baseline_origin.has_value() ? weak_this->to_widget_position(*lookup->baseline_origin) : widget_position;
+            weak_this->on_request_dictionary_lookup(*lookup, lookup_position);
+            return;
+        }
 
-    auto lookup_position = lookup->baseline_origin.has_value() ? to_widget_position(*lookup->baseline_origin) : widget_position;
-    on_request_dictionary_lookup(*lookup, lookup_position);
+        weak_this->select_word_for_dictionary_lookup(widget_position)->when_resolved([weak_this, widget_position](bool& selected) {
+            if (!weak_this || !selected)
+                return;
+
+            weak_this->selected_text_for_dictionary_lookup()->when_resolved([weak_this, widget_position](auto& lookup) {
+                if (!weak_this || !lookup.has_value())
+                    return;
+
+                auto lookup_position = lookup->baseline_origin.has_value() ? weak_this->to_widget_position(*lookup->baseline_origin) : widget_position;
+                weak_this->on_request_dictionary_lookup(*lookup, lookup_position);
+            });
+        });
+    });
     return true;
 }
 
@@ -1756,6 +1826,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
     m_needs_beforeunload_check = true;
 
     if (create_new_client == CreateNewClient::Yes) {
+        reject_pending_selection_requests();
+
         if (m_history_operation_handling_for_next_client == HistoryOperationHandling::Abandon) {
             // NB: Replies from the previous process will never arrive; complete the in-flight operations so the
             //     traversal queue can serve the new process.
@@ -2104,6 +2176,8 @@ void ViewImplementation::did_complete_webdriver_content_command(Badge<WebContent
 
 void ViewImplementation::did_close_browsing_context(Badge<WebContentClient>)
 {
+    reject_pending_selection_requests();
+
     auto window_handle = move(m_client_state.client_handle);
 
     // Headless views retain their closed children. Remove the view from routing immediately so a command racing
@@ -2610,6 +2684,8 @@ void ViewImplementation::dump_session_history(StringView reason, SessionHistoryD
 
 void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_error_page)
 {
+    reject_pending_selection_requests();
+
     set_loading_state(false);
     m_top_level_traversable.clear_ongoing_navigation();
 
@@ -3287,64 +3363,117 @@ void ViewImplementation::update_look_up_selected_text_action(Optional<Dictionary
     m_look_up_selected_text_action->set_visible(m_look_up.has_value());
 }
 
-void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target)
+void ViewImplementation::request_context_menu_dictionary_lookup(Function<void(Optional<DictionaryLookup> const&)> on_complete)
 {
-    auto& cut_selection_action = Application::the().cut_selection_action();
-    cut_selection_action.set_visible(for_input_events_target == Web::ContextMenuForInputEventsTarget::Yes);
-
-    auto const& search_engine = Application::settings().search_engine();
-    auto lookup = on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {};
-    auto selected_text = lookup.map([](auto const& lookup) { return lookup.text; });
-    if (!selected_text.has_value())
-        selected_text = selected_text_with_whitespace_collapsed();
-    m_search_text = search_engine.has_value() ? selected_text : OptionalNone {};
-    auto selected_text_url = selected_text.has_value() ? url_from_text(*selected_text) : OptionalNone {};
-    update_look_up_selected_text_action(lookup, content_position);
-
-    ScopeGuard guard { [&]() {
-        cut_selection_action.set_visible(true);
-        m_search_text.clear();
-    } };
-
-    if (m_search_text.has_value()) {
-        m_search_selected_text_action->set_text(search_engine->format_search_query_for_display(*m_search_text));
-        m_search_selected_text_action->set_visible(true);
-    } else {
-        m_search_selected_text_action->set_visible(false);
-    }
-
-    if (selected_text_url.has_value() && m_selected_text_link_context_menu->on_activation) {
-        m_context_menu_url = selected_text_url.release_value();
-        m_open_in_new_tab_action->set_text("Open in New Tab"sv);
-        m_selected_text_link_context_menu->on_activation(to_widget_position(content_position));
+    if (!on_request_dictionary_lookup) {
+        Optional<DictionaryLookup> lookup;
+        on_complete(lookup);
         return;
     }
 
-    if (m_page_context_menu->on_activation)
-        m_page_context_menu->on_activation(to_widget_position(content_position));
+    selected_text_for_dictionary_lookup()->when_resolved([on_complete = move(on_complete)](auto& lookup) mutable {
+        on_complete(lookup);
+    });
+}
+
+void ViewImplementation::reject_pending_selection_requests()
+{
+    ++m_context_menu_request_id;
+
+    auto reject_requests = [](auto& requests) {
+        auto pending_requests = move(requests);
+        for (auto& request : pending_requests)
+            request.value->reject(Error::from_string_literal("WebContent was replaced before completing a selection request"));
+    };
+
+    reject_requests(m_pending_selected_text_requests);
+    reject_requests(m_pending_selected_text_for_lookup_requests);
+    reject_requests(m_pending_select_word_for_dictionary_lookup_requests);
+    reject_requests(m_pending_cut_selected_text_requests);
+}
+
+void ViewImplementation::did_request_page_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target)
+{
+    auto request_id = ++m_context_menu_request_id;
+    auto weak_this = make_weak_ptr();
+    request_context_menu_dictionary_lookup([weak_this, request_id, content_position, for_input_events_target](auto const& lookup) {
+        if (!weak_this || request_id != weak_this->m_context_menu_request_id)
+            return;
+
+        auto show_context_menu = [weak_this, request_id, content_position, for_input_events_target, lookup](Optional<String> selected_text) {
+            if (!weak_this || request_id != weak_this->m_context_menu_request_id)
+                return;
+
+            auto& cut_selection_action = Application::the().cut_selection_action();
+            cut_selection_action.set_visible(for_input_events_target == Web::ContextMenuForInputEventsTarget::Yes);
+
+            auto const& search_engine = Application::settings().search_engine();
+            weak_this->m_search_text = search_engine.has_value() ? selected_text : OptionalNone {};
+            auto selected_text_url = selected_text.has_value() ? url_from_text(*selected_text) : OptionalNone {};
+            weak_this->update_look_up_selected_text_action(lookup, content_position);
+
+            ScopeGuard guard { [&]() {
+                cut_selection_action.set_visible(true);
+                weak_this->m_search_text.clear();
+            } };
+
+            if (weak_this->m_search_text.has_value()) {
+                weak_this->m_search_selected_text_action->set_text(search_engine->format_search_query_for_display(*weak_this->m_search_text));
+                weak_this->m_search_selected_text_action->set_visible(true);
+            } else {
+                weak_this->m_search_selected_text_action->set_visible(false);
+            }
+
+            if (selected_text_url.has_value() && weak_this->m_selected_text_link_context_menu->on_activation) {
+                weak_this->m_context_menu_url = selected_text_url.release_value();
+                weak_this->m_open_in_new_tab_action->set_text("Open in New Tab"sv);
+                weak_this->m_selected_text_link_context_menu->on_activation(weak_this->to_widget_position(content_position));
+                return;
+            }
+
+            if (weak_this->m_page_context_menu->on_activation)
+                weak_this->m_page_context_menu->on_activation(weak_this->to_widget_position(content_position));
+        };
+
+        if (lookup.has_value()) {
+            show_context_menu(lookup->text);
+            return;
+        }
+
+        weak_this->selected_text_with_whitespace_collapsed()->when_resolved([show_context_menu = move(show_context_menu)](auto& selected_text) mutable {
+            show_context_menu(selected_text);
+        });
+    });
 }
 
 void ViewImplementation::did_request_link_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, URL::URL url)
 {
-    m_context_menu_url = move(url);
-    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
+    auto request_id = ++m_context_menu_request_id;
+    auto weak_this = make_weak_ptr();
+    request_context_menu_dictionary_lookup([weak_this, request_id, content_position, url = move(url)](auto const& lookup) mutable {
+        if (!weak_this || request_id != weak_this->m_context_menu_request_id)
+            return;
 
-    m_open_in_new_tab_action->set_text("Open in New Tab"sv);
+        weak_this->m_context_menu_url = move(url);
+        weak_this->update_look_up_selected_text_action(lookup, content_position);
 
-    switch (url_type(m_context_menu_url)) {
-    case URLType::Email:
-        m_copy_url_action->set_text("Copy Email Address"sv);
-        break;
-    case URLType::Telephone:
-        m_copy_url_action->set_text("Copy Phone Number"sv);
-        break;
-    case URLType::Other:
-        m_copy_url_action->set_text("Copy Link Address"sv);
-        break;
-    }
+        weak_this->m_open_in_new_tab_action->set_text("Open in New Tab"sv);
 
-    if (m_link_context_menu->on_activation)
-        m_link_context_menu->on_activation(to_widget_position(content_position));
+        switch (url_type(weak_this->m_context_menu_url)) {
+        case URLType::Email:
+            weak_this->m_copy_url_action->set_text("Copy Email Address"sv);
+            break;
+        case URLType::Telephone:
+            weak_this->m_copy_url_action->set_text("Copy Phone Number"sv);
+            break;
+        case URLType::Other:
+            weak_this->m_copy_url_action->set_text("Copy Link Address"sv);
+            break;
+        }
+
+        if (weak_this->m_link_context_menu->on_activation)
+            weak_this->m_link_context_menu->on_activation(weak_this->to_widget_position(content_position));
+    });
 }
 
 void ViewImplementation::download_context_menu_url(PromptForPath prompt_for_path)
@@ -3363,46 +3492,60 @@ void ViewImplementation::download_context_menu_url(PromptForPath prompt_for_path
 
 void ViewImplementation::did_request_image_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, URL::URL url, Optional<Gfx::ShareableBitmap> bitmap)
 {
-    m_context_menu_url = move(url);
-    m_image_context_menu_bitmap = move(bitmap);
-    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
+    auto request_id = ++m_context_menu_request_id;
+    auto weak_this = make_weak_ptr();
+    request_context_menu_dictionary_lookup([weak_this, request_id, content_position, url = move(url), bitmap = move(bitmap)](auto const& lookup) mutable {
+        if (!weak_this || request_id != weak_this->m_context_menu_request_id)
+            return;
 
-    m_open_in_new_tab_action->set_text("Open Image in New Tab"sv);
-    m_copy_url_action->set_text("Copy Image URL"sv);
+        weak_this->m_context_menu_url = move(url);
+        weak_this->m_image_context_menu_bitmap = move(bitmap);
+        weak_this->update_look_up_selected_text_action(lookup, content_position);
 
-    m_copy_image_action->set_enabled(m_image_context_menu_bitmap.has_value());
+        weak_this->m_open_in_new_tab_action->set_text("Open Image in New Tab"sv);
+        weak_this->m_copy_url_action->set_text("Copy Image URL"sv);
 
-    if (m_image_context_menu->on_activation)
-        m_image_context_menu->on_activation(to_widget_position(content_position));
+        weak_this->m_copy_image_action->set_enabled(weak_this->m_image_context_menu_bitmap.has_value());
+
+        if (weak_this->m_image_context_menu->on_activation)
+            weak_this->m_image_context_menu->on_activation(weak_this->to_widget_position(content_position));
+    });
 }
 
 void ViewImplementation::did_request_media_context_menu(Badge<WebContentClient>, Gfx::IntPoint content_position, Web::Page::MediaContextMenu menu)
 {
-    m_context_menu_url = move(menu.media_url);
-    update_look_up_selected_text_action(on_request_dictionary_lookup ? selected_text_for_dictionary_lookup() : OptionalNone {}, content_position);
+    auto request_id = ++m_context_menu_request_id;
+    auto weak_this = make_weak_ptr();
+    request_context_menu_dictionary_lookup([weak_this, request_id, content_position, menu = move(menu)](auto const& lookup) mutable {
+        if (!weak_this || request_id != weak_this->m_context_menu_request_id)
+            return;
 
-    m_open_in_new_tab_action->set_text(menu.is_video ? "Open Video in New Tab"sv : "Open Audio in new Tab"sv);
-    m_copy_url_action->set_text(menu.is_video ? "Copy Video URL"sv : "Copy Audio URL"sv);
+        weak_this->m_context_menu_url = move(menu.media_url);
+        weak_this->update_look_up_selected_text_action(lookup, content_position);
 
-    m_open_audio_action->set_visible(!menu.is_video);
-    m_open_video_action->set_visible(menu.is_video);
+        weak_this->m_open_in_new_tab_action->set_text(menu.is_video ? "Open Video in New Tab"sv : "Open Audio in new Tab"sv);
+        weak_this->m_copy_url_action->set_text(menu.is_video ? "Copy Video URL"sv : "Copy Audio URL"sv);
 
-    m_media_play_action->set_visible(!menu.is_playing);
-    m_media_pause_action->set_visible(menu.is_playing);
+        weak_this->m_open_audio_action->set_visible(!menu.is_video);
+        weak_this->m_open_video_action->set_visible(menu.is_video);
 
-    m_media_mute_action->set_visible(!menu.is_muted);
-    m_media_unmute_action->set_visible(menu.is_muted);
+        weak_this->m_media_play_action->set_visible(!menu.is_playing);
+        weak_this->m_media_pause_action->set_visible(menu.is_playing);
 
-    m_media_show_controls_action->set_visible(!menu.has_user_agent_controls);
-    m_media_hide_controls_action->set_visible(menu.has_user_agent_controls);
+        weak_this->m_media_mute_action->set_visible(!menu.is_muted);
+        weak_this->m_media_unmute_action->set_visible(menu.is_muted);
 
-    m_media_loop_action->set_checked(menu.is_looping);
+        weak_this->m_media_show_controls_action->set_visible(!menu.has_user_agent_controls);
+        weak_this->m_media_hide_controls_action->set_visible(menu.has_user_agent_controls);
 
-    m_media_enter_fullscreen_action->set_visible(menu.is_video && !menu.is_fullscreen);
-    m_media_exit_fullscreen_action->set_visible(menu.is_video && menu.is_fullscreen);
+        weak_this->m_media_loop_action->set_checked(menu.is_looping);
 
-    if (m_media_context_menu->on_activation)
-        m_media_context_menu->on_activation(to_widget_position(content_position));
+        weak_this->m_media_enter_fullscreen_action->set_visible(menu.is_video && !menu.is_fullscreen);
+        weak_this->m_media_exit_fullscreen_action->set_visible(menu.is_video && menu.is_fullscreen);
+
+        if (weak_this->m_media_context_menu->on_activation)
+            weak_this->m_media_context_menu->on_activation(weak_this->to_widget_position(content_position));
+    });
 }
 
 u64 ViewImplementation::add_navigation_listener(NavigationListener listener)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -187,11 +187,15 @@ public:
     void clear_indexed_database_object_store(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
     void delete_indexed_database_record(String const& host, String const& name, DevTools::DevToolsDelegate::OnIndexedDBInspectionComplete);
 
-    ByteString selected_text();
-    ByteString cut_selected_text();
-    Optional<String> selected_text_with_whitespace_collapsed();
-    Optional<DictionaryLookup> selected_text_for_dictionary_lookup();
+    NonnullRefPtr<Core::Promise<ByteString>> selected_text();
+    NonnullRefPtr<Core::Promise<ByteString>> cut_selected_text();
+    NonnullRefPtr<Core::Promise<Optional<String>>> selected_text_with_whitespace_collapsed();
+    NonnullRefPtr<Core::Promise<Optional<DictionaryLookup>>> selected_text_for_dictionary_lookup();
     bool look_up_selected_text_at(Gfx::IntPoint widget_position);
+    void did_receive_selected_text(Badge<WebContentClient>, u64 request_id, ByteString selection);
+    void did_receive_selected_text_for_lookup(Badge<WebContentClient>, u64 request_id, Optional<DictionaryLookup> lookup);
+    void did_select_word_for_dictionary_lookup(Badge<WebContentClient>, u64 request_id, bool selected);
+    void did_cut_selected_text(Badge<WebContentClient>, u64 request_id, ByteString selection);
     void select_all();
     void undo();
     void redo();
@@ -557,6 +561,9 @@ protected:
     void complete_external_url_request();
     void process_next_external_url_request();
     void update_look_up_selected_text_action(Optional<DictionaryLookup> const& lookup, Gfx::IntPoint content_position);
+    void request_context_menu_dictionary_lookup(Function<void(Optional<DictionaryLookup> const&)> on_complete);
+    NonnullRefPtr<Core::Promise<bool>> select_word_for_dictionary_lookup(Gfx::IntPoint widget_position);
+    void reject_pending_selection_requests();
     enum class PromptForPath : u8 {
         No,
         Yes,
@@ -602,6 +609,7 @@ protected:
     RefPtr<Menu> m_selected_text_link_context_menu;
     RefPtr<Menu> m_image_context_menu;
     RefPtr<Menu> m_media_context_menu;
+    u64 m_context_menu_request_id { 0 };
 
     RefPtr<Menu> m_bookmarks_bar_context_menu;
     RefPtr<Menu> m_bookmark_context_menu;
@@ -620,6 +628,12 @@ protected:
 
     RefPtr<Action> m_search_selected_text_action;
     Optional<String> m_search_text;
+
+    u64 m_next_selection_request_id { 1 };
+    HashMap<u64, NonnullRefPtr<Core::Promise<ByteString>>> m_pending_selected_text_requests;
+    HashMap<u64, NonnullRefPtr<Core::Promise<Optional<DictionaryLookup>>>> m_pending_selected_text_for_lookup_requests;
+    HashMap<u64, NonnullRefPtr<Core::Promise<bool>>> m_pending_select_word_for_dictionary_lookup_requests;
+    HashMap<u64, NonnullRefPtr<Core::Promise<ByteString>>> m_pending_cut_selected_text_requests;
 
     RefPtr<Action> m_take_visible_screenshot_action;
     RefPtr<Action> m_take_full_screenshot_action;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1183,6 +1183,30 @@ void WebContentClient::did_get_internal_page_info(u64 page_id, WebView::PageInfo
         view->did_receive_internal_page_info({}, type, info);
 }
 
+void WebContentClient::did_get_selected_text(u64 page_id, u64 request_id, ByteString selection)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_receive_selected_text({}, request_id, move(selection));
+}
+
+void WebContentClient::did_get_selected_text_for_lookup(u64 page_id, u64 request_id, Optional<DictionaryLookup> lookup)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_receive_selected_text_for_lookup({}, request_id, move(lookup));
+}
+
+void WebContentClient::did_select_word_for_dictionary_lookup(u64 page_id, u64 request_id, bool selected)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_select_word_for_dictionary_lookup({}, request_id, selected);
+}
+
+void WebContentClient::did_cut_selected_text(u64 page_id, u64 request_id, ByteString selection)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_cut_selected_text({}, request_id, move(selection));
+}
+
 void WebContentClient::did_execute_js_console_input(u64 page_id, JsonValue result)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -183,6 +183,10 @@ private:
     virtual void did_resolve_dom_node_url(u64 page_id, u64 request_id, String resolved_url) override;
     virtual void did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) override;
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
+    virtual void did_get_selected_text(u64 page_id, u64 request_id, ByteString selection) override;
+    virtual void did_get_selected_text_for_lookup(u64 page_id, u64 request_id, Optional<DictionaryLookup> lookup) override;
+    virtual void did_select_word_for_dictionary_lookup(u64 page_id, u64 request_id, bool selected) override;
+    virtual void did_cut_selected_text(u64 page_id, u64 request_id, ByteString selection) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;
     virtual void did_output_js_console_message(u64 page_id, ConsoleOutput) override;
     virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1905,11 +1905,12 @@ void ConnectionFromClient::request_internal_page_info(u64 page_id, WebView::Page
     async_did_get_internal_page_info(page_id, type, buffer);
 }
 
-Messages::WebContentServer::GetSelectedTextResponse ConnectionFromClient::get_selected_text(u64 page_id)
+void ConnectionFromClient::get_selected_text(u64 page_id, u64 request_id)
 {
+    ByteString selection;
     if (auto page = this->page(page_id); page.has_value())
-        return page->page().focused_navigable().selected_text().to_utf8().to_byte_string();
-    return ByteString {};
+        selection = page->page().focused_navigable().selected_text().to_utf8().to_byte_string();
+    async_did_get_selected_text(page_id, request_id, selection);
 }
 
 static WebView::DictionaryLookupTextStyle dictionary_lookup_text_style_from_layout_node(Web::Layout::Node const& layout_node, double zoom_level)
@@ -1959,16 +1960,20 @@ static Optional<Gfx::IntPoint> dictionary_lookup_baseline_origin_for_range(Web::
     return page.css_to_device_point(to_top_level_viewport_point(baseline_origin)).to_type<int>();
 }
 
-Messages::WebContentServer::GetSelectedTextForLookupResponse ConnectionFromClient::get_selected_text_for_lookup(u64 page_id)
+void ConnectionFromClient::get_selected_text_for_lookup(u64 page_id, u64 request_id)
 {
     auto page = this->page(page_id);
-    if (!page.has_value())
-        return Optional<WebView::DictionaryLookup> {};
+    if (!page.has_value()) {
+        async_did_get_selected_text_for_lookup(page_id, request_id, {});
+        return;
+    }
 
     auto& navigable = page->page().focused_navigable();
     auto text = navigable.selected_text();
-    if (text.is_empty())
-        return Optional<WebView::DictionaryLookup> {};
+    if (text.is_empty()) {
+        async_did_get_selected_text_for_lookup(page_id, request_id, {});
+        return;
+    }
 
     auto document = navigable.active_document();
     auto range = document ? document->get_selection()->range() : nullptr;
@@ -1986,30 +1991,31 @@ Messages::WebContentServer::GetSelectedTextForLookupResponse ConnectionFromClien
             baseline_origin = dictionary_lookup_baseline_origin_for_range(*range, page->page(), *layout_node);
     }
 
-    return WebView::DictionaryLookup {
-        .text = text.to_utf8(),
-        .style = move(style),
-        .baseline_origin = baseline_origin,
-    };
+    async_did_get_selected_text_for_lookup(page_id, request_id, WebView::DictionaryLookup {
+                                                                    .text = text.to_utf8(),
+                                                                    .style = move(style),
+                                                                    .baseline_origin = baseline_origin,
+                                                                });
 }
 
-Messages::WebContentServer::SelectWordForDictionaryLookupResponse ConnectionFromClient::select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position)
+void ConnectionFromClient::select_word_for_dictionary_lookup(u64 page_id, u64 request_id, Web::DevicePixelPoint position)
 {
+    bool selected = false;
 #if defined(AK_OS_MACOS)
     if (auto page = this->page(page_id); page.has_value())
-        return page->page().select_word_for_dictionary_lookup(position);
+        selected = page->page().select_word_for_dictionary_lookup(position);
 #else
-    (void)page_id;
     (void)position;
 #endif
-    return false;
+    async_did_select_word_for_dictionary_lookup(page_id, request_id, selected);
 }
 
-Messages::WebContentServer::CutSelectedTextResponse ConnectionFromClient::cut_selected_text(u64 page_id)
+void ConnectionFromClient::cut_selected_text(u64 page_id, u64 request_id)
 {
+    ByteString selection;
     if (auto page = this->page(page_id); page.has_value())
-        return page->page().focused_navigable().cut_selected_text().to_utf8().to_byte_string();
-    return ByteString {};
+        selection = page->page().focused_navigable().cut_selected_text().to_utf8().to_byte_string();
+    async_did_cut_selected_text(page_id, request_id, selection);
 }
 
 void ConnectionFromClient::select_all(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -214,10 +214,10 @@ private:
 
     virtual void request_internal_page_info(u64 page_id, WebView::PageInfoType) override;
 
-    virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text(u64 page_id) override;
-    virtual Messages::WebContentServer::GetSelectedTextForLookupResponse get_selected_text_for_lookup(u64 page_id) override;
-    virtual Messages::WebContentServer::SelectWordForDictionaryLookupResponse select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position) override;
-    virtual Messages::WebContentServer::CutSelectedTextResponse cut_selected_text(u64 page_id) override;
+    virtual void get_selected_text(u64 page_id, u64 request_id) override;
+    virtual void get_selected_text_for_lookup(u64 page_id, u64 request_id) override;
+    virtual void select_word_for_dictionary_lookup(u64 page_id, u64 request_id, Web::DevicePixelPoint position) override;
+    virtual void cut_selected_text(u64 page_id, u64 request_id) override;
     virtual void select_all(u64 page_id) override;
     virtual void undo(u64 page_id) override;
     virtual void redo(u64 page_id) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -42,6 +42,7 @@
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
+#include <LibWebView/DictionaryLookup.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/StorageSetResult.h>
@@ -117,6 +118,11 @@ endpoint WebContentClient
     did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) =|
 
     did_get_internal_page_info(u64 page_id, WebView::PageInfoType type, Optional<Core::AnonymousBuffer> info) =|
+
+    did_get_selected_text(u64 page_id, u64 request_id, ByteString selection) =|
+    did_get_selected_text_for_lookup(u64 page_id, u64 request_id, Optional<WebView::DictionaryLookup> lookup) =|
+    did_select_word_for_dictionary_lookup(u64 page_id, u64 request_id, bool selected) =|
+    did_cut_selected_text(u64 page_id, u64 request_id, ByteString selection) =|
 
     did_change_favicon(u64 page_id, Gfx::ShareableBitmap favicon) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -147,10 +147,10 @@ endpoint WebContentServer
 
     request_internal_page_info(u64 page_id, WebView::PageInfoType type) =|
 
-    get_selected_text(u64 page_id) => (ByteString selection)
-    get_selected_text_for_lookup(u64 page_id) => (Optional<WebView::DictionaryLookup> lookup)
-    select_word_for_dictionary_lookup(u64 page_id, Web::DevicePixelPoint position) => (bool selected)
-    cut_selected_text(u64 page_id) => (ByteString selection)
+    get_selected_text(u64 page_id, u64 request_id) =|
+    get_selected_text_for_lookup(u64 page_id, u64 request_id) =|
+    select_word_for_dictionary_lookup(u64 page_id, u64 request_id, Web::DevicePixelPoint position) =|
+    cut_selected_text(u64 page_id, u64 request_id) =|
     select_all(u64 page_id) =|
     undo(u64 page_id) =|
     redo(u64 page_id) =|

--- a/UI/AppKit/Interface/SearchPanel.mm
+++ b/UI/AppKit/Interface/SearchPanel.mm
@@ -21,6 +21,8 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 @interface SearchPanel () <NSSearchFieldDelegate>
 {
     CaseSensitivity m_case_sensitivity;
+    u64 m_search_field_revision;
+    u64 m_selected_text_request_id;
 }
 
 @property (nonatomic, strong) NSSearchField* search_field;
@@ -112,17 +114,28 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 
 - (void)useSelectionForFind:(id)sender
 {
-    auto selected_text = [[[self tab] web_view] view].selected_text();
-    auto* query = Ladybird::string_to_ns_string(selected_text);
+    __weak SearchPanel* weak_self = self;
+    auto case_sensitivity = m_case_sensitivity;
+    auto request_id = ++m_selected_text_request_id;
+    auto search_field_revision = m_search_field_revision;
+    NSString* search_text_before_request = [self.search_field stringValue];
+    [[[self tab] web_view] view].selected_text()->when_resolved([weak_self, case_sensitivity, request_id, search_field_revision, search_text_before_request](auto& selected_text) {
+        SearchPanel* strong_self = weak_self;
+        if (!strong_self || request_id != strong_self->m_selected_text_request_id || search_field_revision != strong_self->m_search_field_revision || ![[strong_self.search_field stringValue] isEqualToString:search_text_before_request])
+            return;
 
-    [self setPasteBoardContents:query];
+        auto* query = Ladybird::string_to_ns_string(selected_text);
 
-    if (![self isHidden]) {
-        [self.search_field setStringValue:query];
-        [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity];
+        [strong_self setPasteBoardContents:query];
 
-        [self.window makeFirstResponder:self.search_field];
-    }
+        if (![strong_self isHidden]) {
+            ++strong_self->m_search_field_revision;
+            [strong_self.search_field setStringValue:query];
+            [[[strong_self tab] web_view] findInPage:query caseSensitivity:case_sensitivity];
+
+            [strong_self.window makeFirstResponder:strong_self.search_field];
+        }
+    });
 }
 
 - (void)onFindInPageResult:(size_t)current_match_index
@@ -172,6 +185,7 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
             : CaseSensitivity::CaseSensitive;
 
         if (case_sensitivity != m_case_sensitivity || ![[self.search_field stringValue] isEqual:query]) {
+            ++m_search_field_revision;
             [self.search_field setStringValue:query];
             m_case_sensitivity = case_sensitivity;
 
@@ -192,6 +206,7 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
 
 - (void)controlTextDidChange:(NSNotification*)notification
 {
+    ++m_search_field_revision;
     auto* query = [self.search_field stringValue];
     [[[self tab] web_view] findInPage:query caseSensitivity:m_case_sensitivity];
 

--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -12,6 +12,7 @@
 
 #include <QEvent>
 #include <QKeyEvent>
+#include <QPointer>
 #include <QStyle>
 
 namespace Ladybird {
@@ -163,9 +164,15 @@ void FindInPageWidget::focusInEvent(QFocusEvent* event)
 {
     QWidget::focusInEvent(event);
     m_find_text->setFocus();
-    auto selected_text = m_content_view->selected_text();
-    if (!selected_text.is_empty())
-        m_find_text->setText(qstring_from_ak_string(selected_text));
+    auto find_text_before_request = m_find_text->text();
+    auto request_id = ++m_selected_text_request_id;
+    m_content_view->selected_text()->when_resolved([guarded_this = QPointer<FindInPageWidget> { this }, request_id, find_text_before_request = AK::move(find_text_before_request)](auto& selected_text) {
+        if (!guarded_this || request_id != guarded_this->m_selected_text_request_id || guarded_this->m_find_text->text() != find_text_before_request)
+            return;
+        if (!selected_text.is_empty())
+            guarded_this->m_find_text->setText(qstring_from_ak_string(selected_text));
+        guarded_this->m_find_text->selectAll();
+    });
     m_find_text->selectAll();
 }
 

--- a/UI/Qt/FindInPageWidget.h
+++ b/UI/Qt/FindInPageWidget.h
@@ -56,6 +56,7 @@ private:
     QCheckBox* m_match_case { nullptr };
     QLabel* m_result_label { nullptr };
     bool m_is_updating_chrome_style { false };
+    u64 m_selected_text_request_id { 0 };
 };
 
 }


### PR DESCRIPTION
Selection queries could deadlock when the UI process and WebContent made synchronous IPC calls to each other at the same time.

Replace them with asynchronous request/result messages correlated by request IDs. Complete UI consumers through promises.