### PR TITLE
LibWeb: Traverse live ranges once per DOM mutation

### DIFF
--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -133,38 +133,31 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // 8. For each live range whose start node is node and start offset is greater than offset but less than or equal to
     //    offset plus count, set its start offset to offset.
-    for (auto* range : Range::live_ranges()) {
-        if (range == selection_range_to_preserve.ptr())
-            continue;
-        if (range->start_container().ptr() == this && range->start_offset() > offset && range->start_offset() <= (offset + count))
-            range->set_start_offset(offset);
-    }
-
     // 9. For each live range whose end node is node and end offset is greater than offset but less than or equal to
     //    offset plus count, set its end offset to offset.
-    for (auto* range : Range::live_ranges()) {
-        if (range == selection_range_to_preserve.ptr())
-            continue;
-        if (range->end_container().ptr() == this && range->end_offset() > offset && range->end_offset() <= (offset + count))
-            range->set_end_offset(offset);
-    }
-
     // 10. For each live range whose start node is node and start offset is greater than offset plus count, increase its
     //     start offset by data’s length and decrease it by count.
-    for (auto* range : Range::live_ranges()) {
-        if (range == selection_range_to_preserve.ptr())
-            continue;
-        if (range->start_container().ptr() == this && range->start_offset() > (offset + count))
-            range->set_start_offset(range->start_offset() + data.length_in_code_units() - count);
-    }
-
     // 11. For each live range whose end node is node and end offset is greater than offset plus count, increase its end
     //     offset by data’s length and decrease it by count.
+    // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
+    auto replaced_data_end_offset = offset + count;
+    auto replacement_data_length = data.length_in_code_units();
     for (auto* range : Range::live_ranges()) {
         if (range == selection_range_to_preserve.ptr())
             continue;
-        if (range->end_container().ptr() == this && range->end_offset() > (offset + count))
-            range->set_end_offset(range->end_offset() + data.length_in_code_units() - count);
+
+        if (range->start_container().ptr() == this) {
+            if (range->start_offset() > offset && range->start_offset() <= replaced_data_end_offset)
+                range->set_start_offset(offset);
+            else if (range->start_offset() > replaced_data_end_offset)
+                range->set_start_offset(range->start_offset() + replacement_data_length - count);
+        }
+        if (range->end_container().ptr() == this) {
+            if (range->end_offset() > offset && range->end_offset() <= replaced_data_end_offset)
+                range->set_end_offset(offset);
+            else if (range->end_offset() > replaced_data_end_offset)
+                range->set_end_offset(range->end_offset() + replacement_data_length - count);
+        }
     }
 
     // 12. If node’s parent is non-null, then run the children changed steps for node’s parent.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -502,35 +502,29 @@ WebIDL::ExceptionOr<void> Node::normalize()
         while (current_node && current_node->is_exclusive_text()) {
             // 1. For each live range whose start node is currentNode, add length to its start offset and set its start
             //    node to node.
+            // 2. For each live range whose end node is currentNode, add length to its end offset and set its end node
+            //    to node.
+            // 3. For each live range whose start node is currentNode’s parent and start offset is currentNode’s index,
+            //    set its start node to node and its start offset to length.
+            // 4. For each live range whose end node is currentNode’s parent and end offset is currentNode’s index, set
+            //    its end node to node and its end offset to length.
+            // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
+            auto* current_node_parent = current_node->parent();
+            auto current_node_index = current_node->index();
             for (auto& range : Range::live_ranges()) {
                 if (range->start_container().ptr() == current_node) {
                     range->increase_start_offset(length);
                     range->set_start_node(node);
                 }
-            }
-
-            // 2. For each live range whose end node is currentNode, add length to its end offset and set its end node
-            //    to node.
-            for (auto& range : Range::live_ranges()) {
                 if (range->end_container().ptr() == current_node) {
                     range->increase_end_offset(length);
                     range->set_end_node(node);
                 }
-            }
-
-            // 3. For each live range whose start node is currentNode’s parent and start offset is currentNode’s index,
-            //    set its start node to node and its start offset to length.
-            for (auto& range : Range::live_ranges()) {
-                if (range->start_container().ptr() == current_node->parent() && range->start_offset() == current_node->index()) {
+                if (range->start_container().ptr() == current_node_parent && range->start_offset() == current_node_index) {
                     range->set_start_node(node);
                     range->set_start_offset(length);
                 }
-            }
-
-            // 4. For each live range whose end node is currentNode’s parent and end offset is currentNode’s index, set
-            //    its end node to node and its end offset to length.
-            for (auto& range : Range::live_ranges()) {
-                if (range->end_container().ptr() == current_node->parent() && range->end_offset() == current_node->index()) {
+                if (range->end_container().ptr() == current_node_parent && range->end_offset() == current_node_index) {
                     range->set_end_node(node);
                     range->set_end_offset(length);
                 }
@@ -869,15 +863,14 @@ void Node::insert_nodes_before(Vector<GC::Root<Node>> nodes, GC::Ptr<Node> child
     if (child) {
         // 1. For each live range whose start node is parent and start offset is greater than child’s index:
         //    increase its start offset by count.
-        for (auto& range : Range::live_ranges()) {
-            if (range->start_container().ptr() == this && range->start_offset() > child->index())
-                range->increase_start_offset(count);
-        }
-
         // 2. For each live range whose end node is parent and end offset is greater than child’s index:
         //    increase its end offset by count.
+        // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
+        auto child_index = child->index();
         for (auto& range : Range::live_ranges()) {
-            if (range->end_container().ptr() == this && range->end_offset() > child->index())
+            if (range->start_container().ptr() == this && range->start_offset() > child_index)
+                range->increase_start_offset(count);
+            if (range->end_container().ptr() == this && range->end_offset() > child_index)
                 range->increase_end_offset(count);
         }
     }
@@ -1105,26 +1098,18 @@ void Node::live_range_pre_remove()
     auto index = this->index();
 
     // 4. For each live range whose start node is an inclusive descendant of node, set its start to (parent, index).
+    // 5. For each live range whose end node is an inclusive descendant of node, set its end to (parent, index).
+    // 6. For each live range whose start node is parent and start offset is greater than index, decrease its start
+    //    offset by 1.
+    // 7. For each live range whose end node is parent and end offset is greater than index, decrease its end offset by 1.
+    // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
     for (auto* range : Range::live_ranges()) {
         if (range->start_container()->is_inclusive_descendant_of(*this))
             MUST(range->set_start(*parent, index));
-    }
-
-    // 5. For each live range whose end node is an inclusive descendant of node, set its end to (parent, index).
-    for (auto* range : Range::live_ranges()) {
         if (range->end_container()->is_inclusive_descendant_of(*this))
             MUST(range->set_end(*parent, index));
-    }
-
-    // 6. For each live range whose start node is parent and start offset is greater than index, decrease its start
-    //    offset by 1.
-    for (auto* range : Range::live_ranges()) {
         if (range->start_container().ptr() == parent && range->start_offset() > index)
             range->decrease_start_offset(1);
-    }
-
-    // 7. For each live range whose end node is parent and end offset is greater than index, decrease its end offset by 1.
-    for (auto* range : Range::live_ranges()) {
         if (range->end_container().ptr() == parent && range->end_offset() > index)
             range->decrease_end_offset(1);
     }
@@ -1664,15 +1649,14 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
     if (child) {
         // 1. For each live range whose start node is newParent and start offset is greater than child’s index:
         //    increase its start offset by 1.
-        for (auto& range : Range::live_ranges()) {
-            if (range->start_container().ptr() == &new_parent && range->start_offset() > child->index())
-                range->increase_start_offset(1);
-        }
-
         // 2. For each live range whose end node is newParent and end offset is greater than child’s index:
         //    increase its end offset by 1.
+        // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
+        auto child_index = child->index();
         for (auto& range : Range::live_ranges()) {
-            if (range->end_container().ptr() == &new_parent && range->end_offset() > child->index())
+            if (range->start_container().ptr() == &new_parent && range->start_offset() > child_index)
+                range->increase_start_offset(1);
+            if (range->end_container().ptr() == &new_parent && range->end_offset() > child_index)
                 range->increase_end_offset(1);
         }
     }

--- a/Libraries/LibWeb/DOM/Text.cpp
+++ b/Libraries/LibWeb/DOM/Text.cpp
@@ -102,33 +102,26 @@ WebIDL::ExceptionOr<GC::Ref<Text>> Text::split_text(size_t offset)
 
         // 2. For each live range whose start node is node and start offset is greater than offset, set its start node
         //    to new node and decrease its start offset by offset.
+        // 3. For each live range whose end node is node and end offset is greater than offset, set its end node to new
+        //    node and decrease its end offset by offset.
+        // 4. For each live range whose start node is parent and start offset is equal to the index of node plus 1,
+        //    increase its start offset by 1.
+        // 5. For each live range whose end node is parent and end offset is equal to the index of node plus 1, increase
+        //    its end offset by 1.
+        // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
+        auto node_index = index();
         for (auto* range : Range::live_ranges()) {
             if (range->start_container().ptr() == this && range->start_offset() > offset) {
                 range->set_start_node(*new_node);
                 range->decrease_start_offset(offset);
             }
-        }
-
-        // 3. For each live range whose end node is node and end offset is greater than offset, set its end node to new
-        //    node and decrease its end offset by offset.
-        for (auto* range : Range::live_ranges()) {
             if (range->end_container().ptr() == this && range->end_offset() > offset) {
                 range->set_end_node(*new_node);
                 range->decrease_end_offset(offset);
             }
-        }
-
-        // 4. For each live range whose start node is parent and start offset is equal to the index of node plus 1,
-        //    increase its start offset by 1.
-        for (auto* range : Range::live_ranges()) {
-            if (range->start_container().ptr() == parent.ptr() && range->start_offset() == index() + 1)
+            if (range->start_container().ptr() == parent.ptr() && range->start_offset() == node_index + 1)
                 range->increase_start_offset(1);
-        }
-
-        // 5. For each live range whose end node is parent and end offset is equal to the index of node plus 1, increase
-        //    its end offset by 1.
-        for (auto* range : Range::live_ranges()) {
-            if (range->end_container().ptr() == parent.ptr() && range->end_offset() == index() + 1)
+            if (range->end_container().ptr() == parent.ptr() && range->end_offset() == node_index + 1)
                 range->increase_end_offset(1);
         }
     }


### PR DESCRIPTION
Range boundary updates traverse the global live range set separately for each start and end step in the DOM specification. Unreachable Range objects stay registered until garbage collection, so repeated mutations become increasingly expensive as ranges accumulate.

Combine adjacent, independent boundary updates into one traversal for text splitting and replacement, normalization, insertion, removal, and moves. Match the per-range mutation update shape used by other engines while preserving the specification step order within each range.