### PR TITLE
LibWeb: Borrow paintable rows through arena views

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -21,7 +21,7 @@ fn commit_subtree(
     node: Node,
     callbacks: &FfiLayoutFcCallbacks,
     sink: &FfiCommitSink,
-    paintables: &crate::painting::paintable_build::PaintableCommit<'_>,
+    paintables: &mut crate::painting::paintable_build::PaintableCommit<'_>,
     links_by_slot: &std::collections::HashMap<u32, &crate::layout::FragmentLink>,
     pass_fragments: &crate::layout::CompletedPassFragments,
 ) {
@@ -73,7 +73,7 @@ fn commit_subtree(
     let mut child = callbacks.first_child(node);
     while !child.is_invalid() {
         let next = callbacks.next_sibling(child);
-        commit_subtree(child, callbacks, sink, paintables, links_by_slot, pass_fragments);
+        commit_subtree(child, callbacks, sink, &mut *paintables, links_by_slot, pass_fragments);
         child = next;
     }
 
@@ -92,9 +92,16 @@ pub(crate) fn commit_replacing(
     pass_fragments: &crate::layout::CompletedPassFragments,
 ) {
     let links_by_slot = pass_fragments.links_by_slot();
-    let paintables = crate::painting::paintable_build::PaintableCommit::new(callbacks);
+    let mut paintables = crate::painting::paintable_build::PaintableCommit::new(callbacks);
     paintables.begin_commit(root);
-    commit_subtree(root, callbacks, sink, &paintables, &links_by_slot, pass_fragments);
+    commit_subtree(
+        root,
+        callbacks,
+        sink,
+        &mut paintables,
+        &links_by_slot,
+        pass_fragments,
+    );
     paintables.translate_reused_subtrees();
     paintables.discard_absolute_rects_memoized_during_commit();
     let viewport_shells = paintables.committed_navigable_container_viewport_shells();

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1619,6 +1619,13 @@ impl LayoutNodeArena {
         unsafe { &*arena.cast::<Self>() }
     }
 
+    pub(crate) unsafe fn from_handle_mut<'a>(arena: *mut c_void) -> &'a mut Self {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The caller guarantees exclusive access to the arena for the
+        // duration of the returned borrow.
+        unsafe { &mut *arena.cast::<Self>() }
+    }
+
     fn data_mut(&mut self, index: u32) -> &mut NodeData {
         let index = index as usize;
         let chunk = self
@@ -1682,7 +1689,10 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, g
         assert!(!arena.is_null(), "layout node arena handle is null");
         // SAFETY: The C++ wrapper keeps the arena alive for this call and
         // serializes all access on the document thread.
-        let paintable_row_reset = unsafe { &mut *arena.cast::<LayoutNodeArena>() }.free(id, generation);
+        let paintable_row_reset = {
+            let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
+            arena.free(id, generation)
+        };
         if let Some(reset) = paintable_row_reset {
             reset.invoke_callback();
         }

--- a/Libraries/LibWeb/Rust/src/painting/caret.rs
+++ b/Libraries/LibWeb/Rust/src/painting/caret.rs
@@ -5,9 +5,9 @@
  */
 
 use crate::css::css_pixels::CssPixelRect;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_START_AND_END};
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::text_fragment::{self, CaretMatch};
 
 pub(crate) struct CaretRectResult {
@@ -18,7 +18,7 @@ pub(crate) struct CaretRectResult {
 }
 
 fn caret_rect_in_fragment(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     owner: NodeSlotId,
     fragment: &FragmentRecord,
     offset: usize,
@@ -32,7 +32,7 @@ fn caret_rect_in_fragment(
 }
 
 pub(crate) fn caret_rect_for_position(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     node_slots: &[NodeSlotId],
     offset: usize,
     affinity_is_downstream: bool,
@@ -60,7 +60,7 @@ pub(crate) fn caret_rect_for_position(
 }
 
 pub(crate) fn caret_rect_in_dom_range(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     node_slots: &[NodeSlotId],
     offset: usize,
 ) -> Option<CssPixelRect> {

--- a/Libraries/LibWeb/Rust/src/painting/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/dump.rs
@@ -5,11 +5,11 @@
  */
 
 use crate::css::css_pixels::CssPixels;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::fragment_ownership;
 use crate::painting::paintable_data::FragmentRecord;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::text_fragment;
 
 fn push_class_name(out: &mut Vec<u8>, kind: NodeKind) {
@@ -69,7 +69,7 @@ fn push_indent(out: &mut Vec<u8>, indent: usize) {
 
 fn dump_fragment(
     out: &mut Vec<u8>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     fragment_index: usize,
     indent: usize,
@@ -127,7 +127,7 @@ fn dump_fragment(
 
 pub(crate) fn dump_block_fragments(
     out: &mut Vec<u8>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     block: NodeSlotId,
     indent: usize,
     interactive: bool,
@@ -146,7 +146,7 @@ pub(crate) fn dump_block_fragments(
 
 pub(crate) fn dump_inline_piece_fragments(
     out: &mut Vec<u8>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     inline_paintable: NodeSlotId,
     indent: usize,
     interactive: bool,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -12,12 +12,19 @@ use crate::layout::FfiCssPixelSize;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::*;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use std::ffi::c_void;
 
 /// SAFETY: `arena` must be a live handle from `layout_arena_create`, borrowed for this call on
 /// the document thread.
 unsafe fn arena_from_handle<'a>(arena: *mut c_void) -> &'a LayoutNodeArena {
     unsafe { LayoutNodeArena::from_handle(arena) }
+}
+
+/// SAFETY: `arena` must be a live handle from `layout_arena_create`, exclusively borrowed for
+/// this call on the document thread. No C++ callback may re-enter the arena during the borrow.
+unsafe fn arena_from_handle_mut<'a>(arena: *mut c_void) -> &'a mut LayoutNodeArena {
+    unsafe { LayoutNodeArena::from_handle_mut(arena) }
 }
 
 /// # Safety
@@ -50,13 +57,14 @@ pub unsafe extern "C" fn layout_arena_clear_chrome_state_callback(arena: *mut c_
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: NodeSlotId) -> *mut PaintableData {
+pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: NodeSlotId) -> *const PaintableData {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return std::ptr::null_mut();
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
+            return std::ptr::null();
         }
-        arena.paintable_data_ptr(slot)
+        paintable_rows.paintable_data_ptr(slot)
     })
 }
 
@@ -66,10 +74,14 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: No
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.clear_committed_fragment_link(layout_node);
-        if let Some(reset) = arena.prepare_paintable_row_cleared_reset(layout_node) {
+        let reset = {
+            let arena = unsafe { arena_from_handle(arena) };
+            arena.clear_committed_fragment_link(layout_node);
+            arena.prepare_paintable_row_cleared_reset(layout_node)
+        };
+        if let Some(reset) = reset {
             reset.invoke_callback();
+            let arena = unsafe { arena_from_handle_mut(arena) };
             arena.paintable_row_cleared(reset);
         }
     });
@@ -114,14 +126,15 @@ pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
 ) -> *mut c_void {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let mut current = arena.paintable_row_is_populated(slot).then_some(slot);
+        let paintable_rows = arena.paintable_rows();
+        let mut current = paintable_rows.paintable_row_is_populated(slot).then_some(slot);
         while let Some(paintable) = current {
             let layout_node = paintable;
             let flags = arena.node_flags_if_live(layout_node);
             if flags & crate::layout::node_data::NodeFlag::Anonymous as u32 == 0 {
                 return arena.shell_if_live(layout_node);
             }
-            current = crate::painting::paint_order::paint_parent(arena, paintable);
+            current = crate::painting::paint_order::paint_parent(&paintable_rows, paintable);
         }
         std::ptr::null_mut()
     })
@@ -148,7 +161,7 @@ pub unsafe extern "C" fn layout_arena_paintable_layout_node_shell(arena: *mut c_
 pub unsafe extern "C" fn layout_arena_paintable_has_child_paintables(arena: *mut c_void, slot: NodeSlotId) -> bool {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::paint_order::first_paint_child(arena, slot).is_some()
+        crate::painting::paint_order::first_paint_child(&arena.paintable_rows(), slot).is_some()
     })
 }
 
@@ -176,13 +189,13 @@ pub unsafe extern "C" fn layout_arena_selection_apply(
     range_end_offset: usize,
 ) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
+        let arena = unsafe { arena_from_handle_mut(arena) };
         if !arena.paintable_row_is_populated(viewport) {
             return;
         }
         // SAFETY: The caller guarantees the entry span is valid for this synchronous call.
         let entries = unsafe { ffi_slice(entries, entry_count) };
-        crate::painting::selection::apply(arena, viewport, entries);
+        crate::painting::selection::apply(&mut arena.paintable_rows_mut(), viewport, entries);
         arena.paint_state().borrow_mut().selection = Some(crate::painting::selection::SelectionRange {
             start_offset: range_start_offset,
             end_offset: range_end_offset,
@@ -196,11 +209,11 @@ pub unsafe extern "C" fn layout_arena_selection_apply(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_selection_clear(arena: *mut c_void, viewport: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
+        let arena = unsafe { arena_from_handle_mut(arena) };
         if !arena.paintable_row_is_populated(viewport) {
             return;
         }
-        crate::painting::selection::clear(arena, viewport);
+        crate::painting::selection::clear(&mut arena.paintable_rows_mut(), viewport);
         arena.paint_state().borrow_mut().selection = None;
     });
 }
@@ -216,12 +229,12 @@ pub unsafe extern "C" fn layout_arena_paintable_set_sticky_insets(
     has_insets: bool,
 ) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if arena.paintable_row_is_populated(slot) {
-            arena.update_paintable_data(slot, |data| {
-                data.sticky_insets = insets;
-                data.has_sticky_insets = has_insets;
-            });
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut paintable_rows = arena.paintable_rows_mut();
+        if paintable_rows.paintable_row_is_populated(slot) {
+            let data = paintable_rows.paintable_data_mut(slot);
+            data.sticky_insets = insets;
+            data.has_sticky_insets = has_insets;
         }
     });
 }
@@ -232,12 +245,12 @@ pub unsafe extern "C" fn layout_arena_paintable_set_sticky_insets(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if arena.paintable_row_is_populated(slot) {
-            arena.update_paintable_data(slot, |data| {
-                data.overflow = FfiOverflowData::default();
-                data.has_overflow = false;
-            });
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut paintable_rows = arena.paintable_rows_mut();
+        if paintable_rows.paintable_row_is_populated(slot) {
+            let data = paintable_rows.paintable_data_mut(slot);
+            data.overflow = FfiOverflowData::default();
+            data.has_overflow = false;
         }
     });
 }
@@ -248,12 +261,12 @@ pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_cached_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if arena.paintable_row_is_populated(slot) {
-            arena.update_paintable_data(slot, |data| {
-                data.cached_overflow = FfiOverflowData::default();
-                data.has_cached_overflow = false;
-            });
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut paintable_rows = arena.paintable_rows_mut();
+        if paintable_rows.paintable_row_is_populated(slot) {
+            let data = paintable_rows.paintable_data_mut(slot);
+            data.cached_overflow = FfiOverflowData::default();
+            data.has_cached_overflow = false;
         }
     });
 }
@@ -275,18 +288,26 @@ pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
     overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
 ) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(box_paintable) {
-            return;
+        let assignments = {
+            let arena = unsafe { arena_from_handle(arena) };
+            let paintable_rows = arena.paintable_rows();
+            if !paintable_rows.paintable_row_is_populated(box_paintable) {
+                return;
+            }
+            let paint_state = arena.paint_state().borrow();
+            crate::painting::scrollable_overflow::measure_scrollable_overflow(
+                &paintable_rows,
+                &paint_state.scrollable_overflow_contained_boxes,
+                &visual_context_callbacks,
+                &overflow_callbacks,
+                box_paintable,
+            )
+        };
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut paintable_rows = arena.paintable_rows_mut();
+        for assignment in assignments {
+            assignment.apply(&mut paintable_rows);
         }
-        let paint_state = arena.paint_state().borrow();
-        crate::painting::scrollable_overflow::measure_scrollable_overflow(
-            arena,
-            &paint_state.scrollable_overflow_contained_boxes,
-            &visual_context_callbacks,
-            &overflow_callbacks,
-            box_paintable,
-        );
     });
 }
 
@@ -306,10 +327,11 @@ pub struct FfiBoxModelMetrics {
 pub unsafe extern "C" fn layout_arena_paintable_offset(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelPoint {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelPoint::default();
         }
-        crate::painting::paintable_geometry::committed_offset(arena, slot)
+        crate::painting::paintable_geometry::committed_offset(&paintable_rows, slot)
     })
 }
 
@@ -320,10 +342,11 @@ pub unsafe extern "C" fn layout_arena_paintable_offset(arena: *mut c_void, slot:
 pub unsafe extern "C" fn layout_arena_paintable_content_size(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelSize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelSize::default();
         }
-        crate::painting::paintable_geometry::committed_content_size(arena, slot)
+        crate::painting::paintable_geometry::committed_content_size(&paintable_rows, slot)
     })
 }
 
@@ -337,10 +360,11 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_size(
 ) -> FfiCssPixelSize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelSize::default();
         }
-        crate::painting::paintable_geometry::committed_svg_viewport_size(arena, slot)
+        crate::painting::paintable_geometry::committed_svg_viewport_size(&paintable_rows, slot)
     })
 }
 
@@ -415,10 +439,11 @@ pub unsafe extern "C" fn layout_arena_paintable_uses_collapsing_borders_model(
 pub unsafe extern "C" fn layout_arena_paintable_absolute_rect(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelRect::default();
         }
-        crate::painting::paintable_geometry::absolute_rect(arena, slot).into()
+        crate::painting::paintable_geometry::absolute_rect(&paintable_rows, slot).into()
     })
 }
 
@@ -432,10 +457,11 @@ pub unsafe extern "C" fn layout_arena_paintable_absolute_padding_box_rect(
 ) -> FfiCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelRect::default();
         }
-        crate::painting::paintable_geometry::absolute_padding_box_rect(arena, slot).into()
+        crate::painting::paintable_geometry::absolute_padding_box_rect(&paintable_rows, slot).into()
     })
 }
 
@@ -449,10 +475,11 @@ pub unsafe extern "C" fn layout_arena_paintable_absolute_border_box_rect(
 ) -> FfiCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(slot) {
             return FfiCssPixelRect::default();
         }
-        crate::painting::paintable_geometry::absolute_border_box_rect(arena, slot).into()
+        crate::painting::paintable_geometry::absolute_border_box_rect(&paintable_rows, slot).into()
     })
 }
 
@@ -466,9 +493,10 @@ pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxe
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         let mut paint_state = arena.paint_state().borrow_mut();
         crate::painting::scrollable_overflow::refill_contained_boxes_index(
-            arena,
+            &paintable_rows,
             root,
             &mut paint_state.scrollable_overflow_contained_boxes,
         );
@@ -518,15 +546,16 @@ pub unsafe extern "C" fn layout_arena_physical_overflow_directions(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_build_stacking_context_tree(arena: *mut c_void, root: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut paintable_rows = arena.paintable_rows_mut();
         let tree = {
-            if !arena.paintable_row_is_populated(root) {
+            if !paintable_rows.paintable_row_is_populated(root) {
                 return;
             }
-            crate::painting::stacking_context::build_stacking_context_tree(arena, root)
+            crate::painting::stacking_context::build_stacking_context_tree(&mut paintable_rows, root)
         };
-        arena.paint_state().borrow_mut().stacking_context_tree = Some(tree);
-        crate::painting::fragment_ownership::assign_fragment_ownership(arena, root);
+        paintable_rows.paint_state().borrow_mut().stacking_context_tree = Some(tree);
+        crate::painting::fragment_ownership::assign_fragment_ownership(&paintable_rows, root);
     });
 }
 
@@ -543,17 +572,35 @@ pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
     force_incompatible_rebuild: bool,
 ) -> bool {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let (mut tree, scroll_state, paintables_with_mask_nodes, previous_assignments) = {
-            if !arena.paintable_row_is_populated(viewport) {
+        let (mut tree, scroll_state, paintables_with_mask_nodes, previous_assignments, assignments) = {
+            let arena = unsafe { arena_from_handle(arena) };
+            let paintable_rows = arena.paintable_rows();
+            if !paintable_rows.paintable_row_is_populated(viewport) {
                 return false;
             }
-            let previous_assignments = arena.visual_context_assignments();
-            let (tree, scroll_state, paintables_with_mask_nodes) =
-                crate::painting::visual_context::build::build_visual_context_tree(arena, &callbacks, viewport);
-            (tree, scroll_state, paintables_with_mask_nodes, previous_assignments)
+            let previous_assignments = paintable_rows.visual_context_assignments();
+            let (tree, scroll_state, paintables_with_mask_nodes, assignments) =
+                crate::painting::visual_context::build::build_visual_context_tree(
+                    &paintable_rows,
+                    &callbacks,
+                    viewport,
+                );
+            (
+                tree,
+                scroll_state,
+                paintables_with_mask_nodes,
+                previous_assignments,
+                assignments,
+            )
         };
-        let assignments_changed = previous_assignments != arena.visual_context_assignments();
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let assignments_changed = {
+            let mut paintable_rows = arena.paintable_rows_mut();
+            for assignment in assignments {
+                assignment.apply(&mut paintable_rows);
+            }
+            previous_assignments != paintable_rows.visual_context_assignments()
+        };
         let mut paint_state = arena.paint_state().borrow_mut();
         let state = &mut paint_state.visual_context;
         state.build_count += 1;
@@ -590,22 +637,33 @@ pub unsafe extern "C" fn layout_arena_update_visual_context_values(
     callbacks: FfiVisualContextHostCallbacks,
 ) -> bool {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
         let pixel_ratio = callbacks.tree_inputs().device_pixels_per_css_pixel;
-        if !arena.paintable_row_is_populated(paintable) {
-            return false;
-        }
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let Some(tree) = paint_state.visual_context.tree.as_mut() else {
-            return false;
+        let (compatible, has_non_invertible_css_transform) = {
+            let arena = unsafe { arena_from_handle(arena) };
+            let paintable_rows = arena.paintable_rows();
+            if !paintable_rows.paintable_row_is_populated(paintable) {
+                return false;
+            }
+            let mut paint_state = arena.paint_state().borrow_mut();
+            let Some(tree) = paint_state.visual_context.tree.as_mut() else {
+                return false;
+            };
+            crate::painting::visual_context::build::update_visual_context_values(
+                &paintable_rows,
+                &callbacks,
+                tree,
+                paintable,
+                pixel_ratio,
+            )
         };
-        crate::painting::visual_context::build::update_visual_context_values(
-            arena,
-            &callbacks,
-            tree,
-            paintable,
-            pixel_ratio,
-        )
+        if let Some(value) = has_non_invertible_css_transform {
+            let arena = unsafe { arena_from_handle_mut(arena) };
+            arena.paintable_rows_mut().paintable_data_mut(paintable).set_flag(
+                crate::painting::paintable_data::PaintableFlag::HasNonInvertibleCssTransform,
+                value,
+            );
+        }
+        compatible
     })
 }
 
@@ -668,9 +726,10 @@ pub unsafe extern "C" fn layout_arena_clear_scroll_state(arena: *mut c_void) {
 pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(arena: *mut c_void) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         let mut paint_state = arena.paint_state().borrow_mut();
         let state = &mut paint_state.visual_context;
-        crate::painting::visual_context::refresh::refresh_sticky_constraints(arena, &mut state.scroll_state);
+        crate::painting::visual_context::refresh::refresh_sticky_constraints(&paintable_rows, &mut state.scroll_state);
         state.needs_to_refresh_scroll_state = true;
     });
 }
@@ -685,13 +744,18 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         let mut paint_state = arena.paint_state().borrow_mut();
         let state = &mut paint_state.visual_context;
         if !state.needs_to_refresh_scroll_state {
             return;
         }
         state.needs_to_refresh_scroll_state = false;
-        crate::painting::visual_context::refresh::refresh_scroll_state(arena, &callbacks, &mut state.scroll_state);
+        crate::painting::visual_context::refresh::refresh_scroll_state(
+            &paintable_rows,
+            &callbacks,
+            &mut state.scroll_state,
+        );
         state.scroll_state_snapshot = state
             .scroll_state
             .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
@@ -1091,10 +1155,11 @@ pub unsafe extern "C" fn layout_arena_paintable_computed_svg_path(
 ) -> *const c_void {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(paintable) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(paintable) {
             return std::ptr::null();
         }
-        crate::painting::paintable_geometry::committed_svg_path(arena, paintable)
+        crate::painting::paintable_geometry::committed_svg_path(&paintable_rows, paintable)
             .map_or(std::ptr::null(), |path| path.as_raw())
     })
 }
@@ -1129,11 +1194,15 @@ pub unsafe extern "C" fn layout_arena_text_caret_rect_for_position(
             nearest_self_painting_inline: NodeSlotId::INVALID,
         };
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        let Some(answer) =
-            crate::painting::caret::caret_rect_for_position(arena, node_slots, offset, affinity_is_downstream)
-        else {
+        let Some(answer) = crate::painting::caret::caret_rect_for_position(
+            &paintable_rows,
+            node_slots,
+            offset,
+            affinity_is_downstream,
+        ) else {
             return result;
         };
         result.found = true;
@@ -1141,7 +1210,7 @@ pub unsafe extern "C" fn layout_arena_text_caret_rect_for_position(
         result.style_source = arena.shell_if_live(answer.style_source);
         result.owner_paintable = answer.owner;
         result.nearest_self_painting_inline =
-            crate::painting::fragment_ownership::nearest_self_painting_inline_box(arena, answer.node)
+            crate::painting::fragment_ownership::nearest_self_painting_inline_box(&paintable_rows, answer.node)
                 .unwrap_or(NodeSlotId::INVALID);
         result
     })
@@ -1160,9 +1229,10 @@ pub unsafe extern "C" fn layout_arena_text_caret_rect_in_dom_range(
 ) -> FfiOptionalCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        match crate::painting::caret::caret_rect_in_dom_range(arena, node_slots, offset) {
+        match crate::painting::caret::caret_rect_in_dom_range(&paintable_rows, node_slots, offset) {
             Some(rect) => FfiOptionalCssPixelRect {
                 has_value: true,
                 rect: rect.into(),
@@ -1201,7 +1271,8 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
             style_source: std::ptr::null_mut(),
         };
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(block) {
             return result;
         }
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
@@ -1213,12 +1284,14 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
         if !node_slots.contains(&first_fragment.layout_node) {
             return result;
         }
-        for target in crate::painting::visual_lines::empty_line_caret_targets(arena, block) {
+        for target in crate::painting::visual_lines::empty_line_caret_targets(&paintable_rows, block) {
             if target.offset == offset {
                 result.has_value = true;
                 result.rect = target.rect.into();
-                result.style_source =
-                    arena.shell_if_live(crate::painting::text_fragment::style_source(arena, first_fragment));
+                result.style_source = arena.shell_if_live(crate::painting::text_fragment::style_source(
+                    &paintable_rows,
+                    first_fragment,
+                ));
                 break;
             }
         }
@@ -1227,7 +1300,7 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
 }
 
 fn with_inline_pieces(
-    arena: &crate::layout::LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     inline_paintable: NodeSlotId,
     mut callback: impl FnMut(&InlineBoxPieceRecord, &PaintableData) -> bool,
 ) {
@@ -1238,7 +1311,7 @@ fn with_inline_pieces(
     let root_side = arena.paintable_side_data(root);
     for piece_index in &arena.paintable_side_data(inline_paintable).piece_indices {
         let piece = &root_side.inline_box_pieces[*piece_index as usize];
-        if !callback(piece, &data) {
+        if !callback(piece, data) {
             return;
         }
     }
@@ -1256,11 +1329,12 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_piece_border_box_rects(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let Some(root) = arena.inline_pieces_root(inline_paintable) else {
+        let paintable_rows = arena.paintable_rows();
+        let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
             return;
         };
-        let root_position = crate::painting::paintable_geometry::absolute_position(arena, root);
-        with_inline_pieces(arena, inline_paintable, |piece, _| {
+        let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
+        with_inline_pieces(&paintable_rows, inline_paintable, |piece, _| {
             if piece.is_geometry_only_placeholder {
                 return true;
             }
@@ -1283,7 +1357,7 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_has_content_pieces(
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let mut has_content = false;
-        with_inline_pieces(arena, inline_paintable, |piece, _| {
+        with_inline_pieces(&arena.paintable_rows(), inline_paintable, |piece, _| {
             if !piece.is_geometry_only_placeholder {
                 has_content = true;
                 return false;
@@ -1316,13 +1390,14 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_first_piece_position(
             y: CssPixels::from_raw(0),
         };
         let arena = unsafe { arena_from_handle(arena) };
-        let Some(root) = arena.inline_pieces_root(inline_paintable) else {
+        let paintable_rows = arena.paintable_rows();
+        let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
             return result;
         };
-        let root_position = crate::painting::paintable_geometry::absolute_position(arena, root);
+        let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
         let border_widths = crate::painting::paintable_geometry::committed_border(arena, inline_paintable);
         let padding_widths = crate::painting::paintable_geometry::committed_padding(arena, inline_paintable);
-        with_inline_pieces(arena, inline_paintable, |piece, _data| {
+        with_inline_pieces(&paintable_rows, inline_paintable, |piece, _data| {
             let border_rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect);
             let rect = if piece.is_geometry_only_placeholder {
                 border_rect
@@ -1363,9 +1438,10 @@ pub unsafe extern "C" fn layout_arena_text_visual_lines(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        for line in crate::painting::visual_lines::collect_visual_lines(arena, node_slots) {
+        for line in crate::painting::visual_lines::collect_visual_lines(&paintable_rows, node_slots) {
             // SAFETY: The consumer copies the POD line synchronously.
             unsafe {
                 push(
@@ -1385,7 +1461,7 @@ pub unsafe extern "C" fn layout_arena_text_visual_lines(
 }
 
 fn has_rendered_text_matching(
-    arena: &LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     node_slots: &[NodeSlotId],
     matches: impl Fn(&FragmentRecord) -> bool,
 ) -> bool {
@@ -1415,7 +1491,9 @@ pub unsafe extern "C" fn layout_arena_text_has_rendered_text_before(
         let arena = unsafe { arena_from_handle(arena) };
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        has_rendered_text_matching(arena, node_slots, |fragment| fragment.dom_start_offset_in_node < offset)
+        has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
+            fragment.dom_start_offset_in_node < offset
+        })
     })
 }
 
@@ -1434,7 +1512,9 @@ pub unsafe extern "C" fn layout_arena_text_has_rendered_text_after(
         let arena = unsafe { arena_from_handle(arena) };
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        has_rendered_text_matching(arena, node_slots, |fragment| fragment.dom_end_offset_in_node > offset)
+        has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
+            fragment.dom_end_offset_in_node > offset
+        })
     })
 }
 
@@ -1459,10 +1539,11 @@ pub unsafe extern "C" fn layout_arena_visual_line_caret_inline_coordinate(
 ) -> FfiOptionalCssPixels {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
         let coordinate = crate::painting::visual_lines::caret_inline_coordinate(
-            arena,
+            &paintable_rows,
             owner_paintable,
             line_index,
             node_slots,
@@ -1494,10 +1575,11 @@ pub unsafe extern "C" fn layout_arena_visual_line_offset_closest_to_inline_coord
 ) -> usize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
         crate::painting::visual_lines::offset_closest_to_inline_coordinate(
-            arena,
+            &paintable_rows,
             owner_paintable,
             line_index,
             node_slots,
@@ -1596,7 +1678,8 @@ pub unsafe extern "C" fn layout_arena_paintable_fragment_index_in_node_for_point
 ) -> usize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(block) {
             return 0;
         }
         let side_data = arena.paintable_side_data(block);
@@ -1604,7 +1687,7 @@ pub unsafe extern "C" fn layout_arena_paintable_fragment_index_in_node_for_point
             return 0;
         };
         crate::painting::text_fragment::index_in_node_for_point(
-            arena,
+            &paintable_rows,
             fragment,
             crate::css::css_pixels::CssPixelPoint { x, y },
         )
@@ -1623,7 +1706,8 @@ pub unsafe extern "C" fn layout_arena_paintable_fragment_caret_range_rect(
 ) -> FfiCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(block) {
             return FfiCssPixelRect::default();
         }
         let side_data = arena.paintable_side_data(block);
@@ -1631,7 +1715,7 @@ pub unsafe extern "C" fn layout_arena_paintable_fragment_caret_range_rect(
             return FfiCssPixelRect::default();
         };
         let offsets = crate::painting::text_fragment::compute_selection_offsets(
-            arena,
+            &paintable_rows,
             fragment,
             SELECTION_STATE_START_AND_END,
             offset,
@@ -1639,8 +1723,8 @@ pub unsafe extern "C" fn layout_arena_paintable_fragment_caret_range_rect(
         );
         match offsets {
             Some(offsets) => {
-                crate::painting::text_fragment::rect_for_selection_offsets(arena, fragment, offsets, || {
-                    crate::painting::text_fragment::first_available_font(arena, fragment)
+                crate::painting::text_fragment::rect_for_selection_offsets(&paintable_rows, fragment, offsets, || {
+                    crate::painting::text_fragment::first_available_font(&paintable_rows, fragment)
                 })
                 .into()
             }
@@ -1668,16 +1752,17 @@ pub unsafe extern "C" fn layout_arena_text_range_rects(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        crate::painting::text_fragment::for_each_fragment_of_nodes(arena, node_slots, |_, _, fragment| {
+        crate::painting::text_fragment::for_each_fragment_of_nodes(&paintable_rows, node_slots, |_, _, fragment| {
             let fragment_dom_start = fragment.dom_start_offset_in_node;
             let fragment_dom_end = fragment.dom_end_offset_in_node;
             if fragment_dom_end <= filter_dom_start || fragment_dom_start >= filter_dom_end {
                 return true;
             }
             let rect = crate::painting::text_fragment::range_rect(
-                arena,
+                &paintable_rows,
                 fragment,
                 selection_state,
                 range_start_offset,
@@ -1711,7 +1796,8 @@ pub unsafe extern "C" fn layout_arena_paintable_first_fragment_rect_for_node(
             rect: FfiCssPixelRect::default(),
         };
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(block) {
             return result;
         }
         for fragment in &arena.paintable_side_data(block).fragments {
@@ -1719,7 +1805,7 @@ pub unsafe extern "C" fn layout_arena_paintable_first_fragment_rect_for_node(
                 continue;
             }
             result.has_value = true;
-            result.rect = crate::painting::text_fragment::absolute_rect(arena, fragment).into();
+            result.rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
             break;
         }
         result
@@ -1738,13 +1824,14 @@ pub unsafe extern "C" fn layout_arena_for_each_subtree_fragment_rect(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(root) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(root) {
             return;
         }
-        crate::painting::paint_order::for_each_in_paint_subtree(arena, root, |current| {
+        crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, root, |current| {
             for fragment in &arena.paintable_side_data(current).fragments {
                 let shell = arena.shell_if_live(fragment.layout_node);
-                let rect = crate::painting::text_fragment::absolute_rect(arena, fragment).into();
+                let rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
                 // SAFETY: The consumer copies its plain-data arguments synchronously.
                 unsafe { consume(context, shell, rect) };
             }
@@ -1766,11 +1853,12 @@ pub unsafe extern "C" fn layout_arena_paintable_dump_block_fragments(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(paintable) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(paintable) {
             return;
         }
         let mut out = Vec::new();
-        crate::painting::dump::dump_block_fragments(&mut out, arena, paintable, indent, interactive);
+        crate::painting::dump::dump_block_fragments(&mut out, &paintable_rows, paintable, indent, interactive);
         if !out.is_empty() {
             // SAFETY: The consumer copies the byte span synchronously.
             unsafe { consume(context, out.as_ptr(), out.len()) };
@@ -1792,11 +1880,18 @@ pub unsafe extern "C" fn layout_arena_paintable_dump_inline_piece_fragments(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(inline_paintable) {
+        let paintable_rows = arena.paintable_rows();
+        if !paintable_rows.paintable_row_is_populated(inline_paintable) {
             return;
         }
         let mut out = Vec::new();
-        crate::painting::dump::dump_inline_piece_fragments(&mut out, arena, inline_paintable, indent, interactive);
+        crate::painting::dump::dump_inline_piece_fragments(
+            &mut out,
+            &paintable_rows,
+            inline_paintable,
+            indent,
+            interactive,
+        );
         if !out.is_empty() {
             // SAFETY: The consumer copies the byte span synchronously.
             unsafe { consume(context, out.as_ptr(), out.len()) };
@@ -2069,11 +2164,11 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
 }
 
 fn paint_tree_dump_entries(
-    arena: &LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     root: NodeSlotId,
 ) -> Vec<crate::painting::host::FfiPaintTreeDumpEntry> {
     fn visit(
-        arena: &LayoutNodeArena,
+        arena: &impl PaintableRowsRead,
         slot: NodeSlotId,
         depth: u32,
         entries: &mut Vec<crate::painting::host::FfiPaintTreeDumpEntry>,
@@ -2102,7 +2197,7 @@ fn paint_tree_dump_entries(
 pub unsafe extern "C" fn layout_arena_paint_tree_dump_entry_count(arena: *mut c_void, root: NodeSlotId) -> usize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        paint_tree_dump_entries(arena, root).len()
+        paint_tree_dump_entries(&arena.paintable_rows(), root).len()
     })
 }
 
@@ -2119,7 +2214,7 @@ pub unsafe extern "C" fn layout_arena_export_paint_tree_dump_entries(
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let entries = paint_tree_dump_entries(arena, root);
+        let entries = paint_tree_dump_entries(&arena.paintable_rows(), root);
         assert_eq!(entries.len(), output_length);
         if entries.is_empty() {
             return;

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -7,6 +7,7 @@
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
 use crate::painting::paintable_data::*;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::stacking_context::NO_STACKING_CONTEXT;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -92,11 +93,14 @@ pub(crate) fn nearest_fragmented_inline_ancestor(
     None
 }
 
-pub(crate) fn nearest_self_painting_inline_box(layout_arena: &LayoutNodeArena, node: NodeSlotId) -> Option<NodeSlotId> {
+pub(crate) fn nearest_self_painting_inline_box(
+    layout_arena: &impl PaintableRowsRead,
+    node: NodeSlotId,
+) -> Option<NodeSlotId> {
     let mut ancestor = nearest_fragmented_inline_ancestor(layout_arena, node);
     while let Some(candidate) = ancestor {
         if layout_arena.paintable_row_is_populated(candidate)
-            && is_self_painting_inline(&layout_arena.paintable_data(candidate))
+            && is_self_painting_inline(layout_arena.paintable_data(candidate))
         {
             return Some(candidate);
         }
@@ -105,7 +109,7 @@ pub(crate) fn nearest_self_painting_inline_box(layout_arena: &LayoutNodeArena, n
     None
 }
 
-pub(crate) fn assign_fragment_ownership(layout_arena: &LayoutNodeArena, viewport: NodeSlotId) {
+pub(crate) fn assign_fragment_ownership(layout_arena: &impl PaintableRowsRead, viewport: NodeSlotId) {
     // Whether a box is self-painting depends on the stacking context tree, so this runs
     // whenever that tree is rebuilt.
     let mut stack = vec![viewport];
@@ -125,7 +129,7 @@ pub(crate) fn assign_fragment_ownership(layout_arena: &LayoutNodeArena, viewport
     }
 }
 
-fn assign_for_block(layout_arena: &LayoutNodeArena, block: NodeSlotId) {
+fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
     let pieces = layout_arena.paintable_side_data(block).inline_box_pieces.clone();
     let mut block_filter = FragmentOwnershipFilter::everything();
 
@@ -164,7 +168,7 @@ fn assign_for_block(layout_arena: &LayoutNodeArena, block: NodeSlotId) {
         let Some(piece_paintable) = piece_paintable_of(piece.node) else {
             continue;
         };
-        if !is_self_painting_inline(&layout_arena.paintable_data(piece_paintable)) {
+        if !is_self_painting_inline(layout_arena.paintable_data(piece_paintable)) {
             continue;
         }
         let range = FragmentRange {
@@ -191,7 +195,10 @@ fn assign_for_block(layout_arena: &LayoutNodeArena, block: NodeSlotId) {
     }
 }
 
-pub(crate) fn effective_filter(layout_arena: &LayoutNodeArena, paintable: NodeSlotId) -> FragmentOwnershipFilter {
+pub(crate) fn effective_filter(
+    layout_arena: &impl PaintableRowsRead,
+    paintable: NodeSlotId,
+) -> FragmentOwnershipFilter {
     if let Some(filter) = &layout_arena.paintable_side_data(paintable).fragment_ownership {
         return filter.clone();
     }

--- a/Libraries/LibWeb/Rust/src/painting/paint_order.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_order.rs
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::fragment_ownership;
+use crate::painting::paintable_rows::PaintableRowsRead;
 
-pub(crate) fn paint_parent(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -> Option<NodeSlotId> {
+pub(crate) fn paint_parent(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<NodeSlotId> {
     if !layout_arena.paintable_row_is_populated(slot)
         || layout_arena.paintable_data(slot).kind.forms_unconnected_subtree()
     {
@@ -29,7 +29,7 @@ pub(crate) fn paint_parent(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -> 
 }
 
 fn first_paintable_in_layout_siblings(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     first_node: Option<NodeSlotId>,
 ) -> Option<NodeSlotId> {
     let mut pending_siblings = Vec::new();
@@ -54,14 +54,14 @@ fn first_paintable_in_layout_siblings(
     None
 }
 
-pub(crate) fn first_paint_child(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -> Option<NodeSlotId> {
+pub(crate) fn first_paint_child(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<NodeSlotId> {
     if !layout_arena.paintable_row_is_populated(slot) {
         return None;
     }
     first_paintable_in_layout_siblings(layout_arena, layout_arena.node_first_child_if_live(slot))
 }
 
-pub(crate) fn next_paint_sibling(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -> Option<NodeSlotId> {
+pub(crate) fn next_paint_sibling(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<NodeSlotId> {
     if !layout_arena.paintable_row_is_populated(slot)
         || layout_arena.paintable_data(slot).kind.forms_unconnected_subtree()
     {
@@ -86,7 +86,7 @@ pub(crate) fn next_paint_sibling(layout_arena: &LayoutNodeArena, slot: NodeSlotI
 }
 
 pub(crate) fn for_each_paint_child(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
     mut callback: impl FnMut(NodeSlotId),
 ) {
@@ -98,11 +98,11 @@ pub(crate) fn for_each_paint_child(
 }
 
 pub(crate) fn for_each_in_paint_subtree(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     root: NodeSlotId,
     mut callback: impl FnMut(NodeSlotId),
 ) {
-    fn visit(layout_arena: &LayoutNodeArena, slot: NodeSlotId, callback: &mut impl FnMut(NodeSlotId)) {
+    fn visit(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId, callback: &mut impl FnMut(NodeSlotId)) {
         callback(slot);
         for_each_paint_child(layout_arena, slot, |child| {
             visit(layout_arena, child, callback);

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -13,7 +13,7 @@ use crate::layout::{
     Node, NodeFacts,
 };
 use crate::painting::paintable_data::*;
-use std::cell::RefCell;
+use crate::painting::paintable_rows::PaintableRowsRead;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PreparedPaintable {
@@ -66,7 +66,7 @@ pub(crate) fn paintable_kind_for_node(facts: &NodeFacts<'_>, kind: NodeKind) -> 
 }
 
 fn committed_offset_delta(
-    arena: &LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     offsets_before_commit: &std::collections::HashMap<NodeSlotId, FfiCssPixelPoint>,
     slot: NodeSlotId,
 ) -> FfiCssPixelPoint {
@@ -81,7 +81,7 @@ fn committed_offset_delta(
 }
 
 fn reused_subtree_absolute_position_delta(
-    arena: &LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     offsets_before_commit: &std::collections::HashMap<NodeSlotId, FfiCssPixelPoint>,
     root: NodeSlotId,
 ) -> FfiCssPixelPoint {
@@ -110,50 +110,61 @@ fn reused_subtree_absolute_position_delta(
 
 pub(crate) struct PaintableCommit<'a> {
     callbacks: &'a FfiLayoutFcCallbacks,
-    offsets_before_commit: RefCell<std::collections::HashMap<NodeSlotId, FfiCssPixelPoint>>,
-    reused_subtree_roots: RefCell<Vec<NodeSlotId>>,
-    committed_navigable_container_viewports: RefCell<Vec<NodeSlotId>>,
+    offsets_before_commit: std::collections::HashMap<NodeSlotId, FfiCssPixelPoint>,
+    reused_subtree_roots: Vec<NodeSlotId>,
+    committed_navigable_container_viewports: Vec<NodeSlotId>,
 }
 
 impl<'a> PaintableCommit<'a> {
     pub(crate) fn new(callbacks: &'a FfiLayoutFcCallbacks) -> Self {
         Self {
             callbacks,
-            offsets_before_commit: RefCell::new(std::collections::HashMap::new()),
-            reused_subtree_roots: RefCell::new(Vec::new()),
-            committed_navigable_container_viewports: RefCell::new(Vec::new()),
+            offsets_before_commit: std::collections::HashMap::new(),
+            reused_subtree_roots: Vec::new(),
+            committed_navigable_container_viewports: Vec::new(),
         }
     }
 
-    fn arena(&self) -> &'a LayoutNodeArena {
+    fn arena(&self) -> &LayoutNodeArena {
         self.callbacks.arena()
+    }
+
+    fn arena_mut(&mut self) -> &mut LayoutNodeArena {
+        // SAFETY: Layout commit is synchronous on the document thread. The mutable
+        // PaintableCommit borrow prevents Rust code from retaining another arena
+        // borrow across this callback-free mutation phase.
+        unsafe { LayoutNodeArena::from_handle_mut(self.callbacks.arena) }
     }
 
     pub(crate) fn discard_absolute_rects_memoized_during_commit(&self) {
         self.arena().clear_absolute_rect_memo();
     }
 
-    pub(crate) fn translate_reused_subtrees(&self) {
-        let roots = self.reused_subtree_roots.borrow();
+    pub(crate) fn translate_reused_subtrees(&mut self) {
+        let roots = std::mem::take(&mut self.reused_subtree_roots);
         if roots.is_empty() {
             return;
         }
-        let arena = self.arena();
-        let offsets_before_commit = self.offsets_before_commit.borrow();
-        for &root in roots.iter() {
-            let delta = reused_subtree_absolute_position_delta(arena, &offsets_before_commit, root);
+        let offsets_before_commit = std::mem::take(&mut self.offsets_before_commit);
+        let arena = self.arena_mut();
+        let mut paintable_rows = arena.paintable_rows_mut();
+        for root in roots {
+            let delta = reused_subtree_absolute_position_delta(&paintable_rows, &offsets_before_commit, root);
             if delta == FfiCssPixelPoint::default() {
                 continue;
             }
-            crate::painting::paint_order::for_each_in_paint_subtree(arena, root, |slot| {
-                arena.update_paintable_data(slot, |data| {
-                    if data.has_overflow {
-                        data.overflow.rect.x += delta.x;
-                        data.overflow.rect.y += delta.y;
-                    }
-                });
-                arena.invalidate_paint_cache(slot);
+            let mut slots = Vec::new();
+            crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, root, |slot| {
+                slots.push(slot);
             });
+            for slot in slots {
+                let data = paintable_rows.paintable_data_mut(slot);
+                if data.has_overflow {
+                    data.overflow.rect.x += delta.x;
+                    data.overflow.rect.y += delta.y;
+                }
+                paintable_rows.invalidate_paint_cache(slot);
+            }
         }
     }
 
@@ -167,45 +178,54 @@ impl<'a> PaintableCommit<'a> {
     }
 
     pub(crate) fn prepare_node(
-        &self,
+        &mut self,
         node: Node,
         has_used_values: bool,
         reuses_committed_subtree: bool,
     ) -> PreparedPaintable {
-        let facts = NodeFacts::new(self.callbacks, node);
-        let data = self.callbacks.node_data(node);
-        let expected_kind = paintable_kind_for_node(&facts, data.kind);
-        let wants_paintable = (has_used_values || (facts.is_fragmented_inline() && facts.has_dom_node()))
-            && expected_kind != PaintableKind::None;
-        let row_existed_before_this_commit = self.arena().paintable_row_is_populated(node);
+        let (expected_kind, wants_paintable, node_kind, node_flags, is_inline) = {
+            let facts = NodeFacts::new(self.callbacks, node);
+            let data = self.callbacks.node_data(node);
+            let expected_kind = paintable_kind_for_node(&facts, data.kind);
+            (
+                expected_kind,
+                (has_used_values || (facts.is_fragmented_inline() && facts.has_dom_node()))
+                    && expected_kind != PaintableKind::None,
+                data.kind,
+                data.flags,
+                facts.is_inline(),
+            )
+        };
+        let row_existed_before_this_commit = self.arena().paintable_rows().paintable_row_is_populated(node);
         if !wants_paintable {
             self.arena().clear_committed_fragment_link(node);
             if row_existed_before_this_commit {
-                let arena = self.arena();
-                arena.invalidate_paint_cache(node);
-                let reset = arena
-                    .prepare_paintable_row_cleared_reset(node)
-                    .expect("live row for node could not be cleared");
+                let reset = {
+                    let arena = self.arena();
+                    arena.invalidate_paint_cache(node);
+                    arena
+                        .prepare_paintable_row_cleared_reset(node)
+                        .expect("live row for node could not be cleared")
+                };
                 reset.invoke_callback();
-                arena.paintable_row_cleared(reset);
+                self.arena_mut().paintable_row_cleared(reset);
             }
             return PreparedPaintable {
                 has_paintable_row: false,
                 row_existed_before_this_commit: false,
             };
         }
-        if data.kind == NodeKind::NavigableContainerViewport {
-            self.committed_navigable_container_viewports.borrow_mut().push(node);
+        if node_kind == NodeKind::NavigableContainerViewport {
+            self.committed_navigable_container_viewports.push(node);
         }
         if reuses_committed_subtree {
             assert!(
                 row_existed_before_this_commit,
                 "a kept subtree root has no committed row"
             );
-            self.offsets_before_commit
-                .borrow_mut()
-                .insert(node, self.arena().paintable_data(node).offset);
-            self.reused_subtree_roots.borrow_mut().push(node);
+            let offset = self.arena().paintable_rows().paintable_data(node).offset;
+            self.offsets_before_commit.insert(node, offset);
+            self.reused_subtree_roots.push(node);
             return PreparedPaintable {
                 has_paintable_row: true,
                 row_existed_before_this_commit: true,
@@ -232,25 +252,31 @@ impl<'a> PaintableCommit<'a> {
                 crate::css::display::FfiDisplay::none(),
             ),
         };
-        let is_item = data.flags & (NodeFlag::IsFlexItem as u32 | NodeFlag::IsGridItem as u32) != 0;
-        let arena = self.arena();
+        let is_item = node_flags & (NodeFlag::IsFlexItem as u32 | NodeFlag::IsGridItem as u32) != 0;
         if row_existed_before_this_commit {
-            self.offsets_before_commit
-                .borrow_mut()
-                .insert(node, arena.paintable_data(node).offset);
-            let notification = arena.prepare_paintable_row_recommit_notification(node);
+            let (offset, notification) = {
+                let paintable_rows = self.arena().paintable_rows();
+                (
+                    paintable_rows.paintable_data(node).offset,
+                    paintable_rows.prepare_paintable_row_recommit_notification(node),
+                )
+            };
+            self.offsets_before_commit.insert(node, offset);
             notification.invoke_callback();
-            arena.begin_paintable_row_recommit(node);
+        }
+        let arena = self.arena_mut();
+        if row_existed_before_this_commit {
+            arena.paintable_rows_mut().begin_paintable_row_recommit(node);
         } else {
             arena.populate_paintable_row(node);
             if expected_kind == PaintableKind::ViewportPaintable {
                 arena.paint_state().borrow_mut().reset_visual_context_state();
             }
-            arena.update_paintable_data(node, |paintable| {
-                paintable.kind = expected_kind;
-            });
+            arena.paintable_rows_mut().paintable_data_mut(node).kind = expected_kind;
         }
-        arena.update_paintable_data(node, |paintable| {
+        {
+            let mut paintable_rows = arena.paintable_rows_mut();
+            let paintable = paintable_rows.paintable_data_mut(node);
             // Flex and grid items with a z-index other than auto behave as if positioned.
             paintable.set_flag(
                 PaintableFlag::Positioned,
@@ -267,21 +293,21 @@ impl<'a> PaintableCommit<'a> {
             );
             paintable.set_flag(
                 PaintableFlag::Floating,
-                floating && data.flags & NodeFlag::IsFlexItem as u32 == 0,
+                floating && node_flags & NodeFlag::IsFlexItem as u32 == 0,
             );
-            paintable.set_flag(PaintableFlag::Inline, facts.is_inline());
-            paintable.set_flag(PaintableFlag::Anonymous, data.flags & NodeFlag::Anonymous as u32 != 0);
+            paintable.set_flag(PaintableFlag::Inline, is_inline);
+            paintable.set_flag(PaintableFlag::Anonymous, node_flags & NodeFlag::Anonymous as u32 != 0);
             paintable.set_flag(
                 PaintableFlag::Replaced,
-                data.flags & NodeFlag::IsReplacedElement as u32 != 0,
+                node_flags & NodeFlag::IsReplacedElement as u32 != 0,
             );
             paintable.set_flag(PaintableFlag::FlexOrGridItem, is_item);
             paintable.set_flag(
                 PaintableFlag::ReplacedBox,
-                crate::layout::kind_is_replaced_box(data.kind),
+                crate::layout::kind_is_replaced_box(node_kind),
             );
             paintable.display = display.encoded();
-        });
+        }
         PreparedPaintable {
             has_paintable_row: true,
             row_existed_before_this_commit,
@@ -290,14 +316,13 @@ impl<'a> PaintableCommit<'a> {
 
     pub(crate) fn committed_navigable_container_viewport_shells(&self) -> Vec<*mut std::ffi::c_void> {
         self.committed_navigable_container_viewports
-            .borrow()
             .iter()
             .map(|node| self.callbacks.shell(*node))
             .collect()
     }
 
     pub(crate) fn replace_committed_fragment_link(
-        &self,
+        &mut self,
         node: Node,
         link: &FragmentLink,
         reuses_committed_subtree: bool,
@@ -308,8 +333,7 @@ impl<'a> PaintableCommit<'a> {
             height: fragment.content_block_size,
         };
         let mut content_size_change = None;
-        let arena = self.arena();
-        let (old_identity, old_content_size) = arena.with_committed_fragment_link(node, |old_link| {
+        let (old_identity, old_content_size) = self.arena().with_committed_fragment_link(node, |old_link| {
             old_link.map_or((0, FfiCssPixelSize::default()), |old_link| {
                 (
                     old_link.fragment.identity,
@@ -332,20 +356,23 @@ impl<'a> PaintableCommit<'a> {
             );
             content_size_change = Some((previous_content_size_for_diff, new_content_size));
         }
-        arena.update_paintable_data(node, |data| {
+        {
+            let arena = self.arena_mut();
+            let mut paintable_rows = arena.paintable_rows_mut();
+            let data = paintable_rows.paintable_data_mut(node);
             if old_identity != fragment.identity {
                 data.cached_overflow = FfiOverflowData::default();
                 data.has_cached_overflow = false;
             }
             data.content_size = new_content_size;
             data.offset = link.committed_offset;
-        });
+        }
         self.callbacks.set_committed_fragment_link(node, link.clone());
         content_size_change
     }
 
     pub(crate) fn set_line_data(&self, slot: NodeSlotId, line_data: &LineData, content_inline_size: CssPixels) -> bool {
-        if !self.arena().paintable_data(slot).kind.has_lines() {
+        if !self.arena().paintable_rows().paintable_data(slot).kind.has_lines() {
             return false;
         }
         let (lines, fragments, pieces) = self.build_line_records(line_data, content_inline_size);
@@ -535,24 +562,31 @@ impl<'a> PaintableCommit<'a> {
         )
     }
 
-    pub(crate) fn stamp_containing_block(&self, node: Node) {
-        let arena = self.arena();
-        if !arena.paintable_row_is_populated(node) {
+    pub(crate) fn stamp_containing_block(&mut self, node: Node) {
+        let containing_block = self.callbacks.node_data(node).containing_block;
+        let arena = self.arena_mut();
+        let mut paintable_rows = arena.paintable_rows_mut();
+        if !paintable_rows.paintable_row_is_populated(node) {
             return;
         }
-        let containing_block = self.callbacks.node_data(node).containing_block;
-        let containing_block = if arena.paintable_row_is_populated(containing_block) {
+        let containing_block = if paintable_rows.paintable_row_is_populated(containing_block) {
             containing_block
         } else {
             NodeSlotId::INVALID
         };
-        arena.update_paintable_data(node, |data| data.containing_block = containing_block);
+        paintable_rows.paintable_data_mut(node).containing_block = containing_block;
     }
 
-    pub(crate) fn assign_inline_box_geometry(&self, slot: NodeSlotId) {
-        let arena = self.arena();
+    pub(crate) fn assign_inline_box_geometry(&mut self, slot: NodeSlotId) {
+        let arena = self.arena_mut();
+        let mut paintable_rows = arena.paintable_rows_mut();
         let mut piece_indices_by_node: Vec<(NodeSlotId, Vec<u32>)> = Vec::new();
-        for (piece_index, piece) in arena.paintable_side_data(slot).inline_box_pieces.iter().enumerate() {
+        for (piece_index, piece) in paintable_rows
+            .paintable_side_data(slot)
+            .inline_box_pieces
+            .iter()
+            .enumerate()
+        {
             if piece.node.is_invalid() {
                 continue;
             }
@@ -562,13 +596,13 @@ impl<'a> PaintableCommit<'a> {
             }
         }
         for (piece_node, piece_indices) in piece_indices_by_node {
-            if !arena.paintable_row_is_populated(piece_node)
-                || arena.paintable_data(piece_node).kind != PaintableKind::InlinePaintable
+            if !paintable_rows.paintable_row_is_populated(piece_node)
+                || paintable_rows.paintable_data(piece_node).kind != PaintableKind::InlinePaintable
             {
                 continue;
             }
-            let padding_widths = crate::painting::paintable_geometry::committed_padding(arena, piece_node);
-            let border_widths = crate::painting::paintable_geometry::committed_border(arena, piece_node);
+            let padding_widths = crate::painting::paintable_geometry::committed_padding(&paintable_rows, piece_node);
+            let border_widths = crate::painting::paintable_geometry::committed_border(&paintable_rows, piece_node);
             let mut content_union: Option<CssPixelRect> = None;
             let mut padding_union: Option<CssPixelRect> = None;
             let mut border_union: Option<CssPixelRect> = None;
@@ -587,7 +621,7 @@ impl<'a> PaintableCommit<'a> {
                 }
             };
             for piece_index in &piece_indices {
-                let piece = arena.paintable_side_data(slot).inline_box_pieces[*piece_index as usize];
+                let piece = paintable_rows.paintable_side_data(slot).inline_box_pieces[*piece_index as usize];
                 let border_rect = CssPixelRect::from(piece.border_box_rect);
                 if piece.is_geometry_only_placeholder {
                     let content_rect = border_rect;
@@ -619,14 +653,15 @@ impl<'a> PaintableCommit<'a> {
             };
             let padding_union = padding_union.expect("padding union set alongside content union");
             let border_union = border_union.expect("border union set alongside content union");
-            arena.update_paintable_data(piece_node, |data| {
+            {
+                let data = paintable_rows.paintable_data_mut(piece_node);
                 data.offset = content_union.location().into();
                 data.content_size = content_union.size().into();
                 data.local_padding_box_union = padding_union.translated(-content_union.x, -content_union.y).into();
                 data.local_border_box_union = border_union.translated(-content_union.x, -content_union.y).into();
-            });
+            }
             // This box has at most one piece per line, so its piece indices are ordered by line.
-            arena.paintable_side_data_mut(piece_node).piece_indices = piece_indices;
+            paintable_rows.paintable_side_data_mut(piece_node).piece_indices = piece_indices;
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -9,6 +9,7 @@ use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::*;
+use crate::painting::paintable_rows::PaintableRowsRead;
 
 pub(crate) fn is_svg_paintable(kind: PaintableKind) -> bool {
     matches!(
@@ -22,7 +23,7 @@ pub(crate) fn is_svg_paintable(kind: PaintableKind) -> bool {
     )
 }
 
-pub(crate) fn committed_offset(arena: &LayoutNodeArena, slot: NodeSlotId) -> crate::layout::FfiCssPixelPoint {
+pub(crate) fn committed_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> crate::layout::FfiCssPixelPoint {
     let data = arena.paintable_data(slot);
     if data.kind == PaintableKind::InlinePaintable {
         return data.offset;
@@ -32,7 +33,10 @@ pub(crate) fn committed_offset(arena: &LayoutNodeArena, slot: NodeSlotId) -> cra
     })
 }
 
-pub(crate) fn committed_content_size(arena: &LayoutNodeArena, slot: NodeSlotId) -> crate::layout::FfiCssPixelSize {
+pub(crate) fn committed_content_size(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+) -> crate::layout::FfiCssPixelSize {
     let data = arena.paintable_data(slot);
     if data.kind == PaintableKind::InlinePaintable {
         return data.content_size;
@@ -134,7 +138,7 @@ pub(crate) fn committed_collapsed_table_borders(
 }
 
 pub(crate) fn committed_svg_path(
-    arena: &LayoutNodeArena,
+    arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
 ) -> Option<std::rc::Rc<libgfx_rust::path::OwnedPath>> {
     if arena.paintable_data(slot).kind != PaintableKind::SVGPathPaintable {
@@ -156,7 +160,10 @@ pub(crate) fn committed_svg_viewport_transform(
     arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.fragment.svg_viewport_transform))
 }
 
-pub(crate) fn committed_svg_viewport_size(arena: &LayoutNodeArena, slot: NodeSlotId) -> crate::layout::FfiCssPixelSize {
+pub(crate) fn committed_svg_viewport_size(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+) -> crate::layout::FfiCssPixelSize {
     if arena.paintable_data(slot).kind != PaintableKind::SVGSVGPaintable {
         return crate::layout::FfiCssPixelSize::default();
     }
@@ -166,7 +173,7 @@ pub(crate) fn committed_svg_viewport_size(arena: &LayoutNodeArena, slot: NodeSlo
     })
 }
 
-pub(crate) fn absolute_rect(arena: &LayoutNodeArena, slot: NodeSlotId) -> CssPixelRect {
+pub(crate) fn absolute_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
     if let Some(rect) = arena.memoized_absolute_rect(slot) {
         return rect;
     }
@@ -195,11 +202,11 @@ pub(crate) fn absolute_rect(arena: &LayoutNodeArena, slot: NodeSlotId) -> CssPix
     rect
 }
 
-pub(crate) fn absolute_position(arena: &LayoutNodeArena, slot: NodeSlotId) -> CssPixelPoint {
+pub(crate) fn absolute_position(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
     absolute_rect(arena, slot).location()
 }
 
-pub(crate) fn absolute_padding_box_rect(arena: &LayoutNodeArena, slot: NodeSlotId) -> CssPixelRect {
+pub(crate) fn absolute_padding_box_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
     let data = arena.paintable_data(slot);
     let absolute = absolute_rect(arena, slot);
     if data.kind == PaintableKind::InlinePaintable {
@@ -215,7 +222,7 @@ pub(crate) fn absolute_padding_box_rect(arena: &LayoutNodeArena, slot: NodeSlotI
     )
 }
 
-pub(crate) fn absolute_border_box_rect(arena: &LayoutNodeArena, slot: NodeSlotId) -> CssPixelRect {
+pub(crate) fn absolute_border_box_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
     let data = arena.paintable_data(slot);
     if data.kind == PaintableKind::InlinePaintable {
         return CssPixelRect::from(data.local_border_box_union).translated_by(absolute_rect(arena, slot).location());
@@ -241,7 +248,7 @@ pub(crate) fn absolute_border_box_rect(arena: &LayoutNodeArena, slot: NodeSlotId
     )
 }
 
-pub(crate) fn scrollable_overflow_rect(arena: &LayoutNodeArena, slot: NodeSlotId) -> Option<CssPixelRect> {
+pub(crate) fn scrollable_overflow_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<CssPixelRect> {
     let data = arena.paintable_data(slot);
     if data.has_overflow {
         return Some(data.overflow.rect.into());

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -11,12 +11,13 @@ use crate::painting::paintable_data::*;
 use crate::painting::record::cache::PaintCache;
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::ffi::c_void;
+use std::ops::{Deref, DerefMut};
 
 pub(crate) const PAINTABLE_SLOTS_PER_CHUNK: usize = 64;
 
 #[repr(align(64))]
 struct PaintableRowChunk {
-    slots: [Cell<PaintableData>; PAINTABLE_SLOTS_PER_CHUNK],
+    slots: [PaintableData; PAINTABLE_SLOTS_PER_CHUNK],
 }
 
 fn new_chunk() -> Box<PaintableRowChunk> {
@@ -26,7 +27,7 @@ fn new_chunk() -> Box<PaintableRowChunk> {
         let mut chunk = Box::<PaintableRowChunk>::new_uninit();
         let slots = &raw mut (*chunk.as_mut_ptr()).slots;
         for offset in 0..PAINTABLE_SLOTS_PER_CHUNK {
-            (&raw mut (*slots)[offset]).write(Cell::new(PaintableData::default()));
+            (&raw mut (*slots)[offset]).write(PaintableData::default());
         }
         chunk.assume_init()
     }
@@ -61,13 +62,287 @@ struct CommittedFragmentLinkSlot {
 
 #[derive(Default)]
 pub(crate) struct PaintableRowStore {
-    chunks: RefCell<Vec<Box<PaintableRowChunk>>>,
+    chunks: Vec<Box<PaintableRowChunk>>,
     side_data: RefCell<Vec<PaintableSideData>>,
     paint_caches: RefCell<Vec<PaintCache>>,
     absolute_rect_memo: RefCell<Vec<Option<(NodeSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
     absolute_rect_memo_epoch: Cell<u64>,
     committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
     chrome_state_callback: Cell<Option<ChromeStateCallback>>,
+}
+
+pub(crate) struct PaintableRows<Arena> {
+    arena: Arena,
+}
+
+pub(crate) type PaintableRowsRef<'a> = PaintableRows<&'a LayoutNodeArena>;
+pub(crate) type PaintableRowsMut<'a> = PaintableRows<&'a mut LayoutNodeArena>;
+
+impl Clone for PaintableRowsRef<'_> {
+    fn clone(&self) -> Self {
+        Self { arena: self.arena }
+    }
+}
+
+pub(crate) trait PaintableRowsRead: Deref<Target = LayoutNodeArena> {
+    fn paintable_data(&self, id: NodeSlotId) -> &PaintableData;
+    fn paintable_row_is_populated(&self, id: NodeSlotId) -> bool;
+}
+
+pub(crate) trait PaintableRowsWrite: PaintableRowsRead {
+    fn paintable_data_mut(&mut self, id: NodeSlotId) -> &mut PaintableData;
+}
+
+impl<Arena> Deref for PaintableRows<Arena>
+where
+    Arena: Deref<Target = LayoutNodeArena>,
+{
+    type Target = LayoutNodeArena;
+
+    fn deref(&self) -> &Self::Target {
+        self.arena.deref()
+    }
+}
+
+impl<Arena> DerefMut for PaintableRows<Arena>
+where
+    Arena: DerefMut<Target = LayoutNodeArena>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.arena.deref_mut()
+    }
+}
+
+impl<Arena> PaintableRows<Arena>
+where
+    Arena: Deref<Target = LayoutNodeArena>,
+{
+    pub(crate) fn paintable_data(&self, id: NodeSlotId) -> &PaintableData {
+        assert!(!id.is_invalid(), "invalid paintable arena slot ID");
+        let index = id.slot_index() as usize;
+        let chunk = self
+            .arena
+            .paintable_rows
+            .chunks
+            .get(index / PAINTABLE_SLOTS_PER_CHUNK)
+            .expect("invalid paintable arena slot ID");
+        let data = &chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK];
+        assert_eq!(
+            data.slot_generation,
+            id.generation(),
+            "paintable arena read a stale or unused slot"
+        );
+        data
+    }
+
+    pub(crate) fn paintable_data_ptr(&self, id: NodeSlotId) -> *const PaintableData {
+        self.paintable_data(id)
+    }
+
+    pub(crate) fn paintable_row_is_populated(&self, id: NodeSlotId) -> bool {
+        if id.is_invalid() {
+            return false;
+        }
+        let index = id.slot_index() as usize;
+        let Some(chunk) = self.arena.paintable_rows.chunks.get(index / PAINTABLE_SLOTS_PER_CHUNK) else {
+            return false;
+        };
+        let generation = chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK].slot_generation;
+        generation != 0 && generation == id.generation()
+    }
+
+    pub(crate) fn inline_pieces_root(&self, inline_paintable: NodeSlotId) -> Option<NodeSlotId> {
+        if !self.paintable_row_is_populated(inline_paintable) {
+            return None;
+        }
+        let root = self.paintable_data(inline_paintable).containing_block;
+        (self.paintable_row_is_populated(root) && self.paintable_data(root).kind.has_lines()).then_some(root)
+    }
+
+    pub(crate) fn visual_context_assignments(&self) -> Vec<(u32, bool, usize, usize, usize, usize)> {
+        (0..self.arena.paintable_row_count())
+            .map(|index| {
+                let chunk = &self.arena.paintable_rows.chunks[index / PAINTABLE_SLOTS_PER_CHUNK];
+                let data = &chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK];
+                (
+                    u32::from(data.slot_generation),
+                    data.has_accumulated_visual_context,
+                    data.accumulated_visual_context_index,
+                    data.accumulated_visual_context_for_descendants_index,
+                    data.visual_context_nodes_begin,
+                    data.visual_context_nodes_end,
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn invalidate_paint_cache(&self, id: NodeSlotId) {
+        if !self.paintable_row_is_populated(id) {
+            return;
+        }
+        self.arena.paintable_paint_cache(id).clear();
+        let mut ancestor = crate::painting::paint_order::paint_parent(self, id);
+        while let Some(current) = ancestor {
+            self.arena.paintable_paint_cache(current).clear_descendant_subtrees();
+            ancestor = crate::painting::paint_order::paint_parent(self, current);
+        }
+    }
+
+    pub(crate) fn clear_descendant_subtree_caches_along_paint_chain(&self, id: NodeSlotId) {
+        if !self.paintable_row_is_populated(id) {
+            return;
+        }
+        let mut current = Some(id);
+        while let Some(slot) = current {
+            self.arena.paintable_paint_cache(slot).clear_descendant_subtrees();
+            current = crate::painting::paint_order::paint_parent(self, slot);
+        }
+    }
+
+    pub(crate) fn clear_descendant_subtree_caches_from_layout_node(&self, mut node: NodeSlotId) {
+        loop {
+            if self.paintable_row_is_populated(node) {
+                self.clear_descendant_subtree_caches_along_paint_chain(node);
+                return;
+            }
+            if !crate::painting::fragment_ownership::node_is_fragmented_inline(self.arena.deref(), node) {
+                return;
+            }
+            let Some(parent) = self.arena.node_parent_if_live(node) else {
+                return;
+            };
+            node = parent;
+        }
+    }
+
+    pub(crate) fn invalidate_for_repaint(&self, id: NodeSlotId) {
+        if !self.paintable_row_is_populated(id) {
+            return;
+        }
+        self.invalidate_paint_cache(id);
+        let mut stack = vec![id];
+        while let Some(current) = stack.pop() {
+            let mut child = crate::painting::paint_order::first_paint_child(self, current);
+            while let Some(child_slot) = child {
+                let child_flags = self.arena.node_flags_if_live(child_slot);
+                if child_flags & NodeFlag::Anonymous as u32 != 0 {
+                    self.arena.paintable_paint_cache(child_slot).clear();
+                    stack.push(child_slot);
+                }
+                child = crate::painting::paint_order::next_paint_sibling(self, child_slot);
+            }
+        }
+        if self.paintable_data(id).kind == PaintableKind::InlinePaintable {
+            let mut ancestor = crate::painting::paint_order::paint_parent(self, id);
+            while let Some(current) = ancestor {
+                self.invalidate_paint_cache(current);
+                if self.paintable_data(current).kind.has_lines() {
+                    break;
+                }
+                ancestor = crate::painting::paint_order::paint_parent(self, current);
+            }
+        }
+    }
+
+    pub(crate) fn invalidate_propagated_text_decoration_caches(&self, root: NodeSlotId) {
+        if !self.paintable_row_is_populated(root) {
+            return;
+        }
+
+        let mut stack = Vec::new();
+        if let Some(first_child) = crate::painting::paint_order::first_paint_child(self, root) {
+            stack.push(first_child);
+        }
+        while let Some(current) = stack.pop() {
+            if let Some(next_sibling) = crate::painting::paint_order::next_paint_sibling(self, current) {
+                stack.push(next_sibling);
+            }
+
+            let data = self.paintable_data(current);
+            if crate::painting::style_queries::is_text_decoration_propagation_boundary(self.arena.deref(), current) {
+                continue;
+            }
+            if data.kind.has_lines() || data.kind == PaintableKind::InlinePaintable {
+                self.arena.paintable_paint_cache(current).clear();
+            }
+            if let Some(first_child) = crate::painting::paint_order::first_paint_child(self, current) {
+                stack.push(first_child);
+            }
+        }
+        let mut ancestor = Some(root);
+        while let Some(current) = ancestor {
+            self.arena.paintable_paint_cache(current).clear_descendant_subtrees();
+            ancestor = crate::painting::paint_order::paint_parent(self, current);
+        }
+    }
+
+    pub(crate) fn prepare_paintable_row_recommit_notification(&self, id: NodeSlotId) -> PaintableRowReset {
+        assert!(self.paintable_row_is_populated(id));
+        self.arena
+            .prepare_paintable_row_reset(id, PaintableRowResetKind::Recommitted)
+    }
+}
+
+impl<Arena> PaintableRows<Arena>
+where
+    Arena: DerefMut<Target = LayoutNodeArena>,
+{
+    pub(crate) fn paintable_data_mut(&mut self, id: NodeSlotId) -> &mut PaintableData {
+        assert!(!id.is_invalid(), "invalid paintable arena slot ID");
+        let index = id.slot_index() as usize;
+        let chunk = self
+            .arena
+            .paintable_rows
+            .chunks
+            .get_mut(index / PAINTABLE_SLOTS_PER_CHUNK)
+            .expect("invalid paintable arena slot ID");
+        let data = &mut chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK];
+        assert_eq!(
+            data.slot_generation,
+            id.generation(),
+            "paintable arena read a stale or unused slot"
+        );
+        data
+    }
+
+    pub(crate) fn begin_paintable_row_recommit(&mut self, id: NodeSlotId) {
+        {
+            let data = self.paintable_data_mut(id);
+            data.offset = FfiCssPixelPoint::default();
+            data.content_size = FfiCssPixelSize::default();
+            data.overflow = FfiOverflowData::default();
+            data.has_overflow = false;
+            data.sticky_insets = FfiStickyInsets::default();
+            data.has_sticky_insets = false;
+            data.local_padding_box_union = FfiCssPixelRect::default();
+            data.local_border_box_union = FfiCssPixelRect::default();
+            data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;
+        }
+        self.arena.paintable_paint_cache(id).clear();
+        self.arena.paintable_side_data_mut(id).clear_committed_records();
+    }
+}
+
+impl<Arena> PaintableRowsRead for PaintableRows<Arena>
+where
+    Arena: Deref<Target = LayoutNodeArena>,
+{
+    fn paintable_data(&self, id: NodeSlotId) -> &PaintableData {
+        PaintableRows::paintable_data(self, id)
+    }
+
+    fn paintable_row_is_populated(&self, id: NodeSlotId) -> bool {
+        PaintableRows::paintable_row_is_populated(self, id)
+    }
+}
+
+impl<Arena> PaintableRowsWrite for PaintableRows<Arena>
+where
+    Arena: DerefMut<Target = LayoutNodeArena>,
+{
+    fn paintable_data_mut(&mut self, id: NodeSlotId) -> &mut PaintableData {
+        PaintableRows::paintable_data_mut(self, id)
+    }
 }
 
 impl PaintableRowStore {
@@ -131,6 +406,14 @@ impl PaintableRowStore {
 }
 
 impl LayoutNodeArena {
+    pub(crate) fn paintable_rows(&self) -> PaintableRowsRef<'_> {
+        PaintableRows { arena: self }
+    }
+
+    pub(crate) fn paintable_rows_mut(&mut self) -> PaintableRowsMut<'_> {
+        PaintableRows { arena: self }
+    }
+
     pub(crate) fn set_chrome_state_callback(
         &self,
         context: *mut c_void,
@@ -191,22 +474,6 @@ impl LayoutNodeArena {
         self.paintable_rows.side_data.borrow().len()
     }
 
-    pub(crate) fn visual_context_assignments(&self) -> Vec<(u32, bool, usize, usize, usize, usize)> {
-        (0..self.paintable_row_count())
-            .map(|index| {
-                let data = self.paintable_data_by_index(index as u32);
-                (
-                    u32::from(data.slot_generation),
-                    data.has_accumulated_visual_context,
-                    data.accumulated_visual_context_index,
-                    data.accumulated_visual_context_for_descendants_index,
-                    data.visual_context_nodes_begin,
-                    data.visual_context_nodes_end,
-                )
-            })
-            .collect()
-    }
-
     pub(crate) fn clear_descendant_subtree_caches(&self) {
         for cache in self.paintable_rows.paint_caches.borrow().iter() {
             cache.clear_descendant_subtrees();
@@ -220,17 +487,13 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn inline_pieces_root(&self, inline_paintable: NodeSlotId) -> Option<NodeSlotId> {
-        if !self.paintable_row_is_populated(inline_paintable) {
-            return None;
-        }
-        let root = self.paintable_data(inline_paintable).containing_block;
-        (self.paintable_row_is_populated(root) && self.paintable_data(root).kind.has_lines()).then_some(root)
+        self.paintable_rows().inline_pieces_root(inline_paintable)
     }
 
-    pub(crate) fn populate_paintable_row(&self, layout_node: NodeSlotId) {
-        let store = &self.paintable_rows;
+    pub(crate) fn populate_paintable_row(&mut self, layout_node: NodeSlotId) {
+        let store = &mut self.paintable_rows;
         let index = layout_node.slot_index() as usize;
-        let mut chunks = store.chunks.borrow_mut();
+        let chunks = &mut store.chunks;
         let mut side_data = store.side_data.borrow_mut();
         let mut paint_caches = store.paint_caches.borrow_mut();
         let mut absolute_rect_memo = store.absolute_rect_memo.borrow_mut();
@@ -243,25 +506,25 @@ impl LayoutNodeArena {
             absolute_rect_memo.push(None);
         }
 
-        chunks[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK].set(PaintableData {
+        chunks[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK] = PaintableData {
             slot_generation: layout_node.generation(),
             ..PaintableData::default()
-        });
+        };
         side_data[index] = PaintableSideData::default();
         paint_caches[index].clear();
         absolute_rect_memo[index] = None;
     }
 
-    fn reset_paintable_row(&self, clear_caches_along_paint_chain: bool, reset: PaintableRowReset) {
+    fn reset_paintable_row(&mut self, clear_caches_along_paint_chain: bool, reset: PaintableRowReset) {
         let id = reset.slot;
         if clear_caches_along_paint_chain {
             self.clear_descendant_subtree_caches_along_paint_chain(id);
         }
         self.clear_absolute_rect_memo();
-        let store = &self.paintable_rows;
+        let store = &mut self.paintable_rows;
         let index = id.slot_index() as usize;
-        store.chunks.borrow()[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK]
-            .set(PaintableData::default());
+        store.chunks[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK] =
+            PaintableData::default();
         store.side_data.borrow_mut()[index] = PaintableSideData::default();
         store.paint_caches.borrow()[index].clear();
     }
@@ -280,7 +543,7 @@ impl LayoutNodeArena {
         ))
     }
 
-    pub(crate) fn paintable_row_freed(&self, reset: PaintableRowReset) {
+    pub(crate) fn paintable_row_freed(&mut self, reset: PaintableRowReset) {
         self.reset_paintable_row(false, reset);
     }
 
@@ -289,61 +552,21 @@ impl LayoutNodeArena {
             .then(|| self.prepare_paintable_row_reset(layout_node, PaintableRowResetKind::Cleared))
     }
 
-    pub(crate) fn paintable_row_cleared(&self, reset: PaintableRowReset) {
+    pub(crate) fn paintable_row_cleared(&mut self, reset: PaintableRowReset) {
         self.reset_paintable_row(true, reset);
     }
 
     pub(crate) fn paintable_row_is_populated(&self, id: NodeSlotId) -> bool {
-        if id.is_invalid() {
-            return false;
-        }
-        let index = id.slot_index() as usize;
-        if index >= self.paintable_row_count() {
-            return false;
-        }
-        let generation = self.paintable_data_by_index(index as u32).slot_generation;
-        generation != 0 && generation == id.generation()
+        self.paintable_rows().paintable_row_is_populated(id)
     }
 
-    fn paintable_data_by_index(&self, index: u32) -> PaintableData {
-        let chunks = self.paintable_rows.chunks.borrow();
-        let chunk = chunks
+    fn paintable_data_by_index(&self, index: u32) -> &PaintableData {
+        let chunk = self
+            .paintable_rows
+            .chunks
             .get(index as usize / PAINTABLE_SLOTS_PER_CHUNK)
             .expect("invalid paintable arena slot index");
-        chunk.slots[index as usize % PAINTABLE_SLOTS_PER_CHUNK].get()
-    }
-
-    fn with_paintable_data_cell<R>(&self, id: NodeSlotId, read: impl FnOnce(&Cell<PaintableData>) -> R) -> R {
-        assert!(!id.is_invalid(), "invalid paintable arena slot ID");
-        let index = id.slot_index() as usize;
-        let chunks = self.paintable_rows.chunks.borrow();
-        let chunk = chunks
-            .get(index / PAINTABLE_SLOTS_PER_CHUNK)
-            .expect("invalid paintable arena slot ID");
-        let cell = &chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK];
-        assert_eq!(
-            cell.get().slot_generation,
-            id.generation(),
-            "paintable arena read a stale or unused slot"
-        );
-        read(cell)
-    }
-
-    pub(crate) fn paintable_data_ptr(&self, id: NodeSlotId) -> *mut PaintableData {
-        self.with_paintable_data_cell(id, Cell::as_ptr)
-    }
-
-    pub(crate) fn paintable_data(&self, id: NodeSlotId) -> PaintableData {
-        self.with_paintable_data_cell(id, Cell::get)
-    }
-
-    pub(crate) fn update_paintable_data<R>(&self, id: NodeSlotId, callback: impl FnOnce(&mut PaintableData) -> R) -> R {
-        self.with_paintable_data_cell(id, |cell| {
-            let mut data = cell.get();
-            let result = callback(&mut data);
-            cell.set(data);
-            result
-        })
+        &chunk.slots[index as usize % PAINTABLE_SLOTS_PER_CHUNK]
     }
 
     pub(crate) fn paintable_paint_cache(&self, id: NodeSlotId) -> Ref<'_, PaintCache> {
@@ -360,104 +583,25 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn invalidate_paint_cache(&self, id: NodeSlotId) {
-        if !self.paintable_row_is_populated(id) {
-            return;
-        }
-        self.paintable_paint_cache(id).clear();
-        let mut ancestor = crate::painting::paint_order::paint_parent(self, id);
-        while let Some(current) = ancestor {
-            self.paintable_paint_cache(current).clear_descendant_subtrees();
-            ancestor = crate::painting::paint_order::paint_parent(self, current);
-        }
+        self.paintable_rows().invalidate_paint_cache(id);
     }
 
     pub(crate) fn clear_descendant_subtree_caches_along_paint_chain(&self, id: NodeSlotId) {
-        if !self.paintable_row_is_populated(id) {
-            return;
-        }
-        let mut current = Some(id);
-        while let Some(slot) = current {
-            self.paintable_paint_cache(slot).clear_descendant_subtrees();
-            current = crate::painting::paint_order::paint_parent(self, slot);
-        }
+        self.paintable_rows()
+            .clear_descendant_subtree_caches_along_paint_chain(id);
     }
 
-    pub(crate) fn clear_descendant_subtree_caches_from_layout_node(&self, mut node: NodeSlotId) {
-        loop {
-            if self.paintable_row_is_populated(node) {
-                self.clear_descendant_subtree_caches_along_paint_chain(node);
-                return;
-            }
-            if !crate::painting::fragment_ownership::node_is_fragmented_inline(self, node) {
-                return;
-            }
-            let Some(parent) = self.node_parent_if_live(node) else {
-                return;
-            };
-            node = parent;
-        }
+    pub(crate) fn clear_descendant_subtree_caches_from_layout_node(&self, node: NodeSlotId) {
+        self.paintable_rows()
+            .clear_descendant_subtree_caches_from_layout_node(node);
     }
 
     pub(crate) fn invalidate_for_repaint(&self, id: NodeSlotId) {
-        if !self.paintable_row_is_populated(id) {
-            return;
-        }
-        self.invalidate_paint_cache(id);
-        let mut stack = vec![id];
-        while let Some(current) = stack.pop() {
-            let mut child = crate::painting::paint_order::first_paint_child(self, current);
-            while let Some(child_slot) = child {
-                let child_flags = self.node_flags_if_live(child_slot);
-                if child_flags & NodeFlag::Anonymous as u32 != 0 {
-                    self.paintable_paint_cache(child_slot).clear();
-                    stack.push(child_slot);
-                }
-                child = crate::painting::paint_order::next_paint_sibling(self, child_slot);
-            }
-        }
-        if self.paintable_data(id).kind == PaintableKind::InlinePaintable {
-            let mut ancestor = crate::painting::paint_order::paint_parent(self, id);
-            while let Some(current) = ancestor {
-                self.invalidate_paint_cache(current);
-                if self.paintable_data(current).kind.has_lines() {
-                    break;
-                }
-                ancestor = crate::painting::paint_order::paint_parent(self, current);
-            }
-        }
+        self.paintable_rows().invalidate_for_repaint(id);
     }
 
     pub(crate) fn invalidate_propagated_text_decoration_caches(&self, root: NodeSlotId) {
-        if !self.paintable_row_is_populated(root) {
-            return;
-        }
-
-        let mut stack = Vec::new();
-        if let Some(first_child) = crate::painting::paint_order::first_paint_child(self, root) {
-            stack.push(first_child);
-        }
-        while let Some(current) = stack.pop() {
-            if let Some(next_sibling) = crate::painting::paint_order::next_paint_sibling(self, current) {
-                stack.push(next_sibling);
-            }
-
-            let data = self.paintable_data(current);
-            if crate::painting::style_queries::is_text_decoration_propagation_boundary(self, current) {
-                continue;
-            }
-            // Only fragment-painting paintables record propagated decorations.
-            if data.kind.has_lines() || data.kind == PaintableKind::InlinePaintable {
-                self.paintable_paint_cache(current).clear();
-            }
-            if let Some(first_child) = crate::painting::paint_order::first_paint_child(self, current) {
-                stack.push(first_child);
-            }
-        }
-        let mut ancestor = Some(root);
-        while let Some(current) = ancestor {
-            self.paintable_paint_cache(current).clear_descendant_subtrees();
-            ancestor = crate::painting::paint_order::paint_parent(self, current);
-        }
+        self.paintable_rows().invalidate_propagated_text_decoration_caches(root);
     }
 
     pub(crate) fn paintable_side_data(&self, id: NodeSlotId) -> Ref<'_, PaintableSideData> {
@@ -472,26 +616,5 @@ impl LayoutNodeArena {
         RefMut::map(self.paintable_rows.side_data.borrow_mut(), |side_data| {
             &mut side_data[id.slot_index() as usize]
         })
-    }
-
-    pub(crate) fn prepare_paintable_row_recommit_notification(&self, id: NodeSlotId) -> PaintableRowReset {
-        assert!(self.paintable_row_is_populated(id));
-        self.prepare_paintable_row_reset(id, PaintableRowResetKind::Recommitted)
-    }
-
-    pub(crate) fn begin_paintable_row_recommit(&self, id: NodeSlotId) {
-        self.update_paintable_data(id, |data| {
-            data.offset = FfiCssPixelPoint::default();
-            data.content_size = FfiCssPixelSize::default();
-            data.overflow = FfiOverflowData::default();
-            data.has_overflow = false;
-            data.sticky_insets = FfiStickyInsets::default();
-            data.has_sticky_insets = false;
-            data.local_padding_box_union = FfiCssPixelRect::default();
-            data.local_border_box_union = FfiCssPixelRect::default();
-            data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;
-        });
-        self.paintable_paint_cache(id).clear();
-        self.paintable_side_data_mut(id).clear_committed_records();
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -162,7 +162,7 @@ impl<'a> PaintRecorder<'a> {
             return;
         }
 
-        if fragment_ownership::is_self_painting_inline(&self.data(paintable)) {
+        if fragment_ownership::is_self_painting_inline(self.data(paintable)) {
             let Some(root) = self.inline_root(paintable) else {
                 return;
             };
@@ -422,7 +422,7 @@ impl<'a> PaintRecorder<'a> {
             };
         let can_produce_caret_position = (self.is_atomic_inline(target) || self.is_replaced_box(target)) && {
             let negative_z =
-                crate::painting::style_queries::effective_z_index(self.layout_arena, &self.data(target), target)
+                crate::painting::style_queries::effective_z_index(self.layout_arena, self.data(target), target)
                     .unwrap_or(0)
                     < 0;
             let target_node = target;

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -12,7 +12,6 @@ pub mod paint;
 pub mod traversal;
 
 use crate::css::css_enums;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::border_radii::BorderRadii;
@@ -24,6 +23,7 @@ use crate::painting::host::{
     FfiRecordingInputs, FfiVisualContextHostCallbacks,
 };
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
+use crate::painting::paintable_rows::PaintableRowsRef;
 use crate::painting::stacking_context::{NO_STACKING_CONTEXT, StackingContextTree};
 use crate::painting::visual_context::nested::NestedAssignments;
 use std::collections::HashMap;
@@ -59,7 +59,7 @@ pub(crate) struct NestedRecordingState {
 }
 
 pub struct PaintRecorder<'a> {
-    pub(crate) layout_arena: &'a LayoutNodeArena,
+    pub(crate) layout_arena: &'a PaintableRowsRef<'a>,
     pub(crate) paint_state: &'a crate::painting::paint_state::PaintState,
     stacking_contexts: &'a StackingContextTree,
     pub(crate) host: &'a FfiHitTestHostCallbacks,
@@ -106,7 +106,7 @@ impl<'a> PaintRecorder<'a> {
             .expect("uncacheable paint generation overflowed");
     }
 
-    pub(crate) fn data(&self, paintable: NodeSlotId) -> PaintableData {
+    pub(crate) fn data(&self, paintable: NodeSlotId) -> &PaintableData {
         self.layout_arena.paintable_data(paintable)
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -30,7 +30,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
     let piece_indices = &layout_arena.paintable_side_data(paintable).piece_indices;
     let root_pieces = &layout_arena.paintable_side_data(root).inline_box_pieces;
     let facts = recorder.base_paint_facts(paintable);
-    let data = recorder.data(paintable);
+    let self_painting_inline = crate::painting::fragment_ownership::is_self_painting_inline(recorder.data(paintable));
 
     if phase == PaintPhase::Background && facts.is_visible {
         crate::painting::record::paint::paint_backdrop_filter(recorder, paintable, &facts);
@@ -184,7 +184,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
         // Fragments (and the caret between their glyphs) are not gated on this box being
         // visible: descendants may set visibility: visible again under a hidden box, so each
         // fragment is filtered by its own node's visibility.
-        if crate::painting::fragment_ownership::is_self_painting_inline(&data) {
+        if self_painting_inline {
             text::paint_fragments_foreground(recorder, root, Some(paintable));
             text::paint_cursor(recorder, root, Some(paintable));
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -85,8 +85,9 @@ pub(crate) fn record_display_list(
         .filter(|source| source.compatible_visual_context_tree_version == visual_context_tree_version);
     let item_cache_source =
         item_cache_source.filter(|source| source.visual_context_tree_version == visual_context_tree_version);
+    let paintable_rows = layout_arena.paintable_rows();
     let mut recorder = PaintRecorder {
-        layout_arena,
+        layout_arena: &paintable_rows,
         paint_state,
         stacking_contexts,
         host,
@@ -405,6 +406,7 @@ impl PaintRecorder<'_> {
         let floating = child_data.has_flag(PaintableFlag::Floating);
         let inline = child_data.has_flag(PaintableFlag::Inline);
         let child_kind = child_data.kind;
+        let is_item = child_data.has_flag(PaintableFlag::FlexOrGridItem);
 
         // Positioned descendants at stack level 0 are painted in a separate pass.
         if positioned && self.z_index(child).unwrap_or(0) == 0 {
@@ -416,7 +418,6 @@ impl PaintRecorder<'_> {
             return;
         }
 
-        let is_item = child_data.has_flag(PaintableFlag::FlexOrGridItem);
         // NOTE: Flex and grid items should be treated the same way as CSS2 defines for inline-blocks:
         //       - https://drafts.csswg.org/css-flexbox-1/#painting
         //       - https://www.w3.org/TR/css-grid-2/#z-order

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -11,13 +11,14 @@ use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::painting::host::{FfiScrollableOverflowHostCallbacks, FfiVisualContextHostCallbacks};
 use crate::painting::paintable_data::FfiOverflowData;
+use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
 use crate::painting::visual_context::node_values;
 use crate::painting::{paintable_geometry, style_queries, text_fragment};
 use libgfx_rust::matrix::{AffineTransform, FloatMatrix4x4};
 use std::collections::HashMap;
 
 pub(crate) fn refill_contained_boxes_index(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     root: NodeSlotId,
     contained_boxes_by_containing_block: &mut HashMap<NodeSlotId, Vec<NodeSlotId>>,
 ) {
@@ -186,7 +187,7 @@ fn affine_map_float_rect(affine: &AffineTransform, rect: FloatRectEdges) -> Floa
 }
 
 fn apply_css_transform_to_scrollable_overflow_rect(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     visual_context_callbacks: &FfiVisualContextHostCallbacks,
     box_paintable: NodeSlotId,
     rect: CssPixelRect,
@@ -220,7 +221,7 @@ fn apply_css_transform_to_scrollable_overflow_rect(
 }
 
 fn padding_inflated_scrollable_overflow(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     box_paintable: NodeSlotId,
     box_node: NodeSlotId,
     in_flow_and_floated_content_bounds: CssPixelRect,
@@ -274,49 +275,100 @@ fn fragment_node_is_in_focused_text_control(
     overflow_callbacks.layout_node_is_in_focused_text_control(shell)
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct OverflowAssignment {
+    box_paintable: NodeSlotId,
+    overflow: FfiOverflowData,
+    cached_overflow: Option<FfiOverflowData>,
+}
+
+impl OverflowAssignment {
+    pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
+        let data = layout_arena.paintable_data_mut(self.box_paintable);
+        data.overflow = self.overflow;
+        data.has_overflow = true;
+        if let Some(cached_overflow) = self.cached_overflow {
+            data.cached_overflow = cached_overflow;
+            data.has_cached_overflow = true;
+        }
+    }
+}
+
+fn store_overflow_data(
+    assignments: &mut [Option<OverflowAssignment>],
+    box_paintable: NodeSlotId,
+    paintable_absolute_padding_box: CssPixelRect,
+    scrollable_overflow_rect: CssPixelRect,
+    has_scrollable_overflow: bool,
+) {
+    let rect_relative_to_padding_box =
+        scrollable_overflow_rect.translated(-paintable_absolute_padding_box.x, -paintable_absolute_padding_box.y);
+    assignments[box_paintable.slot_index() as usize] = Some(OverflowAssignment {
+        box_paintable,
+        overflow: FfiOverflowData {
+            rect: scrollable_overflow_rect.into(),
+            has_scrollable_overflow,
+        },
+        cached_overflow: Some(FfiOverflowData {
+            rect: rect_relative_to_padding_box.into(),
+            has_scrollable_overflow,
+        }),
+    });
+}
+
 // https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-calculation
 pub(crate) fn measure_scrollable_overflow(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     contained_boxes_by_containing_block: &HashMap<NodeSlotId, Vec<NodeSlotId>>,
     visual_context_callbacks: &FfiVisualContextHostCallbacks,
     overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
     box_paintable: NodeSlotId,
+) -> Vec<OverflowAssignment> {
+    let mut assignments = vec![None; layout_arena.paintable_row_count()];
+    measure_scrollable_overflow_impl(
+        layout_arena,
+        contained_boxes_by_containing_block,
+        visual_context_callbacks,
+        overflow_callbacks,
+        box_paintable,
+        &mut assignments,
+    );
+    assignments.into_iter().flatten().collect()
+}
+
+fn measure_scrollable_overflow_impl(
+    layout_arena: &impl PaintableRowsRead,
+    contained_boxes_by_containing_block: &HashMap<NodeSlotId, Vec<NodeSlotId>>,
+    visual_context_callbacks: &FfiVisualContextHostCallbacks,
+    overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
+    box_paintable: NodeSlotId,
+    assignments: &mut [Option<OverflowAssignment>],
 ) -> CssPixelRect {
-    let data = layout_arena.paintable_data(box_paintable);
-    if data.has_overflow {
-        return data.overflow.rect.into();
+    if let Some(assignment) = assignments[box_paintable.slot_index() as usize] {
+        return assignment.overflow.rect.into();
     }
+    let (kind, cached_overflow) = {
+        let data = layout_arena.paintable_data(box_paintable);
+        if data.has_overflow {
+            return data.overflow.rect.into();
+        }
+        (data.kind, data.has_cached_overflow.then_some(data.cached_overflow))
+    };
 
     let box_node = box_paintable;
     let paintable_absolute_padding_box = paintable_geometry::absolute_padding_box_rect(layout_arena, box_paintable);
     let paintable_absolute_content_box = paintable_geometry::absolute_rect(layout_arena, box_paintable);
 
-    let store_overflow_data = |scrollable_overflow_rect: CssPixelRect, has_scrollable_overflow: bool| {
-        let rect_relative_to_padding_box =
-            scrollable_overflow_rect.translated(-paintable_absolute_padding_box.x, -paintable_absolute_padding_box.y);
-        layout_arena.update_paintable_data(box_paintable, |data| {
-            data.overflow = FfiOverflowData {
-                rect: scrollable_overflow_rect.into(),
-                has_scrollable_overflow,
-            };
-            data.has_overflow = true;
-            data.cached_overflow = FfiOverflowData {
-                rect: rect_relative_to_padding_box.into(),
-                has_scrollable_overflow,
-            };
-            data.has_cached_overflow = true;
-        });
-    };
-
-    if data.has_cached_overflow {
+    if let Some(cached_overflow) = cached_overflow {
         let scrollable_overflow_rect =
-            CssPixelRect::from(data.cached_overflow.rect).translated_by(paintable_absolute_padding_box.location());
-        layout_arena.update_paintable_data(box_paintable, |data| {
-            data.overflow = FfiOverflowData {
+            CssPixelRect::from(cached_overflow.rect).translated_by(paintable_absolute_padding_box.location());
+        assignments[box_paintable.slot_index() as usize] = Some(OverflowAssignment {
+            box_paintable,
+            overflow: FfiOverflowData {
                 rect: scrollable_overflow_rect.into(),
-                has_scrollable_overflow: data.cached_overflow.has_scrollable_overflow,
-            };
-            data.has_overflow = true;
+                has_scrollable_overflow: cached_overflow.has_scrollable_overflow,
+            },
+            cached_overflow: None,
         });
         return scrollable_overflow_rect;
     }
@@ -329,14 +381,20 @@ pub(crate) fn measure_scrollable_overflow(
 
     // Replaced SVG viewports clip their content
     if layout_arena.node_kind_if_live(box_node) == Some(NodeKind::SVGSVGBox) {
-        store_overflow_data(scrollable_overflow_rect, false);
+        store_overflow_data(
+            assignments,
+            box_paintable,
+            paintable_absolute_padding_box,
+            scrollable_overflow_rect,
+            false,
+        );
         return scrollable_overflow_rect;
     }
 
     let overflow_directions = physical_overflow_directions(layout_arena, box_node);
 
     // - All line boxes it directly contains.
-    if data.kind.has_lines() {
+    if kind.has_lines() {
         for fragment in &layout_arena.paintable_side_data(box_paintable).fragments {
             let mut fragment_rect = text_fragment::absolute_rect(layout_arena, fragment);
             if fragment_node_is_in_focused_text_control(layout_arena, overflow_callbacks, fragment.layout_node)
@@ -387,33 +445,35 @@ pub(crate) fn measure_scrollable_overflow(
                 continue;
             }
 
-            let child_data = layout_arena.paintable_data(child_node);
             let child_has_css_transform =
                 child_style.is_some_and(|style| style_queries::has_css_transform(layout_arena, child_node, style));
             let child_is_flex_item = layout_arena.node_flags_if_live(child_node) & NodeFlag::IsFlexItem as u32 != 0;
             let child_is_floating = !child_is_flex_item && child_style.is_some_and(|style| style.is_floating());
             let child_display = child_style.map_or_else(FfiDisplay::block, |style| style.display());
 
-            if child_position == positioning::STATIC
-                && child_display.is_inline_outside()
-                && !child_is_floating
-                && !child_has_css_transform
-                && child_data.has_cached_overflow
             {
-                let border = crate::painting::paintable_geometry::committed_border(layout_arena, child_node);
-                let zero = CssPixels::from_raw(0);
-                let has_border =
-                    border.top != zero || border.right != zero || border.bottom != zero || border.left != zero;
-                if !has_border {
-                    let padding = crate::painting::paintable_geometry::committed_padding(layout_arena, child_node);
-                    let content_size =
-                        crate::painting::paintable_geometry::committed_content_size(layout_arena, child_node);
-                    let content_box_relative_to_padding_box =
-                        CssPixelRect::new(padding.left, padding.top, content_size.width, content_size.height);
-                    // The committed line fragment already contributes this content box. A box with no border whose
-                    // cached overflow fits inside the content box cannot expand its containing block's overflow.
-                    if content_box_relative_to_padding_box.contains_rect(child_data.cached_overflow.rect.into()) {
-                        continue;
+                let child_data = layout_arena.paintable_data(child_node);
+                if child_position == positioning::STATIC
+                    && child_display.is_inline_outside()
+                    && !child_is_floating
+                    && !child_has_css_transform
+                    && child_data.has_cached_overflow
+                {
+                    let border = crate::painting::paintable_geometry::committed_border(layout_arena, child_node);
+                    let zero = CssPixels::from_raw(0);
+                    let has_border =
+                        border.top != zero || border.right != zero || border.bottom != zero || border.left != zero;
+                    if !has_border {
+                        let padding = crate::painting::paintable_geometry::committed_padding(layout_arena, child_node);
+                        let content_size =
+                            crate::painting::paintable_geometry::committed_content_size(layout_arena, child_node);
+                        let content_box_relative_to_padding_box =
+                            CssPixelRect::new(padding.left, padding.top, content_size.width, content_size.height);
+                        // The committed line fragment already contributes this content box. A box with no border whose
+                        // cached overflow fits inside the content box cannot expand its containing block's overflow.
+                        if content_box_relative_to_padding_box.contains_rect(child_data.cached_overflow.rect.into()) {
+                            continue;
+                        }
                     }
                 }
             }
@@ -468,17 +528,19 @@ pub(crate) fn measure_scrollable_overflow(
             let child_overflow_x = child_style.map_or(overflow::VISIBLE, |style| style.overflow_x());
             let child_overflow_y = child_style.map_or(overflow::VISIBLE, |style| style.overflow_y());
             if child_overflow_x == overflow::VISIBLE || child_overflow_y == overflow::VISIBLE {
+                let untransformed_child_scrollable_overflow = measure_scrollable_overflow_impl(
+                    layout_arena,
+                    contained_boxes_by_containing_block,
+                    visual_context_callbacks,
+                    overflow_callbacks,
+                    child_node,
+                    assignments,
+                );
                 let child_scrollable_overflow = apply_css_transform_to_scrollable_overflow_rect(
                     layout_arena,
                     visual_context_callbacks,
                     child_node,
-                    measure_scrollable_overflow(
-                        layout_arena,
-                        contained_boxes_by_containing_block,
-                        visual_context_callbacks,
-                        overflow_callbacks,
-                        child_node,
-                    ),
+                    untransformed_child_scrollable_overflow,
                     child_has_css_transform,
                 );
                 if !child_scrollable_overflow.is_empty() {
@@ -560,7 +622,13 @@ pub(crate) fn measure_scrollable_overflow(
             !paintable_absolute_padding_box.contains_rect(scrollable_overflow_rect) && box_is_scroll_container;
     }
 
-    store_overflow_data(scrollable_overflow_rect, has_scrollable_overflow);
+    store_overflow_data(
+        assignments,
+        box_paintable,
+        paintable_absolute_padding_box,
+        scrollable_overflow_rect,
+        has_scrollable_overflow,
+    );
 
     scrollable_overflow_rect
 }

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -295,7 +295,7 @@ impl OverflowAssignment {
 }
 
 fn store_overflow_data(
-    assignments: &mut [Option<OverflowAssignment>],
+    assignments: &mut Vec<OverflowAssignment>,
     box_paintable: NodeSlotId,
     paintable_absolute_padding_box: CssPixelRect,
     scrollable_overflow_rect: CssPixelRect,
@@ -303,7 +303,7 @@ fn store_overflow_data(
 ) {
     let rect_relative_to_padding_box =
         scrollable_overflow_rect.translated(-paintable_absolute_padding_box.x, -paintable_absolute_padding_box.y);
-    assignments[box_paintable.slot_index() as usize] = Some(OverflowAssignment {
+    assignments.push(OverflowAssignment {
         box_paintable,
         overflow: FfiOverflowData {
             rect: scrollable_overflow_rect.into(),
@@ -324,7 +324,9 @@ pub(crate) fn measure_scrollable_overflow(
     overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
     box_paintable: NodeSlotId,
 ) -> Vec<OverflowAssignment> {
-    let mut assignments = vec![None; layout_arena.paintable_row_count()];
+    // Each box occurs under only one containing block, so this traversal visits each box at most once and can stage
+    // assignments append-only.
+    let mut assignments = Vec::new();
     measure_scrollable_overflow_impl(
         layout_arena,
         contained_boxes_by_containing_block,
@@ -333,7 +335,7 @@ pub(crate) fn measure_scrollable_overflow(
         box_paintable,
         &mut assignments,
     );
-    assignments.into_iter().flatten().collect()
+    assignments
 }
 
 fn measure_scrollable_overflow_impl(
@@ -342,11 +344,8 @@ fn measure_scrollable_overflow_impl(
     visual_context_callbacks: &FfiVisualContextHostCallbacks,
     overflow_callbacks: &FfiScrollableOverflowHostCallbacks,
     box_paintable: NodeSlotId,
-    assignments: &mut [Option<OverflowAssignment>],
+    assignments: &mut Vec<OverflowAssignment>,
 ) -> CssPixelRect {
-    if let Some(assignment) = assignments[box_paintable.slot_index() as usize] {
-        return assignment.overflow.rect.into();
-    }
     let (kind, cached_overflow) = {
         let data = layout_arena.paintable_data(box_paintable);
         if data.has_overflow {
@@ -362,7 +361,7 @@ fn measure_scrollable_overflow_impl(
     if let Some(cached_overflow) = cached_overflow {
         let scrollable_overflow_rect =
             CssPixelRect::from(cached_overflow.rect).translated_by(paintable_absolute_padding_box.location());
-        assignments[box_paintable.slot_index() as usize] = Some(OverflowAssignment {
+        assignments.push(OverflowAssignment {
             box_paintable,
             overflow: FfiOverflowData {
                 rect: scrollable_overflow_rect.into(),

--- a/Libraries/LibWeb/Rust/src/painting/selection.rs
+++ b/Libraries/LibWeb/Rust/src/painting/selection.rs
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::fragment_ownership;
 use crate::painting::paintable_data::{FfiSelectionEntry, SELECTION_STATE_NONE};
+use crate::painting::paintable_rows::PaintableRowsMut;
 use crate::painting::text_fragment;
 
 #[derive(Clone, Copy, Debug)]
@@ -16,7 +16,7 @@ pub(crate) struct SelectionRange {
     pub end_offset: usize,
 }
 
-fn invalidate_block_and_ancestors(layout_arena: &LayoutNodeArena, block: NodeSlotId) {
+fn invalidate_block_and_ancestors(layout_arena: &PaintableRowsMut<'_>, block: NodeSlotId) {
     let mut current = Some(block);
     while let Some(slot) = current {
         layout_arena.invalidate_paint_cache(slot);
@@ -24,20 +24,20 @@ fn invalidate_block_and_ancestors(layout_arena: &LayoutNodeArena, block: NodeSlo
     }
 }
 
-fn invalidate_self_painting_inline_box(layout_arena: &LayoutNodeArena, node: NodeSlotId) {
+fn invalidate_self_painting_inline_box(layout_arena: &PaintableRowsMut<'_>, node: NodeSlotId) {
     if let Some(inline_box) = fragment_ownership::nearest_self_painting_inline_box(layout_arena, node) {
         layout_arena.invalidate_paint_cache(inline_box);
     }
 }
 
-fn reset_states(layout_arena: &LayoutNodeArena, viewport: NodeSlotId) {
+fn reset_states(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
     let mut slots = Vec::new();
     crate::painting::paint_order::for_each_in_paint_subtree(layout_arena, viewport, |slot| {
         slots.push(slot);
     });
     for current in slots {
         if layout_arena.paintable_data(current).selection_state != SELECTION_STATE_NONE {
-            layout_arena.update_paintable_data(current, |data| data.selection_state = SELECTION_STATE_NONE);
+            layout_arena.paintable_data_mut(current).selection_state = SELECTION_STATE_NONE;
             layout_arena.invalidate_paint_cache(current);
         }
         let mut changed_fragment_nodes: Vec<NodeSlotId> = Vec::new();
@@ -56,7 +56,7 @@ fn reset_states(layout_arena: &LayoutNodeArena, viewport: NodeSlotId) {
     }
 }
 
-pub(crate) fn apply(layout_arena: &LayoutNodeArena, viewport: NodeSlotId, entries: &[FfiSelectionEntry]) {
+pub(crate) fn apply(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId, entries: &[FfiSelectionEntry]) {
     reset_states(layout_arena, viewport);
     for entry in entries {
         if entry.is_text_node_entry {
@@ -79,13 +79,13 @@ pub(crate) fn apply(layout_arena: &LayoutNodeArena, viewport: NodeSlotId, entrie
                 continue;
             }
             if layout_arena.paintable_data(entry.layout_node).selection_state != entry.state {
-                layout_arena.update_paintable_data(entry.layout_node, |data| data.selection_state = entry.state);
+                layout_arena.paintable_data_mut(entry.layout_node).selection_state = entry.state;
                 layout_arena.invalidate_paint_cache(entry.layout_node);
             }
         }
     }
 }
 
-pub(crate) fn clear(layout_arena: &LayoutNodeArena, viewport: NodeSlotId) {
+pub(crate) fn clear(layout_arena: &mut PaintableRowsMut<'_>, viewport: NodeSlotId) {
     reset_states(layout_arena, viewport);
 }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context.rs
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::*;
+use crate::painting::paintable_rows::PaintableRowsWrite;
 use crate::painting::style_queries::effective_z_index;
 
 pub use crate::painting::paintable_data::NO_STACKING_CONTEXT;
@@ -27,19 +27,22 @@ pub struct StackingContextTree {
     pub nodes: Vec<StackingContextNode>,
 }
 
-pub(crate) fn build_stacking_context_tree(layout_arena: &LayoutNodeArena, root: NodeSlotId) -> StackingContextTree {
+pub(crate) fn build_stacking_context_tree(
+    layout_arena: &mut impl PaintableRowsWrite,
+    root: NodeSlotId,
+) -> StackingContextTree {
     let mut tree = StackingContextTree::default();
     tree.nodes.push(StackingContextNode {
         paintable: root,
         parent: NO_STACKING_CONTEXT,
         children: Vec::new(),
         index_in_tree_order: 0,
-        effective_z_index: effective_z_index(layout_arena, &layout_arena.paintable_data(root), root),
+        effective_z_index: effective_z_index(layout_arena, layout_arena.paintable_data(root), root),
         positioned_descendants_and_stacking_contexts_with_stack_level_0: Vec::new(),
         non_positioned_floating_descendants: Vec::new(),
         contains_inline_or_replaced_descendants: false,
     });
-    layout_arena.update_paintable_data(root, |data| data.stacking_context = 0);
+    layout_arena.paintable_data_mut(root).stacking_context = 0;
 
     let mut index_in_tree_order = 1;
     let mut stack: Vec<NodeSlotId> = Vec::new();
@@ -63,12 +66,11 @@ pub(crate) fn build_stacking_context_tree(layout_arena: &LayoutNodeArena, root: 
 }
 
 fn visit(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &mut impl PaintableRowsWrite,
     tree: &mut StackingContextTree,
     paintable: NodeSlotId,
     index_in_tree_order: &mut usize,
 ) {
-    let data = layout_arena.paintable_data(paintable);
     let mut ancestor = crate::painting::paint_order::paint_parent(layout_arena, paintable);
     let mut parent_context = NO_STACKING_CONTEXT;
     while let Some(candidate) = ancestor {
@@ -87,8 +89,15 @@ fn visit(
 
     let establishes_stacking_context =
         crate::painting::style_queries::establishes_stacking_context(layout_arena, paintable);
-    let z_index = effective_z_index(layout_arena, &data, paintable);
-    let positioned = data.has_flag(PaintableFlag::Positioned);
+    let (z_index, positioned, floating, inline) = {
+        let data = layout_arena.paintable_data(paintable);
+        (
+            effective_z_index(layout_arena, data, paintable),
+            data.has_flag(PaintableFlag::Positioned),
+            data.has_flag(PaintableFlag::Floating),
+            data.has_flag(PaintableFlag::Inline),
+        )
+    };
     {
         let parent = &mut tree.nodes[parent_context as usize];
         if (positioned || establishes_stacking_context) && z_index.unwrap_or(0) == 0 {
@@ -96,18 +105,16 @@ fn visit(
                 .positioned_descendants_and_stacking_contexts_with_stack_level_0
                 .push(paintable);
         }
-        if !positioned && data.has_flag(PaintableFlag::Floating) {
+        if !positioned && floating {
             parent.non_positioned_floating_descendants.push(paintable);
         }
         let layout_kind = layout_arena.node_kind_if_live(paintable);
-        if !establishes_stacking_context
-            && (data.has_flag(PaintableFlag::Inline) || layout_kind.is_some_and(crate::layout::kind_is_replaced_box))
-        {
+        if !establishes_stacking_context && (inline || layout_kind.is_some_and(crate::layout::kind_is_replaced_box)) {
             parent.contains_inline_or_replaced_descendants = true;
         }
     }
     if !establishes_stacking_context {
-        layout_arena.update_paintable_data(paintable, |data| data.stacking_context = NO_STACKING_CONTEXT);
+        layout_arena.paintable_data_mut(paintable).stacking_context = NO_STACKING_CONTEXT;
         return;
     }
     let index = tree.nodes.len() as u32;
@@ -123,7 +130,7 @@ fn visit(
     });
     *index_in_tree_order += 1;
     tree.nodes[parent_context as usize].children.push(index);
-    layout_arena.update_paintable_data(paintable, |data| data.stacking_context = index);
+    layout_arena.paintable_data_mut(paintable).stacking_context = index;
 }
 
 fn sort(tree: &mut StackingContextTree, index: u32) {

--- a/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
@@ -6,13 +6,13 @@
 
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::FragmentRecord;
 use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
 
 pub(crate) fn containing_block_paintable_of_node(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     node: NodeSlotId,
 ) -> Option<NodeSlotId> {
     if layout_arena.paintable_row_is_populated(node) {
@@ -24,13 +24,13 @@ pub(crate) fn containing_block_paintable_of_node(
 }
 
 pub(crate) fn containing_block_paintable(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
 ) -> Option<NodeSlotId> {
     containing_block_paintable_of_node(layout_arena, fragment.layout_node)
 }
 
-pub(crate) fn absolute_rect(layout_arena: &LayoutNodeArena, fragment: &FragmentRecord) -> CssPixelRect {
+pub(crate) fn absolute_rect(layout_arena: &impl PaintableRowsRead, fragment: &FragmentRecord) -> CssPixelRect {
     let mut rect = CssPixelRect::from_location_and_size(fragment.offset.into(), fragment.size.into());
     if let Some(block) = containing_block_paintable(layout_arena, fragment) {
         rect = rect.translated_by(paintable_geometry::absolute_position(layout_arena, block));
@@ -39,7 +39,7 @@ pub(crate) fn absolute_rect(layout_arena: &LayoutNodeArena, fragment: &FragmentR
 }
 
 pub(crate) fn absolute_line_box_rect(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     owner: NodeSlotId,
     fragment: &FragmentRecord,
 ) -> CssPixelRect {
@@ -77,7 +77,7 @@ pub struct SelectionOffsets {
 }
 
 pub(crate) fn range_rect(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     selection_state: u8,
     start_offset_in_code_units: usize,
@@ -98,7 +98,7 @@ pub(crate) fn range_rect(
 }
 
 pub(crate) fn compute_selection_offsets(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     selection_state: u8,
     start_offset_in_code_units: usize,
@@ -154,7 +154,7 @@ pub(crate) fn compute_selection_offsets(
 }
 
 pub(crate) fn for_each_fragment_of_nodes(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     node_slots: &[NodeSlotId],
     mut callback: impl FnMut(NodeSlotId, u32, &FragmentRecord) -> bool,
 ) {
@@ -193,7 +193,7 @@ pub(crate) fn caret_match(fragment: &FragmentRecord, offset: usize, affinity_is_
 }
 
 pub(crate) fn selection_offsets_for_dom_range(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     start_offset_in_code_units: usize,
     end_offset_in_code_units: usize,
@@ -250,7 +250,7 @@ fn for_each_cluster_in_glyph_run(
 }
 
 pub(crate) fn rect_for_selection_offsets(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     offsets: SelectionOffsets,
     first_available_font: impl FnOnce() -> Option<*const std::ffi::c_void>,
@@ -346,7 +346,7 @@ pub(crate) fn rect_for_selection_offsets(
 }
 
 pub(crate) fn whole_range_rect(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     first_available_font: impl FnOnce() -> Option<*const std::ffi::c_void>,
 ) -> CssPixelRect {
@@ -357,13 +357,13 @@ pub(crate) fn whole_range_rect(
     rect_for_selection_offsets(layout_arena, fragment, offsets, first_available_font)
 }
 
-pub(crate) fn is_block_level_box(layout_arena: &LayoutNodeArena, fragment: &FragmentRecord) -> bool {
+pub(crate) fn is_block_level_box(layout_arena: &impl PaintableRowsRead, fragment: &FragmentRecord) -> bool {
     layout_arena
         .node_style_if_live(fragment.layout_node)
         .is_some_and(|style| style.display().is_block_outside())
 }
 
-pub(crate) fn style_source(layout_arena: &LayoutNodeArena, fragment: &FragmentRecord) -> NodeSlotId {
+pub(crate) fn style_source(layout_arena: &impl PaintableRowsRead, fragment: &FragmentRecord) -> NodeSlotId {
     if layout_arena.node_style_if_live(fragment.layout_node).is_some() {
         return fragment.layout_node;
     }
@@ -373,7 +373,7 @@ pub(crate) fn style_source(layout_arena: &LayoutNodeArena, fragment: &FragmentRe
 }
 
 pub(crate) fn first_available_font(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
 ) -> Option<*const std::ffi::c_void> {
     let source = style_source(layout_arena, fragment);
@@ -424,7 +424,7 @@ impl GraphemeEdgeTracker {
 }
 
 pub(crate) fn index_in_node_for_point(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     fragment: &FragmentRecord,
     position: crate::css::css_pixels::CssPixelPoint,
 ) -> usize {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/basic_shapes.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/basic_shapes.rs
@@ -9,10 +9,10 @@ use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixelSize};
 use crate::css::serialize::{StringUnits, with_fly_string_units};
 use crate::css::style_value::{RetainedStyleValueData, StyleValueData};
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::border_radii::normalize_border_radii_data;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::{paintable_geometry, style_queries};
 use libgfx_rust::WindingRule;
 use libgfx_rust::path::{OwnedPath, PathBuilder};
@@ -437,7 +437,7 @@ fn svg_path_data_to_path(path_string: &crate::css::retained_fly_string::Retained
 }
 
 pub(crate) fn compute_basic_shape_clip_path_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
     pixel_ratio: f64,
 ) -> Option<(OwnedPath, libgfx_rust::IntRect, WindingRule, bool)> {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -7,22 +7,72 @@
 use super::refresh::precompute_sticky_constraints;
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
 use super::*;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::painting::host::FfiVisualContextHostCallbacks;
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
 use libgfx_rust::{
     AffineTransform, FloatPoint, IntRect, WindingRule, affine_to_matrix, scale_matrix_for_device_pixels,
     translated_then_multiplied,
 };
 use std::collections::HashSet;
 
+#[derive(Clone, Copy)]
+pub(crate) struct PaintableVisualContextAssignment {
+    slot: NodeSlotId,
+    enclosing_scroll_node_index: usize,
+    own_scroll_node_index: usize,
+    has_accumulated_visual_context: bool,
+    accumulated_visual_context_index: usize,
+    accumulated_visual_context_for_descendants_index: usize,
+    fixed_background_visual_context: usize,
+    has_fixed_background_visual_context: bool,
+    visual_context_nodes_begin: usize,
+    visual_context_nodes_end: usize,
+    has_non_invertible_css_transform: bool,
+}
+
+impl PaintableVisualContextAssignment {
+    fn from_data(slot: NodeSlotId, data: &PaintableData) -> Self {
+        Self {
+            slot,
+            enclosing_scroll_node_index: data.enclosing_scroll_node_index,
+            own_scroll_node_index: data.own_scroll_node_index,
+            has_accumulated_visual_context: data.has_accumulated_visual_context,
+            accumulated_visual_context_index: data.accumulated_visual_context_index,
+            accumulated_visual_context_for_descendants_index: data.accumulated_visual_context_for_descendants_index,
+            fixed_background_visual_context: data.fixed_background_visual_context,
+            has_fixed_background_visual_context: data.has_fixed_background_visual_context,
+            visual_context_nodes_begin: data.visual_context_nodes_begin,
+            visual_context_nodes_end: data.visual_context_nodes_end,
+            has_non_invertible_css_transform: data.has_flag(PaintableFlag::HasNonInvertibleCssTransform),
+        }
+    }
+
+    pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
+        let data = layout_arena.paintable_data_mut(self.slot);
+        data.enclosing_scroll_node_index = self.enclosing_scroll_node_index;
+        data.own_scroll_node_index = self.own_scroll_node_index;
+        data.has_accumulated_visual_context = self.has_accumulated_visual_context;
+        data.accumulated_visual_context_index = self.accumulated_visual_context_index;
+        data.accumulated_visual_context_for_descendants_index = self.accumulated_visual_context_for_descendants_index;
+        data.fixed_background_visual_context = self.fixed_background_visual_context;
+        data.has_fixed_background_visual_context = self.has_fixed_background_visual_context;
+        data.visual_context_nodes_begin = self.visual_context_nodes_begin;
+        data.visual_context_nodes_end = self.visual_context_nodes_end;
+        data.set_flag(
+            PaintableFlag::HasNonInvertibleCssTransform,
+            self.has_non_invertible_css_transform,
+        );
+    }
+}
+
 // Content below a viewport node records in the viewport's user units scaled by the device pixel
 // ratio, mirroring how ordinary content records in CSS pixels scaled by it; the node folds the
 // viewport box's position in its own recorded space together with the viewBox transform.
 pub(crate) fn compute_svg_viewport_transform_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
     viewbox_transform: AffineTransform,
     pixel_ratio: f64,
@@ -82,7 +132,7 @@ impl BoxFacts {
     }
 
     pub(crate) fn gather(
-        layout_arena: &LayoutNodeArena,
+        layout_arena: &impl PaintableRowsRead,
         callbacks: &FfiVisualContextHostCallbacks,
         slot: NodeSlotId,
         pixel_ratio: f64,
@@ -213,18 +263,35 @@ struct DescendantVisualContexts {
     sorting_context_root: Option<usize>,
 }
 
-struct Builder<'a> {
-    layout_arena: &'a LayoutNodeArena,
+struct Builder<'a, Arena> {
+    layout_arena: &'a Arena,
     callbacks: &'a FfiVisualContextHostCallbacks,
     tree: VisualContextTree,
     scroll_state: ScrollState,
     paintables_with_mask_nodes: Vec<NodeSlotId>,
+    assignments: Vec<Option<PaintableVisualContextAssignment>>,
     pixel_ratio: f64,
     root_background_source: crate::painting::host::FfiRootBackgroundSource,
     may_have_default_scroll_shift_anchor: bool,
 }
 
-impl Builder<'_> {
+impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
+    fn assignment_mut(&mut self, slot: NodeSlotId) -> &mut PaintableVisualContextAssignment {
+        let index = slot.slot_index() as usize;
+        if self.assignments[index].is_none() {
+            let assignment = PaintableVisualContextAssignment::from_data(slot, self.layout_arena.paintable_data(slot));
+            self.assignments[index] = Some(assignment);
+        }
+        self.assignments[index].as_mut().unwrap()
+    }
+
+    fn enclosing_scroll_node_index(&self, slot: NodeSlotId) -> usize {
+        self.assignments[slot.slot_index() as usize].map_or_else(
+            || self.layout_arena.paintable_data(slot).enclosing_scroll_node_index,
+            |assignment| assignment.enclosing_scroll_node_index,
+        )
+    }
+
     fn default_scroll_shift_anchor(&self, slot: NodeSlotId) -> NodeSlotId {
         if !self.may_have_default_scroll_shift_anchor {
             return NodeSlotId::INVALID;
@@ -290,12 +357,13 @@ impl Builder<'_> {
                 slot,
             )
         };
-        self.layout_arena.update_paintable_data(slot, |data| {
-            data.enclosing_scroll_node_index = 0;
-            data.own_scroll_node_index = 0;
-            data.fixed_background_visual_context = 0;
-            data.has_fixed_background_visual_context = false;
-        });
+        {
+            let assignment = self.assignment_mut(slot);
+            assignment.enclosing_scroll_node_index = 0;
+            assignment.own_scroll_node_index = 0;
+            assignment.fixed_background_visual_context = 0;
+            assignment.has_fixed_background_visual_context = false;
+        }
 
         let mut nearest_scroll_nodes_for_descendants = if is_fixed {
             NearestScrollNodeIndices {
@@ -315,9 +383,7 @@ impl Builder<'_> {
             nearest_scroll_nodes_for_descendants.stopping_at_fixed_position_ancestors
         };
         if !is_fixed && !is_sticky {
-            self.layout_arena.update_paintable_data(slot, |data| {
-                data.enclosing_scroll_node_index = nearest_ancestor_scroll_node_index;
-            });
+            self.assignment_mut(slot).enclosing_scroll_node_index = nearest_ancestor_scroll_node_index;
         }
 
         let creates_sticky_scroll_node = is_sticky && has_sticky_insets;
@@ -363,14 +429,12 @@ impl Builder<'_> {
                     compensate_horizontal_scroll && box_flags & NodeFlag::CompensatesForHorizontalScroll as u32 != 0;
                 compensate_vertical_scroll =
                     compensate_vertical_scroll && box_flags & NodeFlag::CompensatesForVerticalScroll as u32 != 0;
-                let anchor_scroll_slot = self.tree.scroll_state_slot_for_node(
-                    self.layout_arena
-                        .paintable_data(anchor_node)
-                        .enclosing_scroll_node_index,
-                );
+                let anchor_scroll_slot = self
+                    .tree
+                    .scroll_state_slot_for_node(self.enclosing_scroll_node_index(anchor_node));
                 let base_scroll_slot = self
                     .tree
-                    .scroll_state_slot_for_node(self.layout_arena.paintable_data(box_node).enclosing_scroll_node_index);
+                    .scroll_state_slot_for_node(self.enclosing_scroll_node_index(box_node));
                 let shared_scroll_slot = common_ancestor_slot_along_scroll_parent_chain(
                     &self.scroll_state,
                     anchor_scroll_slot,
@@ -438,10 +502,11 @@ impl Builder<'_> {
             );
             own_state = sticky_scroll_node_index;
             self.register_sticky_node(sticky_scroll_node_index, slot, nearest_ancestor_scroll_node_index);
-            self.layout_arena.update_paintable_data(slot, |data| {
-                data.enclosing_scroll_node_index = sticky_scroll_node_index;
-                data.own_scroll_node_index = sticky_scroll_node_index;
-            });
+            {
+                let assignment = self.assignment_mut(slot);
+                assignment.enclosing_scroll_node_index = sticky_scroll_node_index;
+                assignment.own_scroll_node_index = sticky_scroll_node_index;
+            }
             nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
                 stopping_at_fixed_position_ancestors: sticky_scroll_node_index,
                 continuing_through_fixed_position_ancestors: sticky_scroll_node_index,
@@ -462,18 +527,11 @@ impl Builder<'_> {
         if let Some(mut transform) = transform_data {
             transform.flattens_inherited_transform = flattens_inherited_transform;
             transform.sorting_context_root_index = inherited.sorting_context_root;
-            self.layout_arena.update_paintable_data(slot, |data| {
-                data.set_flag(
-                    PaintableFlag::HasNonInvertibleCssTransform,
-                    !facts.transform_is_invertible,
-                );
-            });
+            self.assignment_mut(slot).has_non_invertible_css_transform = !facts.transform_is_invertible;
             own_state = self.tree.append(VisualContextData::Transform(transform), own_state);
             appended_transform_node = true;
         } else {
-            self.layout_arena.update_paintable_data(slot, |data| {
-                data.set_flag(PaintableFlag::HasNonInvertibleCssTransform, false);
-            });
+            self.assignment_mut(slot).has_non_invertible_css_transform = false;
         }
 
         let inherited_plane_root = if is_fixed {
@@ -579,10 +637,11 @@ impl Builder<'_> {
             append_to_own_and_positioned_descendant_contexts!(VisualContextData::Mask(*mask_layer));
         }
 
-        self.layout_arena.update_paintable_data(slot, |data| {
-            data.has_accumulated_visual_context = true;
-            data.accumulated_visual_context_index = own_state;
-        });
+        {
+            let assignment = self.assignment_mut(slot);
+            assignment.has_accumulated_visual_context = true;
+            assignment.accumulated_visual_context_index = own_state;
+        }
 
         if super::node_values::wants_fixed_background_visual_context(
             self.layout_arena,
@@ -605,10 +664,11 @@ impl Builder<'_> {
                 }
                 index = self.tree.nodes[index].parent_index;
             }
-            self.layout_arena.update_paintable_data(slot, |data| {
-                data.fixed_background_visual_context = fixed_background_context;
-                data.has_fixed_background_visual_context = true;
-            });
+            {
+                let assignment = self.assignment_mut(slot);
+                assignment.fixed_background_visual_context = fixed_background_context;
+                assignment.has_fixed_background_visual_context = true;
+            }
         }
 
         // Build state for descendants: own state + perspective + clip + scroll.
@@ -630,7 +690,7 @@ impl Builder<'_> {
                 .append(VisualContextData::Clip(overflow_clip), state_for_descendants);
         }
 
-        if paintable_geometry::has_scrollable_overflow(&self.layout_arena.paintable_data(slot)) {
+        if paintable_geometry::has_scrollable_overflow(self.layout_arena.paintable_data(slot)) {
             let parent_index = if creates_sticky_scroll_node {
                 sticky_scroll_node_index
             } else {
@@ -645,8 +705,7 @@ impl Builder<'_> {
             );
             state_for_descendants = scroll_node_index;
             self.register_scroll_node(scroll_node_index, slot, parent_index);
-            self.layout_arena
-                .update_paintable_data(slot, |data| data.own_scroll_node_index = scroll_node_index);
+            self.assignment_mut(slot).own_scroll_node_index = scroll_node_index;
             nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
                 stopping_at_fixed_position_ancestors: scroll_node_index,
                 continuing_through_fixed_position_ancestors: scroll_node_index,
@@ -668,11 +727,13 @@ impl Builder<'_> {
             );
         }
 
-        self.layout_arena.update_paintable_data(slot, |data| {
-            data.accumulated_visual_context_for_descendants_index = state_for_descendants;
-            data.visual_context_nodes_begin = first_visual_context_node_index;
-            data.visual_context_nodes_end = self.tree.nodes.len();
-        });
+        {
+            let visual_context_nodes_end = self.tree.nodes.len();
+            let assignment = self.assignment_mut(slot);
+            assignment.accumulated_visual_context_for_descendants_index = state_for_descendants;
+            assignment.visual_context_nodes_begin = first_visual_context_node_index;
+            assignment.visual_context_nodes_end = visual_context_nodes_end;
+        }
         let mut absolute_position_nearest_scroll_nodes = inherited.absolute_position_nearest_scroll_nodes;
         let mut fixed_position_nearest_scroll_nodes = inherited.fixed_position_nearest_scroll_nodes;
         let mut absolute_position_plane_root = inherited.absolute_position_plane_root;
@@ -716,10 +777,15 @@ struct PendingPaintable {
 }
 
 pub(crate) fn build_visual_context_tree(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     viewport: NodeSlotId,
-) -> (VisualContextTree, ScrollState, Vec<NodeSlotId>) {
+) -> (
+    VisualContextTree,
+    ScrollState,
+    Vec<NodeSlotId>,
+    Vec<PaintableVisualContextAssignment>,
+) {
     let inputs = callbacks.tree_inputs();
     let mut builder = Builder {
         layout_arena,
@@ -727,12 +793,13 @@ pub(crate) fn build_visual_context_tree(
         tree: VisualContextTree::create(super::node_values::visual_viewport_transform_data(&inputs)),
         scroll_state: ScrollState::default(),
         paintables_with_mask_nodes: Vec::new(),
+        assignments: vec![None; layout_arena.paintable_row_count()],
         pixel_ratio: inputs.device_pixels_per_css_pixel,
         root_background_source: callbacks.root_background_source(),
         may_have_default_scroll_shift_anchor: inputs.may_have_default_scroll_shift_anchor,
     };
 
-    layout_arena.update_paintable_data(viewport, |data| data.enclosing_scroll_node_index = 0);
+    builder.assignment_mut(viewport).enclosing_scroll_node_index = 0;
     let viewport_state_for_descendants = builder.tree.append(
         VisualContextData::Scroll(ScrollData {
             is_sticky: false,
@@ -741,12 +808,13 @@ pub(crate) fn build_visual_context_tree(
         VISUAL_VIEWPORT_NODE_INDEX,
     );
     builder.register_scroll_node(viewport_state_for_descendants, viewport, 0);
-    layout_arena.update_paintable_data(viewport, |data| {
-        data.own_scroll_node_index = viewport_state_for_descendants;
-        data.has_accumulated_visual_context = true;
-        data.accumulated_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
-        data.accumulated_visual_context_for_descendants_index = viewport_state_for_descendants;
-    });
+    {
+        let assignment = builder.assignment_mut(viewport);
+        assignment.own_scroll_node_index = viewport_state_for_descendants;
+        assignment.has_accumulated_visual_context = true;
+        assignment.accumulated_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
+        assignment.accumulated_visual_context_for_descendants_index = viewport_state_for_descendants;
+    }
 
     let viewport_nearest_scroll_nodes = NearestScrollNodeIndices {
         stopping_at_fixed_position_ancestors: viewport_state_for_descendants,
@@ -773,7 +841,7 @@ pub(crate) fn build_visual_context_tree(
     let mut deferred_awaiting_build: HashSet<NodeSlotId> = HashSet::new();
 
     fn build_deferring_anchor_positioned(
-        builder: &mut Builder<'_>,
+        builder: &mut Builder<'_, impl PaintableRowsRead>,
         stack: &mut Vec<PendingPaintable>,
         exempt: Option<NodeSlotId>,
         deferred: &mut Vec<PendingPaintable>,
@@ -803,7 +871,7 @@ pub(crate) fn build_visual_context_tree(
 
     let mut pending: Vec<PendingPaintable> = Vec::new();
     let mut viewport_children = Vec::new();
-    crate::painting::paint_order::for_each_paint_child(layout_arena, viewport, |child| {
+    crate::painting::paint_order::for_each_paint_child(builder.layout_arena, viewport, |child| {
         viewport_children.push(child);
     });
     for child in viewport_children.into_iter().rev() {
@@ -821,7 +889,11 @@ pub(crate) fn build_visual_context_tree(
         &mut deferred_awaiting_build,
     );
 
-    let anchor_is_awaiting_build = |builder: &Builder<'_>, slot: NodeSlotId, awaiting: &HashSet<NodeSlotId>| {
+    fn anchor_is_awaiting_build(
+        builder: &Builder<'_, impl PaintableRowsRead>,
+        slot: NodeSlotId,
+        awaiting: &HashSet<NodeSlotId>,
+    ) -> bool {
         let anchor_node = builder.default_scroll_shift_anchor(slot);
         let mut paintable = builder
             .layout_arena
@@ -834,13 +906,13 @@ pub(crate) fn build_visual_context_tree(
             paintable = crate::painting::paint_order::paint_parent(builder.layout_arena, current);
         }
         false
-    };
+    }
 
     while !deferred_anchor_positioned.is_empty() {
         let entries = std::mem::take(&mut deferred_anchor_positioned);
         let mut still_deferred = Vec::new();
         for entry in &entries {
-            if anchor_is_awaiting_build(&mut builder, entry.paintable, &deferred_awaiting_build) {
+            if anchor_is_awaiting_build(&builder, entry.paintable, &deferred_awaiting_build) {
                 still_deferred.push(*entry);
             } else {
                 deferred_awaiting_build.remove(&entry.paintable);
@@ -876,24 +948,29 @@ pub(crate) fn build_visual_context_tree(
         }
     }
 
-    (builder.tree, builder.scroll_state, builder.paintables_with_mask_nodes)
+    (
+        builder.tree,
+        builder.scroll_state,
+        builder.paintables_with_mask_nodes,
+        builder.assignments.into_iter().flatten().collect(),
+    )
 }
 
 // Patches the transform/effects/perspective values of the box's existing visual context nodes in place.
 // Returns false if the box's node structure no longer matches; the caller must then do a full rebuild.
 pub(crate) fn update_visual_context_values(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     tree: &mut VisualContextTree,
     slot: NodeSlotId,
     pixel_ratio: f64,
-) -> bool {
+) -> (bool, Option<bool>) {
     let (begin, end) = {
         let data = layout_arena.paintable_data(slot);
         (data.visual_context_nodes_begin, data.visual_context_nodes_end)
     };
     if end > tree.nodes.len() {
-        return false;
+        return (false, None);
     }
     let transform_with_invertibility =
         super::node_values::compute_transform(layout_arena, callbacks, slot, pixel_ratio);
@@ -904,71 +981,69 @@ pub(crate) fn update_visual_context_values(
     let svg_viewport_transform_data = svg_viewport_transform_of(layout_arena, slot)
         .map(|transform| compute_svg_viewport_transform_data(layout_arena, slot, transform, pixel_ratio));
 
-    layout_arena.update_paintable_data(slot, |data| {
-        data.set_flag(
-            PaintableFlag::HasNonInvertibleCssTransform,
-            transform.is_some() && !transform_is_invertible,
-        );
-    });
+    let has_non_invertible_css_transform = transform.is_some() && !transform_is_invertible;
 
-    let mut found_css_transform = false;
-    let mut found_svg_viewport_transform = false;
-    let mut found_effects = false;
-    let mut found_perspective = false;
-    for index in begin..end {
-        match &mut tree.nodes[index].data {
-            VisualContextData::Transform(transform_data) => {
-                if transform_data.role == TransformDataRole::SvgViewportTransform {
-                    let Some(mut new_data) = svg_viewport_transform_data else {
+    let compatible = (|| {
+        let mut found_css_transform = false;
+        let mut found_svg_viewport_transform = false;
+        let mut found_effects = false;
+        let mut found_perspective = false;
+        for index in begin..end {
+            match &mut tree.nodes[index].data {
+                VisualContextData::Transform(transform_data) => {
+                    if transform_data.role == TransformDataRole::SvgViewportTransform {
+                        let Some(mut new_data) = svg_viewport_transform_data else {
+                            return false;
+                        };
+                        new_data.flattens_inherited_transform = transform_data.flattens_inherited_transform;
+                        *transform_data = new_data;
+                        found_svg_viewport_transform = true;
+                        continue;
+                    }
+                    // A synthetic plane node has no computed transform behind it. It stays as-is unless the element
+                    // gained a real transform, which changes the structure the node was built for.
+                    if transform_data.synthetic_plane {
+                        if transform.is_some() {
+                            return false;
+                        }
+                        continue;
+                    }
+                    let Some(mut new_data) = transform else {
                         return false;
                     };
                     new_data.flattens_inherited_transform = transform_data.flattens_inherited_transform;
+                    new_data.sorting_context_root_index = transform_data.sorting_context_root_index;
                     *transform_data = new_data;
-                    found_svg_viewport_transform = true;
-                    continue;
+                    found_css_transform = true;
                 }
-                // A synthetic plane node has no computed transform behind it. It stays as-is unless the element
-                // gained a real transform, which changes the structure the node was built for.
-                if transform_data.synthetic_plane {
-                    if transform.is_some() {
+                VisualContextData::Effects(effects_data) => {
+                    // The builder duplicates a box's EffectsData into the positioned-descendant chains, so every
+                    // node of a kind is patched with the same recomputed payload.
+                    let Some(new_effects) = &effects else {
                         return false;
-                    }
-                    continue;
+                    };
+                    *effects_data = EffectsData {
+                        opacity: new_effects.opacity,
+                        blend_mode: new_effects.blend_mode,
+                        filter: new_effects.filter.clone(),
+                    };
+                    found_effects = true;
                 }
-                let Some(mut new_data) = transform else {
-                    return false;
-                };
-                new_data.flattens_inherited_transform = transform_data.flattens_inherited_transform;
-                new_data.sorting_context_root_index = transform_data.sorting_context_root_index;
-                *transform_data = new_data;
-                found_css_transform = true;
+                VisualContextData::Perspective(perspective_data) => {
+                    let Some(mut new_data) = perspective else {
+                        return false;
+                    };
+                    new_data.flattens_inherited_transform = perspective_data.flattens_inherited_transform;
+                    *perspective_data = new_data;
+                    found_perspective = true;
+                }
+                _ => {}
             }
-            VisualContextData::Effects(effects_data) => {
-                // The builder duplicates a box's EffectsData into the positioned-descendant chains, so every
-                // node of a kind is patched with the same recomputed payload.
-                let Some(new_effects) = &effects else {
-                    return false;
-                };
-                *effects_data = EffectsData {
-                    opacity: new_effects.opacity,
-                    blend_mode: new_effects.blend_mode,
-                    filter: new_effects.filter.clone(),
-                };
-                found_effects = true;
-            }
-            VisualContextData::Perspective(perspective_data) => {
-                let Some(mut new_data) = perspective else {
-                    return false;
-                };
-                new_data.flattens_inherited_transform = perspective_data.flattens_inherited_transform;
-                *perspective_data = new_data;
-                found_perspective = true;
-            }
-            _ => {}
         }
-    }
-    transform.is_some() == found_css_transform
-        && effects.is_some() == found_effects
-        && perspective.is_some() == found_perspective
-        && svg_viewport_transform_data.is_some() == found_svg_viewport_transform
+        transform.is_some() == found_css_transform
+            && effects.is_some() == found_effects
+            && perspective.is_some() == found_perspective
+            && svg_viewport_transform_data.is_some() == found_svg_viewport_transform
+    })();
+    (compatible, Some(has_non_invertible_css_transform))
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/nested.rs
@@ -6,9 +6,9 @@
 
 use std::collections::HashMap;
 
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::host::FfiVisualContextHostCallbacks;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::visual_context::build::{
     BoxFacts, compute_svg_viewport_transform_data, svg_viewport_transform_of,
 };
@@ -20,15 +20,15 @@ pub struct NestedAssignments {
     pub mask_node_indices: HashMap<u32, Vec<usize>>,
 }
 
-struct NestedBuilder<'a> {
-    layout_arena: &'a LayoutNodeArena,
+struct NestedBuilder<'a, Arena> {
+    layout_arena: &'a Arena,
     callbacks: &'a FfiVisualContextHostCallbacks,
     tree: VisualContextTree,
     assignments: NestedAssignments,
     pixel_ratio: f64,
 }
 
-impl NestedBuilder<'_> {
+impl<Arena: PaintableRowsRead> NestedBuilder<'_, Arena> {
     fn build_subtree(&mut self, slot: NodeSlotId, inherited_state: usize, include_element_transform: bool) {
         let facts = BoxFacts::gather(self.layout_arena, self.callbacks, slot, self.pixel_ratio, false);
         let mut own_state = inherited_state;
@@ -83,7 +83,7 @@ impl NestedBuilder<'_> {
 }
 
 pub(crate) fn build_nested_svg_visual_context_tree(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     root: NodeSlotId,
     root_transform: TransformData,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -11,12 +11,12 @@ use crate::css::css_enums;
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::css::style_value::StyleValueData;
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::border_radii::BorderRadii;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::host::{FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
 use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::style_queries;
 use libgfx_rust::{
     AffineTransform, CompositingAndBlendingOperator, CornerRadii, FloatPoint, affine_to_matrix, perspective_matrix,
@@ -47,7 +47,7 @@ pub(crate) fn visual_viewport_transform_data(inputs: &FfiVisualContextTreeInputs
 
 pub(crate) fn transform_reference_box(
     style: ComputedValuesView<'_>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
 ) -> CssPixelRect {
@@ -113,7 +113,7 @@ fn resolved_transform_to_matrix(
 
 // https://drafts.csswg.org/css-transforms-2/#ctm
 pub(crate) fn compute_transform(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     node: NodeSlotId,
     pixel_ratio: f64,
@@ -200,7 +200,7 @@ pub(crate) fn compute_transform(
 
 // https://drafts.csswg.org/css-transforms-2/#perspective-matrix
 pub(crate) fn compute_perspective_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
     pixel_ratio: f64,
@@ -249,7 +249,7 @@ pub(crate) fn compute_perspective_data(
 }
 
 pub(crate) fn compute_css_clip_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
     pixel_ratio: f64,
 ) -> Option<ClipData> {
@@ -333,7 +333,7 @@ fn border_radius_is_initial(handle: &ComputedStyleValueHandle) -> bool {
 
 pub(crate) fn border_radii_data(
     style: ComputedValuesView<'_>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
 ) -> BorderRadii {
     let border = style.border();
@@ -414,7 +414,7 @@ pub(crate) fn piece_border_radii_data(
     crate::painting::border_radii::scale_radii_to_fit(border_rect, radii)
 }
 
-fn overflow_property_applies(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
+fn overflow_property_applies(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
     // https://drafts.csswg.org/css-overflow-3/#overflow-control
     // Overflow properties apply to block containers, flex containers and grid containers.
     // FIXME: Ideally we would check whether overflow applies positively rather than listing exceptions. However,
@@ -439,7 +439,7 @@ fn overflow_property_applies(layout_arena: &LayoutNodeArena, slot: NodeSlotId) -
 // https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge
 fn overflow_clip_edge_rect(
     style: ComputedValuesView<'_>,
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
 ) -> CssPixelRect {
     use crate::css::css_enums::background_box::{BORDER_BOX, CONTENT_BOX};
@@ -504,7 +504,7 @@ pub(crate) fn mix_blend_mode_to_compositing_and_blending_operator(
 }
 
 pub(crate) fn compute_effects_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
 ) -> Option<EffectsData> {
@@ -557,7 +557,7 @@ fn any_background_layer_has_a_fixed_attachment_image(style: ComputedValuesView<'
 }
 
 pub(crate) fn wants_fixed_background_visual_context(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     root_background_source: crate::painting::host::FfiRootBackgroundSource,
     node: NodeSlotId,
     may_be_root_element: bool,
@@ -623,7 +623,7 @@ fn mask_kind_from(value: i32) -> libgfx_rust::MaskKind {
 }
 
 pub(crate) fn mask_layer_presence(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
     include_css_mask_layers: bool,
@@ -667,7 +667,7 @@ pub(crate) fn mask_layer_presence(
     layers
 }
 
-pub(crate) fn backface_hidden(layout_arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
+pub(crate) fn backface_hidden(layout_arena: &impl PaintableRowsRead, node: NodeSlotId) -> bool {
     use crate::css::css_enums::backface_visibility;
     let Some(style) = layout_arena.node_style_if_live(node) else {
         return false;
@@ -676,7 +676,7 @@ pub(crate) fn backface_hidden(layout_arena: &LayoutNodeArena, node: NodeSlotId) 
         && style_queries::is_transformable(layout_arena, node)
 }
 
-pub(crate) fn may_have_clip(layout_arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
+pub(crate) fn may_have_clip(layout_arena: &impl PaintableRowsRead, node: NodeSlotId) -> bool {
     use crate::css::css_enums::{content_visibility, overflow};
     let Some(style) = layout_arena.node_style_if_live(node) else {
         return false;
@@ -689,7 +689,7 @@ pub(crate) fn may_have_clip(layout_arena: &LayoutNodeArena, node: NodeSlotId) ->
 }
 
 pub(crate) fn compute_clip_data(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
     pixel_ratio: f64,
 ) -> Option<ClipData> {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
@@ -6,13 +6,13 @@
 
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot, StickyConstraints};
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
-use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::host::FfiVisualContextHostCallbacks;
 use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
 
 pub(crate) fn precompute_sticky_constraints(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     scroll_state: &mut ScrollState,
     sticky_slot: ScrollStateSlot,
     paintable: NodeSlotId,
@@ -57,7 +57,7 @@ pub(crate) fn precompute_sticky_constraints(
     });
 }
 
-pub(crate) fn refresh_sticky_constraints(layout_arena: &LayoutNodeArena, scroll_state: &mut ScrollState) {
+pub(crate) fn refresh_sticky_constraints(layout_arena: &impl PaintableRowsRead, scroll_state: &mut ScrollState) {
     for slot in 0..scroll_state.slot_count() {
         let state = scroll_state.state_at_slot(slot);
         if !state.is_sticky {
@@ -73,7 +73,7 @@ pub(crate) fn refresh_sticky_constraints(layout_arena: &LayoutNodeArena, scroll_
 }
 
 pub(crate) fn refresh_scroll_state(
-    layout_arena: &crate::layout::LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     scroll_state: &mut ScrollState,
 ) {

--- a/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_lines.rs
@@ -7,6 +7,7 @@
 use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
+use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::{paintable_geometry, text_fragment};
 
 pub(crate) struct RecordVisualLine {
@@ -76,7 +77,10 @@ fn has_empty_visual_line_positions(layout_arena: &LayoutNodeArena, node_slots: &
     found
 }
 
-pub(crate) fn collect_visual_lines(layout_arena: &LayoutNodeArena, node_slots: &[NodeSlotId]) -> Vec<RecordVisualLine> {
+pub(crate) fn collect_visual_lines(
+    layout_arena: &impl PaintableRowsRead,
+    node_slots: &[NodeSlotId],
+) -> Vec<RecordVisualLine> {
     let mut lines: Vec<RecordVisualLine> = Vec::new();
     text_fragment::for_each_fragment_of_nodes(layout_arena, node_slots, |block, _, fragment| {
         let dom_start = fragment.dom_start_offset_in_node;
@@ -129,7 +133,10 @@ pub(crate) struct EmptyLineCaretTarget {
     pub rect: CssPixelRect,
 }
 
-pub(crate) fn empty_line_caret_targets(layout_arena: &LayoutNodeArena, block: NodeSlotId) -> Vec<EmptyLineCaretTarget> {
+pub(crate) fn empty_line_caret_targets(
+    layout_arena: &impl PaintableRowsRead,
+    block: NodeSlotId,
+) -> Vec<EmptyLineCaretTarget> {
     let side = layout_arena.paintable_side_data(block);
     if side.fragments.is_empty() || side.lines.is_empty() {
         return Vec::new();
@@ -209,7 +216,7 @@ pub(crate) fn empty_line_caret_targets(layout_arena: &LayoutNodeArena, block: No
 }
 
 fn fragments_of_line(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     owner_paintable: u32,
     line_index: u32,
     node_slots: &[NodeSlotId],
@@ -225,7 +232,7 @@ fn fragments_of_line(
 }
 
 pub(crate) fn caret_inline_coordinate(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     owner_paintable: u32,
     line_index: u32,
     node_slots: &[NodeSlotId],
@@ -265,7 +272,7 @@ pub(crate) fn caret_inline_coordinate(
 }
 
 pub(crate) fn offset_closest_to_inline_coordinate(
-    layout_arena: &LayoutNodeArena,
+    layout_arena: &impl PaintableRowsRead,
     owner_paintable: u32,
     line_index: u32,
     node_slots: &[NodeSlotId],


### PR DESCRIPTION
Store paintable row chunks as ordinary arena-owned data and pass shared
or exclusive row views through painting algorithms. This removes full
PaintableData copies and runtime borrow checks from hot lookups.

Compute callback-dependent visual-context and overflow changes with
shared access, then apply them in callback-free exclusive phases. C++
re-entry cannot overlap an exclusive Rust borrow, while row references
and mutations are checked statically.

Fixes an issue where StyleBench was spending 17% of CPU time in `paintable_data()` after recent changes.