### PR TITLE
LibWeb: Fix CSS-connected font face lifecycle and invalidation

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -885,6 +885,10 @@ AnimationUpdateContext::~AnimationUpdateContext()
             continue;
         auto& element = it.key;
         GC::Ref<DOM::Element> target = element.element();
+        // Disconnected elements no longer have a style-engine row to publish refreshed
+        // animation style into.
+        if (target->style_node_id() == 0)
+            continue;
         // Provisionally started transitions are not associated with the element yet, so they are
         // never among the collected effects, but their values are already part of the published
         // style. Collect them first, in composite order below every associated effect, or this

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -195,13 +195,12 @@ void CSSFontFaceRule::disconnect_font_face()
     if (!m_css_connected_font_face)
         return;
 
-    m_css_connected_font_face->disconnect_from_css_rule();
-
     if (auto* style_sheet = parent_style_sheet()) {
         if (auto document = style_sheet->owning_document())
-            document->fonts()->delete_(*m_css_connected_font_face);
+            document->fonts()->remove_css_connected_font(*m_css_connected_font_face);
     }
 
+    m_css_connected_font_face->disconnect_from_css_rule();
     m_css_connected_font_face = nullptr;
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -409,13 +409,23 @@ void CSSStyleSheet::add_owning_document_or_shadow_root(DOM::Node& document_or_sh
 
 void CSSStyleSheet::remove_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root)
 {
-    auto had_document_owner = has_document_owner();
-    m_owning_documents_or_shadow_roots.remove(document_or_shadow_root);
+    bool is_removing_last_document_owner = false;
+    if (document_or_shadow_root.is_document() && m_owning_documents_or_shadow_roots.contains(document_or_shadow_root)) {
+        is_removing_last_document_owner = true;
+        for (auto& owner : m_owning_documents_or_shadow_roots) {
+            if (owner.ptr() != &document_or_shadow_root && owner->is_document()) {
+                is_removing_last_document_owner = false;
+                break;
+            }
+        }
+    }
 
     // CSS @font-face rules contribute to the document font source. Shadow-root-only sheets remain CSSOM-visible and
     // still style their tree, but match other browsers by not contributing shadow-scoped @font-face rules there.
-    if (!disabled() && document_or_shadow_root.is_document() && had_document_owner && !has_document_owner())
+    if (!disabled() && is_removing_last_document_owner)
         document_or_shadow_root.document().font_computer().unload_fonts_from_sheet(*this);
+
+    m_owning_documents_or_shadow_roots.remove(document_or_shadow_root);
 
     for (auto const& import_rule : m_import_rules) {
         if (import_rule->loaded_style_sheet())

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -389,15 +389,17 @@ void CSSStyleSheet::for_each_effective_function_at_rule(Function<void(CSSFunctio
 void CSSStyleSheet::add_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root)
 {
     VERIFY(document_or_shadow_root.is_document() || document_or_shadow_root.is_shadow_root());
+    auto had_document_owner = has_document_owner();
     m_owning_documents_or_shadow_roots.set(document_or_shadow_root);
 
     // CSSOM's "add a CSS style sheet" steps bail out once the disabled flag is set, so ownership alone should not
     // make a disabled sheet observable in the destination document. Delay its media-query evaluation and
     // CSS-connected font activation until the sheet actually becomes enabled.
-    if (!disabled() && this->owning_documents_or_shadow_roots().size() == 1) {
+    if (!disabled() && this->owning_documents_or_shadow_roots().size() == 1)
         evaluate_media_queries(document_or_shadow_root.document());
+
+    if (!disabled() && document_or_shadow_root.is_document() && !had_document_owner)
         document_or_shadow_root.document().font_computer().load_fonts_from_sheet(*this);
-    }
 
     for (auto const& import_rule : m_import_rules) {
         if (import_rule->loaded_style_sheet())
@@ -407,11 +409,12 @@ void CSSStyleSheet::add_owning_document_or_shadow_root(DOM::Node& document_or_sh
 
 void CSSStyleSheet::remove_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root)
 {
+    auto had_document_owner = has_document_owner();
     m_owning_documents_or_shadow_roots.remove(document_or_shadow_root);
 
-    // All owning documents or shadow roots must be part of the same document so we only need to unload this style
-    // sheet's fonts once we have none remaining.
-    if (this->owning_documents_or_shadow_roots().size() == 0)
+    // CSS @font-face rules contribute to the document font source. Shadow-root-only sheets remain CSSOM-visible and
+    // still style their tree, but match other browsers by not contributing shadow-scoped @font-face rules there.
+    if (!disabled() && document_or_shadow_root.is_document() && had_document_owner && !has_document_owner())
         document_or_shadow_root.document().font_computer().unload_fonts_from_sheet(*this);
 
     for (auto const& import_rule : m_import_rules) {
@@ -443,10 +446,11 @@ void CSSStyleSheet::set_disabled(bool disabled)
 
     if (!disabled) {
         if (document) {
-            document->font_computer().load_fonts_from_sheet(*this);
+            if (has_document_owner())
+                document->font_computer().load_fonts_from_sheet(*this);
             load_pending_image_resources(*document);
         }
-    } else if (document) {
+    } else if (document && has_document_owner()) {
         document->font_computer().unload_fonts_from_sheet(*this);
     }
 
@@ -505,10 +509,19 @@ void CSSStyleSheet::invalidate_owners()
 
 void CSSStyleSheet::reload_fonts_after_media_query_change()
 {
-    if (auto document = owning_document()) {
+    if (auto document = owning_document(); document && has_document_owner()) {
         document->font_computer().unload_fonts_from_sheet(*this);
         document->font_computer().load_fonts_from_sheet(*this);
     }
+}
+
+bool CSSStyleSheet::has_document_owner() const
+{
+    for (auto& document_or_shadow_root : m_owning_documents_or_shadow_roots) {
+        if (document_or_shadow_root->is_document())
+            return true;
+    }
+    return false;
 }
 
 GC::Ptr<DOM::Document> CSSStyleSheet::owning_document() const

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -165,6 +165,7 @@ private:
 
     void recalculate_rule_caches();
     void invalidate_shared_style_cache();
+    bool has_document_owner() const;
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
     void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -953,12 +953,6 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 
             auto font_face = FontFace::create_css_connected(HTML::relevant_realm(document()), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
-
-            // Register the face for font matching without fetching anything. The fetch starts once the face is actually
-            // needed for rendering: When style computation first selects the face — or, for a face with a subsetting
-            // unicode-range, once a rendered codepoint falls within that range.
-            // INTEROP: Blink, Gecko, and WebKit similarly defer @font-face fetches.
-            register_font_face(font_face);
         }
 
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
@@ -972,8 +966,6 @@ void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
     for_each_nested_font_rule(sheet.rules(), [&](auto& rule) {
         if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
-            if (auto font_face = font_face_rule->css_connected_font_face())
-                unregister_font_face(*font_face);
             font_face_rule->disconnect_font_face();
         }
 

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -10,6 +10,7 @@
 
 #include "FontComputer.h"
 #include <AK/Platform.h>
+#include <AK/ScopeGuard.h>
 #include <LibGC/RootHashTable.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -749,7 +750,7 @@ Gfx::Font const& FontComputer::initial_font() const
     return font;
 }
 
-static bool style_value_references_font_family(StyleValue const& font_family_value, Utf16FlyString const& family_name)
+static bool style_value_references_any_font_family(StyleValue const& font_family_value, Vector<Utf16FlyString> const& family_names)
 {
     if (!font_family_value.is_value_list())
         return false;
@@ -760,37 +761,46 @@ static bool style_value_references_font_family(StyleValue const& font_family_val
 
         auto item_family_name = string_from_style_value(*item);
 
-        if (item_family_name.equals_ignoring_ascii_case(family_name))
+        if (any_of(family_names, [&](auto const& family_name) { return item_family_name.equals_ignoring_ascii_case(family_name); }))
             return true;
     }
     return false;
 }
 
-static bool computed_font_families_reference_family(ReadonlySpan<ComputedFontFamily const> font_families, Utf16FlyString const& family_name)
+static bool computed_font_families_reference_any_family(ReadonlySpan<ComputedFontFamily const> font_families, Vector<Utf16FlyString> const& family_names)
 {
     return any_of(font_families, [&](ComputedFontFamily const& family) {
         return family.has<ComputedFontFamilyName>()
-            && family.get<ComputedFontFamilyName>().name.equals_ignoring_ascii_case(family_name);
+            && any_of(family_names, [&](auto const& family_name) { return family.get<ComputedFontFamilyName>().name.equals_ignoring_ascii_case(family_name); });
     });
 }
 
-static bool font_values_reference_font_family(ComputedValues::FontValues const& font_values, Utf16FlyString const& family_name)
+static bool font_values_reference_any_font_family(ComputedValues::FontValues const& font_values, Vector<Utf16FlyString> const& family_names)
 {
     auto font_family = font_values.font_family_style_value();
-    return font_family && style_value_references_font_family(*font_family, family_name);
+    return font_family && style_value_references_any_font_family(*font_family, family_names);
 }
 
 void FontComputer::clear_computed_font_cache(Utf16FlyString const& family_name)
 {
+    Vector<Utf16FlyString> family_names;
+    family_names.append(family_name);
+    clear_computed_font_cache_for_families(family_names);
+}
+
+void FontComputer::clear_computed_font_cache_for_families(Vector<Utf16FlyString> const& family_names)
+{
+    VERIFY(!family_names.is_empty());
+
     // Only clear cache entries that reference the loaded font family.
     m_computed_font_cache.remove_all_matching([&](auto const& key, auto const&) {
-        return computed_font_families_reference_family(key.font_families, family_name);
+        return computed_font_families_reference_any_family(key.font_families, family_names);
     });
 
     auto element_uses_font_family = [&](DOM::Element const& element) {
         // Check the element's own font-family.
         if (auto const* values = element.style_group<ComputedValues::FontValues>()) {
-            if (font_values_reference_font_family(*values, family_name))
+            if (font_values_reference_any_font_family(*values, family_names))
                 return true;
         }
 
@@ -798,7 +808,7 @@ void FontComputer::clear_computed_font_cache(Utf16FlyString const& family_name)
         bool synthetic_pseudo_element_uses_font_family = false;
         element.for_each_synthetic_pseudo_element([&](Web::CSS::PseudoElement pseudo_element, Web::DOM::SyntheticPseudoElement const&) {
             if (auto const* values = element.style_group<ComputedValues::FontValues>(pseudo_element)) {
-                if (font_values_reference_font_family(*values, family_name)) {
+                if (font_values_reference_any_font_family(*values, family_names)) {
                     synthetic_pseudo_element_uses_font_family = true;
                     return IterationDecision::Break;
                 }
@@ -831,10 +841,36 @@ void FontComputer::clear_font_feature_values_cache(Utf16FlyString const& family_
 
 void FontComputer::did_load_font(Utf16FlyString const& family_name)
 {
+    if (m_font_face_change_batch_depth > 0) {
+        if (!any_of(m_batched_font_face_change_families, [&](auto const& existing_family_name) { return existing_family_name.equals_ignoring_ascii_case(family_name); }))
+            m_batched_font_face_change_families.append(family_name);
+        return;
+    }
+
     // What a computation resolves a family to is not named by any word of a style input record, so
     // the records taken before this font arrived answer for nothing.
     m_document->bump_style_environment_version();
     clear_computed_font_cache(family_name);
+}
+
+void FontComputer::begin_font_face_change_batch()
+{
+    ++m_font_face_change_batch_depth;
+}
+
+void FontComputer::end_font_face_change_batch()
+{
+    VERIFY(m_font_face_change_batch_depth > 0);
+    --m_font_face_change_batch_depth;
+
+    if (m_font_face_change_batch_depth > 0 || m_batched_font_face_change_families.is_empty())
+        return;
+
+    // What a computation resolves a family to is not named by any word of a style input record, so
+    // the records taken before these fonts arrived answer for nothing.
+    m_document->bump_style_environment_version();
+    clear_computed_font_cache_for_families(m_batched_font_face_change_families);
+    m_batched_font_face_change_families.clear();
 }
 
 void FontComputer::register_font_face(GC::Ref<FontFace> face)
@@ -946,6 +982,11 @@ static void for_each_effective_font_rule(CSSStyleSheet& sheet, Function<void(CSS
 
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
+    begin_font_face_change_batch();
+    ScopeGuard finish_font_face_change_batch = [&] {
+        end_font_face_change_batch();
+    };
+
     for_each_effective_font_rule(sheet, [&](auto& rule) {
         if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (!font_face_rule->is_valid())
@@ -962,6 +1003,11 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
 {
+    begin_font_face_change_batch();
+    ScopeGuard finish_font_face_change_batch = [&] {
+        end_font_face_change_batch();
+    };
+
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
     for_each_nested_font_rule(sheet.rules(), [&](auto& rule) {

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -150,6 +150,10 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
+    void begin_font_face_change_batch();
+    void end_font_face_change_batch();
+    void clear_computed_font_cache_for_families(Vector<Utf16FlyString> const& family_names);
+
     struct MatchingFontCandidate;
     RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const;
     RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const;
@@ -169,6 +173,9 @@ private:
     // including cascades evicted after a web font finishes loading.
     mutable Vector<NonnullRefPtr<Gfx::FontCascadeList const>> m_style_record_font_list_pins;
     mutable HashMap<Utf16FlyString, HashMap<FontFeatureValueKey, Vector<u32>>> m_font_feature_values_cache;
+
+    u32 m_font_face_change_batch_depth { 0 };
+    Vector<Utf16FlyString> m_batched_font_face_change_families;
 };
 
 }

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -116,10 +116,23 @@ void FontFaceSet::add_css_connected_font(GC::Ref<FontFace> face)
 // https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-delete
 bool FontFaceSet::delete_(GC::Ref<FontFace> face)
 {
+    return remove_font_face(face, AllowCSSConnected::No);
+}
+
+void FontFaceSet::remove_css_connected_font(GC::Ref<FontFace> face)
+{
+    remove_font_face(face, AllowCSSConnected::Yes);
+}
+
+bool FontFaceSet::remove_font_face(GC::Ref<FontFace> face, AllowCSSConnected allow_css_connected)
+{
     // 1. If font is CSS-connected, return false and exit this algorithm immediately.
-    if (face->is_css_connected()) {
+    if (allow_css_connected == AllowCSSConnected::No && face->is_css_connected()) {
         return false;
     }
+
+    if (!m_font_faces.contains_slow(face))
+        return false;
 
     if (face->should_be_registered_with_font_computer()) {
         auto& global = relevant_settings_object().global_object();
@@ -129,10 +142,9 @@ bool FontFaceSet::delete_(GC::Ref<FontFace> face)
 
     // 2. Let deleted be the result of removing font from the FontFaceSet’s set entries.
     bool deleted = m_font_faces.remove_first_matching([&](auto const& entry) { return entry.ptr() == face.ptr(); });
-    if (deleted) {
-        Bindings::did_remove_font_face(*this, GC::Ref { *face });
-        face->remove_from_set(*this);
-    }
+    VERIFY(deleted);
+    Bindings::did_remove_font_face(*this, GC::Ref { *face });
+    face->remove_from_set(*this);
 
     // 3. If font is present in the FontFaceSet’s [[LoadedFonts]], or [[FailedFonts]] lists, remove it.
     m_loaded_fonts.remove_all_matching([face](auto const& entry) { return entry == face; });

--- a/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -42,6 +42,7 @@ public:
     void clear();
 
     void add_css_connected_font(GC::Ref<FontFace>);
+    void remove_css_connected_font(GC::Ref<FontFace>);
 
     void set_onloading(WebIDL::CallbackType*);
     WebIDL::CallbackType* onloading();
@@ -68,8 +69,14 @@ public:
     void switch_to_loaded();
 
 private:
+    enum class AllowCSSConnected {
+        No,
+        Yes,
+    };
+
     explicit FontFaceSet(HTML::EnvironmentSettingsObject&);
     virtual void visit_edges(Cell::Visitor&) override;
+    bool remove_font_face(GC::Ref<FontFace>, AllowCSSConnected);
 
     Vector<GC::Ref<FontFace>> m_font_faces;
     GC::Ref<HTML::EnvironmentSettingsObject> m_environment;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -12,6 +12,7 @@
 #include <AK/JsonObjectSerializer.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/Utf16StringBuilder.h>
+#include <AK/Vector.h>
 #include <LibGC/ConservativeVector.h>
 #include <LibGC/DeferGC.h>
 #include <LibGC/Heap.h>
@@ -1170,22 +1171,68 @@ static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& 
     return parent_layout_node->children_are_inline() && layout_node->is_inline_block() && !layout_node->is_out_of_flow();
 }
 
-static void pin_layout_style_records_for_removal(Node& node)
-{
-    node.for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
-        if (auto* layout_node = inclusive_descendant.unsafe_layout_node())
-            layout_node->pin_style_record_for_detachment();
+class RemovalStyleRecordPins {
+public:
+    explicit RemovalStyleRecordPins(CSS::StyleComputer const& style_computer)
+        : m_style_computer(style_computer)
+    {
+    }
 
-        if (auto* element = as_if<Element>(inclusive_descendant)) {
-            element->for_each_synthetic_pseudo_element([](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
-                if (auto* layout_node = pseudo_element.unsafe_layout_node())
-                    layout_node->pin_style_record_for_detachment();
-            });
-        }
+    ~RemovalStyleRecordPins()
+    {
+        release_dom_style_records();
+    }
 
-        return TraversalDecision::Continue;
-    });
-}
+    void pin_layout_style_records(Node& node)
+    {
+        node.for_each_shadow_including_inclusive_descendant([](Node& inclusive_descendant) {
+            if (auto* layout_node = inclusive_descendant.unsafe_layout_node())
+                layout_node->pin_style_record_for_detachment();
+
+            if (auto* element = as_if<Element>(inclusive_descendant)) {
+                element->for_each_synthetic_pseudo_element([](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+                    if (auto* layout_node = pseudo_element.unsafe_layout_node())
+                        layout_node->pin_style_record_for_detachment();
+                });
+            }
+
+            return TraversalDecision::Continue;
+        });
+    }
+
+    void pin_dom_style_records_for_removing_steps(Node& node)
+    {
+        node.for_each_shadow_including_inclusive_descendant([&](Node& inclusive_descendant) {
+            if (auto* element = as_if<Element>(inclusive_descendant)) {
+                pin_dom_style_record(element->style_record_identity());
+                element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+                    pin_dom_style_record(pseudo_element.style_record_identity());
+                });
+            }
+
+            return TraversalDecision::Continue;
+        });
+    }
+
+    void release_dom_style_records()
+    {
+        for (auto style_record_identity : m_dom_style_record_pins)
+            m_style_computer->unpin_style_record(style_record_identity);
+        m_dom_style_record_pins.clear();
+    }
+
+private:
+    void pin_dom_style_record(CSS::StyleRecordID style_record_identity)
+    {
+        if (!style_record_identity)
+            return;
+        m_style_computer->pin_style_record(style_record_identity);
+        m_dom_style_record_pins.append(style_record_identity);
+    }
+
+    GC::Ref<CSS::StyleComputer const> m_style_computer;
+    Vector<CSS::StyleRecordID> m_dom_style_record_pins;
+};
 
 // https://dom.spec.whatwg.org/#concept-node-remove
 void Node::remove(bool suppress_observers)
@@ -1201,6 +1248,8 @@ void Node::remove(bool suppress_observers)
     VERIFY(parent);
 
     document().flush_deferred_style_change_event();
+    bool const was_connected = is_connected();
+    RemovalStyleRecordPins removal_style_record_pins { document().style_computer() };
 
     // 3. Run the live range pre-remove steps, given node.
     live_range_pre_remove();
@@ -1228,7 +1277,13 @@ void Node::remove(bool suppress_observers)
         }
     }
 
-    if (is_connected()) {
+    if (was_connected) {
+        // NB: record_subtree_disconnecting() makes the style engine give up ownership of
+        //     disconnected records before removed_from() clears the DOM-held identities.
+        //     Preserve those identities only across the removing callback window.
+        removal_style_record_pins.pin_layout_style_records(*this);
+        removal_style_record_pins.pin_dom_style_records_for_removing_steps(*this);
+
         // A text or comment node leaving connects no element to record a delta from, but it can
         // leave its parent empty, and `:empty` is about the parent.
         if (!is<Element>(*this)) {
@@ -1302,10 +1357,10 @@ void Node::remove(bool suppress_observers)
         assign_slottables_for_a_tree(*this);
     }
 
-    // NB: Removing steps may synchronously update layout. Preserve style records for the whole
-    //     removed subtree before a callback can replace an active animation overlay still held by
-    //     another detached layout node.
-    pin_layout_style_records_for_removal(*this);
+    // NB: Detached subtrees do not need DOM-held record pins, but layout nodes can still outlive
+    //     removing steps and keep their detachment pins.
+    if (!was_connected)
+        removal_style_record_pins.pin_layout_style_records(*this);
 
     // 11. Run the removing steps with node, true, and parent.
     removed_from(IsSubtreeRoot::Yes, parent, parent_root);
@@ -1340,6 +1395,8 @@ void Node::remove(bool suppress_observers)
 
         return TraversalDecision::Continue;
     });
+
+    removal_style_record_pins.release_dom_style_records();
 
     // 15. For each inclusive ancestor inclusiveAncestor of parent, and then for each registered of inclusiveAncestor’s
     //     registered observer list, if registered’s options["subtree"] is true, then append a new transient registered

--- a/Tests/LibWeb/Text/expected/css/font-face-css-connected-registration-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-css-connected-registration-invalidation.txt
@@ -13,3 +13,8 @@ ScriptFace count after delete: 0
 LoadedSheetFace status before removal: loaded
 remove loaded CSS-connected face: 1
 LoadedSheetFace count after removal: 0
+adopt constructed CSS-connected face: 1
+ConstructedSheetFace count after adoption: 1
+ConstructedSheetFace status before removal: loaded
+unadopt constructed CSS-connected face: 1
+ConstructedSheetFace count after removal: 0

--- a/Tests/LibWeb/Text/expected/css/font-face-css-connected-registration-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-css-connected-registration-invalidation.txt
@@ -1,0 +1,15 @@
+append unloaded CSS-connected face: 1
+UnloadedSheetFace count after append: 1
+public delete CSS-connected face: false
+public delete CSS-connected face delta: 0
+UnloadedSheetFace count after public delete: 1
+remove unloaded CSS-connected face: 1
+UnloadedSheetFace count after removal: 0
+add unloaded script-created face: 0
+ScriptFace count after add: 1
+ScriptFace status before removal: loaded
+delete loaded script-created face: 1
+ScriptFace count after delete: 0
+LoadedSheetFace status before removal: loaded
+remove loaded CSS-connected face: 1
+LoadedSheetFace count after removal: 0

--- a/Tests/LibWeb/Text/expected/css/font-face-sheet-invalidation-batching.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-sheet-invalidation-batching.txt
@@ -11,10 +11,10 @@ remove first repeated sheet: 1
 RepeatedBatch face count after first removal: 2
 remove second repeated sheet: 1
 RepeatedBatch face count after second removal: 0
-append shadow sheet with multiple CSS-connected faces: 1
-ShadowBatch face count after append: 2
-Shadow target width after ShadowBatchA loads: 100
-remove shadow sheet with multiple CSS-connected faces: 1
+append shadow sheet with shadow-only font faces: 0
+ShadowBatch face count after append: 0
+Shadow target ignores shadow-only font face: true
+remove shadow sheet with shadow-only font faces: 0
 ShadowBatch face count after removal: 0
 add unloaded script-created face: 0
 load script-created face: 1

--- a/Tests/LibWeb/Text/expected/css/font-face-sheet-invalidation-batching.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-sheet-invalidation-batching.txt
@@ -1,0 +1,21 @@
+append sheet with multiple CSS-connected faces: 1
+Batch face count after append: 4
+Document target width after BatchFamilyA loads: 100
+remove sheet with multiple CSS-connected faces: 1
+Batch face count after removal: 0
+append first repeated sheet: 1
+RepeatedBatch face count after first append: 2
+append second repeated sheet: 1
+RepeatedBatch face count after second append: 4
+remove first repeated sheet: 1
+RepeatedBatch face count after first removal: 2
+remove second repeated sheet: 1
+RepeatedBatch face count after second removal: 0
+append shadow sheet with multiple CSS-connected faces: 1
+ShadowBatch face count after append: 2
+Shadow target width after ShadowBatchA loads: 100
+remove shadow sheet with multiple CSS-connected faces: 1
+ShadowBatch face count after removal: 0
+add unloaded script-created face: 0
+load script-created face: 1
+delete loaded script-created face: 1

--- a/Tests/LibWeb/Text/expected/css/shadow-root-font-face-rules.txt
+++ b/Tests/LibWeb/Text/expected/css/shadow-root-font-face-rules.txt
@@ -1,0 +1,18 @@
+initial document.fonts.size: 1
+SharedShadowFace count: 1
+ShadowOnlyFace count: 0
+ShadowLinkOnlyFace count: 0
+document target uses SharedShadowFace: true
+open shadow target uses document SharedShadowFace: true
+closed shadow target uses document SharedShadowFace: true
+open shadow-only target ignores shadow @font-face: true
+closed shadow-only target ignores shadow @font-face: true
+linked shadow-only target ignores shadow @font-face: true
+inline shadow stylesheet rules: 3
+linked shadow stylesheet rules: 4
+after removing one shadow link size: 1
+after removing one shadow link shared count: 1
+after reappend one shadow link size: 1
+after reappend one shadow link shared count: 1
+after document descriptor mutation old count: 0
+after document descriptor mutation new count: 1

--- a/Tests/LibWeb/Text/expected/css/style-engine/removing-stylesheet-preserves-non-layout-descendant-record.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/removing-stylesheet-preserves-non-layout-descendant-record.txt
@@ -1,0 +1,9 @@
+font status before removal: loading
+live overlays before removal: 1
+prepared style-record activity before removal: true
+later link has style record before removal: true
+later link has layout before removal: false
+non-layout pseudo-element has computed style before removal: true
+shadow link has style record before removal: true
+shadow link has layout before removal: false
+PASS (did not crash)

--- a/Tests/LibWeb/Text/input/css/font-face-css-connected-registration-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/font-face-css-connected-registration-invalidation.html
@@ -70,5 +70,27 @@
             loadedStyle.remove();
         });
         println(`LoadedSheetFace count after removal: ${countFaces("LoadedSheetFace")}`);
+
+        const constructedSheet = new CSSStyleSheet();
+        constructedSheet.replaceSync(`
+            @font-face {
+                font-family: "ConstructedSheetFace";
+                src: url("../../../Assets/HashSans.woff");
+            }
+        `);
+
+        printVersionDelta("adopt constructed CSS-connected face", () => {
+            document.adoptedStyleSheets = [constructedSheet];
+        });
+        println(`ConstructedSheetFace count after adoption: ${countFaces("ConstructedSheetFace")}`);
+
+        await document.fonts.load("16px ConstructedSheetFace", "A");
+        await document.fonts.ready;
+        println(`ConstructedSheetFace status before removal: ${[...document.fonts].find(face => face.family === "ConstructedSheetFace").status}`);
+
+        printVersionDelta("unadopt constructed CSS-connected face", () => {
+            document.adoptedStyleSheets = [];
+        });
+        println(`ConstructedSheetFace count after removal: ${countFaces("ConstructedSheetFace")}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/font-face-css-connected-registration-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/font-face-css-connected-registration-invalidation.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function countFaces(family) {
+        return [...document.fonts].filter(face => face.family === family).length;
+    }
+
+    function styleEnvironmentVersion() {
+        return internals.getStyleInvalidationCounters().styleEnvironmentVersion;
+    }
+
+    function printVersionDelta(label, callback) {
+        internals.updateStyle();
+        const before = styleEnvironmentVersion();
+        callback();
+        const after = styleEnvironmentVersion();
+        println(`${label}: ${after - before}`);
+    }
+
+    promiseTest(async () => {
+        let style = document.createElement("style");
+
+        printVersionDelta("append unloaded CSS-connected face", () => {
+            style.textContent = '@font-face { font-family: "UnloadedSheetFace"; src: url("unloaded-sheet-face.woff"); }';
+            document.head.appendChild(style);
+        });
+        println(`UnloadedSheetFace count after append: ${countFaces("UnloadedSheetFace")}`);
+
+        internals.updateStyle();
+        const cssConnectedFace = [...document.fonts].find(face => face.family === "UnloadedSheetFace");
+        const beforePublicDelete = styleEnvironmentVersion();
+        println(`public delete CSS-connected face: ${document.fonts.delete(cssConnectedFace)}`);
+        const afterPublicDelete = styleEnvironmentVersion();
+        println(`public delete CSS-connected face delta: ${afterPublicDelete - beforePublicDelete}`);
+        println(`UnloadedSheetFace count after public delete: ${countFaces("UnloadedSheetFace")}`);
+
+        printVersionDelta("remove unloaded CSS-connected face", () => {
+            style.remove();
+        });
+        println(`UnloadedSheetFace count after removal: ${countFaces("UnloadedSheetFace")}`);
+
+        const scriptFace = new FontFace("ScriptFace", 'url("../../../Assets/HashSans.woff")');
+        printVersionDelta("add unloaded script-created face", () => {
+            document.fonts.add(scriptFace);
+        });
+        println(`ScriptFace count after add: ${countFaces("ScriptFace")}`);
+
+        await scriptFace.load();
+        await document.fonts.ready;
+        println(`ScriptFace status before removal: ${scriptFace.status}`);
+
+        printVersionDelta("delete loaded script-created face", () => {
+            document.fonts.delete(scriptFace);
+        });
+        println(`ScriptFace count after delete: ${countFaces("ScriptFace")}`);
+
+        const loadedStyle = document.createElement("style");
+        loadedStyle.textContent = `
+            @font-face {
+                font-family: "LoadedSheetFace";
+                src: url("../../../Assets/HashSans.woff");
+            }
+        `;
+        document.head.appendChild(loadedStyle);
+        await document.fonts.load("16px LoadedSheetFace", "A");
+        await document.fonts.ready;
+        println(`LoadedSheetFace status before removal: ${[...document.fonts].find(face => face.family === "LoadedSheetFace").status}`);
+
+        printVersionDelta("remove loaded CSS-connected face", () => {
+            loadedStyle.remove();
+        });
+        println(`LoadedSheetFace count after removal: ${countFaces("LoadedSheetFace")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/font-face-sheet-invalidation-batching.html
+++ b/Tests/LibWeb/Text/input/css/font-face-sheet-invalidation-batching.html
@@ -88,15 +88,15 @@
             @font-face { font-family: ShadowBatchA; src: url("../../../Ref/data/fonts/Ahem.ttf"); }
             @font-face { font-family: ShadowBatchB; src: url("shadow-b.woff"); }
         `);
-        printVersionDelta("append shadow sheet with multiple CSS-connected faces", () => {
+        printVersionDelta("append shadow sheet with shadow-only font faces", () => {
             shadowRoot.appendChild(shadowStyle);
         });
         println(`ShadowBatch face count after append: ${countFaces("ShadowBatch")}`);
         await document.fonts.load("20px ShadowBatchA");
         document.body.offsetWidth;
-        println(`Shadow target width after ShadowBatchA loads: ${Math.round(shadowRoot.getElementById("shadow-target").getBoundingClientRect().width)}`);
+        println(`Shadow target ignores shadow-only font face: ${Math.round(shadowRoot.getElementById("shadow-target").getBoundingClientRect().width) !== 100}`);
 
-        printVersionDelta("remove shadow sheet with multiple CSS-connected faces", () => {
+        printVersionDelta("remove shadow sheet with shadow-only font faces", () => {
             shadowStyle.remove();
         });
         println(`ShadowBatch face count after removal: ${countFaces("ShadowBatch")}`);

--- a/Tests/LibWeb/Text/input/css/font-face-sheet-invalidation-batching.html
+++ b/Tests/LibWeb/Text/input/css/font-face-sheet-invalidation-batching.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<div id="document-target" style="display: inline-block; font: 20px BatchFamilyA, serif">XXXXX</div>
+<div id="shadow-host"></div>
+<script src="../include.js"></script>
+<script>
+    function countFaces(familyPrefix) {
+        return [...document.fonts].filter(face => face.family.startsWith(familyPrefix)).length;
+    }
+
+    function styleEnvironmentVersion() {
+        return internals.getStyleInvalidationCounters().styleEnvironmentVersion;
+    }
+
+    function printVersionDelta(label, callback) {
+        internals.updateStyle();
+        const before = styleEnvironmentVersion();
+        callback();
+        const after = styleEnvironmentVersion();
+        println(`${label}: ${after - before}`);
+    }
+
+    function makeStyle(source) {
+        const style = document.createElement("style");
+        style.textContent = source;
+        return style;
+    }
+
+    const multiFaceSheet = `
+        @font-face { font-family: BatchFamilyA; src: url("../../../Ref/data/fonts/Ahem.ttf"); }
+        @font-face { font-family: BatchFamilyA; font-weight: 700; src: url("../../../Ref/data/fonts/Ahem.ttf"); }
+        @font-face { font-family: BatchFamilyB; src: url("batch-b.woff"); }
+        @supports (display: block) {
+            @font-face { font-family: BatchFamilyC; src: url("batch-c.woff"); }
+        }
+        @media not all {
+            @font-face { font-family: BatchInactive; src: url("batch-inactive.woff"); }
+        }
+    `;
+
+    promiseTest(async () => {
+        getComputedStyle(document.getElementById("document-target")).fontFamily;
+
+        const style = makeStyle(multiFaceSheet);
+        printVersionDelta("append sheet with multiple CSS-connected faces", () => {
+            document.head.appendChild(style);
+        });
+        println(`Batch face count after append: ${countFaces("Batch")}`);
+        await document.fonts.load("20px BatchFamilyA");
+        document.body.offsetWidth;
+        println(`Document target width after BatchFamilyA loads: ${Math.round(document.getElementById("document-target").getBoundingClientRect().width)}`);
+
+        printVersionDelta("remove sheet with multiple CSS-connected faces", () => {
+            style.remove();
+        });
+        println(`Batch face count after removal: ${countFaces("Batch")}`);
+
+        const repeatedSheetA = makeStyle(`
+            @font-face { font-family: RepeatedBatchA; src: url("repeated-a.woff"); }
+            @font-face { font-family: RepeatedBatchB; src: url("repeated-b.woff"); }
+        `);
+        const repeatedSheetB = makeStyle(repeatedSheetA.textContent);
+
+        printVersionDelta("append first repeated sheet", () => {
+            document.head.appendChild(repeatedSheetA);
+        });
+        println(`RepeatedBatch face count after first append: ${countFaces("RepeatedBatch")}`);
+
+        printVersionDelta("append second repeated sheet", () => {
+            document.head.appendChild(repeatedSheetB);
+        });
+        println(`RepeatedBatch face count after second append: ${countFaces("RepeatedBatch")}`);
+
+        printVersionDelta("remove first repeated sheet", () => {
+            repeatedSheetA.remove();
+        });
+        println(`RepeatedBatch face count after first removal: ${countFaces("RepeatedBatch")}`);
+
+        printVersionDelta("remove second repeated sheet", () => {
+            repeatedSheetB.remove();
+        });
+        println(`RepeatedBatch face count after second removal: ${countFaces("RepeatedBatch")}`);
+
+        const shadowRoot = document.getElementById("shadow-host").attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = `<span id="shadow-target" style="display: inline-block; font: 20px ShadowBatchA, serif">XXXXX</span>`;
+        getComputedStyle(shadowRoot.getElementById("shadow-target")).fontFamily;
+
+        const shadowStyle = makeStyle(`
+            @font-face { font-family: ShadowBatchA; src: url("../../../Ref/data/fonts/Ahem.ttf"); }
+            @font-face { font-family: ShadowBatchB; src: url("shadow-b.woff"); }
+        `);
+        printVersionDelta("append shadow sheet with multiple CSS-connected faces", () => {
+            shadowRoot.appendChild(shadowStyle);
+        });
+        println(`ShadowBatch face count after append: ${countFaces("ShadowBatch")}`);
+        await document.fonts.load("20px ShadowBatchA");
+        document.body.offsetWidth;
+        println(`Shadow target width after ShadowBatchA loads: ${Math.round(shadowRoot.getElementById("shadow-target").getBoundingClientRect().width)}`);
+
+        printVersionDelta("remove shadow sheet with multiple CSS-connected faces", () => {
+            shadowStyle.remove();
+        });
+        println(`ShadowBatch face count after removal: ${countFaces("ShadowBatch")}`);
+
+        const scriptFace = new FontFace("ScriptBatch", 'url("../../../Assets/HashSans.woff")');
+        printVersionDelta("add unloaded script-created face", () => {
+            document.fonts.add(scriptFace);
+        });
+
+        internals.updateStyle();
+        const beforeLoad = styleEnvironmentVersion();
+        await scriptFace.load();
+        const afterLoad = styleEnvironmentVersion();
+        println(`load script-created face: ${afterLoad - beforeLoad}`);
+
+        printVersionDelta("delete loaded script-created face", () => {
+            document.fonts.delete(scriptFace);
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/shadow-root-font-face-rules.html
+++ b/Tests/LibWeb/Text/input/css/shadow-root-font-face-rules.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<style id="document-fonts">
+    @font-face {
+        font-family: SharedShadowFace;
+        src: url("../../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    #document-target {
+        display: inline-block;
+        font: 20px SharedShadowFace, serif;
+    }
+</style>
+<div id="document-target">XXXXX</div>
+<div id="inline-open-host"></div>
+<div id="inline-closed-host"></div>
+<div id="link-host-a"></div>
+<div id="link-host-b"></div>
+<script src="../include.js"></script>
+<script>
+    function familyCount(name) {
+        return [...document.fonts].filter(face => face.family === name).length;
+    }
+
+    function roundedWidth(element) {
+        document.body.offsetWidth;
+        return Math.round(element.getBoundingClientRect().width);
+    }
+
+    function attachInlineShadow(host, mode) {
+        const shadowRoot = host.attachShadow({ mode });
+        shadowRoot.innerHTML = `
+            <style>
+                @font-face {
+                    font-family: ShadowOnlyFace;
+                    src: url("../../../Ref/data/fonts/Ahem.ttf");
+                }
+
+                .shared-target {
+                    display: inline-block;
+                    font: 20px SharedShadowFace, serif;
+                }
+
+                .shadow-only-target {
+                    display: inline-block;
+                    font: 20px ShadowOnlyFace, serif;
+                }
+            </style>
+            <span class="shared-target">XXXXX</span>
+            <span class="shadow-only-target">XXXXX</span>
+        `;
+        return {
+            shadowRoot,
+            sharedTarget: shadowRoot.querySelector(".shared-target"),
+            shadowOnlyTarget: shadowRoot.querySelector(".shadow-only-target"),
+            style: shadowRoot.querySelector("style"),
+        };
+    }
+
+    function attachLinkedShadow(host) {
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = "style-engine/shadow-font-face-sheet.css";
+
+        const sharedTarget = document.createElement("span");
+        sharedTarget.className = "shared-target";
+        sharedTarget.textContent = "XXXXX";
+
+        const shadowOnlyTarget = document.createElement("span");
+        shadowOnlyTarget.className = "shadow-link-only-target";
+        shadowOnlyTarget.textContent = "XXXXX";
+
+        shadowRoot.append(link, sharedTarget, shadowOnlyTarget);
+        return { shadowRoot, link, sharedTarget, shadowOnlyTarget };
+    }
+
+    function waitForLoad(element) {
+        return new Promise(resolve => element.addEventListener("load", resolve, { once: true }));
+    }
+
+    promiseTest(async () => {
+        const inlineOpen = attachInlineShadow(document.getElementById("inline-open-host"), "open");
+        const inlineClosed = attachInlineShadow(document.getElementById("inline-closed-host"), "closed");
+        const linkedA = attachLinkedShadow(document.getElementById("link-host-a"));
+        const linkedB = attachLinkedShadow(document.getElementById("link-host-b"));
+
+        await Promise.all([waitForLoad(linkedA.link), waitForLoad(linkedB.link)]);
+        await document.fonts.load("20px SharedShadowFace", "X");
+
+        println(`initial document.fonts.size: ${document.fonts.size}`);
+        println(`SharedShadowFace count: ${familyCount("SharedShadowFace")}`);
+        println(`ShadowOnlyFace count: ${familyCount("ShadowOnlyFace")}`);
+        println(`ShadowLinkOnlyFace count: ${familyCount("ShadowLinkOnlyFace")}`);
+        println(`document target uses SharedShadowFace: ${roundedWidth(document.getElementById("document-target")) === 100}`);
+        println(`open shadow target uses document SharedShadowFace: ${roundedWidth(inlineOpen.sharedTarget) === 100}`);
+        println(`closed shadow target uses document SharedShadowFace: ${roundedWidth(inlineClosed.sharedTarget) === 100}`);
+        println(`open shadow-only target ignores shadow @font-face: ${roundedWidth(inlineOpen.shadowOnlyTarget) !== 100}`);
+        println(`closed shadow-only target ignores shadow @font-face: ${roundedWidth(inlineClosed.shadowOnlyTarget) !== 100}`);
+        println(`linked shadow-only target ignores shadow @font-face: ${roundedWidth(linkedA.shadowOnlyTarget) !== 100}`);
+        println(`inline shadow stylesheet rules: ${inlineOpen.style.sheet.cssRules.length}`);
+        println(`linked shadow stylesheet rules: ${linkedA.link.sheet.cssRules.length}`);
+
+        linkedA.link.remove();
+        document.body.offsetWidth;
+        println(`after removing one shadow link size: ${document.fonts.size}`);
+        println(`after removing one shadow link shared count: ${familyCount("SharedShadowFace")}`);
+
+        const reloaded = waitForLoad(linkedA.link);
+        linkedA.shadowRoot.prepend(linkedA.link);
+        await reloaded;
+        document.body.offsetWidth;
+        println(`after reappend one shadow link size: ${document.fonts.size}`);
+        println(`after reappend one shadow link shared count: ${familyCount("SharedShadowFace")}`);
+
+        const documentRule = document.getElementById("document-fonts").sheet.cssRules[0];
+        documentRule.style.setProperty("font-family", "MutatedDocumentFace");
+        document.body.offsetWidth;
+        println(`after document descriptor mutation old count: ${familyCount("SharedShadowFace")}`);
+        println(`after document descriptor mutation new count: ${familyCount("MutatedDocumentFace")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-descendant-animation-overlay.html
@@ -31,7 +31,9 @@
         document.body.append(container);
         await linkLoaded;
 
-        target.animate({ opacity: [0, 1] }, { duration: 10000 });
+        const animation = target.animate({ opacity: [0, 1] }, { duration: 1000 });
+        animation.pause();
+        await animation.ready;
         await new Promise(requestAnimationFrame);
         internals.updateStyle();
         target.offsetWidth;

--- a/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-non-layout-descendant-record.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/removing-stylesheet-preserves-non-layout-descendant-record.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #churn-target, #later-removal-link { color: attr(data-color type(<color>)); }
+    #pseudo-target::before { content: ""; display: none; color: rgb(7, 8, 9); }
+</style>
+<div id="churn-target" data-color="rgb(0, 0, 0)"></div>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const token = crypto.randomUUID();
+        const fontUrl = await server.createEcho("GET", `/removing-stylesheet-preserves-non-layout-descendant-record-${token}.ttf`, {
+            status: 200,
+            headers: { "Content-Type": "font/ttf" },
+            body: "blocked font response",
+            wait_for_unblock: token,
+        });
+
+        const stylesheetUrl = await server.createEcho("GET", `/removing-stylesheet-preserves-non-layout-descendant-record-${token}.css`, {
+            status: 200,
+            headers: { "Content-Type": "text/css" },
+            body: `@font-face { font-family: SlowAhem; src: url("${fontUrl}"); }`,
+        });
+
+        const churnTarget = document.getElementById("churn-target");
+        let churnIndex = 1;
+        const churnOnce = () => {
+            churnTarget.dataset.color = `rgb(${churnIndex & 255}, ${(churnIndex >> 8) & 255}, ${(churnIndex >> 16) & 255})`;
+            ++churnIndex;
+            internals.updateStyle();
+        };
+
+        const sweepKey = () => {
+            const counters = internals.styleEngineCounters();
+            return `${counters.computedGroupsRetained}:${counters.computedGroupsReachable}`;
+        };
+
+        const container = document.createElement("div");
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = stylesheetUrl;
+        const linkLoaded = new Promise(resolve => link.onload = resolve);
+        container.append(link);
+
+        const target = document.createElement("div");
+        target.textContent = "X";
+        target.style.fontFamily = "SlowAhem";
+        container.append(target);
+
+        const laterLink = document.createElement("link");
+        laterLink.id = "later-removal-link";
+        laterLink.dataset.color = "rgb(4, 5, 6)";
+        container.append(laterLink);
+
+        const pseudoTarget = document.createElement("div");
+        pseudoTarget.id = "pseudo-target";
+        container.append(pseudoTarget);
+
+        const shadowHost = document.createElement("div");
+        const shadowRoot = shadowHost.attachShadow({ mode: "closed" });
+        const shadowStyle = document.createElement("style");
+        shadowStyle.textContent = `#shadow-later-removal-link { color: rgb(10, 11, 12); }`;
+        const shadowLaterLink = document.createElement("link");
+        shadowLaterLink.id = "shadow-later-removal-link";
+        shadowRoot.append(shadowStyle, shadowLaterLink);
+        container.append(shadowHost);
+
+        document.body.append(container);
+        await linkLoaded;
+
+        const animation = target.animate({ opacity: [0, 1] }, { duration: 1000 });
+        animation.pause();
+        await animation.ready;
+        await new Promise(requestAnimationFrame);
+        internals.updateStyle();
+        target.offsetWidth;
+        const pseudoColor = getComputedStyle(pseudoTarget, "::before").color;
+        const fontLoadPromise = document.fonts.load("16px SlowAhem", "X").catch(() => {});
+
+        let sweepInterval = 0;
+        let sweeps = 0;
+        let iterationsSinceSweep = 0;
+        let lastSweepKey = sweepKey();
+        for (let count = 0; count < 20000; ++count) {
+            churnOnce();
+            ++iterationsSinceSweep;
+            const currentSweepKey = sweepKey();
+            if (currentSweepKey !== lastSweepKey) {
+                ++sweeps;
+                sweepInterval = iterationsSinceSweep;
+                iterationsSinceSweep = 0;
+                lastSweepKey = currentSweepKey;
+                if (sweeps === 2)
+                    break;
+            }
+        }
+        for (let count = 1; count < sweepInterval; ++count)
+            churnOnce();
+
+        println(`font status before removal: ${document.fonts.status}`);
+        println(`live overlays before removal: ${internals.styleEngineCounters().liveAnimationOverlayRecords}`);
+        println(`prepared style-record activity before removal: ${sweeps === 2}`);
+        println(`later link has style record before removal: ${internals.styleRecordIdentity(laterLink) !== 0}`);
+        println(`later link has layout before removal: ${internals.layoutNodeIdentity(laterLink) !== 0}`);
+        println(`non-layout pseudo-element has computed style before removal: ${pseudoColor === "rgb(7, 8, 9)"}`);
+        println(`shadow link has style record before removal: ${internals.styleRecordIdentity(shadowLaterLink) !== 0}`);
+        println(`shadow link has layout before removal: ${internals.layoutNodeIdentity(shadowLaterLink) !== 0}`);
+
+        await new Promise(requestAnimationFrame);
+        churnTarget.dataset.color = `rgb(${churnIndex & 255}, ${(churnIndex >> 8) & 255}, ${(churnIndex >> 16) & 255})`;
+        container.remove();
+        println("PASS (did not crash)");
+
+        await fetch(`${server.baseURL}/unblock/${token}`);
+        await fontLoadPromise;
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/shadow-font-face-sheet.css
+++ b/Tests/LibWeb/Text/input/css/style-engine/shadow-font-face-sheet.css
@@ -1,0 +1,19 @@
+@font-face {
+    font-family: SharedShadowFace;
+    src: url("../../../../Ref/data/fonts/Ahem.ttf");
+}
+
+@font-face {
+    font-family: ShadowLinkOnlyFace;
+    src: url("../../../../Ref/data/fonts/Ahem.ttf");
+}
+
+.shared-target {
+    display: inline-block;
+    font: 20px SharedShadowFace, serif;
+}
+
+.shadow-link-only-target {
+    display: inline-block;
+    font: 20px ShadowLinkOnlyFace, serif;
+}


### PR DESCRIPTION
Keep DOM-held element and pseudo-element style records pinned until subtree removal callbacks finish, and avoid publishing refreshed animation records for disconnected targets. This prevents synchronous stylesheet and font invalidation during removal from reclaiming records that the DOM can still observe.

Make FontFaceSet the single owner of CSS-connected font registration side effects, and batch stylesheet font changes into one style-environment update. Only document-owned stylesheets now contribute `@font-face` rules, matching Chromium’s behavior for shadow-root sheets and avoiding duplicate registrations across repeated components.

Unload constructed stylesheet fonts before clearing their final document owner so detached faces disappear from document.fonts and font matching. Add coverage for loaded and unloaded faces, script-created faces, batched family invalidation, shadow-root stylesheet lifecycles, adopted constructed sheets, and style-record preservation during removal.