### PR TITLE
AK+LibWeb: Speed up Encoding APIs and URL construction

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -47,6 +47,24 @@ ErrorOr<ByteString> Utf16View::to_byte_string(AllowLonelySurrogates allow_lonely
     return TRY(to_utf8(allow_lonely_surrogates)).to_byte_string();
 }
 
+Optional<size_t> Utf16View::to_utf8_with_replacement_into(Bytes output) const
+{
+    if (has_ascii_storage()) {
+        if (output.size() < bytes().size())
+            return {};
+        return bytes().copy_to(output);
+    }
+
+    auto utf16 = utf16_span();
+    auto utf8_length = simdutf::utf8_length_from_utf16_with_replacement(utf16.data(), utf16.size()).count;
+    if (output.size() < utf8_length)
+        return {};
+
+    auto bytes_written = simdutf::convert_utf16_to_utf8_with_replacement(utf16.data(), utf16.size(), reinterpret_cast<char*>(output.data()));
+    VERIFY(bytes_written == utf8_length);
+    return bytes_written;
+}
+
 Utf16String Utf16View::to_ascii_lowercase() const
 {
     Utf16StringBuilder builder(length_in_code_units());

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -171,6 +171,7 @@ public:
 
     ErrorOr<String> to_utf8(AllowLonelySurrogates = AllowLonelySurrogates::Yes) const;
     ErrorOr<ByteString> to_byte_string(AllowLonelySurrogates = AllowLonelySurrogates::Yes) const;
+    [[nodiscard]] Optional<size_t> to_utf8_with_replacement_into(Bytes output) const;
 
     ALWAYS_INLINE String to_utf8_but_should_be_ported_to_utf16(AllowLonelySurrogates allow_lonely_surrogates = AllowLonelySurrogates::Yes) const
     {

--- a/Libraries/LibTextCodec/Decoder.cpp
+++ b/Libraries/LibTextCodec/Decoder.cpp
@@ -520,9 +520,9 @@ ErrorOr<String> StreamingDecoder::to_utf8(ReadonlyBytes input)
     return rust_streaming_decode_to_utf8(static_cast<FFI::TextCodecRustStreamingDecoder*>(m_decoder), input, false, m_error_mode);
 }
 
-ErrorOr<Utf16String> StreamingDecoder::to_utf16(ReadonlyBytes input)
+ErrorOr<Utf16String> StreamingDecoder::to_utf16(ReadonlyBytes input, Flush flush)
 {
-    return rust_streaming_decode_to_utf16(static_cast<FFI::TextCodecRustStreamingDecoder*>(m_decoder), input, false, m_error_mode);
+    return rust_streaming_decode_to_utf16(static_cast<FFI::TextCodecRustStreamingDecoder*>(m_decoder), input, flush == Flush::Yes, m_error_mode);
 }
 
 ErrorOr<String> StreamingDecoder::finish()

--- a/Libraries/LibTextCodec/Decoder.h
+++ b/Libraries/LibTextCodec/Decoder.h
@@ -24,6 +24,11 @@ enum class IgnoreBOM {
     No,
 };
 
+enum class Flush {
+    No,
+    Yes,
+};
+
 // https://encoding.spec.whatwg.org/#concept-encoding-error-mode
 enum class ErrorMode {
     Replacement,
@@ -50,7 +55,7 @@ public:
     ~StreamingDecoder();
 
     ErrorOr<String> to_utf8(ReadonlyBytes);
-    ErrorOr<Utf16String> to_utf16(ReadonlyBytes);
+    ErrorOr<Utf16String> to_utf16(ReadonlyBytes, Flush = Flush::No);
     ErrorOr<String> finish();
     ErrorOr<Utf16String> finish_to_utf16();
 

--- a/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -20,9 +20,9 @@ namespace Web::DOMURL {
 
 GC_DEFINE_ALLOCATOR(DOMURL);
 
-GC::Ref<DOMURL> DOMURL::create(URL::URL url, GC::Ref<URLSearchParams> query)
+GC::Ref<DOMURL> DOMURL::create(URL::URL url)
 {
-    return GC::Heap::the().allocate<DOMURL>(move(url), query);
+    return GC::Heap::the().allocate<DOMURL>(move(url));
 }
 
 // https://url.spec.whatwg.org/#api-url-parser
@@ -50,20 +50,8 @@ static Optional<URL::URL> parse_api_url(Utf16View url, Optional<Utf16String> con
 // https://url.spec.whatwg.org/#url-initialize
 GC::Ref<DOMURL> DOMURL::initialize_a_url(URL::URL const& url_record)
 {
-    // 1. Let query be urlRecord’s query, if that is non-null; otherwise the empty string.
-    auto query = url_record.query().value_or(String {});
-
-    // 2. Set url’s URL to urlRecord.
-    // 3. Set url’s query object to a new URLSearchParams object.
-    auto query_object = URLSearchParams::create(query);
-
-    // 4. Initialize url’s query object with query.
-    auto result_url = DOMURL::create(url_record, move(query_object));
-
-    // 5. Set url’s query object’s URL object to url.
-    result_url->m_query->m_url = result_url;
-
-    return result_url;
+    // OPTIMIZATION: Defer creating and initializing the query object until searchParams is accessed.
+    return DOMURL::create(url_record);
 }
 
 // https://url.spec.whatwg.org/#dom-url-parse
@@ -96,9 +84,8 @@ WebIDL::ExceptionOr<GC::Ref<DOMURL>> DOMURL::create_from_url(Utf16String const& 
     return initialize_a_url(parsed_url.value());
 }
 
-DOMURL::DOMURL(URL::URL url, GC::Ref<URLSearchParams> query)
+DOMURL::DOMURL(URL::URL url)
     : m_url(move(url))
-    , m_query(move(query))
 {
 }
 
@@ -191,15 +178,17 @@ WebIDL::ExceptionOr<void> DOMURL::set_href(Utf16String const& value)
     // 3. Set this’s URL to parsedURL.
     m_url = parsed_url.release_value();
 
-    // 4. Empty this’s query object’s list.
-    m_query->m_list.clear();
+    if (m_query) {
+        // 4. Empty this’s query object’s list.
+        m_query->m_list.clear();
 
-    // 5. Let query be this’s URL’s query.
-    auto query = m_url.query();
+        // 5. Let query be this’s URL’s query.
+        auto query = m_url.query();
 
-    // 6. If query is non-null, then set this’s query object’s list to the result of parsing query.
-    if (query.has_value())
-        m_query->m_list = url_decode(*query);
+        // 6. If query is non-null, then set this’s query object’s list to the result of parsing query.
+        if (query.has_value())
+            m_query->m_list = url_decode(*query);
+    }
     return {};
 }
 
@@ -382,7 +371,8 @@ void DOMURL::set_search(Utf16String const& search)
     // 2. If the given value is the empty string, then set url’s query to null, empty this’s query object’s list, and return.
     if (search.is_empty()) {
         url.set_query({});
-        m_query->m_list.clear();
+        if (m_query)
+            m_query->m_list.clear();
         return;
     }
 
@@ -397,14 +387,21 @@ void DOMURL::set_search(Utf16String const& search)
     (void)URL::Parser::basic_parse(input, {}, &url, URL::Parser::State::Query);
 
     // 6. Set this’s query object’s list to the result of parsing input.
-    m_query->m_list = url_decode(input);
+    if (m_query)
+        m_query->m_list = url_decode(input);
 }
 
 // https://url.spec.whatwg.org/#dom-url-searchparams
-GC::Ref<URLSearchParams const> DOMURL::search_params() const
+GC::Ref<URLSearchParams const> DOMURL::search_params()
 {
     // The searchParams getter steps are to return this’s query object.
-    return m_query;
+    if (!m_query) {
+        auto query = m_url.query().value_or(String {});
+        m_query = URLSearchParams::create(query);
+        m_query->m_url = this;
+    }
+
+    return *m_query;
 }
 
 // https://url.spec.whatwg.org/#dom-url-hash

--- a/Libraries/LibWeb/DOMURL/DOMURL.h
+++ b/Libraries/LibWeb/DOMURL/DOMURL.h
@@ -24,7 +24,7 @@ class DOMURL : public Bindings::GCAllocatedWrappable {
     GC_DECLARE_ALLOCATOR(DOMURL);
 
 public:
-    [[nodiscard]] static GC::Ref<DOMURL> create(URL::URL, GC::Ref<URLSearchParams> query);
+    [[nodiscard]] static GC::Ref<DOMURL> create(URL::URL);
     static WebIDL::ExceptionOr<GC::Ref<DOMURL>> create_from_url(Utf16String const& url, Optional<Utf16String> const& base = {});
 
     virtual ~DOMURL() override;
@@ -72,7 +72,7 @@ public:
     Utf16String search() const;
     void set_search(Utf16String const&);
 
-    GC::Ref<URLSearchParams const> search_params() const;
+    GC::Ref<URLSearchParams const> search_params();
 
     Utf16String hash() const;
     void set_hash(Utf16String const&);
@@ -85,14 +85,15 @@ public:
     virtual Optional<URL::Origin> extract_an_origin() const override;
 
 private:
-    DOMURL(URL::URL, GC::Ref<URLSearchParams> query);
+    explicit DOMURL(URL::URL);
 
     static GC::Ref<DOMURL> initialize_a_url(URL::URL const&);
 
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
     URL::URL m_url;
-    GC::Ref<URLSearchParams> m_query;
+    // Most URL users never access searchParams, so avoid its parsing and allocation until needed.
+    GC::Ptr<URLSearchParams> m_query;
 };
 
 // https://url.spec.whatwg.org/#concept-url-parser

--- a/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -54,7 +54,7 @@ TextDecoder::TextDecoder(FlyString encoding, TextCodec::ErrorMode error_mode, bo
 
 TextDecoder::~TextDecoder() = default;
 
-WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<WebIDL::BufferSourceVariant> const& input, Optional<TextDecodeOptions> const& options) const
+WebIDL::ExceptionOr<Utf16String> TextDecoder::decode(Optional<WebIDL::BufferSourceVariant> const& input, Optional<TextDecodeOptions> const& options) const
 {
     Optional<ByteBuffer> data_buffer;
     if (input.has_value()) {
@@ -68,11 +68,11 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<WebIDL::BufferSourceVar
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder-decode
-WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<ReadonlyBytes> input, bool stream) const
+WebIDL::ExceptionOr<Utf16String> TextDecoder::decode(Optional<ReadonlyBytes> input, bool stream) const
 {
     auto& vm = JS::VM::the();
 
-    auto decode_bytes = [&](ErrorOr<String> decoded) -> WebIDL::ExceptionOr<String> {
+    auto decode_bytes = [&](ErrorOr<Utf16String> decoded) -> WebIDL::ExceptionOr<Utf16String> {
         if (decoded.is_error()) {
             // Decoder errors in fatal mode are reported as a TypeError. Only
             // allocation failures should become an internal out-of-memory
@@ -85,27 +85,15 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<ReadonlyBytes> input, b
     };
 
     if (stream)
-        return decode_bytes(m_decoder->to_utf8(input.has_value() ? input.value() : ReadonlyBytes {}));
+        return decode_bytes(m_decoder->to_utf16(input.has_value() ? input.value() : ReadonlyBytes {}));
 
     // A non-streaming decode signals end-of-queue to the decoder. This flushes any pending partial sequence.
     // encoding_rs permanently finishes a decoder after that operation, so replace it before returning; the
     // TextDecoder object must be reusable for a subsequent independent decode().
-    auto decoded_or_error = m_decoder->to_utf8(input.has_value() ? input.value() : ReadonlyBytes {});
-    if (decoded_or_error.is_error()) {
-        set_decoder_to_new_instance_of_encoding_decoder();
-        return decode_bytes(move(decoded_or_error));
-    }
-
-    auto final_or_error = m_decoder->finish();
+    auto decoded_or_error = m_decoder->to_utf16(input.has_value() ? input.value() : ReadonlyBytes {}, TextCodec::Flush::Yes);
     set_decoder_to_new_instance_of_encoding_decoder();
 
-    auto decoded = TRY(decode_bytes(move(decoded_or_error)));
-    auto final = TRY(decode_bytes(move(final_or_error)));
-
-    StringBuilder result;
-    TRY_OR_THROW_OOM(vm, result.try_append(decoded.bytes_as_string_view()));
-    TRY_OR_THROW_OOM(vm, result.try_append(final.bytes_as_string_view()));
-    return TRY_OR_THROW_OOM(vm, result.to_string());
+    return decode_bytes(move(decoded_or_error));
 }
 
 }

--- a/Libraries/LibWeb/Encoding/TextDecoder.h
+++ b/Libraries/LibWeb/Encoding/TextDecoder.h
@@ -30,8 +30,8 @@ public:
 
     virtual ~TextDecoder() override;
 
-    WebIDL::ExceptionOr<String> decode(Optional<WebIDL::BufferSourceVariant> const& input, Optional<TextDecodeOptions> const&) const;
-    WebIDL::ExceptionOr<String> decode(Optional<ReadonlyBytes>, bool stream) const;
+    WebIDL::ExceptionOr<Utf16String> decode(Optional<WebIDL::BufferSourceVariant> const& input, Optional<TextDecodeOptions> const&) const;
+    WebIDL::ExceptionOr<Utf16String> decode(Optional<ReadonlyBytes>, bool stream) const;
 
 private:
     TextDecoder(FlyString encoding, TextCodec::ErrorMode error_mode, bool ignore_bom);

--- a/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -65,6 +65,15 @@ EncodeIntoResult TextEncoder::encode_into_result(Utf16String const& source, GC::
         return { 0, 0 };
     auto destination_byte_length = JS::typed_array_byte_length(destination_record);
 
+    // OPTIMIZATION: Encode directly into a non-shared destination when the input fits.
+    // Keep shared destinations on the existing path to avoid changing shared-memory write semantics.
+    auto& destination_buffer = *destination->viewed_array_buffer();
+    if (!destination_buffer.is_shared_array_buffer()) {
+        auto destination_bytes = Bytes { destination_buffer.data_at(destination->byte_offset()), destination_byte_length };
+        if (auto bytes_written = source.utf16_view().to_utf8_with_replacement_into(destination_bytes); bytes_written.has_value())
+            return { source.length_in_code_units(), *bytes_written };
+    }
+
     // 1. Let read be 0.
     WebIDL::UnsignedLongLong read = 0;
     // 2. Let written be 0.

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -102,6 +102,11 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
     if (es_array_buffer->is_detached())
         return ByteBuffer {};
 
+    // OPTIMIZATION: Copy non-shared data blocks in bulk.
+    // Shared data blocks use the element-wise path to preserve memory ordering.
+    if (!es_array_buffer->is_shared_array_buffer())
+        return es_array_buffer->copy_to_byte_buffer(offset, length);
+
     // 8. Let bytes be a new byte sequence of length equal to length.
     auto bytes = TRY(ByteBuffer::create_zeroed(length));
 

--- a/Tests/AK/TestUtf16View.cpp
+++ b/Tests/AK/TestUtf16View.cpp
@@ -67,6 +67,34 @@ TEST_CASE(encode_utf8)
     }
 }
 
+TEST_CASE(encode_utf8_with_replacement_into)
+{
+    {
+        Array<u8, 5> output {};
+        auto bytes_written = Utf16View { "Hello"sv }.to_utf8_with_replacement_into(output);
+        EXPECT_EQ(bytes_written, 5uz);
+        EXPECT_EQ(output, (Array<u8, 5> { 'H', 'e', 'l', 'l', 'o' }));
+    }
+    {
+        Array<u8, 5> output {};
+        auto bytes_written = Utf16View { u"A\U0001F600"sv }.to_utf8_with_replacement_into(output);
+        EXPECT_EQ(bytes_written, 5uz);
+        EXPECT_EQ(output, (Array<u8, 5> { 0x41, 0xf0, 0x9f, 0x98, 0x80 }));
+    }
+    {
+        Array<u8, 7> output {};
+        auto bytes_written = Utf16View { u"\xd834\u0041\xdf06"sv }.to_utf8_with_replacement_into(output);
+        EXPECT_EQ(bytes_written, 7uz);
+        EXPECT_EQ(output, (Array<u8, 7> { 0xef, 0xbf, 0xbd, 0x41, 0xef, 0xbf, 0xbd }));
+    }
+    {
+        Array<u8, 3> output { 0xaa, 0xbb, 0xcc };
+        auto bytes_written = Utf16View { u"\U0001F600"sv }.to_utf8_with_replacement_into(output);
+        EXPECT(!bytes_written.has_value());
+        EXPECT_EQ(output, (Array<u8, 3> { 0xaa, 0xbb, 0xcc }));
+    }
+}
+
 TEST_CASE(decode_utf16)
 {
     Utf16View view { u"Привет, мир! 😀 γειά σου κόσμος こんにちは世界"sv };


### PR DESCRIPTION
Some low hanging optimizations found by MicroWeb suite in https://github.com/LadybirdBrowser/web-benchmarks

Benchmark | Before | After
-- | -- | --
text-encode-decode | 216.0 ms | 12.1 ms
text-encode-into | 113.4 ms | 2.2 ms
url-construct-only | 29.2 ms | 23.0 ms

