### PR TITLE
LibWeb: Track radio button groups in per-scope registries

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -690,6 +690,7 @@ set(SOURCES
     HTML/PotentialCORSRequest.cpp
     HTML/PreloadEntry.cpp
     HTML/PromiseRejectionEvent.cpp
+    HTML/RadioButtonGroupRegistry.cpp
     HTML/RadioNodeList.cpp
     HTML/ReplicatedNavigableState.cpp
     HTML/SandboxingFlagSet.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -171,6 +171,7 @@
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/PopStateEvent.h>
+#include <LibWeb/HTML/RadioButtonGroupRegistry.h>
 #include <LibWeb/HTML/Scripting/Agent.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -814,6 +815,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     for (auto* form_associated_element : m_form_associated_elements_with_form_attribute)
         visitor.visit(form_associated_element->form_associated_element_to_html_element());
+
+    visitor.visit(m_radio_button_group_registry);
 
     visitor.visit(m_potentially_named_elements);
     m_anchor_name_map.visit_edges(visitor);
@@ -7632,6 +7635,13 @@ GC::Ptr<Element> Document::element_by_anchor_name(Utf16FlyString const& name, No
             return {};
     }
     return m_anchor_name_map.last_element_by_name_matching(name, is_acceptable);
+}
+
+HTML::RadioButtonGroupRegistry& Document::ensure_radio_button_group_registry()
+{
+    if (!m_radio_button_group_registry)
+        m_radio_button_group_registry = heap().allocate<HTML::RadioButtonGroupRegistry>();
+    return *m_radio_button_group_registry;
 }
 
 void Document::add_form_associated_element_with_form_attribute(HTML::FormAssociatedElement& form_associated_element)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1037,6 +1037,8 @@ public:
     void add_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
     void remove_form_associated_element_with_form_attribute(HTML::FormAssociatedElement&);
 
+    HTML::RadioButtonGroupRegistry& ensure_radio_button_group_registry();
+
     bool design_mode_enabled_state() const { return m_design_mode_enabled; }
     void set_design_mode_enabled_state(bool);
     Utf16FlyString design_mode() const;
@@ -1820,6 +1822,8 @@ private:
     GC::Ptr<GC::Function<void()>> m_deferred_parser_start;
 
     Vector<HTML::FormAssociatedElement*> m_form_associated_elements_with_form_attribute;
+
+    GC::Ptr<HTML::RadioButtonGroupRegistry> m_radio_button_group_registry;
 
     Vector<GC::Ref<DOM::Element>> m_potentially_named_elements;
 

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
+#include <LibWeb/HTML/RadioButtonGroupRegistry.h>
 #include <LibWeb/HTML/XMLSerializer.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/TrustedTypes/RequireTrustedTypesForDirective.h>
@@ -197,6 +198,14 @@ void ShadowRoot::visit_edges(Visitor& visitor)
             element.visit(visitor);
     }
     visitor.visit(m_custom_element_registry);
+    visitor.visit(m_radio_button_group_registry);
+}
+
+HTML::RadioButtonGroupRegistry& ShadowRoot::ensure_radio_button_group_registry()
+{
+    if (!m_radio_button_group_registry)
+        m_radio_button_group_registry = heap().allocate<HTML::RadioButtonGroupRegistry>();
+    return *m_radio_button_group_registry;
 }
 
 GC::Ref<WebIDL::ObservableArray> ShadowRoot::adopted_style_sheets() const

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -110,6 +110,8 @@ public:
     bool keep_custom_element_registry_null() const { return m_keep_custom_element_registry_null; }
     void set_keep_custom_element_registry_null(bool value) { m_keep_custom_element_registry_null = value; }
 
+    HTML::RadioButtonGroupRegistry& ensure_radio_button_group_registry();
+
     virtual void finalize() override;
 
     GC::Ptr<Element> retargeted_fullscreen_element() const;
@@ -187,6 +189,8 @@ private:
 
     // https://dom.spec.whatwg.org/#shadowroot-keep-custom-element-registry-null
     bool m_keep_custom_element_registry_null { false };
+
+    GC::Ptr<HTML::RadioButtonGroupRegistry> m_radio_button_group_registry;
 
 public:
     using DocumentShadowRootList = IntrusiveList<&ShadowRoot::m_list_node>;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -881,6 +881,7 @@ class PopoverTargetAttributes;
 class PreloadEntry;
 struct PreloadKey;
 class PromiseRejectionEvent;
+class RadioButtonGroupRegistry;
 class RadioNodeList;
 class ScriptRegistry;
 class SelectedFile;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -182,8 +182,10 @@ void FormAssociatedElement::set_form(HTMLFormElement* form)
         rare_data->form = nullptr;
     if (form)
         form->add_associated_element({}, element);
-    if (old_form.ptr() != form)
+    if (old_form.ptr() != form) {
         element.document().bump_form_controls_version();
+        form_associated_element_form_owner_changed();
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
@@ -388,6 +390,10 @@ void FormAssociatedElement::form_associated_element_was_removed(DOM::Node*)
 void FormAssociatedElement::form_associated_element_was_moved(GC::Ptr<DOM::Node>)
 {
     update_face_disabled_state();
+}
+
+void FormAssociatedElement::form_associated_element_form_owner_changed()
+{
 }
 
 void FormAssociatedElement::form_associated_element_attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const&, Optional<Utf16String> const&, Optional<Utf16FlyString> const&)

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -161,6 +161,7 @@ protected:
     virtual void form_associated_element_was_inserted();
     virtual void form_associated_element_was_removed(DOM::Node*);
     virtual void form_associated_element_was_moved(GC::Ptr<DOM::Node>);
+    virtual void form_associated_element_form_owner_changed();
     virtual void form_associated_element_attribute_changed(Utf16FlyString const&, Optional<Utf16String> const&, Optional<Utf16String> const&, Optional<Utf16FlyString> const&);
 
     void form_node_was_inserted();

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/RadioButtonGroupRegistry.h>
 #include <LibWeb/HTML/RadioNodeList.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/SubmitEvent.h>
@@ -62,6 +63,14 @@ void HTMLFormElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_planned_navigation);
     visitor.visit(m_rel_list);
     visitor.visit(m_past_names_map);
+    visitor.visit(m_radio_button_group_registry);
+}
+
+RadioButtonGroupRegistry& HTMLFormElement::ensure_radio_button_group_registry()
+{
+    if (!m_radio_button_group_registry)
+        m_radio_button_group_registry = heap().allocate<RadioButtonGroupRegistry>();
+    return *m_radio_button_group_registry;
 }
 
 void HTMLFormElement::inserted()

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -111,6 +111,8 @@ public:
     void default_button_state_maybe_changed();
     void default_button_state_maybe_changed(DOM::Element&, bool was_default);
 
+    RadioButtonGroupRegistry& ensure_radio_button_group_registry();
+
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);
 
@@ -142,6 +144,8 @@ private:
     bool m_locked_for_reset { false };
 
     Vector<GC::Ref<HTMLElement>> m_associated_elements;
+
+    GC::Ptr<RadioButtonGroupRegistry> m_radio_button_group_registry;
     GC::Weak<HTMLElement> m_default_button_for_style_invalidation;
     bool m_default_button_for_style_invalidation_initialized { false };
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -218,22 +218,23 @@ void HTMLInputElement::set_checked(bool checked)
 
     set_needs_repaint();
 
+    // NB: The registry unchecks the other members of the group and republishes their validity. The tree walks
+    //     below are a fallback for radio buttons that have no registry.
     if (m_radio_button_group_registry) {
         m_radio_button_group_registry->checked_state_changed(m_radio_button_group_name, *this);
-    } else if (checked && type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
+    } else if (type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
-                element.set_checked(false);
-            return TraversalDecision::Continue;
-        });
-    }
-
-    if (type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
-        root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (is_in_same_radio_button_group_as(element))
+            if (&element != this && is_in_same_radio_button_group_as(element))
                 CSS::Invalidation::invalidate_style_after_validity_change(element);
             return TraversalDecision::Continue;
         });
+        if (checked) {
+            root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
+                if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
+                    element.set_checked(false);
+                return TraversalDecision::Continue;
+            });
+        }
     }
 }
 
@@ -2211,6 +2212,8 @@ void HTMLInputElement::update_radio_button_group_registration()
     m_radio_button_group_name = move(group_name);
     if (m_radio_button_group_registry)
         m_radio_button_group_registry->add_button(m_radio_button_group_name, *this);
+
+    CSS::Invalidation::invalidate_style_after_validity_change(*this);
 }
 
 void HTMLInputElement::form_associated_element_was_inserted()

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
+#include <LibWeb/HTML/RadioButtonGroupRegistry.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SharedResourceRequest.h>
@@ -130,6 +131,7 @@ void HTMLInputElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_file_button);
     visitor.visit(m_file_label);
     visitor.visit(m_legacy_pre_activation_behavior_checked_element_in_group);
+    visitor.visit(m_radio_button_group_registry);
     visitor.visit(m_selected_files);
     visitor.visit(m_slider_runnable_track);
     visitor.visit(m_slider_progress_element);
@@ -213,25 +215,23 @@ void HTMLInputElement::set_checked(bool checked)
     // Checkedness decides value-missing validity: for a checkbox its own, and for a radio button
     // that of every member of its radio button group.
     CSS::Invalidation::invalidate_style_after_validity_change(*this);
-    if (type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
+
+    set_needs_repaint();
+
+    if (m_radio_button_group_registry) {
+        m_radio_button_group_registry->checked_state_changed(m_radio_button_group_name, *this);
+    } else if (checked && type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (&element != this && is_in_same_radio_button_group_as(element))
-                CSS::Invalidation::invalidate_style_after_validity_change(element);
+            if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
+                element.set_checked(false);
             return TraversalDecision::Continue;
         });
     }
 
-    set_needs_repaint();
-
-    // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
-    if (type_state() == TypeAttributeState::RadioButton && checked) {
-        // No point iterating the tree if we have an empty name.
-        if (!name().has_value() || name()->is_empty())
-            return;
-
+    if (type_state() == TypeAttributeState::RadioButton && name().has_value() && !name()->is_empty()) {
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
-                element.set_checked(false);
+            if (is_in_same_radio_button_group_as(element))
+                CSS::Invalidation::invalidate_style_after_validity_change(element);
             return TraversalDecision::Continue;
         });
     }
@@ -1686,6 +1686,11 @@ void HTMLInputElement::form_associated_element_attribute_changed(Utf16FlyString 
         // through the replaced-content facts; nothing else schedules a relayout.
         if (old_value != value)
             set_needs_layout_update(DOM::SetNeedsLayoutReason::DefaultPreferredSizeAttributeChange);
+    } else if (name == HTML::AttributeNames::name) {
+        update_radio_button_group_registration();
+    } else if (name == HTML::AttributeNames::required) {
+        if (m_radio_button_group_registry && old_value.has_value() != value.has_value())
+            m_radio_button_group_registry->required_state_changed(m_radio_button_group_name, *this);
     }
 
     // AD-HOC: A change to any of these attributes can change whether the element satisfies its constraints, and
@@ -1741,6 +1746,7 @@ void HTMLInputElement::type_attribute_changed(TypeAttributeState old_state, Type
 
     // 4. Update the element's rendering and behavior to the new state's.
     m_type = new_state;
+    update_radio_button_group_registration();
     if (auto* form = this->form())
         form->default_button_state_maybe_changed(*this, was_default);
     else
@@ -1787,6 +1793,10 @@ void HTMLInputElement::signal_a_type_change()
     // the checkedness state of all the other elements in the same radio button group must be set to false:
     // ...
     // - A type change is signalled for the element.
+    // NB: Registering the element with its new radio button group has already unchecked the other members of the
+    //     group. The tree walk below is a fallback for radio buttons that have no registry.
+    if (m_radio_button_group_registry)
+        return;
     if (type_state() == TypeAttributeState::RadioButton && checked()) {
         root().for_each_in_inclusive_subtree_of_type<HTMLInputElement>([&](auto& element) {
             if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
@@ -2166,26 +2176,74 @@ void HTMLInputElement::clear_algorithm()
     update_shadow_tree();
 }
 
+RadioButtonGroupRegistry* HTMLInputElement::radio_button_group_registry()
+{
+    // NB: A radio button group is scoped to the members' common form owner when they have one, and to the root of
+    //     the tree that contains them otherwise. Radio buttons in a detached subtree that is neither a shadow tree
+    //     nor the tree containing their form owner have no registry.
+    if (type_state() != TypeAttributeState::RadioButton)
+        return nullptr;
+    if (!name().has_value() || name()->is_empty())
+        return nullptr;
+    auto& root = this->root();
+    if (auto* form = this->form()) {
+        if (&form->root() != &root)
+            return nullptr;
+        return &form->ensure_radio_button_group_registry();
+    }
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(root))
+        return &shadow_root->ensure_radio_button_group_registry();
+    if (auto* document = as_if<DOM::Document>(root))
+        return &document->ensure_radio_button_group_registry();
+    return nullptr;
+}
+
+void HTMLInputElement::update_radio_button_group_registration()
+{
+    auto* registry = radio_button_group_registry();
+    auto group_name = registry ? name().value() : Utf16FlyString {};
+    if (registry == m_radio_button_group_registry.ptr() && group_name == m_radio_button_group_name)
+        return;
+
+    if (m_radio_button_group_registry)
+        m_radio_button_group_registry->remove_button(m_radio_button_group_name, *this);
+    m_radio_button_group_registry = registry;
+    m_radio_button_group_name = move(group_name);
+    if (m_radio_button_group_registry)
+        m_radio_button_group_registry->add_button(m_radio_button_group_name, *this);
+}
+
 void HTMLInputElement::form_associated_element_was_inserted()
 {
     // NB: The user-agent shadow tree is rendering state. It is created when a connected control first participates in
     //     a style update, before computed properties are assigned. Creating it in the insertion steps would also
     //     materialize controls in detached and short-lived trees.
 
-    if (is_connected()) {
-        // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
-        // When any of the following phenomena occur, if the element's checkedness state is true after the occurrence,
-        // the checkedness state of all the other elements in the same radio button group must be set to false:
-        // ...
-        // - The element becomes connected.
-        if (type_state() == TypeAttributeState::RadioButton && checked()) {
-            root().for_each_in_inclusive_subtree_of_type<HTMLInputElement>([&](auto& element) {
-                if (element.checked() && &element != this && is_in_same_radio_button_group_as(element))
-                    element.set_checked(false);
-                return TraversalDecision::Continue;
-            });
-        }
-    }
+    // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)
+    // When any of the following phenomena occur, if the element's checkedness state is true after the occurrence,
+    // the checkedness state of all the other elements in the same radio button group must be set to false:
+    // ...
+    // - The element becomes connected.
+    // NB: Registering the element with its radio button group sets the checkedness of the other elements in the
+    //     group to false.
+    update_radio_button_group_registration();
+}
+
+void HTMLInputElement::form_associated_element_was_removed(DOM::Node* old_parent)
+{
+    FormAssociatedElement::form_associated_element_was_removed(old_parent);
+    update_radio_button_group_registration();
+}
+
+void HTMLInputElement::form_associated_element_was_moved(GC::Ptr<DOM::Node> old_parent)
+{
+    FormAssociatedElement::form_associated_element_was_moved(old_parent);
+    update_radio_button_group_registration();
+}
+
+void HTMLInputElement::form_associated_element_form_owner_changed()
+{
+    update_radio_button_group_registration();
 }
 
 EventResult HTMLInputElement::handle_return_key(Utf16FlyString const&)
@@ -2328,13 +2386,17 @@ void HTMLInputElement::legacy_pre_activation_behavior()
     //    element's radio button group that has its checkedness set to true, if any, and then set this element's
     //    checkedness to true.
     if (type_state() == TypeAttributeState::RadioButton) {
-        root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
-            if (element.checked() && is_in_same_radio_button_group_as(element)) {
-                m_legacy_pre_activation_behavior_checked_element_in_group = &element;
-                return TraversalDecision::Break;
-            }
-            return TraversalDecision::Continue;
-        });
+        if (m_radio_button_group_registry) {
+            m_legacy_pre_activation_behavior_checked_element_in_group = m_radio_button_group_registry->checked_button(m_radio_button_group_name);
+        } else {
+            root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
+                if (element.checked() && is_in_same_radio_button_group_as(element)) {
+                    m_legacy_pre_activation_behavior_checked_element_in_group = &element;
+                    return TraversalDecision::Break;
+                }
+                return TraversalDecision::Continue;
+            });
+        }
 
         set_checked(true);
     }
@@ -3678,6 +3740,8 @@ bool HTMLInputElement::suffering_from_being_missing() const
         // https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type%3Dradio)%3Asuffering-from-being-missing
         // If an element in the radio button group is required, and all of the input elements in the radio button group
         // have a checkedness that is false, then the element is suffering from being missing.
+        if (m_radio_button_group_registry)
+            return m_radio_button_group_registry->group_is_suffering_from_being_missing(m_radio_button_group_name);
         root().for_each_in_inclusive_subtree_of_type<HTML::HTMLInputElement>([&](auto& element) {
             if (is_in_same_radio_button_group_as(element)) {
                 if (element.checked())

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -205,6 +205,9 @@ public:
     virtual void clear_algorithm() override;
 
     virtual void form_associated_element_was_inserted() override;
+    virtual void form_associated_element_was_removed(DOM::Node*) override;
+    virtual void form_associated_element_was_moved(GC::Ptr<DOM::Node>) override;
+    virtual void form_associated_element_form_owner_changed() override;
     virtual void form_associated_element_attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
 
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
@@ -282,6 +285,8 @@ private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 
     void type_attribute_changed(TypeAttributeState old_state, TypeAttributeState new_state);
+    RadioButtonGroupRegistry* radio_button_group_registry();
+    void update_radio_button_group_registration();
     virtual void computed_properties_changed() override;
     virtual void prepare_for_style_computation() override { create_shadow_tree_if_needed(); }
 
@@ -407,6 +412,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#user-validity
     bool m_user_validity { false };
+
+    GC::Ptr<RadioButtonGroupRegistry> m_radio_button_group_registry;
+    Utf16FlyString m_radio_button_group_name;
 
     // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
     bool m_before_legacy_pre_activation_behavior_checked { false };

--- a/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.cpp
+++ b/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Invalidation/FormControlInvalidator.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/RadioButtonGroupRegistry.h>
@@ -33,6 +34,8 @@ void RadioButtonGroupRegistry::add_button(Utf16FlyString const& group_name, HTML
         ++group.required_count;
     if (button.checked())
         set_checked_button(group, button);
+
+    update_group_suffering_from_being_missing(group);
 }
 
 void RadioButtonGroupRegistry::remove_button(Utf16FlyString const& group_name, HTMLInputElement& button)
@@ -49,8 +52,11 @@ void RadioButtonGroupRegistry::remove_button(Utf16FlyString const& group_name, H
     if (group.checked_button.ptr() == &button)
         group.checked_button = nullptr;
 
-    if (group.members.is_empty())
+    if (group.members.is_empty()) {
         m_groups.remove(it);
+        return;
+    }
+    update_group_suffering_from_being_missing(group);
 }
 
 void RadioButtonGroupRegistry::checked_state_changed(Utf16FlyString const& group_name, HTMLInputElement& button)
@@ -64,6 +70,8 @@ void RadioButtonGroupRegistry::checked_state_changed(Utf16FlyString const& group
         set_checked_button(group, button);
     else if (group.checked_button.ptr() == &button)
         group.checked_button = nullptr;
+
+    update_group_suffering_from_being_missing(group);
 }
 
 void RadioButtonGroupRegistry::required_state_changed(Utf16FlyString const& group_name, HTMLInputElement& button)
@@ -79,6 +87,8 @@ void RadioButtonGroupRegistry::required_state_changed(Utf16FlyString const& grou
         VERIFY(group.required_count > 0);
         --group.required_count;
     }
+
+    update_group_suffering_from_being_missing(group);
 }
 
 GC::Ptr<HTMLInputElement> RadioButtonGroupRegistry::checked_button(Utf16FlyString const& group_name) const
@@ -92,8 +102,7 @@ bool RadioButtonGroupRegistry::group_is_suffering_from_being_missing(Utf16FlyStr
 {
     auto it = m_groups.find(group_name);
     VERIFY(it != m_groups.end());
-    auto const& group = it->value;
-    return group.required_count > 0 && !group.checked_button;
+    return it->value.suffering_from_being_missing;
 }
 
 void RadioButtonGroupRegistry::set_checked_button(RadioButtonGroup& group, HTMLInputElement& button)
@@ -105,6 +114,19 @@ void RadioButtonGroupRegistry::set_checked_button(RadioButtonGroup& group, HTMLI
 
     if (old_checked_button)
         old_checked_button->set_checked(false);
+}
+
+void RadioButtonGroupRegistry::update_group_suffering_from_being_missing(RadioButtonGroup& group)
+{
+    auto suffering_from_being_missing = group.required_count > 0 && !group.checked_button;
+    if (suffering_from_being_missing == group.suffering_from_being_missing)
+        return;
+    group.suffering_from_being_missing = suffering_from_being_missing;
+
+    // Every member answers value-missing validity queries with the state of its group, so a change to the group's
+    // state changes which validity pseudo-classes match on all of them.
+    for (auto const& member : group.members)
+        CSS::Invalidation::invalidate_style_after_validity_change(member);
 }
 
 }

--- a/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.cpp
+++ b/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/AttributeNames.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/RadioButtonGroupRegistry.h>
+
+namespace Web::HTML {
+
+GC_DEFINE_ALLOCATOR(RadioButtonGroupRegistry);
+
+void RadioButtonGroupRegistry::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto const& [name, group] : m_groups) {
+        for (auto const& member : group.members)
+            visitor.visit(member);
+        visitor.visit(group.checked_button);
+    }
+}
+
+void RadioButtonGroupRegistry::add_button(Utf16FlyString const& group_name, HTMLInputElement& button)
+{
+    VERIFY(!group_name.is_empty());
+    auto& group = m_groups.ensure(group_name);
+    auto result = group.members.set(button);
+    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+
+    if (button.has_attribute(AttributeNames::required))
+        ++group.required_count;
+    if (button.checked())
+        set_checked_button(group, button);
+}
+
+void RadioButtonGroupRegistry::remove_button(Utf16FlyString const& group_name, HTMLInputElement& button)
+{
+    auto it = m_groups.find(group_name);
+    VERIFY(it != m_groups.end());
+    auto& group = it->value;
+    VERIFY(group.members.remove(button));
+
+    if (button.has_attribute(AttributeNames::required)) {
+        VERIFY(group.required_count > 0);
+        --group.required_count;
+    }
+    if (group.checked_button.ptr() == &button)
+        group.checked_button = nullptr;
+
+    if (group.members.is_empty())
+        m_groups.remove(it);
+}
+
+void RadioButtonGroupRegistry::checked_state_changed(Utf16FlyString const& group_name, HTMLInputElement& button)
+{
+    auto it = m_groups.find(group_name);
+    VERIFY(it != m_groups.end());
+    auto& group = it->value;
+    VERIFY(group.members.contains(button));
+
+    if (button.checked())
+        set_checked_button(group, button);
+    else if (group.checked_button.ptr() == &button)
+        group.checked_button = nullptr;
+}
+
+void RadioButtonGroupRegistry::required_state_changed(Utf16FlyString const& group_name, HTMLInputElement& button)
+{
+    auto it = m_groups.find(group_name);
+    VERIFY(it != m_groups.end());
+    auto& group = it->value;
+    VERIFY(group.members.contains(button));
+
+    if (button.has_attribute(AttributeNames::required)) {
+        ++group.required_count;
+    } else {
+        VERIFY(group.required_count > 0);
+        --group.required_count;
+    }
+}
+
+GC::Ptr<HTMLInputElement> RadioButtonGroupRegistry::checked_button(Utf16FlyString const& group_name) const
+{
+    auto it = m_groups.find(group_name);
+    VERIFY(it != m_groups.end());
+    return it->value.checked_button;
+}
+
+bool RadioButtonGroupRegistry::group_is_suffering_from_being_missing(Utf16FlyString const& group_name) const
+{
+    auto it = m_groups.find(group_name);
+    VERIFY(it != m_groups.end());
+    auto const& group = it->value;
+    return group.required_count > 0 && !group.checked_button;
+}
+
+void RadioButtonGroupRegistry::set_checked_button(RadioButtonGroup& group, HTMLInputElement& button)
+{
+    auto old_checked_button = group.checked_button;
+    if (old_checked_button.ptr() == &button)
+        return;
+    group.checked_button = &button;
+
+    if (old_checked_button)
+        old_checked_button->set_checked(false);
+}
+
+}

--- a/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.h
+++ b/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.h
@@ -33,11 +33,13 @@ private:
         HashTable<GC::Ref<HTMLInputElement>> members;
         GC::Ptr<HTMLInputElement> checked_button;
         size_t required_count { 0 };
+        bool suffering_from_being_missing { false };
     };
 
     virtual void visit_edges(Cell::Visitor&) override;
 
     void set_checked_button(RadioButtonGroup&, HTMLInputElement&);
+    void update_group_suffering_from_being_missing(RadioButtonGroup&);
 
     HashMap<Utf16FlyString, RadioButtonGroup> m_groups;
 };

--- a/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.h
+++ b/Libraries/LibWeb/HTML/RadioButtonGroupRegistry.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/Utf16FlyString.h>
+#include <LibGC/Cell.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::HTML {
+
+class RadioButtonGroupRegistry final : public GC::Cell {
+    GC_CELL(RadioButtonGroupRegistry, GC::Cell);
+    GC_DECLARE_ALLOCATOR(RadioButtonGroupRegistry);
+
+public:
+    void add_button(Utf16FlyString const& group_name, HTMLInputElement&);
+    void remove_button(Utf16FlyString const& group_name, HTMLInputElement&);
+    void checked_state_changed(Utf16FlyString const& group_name, HTMLInputElement&);
+    void required_state_changed(Utf16FlyString const& group_name, HTMLInputElement&);
+
+    GC::Ptr<HTMLInputElement> checked_button(Utf16FlyString const& group_name) const;
+    bool group_is_suffering_from_being_missing(Utf16FlyString const& group_name) const;
+
+private:
+    struct RadioButtonGroup {
+        HashTable<GC::Ref<HTMLInputElement>> members;
+        GC::Ptr<HTMLInputElement> checked_button;
+        size_t required_count { 0 };
+    };
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    void set_checked_button(RadioButtonGroup&, HTMLInputElement&);
+
+    HashMap<Utf16FlyString, RadioButtonGroup> m_groups;
+};
+
+}

--- a/Tests/LibWeb/Text/expected/css/radio-group-required-and-name-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/radio-group-required-and-name-invalidation.txt
@@ -1,0 +1,5 @@
+before: a invalid=false b invalid=false
+required a: a invalid=true b invalid=true c invalid=false
+optional a: a valid=true b valid=true
+renamed c into group g: c invalid=true
+renamed required a out of group g: a invalid=true b valid=true c valid=true

--- a/Tests/LibWeb/Text/input/css/radio-group-required-and-name-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/radio-group-required-and-name-invalidation.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<form>
+    <input type="radio" name="g" id="a">
+    <input type="radio" name="g" id="b">
+    <input type="radio" name="h" id="c">
+</form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const a = document.getElementById("a");
+        const b = document.getElementById("b");
+        const c = document.getElementById("c");
+        println("before: a invalid=" + a.matches(":invalid") + " b invalid=" + b.matches(":invalid"));
+        a.required = true;
+        println("required a: a invalid=" + a.matches(":invalid") + " b invalid=" + b.matches(":invalid") + " c invalid=" + c.matches(":invalid"));
+        a.removeAttribute("required");
+        println("optional a: a valid=" + a.matches(":valid") + " b valid=" + b.matches(":valid"));
+        a.required = true;
+        c.name = "g";
+        println("renamed c into group g: c invalid=" + c.matches(":invalid"));
+        a.name = "h";
+        println("renamed required a out of group g: a invalid=" + a.matches(":invalid") + " b valid=" + b.matches(":valid") + " c valid=" + c.matches(":valid"));
+    });
+</script>


### PR DESCRIPTION
Previously, every query about a radio button group walked the entire tree to find the group's members. The style engine performs this lookup for every form control it styles, so pages with many radio buttons spent much of their load time inside these walks.

Form elements, documents, and shadow roots now own a registry of the radio button groups they scope. Each group tracks its members, its checked member, and the number of required members, so group queries are answered in constant time. Radio buttons in a detached subtree that is neither a shadow tree nor the tree containing their form owner have no registry and keep the tree walk.

This improves performance on sites with a large number of radio buttons. First noticed in a profile of https://benjaminaster.com/css-minecraft/.

Tested using [this stress test](https://gist.github.com/tcl3/73c49d9a4d3c5bc08e3cf3aa8eaa16cd) - a page of 1000 radio button groups each containing 5 radio buttons:

| Before | After
|---|---
| 6.450s | 0.967s