### PR TITLE
WebCompat: Add runtime site compatibility rules

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -809,6 +809,7 @@ set(SOURCES
     Loader/GeneratedPagesLoader.cpp
     Loader/ProxyMappings.cpp
     Loader/ResourceLoader.cpp
+    Loader/SiteCompatibility.cpp
     MathML/AttributeNames.cpp
     MathML/MathMLAnchorElement.cpp
     MathML/MathMLElement.cpp

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1767,7 +1767,7 @@ GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm& realm, Infrastru
         // 15. If httpRequest’s header list does not contain `User-Agent`, then user agents should append
         //     (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
         if (!http_request->header_list()->contains("User-Agent"sv))
-            http_request->header_list()->append({ "User-Agent"sv, Infrastructure::default_user_agent_value() });
+            http_request->header_list()->append({ "User-Agent"sv, Infrastructure::default_user_agent_value(http_request->current_url()) });
 
         // 16. If httpRequest’s cache mode is "default" and httpRequest’s header list contains `If-Modified-Since`,
         //     `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`, then set httpRequest’s cache mode to

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
@@ -10,10 +10,10 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#default-user-agent-value
-ByteString default_user_agent_value()
+ByteString default_user_agent_value(URL::URL const& url)
 {
     // A default `User-Agent` value is an implementation-defined header value for the `User-Agent` header.
-    return ResourceLoader::the().user_agent().to_byte_string();
+    return ResourceLoader::the().user_agent_for_url(url).to_byte_string();
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibURL/Forward.h>
 
 namespace Web::Fetch::Infrastructure {
 
@@ -17,6 +18,6 @@ enum class RedirectTaint {
     CrossSite,
 };
 
-[[nodiscard]] ByteString default_user_agent_value();
+[[nodiscard]] ByteString default_user_agent_value(URL::URL const&);
 
 }

--- a/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Libraries/LibWeb/HTML/Navigator.cpp
@@ -47,6 +47,11 @@ Navigator::Navigator(Window& window)
 
 Navigator::~Navigator() = default;
 
+URL::URL Navigator::navigator_id_url() const
+{
+    return m_window->associated_document().url();
+}
+
 EnvironmentSettingsObject& Navigator::navigator_storage_settings_object() const
 {
     return relevant_settings_object(*m_window);

--- a/Libraries/LibWeb/HTML/Navigator.h
+++ b/Libraries/LibWeb/HTML/Navigator.h
@@ -92,6 +92,8 @@ protected:
 private:
     explicit Navigator(Window&);
 
+    virtual URL::URL navigator_id_url() const override;
+
     // ^StorageAPI::NavigatorStorage
     virtual EnvironmentSettingsObject& navigator_storage_settings_object() const override;
 

--- a/Libraries/LibWeb/HTML/NavigatorID.cpp
+++ b/Libraries/LibWeb/HTML/NavigatorID.cpp
@@ -18,7 +18,7 @@ Utf16String NavigatorIDMixin::app_version() const
 {
     // 1. Let userAgent be this's relevant settings object's environment default `User-Agent` value.
     // FIXME: Store that on the settings object?
-    auto user_agent = ResourceLoader::the().user_agent();
+    auto user_agent = ResourceLoader::the().user_agent_for_url(navigator_id_url());
 
     // 2. If userAgent does not start with `Mozilla/5.0 (`, then return the empty string.
     if (!user_agent.starts_with_bytes("Mozilla/5.0 ("sv))
@@ -90,7 +90,8 @@ Utf16FlyString NavigatorIDMixin::product_sub() const
 Utf16String NavigatorIDMixin::user_agent() const
 {
     // Must return the default `User-Agent` value.
-    return Utf16String::from_ascii_without_validation(ResourceLoader::the().user_agent().bytes());
+    auto user_agent = ResourceLoader::the().user_agent_for_url(navigator_id_url());
+    return Utf16String::from_ascii_without_validation(user_agent.bytes());
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendor

--- a/Libraries/LibWeb/HTML/NavigatorID.h
+++ b/Libraries/LibWeb/HTML/NavigatorID.h
@@ -8,11 +8,14 @@
 
 #include <AK/Utf16FlyString.h>
 #include <AK/Utf16String.h>
+#include <LibURL/URL.h>
 
 namespace Web::HTML {
 
 class NavigatorIDMixin {
 public:
+    virtual ~NavigatorIDMixin() = default;
+
     // WARNING: Any information in this API that varies from user to user can be used to profile the user. In fact, if
     // enough such information is available, a user can actually be uniquely identified. For this reason, user agent
     // implementers are strongly urged to include as little information in this API as possible.
@@ -47,6 +50,9 @@ public:
     // FIXME: If the navigator compatibility mode is Gecko, then the user agent must also support the following partial interface:
     //       bool taint_enabled()
     //       ByteString oscpu()
+
+protected:
+    virtual URL::URL navigator_id_url() const = 0;
 };
 
 }

--- a/Libraries/LibWeb/HTML/WorkerNavigator.cpp
+++ b/Libraries/LibWeb/HTML/WorkerNavigator.cpp
@@ -27,6 +27,11 @@ WorkerNavigator::WorkerNavigator(WorkerGlobalScope& global_scope)
 
 WorkerNavigator::~WorkerNavigator() = default;
 
+URL::URL WorkerNavigator::navigator_id_url() const
+{
+    return m_global_scope->url();
+}
+
 void WorkerNavigator::visit_edges(GC::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/HTML/WorkerNavigator.h
+++ b/Libraries/LibWeb/HTML/WorkerNavigator.h
@@ -51,6 +51,8 @@ public:
 private:
     explicit WorkerNavigator(WorkerGlobalScope&);
 
+    virtual URL::URL navigator_id_url() const override;
+
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
     // ^StorageAPI::NavigatorStorage

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -680,6 +680,21 @@ WebIDL::ExceptionOr<void> Internals::set_content_blockers(Utf16String const& pat
     return {};
 }
 
+WebIDL::ExceptionOr<void> Internals::set_site_compatibility_data(Utf16String const& source)
+{
+    auto source_utf8 = TRY_OR_THROW_OOM(window().principal_realm().vm(), source.utf16_view().to_utf8());
+    auto json = JsonValue::from_string(source_utf8);
+    if (json.is_error())
+        return window().principal_realm().vm().throw_completion<JS::InternalError>("Could not parse site compatibility data"_utf16);
+
+    auto data = SiteCompatibilityData::from_json(json.value());
+    if (data.is_error())
+        return window().principal_realm().vm().throw_completion<JS::InternalError>(Utf16String::formatted("Could not set site compatibility data: {}", data.error()));
+
+    ResourceLoader::the().set_site_compatibility_data(data.release_value());
+    return {};
+}
+
 void Internals::set_content_blocking_enabled(bool enabled)
 {
     page().set_content_blocking_enabled(enabled);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -113,6 +113,7 @@ public:
     void simulate_request_server_connection_loss();
     void simulate_worker_request_server_connection_loss();
     WebIDL::ExceptionOr<void> set_content_blockers(Utf16String const& patterns);
+    WebIDL::ExceptionOr<void> set_site_compatibility_data(Utf16String const& source);
     void set_content_blocking_enabled(bool enabled);
     WebIDL::UnsignedLongLong partial_layout_count();
     WebIDL::UnsignedLongLong full_layout_count();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -92,6 +92,7 @@ interface Internals {
     undefined simulateRequestServerConnectionLoss();
     undefined simulateWorkerRequestServerConnectionLoss();
     undefined setContentBlockers(Utf16DOMString patterns);
+    undefined setSiteCompatibilityData(Utf16DOMString source);
     undefined setContentBlockingEnabled(boolean enabled);
     unsigned long long partialLayoutCount();
     unsigned long long fullLayoutCount();

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -21,6 +21,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/NavigatorCompatibilityMode.h>
+#include <LibWeb/Loader/SiteCompatibility.h>
 
 namespace Web {
 
@@ -50,7 +51,10 @@ public:
     static bool is_known_hsts_host(Page&, String const& host);
 
     String const& user_agent() const { return m_user_agent; }
+    String user_agent_for_url(URL::URL const& url) const { return m_site_compatibility_data.user_agent_for_url(url, m_user_agent); }
+    String user_agent_for_websocket_url(URL::URL const& url) const { return m_site_compatibility_data.user_agent_for_websocket_url(url, m_user_agent); }
     void set_user_agent(String user_agent) { m_user_agent = move(user_agent); }
+    void set_site_compatibility_data(SiteCompatibilityData data) { m_site_compatibility_data = move(data); }
 
     String const& platform() const { return m_platform; }
     void set_platform(String platform) { m_platform = move(platform); }
@@ -92,6 +96,7 @@ private:
     HashTable<NonnullRefPtr<Requests::Request>> m_active_requests;
 
     String m_user_agent;
+    SiteCompatibilityData m_site_compatibility_data;
     String m_platform;
     Vector<String> m_preferred_languages = { "en"_string };
     NavigatorCompatibilityMode m_navigator_compatibility_mode;

--- a/Libraries/LibWeb/Loader/SiteCompatibility.cpp
+++ b/Libraries/LibWeb/Loader/SiteCompatibility.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/StringBuilder.h>
+#include <LibWeb/Loader/SiteCompatibility.h>
+
+namespace Web {
+
+static ErrorOr<Vector<String>> parse_patterns(JsonObject const& object)
+{
+    auto patterns = object.get_array("matches"sv);
+    if (!patterns.has_value() || patterns->is_empty())
+        return Error::from_string_literal("Site compatibility rule must contain a non-empty 'matches' array");
+
+    Vector<String> result;
+    TRY(result.try_ensure_capacity(patterns->size()));
+    for (size_t i = 0; i < patterns->size(); ++i) {
+        auto const& pattern = patterns->at(i);
+        if (!pattern.is_string() || pattern.as_string().is_empty())
+            return Error::from_string_literal("Site compatibility rule patterns must be non-empty strings");
+        TRY(result.try_append(pattern.as_string()));
+    }
+    return result;
+}
+
+static ErrorOr<Vector<UserAgentTransformation>> parse_user_agent_transformations(JsonObject const& object)
+{
+    auto transformations = object.get_array("user_agent"sv);
+    if (!transformations.has_value() || transformations->is_empty())
+        return Error::from_string_literal("Site compatibility rule must contain a non-empty 'user_agent' array");
+
+    Vector<UserAgentTransformation> result;
+    TRY(result.try_ensure_capacity(transformations->size()));
+    for (size_t i = 0; i < transformations->size(); ++i) {
+        auto const& transformation = transformations->at(i);
+        if (!transformation.is_string())
+            return Error::from_string_literal("User-Agent transformations must be strings");
+        if (transformation.as_string() == "hide_Ladybird"sv)
+            TRY(result.try_append(UserAgentTransformation::HideLadybird));
+        else
+            return Error::from_string_literal("Unknown User-Agent transformation");
+    }
+    return result;
+}
+
+ErrorOr<SiteCompatibilityRule> SiteCompatibilityRule::from_json(JsonValue const& value)
+{
+    if (!value.is_object())
+        return Error::from_string_literal("Site compatibility rule must be a JSON object");
+
+    auto const& object = value.as_object();
+    return create(TRY(parse_patterns(object)), TRY(parse_user_agent_transformations(object)));
+}
+
+ErrorOr<SiteCompatibilityRule> SiteCompatibilityRule::create(Vector<String> patterns, Vector<UserAgentTransformation> transformations)
+{
+    Vector<URL::RustIntegration::URLPattern> compiled_patterns;
+    TRY(compiled_patterns.try_ensure_capacity(patterns.size()));
+
+    for (auto const& pattern : patterns) {
+        auto compiled_pattern = URL::RustIntegration::URLPattern::create(pattern);
+        if (compiled_pattern.is_error())
+            return Error::from_string_literal("Site compatibility rule contains an invalid URL pattern");
+        TRY(compiled_patterns.try_append(compiled_pattern.release_value()));
+    }
+
+    return SiteCompatibilityRule { move(patterns), move(compiled_patterns), move(transformations) };
+}
+
+SiteCompatibilityRule::SiteCompatibilityRule(Vector<String> patterns, Vector<URL::RustIntegration::URLPattern> compiled_patterns, Vector<UserAgentTransformation> transformations)
+    : m_patterns(move(patterns))
+    , m_compiled_patterns(move(compiled_patterns))
+    , m_user_agent_transformations(move(transformations))
+{
+}
+
+bool SiteCompatibilityRule::matches(URL::URL const& url) const
+{
+    auto serialized_url = url.serialize();
+    for (auto const& pattern : m_compiled_patterns) {
+        auto result = pattern.match(serialized_url, {});
+        if (!result.is_error() && result.value().has_value())
+            return true;
+    }
+    return false;
+}
+
+static String remove_ladybird_product(StringView user_agent)
+{
+    StringBuilder builder;
+    bool first = true;
+    for (auto product : user_agent.split_view(' ')) {
+        if (product.starts_with("Ladybird/"sv))
+            continue;
+        if (!first)
+            builder.append(' ');
+        builder.append(product);
+        first = false;
+    }
+    return MUST(builder.to_string());
+}
+
+String SiteCompatibilityRule::apply_user_agent_transformations(StringView user_agent) const
+{
+    auto transformed_user_agent = MUST(String::from_utf8(user_agent));
+    for (auto transformation : m_user_agent_transformations) {
+        switch (transformation) {
+        case UserAgentTransformation::HideLadybird:
+            transformed_user_agent = remove_ladybird_product(transformed_user_agent);
+            break;
+        }
+    }
+    return transformed_user_agent;
+}
+
+String SiteCompatibilityData::user_agent_for_url(URL::URL const& url, StringView default_user_agent) const
+{
+    auto user_agent = MUST(String::from_utf8(default_user_agent));
+    for (auto const& rule : m_rules) {
+        if (rule.matches(url))
+            user_agent = rule.apply_user_agent_transformations(user_agent);
+    }
+    return user_agent;
+}
+
+String SiteCompatibilityData::user_agent_for_websocket_url(URL::URL const& url, StringView default_user_agent) const
+{
+    auto http_url = url;
+    if (http_url.scheme() == "ws"sv)
+        http_url.set_scheme("http"_string);
+    else if (http_url.scheme() == "wss"sv)
+        http_url.set_scheme("https"_string);
+    return user_agent_for_url(http_url, default_user_agent);
+}
+
+ErrorOr<SiteCompatibilityData> SiteCompatibilityData::from_json(JsonValue const& value)
+{
+    if (!value.is_array())
+        return Error::from_string_literal("Site compatibility data must be a JSON array");
+
+    SiteCompatibilityData data;
+    auto const& rules = value.as_array();
+    for (size_t i = 0; i < rules.size(); ++i)
+        data.add_rule(TRY(SiteCompatibilityRule::from_json(rules.at(i))));
+    return data;
+}
+
+}

--- a/Libraries/LibWeb/Loader/SiteCompatibility.h
+++ b/Libraries/LibWeb/Loader/SiteCompatibility.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/JsonValue.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibURL/RustIntegration.h>
+#include <LibURL/URL.h>
+#include <LibWeb/Export.h>
+
+namespace Web {
+
+enum class UserAgentTransformation : u8 {
+    HideLadybird,
+};
+
+class WEB_API SiteCompatibilityRule {
+public:
+    static ErrorOr<SiteCompatibilityRule> from_json(JsonValue const&);
+    static ErrorOr<SiteCompatibilityRule> create(Vector<String> patterns, Vector<UserAgentTransformation> transformations);
+
+    Vector<String> const& patterns() const { return m_patterns; }
+    Vector<UserAgentTransformation> const& user_agent_transformations() const { return m_user_agent_transformations; }
+
+    bool matches(URL::URL const&) const;
+    String apply_user_agent_transformations(StringView user_agent) const;
+
+private:
+    SiteCompatibilityRule(Vector<String> patterns, Vector<URL::RustIntegration::URLPattern> compiled_patterns, Vector<UserAgentTransformation> transformations);
+
+    Vector<String> m_patterns;
+    Vector<URL::RustIntegration::URLPattern> m_compiled_patterns;
+    Vector<UserAgentTransformation> m_user_agent_transformations;
+};
+
+class WEB_API SiteCompatibilityData {
+public:
+    static ErrorOr<SiteCompatibilityData> from_json(JsonValue const&);
+
+    void add_rule(SiteCompatibilityRule rule) { m_rules.append(move(rule)); }
+
+    Vector<SiteCompatibilityRule> const& rules() const { return m_rules; }
+    String user_agent_for_url(URL::URL const&, StringView default_user_agent) const;
+    String user_agent_for_websocket_url(URL::URL const&, StringView default_user_agent) const;
+
+private:
+    Vector<SiteCompatibilityRule> m_rules;
+};
+
+}

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -21,7 +21,6 @@
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOMURL/DOMURL.h>
-#include <LibWeb/Fetch/Infrastructure/HTTP.h>
 #include <LibWeb/FileAPI/Blob.h>
 #include <LibWeb/HTML/CloseEvent.h>
 #include <LibWeb/HTML/EventHandler.h>
@@ -194,7 +193,7 @@ ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL const& url_rec
         additional_headers->append({ "Cookie"sv, cookies.to_byte_string() });
     }
 
-    additional_headers->append({ "User-Agent"sv, Fetch::Infrastructure::default_user_agent_value() });
+    additional_headers->append({ "User-Agent"sv, ResourceLoader::the().user_agent_for_websocket_url(url_record).to_byte_string() });
 
     auto request_client = ResourceLoader::the().request_client();
 

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -1,3 +1,4 @@
+#include <AK/JsonValue.h>
 #include <LibURL/URL.h>
 #include <LibIPC/File.h>
 #include <LibIPC/TransportHandle.h>
@@ -14,6 +15,7 @@ endpoint WebWorkerServer {
     connect_to_image_decoder(IPC::TransportHandle handle) =|
     connect_to_wasm_compiler(IPC::TransportHandle handle) =|
     connect_to_compositor(IPC::TransportHandle handle) =|
+    set_site_compatibility_data(JsonValue data) =|
 
     set_system_font_family(String family) =|
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -43,6 +43,7 @@
 #include <LibWebView/Menu.h>
 #include <LibWebView/ProcessType.h>
 #include <LibWebView/SessionStore.h>
+#include <LibWebView/SiteCompatibility.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
@@ -286,6 +287,7 @@ Requests::RequestClient& Application::request_server_client(IsPrivate is_private
 ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 {
     TRY(handle_attached_debugger());
+    TRY(reload_site_compatibility_data());
     m_arguments = arguments;
 
 #if !defined(AK_OS_WINDOWS)
@@ -825,6 +827,7 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
         client->assign_view({}, *view);
 
     client->async_connect_to_request_server(request_server_handle);
+    client->async_set_site_compatibility_data(m_site_compatibility_data);
     client->async_connect_to_image_decoder(image_decoder_handle);
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     client->async_connect_to_wasm_compiler(wasm_compiler_handle);
@@ -832,6 +835,19 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
     TRY(Application::the().connect_web_content_to_compositor(*client));
 
     return client;
+}
+
+ErrorOr<void> Application::reload_site_compatibility_data()
+{
+    auto data = TRY(load_site_compatibility_data());
+    m_site_compatibility_data = move(data);
+
+    WebContentClient::for_each_client([&](auto& client) {
+        client.async_set_site_compatibility_data(m_site_compatibility_data);
+        return IterationDecision::Continue;
+    });
+    WorkerProcessManager::the().update_site_compatibility_data(m_site_compatibility_data);
+    return {};
 }
 
 u64 Application::allocate_page_id()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Function.h>
+#include <AK/JsonValue.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullRawPtr.h>
 #include <AK/Optional.h>
@@ -86,6 +87,8 @@ public:
     static BrowserOptions const& browser_options() { return the().m_browser_options; }
     static RequestServerOptions const& request_server_options() { return the().m_request_server_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
+    JsonValue const& site_compatibility_data() const { return m_site_compatibility_data; }
+    ErrorOr<void> reload_site_compatibility_data();
 
     bool claim_cpu_profiler(ProcessType);
     void set_cpu_profiler_process(Core::Process);
@@ -461,6 +464,7 @@ private:
     Vector<int> m_cpu_profiler_signal_handlers;
     RequestServerOptions m_request_server_options;
     WebContentOptions m_web_content_options;
+    JsonValue m_site_compatibility_data;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
 
     RefPtr<WebDriverBrowserConnection> m_webdriver_browser_connection;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
     SessionHistoryTraversalQueue.cpp
     SessionStore.cpp
     Settings.cpp
+    SiteCompatibility.cpp
     SiteIsolation.cpp
     SiteIsolationManager.cpp
     SourceHighlighter.cpp

--- a/Libraries/LibWebView/SiteCompatibility.cpp
+++ b/Libraries/LibWebView/SiteCompatibility.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/QuickSort.h>
+#include <LibCore/Resource.h>
+#include <LibWeb/Loader/SiteCompatibility.h>
+#include <LibWebView/SiteCompatibility.h>
+
+namespace WebView {
+
+ErrorOr<JsonValue> load_site_compatibility_data()
+{
+    auto directory_or_error = Core::Resource::load_from_uri("resource://ladybird/site-compatibility"sv);
+    if (directory_or_error.is_error())
+        return JsonValue { JsonArray {} };
+    auto directory = directory_or_error.release_value();
+    auto children = directory->children();
+    quick_sort(children);
+
+    JsonArray rules;
+    for (auto const& child : children) {
+        if (!child.bytes_as_string_view().ends_with(".json"sv))
+            continue;
+
+        auto resource = TRY(Core::Resource::load_from_uri(TRY(String::formatted("{}/{}", directory->uri(), child))));
+        auto rule = TRY(JsonValue::from_string(resource->data()));
+        TRY(rules.append(move(rule)));
+    }
+
+    JsonValue data { move(rules) };
+    TRY(Web::SiteCompatibilityData::from_json(data));
+    return data;
+}
+
+}

--- a/Libraries/LibWebView/SiteCompatibility.h
+++ b/Libraries/LibWebView/SiteCompatibility.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/JsonValue.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+WEBVIEW_API ErrorOr<JsonValue> load_site_compatibility_data();
+
+}

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -122,6 +122,7 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
 #endif
 
     client->async_connect_to_request_server(request_server_handle);
+    client->async_set_site_compatibility_data(Application::the().site_compatibility_data());
     client->async_connect_to_image_decoder(image_decoder_handle);
 #if defined(HAVE_WASM_COMPILER_SERVICE)
     client->async_connect_to_wasm_compiler(wasm_compiler_handle);
@@ -164,6 +165,12 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
     client->async_start_worker(request.url, request.type, request.credentials, request.name, move(request.outside_port), request.outside_settings, request.agent_type);
 
     return agent_id;
+}
+
+void WorkerProcessManager::update_site_compatibility_data(JsonValue const& data)
+{
+    for (auto const& agent : m_agents)
+        agent.value.client->async_set_site_compatibility_data(data);
 }
 
 void WorkerProcessManager::close_worker_agent(WebContentClient& client, Web::HTML::WorkerAgentId agent_id, Web::HTML::WorkerAgentOwnerToken owner_token)

--- a/Libraries/LibWebView/WorkerProcessManager.h
+++ b/Libraries/LibWebView/WorkerProcessManager.h
@@ -9,6 +9,7 @@
 #include <AK/Error.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <AK/JsonValue.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/Utf16String.h>
@@ -37,6 +38,7 @@ public:
 
     Web::HTML::WorkerAgentId start_worker_agent(WebContentClient&, u64 page_id, Web::HTML::WorkerAgentStartRequest);
     Web::HTML::WorkerAgentId start_worker_agent(WebWorkerClient&, Web::HTML::WorkerAgentStartRequest);
+    void update_site_compatibility_data(JsonValue const&);
 
     void close_worker_agent(WebContentClient&, Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken);
     void close_worker_agent(WebWorkerClient&, Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -280,6 +280,16 @@ void ConnectionFromClient::update_system_theme(u64 page_id, Core::AnonymousBuffe
     page->set_palette_impl(*impl);
 }
 
+void ConnectionFromClient::set_site_compatibility_data(JsonValue data)
+{
+    auto parsed_data = Web::SiteCompatibilityData::from_json(data);
+    if (parsed_data.is_error()) {
+        warnln("Ignoring invalid site compatibility data: {}", parsed_data.error());
+        return;
+    }
+    Web::ResourceLoader::the().set_site_compatibility_data(parsed_data.release_value());
+}
+
 void ConnectionFromClient::update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> rects, u32 main_screen)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -88,6 +88,7 @@ private:
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
     virtual void connect_to_wasm_compiler(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor_process(IPC::TransportHandle handle) override;
+    virtual void set_site_compatibility_data(JsonValue data) override;
     virtual void compositor_process_reconnected() override;
     virtual void update_system_theme(u64 page_id, Core::AnonymousBuffer) override;
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect>, u32) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -58,6 +58,7 @@ endpoint WebContentServer
     connect_to_wasm_compiler(IPC::TransportHandle handle) =|
     connect_to_compositor_process(IPC::TransportHandle handle) =|
     compositor_process_reconnected() =|
+    set_site_compatibility_data(JsonValue data) =|
 
     update_system_theme(u64 page_id, Core::AnonymousBuffer theme_buffer) =|
     update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> rects, u32 main_screen_index) =|

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -87,6 +87,16 @@ void ConnectionFromClient::set_system_font_family(String family)
     Web::Platform::FontPlugin::the().set_system_font_family(FlyString { family });
 }
 
+void ConnectionFromClient::set_site_compatibility_data(JsonValue data)
+{
+    auto parsed_data = Web::SiteCompatibilityData::from_json(data);
+    if (parsed_data.is_error()) {
+        warnln("Ignoring invalid site compatibility data: {}", parsed_data.error());
+        return;
+    }
+    Web::ResourceLoader::the().set_site_compatibility_data(parsed_data.release_value());
+}
+
 void ConnectionFromClient::close_worker()
 {
     async_did_close_worker();

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -59,6 +59,7 @@ private:
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
     virtual void connect_to_wasm_compiler(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor(IPC::TransportHandle handle) override;
+    virtual void set_site_compatibility_data(JsonValue data) override;
     virtual void set_system_font_family(String family) override;
     virtual void start_worker(URL::URL url, Web::HTML::WorkerType type, Web::HTML::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::HTML::AgentType) override;
     virtual void connect_shared_worker(Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject) override;

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestSiteCompatibility.cpp
     TestAccumulatedVisualContext.cpp
     TestContentBlocker.cpp
     TestControlMessageQueue.cpp
@@ -59,6 +60,7 @@ endforeach()
 ladybird_utility(css-tokenizer SOURCES css-tokenizer.cpp LIBS LibFileSystem LibMain LibWeb)
 
 target_link_libraries(TestContentBlocker PRIVATE LibURL)
+target_link_libraries(TestSiteCompatibility PRIVATE LibURL)
 target_link_libraries(TestControlMessageQueue PRIVATE LibSync)
 target_link_libraries(TestDisplayListDamage PRIVATE LibGfx)
 target_link_libraries(TestDownloadReader PRIVATE LibGC LibJS LibURL)

--- a/Tests/LibWeb/TestSiteCompatibility.cpp
+++ b/Tests/LibWeb/TestSiteCompatibility.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonValue.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWeb/Loader/SiteCompatibility.h>
+
+static constexpr auto default_user_agent = "Mozilla/5.0 Ladybird/1.0 Chrome/146.0.0.0 Safari/537.36"sv;
+
+static URL::URL url(StringView input)
+{
+    return URL::Parser::basic_parse(input).release_value();
+}
+
+TEST_CASE(rule_matches_url_patterns)
+{
+    auto rule = MUST(Web::SiteCompatibilityRule::from_json(MUST(JsonValue::from_string(R"(
+        {
+            "matches": ["https://www.example.com/*"],
+            "user_agent": ["hide_Ladybird"]
+        }
+    )"sv))));
+
+    EXPECT(rule.matches(url("https://www.example.com/article"sv)));
+    EXPECT(!rule.matches(url("http://www.example.com/article"sv)));
+    EXPECT(!rule.matches(url("https://example.com/article"sv)));
+    EXPECT(!rule.matches(url("https://www.example.com.evil.test/article"sv)));
+}
+
+TEST_CASE(rule_transforms_user_agent)
+{
+    auto rule = MUST(Web::SiteCompatibilityRule::create(
+        { "https://www.example.com/*"_string },
+        { Web::UserAgentTransformation::HideLadybird }));
+
+    EXPECT_EQ(rule.apply_user_agent_transformations(default_user_agent), "Mozilla/5.0 Chrome/146.0.0.0 Safari/537.36"_string);
+}
+
+TEST_CASE(data_only_transforms_matching_urls)
+{
+    Web::SiteCompatibilityData data;
+    data.add_rule(MUST(Web::SiteCompatibilityRule::create(
+        { "https://www.example.com/*"_string },
+        { Web::UserAgentTransformation::HideLadybird })));
+
+    EXPECT_EQ(data.user_agent_for_url(url("https://www.example.com/"sv), default_user_agent), "Mozilla/5.0 Chrome/146.0.0.0 Safari/537.36"_string);
+    EXPECT_EQ(data.user_agent_for_url(url("https://elsewhere.example/"sv), default_user_agent), default_user_agent);
+}
+
+TEST_CASE(data_maps_websocket_urls_to_http_for_matching)
+{
+    Web::SiteCompatibilityData data;
+    data.add_rule(MUST(Web::SiteCompatibilityRule::create(
+        { "http://www.example.com/*"_string, "https://secure.example.com/*"_string },
+        { Web::UserAgentTransformation::HideLadybird })));
+
+    EXPECT_EQ(data.user_agent_for_websocket_url(url("ws://www.example.com/socket"sv), default_user_agent), "Mozilla/5.0 Chrome/146.0.0.0 Safari/537.36"_string);
+    EXPECT_EQ(data.user_agent_for_websocket_url(url("wss://secure.example.com/socket"sv), default_user_agent), "Mozilla/5.0 Chrome/146.0.0.0 Safari/537.36"_string);
+    EXPECT_EQ(data.user_agent_for_websocket_url(url("ws://secure.example.com/socket"sv), default_user_agent), default_user_agent);
+    EXPECT_EQ(data.user_agent_for_websocket_url(url("wss://www.example.com/socket"sv), default_user_agent), default_user_agent);
+}
+
+TEST_CASE(hide_ladybird_only_removes_ladybird_products)
+{
+    auto rule = MUST(Web::SiteCompatibilityRule::create(
+        { "https://www.example.com/*"_string },
+        { Web::UserAgentTransformation::HideLadybird }));
+
+    EXPECT_EQ(rule.apply_user_agent_transformations("Ladybird/1.0"sv), String {});
+    EXPECT_EQ(rule.apply_user_agent_transformations("Ladybird/1.0 Mozilla/5.0"sv), "Mozilla/5.0"_string);
+    EXPECT_EQ(rule.apply_user_agent_transformations("Mozilla/5.0 Ladybird/1.0"sv), "Mozilla/5.0"_string);
+    EXPECT_EQ(rule.apply_user_agent_transformations("Mozilla/5.0 Ladybird Preview/1.0"sv), "Mozilla/5.0 Ladybird Preview/1.0"_string);
+    EXPECT_EQ(rule.apply_user_agent_transformations("Mozilla/5.0 MyLadybird/1.0"sv), "Mozilla/5.0 MyLadybird/1.0"_string);
+}
+
+TEST_CASE(data_parses_rule_array)
+{
+    auto data = MUST(Web::SiteCompatibilityData::from_json(MUST(JsonValue::from_string(R"(
+        [{
+            "matches": ["https://www.example.com/*"],
+            "user_agent": ["hide_Ladybird"]
+        }]
+    )"sv))));
+
+    EXPECT_EQ(data.rules().size(), 1u);
+    EXPECT_EQ(data.user_agent_for_url(url("https://www.example.com/"sv), default_user_agent), "Mozilla/5.0 Chrome/146.0.0.0 Safari/537.36"_string);
+}
+
+TEST_CASE(invalid_rules_are_rejected)
+{
+    auto missing_matches = Web::SiteCompatibilityRule::from_json(MUST(JsonValue::from_string(R"(
+        { "user_agent": ["hide_Ladybird"] }
+    )"sv)));
+    EXPECT(missing_matches.is_error());
+
+    auto unknown_transformation = Web::SiteCompatibilityRule::from_json(MUST(JsonValue::from_string(R"(
+        { "matches": ["https://example.com/*"], "user_agent": ["dance"] }
+    )"sv)));
+    EXPECT(unknown_transformation.is_error());
+
+    auto invalid_pattern = Web::SiteCompatibilityRule::from_json(MUST(JsonValue::from_string(R"(
+        { "matches": ["["], "user_agent": ["hide_Ladybird"] }
+    )"sv)));
+    EXPECT(invalid_pattern.is_error());
+}

--- a/Tests/LibWeb/Text/expected/Fetch/site-compatibility-user-agent-redirects.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/site-compatibility-user-agent-redirects.txt
@@ -1,0 +1,3 @@
+non-matching to matching: PASS
+matching to non-matching: PASS
+explicit User-Agent preserved: PASS

--- a/Tests/LibWeb/Text/input/Fetch/site-compatibility-user-agent-redirects.html
+++ b/Tests/LibWeb/Text/input/Fetch/site-compatibility-user-agent-redirects.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const testID = crypto.randomUUID();
+
+        async function redirectedUserAgent(name, initialMatches, finalMatches, explicitUserAgent) {
+            const initialPath = `/site-compatibility-user-agent-${name}-initial-${testID}`;
+            const finalPath = `/site-compatibility-user-agent-${name}-final-${testID}`;
+            const finalURL = await server.createEcho("GET", finalPath, {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+                reflect_headers_in_body: true,
+            });
+            const initialURL = await server.createEcho("GET", initialPath, {
+                status: 302,
+                headers: { Location: finalURL },
+            });
+
+            const matches = [];
+            if (initialMatches)
+                matches.push(initialURL);
+            if (finalMatches)
+                matches.push(finalURL);
+            internals.setSiteCompatibilityData(JSON.stringify([{
+                matches,
+                user_agent: ["hide_Ladybird"],
+            }]));
+
+            const options = explicitUserAgent
+                ? { headers: { "User-Agent": explicitUserAgent } }
+                : {};
+            const response = await fetch(initialURL, options);
+            return (await response.json())["User-Agent"][0];
+        }
+
+        try {
+            const matchingTarget = await redirectedUserAgent("matching-target", false, true);
+            println(`non-matching to matching: ${matchingTarget.includes("Ladybird/") ? "FAIL" : "PASS"}`);
+
+            const nonMatchingTarget = await redirectedUserAgent("non-matching-target", true, false);
+            println(`matching to non-matching: ${nonMatchingTarget.includes("Ladybird/") ? "PASS" : "FAIL"}`);
+
+            const explicit = await redirectedUserAgent("explicit", true, true, "CustomAgent/42");
+            println(`explicit User-Agent preserved: ${explicit === "CustomAgent/42" ? "PASS" : "FAIL"}`);
+        } catch (error) {
+            println(`FAIL: ${error}`);
+        } finally {
+            internals.setSiteCompatibilityData("[]");
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Fetch/site-compatibility-user-agent-redirects.html.headers
+++ b/Tests/LibWeb/Text/input/Fetch/site-compatibility-user-agent-redirects.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -29,6 +29,11 @@ set(INTERNAL_RESOURCES
 )
 list(TRANSFORM INTERNAL_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/")
 
+set(SITE_COMPATIBILITY_RESOURCES
+    nytimes.com.json
+)
+list(TRANSFORM SITE_COMPATIBILITY_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/WebCompat/")
+
 set(ABOUT_PAGES
     about.html
     bookmarks.html
@@ -159,6 +164,10 @@ function(copy_resources_to_build base_directory bundle_target)
         DESTINATION ${base_directory} TARGET ${bundle_target}
     )
 
+    copy_resource_set(ladybird/site-compatibility RESOURCES ${SITE_COMPATIBILITY_RESOURCES}
+        DESTINATION ${base_directory} TARGET ${bundle_target}
+    )
+
     copy_resource_set(ladybird/about-pages RESOURCES ${ABOUT_PAGES}
         DESTINATION ${base_directory} TARGET ${bundle_target}
     )
@@ -200,6 +209,7 @@ function(install_ladybird_resources destination component)
     install(FILES ${128x128_ICONS} DESTINATION "${destination}/icons/128x128" COMPONENT ${component})
     install(FILES ${THEMES} DESTINATION "${destination}/themes" COMPONENT ${component})
     install(FILES ${INTERNAL_RESOURCES} DESTINATION "${destination}/ladybird" COMPONENT ${component})
+    install(FILES ${SITE_COMPATIBILITY_RESOURCES} DESTINATION "${destination}/ladybird/site-compatibility" COMPONENT ${component})
     install(FILES ${ABOUT_PAGES} DESTINATION "${destination}/ladybird/about-pages" COMPONENT ${component})
     install(FILES ${ABOUT_SETTINGS_RESOURCES} DESTINATION "${destination}/ladybird/about-pages/settings" COMPONENT ${component})
     install(FILES ${WEB_TEMPLATES} DESTINATION "${destination}/ladybird/templates" COMPONENT ${component})

--- a/WebCompat/nytimes.com.json
+++ b/WebCompat/nytimes.com.json
@@ -1,0 +1,8 @@
+{
+    "matches": [
+        "https://www.nytimes.com/*"
+    ],
+    "user_agent": [
+        "hide_Ladybird"
+    ]
+}


### PR DESCRIPTION
Introduce declarative site compatibility rules loaded at runtime from the top-level WebCompat directory. Rules use URL patterns and named `User-Agent` transformations, keeping per-site policy visible without compiling it into C++.

The UI process loads and validates the data, then distributes complete snapshots to WebContent and WebWorker processes. New processes receive the current snapshot, and reloads update all existing processes consistently.

Add the first rule for https://www.nytimes.com, applying `hide_Ladybird` to remove only the `Ladybird/1.0` product token from its `User-Agent`. Other sites continue receiving Ladybird’s normal identity.

Before:
<img width="1232" height="898" alt="Screenshot 2026-08-24 at 11 01 11" src="https://github.com/user-attachments/assets/48a256ca-bed8-4409-b59f-9674801c52d7" />

After:
<img width="1232" height="898" alt="Screenshot 2026-08-24 at 11 00 01" src="https://github.com/user-attachments/assets/fb772e9d-bdf4-4d4c-b9af-e43c0bd78af0" />
