### PR TITLE
LibWeb: Cache unchanged canvas readbacks

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.cpp
@@ -84,6 +84,8 @@ void Canvas2DContextBase::visit_edges(Cell::Visitor& visitor)
 size_t Canvas2DContextBase::external_memory_size() const
 {
     auto size = Base::external_memory_size();
+    if (m_cached_readback)
+        size = JS::saturating_add_external_memory_size(size, m_cached_readback->size_in_bytes());
     if (!has_backing_storage())
         return size;
 
@@ -267,6 +269,7 @@ WebIDL::ExceptionOr<void> Canvas2DContextBase::draw_image_internal(CanvasImageSo
 
 void Canvas2DContextBase::did_draw(Gfx::FloatRect const&)
 {
+    m_cached_readback = nullptr;
     // FIXME: Make use of the rect to reduce the invalidated area when possible.
     did_draw_hook();
 }
@@ -310,8 +313,19 @@ RefPtr<Gfx::Bitmap> Canvas2DContextBase::read_pixels(Gfx::IntRect const& rect)
 {
     if (!has_backing_storage())
         return nullptr;
+
+    // OPTIMIZATION: A remote readback requires a synchronous compositor IPC.
+    // Reuse the snapshot while no drawing command has changed its pixels.
+    if (m_cached_readback && m_cached_readback_rect == rect)
+        return m_cached_readback;
+
     m_transport->flush_shared_stream();
-    return m_transport->read_back_pixels(rect);
+    auto pixels = m_transport->read_back_pixels(rect);
+    if (pixels) {
+        m_cached_readback = pixels;
+        m_cached_readback_rect = rect;
+    }
+    return pixels;
 }
 
 void Canvas2DContextBase::set_size(Gfx::IntSize const& size)
@@ -341,6 +355,7 @@ void Canvas2DContextBase::notify_backing_storage_lost()
 {
     if (!has_backing_storage())
         return;
+    m_cached_readback = nullptr;
 
     // When the user agent detects that the backing storage associated with a canvas context has been lost, then it
     // must queue a global task on the DOM manipulation task source given canvas's relevant global object to run
@@ -396,6 +411,7 @@ void Canvas2DContextBase::ensure_backing_storage()
 
 void Canvas2DContextBase::discard_backing_storage()
 {
+    m_cached_readback = nullptr;
     if (m_transport) {
         // Flush the shared stream before destroying the context: it may still
         // hold commands targeting this canvas, and DrawCanvas commands from

--- a/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.h
+++ b/Libraries/LibWeb/HTML/Canvas/Canvas2DContextBase.h
@@ -190,6 +190,8 @@ protected:
     virtual Gfx::Color resolve_drop_shadow_color(CSS::DropShadowFilterStyleValue const&) const = 0;
 
     RefPtr<RemoteCanvas2DTransport> m_transport;
+    RefPtr<Gfx::Bitmap> m_cached_readback;
+    Gfx::IntRect m_cached_readback_rect;
 
     // https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-origin-clean
     bool m_origin_clean { true };

--- a/Tests/LibWeb/Text/input/HTML/CanvasRenderingContext2D-get-image-data-correctness.html
+++ b/Tests/LibWeb/Text/input/HTML/CanvasRenderingContext2D-get-image-data-correctness.html
@@ -13,7 +13,15 @@
 
         let imageData = areaCtx.getImageData(0, 0, area.width, area.height);
 
-        if (imageData.data[0] == 0xff && imageData.data[1] == 0x80 && imageData.data[2] == 0x40 && imageData.data[3] == 0xff)
+        imageData.data[0] = 0;
+        const secondImageData = areaCtx.getImageData(0, 0, area.width, area.height);
+
+        areaCtx.fillStyle = "#4080ff";
+        areaCtx.fillRect(0, 0, 1, 1);
+        const imageDataAfterDraw = areaCtx.getImageData(0, 0, area.width, area.height);
+
+        if (secondImageData.data[0] == 0xff && secondImageData.data[1] == 0x80 && secondImageData.data[2] == 0x40 && secondImageData.data[3] == 0xff
+            && imageDataAfterDraw.data[0] == 0x40 && imageDataAfterDraw.data[1] == 0x80 && imageDataAfterDraw.data[2] == 0xff && imageDataAfterDraw.data[3] == 0xff)
             println("PASS");
         else
             println("FAIL");


### PR DESCRIPTION
Avoid a synchronous compositor IPC for repeated canvas readbacks when no drawing command has changed its pixels. Retain the most recent region, then invalidate it on drawing, backing-store loss, or destruction. Count the retained bitmap as external memory.

Reduce the MicroWeb getImageData benchmark from about 34.0 ms to 1.6 ms, compared with about 1.1 ms in Chromium. Extend coverage for independent returned arrays and invalidation after drawing.