### PR TITLE
LibWebView: Preserve navigate events across same-document commits

### DIFF
--- a/Libraries/LibWebView/ApplyHistoryStep.cpp
+++ b/Libraries/LibWebView/ApplyHistoryStep.cpp
@@ -154,9 +154,11 @@ void ApplyHistoryStep::get_changing_and_nonchanging_navigables()
 void ApplyHistoryStep::run_changing_navigable_jobs()
 {
     auto navigation_api_abort_behavior = Web::HTML::LocalNavigable::NavigationAPIAbortBehavior::Abort;
-    // Same-document traversals finish their NavigateEvent while updating the Navigation API entry. This decision is
-    // traversable-wide, so derive it from canonical history before dispatching per-document jobs.
-    if (m_navigation_type == Web::Bindings::NavigationType::Traverse
+    // Same-document traversals and same-document push or replace finalizations finish their NavigateEvent while
+    // updating the Navigation API entry. This decision is traversable-wide, so derive it from canonical history
+    // before dispatching per-document jobs.
+    if (m_navigation_type.has_value()
+        && first_is_one_of(*m_navigation_type, Web::Bindings::NavigationType::Traverse, Web::Bindings::NavigationType::Push, Web::Bindings::NavigationType::Replace)
         && m_session_history.get_all_navigables_that_might_experience_a_cross_document_traversal(m_traversable_navigable, m_target_step).is_empty())
         navigation_api_abort_behavior = Web::HTML::LocalNavigable::NavigationAPIAbortBehavior::Preserve;
 

--- a/Tests/LibWeb/Text/expected/navigation/intercepted-push-async-handler-not-aborted.txt
+++ b/Tests/LibWeb/Text/expected/navigation/intercepted-push-async-handler-not-aborted.txt
@@ -1,0 +1,5 @@
+navigate push destination=?pushed canIntercept=true
+handler start
+handler done
+navigatesuccess at ?pushed
+final location=?pushed index=1

--- a/Tests/LibWeb/Text/input/navigation/intercepted-push-async-handler-not-aborted.html
+++ b/Tests/LibWeb/Text/input/navigation/intercepted-push-async-handler-not-aborted.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<a id="link" href="?pushed">go</a>
+<script>
+    asyncTest(done => {
+        const events = [];
+
+        function queryFromURL(url) {
+            return new URL(url).search || "(none)";
+        }
+
+        function finish() {
+            for (const event of events)
+                println(event);
+            println(`final location=${queryFromURL(location.href)} index=${navigation.currentEntry.index}`);
+            done();
+        }
+
+        navigation.addEventListener("navigate", event => {
+            if (event.navigationType !== "push")
+                return;
+
+            events.push(`navigate push destination=${queryFromURL(event.destination.url)} canIntercept=${event.canIntercept}`);
+            if (!event.canIntercept) {
+                events.push("FAIL: cannot intercept");
+                finish();
+                return;
+            }
+
+            event.signal.addEventListener("abort", () => {
+                events.push(`FAIL: signal aborted (${event.signal.reason})`);
+            });
+
+            event.intercept({
+                async handler() {
+                    events.push("handler start");
+                    await new Promise(resolve => setTimeout(resolve, 300));
+                    events.push("handler done");
+                },
+            });
+        });
+
+        navigation.addEventListener("navigatesuccess", () => {
+            events.push(`navigatesuccess at ${queryFromURL(location.href)}`);
+            finish();
+        });
+
+        navigation.addEventListener("navigateerror", event => {
+            events.push(`FAIL: navigateerror ${event.error}`);
+            finish();
+        });
+
+        // Wait until the document is completely loaded so that the link click navigation gets push instead of replace semantics.
+        window.addEventListener("load", () => {
+            setTimeout(() => document.getElementById("link").click(), 0);
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/intercepted-push-async-handler-not-aborted.html.headers
+++ b/Tests/LibWeb/Text/input/navigation/intercepted-push-async-handler-not-aborted.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html


### PR DESCRIPTION
Previously, the history operation that finalized an intercepted same-document push or replace navigation aborted the ongoing navigate event once its changing navigable job ran. An intercept handler that was still pending at that point had its signal aborted, and `navigateerror` fired instead of `navigatesuccess`. This broke link navigation on sites whose routers rely on the navigation API.

Grant the preserve behavior to push and replace history steps that cross no documents, matching same-document traversals. Cross document finalizations and reloads keep the abort behavior.

This fixes navigating to post comments on https://reddit.com.

FIxes a regression introduced by f54dcb89e60.