### PR TITLE
UI/AppKit: Refresh the bundled dependency dylibs on each link

### DIFF
--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -35,4 +35,11 @@ add_executable(ladybird MACOSX_BUNDLE
 target_link_libraries(ladybird_impl PUBLIC "-framework Cocoa -framework Metal -framework QuartzCore -framework UniformTypeIdentifiers" LibUnicode)
 target_link_libraries(ladybird PRIVATE ladybird_impl)
 
+# FIXME: We clear this directory to work around an upstream vcpkg bug and ensure it repopulates from the dependencies
+# actually being linked against — avoiding a dyld rejection. See #11299. The right place to fix this is vcpkg upstream.
+add_custom_command(TARGET ladybird PRE_LINK
+    COMMAND "${CMAKE_COMMAND}" -E rm -rf "$<TARGET_BUNDLE_DIR:ladybird>/Contents/Frameworks"
+    VERBATIM
+)
+
 create_ladybird_bundle(ladybird)


### PR DESCRIPTION
**Problem:** Abort at launch, with dyld reporting “`Symbol not found: _CRYPTO_calloc`”, referenced from `libssl.3.dylib` and expected in the bundle’s own `Contents/Frameworks/libcrypto.3.dylib`.

**Cause:** The `MACOSX_BUNDLE` on our `add_executable()` is what makes vcpkg deploy our dependency dylibs into `Contents/Frameworks` — and rewrite the binary to load them from there. `scripts/buildsystems/osx/applocal.py` is what does that — by copying each dylib only when it’s not already present. But nothing compares what sits in the bundle against the copy it came from — so a dylib that lands there once stays put there forever, no matter how far the vcpkg copy moves ahead. The bundle is then free to pair libraries from different builds of the same dependency — and dyld rejects that at launch over the symbols the newer one expects.

**Fix:** Clear `Contents/Frameworks` before each link. That puts every dylib back to “absent” — which is the one state `applocal.py` will copy into. So it repopulates the bundle from the dependencies being linked against. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11299.
