### PR TITLE
LibWeb: Memoize table cell content measurements across layouts

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -715,6 +715,11 @@ WebIDL::UnsignedLongLong Internals::layout_run_cache_hit_count()
     return window().associated_document().layout_node_arena().formatting_context_run_cache_hit_count();
 }
 
+WebIDL::UnsignedLongLong Internals::table_cell_measurement_cache_miss_count()
+{
+    return window().associated_document().layout_node_arena().table_cell_measurement_cache_miss_count();
+}
+
 WebIDL::UnsignedLongLong Internals::accumulated_visual_context_tree_build_count()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -118,6 +118,7 @@ public:
     WebIDL::UnsignedLongLong partial_layout_count();
     WebIDL::UnsignedLongLong full_layout_count();
     WebIDL::UnsignedLongLong layout_run_cache_hit_count();
+    WebIDL::UnsignedLongLong table_cell_measurement_cache_miss_count();
     WebIDL::UnsignedLongLong accumulated_visual_context_tree_build_count();
     void set_autoplay_policy(Utf16String const& policy);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -97,6 +97,7 @@ interface Internals {
     unsigned long long partialLayoutCount();
     unsigned long long fullLayoutCount();
     unsigned long long layoutRunCacheHitCount();
+    unsigned long long tableCellMeasurementCacheMissCount();
     unsigned long long accumulatedVisualContextTreeBuildCount();
     undefined setAutoplayPolicy(Utf16DOMString policy);
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -186,6 +186,30 @@ void Node::bump_fragment_cache_epoch_of_self_and_ancestors()
     }
 }
 
+// Reset intrinsic size caches for ancestors up to abspos or SVG root boundary.
+// Absolutely positioned elements don't contribute to ancestor intrinsic sizes,
+// so changes inside an abspos box don't require resetting ancestor caches.
+// SVG root elements have intrinsic sizes determined solely by their own attributes
+// (width, height, viewBox), not by their children, so the same logic applies.
+static void reset_cached_intrinsic_sizes_of_ancestors(Node& node)
+{
+    for (auto* ancestor = node.parent(); ancestor; ancestor = ancestor->parent()) {
+        auto* box = as_if<Box>(ancestor);
+        if (!box)
+            continue;
+        box->reset_cached_intrinsic_sizes();
+        if (box->is_absolutely_positioned() || box->is_svg_svg_box())
+            break;
+    }
+}
+
+static void reset_cached_intrinsic_sizes_of_self_and_ancestors(Node& node)
+{
+    if (auto* box = as_if<Box>(node))
+        box->reset_cached_intrinsic_sizes();
+    reset_cached_intrinsic_sizes_of_ancestors(node);
+}
+
 void* Node::arena_handle() const
 {
     return m_arena->handle();
@@ -954,17 +978,15 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     // node data plus the animated-value overlay, which lives outside the groups and
     // disqualifies pointer diffing the same way it disqualifies the style differ's group
     // fast path.
+    auto differs_from = [&](CSS::ComputedValues const& previous_values) {
+        return CSS::ComputedValues::either_carries_animated_overlay(previous_values, *computed_values)
+            || computed_values->differs_in_any_layout_affecting_group_payload_from(previous_values);
+    };
     bool changes_layout_affecting_style = false;
-    if (fragment_cache_epochs_enabled()) {
-        auto differs_from = [&](CSS::ComputedValues const& previous_values) {
-            return CSS::ComputedValues::either_carries_animated_overlay(previous_values, *computed_values)
-                || computed_values->differs_in_any_layout_affecting_group_payload_from(previous_values);
-        };
-        if (m_owned_computed_values)
-            changes_layout_affecting_style = differs_from(*m_owned_computed_values);
-        else if (auto record_view = computed_style_record_view())
-            changes_layout_affecting_style = differs_from(*record_view);
-    }
+    if (m_owned_computed_values)
+        changes_layout_affecting_style = differs_from(*m_owned_computed_values);
+    else if (auto record_view = computed_style_record_view())
+        changes_layout_affecting_style = differs_from(*record_view);
 
     release_pinned_style_record();
     m_background_layers.clear();
@@ -999,8 +1021,10 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     if (m_owned_computed_values)
         pin_style_record_for_cxx_consumers();
 
-    if (changes_layout_affecting_style)
+    if (changes_layout_affecting_style) {
         bump_fragment_cache_epoch_of_self_and_ancestors();
+        reset_cached_intrinsic_sizes_of_self_and_ancestors(*this);
+    }
 
     for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
         if (auto* text_child = as_if<TextNode>(*child))
@@ -1022,13 +1046,10 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     bool should_repin_style_record = m_style_record_owner;
     auto new_record_view = document().style_computer().computed_style_record_view(style_record_identity);
     VERIFY(new_record_view);
-    bool changes_layout_affecting_style = false;
-    if (fragment_cache_epochs_enabled()) {
-        auto old_record_view = computed_style_record_view();
-        changes_layout_affecting_style = !old_record_view
-            || CSS::ComputedValues::either_carries_animated_overlay(*old_record_view, *new_record_view)
-            || new_record_view->differs_in_any_layout_affecting_group_payload_from(*old_record_view);
-    }
+    auto old_record_view = computed_style_record_view();
+    bool changes_layout_affecting_style = !old_record_view
+        || CSS::ComputedValues::either_carries_animated_overlay(*old_record_view, *new_record_view)
+        || new_record_view->differs_in_any_layout_affecting_group_payload_from(*old_record_view);
 
     release_pinned_style_record();
     m_background_layers.clear();
@@ -1046,8 +1067,10 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     if (should_repin_style_record)
         pin_style_record_for_cxx_consumers();
 
-    if (changes_layout_affecting_style)
+    if (changes_layout_affecting_style) {
         bump_fragment_cache_epoch_of_self_and_ancestors();
+        reset_cached_intrinsic_sizes_of_self_and_ancestors(*this);
+    }
 }
 
 void NodeWithStyle::pin_style_record_for_cxx_consumers()
@@ -1471,19 +1494,7 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
         }
     }
 
-    // Reset intrinsic size caches for ancestors up to abspos or SVG root boundary.
-    // Absolutely positioned elements don't contribute to ancestor intrinsic sizes,
-    // so changes inside an abspos box don't require resetting ancestor caches.
-    // SVG root elements have intrinsic sizes determined solely by their own attributes
-    // (width, height, viewBox), not by their children, so the same logic applies.
-    for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-        auto* box = as_if<Box>(ancestor);
-        if (!box)
-            continue;
-        box->reset_cached_intrinsic_sizes();
-        if (box->is_absolutely_positioned() || box->is_svg_svg_box())
-            break;
-    }
+    reset_cached_intrinsic_sizes_of_ancestors(*this);
 }
 
 }

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -40,6 +40,11 @@ u64 NodeArena::formatting_context_run_cache_hit_count() const
     return RustFFI::layout_arena_fc_run_cache_hit_count(m_handle);
 }
 
+u64 NodeArena::table_cell_measurement_cache_miss_count() const
+{
+    return RustFFI::layout_arena_table_cell_measurement_cache_miss_count(m_handle);
+}
+
 void NodeArena::drop_intrinsic_size_cache(RustFFI::NodeData const& node_data) const
 {
     RustFFI::layout_arena_drop_intrinsic_size_cache(m_handle, &node_data);

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -36,6 +36,7 @@ public:
     void free(RustFFI::NodeSlotId, u32 generation);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
+    u64 table_cell_measurement_cache_miss_count() const;
     void drop_intrinsic_size_cache(RustFFI::NodeData const&) const;
 
     void enroll_text_node_for_content_sync(TextNode const&);

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -807,12 +807,6 @@ pub(crate) enum ChildLayoutOutcome {
     ReenterCurrent,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct MeasuredCellContent {
-    pub content_block_size: CssPixels,
-    pub first_baseline: CssPixels,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SizingAxis {
     Inline,

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -7,8 +7,12 @@
 use crate::abort_on_panic;
 use crate::layout::AbsposLayoutInputs;
 use crate::layout::AvailableSize;
+use crate::layout::AvailableSpace;
 use crate::layout::CssPixels;
+use crate::layout::DerivedBaselines;
 use crate::layout::FfiReplacedContentFacts;
+use crate::layout::LayoutMode;
+use crate::layout::SizeConstraint;
 use crate::layout::UsedValues;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use std::cell::Cell;
@@ -70,6 +74,54 @@ impl Hash for IntrinsicSizeCacheKey {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TableCellMeasurementKey {
+    pub(crate) layout_mode: LayoutMode,
+    pub(crate) available_space: AvailableSpace,
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) content_block_size: CssPixels,
+    pub(crate) has_definite_inline_size: bool,
+    pub(crate) has_definite_block_size: bool,
+    pub(crate) inline_size_constraint: SizeConstraint,
+    pub(crate) block_size_constraint: SizeConstraint,
+    pub(crate) uses_collapsing_borders_model: bool,
+    pub(crate) adopt_automatic_content_block_size: bool,
+}
+
+impl Hash for TableCellMeasurementKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        fn hash_available_size<H: Hasher>(size: AvailableSize, state: &mut H) {
+            match size {
+                AvailableSize::Definite(value) => {
+                    0u8.hash(state);
+                    value.raw_value().hash(state);
+                }
+                AvailableSize::Indefinite => 1u8.hash(state),
+                AvailableSize::MinContent => 2u8.hash(state),
+                AvailableSize::MaxContent => 3u8.hash(state),
+            }
+        }
+
+        (self.layout_mode as u8).hash(state);
+        hash_available_size(self.available_space.inline_size, state);
+        hash_available_size(self.available_space.block_size, state);
+        self.content_inline_size.raw_value().hash(state);
+        self.content_block_size.raw_value().hash(state);
+        self.has_definite_inline_size.hash(state);
+        self.has_definite_block_size.hash(state);
+        (self.inline_size_constraint as u8).hash(state);
+        (self.block_size_constraint as u8).hash(state);
+        self.uses_collapsing_borders_model.hash(state);
+        self.adopt_automatic_content_block_size.hash(state);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TableCellMeasurement {
+    pub(crate) automatic_content_block_size: CssPixels,
+    pub(crate) baselines: DerivedBaselines,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IntrinsicSizeCacheKind {
     MinContentInline,
     MaxContentInline,
@@ -100,6 +152,7 @@ struct IntrinsicSizeMaps {
     max_content_inline_size: HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>,
     min_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
     max_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
+    table_cell_measurements: HashMap<TableCellMeasurementKey, TableCellMeasurement>,
 }
 
 impl IntrinsicSizeMaps {
@@ -255,6 +308,7 @@ pub(crate) struct LayoutNodeArena {
     next_index: u32,
     live_count: u32,
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
+    table_cell_measurement_cache_misses: Cell<u64>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
@@ -279,6 +333,7 @@ impl LayoutNodeArena {
             next_index: 0,
             live_count: 0,
             intrinsic_size_caches: RefCell::new(Vec::new()),
+            table_cell_measurement_cache_misses: Cell::new(0),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
@@ -984,6 +1039,40 @@ impl LayoutNodeArena {
                 .expect("inline measurement cache kind must use the inline axis")
                 .insert(key, value);
         });
+    }
+
+    pub(crate) fn table_cell_measurement_cache_get(
+        &self,
+        data: &NodeData,
+        key: TableCellMeasurementKey,
+    ) -> Option<TableCellMeasurement> {
+        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let caches = self.intrinsic_size_caches.borrow();
+        let slot = caches.get(index as usize)?;
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+            return None;
+        }
+        slot.sizes.as_ref()?.table_cell_measurements.get(&key).copied()
+    }
+
+    pub(crate) fn table_cell_measurement_cache_put(
+        &self,
+        data: &NodeData,
+        key: TableCellMeasurementKey,
+        value: TableCellMeasurement,
+    ) {
+        self.with_intrinsic_size_maps_mut(data, |maps| {
+            maps.table_cell_measurements.insert(key, value);
+        });
+    }
+
+    pub(crate) fn note_table_cell_measurement_cache_miss(&self) {
+        self.table_cell_measurement_cache_misses
+            .set(self.table_cell_measurement_cache_misses.get() + 1);
+    }
+
+    pub(crate) fn table_cell_measurement_cache_miss_count(&self) -> u64 {
+        self.table_cell_measurement_cache_misses.get()
     }
 
     pub(crate) fn saved_abspos_layout_inputs(&self, data: *const NodeData) -> Option<AbsposLayoutInputs> {
@@ -1730,6 +1819,16 @@ pub unsafe extern "C" fn layout_arena_fc_run_cache_hit_count(arena: *mut c_void)
     })
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_table_cell_measurement_cache_miss_count(arena: *mut c_void) -> u64 {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &*arena.cast::<LayoutNodeArena>() }.table_cell_measurement_cache_miss_count()
+    })
+}
+
 /// # Safety
 ///
 /// The arena must remain valid for the duration of the call, and `id` must
@@ -1891,10 +1990,12 @@ mod tests {
 
     use crate::layout::layout_node_arena::{
         Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
-        SLOTS_PER_CHUNK,
+        SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
     };
     use crate::layout::node_data::{NodeFlag, NodeSlotId};
-    use crate::layout::{AvailableSize, CssPixels, Fragment, FragmentLink};
+    use crate::layout::{
+        AvailableSize, AvailableSpace, CssPixels, DerivedBaselines, Fragment, FragmentLink, LayoutMode, SizeConstraint,
+    };
 
     fn test_fragment_link(node: NodeSlotId) -> FragmentLink {
         FragmentLink {
@@ -2156,6 +2257,61 @@ mod tests {
             ),
             None
         );
+        arena.free(second.slot, second.generation);
+    }
+
+    #[test]
+    fn table_cell_measurements_follow_the_intrinsic_cache_epoch() {
+        let mut arena = LayoutNodeArena::new();
+        let first = arena.allocate();
+        let key = TableCellMeasurementKey {
+            layout_mode: LayoutMode::Normal,
+            available_space: AvailableSpace {
+                inline_size: AvailableSize::definite(CssPixels::from_raw(640)),
+                block_size: AvailableSize::Indefinite,
+            },
+            content_inline_size: CssPixels::from_raw(640),
+            content_block_size: CssPixels::default(),
+            has_definite_inline_size: true,
+            has_definite_block_size: false,
+            inline_size_constraint: SizeConstraint::None,
+            block_size_constraint: SizeConstraint::None,
+            uses_collapsing_borders_model: true,
+            adopt_automatic_content_block_size: true,
+        };
+        let value = TableCellMeasurement {
+            automatic_content_block_size: CssPixels::from_raw(320),
+            baselines: DerivedBaselines {
+                first: Some(CssPixels::from_raw(64)),
+                last: None,
+            },
+        };
+
+        // SAFETY: The allocation remains live until it is explicitly freed below.
+        let first_data = unsafe { &mut *first.data };
+        assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
+        arena.table_cell_measurement_cache_put(first_data, key, value);
+        assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), Some(value));
+        let percentage_resolved_key = TableCellMeasurementKey {
+            content_block_size: CssPixels::from_raw(512),
+            has_definite_block_size: true,
+            adopt_automatic_content_block_size: false,
+            ..key
+        };
+        assert_eq!(
+            arena.table_cell_measurement_cache_get(first_data, percentage_resolved_key),
+            None
+        );
+
+        first_data.intrinsic_cache_epoch += 1;
+        assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
+        arena.free(first.slot, first.generation);
+
+        let second = arena.allocate();
+        assert_eq!(second.slot.slot_index(), first.slot.slot_index());
+        // SAFETY: The second allocation is live and reuses the first allocation's slot.
+        let second_data = unsafe { &*second.data };
+        assert_eq!(arena.table_cell_measurement_cache_get(second_data, key), None);
         arena.free(second.slot, second.generation);
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -50,6 +50,7 @@ use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKind;
 pub(crate) use crate::layout::layout_node_arena::{LayoutNodeArena, RenderedTextBoundary};
+use crate::layout::layout_node_arena::{TableCellMeasurement, TableCellMeasurementKey};
 pub use crate::layout::node_data::FfiReplacedContentFacts;
 pub use crate::layout::node_data::FfiStylePayloads;
 use crate::layout::node_data::NodeData;

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -2075,9 +2075,7 @@ impl TableFormattingContext {
         used: &UsedValues,
         inner: AvailableSpace,
         adopt_automatic_content_block_size: bool,
-    ) -> Option<MeasuredCellContent> {
-        // The table formatting context owns the cell's outer geometry. Seed the inputs
-        // needed to lay out its contents without copying placement or layout outputs.
+    ) -> Option<TableCellMeasurement> {
         let facts = NodeFacts::new(&self.callbacks, cell.box_);
         if self.layout_mode == LayoutMode::IntrinsicSizing
             && !facts.is_inline()
@@ -2092,6 +2090,39 @@ impl TableFormattingContext {
             return None;
         }
 
+        let key = TableCellMeasurementKey {
+            layout_mode: self.layout_mode,
+            available_space: inner,
+            content_inline_size: used.content_inline_size.get(),
+            content_block_size: used.content_block_size.get(),
+            has_definite_inline_size: used.has_definite_inline_size(),
+            has_definite_block_size: used.has_definite_block_size(),
+            inline_size_constraint: used.inline_size_constraint.get(),
+            block_size_constraint: used.block_size_constraint.get(),
+            uses_collapsing_borders_model: used.uses_collapsing_borders_model.get(),
+            adopt_automatic_content_block_size,
+        };
+        let arena = self.callbacks.arena();
+        let data = self.callbacks.node_data(cell.box_);
+        if let Some(cached) = arena.table_cell_measurement_cache_get(data, key) {
+            return Some(cached);
+        }
+
+        let measured = self.measure_cell_content(cell, used, inner, adopt_automatic_content_block_size);
+        arena.note_table_cell_measurement_cache_miss();
+        arena.table_cell_measurement_cache_put(data, key, measured);
+        Some(measured)
+    }
+
+    fn measure_cell_content(
+        &self,
+        cell: TableCell,
+        used: &UsedValues,
+        inner: AvailableSpace,
+        adopt_automatic_content_block_size: bool,
+    ) -> TableCellMeasurement {
+        // The table formatting context owns the cell's outer geometry. Seed the inputs
+        // needed to lay out its contents without copying placement or layout outputs.
         let measurement = MeasurementState::create(self.callbacks);
         let measured_root = measurement.create_used_values(cell.box_, ContainingBlockConstraints::default());
         used.mirror_box_metrics_and_size_constraints_into(&measured_root);
@@ -2120,17 +2151,10 @@ impl TableFormattingContext {
                 participation: ParticipationInParentFormattingContext::Item,
             },
         );
-        let measured_cell_used = measured_root;
-        Some(MeasuredCellContent {
-            content_block_size: result.automatic_content_block_size,
-            first_baseline: crate::layout::box_baseline_with_content_baselines(
-                measurement.callbacks(),
-                cell.box_,
-                &measured_cell_used,
-                crate::layout::BaselineSet::First,
-                result.baselines,
-            ),
-        })
+        TableCellMeasurement {
+            automatic_content_block_size: result.automatic_content_block_size,
+            baselines: result.baselines,
+        }
     }
 
     fn compute_table_block_size(&mut self, run: &FormattingContextRun) {
@@ -2196,17 +2220,16 @@ impl TableFormattingContext {
                 || style.vertical_align_is_keyword()
                 || self.anonymous_cell_wraps_flex_or_grid(cell);
             self.deferred_cell_inside_layouts[cell_index] = defer_inside_layout;
-            let mut measured_baseline = None;
-            let mut committing_run_baselines = None;
+            let mut content_baselines = None;
             if defer_inside_layout {
                 // This cell's final inside layout happens once row heights are final; measure its
                 // content in a throwaway state instead of laying out the committing state twice.
                 if let Some(measured) = self.measure_cell(cell, &used, inner, true) {
-                    used.set_content_block_size(measured.content_block_size);
-                    measured_baseline = Some(measured.first_baseline);
+                    used.set_content_block_size(measured.automatic_content_block_size);
+                    content_baselines = Some(measured.baselines);
                 }
             } else {
-                committing_run_baselines = Some(self.layout_inside_cell(run, cell, inner, true, None));
+                content_baselines = Some(self.layout_inside_cell(run, cell, inner, true, None));
             }
             if self.needs_fixed_mode_row_measurement {
                 let min_size = style.min_height().to_px(participant_block_basis);
@@ -2218,8 +2241,7 @@ impl TableFormattingContext {
             // https://drafts.csswg.org/css2/#height-layout
             // The baseline of a cell is the baseline of the first in-flow line box in the cell, or the first in-flow
             // table-row in the cell, whichever comes first.
-            let baseline =
-                measured_baseline.unwrap_or_else(|| self.cell_box_baseline(cell.box_, committing_run_baselines));
+            let baseline = self.cell_box_baseline(cell.box_, content_baselines);
             self.cells[cell_index].baseline = baseline;
             // Implements https://www.w3.org/TR/css-tables-3/#computing-the-table-height
 
@@ -2324,9 +2346,10 @@ impl TableFormattingContext {
             self.cell_inside_layout_inputs[cell_index] = inner;
             // The first pass measured this cell at its automatic block size; measure it again at
             // the percentage-resolved size to preserve the baseline its final inside layout will use.
-            let baseline = self
+            let content_baselines = self
                 .measure_cell(cell, &used, inner, false)
-                .map_or_else(|| self.box_baseline(cell.box_), |measured| measured.first_baseline);
+                .map(|measured| measured.baselines);
+            let baseline = self.cell_box_baseline(cell.box_, content_baselines);
             self.cells[cell_index].baseline = baseline;
             if !self.rows[cell.row_index].is_collapsed {
                 let border_size = used.border_box_block_size(collapsed);

--- a/Tests/LibWeb/Text/expected/intrinsic-size-cache-anonymous-cell-font-size.txt
+++ b/Tests/LibWeb/Text/expected/intrinsic-size-cache-anonymous-cell-font-size.txt
@@ -1,0 +1,2 @@
+grew: true
+width ratio: 2

--- a/Tests/LibWeb/Text/expected/table-cell-measurement-cache-misses.txt
+++ b/Tests/LibWeb/Text/expected/table-cell-measurement-cache-misses.txt
@@ -1,0 +1,6 @@
+cells: 120
+misses during the initial layout: 120
+misses after restyling the table: 0
+misses after inserting an abspos marker into one cell: 1
+table height unchanged by the marker: true
+misses after changing the text of another cell: 1

--- a/Tests/LibWeb/Text/input/intrinsic-size-cache-anonymous-cell-font-size.html
+++ b/Tests/LibWeb/Text/input/intrinsic-size-cache-anonymous-cell-font-size.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #outer { display: table; font-size: 12px; }
+</style>
+<div id="outer">words words words</div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+
+        const outer = document.getElementById("outer");
+        const widthBefore = outer.getBoundingClientRect().width;
+
+        outer.style.fontSize = "24px";
+        const widthAfter = outer.getBoundingClientRect().width;
+
+        println(`grew: ${widthAfter > widthBefore}`);
+        println(`width ratio: ${widthAfter / widthBefore}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/table-cell-measurement-cache-misses.html
+++ b/Tests/LibWeb/Text/input/table-cell-measurement-cache-misses.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    table { border-collapse: collapse; width: 400px; }
+    td { padding: 0 4px; font: 12px monospace; vertical-align: middle; }
+    td.num { width: 1%; position: relative; }
+    .marker { position: absolute; left: 0; top: 0; width: 8px; height: 8px; background: green; }
+</style>
+<table id="table"><tbody id="rows"></tbody></table>
+<script>
+    test(() => {
+        const ROWS = 40;
+        const parts = [];
+        for (let i = 0; i < ROWS; ++i)
+            parts.push(`<tr><td class="num">${i}</td><td class="num">${i}</td><td>line ${i} with <span>some</span> <b>markup</b></td></tr>`);
+        document.getElementById("rows").innerHTML = parts.join("");
+        const cells = document.querySelectorAll("td");
+        const table = document.getElementById("table");
+
+        const lines = [];
+        const missesAfterLayout = () => {
+            document.body.offsetHeight;
+            return internals.tableCellMeasurementCacheMissCount();
+        };
+
+        let misses = missesAfterLayout();
+        lines.push(`cells: ${cells.length}`);
+        lines.push(`misses during the initial layout: ${misses}`);
+
+        table.style.marginTop = "10px";
+        let previous = misses;
+        misses = missesAfterLayout();
+        lines.push(`misses after restyling the table: ${misses - previous}`);
+
+        const heightBefore = table.getBoundingClientRect().height;
+        const marker = document.createElement("span");
+        marker.className = "marker";
+        cells[3].appendChild(marker);
+        previous = misses;
+        misses = missesAfterLayout();
+        lines.push(`misses after inserting an abspos marker into one cell: ${misses - previous}`);
+        lines.push(`table height unchanged by the marker: ${table.getBoundingClientRect().height === heightBefore}`);
+
+        cells[8].firstChild.data = "changed";
+        previous = misses;
+        misses = missesAfterLayout();
+        lines.push(`misses after changing the text of another cell: ${misses - previous}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
The table formatting context measures the content of every cell whose
inside layout is deferred (any vertical-align keyword, so every ordinary
cell) in a throwaway state before row heights are known, and those
measurement runs are uncacheable by design because they commit no
fragments. A mutation inside one cell of a large table therefore
re-measured every cell on the next layout, thousands of measurement
runs for a table with a thousand rows, of which the changed cell
accounted for one. The measurement depends only on the cell's subtree
and on the inputs the table seeds into the throwaway root, so it is now
memoized in the cell's intrinsic size cache slot, keyed on those inputs
and invalidated by the slot's epoch like the other intrinsic sizes. The
same mutation now re-measures only the changed cell, which roughly
halves the layout pass for such tables, and
internals.tableCellMeasurementCacheMissCount() lets the new test pin
the per-mutation miss count.