### PR TITLE
Reuse identical rebuilt fragments' identities across layouts

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1437,6 +1437,9 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
         }
 
         set_flag(RustFFI::NodeFlag::NeedsLayoutUpdate, true);
+        // Relayout may rebuild an identical fragment whose cached paint output the commit diff
+        // then keeps, even when what this node paints changed (its image data arrived).
+        invalidate_paint_caches(*this);
     }
 
     if (auto* box = as_if<Box>(this))

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -54,7 +54,12 @@ fn commit_subtree(
                 ),
             "committed path-like fragment carries no computed SVG path"
         );
-        let replaced = paintables.replace_committed_fragment_link(node, link, reuses_committed_subtree);
+        let replaced = paintables.replace_committed_fragment_link(
+            node,
+            link,
+            reuses_committed_subtree,
+            enclosing_line_root_content_changed,
+        );
         if fragment.line_data.is_some() {
             line_root_content_changed_for_children = replaced.committed_fragment_identity_changed;
         }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1003,6 +1003,10 @@ impl FfiLayoutFcCallbacks {
         self.arena().set_committed_fragment_link(self.arena().data(node), link);
     }
 
+    pub(crate) fn has_committed_fragment_link(&self, node: Node) -> bool {
+        self.node_data(node).flags & NodeFlag::HasCommittedFragmentLink as u32 != 0
+    }
+
     pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<crate::layout::AbsposLayoutInputs>) {
         let data = self.arena().data(node);
         // Match prepare_node's former as_if<Box>() guard.

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -45,6 +45,62 @@ pub(crate) struct FragmentLink {
     pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
 }
 
+fn same_allocation<T>(left: Option<&std::rc::Rc<T>>, right: Option<&std::rc::Rc<T>>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => std::rc::Rc::ptr_eq(left, right),
+        _ => false,
+    }
+}
+
+impl Fragment {
+    fn builds_identically_to(&self, previous: &Fragment) -> bool {
+        self.node == previous.node
+            && self.content_inline_size == previous.content_inline_size
+            && self.content_block_size == previous.content_block_size
+            && self.margin_left == previous.margin_left
+            && self.margin_right == previous.margin_right
+            && self.margin_top == previous.margin_top
+            && self.margin_bottom == previous.margin_bottom
+            && self.border_left == previous.border_left
+            && self.border_right == previous.border_right
+            && self.border_top == previous.border_top
+            && self.border_bottom == previous.border_bottom
+            && self.padding_left == previous.padding_left
+            && self.padding_right == previous.padding_right
+            && self.padding_top == previous.padding_top
+            && self.padding_bottom == previous.padding_bottom
+            && self.uses_collapsing_borders_model == previous.uses_collapsing_borders_model
+            && same_allocation(self.collapsed_table_borders.as_ref(), previous.collapsed_table_borders.as_ref())
+            && same_allocation(self.line_data.as_ref(), previous.line_data.as_ref())
+            && same_allocation(self.grid_layout_data.as_ref(), previous.grid_layout_data.as_ref())
+            && same_allocation(self.flex_layout_data.as_ref(), previous.flex_layout_data.as_ref())
+            && same_allocation(self.used_grid_tracks.as_ref(), previous.used_grid_tracks.as_ref())
+            && self.svg_viewport_transform == previous.svg_viewport_transform
+            && self.svg_viewport_size == previous.svg_viewport_size
+            && same_allocation(self.computed_svg_path.as_ref(), previous.computed_svg_path.as_ref())
+            && self.children.len() == previous.children.len()
+            && self
+                .children
+                .iter()
+                .zip(&previous.children)
+                .all(|(link, previous_link)| link.places_same_fragment_identically_to(previous_link))
+    }
+}
+
+impl FragmentLink {
+    fn places_same_fragment_identically_to(&self, previous: &FragmentLink) -> bool {
+        std::rc::Rc::ptr_eq(&self.fragment, &previous.fragment)
+            && self.committed_offset == previous.committed_offset
+            && self.inset_left == previous.inset_left
+            && self.inset_right == previous.inset_right
+            && self.inset_top == previous.inset_top
+            && self.inset_bottom == previous.inset_bottom
+            && self.containing_line_box_index == previous.containing_line_box_index
+            && self.abspos_layout_inputs == previous.abspos_layout_inputs
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AnchorCandidate {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
@@ -152,7 +208,24 @@ fn propagate_payload_toward_run_root_space<Payload: PropagatedPayload>(
     }
 }
 
+fn previously_committed_fragment_matching(
+    callbacks: &FfiLayoutFcCallbacks,
+    candidate: &Fragment,
+) -> Option<std::rc::Rc<Fragment>> {
+    if !callbacks.has_committed_fragment_link(candidate.node) {
+        return None;
+    }
+    callbacks
+        .arena()
+        .with_committed_fragment_link_during_layout(candidate.node, |previous_link| {
+            previous_link
+                .filter(|previous_link| candidate.builds_identically_to(&previous_link.fragment))
+                .map(|previous_link| previous_link.fragment.clone())
+        })
+}
+
 fn snapshot_fragment(
+    callbacks: &FfiLayoutFcCallbacks,
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
     used: &UsedValues,
@@ -180,8 +253,8 @@ fn snapshot_fragment(
         svg_viewport_size,
         computed_svg_path,
     ) = rare_payloads.unwrap_or_default();
-    std::rc::Rc::new(Fragment {
-        identity: NEXT_IDENTITY.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    let mut fragment = Fragment {
+        identity: 0,
         node,
         content_inline_size: used.content_inline_size.get(),
         content_block_size: used.content_block_size.get(),
@@ -207,7 +280,12 @@ fn snapshot_fragment(
         svg_viewport_size,
         computed_svg_path,
         children,
-    })
+    };
+    if let Some(previous) = previously_committed_fragment_matching(callbacks, &fragment) {
+        return previous;
+    }
+    fragment.identity = NEXT_IDENTITY.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::rc::Rc::new(fragment)
 }
 
 pub(crate) struct PlacementData {
@@ -670,7 +748,7 @@ impl RunFragmentBuilder {
             inline_containing_block_rects: inline_containing_block_rects_from_placed_box,
         } = inner.pending_fragments.remove(&slot).unwrap_or_else(|| PendingFragment::new(node));
         let link = link_fragment(
-            snapshot_fragment(node, children, used),
+            snapshot_fragment(callbacks, node, children, used),
             PlacementData::from_record(used, containing_line_box_index, committed_offset),
         );
         self.attach(&mut inner, link, containing_block, containing_block_is_sealed);
@@ -774,7 +852,7 @@ impl RunFragmentBuilder {
             }
             let used = records.used_values(pending_fragment.node);
             inner.top_scope_links.push(link_fragment(
-                snapshot_fragment(pending_fragment.node, pending_fragment.children, &used),
+                snapshot_fragment(callbacks, pending_fragment.node, pending_fragment.children, &used),
                 PlacementData::from_record(&used, None, used.content_offset.get()),
             ));
         }
@@ -782,7 +860,7 @@ impl RunFragmentBuilder {
         for (_, root) in child_roots_awaiting_placement {
             let used = records.used_values(root.node);
             inner.top_scope_links.push(link_fragment(
-                snapshot_fragment(root.node, root.scoped_descendants, &used),
+                snapshot_fragment(callbacks, root.node, root.scoped_descendants, &used),
                 PlacementData::from_record(&used, None, used.content_offset.get()),
             ));
         }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -201,6 +201,7 @@ impl<'a> PaintableCommit<'a> {
         node: Node,
         link: &FragmentLink,
         reuses_committed_subtree: bool,
+        enclosing_line_root_content_changed: bool,
     ) -> ReplacedCommittedFragmentLink {
         let fragment = &link.fragment;
         let new_content_size = FfiCssPixelSize {
@@ -232,10 +233,14 @@ impl<'a> PaintableCommit<'a> {
             content_size_change = Some((previous_content_size_for_diff, new_content_size));
         }
         let committed_fragment_identity_changed = old_identity != fragment.identity;
+        let painted_geometry_lives_in_enclosing_line_root =
+            || NodeFacts::new(self.callbacks, node).is_fragmented_inline();
+        let painted_content_changed = committed_fragment_identity_changed
+            || (enclosing_line_root_content_changed && painted_geometry_lives_in_enclosing_line_root());
         // A reused committed subtree's root counts as unchanged even though its run-root
         // fragment is rebuilt with a fresh identity at placement: the reuse contract guarantees
         // identical replayed output, enforced by the content-size assertion above.
-        let content_unchanged = reuses_committed_subtree || (old_identity != 0 && !committed_fragment_identity_changed);
+        let content_unchanged = reuses_committed_subtree || (old_identity != 0 && !painted_content_changed);
         let offset_unchanged = self
             .committed_offsets_before_recommit_reset
             .get(&node)
@@ -247,7 +252,7 @@ impl<'a> PaintableCommit<'a> {
             let arena = self.arena_mut();
             let mut paintable_rows = arena.paintable_rows_mut();
             let data = paintable_rows.paintable_data_mut(node);
-            if committed_fragment_identity_changed {
+            if painted_content_changed {
                 data.overflow_valid_across_recommits = false;
             }
             data.content_size = new_content_size;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -378,6 +378,21 @@ impl PaintableRowStore {
             .and_then(|slot| slot.link.as_deref().cloned())
     }
 
+    pub(crate) fn with_committed_fragment_link<R>(
+        &self,
+        layout_slot_index: u32,
+        layout_slot_generation: u8,
+        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+    ) -> R {
+        let slots = self.committed_fragment_links.borrow();
+        read(
+            slots
+                .get(layout_slot_index as usize)
+                .filter(|slot| slot.layout_slot_generation == layout_slot_generation)
+                .and_then(|slot| slot.link.as_deref()),
+        )
+    }
+
     pub(crate) fn set_committed_fragment_link(
         &self,
         layout_slot_index: u32,
@@ -458,6 +473,15 @@ impl LayoutNodeArena {
                 .get(node.slot_index() as usize)
                 .and_then(|entry| entry.link.as_deref()),
         )
+    }
+
+    pub(crate) fn with_committed_fragment_link_during_layout<R>(
+        &self,
+        node: NodeSlotId,
+        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+    ) -> R {
+        self.paintable_rows
+            .with_committed_fragment_link(node.slot_index(), node.generation(), read)
     }
 
     fn prepare_paintable_row_reset(&self, slot: NodeSlotId, kind: PaintableRowResetKind) -> PaintableRowReset {


### PR DESCRIPTION
The paint cache keeps a row's captured display list across relayout only while the row's committed fragment identity is unchanged. Identity was minted per built fragment, so it survived only where the run cache replays the same Rc. Every fragment rebuilt by a fresh run got a new identity even when nothing in it changed: html, body and every block in the root formatting context on each full relayout, and every replayed run root. Their rows were marked dirty every time, the marks propagated up to the viewport, and the subtree captures above them died, so resizing one box re-spliced unrelated sibling subtrees row by row.

snapshot_fragment now compares the fragment it built with the node's committed one and returns the committed Rc when they are identical. Plain fields compare by value; line data, table borders, grid/flex data, SVG paths and child fragments compare by pointer, so line data a fresh run rebuilt never interns (comparing it by content would walk all text on every layout). Children are interned before their parent, so an unchanged subtree interns all the way up.