### PR TITLE
LibWeb: Speed up replaceChildren()

### DIFF
--- a/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/FormControlInvalidator.cpp
@@ -36,6 +36,11 @@ void invalidate_style_after_placeholder_shown_change(DOM::Element& element)
 // now has, which is what lets a change that moved nothing publish nothing.
 static void record_validity_states(DOM::Element& element)
 {
+    // An element whose initial features are pending will publish its current state when those
+    // features are recorded. Computing that state here would be discarded by the style engine.
+    if (!can_record_element_state_change(element))
+        return;
+
     auto validity = SelectorMatching::element_validity_state(element);
     record_element_state_changed(element, PseudoClass::Valid, validity == SelectorMatching::ValidityState::Valid);
     record_element_state_changed(element, PseudoClass::Invalid, validity == SelectorMatching::ValidityState::Invalid);

--- a/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/LanguageInvalidator.cpp
@@ -95,6 +95,22 @@ void invalidate_style_after_slot_assignment_change(HTML::HTMLSlotElement& slot)
 // resolves to, for its whole subtree, because a directionality inherits.
 void invalidate_style_after_text_change_under(DOM::Element& parent_of_text)
 {
+    bool ancestor_chain_has_assigned_slot = false;
+    for (auto ancestor = GC::Ptr<DOM::Element> { parent_of_text }; ancestor; ancestor = ancestor->parent_element()) {
+        if (ancestor->assigned_slot_internal()) {
+            ancestor_chain_has_assigned_slot = true;
+            break;
+        }
+    }
+
+    if (!ancestor_chain_has_assigned_slot) {
+        for (auto ancestor = GC::Ptr<DOM::Element> { parent_of_text }; ancestor; ancestor = ancestor->parent_element()) {
+            if (ancestor->has_auto_directionality())
+                publish_language_and_directionality(*ancestor, true);
+        }
+        return;
+    }
+
     HashTable<DOM::Element*> visited;
     publish_directionality_dependent_ancestors(parent_of_text, visited);
 }

--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -2165,6 +2165,17 @@ void record_stylesheet_detached(CSSStyleSheet& sheet, DOM::Node& document_or_sha
 // inputs the engine already routes, not with a state transition published here.
 #include <LibWeb/StyleEngineStateFactsGenerated.inc>
 
+bool can_record_element_state_change(DOM::Element& element)
+{
+    auto* style_engine = style_engine_for(element);
+    if (!style_engine)
+        return false;
+    auto node = element.style_node_id();
+    if (node == no_style_node || has_pending_initial_features(element))
+        return false;
+    return true;
+}
+
 void record_element_state_changed(DOM::Element& element, PseudoClass pseudo_class, bool new_value)
 {
     auto* style_engine = style_engine_for(element);

--- a/Libraries/LibWeb/CSS/StyleEngineInput.h
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.h
@@ -96,6 +96,7 @@ WEB_API void record_element_emptiness_changed(DOM::Element&, DOM::Node const& ch
 
 // Called for each element whose pseudo-class state actually changed, with the value it changed to.
 // Only the states StyleEngine models as facts are recorded; the rest arrive when it models them.
+WEB_API bool can_record_element_state_change(DOM::Element&);
 WEB_API void record_element_state_changed(DOM::Element&, PseudoClass, bool new_value);
 
 // Called before each style flush. The user-agent and user origins have no sheet list to announce

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -810,6 +810,13 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
         node->queue_tree_mutation_record({}, nodes, nullptr, nullptr);
     }
 
+    insert_nodes_before(move(nodes), child, suppress_observers, node, affects_elements);
+}
+
+void Node::insert_nodes_before(Vector<GC::Root<Node>> nodes, GC::Ptr<Node> child, bool suppress_observers, GC::Ref<Node> metadata_node, ChildrenChangedMetadata::AffectsElements affects_elements)
+{
+    auto count = nodes.size();
+
     // 5. If child is non-null:
     if (child) {
         // 1. For each live range whose start node is parent and start offset is greater than child’s index:
@@ -930,7 +937,7 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     }
 
     // 9. Run the children changed steps for parent.
-    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node, affects_elements };
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, metadata_node, affects_elements };
     children_changed(metadata);
     invalidate_html_collection_caches_in_ancestors(affects_elements);
 
@@ -2667,6 +2674,27 @@ void Node::replace_all(GC::Ptr<Node> node)
     if (!added_nodes.is_empty() || !removed_nodes.is_empty()) {
         queue_tree_mutation_record(move(added_nodes), move(removed_nodes), nullptr, nullptr);
     }
+}
+
+void Node::replace_all(Vector<GC::Root<Node>> added_nodes)
+{
+    if (auto history = document().editing_history_if_exists())
+        history->notify_dom_mutation();
+
+    auto removed_nodes = children_as_vector();
+    auto added_nodes_for_mutation_record = added_nodes;
+
+    document().flush_deferred_style_change_event();
+    auto affects_elements = ChildrenChangedMetadata::AffectsElements::No;
+    if (document().has_valid_html_collection_caches())
+        affects_elements = mutation_affects_elements(added_nodes.span());
+
+    remove_all_children(true);
+    if (!added_nodes.is_empty())
+        insert_nodes_before(move(added_nodes), nullptr, true, *this, affects_elements);
+
+    if (!added_nodes_for_mutation_record.is_empty() || !removed_nodes.is_empty())
+        queue_tree_mutation_record(move(added_nodes_for_mutation_record), move(removed_nodes), nullptr, nullptr);
 }
 
 void Node::string_replace_all(Utf16View string)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -451,6 +451,7 @@ public:
     WebIDL::ExceptionOr<void> unsafely_set_html(Variant<GC::Ref<Element>, GC::Ref<DocumentFragment>>, Utf16View);
 
     void replace_all(GC::Ptr<Node>);
+    void replace_all(Vector<GC::Root<Node>>);
     void string_replace_all(Utf16View);
     void string_replace_all(Utf16String);
 
@@ -596,6 +597,7 @@ private:
     void live_range_pre_remove();
 
     void insert_before_impl(GC::Ref<Node>, GC::Ptr<Node> child);
+    void insert_nodes_before(Vector<GC::Root<Node>>, GC::Ptr<Node> child, bool suppress_observers, GC::Ref<Node> metadata_node, ChildrenChangedMetadata::AffectsElements);
     void append_child_impl(GC::Ref<Node>);
     void remove_child_impl(GC::Ref<Node>);
     void set_root_for_subtree(Node&);

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -6,8 +6,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/WeakHashSet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/DOM/NodeOperations.h>
@@ -176,6 +178,29 @@ WebIDL::ExceptionOr<void> ParentNode::append(ReadonlySpan<Variant<GC::Ref<Node>,
 // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
 WebIDL::ExceptionOr<void> ParentNode::replace_children(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
+    // OPTIMIZATION: A newly-created DocumentFragment is unobservable. When every argument is a
+    // detached node, insert the conceptual fragment's children as one batch without first running
+    // insertion and removal steps for the temporary fragment.
+    if (nodes.size() > 1 && !is<Document>(*this)) {
+        GC::WeakHashSet<Node> seen_nodes;
+        Vector<GC::Root<Node>> detached_nodes;
+        detached_nodes.ensure_capacity(nodes.size());
+        for (auto const& node_or_string : nodes) {
+            if (!node_or_string.has<GC::Ref<Node>>())
+                break;
+            auto node = node_or_string.get<GC::Ref<Node>>();
+            if (is<DocumentFragment>(*node) || node->parent() || &node->document() != &document() || seen_nodes.contains(*node))
+                break;
+            TRY(ensure_pre_insertion_validity(node, nullptr, true));
+            seen_nodes.set(*node);
+            detached_nodes.append(GC::make_root(*node));
+        }
+        if (detached_nodes.size() == nodes.size()) {
+            replace_all(move(detached_nodes));
+            return {};
+        }
+    }
+
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
 

--- a/Libraries/LibWeb/Rust/src/css/style/tree.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tree.rs
@@ -488,6 +488,8 @@ pub struct StyleNodeTree {
     /// Allocated only once a shadow tree exists.
     shadow: Option<Box<ShadowRelations>>,
 
+    capacity_bytes: u64,
+
     #[cfg(test)]
     depth_recompute_visits: usize,
 }
@@ -519,6 +521,7 @@ impl StyleNodeTree {
             pending_reuse: Vec::new(),
             free_element_indexes: Vec::new(),
             shadow: None,
+            capacity_bytes: 0,
             #[cfg(test)]
             depth_recompute_visits: 0,
         };
@@ -528,7 +531,8 @@ impl StyleNodeTree {
         tree.next_element_sibling.push(None);
         tree.previous_element_sibling.push(None);
         tree.depth.push(0);
-        tree.charge(memory, 0);
+        tree.capacity_bytes = tree.recompute_capacity_bytes();
+        memory.reserve_required(MemoryCategory::RelationColumns, tree.capacity_bytes);
         tree
     }
 
@@ -556,8 +560,7 @@ impl StyleNodeTree {
     /// Allocate an element identity. Reuses a slot only once the epoch that could still observe its
     /// previous occupant has retired.
     pub fn allocate_element(&mut self, memory: &mut MemoryController) -> StyleNodeID {
-        let before = self.capacity_bytes();
-        let index = match self.free_element_indexes.pop() {
+        let (index, capacity_before_growth) = match self.free_element_indexes.pop() {
             Some(index) => {
                 self.parent[index as usize] = None;
                 self.first_element_child[index as usize] = None;
@@ -567,9 +570,10 @@ impl StyleNodeTree {
                 if let Some(column) = self.tree_scope.as_mut() {
                     column[index as usize] = TreeScopeID::DOCUMENT;
                 }
-                index
+                (index, None)
             }
             None => {
+                let capacity_before_growth = self.identity_capacity_bytes();
                 let index = u32::try_from(self.parent.len()).expect("element index space exhausted");
                 self.parent.push(None);
                 self.first_element_child.push(None);
@@ -579,19 +583,22 @@ impl StyleNodeTree {
                 if let Some(column) = self.tree_scope.as_mut() {
                     column.push(TreeScopeID::DOCUMENT);
                 }
-                index
+                (index, Some(capacity_before_growth))
             }
         };
         self.live.set(index as usize, true);
+        if let Some(capacity_before_growth) = capacity_before_growth {
+            let current = self.identity_capacity_bytes();
+            self.record_capacity_change(memory, capacity_before_growth, current);
+        }
         self.connected_element_count += 1;
-        self.charge(memory, before);
         StyleNodeID::element(index)
     }
 
     /// Retire an element identity. The slot stays reserved until [`Self::release_retired_identities`]
     /// runs at epoch retirement, so no reader can observe a reused identity.
     pub fn retire_element(&mut self, node: StyleNodeID, memory: &mut MemoryController) {
-        let before = self.capacity_bytes();
+        let before = self.retirement_capacity_bytes();
         let index = node
             .element_index()
             .expect("retire_element requires an element identity");
@@ -610,14 +617,16 @@ impl StyleNodeTree {
         self.depth[index as usize] = 0;
         self.connected_element_count -= 1;
         self.pending_reuse.push(index);
-        self.charge(memory, before);
+        let current = self.retirement_capacity_bytes();
+        self.record_capacity_change(memory, before, current);
     }
 
     /// Called once the read epoch that could still name the retired identities has retired.
     pub fn release_retired_identities(&mut self, memory: &mut MemoryController) {
-        let before = self.capacity_bytes();
+        let before = self.reuse_capacity_bytes();
         self.free_element_indexes.append(&mut self.pending_reuse);
-        self.charge(memory, before);
+        let current = self.reuse_capacity_bytes();
+        self.record_capacity_change(memory, before, current);
     }
 
     #[must_use]
@@ -722,9 +731,12 @@ impl StyleNodeTree {
         if self.tree_scope.is_some() {
             return;
         }
-        let before = self.capacity_bytes();
         self.tree_scope = Some(vec![TreeScopeID::DOCUMENT; self.parent.len()]);
-        self.charge(memory, before);
+        let current = self
+            .tree_scope
+            .as_ref()
+            .map_or(0, |column| column.capacity() * size_of::<TreeScopeID>());
+        self.record_capacity_change(memory, 0, current as u64);
     }
 
     #[must_use]
@@ -755,7 +767,7 @@ impl StyleNodeTree {
 
     /// Record that `host` hosts `shadow_root`.
     pub fn set_shadow_root(&mut self, host: StyleNodeID, shadow_root: StyleNodeID, memory: &mut MemoryController) {
-        let before = self.capacity_bytes();
+        let before = self.shadow_capacity_bytes();
         let shadow = self.shadow_mut();
         if let Some(previous_root) = shadow.shadow_root.insert(host, shadow_root)
             && previous_root != shadow_root
@@ -769,7 +781,8 @@ impl StyleNodeTree {
         {
             shadow.shadow_root.remove(previous_host);
         }
-        self.charge(memory, before);
+        let current = self.shadow_capacity_bytes();
+        self.record_capacity_change(memory, before, current);
     }
 
     #[must_use]
@@ -787,7 +800,7 @@ impl StyleNodeTree {
     /// Slot assignment changes flat-tree identity even when the DOM parent does not move, which is
     /// why it is its own relation rather than a derived view of the DOM tree.
     pub fn set_assigned_slot(&mut self, node: StyleNodeID, slot: Option<StyleNodeID>, memory: &mut MemoryController) {
-        let before = self.capacity_bytes();
+        let before = self.shadow_capacity_bytes();
         let shadow = self.shadow_mut();
         if let Some(previous) = shadow.assigned_slot.remove(node)
             && let Some(nodes) = shadow.assigned_nodes.get_mut(&previous)
@@ -798,7 +811,8 @@ impl StyleNodeTree {
             shadow.assigned_slot.insert(node, slot);
             shadow.assigned_nodes.entry(slot).or_default().push(node);
         }
-        self.charge(memory, before);
+        let current = self.shadow_capacity_bytes();
+        self.record_capacity_change(memory, before, current);
     }
 
     /// The shadow host of the tree `node` is in, if it is in one.
@@ -834,14 +848,15 @@ impl StyleNodeTree {
         pairs: &[(StyleAtomID, StyleNodeID)],
         memory: &mut MemoryController,
     ) {
-        let before = self.capacity_bytes();
+        let before = self.shadow_capacity_bytes();
         let shadow = self.shadow_mut();
         if pairs.is_empty() {
             shadow.part_hosts.remove(&node);
         } else {
             shadow.part_hosts.insert(node, pairs.to_vec());
         }
-        self.charge(memory, before);
+        let current = self.shadow_capacity_bytes();
+        self.record_capacity_change(memory, before, current);
     }
 
     /// Every (name, host) pair the element answers a `::part()` rule under.
@@ -987,6 +1002,10 @@ impl StyleNodeTree {
     /// Exact capacity of every column, charged to Tier 1.
     #[must_use]
     pub fn capacity_bytes(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    fn identity_capacity_bytes(&self) -> u64 {
         capacity_bytes! {
             shallow [
                 self.parent,
@@ -994,8 +1013,6 @@ impl StyleNodeTree {
                 self.next_element_sibling,
                 self.previous_element_sibling,
                 self.depth,
-                self.pending_reuse,
-                self.free_element_indexes,
             ];
             cached [];
             nested [
@@ -1003,19 +1020,39 @@ impl StyleNodeTree {
                     .as_ref()
                     .map_or(0, |column| column.capacity() * size_of::<TreeScopeID>()),
                 self.live.capacity_bytes(),
-                self.shadow.as_ref().map_or(0, |relations| relations.capacity_bytes()),
             ];
             skip [];
         }
     }
 
-    fn charge(&self, memory: &mut MemoryController, previous_bytes: u64) {
-        let current = self.capacity_bytes();
-        if current > previous_bytes {
-            memory.reserve_required(MemoryCategory::RelationColumns, current - previous_bytes);
-        } else if previous_bytes > current {
-            memory.release(MemoryCategory::RelationColumns, previous_bytes - current);
+    fn reuse_capacity_bytes(&self) -> u64 {
+        ((self.pending_reuse.capacity() + self.free_element_indexes.capacity()) * size_of::<u32>()) as u64
+    }
+
+    fn shadow_capacity_bytes(&self) -> u64 {
+        self.shadow.as_ref().map_or(0, |relations| relations.capacity_bytes())
+    }
+
+    fn retirement_capacity_bytes(&self) -> u64 {
+        (self.pending_reuse.capacity() * size_of::<u32>()) as u64 + self.shadow_capacity_bytes()
+    }
+
+    fn recompute_capacity_bytes(&self) -> u64 {
+        self.identity_capacity_bytes() + self.reuse_capacity_bytes() + self.shadow_capacity_bytes()
+    }
+
+    fn record_capacity_change(&mut self, memory: &mut MemoryController, previous: u64, current: u64) {
+        if current > previous {
+            let growth = current - previous;
+            self.capacity_bytes += growth;
+            memory.reserve_required(MemoryCategory::RelationColumns, growth);
+        } else if previous > current {
+            let shrinkage = previous - current;
+            self.capacity_bytes -= shrinkage;
+            memory.release(MemoryCategory::RelationColumns, shrinkage);
         }
+        #[cfg(test)]
+        assert_eq!(self.capacity_bytes, self.recompute_capacity_bytes());
     }
 
     fn element_index(&self, node: StyleNodeID) -> usize {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -63,6 +63,7 @@
 #endif
 
 #if !defined(AK_OS_WINDOWS)
+#    include <signal.h>
 #    include <sys/wait.h>
 #endif
 
@@ -175,11 +176,48 @@ Application::~Application()
     if (m_compositor_client)
         m_compositor_client->on_death = nullptr;
 
+    if (m_cpu_profiler_process.has_value()) {
+#if !defined(AK_OS_WINDOWS)
+        for (auto handler : m_cpu_profiler_signal_handlers)
+            Core::EventLoop::unregister_signal(handler);
+        auto wait_result = Core::System::waitpid(m_cpu_profiler_process->pid(), WNOHANG);
+        while (wait_result.is_error() && wait_result.error().code() == EINTR)
+            wait_result = Core::System::waitpid(m_cpu_profiler_process->pid(), WNOHANG);
+        if (!wait_result.is_error() && wait_result.value().pid == 0) {
+            if (auto result = Core::System::kill(m_cpu_profiler_process->pid(), SIGINT); result.is_error())
+                warnln("Unable to stop CPU profiler: {}", result.error());
+            if (auto result = m_cpu_profiler_process->wait_for_termination(); result.is_error())
+                warnln("Unable to wait for CPU profiler: {}", result.error());
+        } else if (wait_result.is_error() && wait_result.error().code() != ECHILD) {
+            warnln("Unable to query CPU profiler: {}", wait_result.error());
+        }
+#endif
+        m_cpu_profiler_process.clear();
+    }
+
     m_spare_web_content_process = nullptr;
     m_process_manager = nullptr;
     m_browser_process = nullptr;
 
     s_the = nullptr;
+}
+
+bool Application::claim_cpu_profiler(ProcessType process_type)
+{
+    if (m_cpu_profiler_claimed || m_browser_options.profile_tool != ProfileTool::CPU || m_browser_options.profile_helper_process != process_type)
+        return false;
+    m_cpu_profiler_claimed = true;
+    return true;
+}
+
+void Application::set_cpu_profiler_process(Core::Process process)
+{
+    VERIFY(!m_cpu_profiler_process.has_value());
+    m_cpu_profiler_process = move(process);
+#if !defined(AK_OS_WINDOWS)
+    m_cpu_profiler_signal_handlers.append(Core::EventLoop::register_signal(SIGINT, [this](int) { m_event_loop->quit(0); }));
+    m_cpu_profiler_signal_handlers.append(Core::EventLoop::register_signal(SIGTERM, [this](int) { m_event_loop->quit(0); }));
+#endif
 }
 
 FaviconStore& Application::favicon_store(IsPrivate is_private)
@@ -276,6 +314,8 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     Optional<u16> devtools_port;
     Vector<StringView> debug_processes;
     Optional<StringView> profile_process;
+    Optional<StringView> profile_tool;
+    Optional<StringView> profile_output;
     Optional<StringView> webdriver_browser_endpoint;
     Optional<StringView> user_agent_preset;
     Optional<StringView> dns_server_address;
@@ -356,7 +396,9 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
             debug_processes.append(value);
             return true;
         } });
-    args_parser.add_option(profile_process, "Enable callgrind profiling of the given process name (WebContent, RequestServer, etc.)", "profile-process", 0, "process-name");
+    args_parser.add_option(profile_process, "Profile the given process name (WebContent, RequestServer, etc.)", "profile-process", 0, "process-name");
+    args_parser.add_option(profile_tool, "Select the profiler to use: 'callgrind' (default) or 'cpu'", "profile-tool", 0, "tool");
+    args_parser.add_option(profile_output, "Write CPU profiler output to the given path", "profile-output", 0, "path");
 #if defined(AK_OS_MACOS)
     args_parser.add_option(webdriver_browser_endpoint, "Mach server name for the browser's WebDriver IPC", "webdriver-browser-mach-server-name", 0, "name", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
 #else
@@ -529,6 +571,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     Vector<ProcessType> debug_process_types;
     Optional<ProcessType> profile_process_type;
+    auto selected_profile_tool = ProfileTool::Callgrind;
 
     for (auto& process_name : debug_processes) {
         auto type = process_type_from_name(process_name);
@@ -536,6 +579,18 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     }
     if (profile_process.has_value())
         profile_process_type = process_type_from_name(*profile_process);
+    if (profile_tool.has_value()) {
+        if (*profile_tool == "callgrind"sv)
+            selected_profile_tool = ProfileTool::Callgrind;
+        else if (*profile_tool == "cpu"sv)
+            selected_profile_tool = ProfileTool::CPU;
+        else
+            return Error::from_string_literal("--profile-tool must be 'callgrind' or 'cpu'");
+    }
+    if (profile_tool.has_value() && !profile_process.has_value())
+        return Error::from_string_literal("--profile-tool requires --profile-process");
+    if (profile_output.has_value() && selected_profile_tool != ProfileTool::CPU)
+        return Error::from_string_literal("--profile-output requires --profile-tool cpu");
 
     auto configured_content_blocker_list_paths = m_settings->config_variable_as_string_array(ConfigVariableID::ContentBlockerListPaths);
 
@@ -564,6 +619,8 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .disable_sql_database = disable_sql_database ? DisableSQLDatabase::Yes : DisableSQLDatabase::No,
         .debug_helper_processes = move(debug_process_types),
         .profile_helper_process = move(profile_process_type),
+        .profile_tool = selected_profile_tool,
+        .profile_output = profile_output.has_value() ? Optional<ByteString> { *profile_output } : OptionalNone {},
         .dns_settings = (dns_server_address.has_value()
                 ? Optional<DNSSettings> { use_dns_over_tls
                           ? DNSSettings(DNSOverTLS(dns_server_address.release_value(), *dns_server_port, validate_dnssec_locally))

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -87,6 +87,9 @@ public:
     static RequestServerOptions const& request_server_options() { return the().m_request_server_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
 
+    bool claim_cpu_profiler(ProcessType);
+    void set_cpu_profiler_process(Core::Process);
+
     virtual Optional<String> system_font_family() const { return {}; }
 
     static Requests::RequestClient& request_server_client(IsPrivate = IsPrivate::No);
@@ -452,6 +455,9 @@ private:
 
     Main::Arguments m_arguments;
     BrowserOptions m_browser_options;
+    Optional<Core::Process> m_cpu_profiler_process;
+    bool m_cpu_profiler_claimed { false };
+    Vector<int> m_cpu_profiler_signal_handlers;
     RequestServerOptions m_request_server_options;
     WebContentOptions m_web_content_options;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Enumerate.h>
+#include <AK/ScopeGuard.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibWebView/Application.h>
@@ -12,7 +14,136 @@
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/Utilities.h>
 
+#if defined(AK_OS_MACOS)
+#    include <notify.h>
+#    include <signal.h>
+#    include <sys/wait.h>
+#elif defined(AK_OS_LINUX)
+#    include <signal.h>
+#    include <sys/socket.h>
+#    include <sys/wait.h>
+#endif
+
 namespace WebView {
+
+static ErrorOr<Core::Process> launch_cpu_profiler(StringView server_name, pid_t pid, Optional<ByteString> const& configured_output)
+{
+#if defined(AK_OS_MACOS)
+    auto output = configured_output.value_or(ByteString::formatted("Ladybird-{}-{}.trace", server_name, pid));
+    auto notification_name = ByteString::formatted("org.ladybird.cpu-profiler-ready.{}.{}", Core::System::getpid(), pid);
+
+    int notification_token = 0;
+    if (notify_register_check(notification_name.characters(), &notification_token) != NOTIFY_STATUS_OK)
+        return Error::from_string_literal("Unable to register for the xctrace startup notification");
+    ScopeGuard cancel_notification = [&] { notify_cancel(notification_token); };
+
+    Vector<ByteString> arguments {
+        "record"sv,
+        "--template"sv,
+        "Time Profiler"sv,
+        "--attach"sv,
+        ByteString::number(pid),
+        "--output"sv,
+        output,
+        "--notify-tracing-started"sv,
+        notification_name,
+        "--no-prompt"sv,
+    };
+    auto profiler = TRY(Core::Process::spawn({
+        .executable = "xctrace"sv,
+        .search_for_executable_in_path = true,
+        .arguments = arguments,
+    }));
+    ArmedScopeGuard stop_profiler = [&] {
+        (void)Core::System::kill(profiler.pid(), SIGINT);
+        (void)profiler.wait_for_termination();
+    };
+
+    auto timer = Core::ElapsedTimer::start_new();
+    for (;;) {
+        int tracing_started = 0;
+        if (notify_check(notification_token, &tracing_started) != NOTIFY_STATUS_OK)
+            return Error::from_string_literal("Unable to check the xctrace startup notification");
+        if (tracing_started)
+            break;
+
+        auto wait_result = TRY(Core::System::waitpid(profiler.pid(), WNOHANG));
+        if (wait_result.pid != 0)
+            return Error::from_string_literal("xctrace exited before profiling started");
+        if (timer.elapsed_milliseconds() >= 30'000)
+            return Error::from_string_literal("Timed out waiting for xctrace to start profiling");
+        TRY(Core::System::sleep_ms(10));
+    }
+
+    dbgln("Launched {} process under Time Profiler; writing {}", server_name, output);
+    stop_profiler.disarm();
+    return profiler;
+#elif defined(AK_OS_LINUX)
+    auto output = configured_output.value_or(ByteString::formatted("perf.data.{}", pid));
+
+    Array<int, 2> control_socket;
+    Array<int, 2> acknowledgement_socket;
+    TRY(Core::System::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, control_socket.data()));
+    TRY(Core::System::socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, acknowledgement_socket.data()));
+    TRY(Core::System::set_close_on_exec(control_socket[1], false));
+    TRY(Core::System::set_close_on_exec(acknowledgement_socket[1], false));
+    ScopeGuard close_sockets = [&] {
+        for (auto fd : control_socket)
+            (void)Core::System::close(fd);
+        for (auto fd : acknowledgement_socket)
+            (void)Core::System::close(fd);
+    };
+
+    Vector<ByteString> arguments {
+        "record"sv,
+        "--pid"sv,
+        ByteString::number(pid),
+        "--output"sv,
+        output,
+        "--delay=-1"sv,
+        ByteString::formatted("--control=fd:{},{}", control_socket[1], acknowledgement_socket[1]),
+    };
+    auto profiler = TRY(Core::Process::spawn({
+        .executable = "perf"sv,
+        .search_for_executable_in_path = true,
+        .arguments = arguments,
+    }));
+    TRY(Core::System::close(control_socket[1]));
+    control_socket[1] = -1;
+    TRY(Core::System::close(acknowledgement_socket[1]));
+    acknowledgement_socket[1] = -1;
+    ArmedScopeGuard stop_profiler = [&] {
+        (void)Core::System::kill(profiler.pid(), SIGINT);
+        (void)profiler.wait_for_termination();
+    };
+
+    // perf acknowledges this command only after it has attached and configured its events.
+    static constexpr Array<u8, 7> enable_command { 'e', 'n', 'a', 'b', 'l', 'e', '\n' };
+    auto sent = TRY(Core::System::send(control_socket[0], enable_command.span(), MSG_NOSIGNAL));
+    if (sent != enable_command.size())
+        return Error::from_string_literal("Unable to enable perf profiling");
+
+    Array<u8, 4> acknowledgement;
+    size_t received = 0;
+    while (received < acknowledgement.size()) {
+        auto bytes_read = TRY(Core::System::read(acknowledgement_socket[0], acknowledgement.span().slice(received)));
+        if (bytes_read == 0)
+            return Error::from_string_literal("perf exited before profiling started");
+        received += bytes_read;
+    }
+    if (acknowledgement != Array<u8, 4> { 'a', 'c', 'k', '\n' })
+        return Error::from_string_literal("perf returned an invalid startup acknowledgement");
+
+    dbgln("Launched {} process under perf; writing {}", server_name, output);
+    stop_profiler.disarm();
+    return profiler;
+#else
+    (void)server_name;
+    (void)pid;
+    (void)configured_output;
+    return Error::from_string_literal("CPU profiling is only supported on macOS and Linux");
+#endif
+}
 
 template<typename ClientType, typename... ClientArguments>
 static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
@@ -25,7 +156,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
 
     auto candidate_server_paths = TRY(get_paths_for_helper_process(server_name));
 
-    if (browser_options.profile_helper_process == process_type) {
+    if (browser_options.profile_helper_process == process_type && browser_options.profile_tool == ProfileTool::Callgrind) {
         arguments.prepend({
             "--tool=callgrind"sv,
             "--instr-atstart=no"sv,
@@ -39,7 +170,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
     for (auto [i, path] : enumerate(candidate_server_paths)) {
         Core::ProcessSpawnOptions options { .name = server_name, .arguments = arguments };
 
-        if (browser_options.profile_helper_process == process_type) {
+        if (browser_options.profile_helper_process == process_type && browser_options.profile_tool == ProfileTool::Callgrind) {
             options.executable = "valgrind"sv;
             options.search_for_executable_in_path = true;
             arguments[2] = path;
@@ -53,6 +184,11 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
         if (!result.is_error()) {
             auto&& [process, client] = result.release_value();
 
+            if (WebView::Application::the().claim_cpu_profiler(process_type)) {
+                auto profiler = TRY(launch_cpu_profiler(server_name, process.pid(), browser_options.profile_output));
+                WebView::Application::the().set_cpu_profiler_process(move(profiler));
+            }
+
             if constexpr (requires { client->set_pid(pid_t {}); })
                 client->set_pid(process.pid());
 
@@ -63,7 +199,7 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
 
             WebView::Application::the().add_child_process(move(process));
 
-            if (browser_options.profile_helper_process == process_type) {
+            if (browser_options.profile_helper_process == process_type && browser_options.profile_tool == ProfileTool::Callgrind) {
                 dbgln();
                 dbgln("\033[1;34mLaunched {} process under callgrind!\033[0m", server_name);
                 dbgln("\033[1;36mRun `\033[4mcallgrind_control -i on\033[24m` to start instrumentation and `\033[4mcallgrind_control -i off\033[24m` stop it again.\033[0m");

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -75,6 +75,11 @@ enum class DisableSandbox {
     Yes,
 };
 
+enum class ProfileTool {
+    Callgrind,
+    CPU,
+};
+
 struct BrowserOptions {
     Vector<URL::URL> urls;
     Vector<ByteString> raw_urls;
@@ -89,6 +94,8 @@ struct BrowserOptions {
     DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
     Vector<ProcessType> debug_helper_processes {};
     Optional<ProcessType> profile_helper_process {};
+    ProfileTool profile_tool { ProfileTool::Callgrind };
+    Optional<ByteString> profile_output {};
     Optional<ByteString> webdriver_browser_endpoint {};
     Optional<DNSSettings> dns_settings {};
     Optional<u16> devtools_port;

--- a/Tests/LibWeb/Text/expected/DOM/ParentNode-replaceChildren-detached-nodes.txt
+++ b/Tests/LibWeb/Text/expected/DOM/ParentNode-replaceChildren-detached-nodes.txt
@@ -1,0 +1,22 @@
+children: first-child, second-child
+child nodes: first-child, second-child
+mutation records: 1
+added: first-child, second-child
+removed: old-child
+duplicate child count: 1
+duplicate child preserved: true
+fragment children: fragment-first, fragment-second, after-fragment
+fragment was emptied: true
+fragment was not inserted: true
+empty fragment children: after-empty-fragment
+empty fragment was not inserted: true
+mixed children: "before", mixed-element, "after"
+parented children: parented-child, after-parented
+parented source was emptied: true
+adopted children: foreign-child, after-foreign
+foreign child was adopted: true
+invalid insertion exception: HierarchyRequestError
+invalid insertion preserved children: true
+invalid insertion preserved detached node: true
+document insertion exception: HierarchyRequestError
+document insertion preserved children: true

--- a/Tests/LibWeb/Text/input/DOM/ParentNode-replaceChildren-detached-nodes.html
+++ b/Tests/LibWeb/Text/input/DOM/ParentNode-replaceChildren-detached-nodes.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const parent = document.createElement("div");
+        const oldChild = document.createElement("old-child");
+        parent.append(oldChild);
+
+        const first = document.createElement("first-child");
+        const second = document.createElement("second-child");
+        const cachedChildren = parent.children;
+        const cachedChildNodes = parent.childNodes;
+        const observer = new MutationObserver(() => {});
+        observer.observe(parent, { childList: true });
+
+        parent.replaceChildren(first, second);
+
+        println(`children: ${Array.from(cachedChildren, child => child.localName).join(", ")}`);
+        println(`child nodes: ${Array.from(cachedChildNodes, child => child.localName).join(", ")}`);
+        const records = observer.takeRecords();
+        println(`mutation records: ${records.length}`);
+        println(`added: ${Array.from(records[0].addedNodes, child => child.localName).join(", ")}`);
+        println(`removed: ${Array.from(records[0].removedNodes, child => child.localName).join(", ")}`);
+        const child = document.createElement("only-child");
+        parent.replaceChildren(child, child);
+        println(`duplicate child count: ${parent.childNodes.length}`);
+        println(`duplicate child preserved: ${parent.firstChild === child}`);
+
+        const fragment = document.createDocumentFragment();
+        fragment.append(document.createElement("fragment-first"), document.createElement("fragment-second"));
+        const afterFragment = document.createElement("after-fragment");
+        parent.replaceChildren(fragment, afterFragment);
+        println(`fragment children: ${Array.from(parent.children, child => child.localName).join(", ")}`);
+        println(`fragment was emptied: ${fragment.childNodes.length === 0}`);
+        println(`fragment was not inserted: ${Array.from(parent.childNodes).every(child => child.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)}`);
+
+        const emptyFragment = document.createDocumentFragment();
+        const afterEmptyFragment = document.createElement("after-empty-fragment");
+        parent.replaceChildren(emptyFragment, afterEmptyFragment);
+        println(`empty fragment children: ${Array.from(parent.children, child => child.localName).join(", ")}`);
+        println(`empty fragment was not inserted: ${Array.from(parent.childNodes).every(child => child.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)}`);
+
+        const mixedElement = document.createElement("mixed-element");
+        parent.replaceChildren("before", mixedElement, "after");
+        println(`mixed children: ${Array.from(parent.childNodes, child => child.localName || JSON.stringify(child.data)).join(", ")}`);
+
+        const source = document.createElement("source");
+        const parentedChild = document.createElement("parented-child");
+        source.append(parentedChild);
+        const afterParented = document.createElement("after-parented");
+        parent.replaceChildren(parentedChild, afterParented);
+        println(`parented children: ${Array.from(parent.children, child => child.localName).join(", ")}`);
+        println(`parented source was emptied: ${source.childNodes.length === 0}`);
+
+        const foreignDocument = document.implementation.createHTMLDocument("");
+        const foreignChild = foreignDocument.createElement("foreign-child");
+        const afterForeign = document.createElement("after-foreign");
+        parent.replaceChildren(foreignChild, afterForeign);
+        println(`adopted children: ${Array.from(parent.children, child => child.localName).join(", ")}`);
+        println(`foreign child was adopted: ${foreignChild.ownerDocument === document}`);
+
+        const preservedChildren = Array.from(parent.childNodes);
+        const detachedBeforeError = document.createElement("detached-before-error");
+        let exceptionName;
+        try {
+            parent.replaceChildren(detachedBeforeError, parent);
+        } catch (error) {
+            exceptionName = error.name;
+        }
+        println(`invalid insertion exception: ${exceptionName}`);
+        println(`invalid insertion preserved children: ${preservedChildren.length === parent.childNodes.length && preservedChildren.every((child, index) => child === parent.childNodes[index])}`);
+        println(`invalid insertion preserved detached node: ${detachedBeforeError.parentNode === null}`);
+
+        const replacementDocument = document.implementation.createHTMLDocument("");
+        const originalDocumentChildren = Array.from(replacementDocument.childNodes);
+        let documentExceptionName;
+        try {
+            replacementDocument.replaceChildren(replacementDocument.createElement("first-root"), replacementDocument.createElement("second-root"));
+        } catch (error) {
+            documentExceptionName = error.name;
+        }
+        println(`document insertion exception: ${documentExceptionName}`);
+        println(`document insertion preserved children: ${originalDocumentChildren.length === replacementDocument.childNodes.length && originalDocumentChildren.every((child, index) => child === replacementDocument.childNodes[index])}`);
+    });
+</script>


### PR DESCRIPTION
This reduces the warmed MicroWeb frameworks/replace-children median from approximately 49.6 ms to 13.45 ms on arm64 macOS, a 3.7x Ladybird speedup. The gap agains Chromium shrinks from roughly 13x to 3.7x. The original short, cold run measured 115.9 ms, while the optimized implementation consistently reaches the 13–14 ms range.

The profiling results led to several targeted improvements:

- Add native CPU profiling for helper processes using Time Profiler through xctrace on macOS and perf record on Linux.
- Defer redundant constraint-validity computation for newly inserted elements.
- Batch unique, detached, same-document replaceChildren() arguments without inserting them into a temporary fragment first.
- Preserve the specification path for strings, duplicates, parented nodes, adoption, DocumentFragment arguments, and Document targets.
- Avoid allocating directionality visit tables for text with simple unslotted ancestry.
- Maintain style-tree capacity accounting incrementally instead of recomputing it during every node lifecycle change.

Regression coverage verifies batched ordering, combined mutation records, duplicate arguments, and correct handling of empty and nonempty DocumentFragment arguments.