### PR TITLE
LibWeb: Preserve forward lists on final item mutations

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Bindings/Node.h>
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/GeneratedContent.h>
 #include <LibWeb/CSS/Invalidation/ElementStateInvalidator.h>
 #include <LibWeb/CSS/Invalidation/LanguageInvalidator.h>
@@ -92,6 +93,53 @@
 #include <LibWeb/XLink/AttributeNames.h>
 
 namespace Web::DOM {
+
+static bool content_uses_list_item_counter(CSS::ComputedContentData const& content)
+{
+    auto item_uses_list_item_counter = [](CSS::ComputedContentItem const& item) {
+        auto const* counter = item.get_pointer<CSS::ComputedContentCounter>();
+        return counter && counter->name == CSS::list_item_counter_name();
+    };
+    return any_of(content.items, item_uses_list_item_counter)
+        || any_of(content.alt_text, item_uses_list_item_counter);
+}
+
+static bool style_after_list_items_depends_on_list_item_counter(Element const& list_owner)
+{
+    auto style_depends_on_list_item_counter = [](CSS::ComputedValues const& style) {
+        auto definitions_contain_list_item_counter = [](auto const& definitions) {
+            return any_of(definitions, [](auto const& definition) {
+                return definition.name == CSS::list_item_counter_name();
+            });
+        };
+        return style.display().is_list_item()
+            || content_uses_list_item_counter(style.computed_content())
+            || definitions_contain_list_item_counter(style.counter_increment())
+            || definitions_contain_list_item_counter(style.counter_reset())
+            || definitions_contain_list_item_counter(style.counter_set());
+    };
+
+    auto style = list_owner.computed_style(CSS::PseudoElement::After);
+    return style && style_depends_on_list_item_counter(*style);
+}
+
+static bool final_direct_list_item_does_not_renumber_existing_content(Element const& list_item)
+{
+    auto list_owner = list_item.parent_element();
+    if (!list_owner || !list_owner->is_html_ol_ul_menu_element() || list_item.next_element_sibling())
+        return false;
+    if (style_after_list_items_depends_on_list_item_counter(*list_owner))
+        return false;
+
+    auto counters_set = list_owner->counters_set();
+    if (!counters_set.has_value())
+        return false;
+    for (auto const& counter : counters_set->counters().in_reverse()) {
+        if (counter.name == CSS::list_item_counter_name())
+            return !counter.reversed && counter.originating_element == DOM::AbstractElement(*list_owner);
+    }
+    return false;
+}
 
 static UniqueNodeID s_next_unique_id;
 static GC::WeakHashMap<UniqueNodeID, Node>& node_directory()
@@ -975,10 +1023,13 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
         }
     }
 
-    // AD-HOC: An inserted list item renumbers the list-item counter for its list owner's whole list.
+    // AD-HOC: An inserted list item can renumber the list-item counter for its list owner's whole list.
+    //         Appending to a forward counter does not change any existing counter value.
     for (auto& inserted_node : nodes) {
         if (inserted_node->is_html_li_element()) {
-            static_cast<Element&>(*inserted_node).invalidate_list_item_counters_for_list_owner();
+            auto& list_item = static_cast<Element&>(*inserted_node);
+            if (!final_direct_list_item_does_not_renumber_existing_content(list_item))
+                list_item.invalidate_list_item_counters_for_list_owner();
             break;
         }
     }
@@ -1157,12 +1208,15 @@ void Node::remove(bool suppress_observers)
     // 6. Let oldNextSibling be node’s next sibling.
     GC::Ptr<Node> old_next_sibling = next_sibling();
 
-    // AD-HOC: A removed list item renumbers the list-item counter for its list owner's whole list.
+    // AD-HOC: A removed list item can renumber the list-item counter for its list owner's whole list.
+    //         Removing the final item from a forward counter does not change any surviving counter value.
     if (is_element()) {
         auto* this_element = static_cast<Element*>(this);
         auto style = this_element->computed_style();
-        if (is_html_li_element() || (style && style->display().is_list_item()))
+        if ((is_html_li_element() || (style && style->display().is_list_item()))
+            && !final_direct_list_item_does_not_renumber_existing_content(*this_element)) {
             this_element->invalidate_list_item_counters_for_list_owner();
+        }
     }
 
     if (is_connected()) {

--- a/Tests/LibWeb/Text/expected/layout-tree-update/direct-child-list-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/direct-child-list-preservation.txt
@@ -36,6 +36,19 @@ PASS: insert implicit list-item counter | preserve before
 PASS: insert implicit list-item counter | preserve after
 PASS: insert implicit list-item counter | layout tree builds=1
 PASS: insert implicit list-item counter | incremental tree matches full rebuild
+PASS: append final HTML list item to forward counter | preserve parent
+PASS: append final HTML list item to forward counter | preserve before
+PASS: append final HTML list item to forward counter | layout tree builds=1
+PASS: append final HTML list item to forward counter | incremental tree matches full rebuild
+PASS: fall back when appending to reversed HTML list | rebuild parent
+PASS: fall back when appending to reversed HTML list | layout tree builds=1
+PASS: fall back when appending to reversed HTML list | incremental tree matches full rebuild
+PASS: fall back when list generated content follows appended item | rebuild parent
+PASS: fall back when list generated content follows appended item | layout tree builds=1
+PASS: fall back when list generated content follows appended item | incremental tree matches full rebuild
+PASS: fall back when list-item after marker follows appended item | rebuild parent
+PASS: fall back when list-item after marker follows appended item | layout tree builds=1
+PASS: fall back when list-item after marker follows appended item | incremental tree matches full rebuild
 PASS: fall back when inserted pseudo-element changes quote depth | rebuild parent
 PASS: fall back when inserted pseudo-element changes quote depth | layout tree builds=1
 PASS: fall back when inserted pseudo-element changes quote depth | incremental tree matches full rebuild
@@ -198,6 +211,19 @@ PASS: remove implicit list-item counter | preserve parent
 PASS: remove implicit list-item counter | preserve after
 PASS: remove implicit list-item counter | layout tree builds=0
 PASS: remove implicit list-item counter | incremental tree matches full rebuild
+PASS: remove final HTML list item from forward counter | preserve parent
+PASS: remove final HTML list item from forward counter | preserve before
+PASS: remove final HTML list item from forward counter | layout tree builds=0
+PASS: remove final HTML list item from forward counter | incremental tree matches full rebuild
+PASS: fall back when removing from reversed HTML list | rebuild parent
+PASS: fall back when removing from reversed HTML list | layout tree builds=1
+PASS: fall back when removing from reversed HTML list | incremental tree matches full rebuild
+PASS: fall back when list generated content follows removed item | rebuild parent
+PASS: fall back when list generated content follows removed item | layout tree builds=1
+PASS: fall back when list generated content follows removed item | incremental tree matches full rebuild
+PASS: fall back when list-item after marker follows removed item | rebuild parent
+PASS: fall back when list-item after marker follows removed item | layout tree builds=1
+PASS: fall back when list-item after marker follows removed item | incremental tree matches full rebuild
 PASS: fall back when removed pseudo-element changes quote depth | rebuild parent
 PASS: fall back when removed pseudo-element changes quote depth | layout tree builds=1
 PASS: fall back when removed pseudo-element changes quote depth | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/input/layout-tree-update/direct-child-list-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/direct-child-list-preservation.html
@@ -17,6 +17,8 @@
     .pseudo-increment::before { counter-increment: direct-child-counter; content: ""; }
     .columns { columns: 2; }
     .list-item { display: list-item; }
+    .list-counter-value::after { content: counter(list-item); }
+    .list-item-after::after { content: ""; display: list-item; }
     .child { display: block; }
     .inline { display: inline; }
     .inline-block { display: inline-block; }
@@ -92,6 +94,33 @@
             markup: '<div class="parent"><div class="before list-item">before</div><div class="after list-item">after</div></div>',
             mutate: parent => parent.querySelector(".after").insertAdjacentHTML("beforebegin", '<div class="target list-item">target</div>'),
             tracked: ["parent", "before", "after"],
+        },
+        {
+            name: "append final HTML list item to forward counter",
+            markup: '<ol class="parent"><li class="before">before</li></ol>',
+            mutate: parent => parent.insertAdjacentHTML("beforeend", '<li class="target">target</li>'),
+            tracked: ["parent", "before"],
+        },
+        {
+            name: "fall back when appending to reversed HTML list",
+            markup: '<ol class="parent" reversed><li class="before">before</li></ol>',
+            mutate: parent => parent.insertAdjacentHTML("beforeend", '<li class="target">target</li>'),
+            tracked: ["parent"],
+            preserve: false,
+        },
+        {
+            name: "fall back when list generated content follows appended item",
+            markup: '<ol class="parent list-counter-value"><li class="before">before</li></ol>',
+            mutate: parent => parent.insertAdjacentHTML("beforeend", '<li class="target">target</li>'),
+            tracked: ["parent"],
+            preserve: false,
+        },
+        {
+            name: "fall back when list-item after marker follows appended item",
+            markup: '<ol class="parent list-item-after"><li class="before">before</li></ol>',
+            mutate: parent => parent.insertAdjacentHTML("beforeend", '<li class="target">target</li>'),
+            tracked: ["parent"],
+            preserve: false,
         },
         {
             name: "fall back when inserted pseudo-element changes quote depth",
@@ -320,6 +349,34 @@
             mutate: parent => parent.querySelector(".target").remove(),
             tracked: ["parent", "after"],
             expectNoBuild: true,
+        },
+        {
+            name: "remove final HTML list item from forward counter",
+            markup: '<ol class="parent"><li class="before">before</li><li class="target">target</li></ol>',
+            mutate: parent => parent.querySelector(".target").remove(),
+            tracked: ["parent", "before"],
+            expectNoBuild: true,
+        },
+        {
+            name: "fall back when removing from reversed HTML list",
+            markup: '<ol class="parent" reversed><li class="before">before</li><li class="target">target</li></ol>',
+            mutate: parent => parent.querySelector(".target").remove(),
+            tracked: ["parent"],
+            preserve: false,
+        },
+        {
+            name: "fall back when list generated content follows removed item",
+            markup: '<ol class="parent list-counter-value"><li class="before">before</li><li class="target">target</li></ol>',
+            mutate: parent => parent.querySelector(".target").remove(),
+            tracked: ["parent"],
+            preserve: false,
+        },
+        {
+            name: "fall back when list-item after marker follows removed item",
+            markup: '<ol class="parent list-item-after"><li class="before">before</li><li class="target">target</li></ol>',
+            mutate: parent => parent.querySelector(".target").remove(),
+            tracked: ["parent"],
+            preserve: false,
         },
         {
             name: "fall back when removed pseudo-element changes quote depth",


### PR DESCRIPTION
Avoid rebuilding list owners when appending or removing the final direct item cannot renumber existing content. Keep conservative rebuilds for reversed counters, externally scoped counters, and generated content that observes the final list-item value.

Extend layout tree preservation coverage for forward, reversed, and generated-content-dependent lists.

Reduce Ladybird's five-iteration median in MicroWeb's style/append-under-big-sheet benchmark from about 577 ms to 73 ms. The corresponding Chromium medians with its JIT disabled were 11.3 ms and 7.2 ms, improving Ladybird's ratio from roughly 51x to 10x.