### PR TITLE
LibWasmCompilerClient: Create the compiler transport on the IPC thread

### DIFF
--- a/Libraries/LibWasmCompilerClient/State.cpp
+++ b/Libraries/LibWasmCompilerClient/State.cpp
@@ -26,17 +26,11 @@ void CompilerState::install_compiler_callback()
     });
 }
 
-static ErrorOr<NonnullRefPtr<ThreadedClient>> connect_to_wasm_compiler(IPC::TransportHandle const& handle)
-{
-    auto transport = TRY(handle.create_transport());
-    return ThreadedClient::create(move(transport));
-}
-
-void CompilerState::replace_connection(IPC::TransportHandle const& handle)
+void CompilerState::replace_connection(IPC::TransportHandle handle)
 {
     RefPtr<ThreadedClient> new_client;
 
-    if (auto result = connect_to_wasm_compiler(handle); result.is_error())
+    if (auto result = ThreadedClient::create(move(handle)); result.is_error())
         dbgln("Failed to connect to WebAssembly compiler: {}", result.error());
     else
         new_client = result.release_value();

--- a/Libraries/LibWasmCompilerClient/State.h
+++ b/Libraries/LibWasmCompilerClient/State.h
@@ -16,7 +16,7 @@ namespace WasmCompilerClient {
 class CompilerState {
 public:
     void install_compiler_callback();
-    void replace_connection(IPC::TransportHandle const&);
+    void replace_connection(IPC::TransportHandle);
 
 private:
     RefPtr<ThreadedClient> m_client;

--- a/Libraries/LibWasmCompilerClient/ThreadedClient.cpp
+++ b/Libraries/LibWasmCompilerClient/ThreadedClient.cpp
@@ -7,15 +7,16 @@
 #include <AK/ScopeGuard.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
+#include <LibIPC/TransportHandle.h>
 #include <LibThreading/Thread.h>
 #include <LibWasmCompilerClient/Client.h>
 #include <LibWasmCompilerClient/ThreadedClient.h>
 
 namespace WasmCompilerClient {
 
-ErrorOr<NonnullRefPtr<ThreadedClient>> ThreadedClient::create(NonnullOwnPtr<IPC::Transport> transport)
+ErrorOr<NonnullRefPtr<ThreadedClient>> ThreadedClient::create(IPC::TransportHandle handle)
 {
-    auto client = adopt_ref(*new ThreadedClient(move(transport)));
+    auto client = adopt_ref(*new ThreadedClient(move(handle)));
 
     Optional<Error> initialization_error;
     {
@@ -30,9 +31,9 @@ ErrorOr<NonnullRefPtr<ThreadedClient>> ThreadedClient::create(NonnullOwnPtr<IPC:
     return client;
 }
 
-ThreadedClient::ThreadedClient(NonnullOwnPtr<IPC::Transport> transport)
-    : m_thread(Threading::Thread::construct("WasmCompiler IPC"sv, [this, transport = move(transport)]() mutable {
-        return thread_main(move(transport));
+ThreadedClient::ThreadedClient(IPC::TransportHandle handle)
+    : m_thread(Threading::Thread::construct("WasmCompiler IPC"sv, [this, handle = move(handle)]() {
+        return thread_main(handle);
     }))
 {
     m_thread->start();
@@ -80,10 +81,27 @@ Core::AnonymousBuffer ThreadedClient::compile(Core::AnonymousBuffer const& buffe
     return client->compile(buffer);
 }
 
-intptr_t ThreadedClient::thread_main(NonnullOwnPtr<IPC::Transport> transport)
+// This must run on the IPC thread. On Windows, the socket's notifier is bound to the event loop of the thread that
+// creates the socket, and the connection must be serviced by that same thread.
+static ErrorOr<NonnullRefPtr<Client>> create_client(IPC::TransportHandle const& handle)
+{
+    auto transport = TRY(handle.create_transport());
+    auto client = TRY(try_make_ref_counted<Client>(move(transport)));
+
+#ifdef AK_OS_WINDOWS
+    if (auto response = client->send_sync_but_allow_failure<Client::InitTransport>(Core::System::getpid()))
+        client->transport().set_peer_pid(response->peer_pid());
+    else
+        return Error::from_string_literal("Failed to initialize WebAssembly compiler transport");
+#endif
+
+    return client;
+}
+
+intptr_t ThreadedClient::thread_main(IPC::TransportHandle const& handle)
 {
     Core::EventLoop event_loop;
-    auto client_or_error = try_make_ref_counted<Client>(move(transport));
+    auto client_or_error = create_client(handle);
 
     if (client_or_error.is_error()) {
         Sync::MutexLocker locker(m_mutex);
@@ -94,18 +112,6 @@ intptr_t ThreadedClient::thread_main(NonnullOwnPtr<IPC::Transport> transport)
     }
 
     auto client = client_or_error.release_value();
-
-#ifdef AK_OS_WINDOWS
-    auto response = client->send_sync_but_allow_failure<Client::InitTransport>(Core::System::getpid());
-    if (!response) {
-        Sync::MutexLocker locker(m_mutex);
-        m_initialization_error = Error::from_string_literal("Failed to initialize WebAssembly compiler transport");
-        m_initialized = true;
-        m_initialization_condition.broadcast();
-        return 1;
-    }
-    client->transport().set_peer_pid(response->peer_pid());
-#endif
 
     {
         Sync::MutexLocker locker(m_mutex);

--- a/Libraries/LibWasmCompilerClient/ThreadedClient.h
+++ b/Libraries/LibWasmCompilerClient/ThreadedClient.h
@@ -27,15 +27,15 @@ class ThreadedClient final : public AtomicRefCounted<ThreadedClient> {
     AK_MAKE_NONMOVABLE(ThreadedClient);
 
 public:
-    static ErrorOr<NonnullRefPtr<ThreadedClient>> create(NonnullOwnPtr<IPC::Transport>);
+    static ErrorOr<NonnullRefPtr<ThreadedClient>> create(IPC::TransportHandle);
     ~ThreadedClient();
 
     Core::AnonymousBuffer compile(Core::AnonymousBuffer const&);
 
 private:
-    explicit ThreadedClient(NonnullOwnPtr<IPC::Transport>);
+    explicit ThreadedClient(IPC::TransportHandle);
 
-    intptr_t thread_main(NonnullOwnPtr<IPC::Transport>);
+    intptr_t thread_main(IPC::TransportHandle const&);
 
     NonnullRefPtr<Threading::Thread> m_thread;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -231,7 +231,7 @@ void ConnectionFromClient::connect_to_wasm_compiler([[maybe_unused]] IPC::Transp
 {
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     if (on_wasm_compiler_connection)
-        on_wasm_compiler_connection(handle);
+        on_wasm_compiler_connection(move(handle));
 #endif
 }
 

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -63,7 +63,7 @@ public:
     Function<void(IPC::TransportHandle const&)> on_request_server_connection;
     Function<void(IPC::TransportHandle const&)> on_image_decoder_connection;
 #if defined(HAVE_WASM_COMPILER_SERVICE)
-    Function<void(IPC::TransportHandle const&)> on_wasm_compiler_connection;
+    Function<void(IPC::TransportHandle)> on_wasm_compiler_connection;
 #endif
 
     Queue<Web::QueuedInputEvent>& input_event_queue() { return m_input_event_queue; }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -269,8 +269,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     WasmCompilerClient::compiler_state().install_compiler_callback();
 
-    webcontent_client->on_wasm_compiler_connection = [](auto const& handle) {
-        WasmCompilerClient::compiler_state().replace_connection(handle);
+    webcontent_client->on_wasm_compiler_connection = [](auto handle) {
+        WasmCompilerClient::compiler_state().replace_connection(move(handle));
     };
 #endif
 

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -55,7 +55,7 @@ void ConnectionFromClient::connect_to_wasm_compiler([[maybe_unused]] IPC::Transp
 {
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     if (on_wasm_compiler_connection)
-        on_wasm_compiler_connection(handle);
+        on_wasm_compiler_connection(move(handle));
 #endif
 }
 

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -45,7 +45,7 @@ public:
     Function<void(IPC::TransportHandle const&)> on_request_server_connection;
     Function<void(IPC::TransportHandle const&)> on_image_decoder_connection;
 #if defined(HAVE_WASM_COMPILER_SERVICE)
-    Function<void(IPC::TransportHandle const&)> on_wasm_compiler_connection;
+    Function<void(IPC::TransportHandle)> on_wasm_compiler_connection;
 #endif
 
 private:

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -121,8 +121,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     WasmCompilerClient::compiler_state().install_compiler_callback();
 
-    client->on_wasm_compiler_connection = [](auto const& handle) {
-        WasmCompilerClient::compiler_state().replace_connection(handle);
+    client->on_wasm_compiler_connection = [](auto handle) {
+        WasmCompilerClient::compiler_state().replace_connection(move(handle));
     };
 #endif
 


### PR DESCRIPTION
This fixes a startup crash on Windows.

The transport was created by the caller of `ThreadedClient::create()`, which runs on the main thread, while the `Client` connection itself is constructed on the dedicated WasmCompiler IPC thread.

On Windows, `TransportSocketWindows` relies on the socket's own `Core::Notifier`, which is bound to the event loop of the thread that creates the socket. The notifier therefore belonged to the main thread, while the connection expected to be serviced on the IPC thread. As soon as the compiler replied, the main thread drained the connection and tripped the owner thread assertion in `IPC::ConnectionBase`, crashing WebContent during startup.

Pass the transport handle to the IPC thread instead, and create the transport there, so that the socket, its notifier, and the connection all belong to the same thread.