### PR TITLE
LibWeb: Traverse Range strings in linear time

### DIFF
--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -585,20 +585,49 @@ Utf16String Range::to_string() const
     if (start_text && start_container() == end_container())
         return MUST(start_text->substring_data(start_offset(), end_offset() - start_offset()));
 
+    auto next_after_subtree = [](GC::Ptr<Node> node) -> GC::Ptr<Node> {
+        while (node) {
+            if (auto* next_sibling = node->next_sibling())
+                return *next_sibling;
+            node = node->parent_node();
+        }
+        return nullptr;
+    };
+
+    GC::Ptr<Node> first_node = start_container();
+    if (!is<CharacterData>(*first_node)) {
+        if (auto* child = first_node->child_at_index(start_offset()))
+            first_node = *child;
+        else if (start_offset() != 0)
+            first_node = next_after_subtree(first_node);
+    }
+
+    GC::Ptr<Node> past_last_node = end_container();
+    if (is<CharacterData>(*past_last_node)) {
+        past_last_node = next_after_subtree(past_last_node);
+    } else if (auto* child = past_last_node->child_at_index(end_offset())) {
+        past_last_node = *child;
+    } else {
+        past_last_node = next_after_subtree(past_last_node);
+    }
+
     // 3. If this’s start node is a Text node, then append the substring of that node’s data from this’s start offset until the end to s.
-    if (start_text)
-        builder.append(MUST(start_text->substring_data(start_offset(), start_text->length_in_utf16_code_units() - start_offset())));
-
     // 4. Append the concatenation of the data of all Text nodes that are contained in this, in tree order, to s.
-    for_each_contained([&](GC::Ref<Node> node) {
-        if (auto* text_node = as_if<Text>(*node))
-            builder.append(text_node->data());
-        return IterationDecision::Continue;
-    });
-
     // 5. If this’s end node is a Text node, then append the substring of that node’s data from its start until this’s end offset to s.
-    if (auto* end_text = as_if<Text>(*end_container()))
-        builder.append(MUST(end_text->substring_data(0, end_offset())));
+    // OPTIMIZATION: Perform these steps in one tree-order traversal instead of testing every candidate node for
+    //               containment, which would repeatedly compare its boundaries with the range boundaries.
+    for (auto node = first_node; node != past_last_node; node = node->next_in_pre_order()) {
+        auto* text_node = as_if<Text>(*node);
+        if (!text_node)
+            continue;
+
+        if (node == start_container())
+            builder.append(MUST(text_node->substring_data(start_offset(), text_node->length_in_utf16_code_units() - start_offset())));
+        else if (node == end_container())
+            builder.append(MUST(text_node->substring_data(0, end_offset())));
+        else
+            builder.append(text_node->data());
+    }
 
     // 6. Return s.
     return builder.to_string();

--- a/Tests/LibWeb/Text/expected/DOM/Range-to-string.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Range-to-string.txt
@@ -1,1 +1,6 @@
 llo💨😮 Wo
+zeroonetwothreefourfivesix
+roonetwothreefourfivesi
+onetwothreefourfive
+two
+collapsed: ""

--- a/Tests/LibWeb/Text/input/DOM/Range-to-string.html
+++ b/Tests/LibWeb/Text/input/DOM/Range-to-string.html
@@ -1,15 +1,37 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <body><p id="p1"><b>Hello💨</b>😮 World</p>
+<div id="nested">zero<span>one<em>two</em>three</span>four<span>five</span>six</div>
 <script src="../include.js"></script>
 <script>
     test(() => {
         const p1 = document.getElementById("p1");
         const hello = p1.firstChild.firstChild;
         const world = p1.lastChild;
-        const range = document.createRange();
+        let range = document.createRange();
         range.setStart(hello, 2);
         range.setEnd(world, 5);
         println(range.toString());
+
+        const nested = document.getElementById("nested");
+        range = document.createRange();
+        range.selectNodeContents(nested);
+        println(range.toString());
+
+        range.setStart(nested.firstChild, 2);
+        range.setEnd(nested.lastChild, 2);
+        println(range.toString());
+
+        range.setStart(nested, 1);
+        range.setEnd(nested, 4);
+        println(range.toString());
+
+        const firstSpan = nested.firstElementChild;
+        range.setStart(firstSpan, 1);
+        range.setEnd(firstSpan, 2);
+        println(range.toString());
+
+        range.collapse();
+        println(`collapsed: "${range.toString()}"`);
     });
 </script>


### PR DESCRIPTION
Range stringification previously checked every candidate node for containment. Each check compared both node boundaries with the range boundaries, making Selection.toString() quadratic in the number of selected nodes.

Compute the first and past-the-last nodes directly from the range boundaries, then collect text with a single tree-order traversal. Extend coverage for nested contents, partial text boundaries, element boundaries, and collapsed ranges.

This reduces MicroWeb’s edit/selection-to-string benchmark from 657.3 ms, 67.1x slower than Chromium, to 2.0 ms, 5.2x faster than Chromium.