### PR TITLE
LibWeb: Preserve animation style records during removal

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1052,14 +1052,16 @@ void KeyframeEffect::update_computed_properties_for_style(AnimationUpdateContext
     auto& style_computer = abstract_element.element().document().style_computer();
     auto& element_data = context.elements.ensure(abstract_element, [&abstract_element, &style_computer] {
         auto computed_values = abstract_element.computed_style();
-        VERIFY(computed_values);
+        if (!computed_values)
+            return AnimationUpdateContext::ElementData {};
         auto old_animated_properties = computed_values->animated_properties_snapshot();
         auto computed_properties = style_computer.reconstruct_computed_properties(*computed_values);
         computed_properties->reset_non_inherited_animated_properties({});
         return AnimationUpdateContext::ElementData { move(old_animated_properties), move(computed_properties) };
     });
 
-    VERIFY(element_data.target_style);
+    if (!element_data.target_style)
+        return;
     element_data.effects.append(*this);
 }
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1170,6 +1170,23 @@ static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& 
     return parent_layout_node->children_are_inline() && layout_node->is_inline_block() && !layout_node->is_out_of_flow();
 }
 
+static void pin_layout_style_records_for_removal(Node& node)
+{
+    node.for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
+        if (auto* layout_node = inclusive_descendant.unsafe_layout_node())
+            layout_node->pin_style_record_for_detachment();
+
+        if (auto* element = as_if<Element>(inclusive_descendant)) {
+            element->for_each_synthetic_pseudo_element([](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+                if (auto* layout_node = pseudo_element.unsafe_layout_node())
+                    layout_node->pin_style_record_for_detachment();
+            });
+        }
+
+        return TraversalDecision::Continue;
+    });
+}
+
 // https://dom.spec.whatwg.org/#concept-node-remove
 void Node::remove(bool suppress_observers)
 {
@@ -1284,6 +1301,11 @@ void Node::remove(bool suppress_observers)
         // 2. Run assign slottables for a tree with node.
         assign_slottables_for_a_tree(*this);
     }
+
+    // NB: Removing steps may synchronously update layout. Preserve style records for the whole
+    //     removed subtree before a callback can replace an active animation overlay still held by
+    //     another detached layout node.
+    pin_layout_style_records_for_removal(*this);
 
     // 11. Run the removing steps with node, true, and parent.
     removed_from(IsSubtreeRoot::Yes, parent, parent_root);

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -32,6 +32,7 @@ Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html
 Text/input/css/font-load-delays-document-load-event.html
 Text/input/css/font-face-unused-face-not-fetched.html
+Text/input/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.html
 Text/input/css/unrecognized-font-family-fallback-honors-weight.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html

--- a/Tests/LibWeb/Text/expected/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.txt
@@ -1,0 +1,3 @@
+font status before removal: loading
+live overlays before removal: 1
+PASS (did not crash)

--- a/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const token = crypto.randomUUID();
+        const fontUrl = await server.createEcho("GET", `/removing-stylesheet-preserves-descendant-animation-overlay-${token}.ttf`, {
+            status: 200,
+            headers: { "Content-Type": "font/ttf" },
+            body: "blocked font response",
+            wait_for_unblock: token,
+        });
+
+        const stylesheetUrl = await server.createEcho("GET", `/removing-stylesheet-preserves-descendant-animation-overlay-${token}.css`, {
+            status: 200,
+            headers: { "Content-Type": "text/css" },
+            body: `@font-face { font-family: SlowAhem; src: url("${fontUrl}"); }`,
+        });
+
+        const container = document.createElement("div");
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = stylesheetUrl;
+        const linkLoaded = new Promise(resolve => link.onload = resolve);
+        container.append(link);
+
+        const target = document.createElement("div");
+        target.textContent = "X";
+        target.style.fontFamily = "SlowAhem";
+        container.append(target);
+        document.body.append(container);
+        await linkLoaded;
+
+        target.animate({ opacity: [0, 1] }, { duration: 10000 });
+        await new Promise(requestAnimationFrame);
+        internals.updateStyle();
+        target.offsetWidth;
+        const fontLoadPromise = document.fonts.load("16px SlowAhem", "X").catch(() => {});
+        println(`font status before removal: ${document.fonts.status}`);
+        println(`live overlays before removal: ${internals.styleEngineCounters().liveAnimationOverlayRecords}`);
+
+        await new Promise(requestAnimationFrame);
+        container.remove();
+        println("PASS (did not crash)");
+
+        await fetch(`${server.baseURL}/unblock/${token}`);
+        await fontLoadPromise;
+    });
+</script>


### PR DESCRIPTION
Keep old layout style records pinned for every node in a removed shadow-including subtree before running removing steps. A stylesheet removal callback can synchronously update layout while later descendants still point at their old layout nodes, and active animation overlays may otherwise be replaced before those nodes pin their records.

Let animation sampling ignore targets whose style record no longer has a live computed style view during the same removal reentrancy. Add an HTTP text test that removes a stylesheet while a descendant animation overlay and a blocked @font-face load are both active.

Fixes a crash on https://nytimes.com/