### PR TITLE
LibWeb: Match simple selector queries directly

### DIFF
--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -354,6 +354,9 @@ GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
             return cached_elements->is_empty() ? nullptr : cached_elements->first().ptr();
     }
 
+    if (m_can_match_in_dom)
+        return cache_result(first_match(root, [&](auto& element) { return matches_simple_selector_in_dom(element); }));
+
     if (!root.is_connected()) {
         auto& tree_root = as<ParentNode>(root.root());
         if (m_is_result_cacheable) {
@@ -389,7 +392,9 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
     }
 
     Vector<GC::RawPtr<Element>> elements;
-    if (!root.is_connected()) {
+    if (m_can_match_in_dom) {
+        collect_matches(root, [&](auto& element) { return matches_simple_selector_in_dom(element); }, elements);
+    } else if (!root.is_connected()) {
         auto& tree_root = as<ParentNode>(root.root());
         if (m_is_result_cacheable) {
             auto& engine = isolated_engine_for(tree_root);

--- a/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
+++ b/Tests/LibWeb/Text/expected/DOM/querySelectorAll-results-stay-fresh-across-mutations.txt
@@ -43,6 +43,8 @@ shadow querySelector found first match: true
 querySelectorAll after shadow querySelector: 2
 fragment querySelector found first match: true
 querySelectorAll after fragment querySelector: 2
+fragment compound querySelector found first match: true
+fragment compound querySelectorAll count: 1
 querySelector before tree mutation found match: true
 querySelector after tree mutation found new first: true
 querySelectorAll after tree mutation: 2

--- a/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
+++ b/Tests/LibWeb/Text/input/DOM/querySelectorAll-results-stay-fresh-across-mutations.html
@@ -172,6 +172,9 @@
         const fragmentFirst = fragmentProbe.querySelector(".fragment-probe");
         println(`fragment querySelector found first match: ${fragmentFirst === fragmentFirstElement}`);
         println(`querySelectorAll after fragment querySelector: ${fragmentProbe.querySelectorAll(".fragment-probe").length}`);
+        fragmentFirstElement.id = "fragment-first";
+        println(`fragment compound querySelector found first match: ${fragmentProbe.querySelector("span#fragment-first.fragment-probe") === fragmentFirstElement}`);
+        println(`fragment compound querySelectorAll count: ${fragmentProbe.querySelectorAll("span#fragment-first.fragment-probe").length}`);
 
         // Structural and character-data mutations invalidate first-only results too.
         const mutationProbe = document.createElement("div");


### PR DESCRIPTION
Avoid constructing and populating a style engine when selector queries contain only a single compound of tag, ID, and class selectors. Traverse the query root with the direct DOM matcher already used by matches() and closest(), while preserving the selector result cache.

Reduce MicroWeb template-instantiate-fill from 97.9 ms to 24.0 ms, compared with Chromium at 5.7 ms. Cover compound selector queries on a disconnected document fragment.