### PR TITLE
LibWeb: Cache each DOM node's tree root

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -122,6 +122,7 @@ Node* Node::from_unique_id(UniqueNodeID unique_id)
 Node::Node(Document& document, NodeType type)
     : EventTarget()
     , m_document(&document)
+    , m_root(this)
     , m_type(type)
 {
     // A Document is its own shadow-including root, so it is always connected.
@@ -267,6 +268,7 @@ void Node::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     TreeNode::visit_edges(visitor);
     visitor.visit(m_document);
+    visitor.visit(m_root);
     if (m_rare_data)
         m_rare_data->visit_edges(visitor);
 }
@@ -3279,6 +3281,7 @@ void Node::append_child_impl(GC::Ref<Node> node)
         return;
 
     TreeNode::append_child(node);
+    node->set_root_for_subtree(root());
 }
 
 void Node::insert_before_impl(GC::Ref<Node> node, GC::Ptr<Node> child)
@@ -3286,11 +3289,21 @@ void Node::insert_before_impl(GC::Ref<Node> node, GC::Ptr<Node> child)
     if (!child)
         return append_child_impl(move(node));
     TreeNode::insert_before(node, child);
+    node->set_root_for_subtree(root());
 }
 
 void Node::remove_child_impl(GC::Ref<Node> node)
 {
     TreeNode::remove_child(node);
+    node->set_root_for_subtree(node);
+}
+
+void Node::set_root_for_subtree(Node& new_root)
+{
+    for_each_in_inclusive_subtree([&](Node& node) {
+        node.m_root = new_root;
+        return TraversalDecision::Continue;
+    });
 }
 
 void Node::build_accessibility_tree(AccessibilityTreeNode& parent)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -325,6 +325,9 @@ public:
         return const_cast<Node*>(this)->shadow_including_root();
     }
 
+    Node& root() { return *m_root; }
+    Node const& root() const { return *m_root; }
+
     bool is_closed_shadow_hidden_from(Node const&) const;
 
     bool is_connected() const { return m_is_connected; }
@@ -571,6 +574,7 @@ protected:
     virtual size_t external_memory_size() const override;
 
     GC::Ptr<Document> m_document;
+    GC::Ptr<Node> m_root;
     WeakPtr<Layout::Node> m_layout_node;
     NodeType m_type { NodeType::INVALID };
     bool m_needs_layout_tree_update { false };
@@ -594,6 +598,7 @@ private:
     void insert_before_impl(GC::Ref<Node>, GC::Ptr<Node> child);
     void append_child_impl(GC::Ref<Node>);
     void remove_child_impl(GC::Ref<Node>);
+    void set_root_for_subtree(Node&);
     void clear_committed_layout_box();
 
     static Optional<Utf16View> first_valid_id(Utf16View, Document const&);

--- a/Tests/LibWeb/Text/expected/DOM/get-root-node-after-tree-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/get-root-node-after-tree-mutations.txt
@@ -1,0 +1,6 @@
+detached insertion: true
+detached move: true
+removal: true
+document insertion: true
+shadow insertion: true
+composed shadow root: true

--- a/Tests/LibWeb/Text/input/DOM/get-root-node-after-tree-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/get-root-node-after-tree-mutations.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const firstParent = document.createElement("div");
+        const secondParent = document.createElement("div");
+        const child = document.createElement("span");
+        const grandchild = document.createElement("b");
+        child.appendChild(grandchild);
+
+        firstParent.appendChild(child);
+        println(`detached insertion: ${child.getRootNode() === firstParent && grandchild.getRootNode() === firstParent}`);
+
+        secondParent.appendChild(child);
+        println(`detached move: ${child.getRootNode() === secondParent && grandchild.getRootNode() === secondParent}`);
+
+        child.remove();
+        println(`removal: ${child.getRootNode() === child && grandchild.getRootNode() === child}`);
+
+        document.body.appendChild(child);
+        println(`document insertion: ${child.getRootNode() === document && grandchild.getRootNode() === document}`);
+
+        const host = document.createElement("div");
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        shadowRoot.appendChild(child);
+        document.body.appendChild(host);
+        println(`shadow insertion: ${child.getRootNode() === shadowRoot && grandchild.getRootNode() === shadowRoot}`);
+        println(`composed shadow root: ${child.getRootNode({ composed: true }) === document}`);
+    });
+</script>


### PR DESCRIPTION
Store each node's tree root and update it whenever a subtree is attached or detached. This makes frequent root lookup constant-time instead of walking the ancestor chain.

Cover root changes across detached and document trees, as well as shadow trees.