### PR TITLE
LibWeb: Preserve more layout trees during incremental updates

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -827,6 +827,7 @@ struct AnimatedPropertyInvalidation {
 static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_properties(CSS::AnimatedProperties const* old_properties, CSS::AnimatedProperties const* new_properties, DOM::AbstractElement const& target)
 {
     AnimatedPropertyInvalidation result;
+    auto current_style = target.computed_style();
     auto old_and_new_properties = MUST(Bitmap::create(CSS::number_of_longhand_properties, 0));
     bool text_decoration_line_animated = false;
     if (old_properties) {
@@ -843,6 +844,18 @@ static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_p
         auto property_id = static_cast<CSS::PropertyID>(i);
         auto const* old_value = animated_property_value(old_properties, property_id);
         auto const* new_value = animated_property_value(new_properties, property_id);
+        RefPtr<CSS::StyleValue const> old_effective_value;
+        RefPtr<CSS::StyleValue const> new_effective_value;
+        // Box-type adjustments can add a synthetic animated value for a property not covered by
+        // the effect. Compare that value with the effective style instead of treating it as new.
+        if (!old_value && current_style) {
+            old_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::Yes);
+            old_value = old_effective_value.ptr();
+        }
+        if (!new_value && current_style) {
+            new_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::No);
+            new_value = new_effective_value.ptr();
+        }
         if (!old_value && !new_value)
             continue;
         if (old_value && new_value && old_value->equals(*new_value))

--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -179,6 +179,10 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // NB: Called during DOM text mutation, layout is stale.
     if (is<Text>(*this)) {
+        if (auto* parent = this->parent()) {
+            if (auto* first_letter_owner = parent->first_letter_owner_for_layout_subtree_from(*parent))
+                first_letter_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::CharacterDataReplaceData);
+        }
         if (is<Layout::TextSliceNode>(unsafe_layout_node())) {
             // NB: Slice nodes cache data that is calculated at layout tree construction time.
             // So for them, we need to invalidate the layout tree, not just layout.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1769,6 +1769,7 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
         }
     }
     if (is_connected()) {
+        set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeInsertBefore);
         new_parent.set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeInsertBefore);
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -121,6 +121,50 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
             Previous,
             Next,
         };
+
+        Node const* last_layout_child = nullptr;
+        for (auto layout_child = layout_node->first_child(); layout_child; layout_child = layout_child->next_sibling())
+            last_layout_child = layout_child.ptr();
+        auto const* trailing_inline_wrapper = last_layout_child && last_layout_child->is_anonymous() && last_layout_child->children_are_inline()
+                && !last_layout_child->is_generated_for_pseudo_element()
+            ? last_layout_child
+            : nullptr;
+        bool will_join_trailing_inline_wrapper = false;
+
+        auto can_place_next_to_layout_node = [&](Node const* sibling_layout_node, SiblingDirection direction, Optional<CSS::PseudoElement> pseudo_element) {
+            if (!sibling_layout_node)
+                return true;
+            if (auto const* node_with_style = as_if<NodeWithStyle>(*sibling_layout_node); node_with_style && node_with_style->is_out_of_flow()) {
+                if (pseudo_element.has_value() || direction == SiblingDirection::Next)
+                    return false;
+            }
+
+            while (sibling_layout_node->parent() && sibling_layout_node->parent() != layout_node)
+                sibling_layout_node = sibling_layout_node->parent();
+            if (sibling_layout_node->parent() != layout_node)
+                return false;
+            if (pseudo_element.has_value()) {
+                // ::after cannot anchor a newly appended anonymous wrapper. In normal flow,
+                // inline ::before content also has to remain in its existing inline run, while
+                // blockified flex/grid pseudo-elements remain separate items.
+                if (direction == SiblingDirection::Next)
+                    return layout_node->children_are_inline();
+
+                auto pseudo_style = element->computed_style(*pseudo_element);
+                auto parent_display = layout_node->display();
+                auto pseudo_belongs_to_inline_run = pseudo_style
+                    && (pseudo_style->display().is_inline_outside() || pseudo_style->display().is_contents())
+                    && !parent_display.is_flex_inside() && !parent_display.is_grid_inside();
+                return layout_node->children_are_inline() || !pseudo_belongs_to_inline_run;
+            }
+            if (sibling_layout_node->is_anonymous()) {
+                if (sibling_layout_node != trailing_inline_wrapper)
+                    return false;
+                will_join_trailing_inline_wrapper = true;
+            }
+            return true;
+        };
+
         auto can_place_next_to_sibling = [&](DOM::Node const* sibling, SiblingDirection direction) {
             for (; sibling; sibling = direction == SiblingDirection::Next ? sibling->next_sibling() : sibling->previous_sibling()) {
                 if (auto const* sibling_element = as_if<DOM::Element>(*sibling)) {
@@ -132,30 +176,32 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
                 auto const* sibling_layout_node = sibling->unsafe_layout_node();
                 if (!sibling_layout_node)
                     continue;
-                while (sibling_layout_node->parent() && sibling_layout_node->parent() != layout_node)
-                    sibling_layout_node = sibling_layout_node->parent();
-                if (sibling_layout_node->parent() != layout_node)
-                    return false;
-                if (!sibling_layout_node->is_anonymous())
-                    return true;
-
-                // Incremental inline insertion can only join the trailing anonymous wrapper.
-                // A full rebuild joins whitespace to an adjacent earlier inline run instead.
-                return !sibling_layout_node->next_sibling()
-                    && sibling_layout_node->children_are_inline();
+                return can_place_next_to_layout_node(sibling_layout_node, direction, {});
             }
-            return true;
+
+            auto pseudo_element = direction == SiblingDirection::Previous
+                ? CSS::PseudoElement::Before
+                : CSS::PseudoElement::After;
+            return can_place_next_to_layout_node(element->pseudo_element_unsafe_layout_node(pseudo_element), direction, pseudo_element);
         };
 
-        return can_place_next_to_sibling(text.previous_sibling(), SiblingDirection::Previous)
-            && can_place_next_to_sibling(text.next_sibling(), SiblingDirection::Next);
+        if (!can_place_next_to_sibling(text.previous_sibling(), SiblingDirection::Previous)
+            || !can_place_next_to_sibling(text.next_sibling(), SiblingDirection::Next)) {
+            return false;
+        }
+
+        // Incremental inline insertion always reuses a trailing anonymous inline wrapper. If the
+        // whitespace belongs to a different run, only a full rebuild can place it correctly.
+        return !trailing_inline_wrapper || will_join_trailing_inline_wrapper;
     };
 
     auto const* first_letter_owner = node.first_letter_owner_for_layout_subtree_from(node);
 
+    bool has_pending_collapsing_whitespace_since_layout_node = false;
     bool pending_children_can_preserve_parent = true;
     for (auto const* child = node.first_child(); child; child = child->next_sibling()) {
         if (child->unsafe_layout_node()) {
+            has_pending_collapsing_whitespace_since_layout_node = false;
             if (child->needs_layout_tree_update() || child->child_needs_layout_tree_update()) {
                 pending_children_can_preserve_parent = false;
             }
@@ -167,6 +213,11 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
             && layout_node->white_space_collapse() == CSS::WhiteSpaceCollapse::Collapse
             && !first_letter_owner
             && collapsing_whitespace_can_be_inserted(*text)) {
+            if (has_pending_collapsing_whitespace_since_layout_node) {
+                pending_children_can_preserve_parent = false;
+                break;
+            }
+            has_pending_collapsing_whitespace_since_layout_node = true;
             continue;
         }
         auto const* child_element = as_if<DOM::Element>(*child);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -116,6 +116,41 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
     if (!element || !layout_node || element->shadow_root() || is<HTML::HTMLSlotElement>(*element))
         return false;
 
+    auto collapsing_whitespace_can_be_inserted = [&](DOM::Text const& text) {
+        enum class SiblingDirection {
+            Previous,
+            Next,
+        };
+        auto can_place_next_to_sibling = [&](DOM::Node const* sibling, SiblingDirection direction) {
+            for (; sibling; sibling = direction == SiblingDirection::Next ? sibling->next_sibling() : sibling->previous_sibling()) {
+                if (auto const* sibling_element = as_if<DOM::Element>(*sibling)) {
+                    auto computed_style = sibling_element->computed_style();
+                    if (computed_style && computed_style->display().is_contents())
+                        return false;
+                }
+
+                auto const* sibling_layout_node = sibling->unsafe_layout_node();
+                if (!sibling_layout_node)
+                    continue;
+                while (sibling_layout_node->parent() && sibling_layout_node->parent() != layout_node)
+                    sibling_layout_node = sibling_layout_node->parent();
+                if (sibling_layout_node->parent() != layout_node)
+                    return false;
+                if (!sibling_layout_node->is_anonymous())
+                    return true;
+
+                // Incremental inline insertion can only join the trailing anonymous wrapper.
+                // A full rebuild joins whitespace to an adjacent earlier inline run instead.
+                return !sibling_layout_node->next_sibling()
+                    && sibling_layout_node->children_are_inline();
+            }
+            return true;
+        };
+
+        return can_place_next_to_sibling(text.previous_sibling(), SiblingDirection::Previous)
+            && can_place_next_to_sibling(text.next_sibling(), SiblingDirection::Next);
+    };
+
     auto const* first_letter_owner = node.first_letter_owner_for_layout_subtree_from(node);
 
     bool pending_children_can_preserve_parent = true;
@@ -130,7 +165,8 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
             continue;
         if (auto const* text = as_if<DOM::Text>(*child); text && text->data().is_ascii_whitespace()
             && layout_node->white_space_collapse() == CSS::WhiteSpaceCollapse::Collapse
-            && !first_letter_owner) {
+            && !first_letter_owner
+            && collapsing_whitespace_can_be_inserted(*text)) {
             continue;
         }
         auto const* child_element = as_if<DOM::Element>(*child);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -116,6 +116,26 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
     if (!element || !layout_node || element->shadow_root() || is<HTML::HTMLSlotElement>(*element))
         return false;
 
+    bool has_pending_unboxed_child = false;
+    bool pending_children_cannot_create_layout_nodes = true;
+    for (auto const* child = node.first_child(); child; child = child->next_sibling()) {
+        if (child->unsafe_layout_node() || !child->needs_layout_tree_update())
+            continue;
+        has_pending_unboxed_child = true;
+        auto const* child_element = as_if<DOM::Element>(*child);
+        if (!child_element) {
+            pending_children_cannot_create_layout_nodes = false;
+            break;
+        }
+        auto computed_style = child_element->computed_style();
+        if (!computed_style || !computed_style->display().is_none()) {
+            pending_children_cannot_create_layout_nodes = false;
+            break;
+        }
+    }
+    if (has_pending_unboxed_child && pending_children_cannot_create_layout_nodes)
+        return true;
+
     auto parent_display = layout_node->display();
     auto parent_has_children = layout_node->has_children();
     auto parent_lays_out_flex_or_grid_children = parent_display.is_flex_inside() || parent_display.is_grid_inside();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -116,25 +116,40 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
     if (!element || !layout_node || element->shadow_root() || is<HTML::HTMLSlotElement>(*element))
         return false;
 
+    auto const* first_letter_owner = node.first_letter_owner_for_layout_subtree_from(node);
+
     bool has_pending_unboxed_child = false;
-    bool pending_children_cannot_create_layout_nodes = true;
+    bool pending_children_can_preserve_parent = true;
     for (auto const* child = node.first_child(); child; child = child->next_sibling()) {
-        if (child->unsafe_layout_node() || !child->needs_layout_tree_update())
+        if (child->unsafe_layout_node()) {
+            if (child->needs_layout_tree_update() || child->child_needs_layout_tree_update()) {
+                pending_children_can_preserve_parent = false;
+                break;
+            }
+            continue;
+        }
+        if (!child->needs_layout_tree_update())
             continue;
         has_pending_unboxed_child = true;
+        if (auto const* text = as_if<DOM::Text>(*child); text && text->data().is_ascii_whitespace()
+            && layout_node->white_space_collapse() == CSS::WhiteSpaceCollapse::Collapse
+            && !first_letter_owner) {
+            continue;
+        }
         auto const* child_element = as_if<DOM::Element>(*child);
         if (!child_element) {
-            pending_children_cannot_create_layout_nodes = false;
+            pending_children_can_preserve_parent = false;
             break;
         }
         auto computed_style = child_element->computed_style();
         if (!computed_style || !computed_style->display().is_none()) {
-            pending_children_cannot_create_layout_nodes = false;
+            pending_children_can_preserve_parent = false;
             break;
         }
     }
-    if (has_pending_unboxed_child && pending_children_cannot_create_layout_nodes)
+    if (has_pending_unboxed_child && pending_children_can_preserve_parent) {
         return true;
+    }
 
     auto parent_display = layout_node->display();
     auto parent_has_children = layout_node->has_children();
@@ -146,7 +161,7 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
     if (!parent_lays_out_flex_or_grid_children && !parent_lays_out_inline_children && !parent_lays_out_block_children) {
         return false;
     }
-    if (node.first_letter_owner_for_layout_subtree_from(node))
+    if (first_letter_owner)
         return false;
 
     bool will_insert_inline_child = false;
@@ -1486,6 +1501,25 @@ static void ffi_insert_child(void*, void* parent_pointer, void* child_pointer, R
     VERIFY(mode == RustFFI::FfiInsertionMode::InDomOrder);
     auto* dom_node = child->dom_node();
     VERIFY(dom_node);
+
+    // An inline child of a block container with block children is placed in a newly appended
+    // anonymous wrapper. Move that empty wrapper to the child's DOM position before filling it.
+    if (parent.is_anonymous() && !parent.has_children()) {
+        if (auto* wrapper_parent = parent.parent()) {
+            for (auto* sibling = dom_node->next_sibling(); sibling; sibling = sibling->next_sibling()) {
+                auto* sibling_layout_node = sibling->unsafe_layout_node();
+                while (sibling_layout_node && sibling_layout_node->parent() != wrapper_parent)
+                    sibling_layout_node = sibling_layout_node->parent();
+                if (!sibling_layout_node || sibling_layout_node == &parent)
+                    continue;
+                NonnullRefPtr wrapper = parent;
+                wrapper_parent->remove_child(parent);
+                wrapper_parent->insert_before(move(wrapper), sibling_layout_node);
+                break;
+            }
+        }
+    }
+
     for (auto* sibling = dom_node->next_sibling(); sibling; sibling = sibling->next_sibling()) {
         auto* sibling_layout_node = sibling->unsafe_layout_node();
         if (sibling_layout_node && sibling_layout_node->parent() == &parent) {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -118,19 +118,16 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
 
     auto const* first_letter_owner = node.first_letter_owner_for_layout_subtree_from(node);
 
-    bool has_pending_unboxed_child = false;
     bool pending_children_can_preserve_parent = true;
     for (auto const* child = node.first_child(); child; child = child->next_sibling()) {
         if (child->unsafe_layout_node()) {
             if (child->needs_layout_tree_update() || child->child_needs_layout_tree_update()) {
                 pending_children_can_preserve_parent = false;
-                break;
             }
             continue;
         }
         if (!child->needs_layout_tree_update())
             continue;
-        has_pending_unboxed_child = true;
         if (auto const* text = as_if<DOM::Text>(*child); text && text->data().is_ascii_whitespace()
             && layout_node->white_space_collapse() == CSS::WhiteSpaceCollapse::Collapse
             && !first_letter_owner) {
@@ -147,9 +144,10 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
             break;
         }
     }
-    if (has_pending_unboxed_child && pending_children_can_preserve_parent) {
+    // An empty set means every insertion was canceled before layout. Moves are marked dirty at
+    // their destination, so they still enter one of the rejection paths above.
+    if (pending_children_can_preserve_parent)
         return true;
-    }
 
     auto parent_display = layout_node->display();
     auto parent_has_children = layout_node->has_children();

--- a/Tests/LibWeb/Text/expected/css/animation-box-adjustment-skips-layout.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-box-adjustment-skips-layout.txt
@@ -1,0 +1,1 @@
+full layouts: 0

--- a/Tests/LibWeb/Text/expected/layout-tree-update/hidden-child-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/hidden-child-insertion-preservation.txt
@@ -1,3 +1,5 @@
 parent preserved: true
 child preserved: true
+transient parent preserved: true
+transient child preserved: true
 incremental tree matches: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/hidden-child-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/hidden-child-insertion-preservation.txt
@@ -1,0 +1,3 @@
+parent preserved: true
+child preserved: true
+incremental tree matches: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
@@ -37,6 +37,9 @@ PASS: insert around block children | insert whitespace between blocks | incremen
 PASS: insert around block children | append whitespace | preserve
 PASS: insert around block children | append whitespace | layout tree builds=1
 PASS: insert around block children | append whitespace | incremental tree matches full rebuild
+PASS: insert around block children | rebuild before blocks with trailing run | rebuild
+PASS: insert around block children | rebuild before blocks with trailing run | layout tree builds=1
+PASS: insert around block children | rebuild before blocks with trailing run | incremental tree matches full rebuild
 PASS: insert around flex items | prepend whitespace | preserve
 PASS: insert around flex items | prepend whitespace | layout tree builds=1
 PASS: insert around flex items | prepend whitespace | incremental tree matches full rebuild
@@ -46,6 +49,9 @@ PASS: insert around flex items | insert whitespace between items | incremental t
 PASS: insert around flex items | append whitespace | preserve
 PASS: insert around flex items | append whitespace | layout tree builds=1
 PASS: insert around flex items | append whitespace | incremental tree matches full rebuild
+PASS: insert around flex items | rebuild before items with trailing text item | rebuild
+PASS: insert around flex items | rebuild before items with trailing text item | layout tree builds=1
+PASS: insert around flex items | rebuild before items with trailing text item | incremental tree matches full rebuild
 PASS: insert around grid items | prepend whitespace | preserve
 PASS: insert around grid items | prepend whitespace | layout tree builds=1
 PASS: insert around grid items | prepend whitespace | incremental tree matches full rebuild
@@ -55,12 +61,237 @@ PASS: insert around grid items | insert whitespace between items | incremental t
 PASS: insert around grid items | append whitespace | preserve
 PASS: insert around grid items | append whitespace | layout tree builds=1
 PASS: insert around grid items | append whitespace | incremental tree matches full rebuild
+PASS: insert around grid items | rebuild between items with trailing text item | rebuild
+PASS: insert around grid items | rebuild between items with trailing text item | layout tree builds=1
+PASS: insert around grid items | rebuild between items with trailing text item | incremental tree matches full rebuild
 PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | preserve
 PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | layout tree builds=1
 PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | incremental tree matches full rebuild
 PASS: insert multiple whitespace nodes | insert at supported positions | preserve
 PASS: insert multiple whitespace nodes | insert at supported positions | layout tree builds=1
 PASS: insert multiple whitespace nodes | insert at supported positions | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between blocks | rebuild for adjacent spaces | rebuild
+PASS: insert adjacent whitespace nodes between blocks | rebuild for adjacent spaces | layout tree builds=1
+PASS: insert adjacent whitespace nodes between blocks | rebuild for adjacent spaces | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between blocks | rebuild when extending the anonymous run | rebuild
+PASS: insert adjacent whitespace nodes between blocks | rebuild when extending the anonymous run | layout tree builds=1
+PASS: insert adjacent whitespace nodes between blocks | rebuild when extending the anonymous run | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between flex items | rebuild for adjacent spaces | rebuild
+PASS: insert adjacent whitespace nodes between flex items | rebuild for adjacent spaces | layout tree builds=1
+PASS: insert adjacent whitespace nodes between flex items | rebuild for adjacent spaces | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between flex items | rebuild when extending the anonymous item | rebuild
+PASS: insert adjacent whitespace nodes between flex items | rebuild when extending the anonymous item | layout tree builds=1
+PASS: insert adjacent whitespace nodes between flex items | rebuild when extending the anonymous item | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between grid items | rebuild for adjacent spaces | rebuild
+PASS: insert adjacent whitespace nodes between grid items | rebuild for adjacent spaces | layout tree builds=1
+PASS: insert adjacent whitespace nodes between grid items | rebuild for adjacent spaces | incremental tree matches full rebuild
+PASS: insert adjacent whitespace nodes between grid items | rebuild when extending the anonymous item | rebuild
+PASS: insert adjacent whitespace nodes between grid items | rebuild when extending the anonymous item | layout tree builds=1
+PASS: insert adjacent whitespace nodes between grid items | rebuild when extending the anonymous item | incremental tree matches full rebuild
+PASS: insert whitespace interleaved with hidden nodes | rebuild for interleaved batch | rebuild
+PASS: insert whitespace interleaved with hidden nodes | rebuild for interleaved batch | layout tree builds=1
+PASS: insert whitespace interleaved with hidden nodes | rebuild for interleaved batch | incremental tree matches full rebuild
+PASS: trailing inline run changes block insertion | create trailing run | preserve
+PASS: trailing inline run changes block insertion | create trailing run | layout tree builds=1
+PASS: trailing inline run changes block insertion | create trailing run | incremental tree matches full rebuild
+PASS: trailing inline run changes block insertion | rebuild for earlier new run | rebuild
+PASS: trailing inline run changes block insertion | rebuild for earlier new run | layout tree builds=1
+PASS: trailing inline run changes block insertion | rebuild for earlier new run | incremental tree matches full rebuild
+PASS: trailing inline run changes block insertion | rebuild beside non-trailing middle run | rebuild
+PASS: trailing inline run changes block insertion | rebuild beside non-trailing middle run | layout tree builds=1
+PASS: trailing inline run changes block insertion | rebuild beside non-trailing middle run | incremental tree matches full rebuild
+PASS: trailing text item changes flex insertion | create trailing text item | preserve
+PASS: trailing text item changes flex insertion | create trailing text item | layout tree builds=1
+PASS: trailing text item changes flex insertion | create trailing text item | incremental tree matches full rebuild
+PASS: trailing text item changes flex insertion | rebuild for earlier text item | rebuild
+PASS: trailing text item changes flex insertion | rebuild for earlier text item | layout tree builds=1
+PASS: trailing text item changes flex insertion | rebuild for earlier text item | incremental tree matches full rebuild
+PASS: trailing text item changes flex insertion | rebuild beside non-trailing middle item | rebuild
+PASS: trailing text item changes flex insertion | rebuild beside non-trailing middle item | layout tree builds=1
+PASS: trailing text item changes flex insertion | rebuild beside non-trailing middle item | incremental tree matches full rebuild
+PASS: trailing text item changes grid insertion | create trailing text item | preserve
+PASS: trailing text item changes grid insertion | create trailing text item | layout tree builds=1
+PASS: trailing text item changes grid insertion | create trailing text item | incremental tree matches full rebuild
+PASS: trailing text item changes grid insertion | rebuild for earlier text item | rebuild
+PASS: trailing text item changes grid insertion | rebuild for earlier text item | layout tree builds=1
+PASS: trailing text item changes grid insertion | rebuild for earlier text item | incremental tree matches full rebuild
+PASS: trailing text item changes grid insertion | rebuild beside non-trailing middle item | rebuild
+PASS: trailing text item changes grid insertion | rebuild beside non-trailing middle item | layout tree builds=1
+PASS: trailing text item changes grid insertion | rebuild beside non-trailing middle item | incremental tree matches full rebuild
+PASS: absolute before block progression | insert before absolute | rebuild
+PASS: absolute before block progression | insert before absolute | layout tree builds=1
+PASS: absolute before block progression | insert before absolute | incremental tree matches full rebuild
+PASS: absolute before block progression | insert between absolute and block | rebuild
+PASS: absolute before block progression | insert between absolute and block | layout tree builds=1
+PASS: absolute before block progression | insert between absolute and block | incremental tree matches full rebuild
+PASS: absolute before block progression | preserve after block | preserve
+PASS: absolute before block progression | preserve after block | layout tree builds=1
+PASS: absolute before block progression | preserve after block | incremental tree matches full rebuild
+PASS: absolute after block progression | insert after absolute | preserve
+PASS: absolute after block progression | insert after absolute | layout tree builds=1
+PASS: absolute after block progression | insert after absolute | incremental tree matches full rebuild
+PASS: absolute after block progression | insert before absolute | rebuild
+PASS: absolute after block progression | insert before absolute | layout tree builds=1
+PASS: absolute after block progression | insert before absolute | incremental tree matches full rebuild
+PASS: absolute after block progression | insert before block | rebuild
+PASS: absolute after block progression | insert before block | layout tree builds=1
+PASS: absolute after block progression | insert before block | incremental tree matches full rebuild
+PASS: float before block progression | insert before float | rebuild
+PASS: float before block progression | insert before float | layout tree builds=1
+PASS: float before block progression | insert before float | incremental tree matches full rebuild
+PASS: float before block progression | insert between float and block | rebuild
+PASS: float before block progression | insert between float and block | layout tree builds=1
+PASS: float before block progression | insert between float and block | incremental tree matches full rebuild
+PASS: float before block progression | preserve after block | preserve
+PASS: float before block progression | preserve after block | layout tree builds=1
+PASS: float before block progression | preserve after block | incremental tree matches full rebuild
+PASS: float after block progression | insert after float | preserve
+PASS: float after block progression | insert after float | layout tree builds=1
+PASS: float after block progression | insert after float | incremental tree matches full rebuild
+PASS: float after block progression | insert before float | rebuild
+PASS: float after block progression | insert before float | layout tree builds=1
+PASS: float after block progression | insert before float | incremental tree matches full rebuild
+PASS: float after block progression | insert before block | rebuild
+PASS: float after block progression | insert before block | layout tree builds=1
+PASS: float after block progression | insert before block | incremental tree matches full rebuild
+PASS: absolute before flex item progression | rebuild before absolute | rebuild
+PASS: absolute before flex item progression | rebuild before absolute | layout tree builds=1
+PASS: absolute before flex item progression | rebuild before absolute | incremental tree matches full rebuild
+PASS: absolute before flex item progression | preserve after absolute | preserve
+PASS: absolute before flex item progression | preserve after absolute | layout tree builds=1
+PASS: absolute before flex item progression | preserve after absolute | incremental tree matches full rebuild
+PASS: absolute before flex item progression | preserve after final item | preserve
+PASS: absolute before flex item progression | preserve after final item | layout tree builds=1
+PASS: absolute before flex item progression | preserve after final item | incremental tree matches full rebuild
+PASS: absolute after flex item progression | insert after absolute | preserve
+PASS: absolute after flex item progression | insert after absolute | layout tree builds=1
+PASS: absolute after flex item progression | insert after absolute | incremental tree matches full rebuild
+PASS: absolute after flex item progression | rebuild before absolute | rebuild
+PASS: absolute after flex item progression | rebuild before absolute | layout tree builds=1
+PASS: absolute after flex item progression | rebuild before absolute | incremental tree matches full rebuild
+PASS: absolute after flex item progression | rebuild before item | rebuild
+PASS: absolute after flex item progression | rebuild before item | layout tree builds=1
+PASS: absolute after flex item progression | rebuild before item | incremental tree matches full rebuild
+PASS: generated before inline progression | rebuild between before and block | rebuild
+PASS: generated before inline progression | rebuild between before and block | layout tree builds=1
+PASS: generated before inline progression | rebuild between before and block | incremental tree matches full rebuild
+PASS: generated before inline progression | preserve after block | preserve
+PASS: generated before inline progression | preserve after block | layout tree builds=1
+PASS: generated before inline progression | preserve after block | incremental tree matches full rebuild
+PASS: generated before inline progression | preserve in trailing inline run | preserve
+PASS: generated before inline progression | preserve in trailing inline run | layout tree builds=1
+PASS: generated before inline progression | preserve in trailing inline run | incremental tree matches full rebuild
+PASS: generated before inline progression | rebuild beside before again | rebuild
+PASS: generated before inline progression | rebuild beside before again | layout tree builds=1
+PASS: generated before inline progression | rebuild beside before again | incremental tree matches full rebuild
+PASS: generated after inline progression | rebuild before block with trailing after run | rebuild
+PASS: generated after inline progression | rebuild before block with trailing after run | layout tree builds=1
+PASS: generated after inline progression | rebuild before block with trailing after run | incremental tree matches full rebuild
+PASS: generated after inline progression | rebuild before trailing after run | rebuild
+PASS: generated after inline progression | rebuild before trailing after run | layout tree builds=1
+PASS: generated after inline progression | rebuild before trailing after run | incremental tree matches full rebuild
+PASS: generated after inline progression | rebuild beside trailing after run | rebuild
+PASS: generated after inline progression | rebuild beside trailing after run | layout tree builds=1
+PASS: generated after inline progression | rebuild beside trailing after run | incremental tree matches full rebuild
+PASS: generated before and after inline progression | rebuild beside before | rebuild
+PASS: generated before and after inline progression | rebuild beside before | layout tree builds=1
+PASS: generated before and after inline progression | rebuild beside before | incremental tree matches full rebuild
+PASS: generated before and after inline progression | rebuild before trailing after run | rebuild
+PASS: generated before and after inline progression | rebuild before trailing after run | layout tree builds=1
+PASS: generated before and after inline progression | rebuild before trailing after run | incremental tree matches full rebuild
+PASS: generated before and after inline progression | rebuild beside before again | rebuild
+PASS: generated before and after inline progression | rebuild beside before again | layout tree builds=1
+PASS: generated before and after inline progression | rebuild beside before again | incremental tree matches full rebuild
+PASS: generated inline in all-inline flow | insert after before | preserve
+PASS: generated inline in all-inline flow | insert after before | layout tree builds=1
+PASS: generated inline in all-inline flow | insert after before | incremental tree matches full rebuild
+PASS: generated inline in all-inline flow | insert before after | preserve
+PASS: generated inline in all-inline flow | insert before after | layout tree builds=1
+PASS: generated inline in all-inline flow | insert before after | incremental tree matches full rebuild
+PASS: generated inline in all-inline flow | insert beside DOM inline | preserve
+PASS: generated inline in all-inline flow | insert beside DOM inline | layout tree builds=1
+PASS: generated inline in all-inline flow | insert beside DOM inline | incremental tree matches full rebuild
+PASS: generated before inline-block | rebuild between before and block | rebuild
+PASS: generated before inline-block | rebuild between before and block | layout tree builds=1
+PASS: generated before inline-block | rebuild between before and block | incremental tree matches full rebuild
+PASS: generated before display contents | rebuild between before and block | rebuild
+PASS: generated before display contents | rebuild between before and block | layout tree builds=1
+PASS: generated before display contents | rebuild between before and block | incremental tree matches full rebuild
+PASS: generated before display contents | preserve after block | preserve
+PASS: generated before display contents | preserve after block | layout tree builds=1
+PASS: generated before display contents | preserve after block | incremental tree matches full rebuild
+PASS: generated before block progression | preserve between generated and DOM blocks | preserve
+PASS: generated before block progression | preserve between generated and DOM blocks | layout tree builds=1
+PASS: generated before block progression | preserve between generated and DOM blocks | incremental tree matches full rebuild
+PASS: generated before block progression | preserve after DOM block | preserve
+PASS: generated before block progression | preserve after DOM block | layout tree builds=1
+PASS: generated before block progression | preserve after DOM block | incremental tree matches full rebuild
+PASS: generated after block progression | preserve before DOM block | preserve
+PASS: generated after block progression | preserve before DOM block | layout tree builds=1
+PASS: generated after block progression | preserve before DOM block | incremental tree matches full rebuild
+PASS: generated after block progression | rebuild before generated block | rebuild
+PASS: generated after block progression | rebuild before generated block | layout tree builds=1
+PASS: generated after block progression | rebuild before generated block | incremental tree matches full rebuild
+PASS: generated before absolute progression | rebuild after generated absolute | rebuild
+PASS: generated before absolute progression | rebuild after generated absolute | layout tree builds=1
+PASS: generated before absolute progression | rebuild after generated absolute | incremental tree matches full rebuild
+PASS: generated before absolute progression | preserve after DOM block | preserve
+PASS: generated before absolute progression | preserve after DOM block | layout tree builds=1
+PASS: generated before absolute progression | preserve after DOM block | incremental tree matches full rebuild
+PASS: generated after absolute progression | preserve before DOM block | preserve
+PASS: generated after absolute progression | preserve before DOM block | layout tree builds=1
+PASS: generated after absolute progression | preserve before DOM block | incremental tree matches full rebuild
+PASS: generated after absolute progression | rebuild before generated absolute | rebuild
+PASS: generated after absolute progression | rebuild before generated absolute | layout tree builds=1
+PASS: generated after absolute progression | rebuild before generated absolute | incremental tree matches full rebuild
+PASS: generated before float progression | rebuild after generated float | rebuild
+PASS: generated before float progression | rebuild after generated float | layout tree builds=1
+PASS: generated before float progression | rebuild after generated float | incremental tree matches full rebuild
+PASS: generated before float progression | preserve after DOM block | preserve
+PASS: generated before float progression | preserve after DOM block | layout tree builds=1
+PASS: generated before float progression | preserve after DOM block | incremental tree matches full rebuild
+PASS: generated after float progression | preserve before DOM block | preserve
+PASS: generated after float progression | preserve before DOM block | layout tree builds=1
+PASS: generated after float progression | preserve before DOM block | incremental tree matches full rebuild
+PASS: generated after float progression | rebuild before generated float | rebuild
+PASS: generated after float progression | rebuild before generated float | layout tree builds=1
+PASS: generated after float progression | rebuild before generated float | incremental tree matches full rebuild
+PASS: list marker progression | prepend after marker | preserve
+PASS: list marker progression | prepend after marker | layout tree builds=1
+PASS: list marker progression | prepend after marker | incremental tree matches full rebuild
+PASS: list marker progression | append after block | preserve
+PASS: list marker progression | append after block | layout tree builds=1
+PASS: list marker progression | append after block | incremental tree matches full rebuild
+PASS: generated before inline in flex | preserve between before and item | preserve
+PASS: generated before inline in flex | preserve between before and item | layout tree builds=1
+PASS: generated before inline in flex | preserve between before and item | incremental tree matches full rebuild
+PASS: generated before inline in flex | preserve after final item | preserve
+PASS: generated before inline in flex | preserve after final item | layout tree builds=1
+PASS: generated before inline in flex | preserve after final item | incremental tree matches full rebuild
+PASS: generated before inline in grid | preserve between before and item | preserve
+PASS: generated before inline in grid | preserve between before and item | layout tree builds=1
+PASS: generated before inline in grid | preserve between before and item | incremental tree matches full rebuild
+PASS: generated before inline in grid | preserve after final item | preserve
+PASS: generated before inline in grid | preserve after final item | layout tree builds=1
+PASS: generated before inline in grid | preserve after final item | incremental tree matches full rebuild
+PASS: generated after content in flex | preserve before item | preserve
+PASS: generated after content in flex | preserve before item | layout tree builds=1
+PASS: generated after content in flex | preserve before item | incremental tree matches full rebuild
+PASS: generated after content in flex | rebuild before trailing after item | rebuild
+PASS: generated after content in flex | rebuild before trailing after item | layout tree builds=1
+PASS: generated after content in flex | rebuild before trailing after item | incremental tree matches full rebuild
+PASS: generated after block in grid | preserve before DOM item | preserve
+PASS: generated after block in grid | preserve before DOM item | layout tree builds=1
+PASS: generated after block in grid | preserve before DOM item | incremental tree matches full rebuild
+PASS: generated after block in grid | rebuild before generated item | rebuild
+PASS: generated after block in grid | rebuild before generated item | layout tree builds=1
+PASS: generated after block in grid | rebuild before generated item | incremental tree matches full rebuild
+PASS: generated before inline with hidden insertion | rebuild for whitespace beside before | rebuild
+PASS: generated before inline with hidden insertion | rebuild for whitespace beside before | layout tree builds=1
+PASS: generated before inline with hidden insertion | rebuild for whitespace beside before | incremental tree matches full rebuild
+PASS: generated before inline with batched positions | rebuild all positions for unsafe leading whitespace | rebuild
+PASS: generated before inline with batched positions | rebuild all positions for unsafe leading whitespace | layout tree builds=1
+PASS: generated before inline with batched positions | rebuild all positions for unsafe leading whitespace | incremental tree matches full rebuild
 PASS: mixed block and inline progression | rebuild before block after inline run | rebuild
 PASS: mixed block and inline progression | rebuild before block after inline run | layout tree builds=1
 PASS: mixed block and inline progression | rebuild before block after inline run | incremental tree matches full rebuild
@@ -106,6 +337,9 @@ PASS: join trailing flex raw text | insert before raw text | incremental tree ma
 PASS: join trailing flex raw text | append after raw text | preserve
 PASS: join trailing flex raw text | append after raw text | layout tree builds=1
 PASS: join trailing flex raw text | append after raw text | incremental tree matches full rebuild
+PASS: join trailing flex raw text | rebuild before item with trailing text item | rebuild
+PASS: join trailing flex raw text | rebuild before item with trailing text item | layout tree builds=1
+PASS: join trailing flex raw text | rebuild before item with trailing text item | incremental tree matches full rebuild
 PASS: grid raw-text progression | rebuild before raw text | rebuild
 PASS: grid raw-text progression | rebuild before raw text | layout tree builds=1
 PASS: grid raw-text progression | rebuild before raw text | incremental tree matches full rebuild
@@ -121,6 +355,9 @@ PASS: join trailing grid raw text | insert before raw text | incremental tree ma
 PASS: join trailing grid raw text | append after raw text | preserve
 PASS: join trailing grid raw text | append after raw text | layout tree builds=1
 PASS: join trailing grid raw text | append after raw text | incremental tree matches full rebuild
+PASS: join trailing grid raw text | rebuild before item with trailing text item | rebuild
+PASS: join trailing grid raw text | rebuild before item with trailing text item | layout tree builds=1
+PASS: join trailing grid raw text | rebuild before item with trailing text item | incremental tree matches full rebuild
 PASS: rebuild beside display-contents inline run | insert whitespace | rebuild
 PASS: rebuild beside display-contents inline run | insert whitespace | layout tree builds=1
 PASS: rebuild beside display-contents inline run | insert whitespace | incremental tree matches full rebuild
@@ -142,6 +379,9 @@ PASS: rebuild for non-whitespace text | append text | incremental tree matches f
 PASS: rebuild under first-letter | append whitespace | rebuild
 PASS: rebuild under first-letter | append whitespace | layout tree builds=1
 PASS: rebuild under first-letter | append whitespace | incremental tree matches full rebuild
+PASS: rebuild under first-letter | append multiple whitespace nodes | rebuild
+PASS: rebuild under first-letter | append multiple whitespace nodes | layout tree builds=1
+PASS: rebuild under first-letter | append multiple whitespace nodes | incremental tree matches full rebuild
 PASS: rebuild under ancestor first-letter | append whitespace | rebuild
 PASS: rebuild under ancestor first-letter | append whitespace | layout tree builds=1
 PASS: rebuild under ancestor first-letter | append whitespace | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
@@ -1,0 +1,16 @@
+PASS: append beside anonymous inline run | preserve
+PASS: append beside anonymous inline run | incremental tree matches full rebuild
+PASS: insert into anonymous inline run | preserve
+PASS: insert into anonymous inline run | incremental tree matches full rebuild
+PASS: insert between block children | preserve
+PASS: insert between block children | incremental tree matches full rebuild
+PASS: append to flex parent | preserve
+PASS: append to flex parent | incremental tree matches full rebuild
+PASS: append to grid parent | preserve
+PASS: append to grid parent | incremental tree matches full rebuild
+PASS: rebuild for preserved whitespace | rebuild
+PASS: rebuild for preserved whitespace | incremental tree matches full rebuild
+PASS: rebuild under first-letter | rebuild
+PASS: rebuild under first-letter | incremental tree matches full rebuild
+PASS: rebuild with concurrent descendant update | rebuild
+PASS: rebuild with concurrent descendant update | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/whitespace-child-insertion-preservation.txt
@@ -1,16 +1,150 @@
-PASS: append beside anonymous inline run | preserve
-PASS: append beside anonymous inline run | incremental tree matches full rebuild
-PASS: insert into anonymous inline run | preserve
-PASS: insert into anonymous inline run | incremental tree matches full rebuild
-PASS: insert between block children | preserve
-PASS: insert between block children | incremental tree matches full rebuild
-PASS: append to flex parent | preserve
-PASS: append to flex parent | incremental tree matches full rebuild
-PASS: append to grid parent | preserve
-PASS: append to grid parent | incremental tree matches full rebuild
-PASS: rebuild for preserved whitespace | rebuild
-PASS: rebuild for preserved whitespace | incremental tree matches full rebuild
-PASS: rebuild under first-letter | rebuild
-PASS: rebuild under first-letter | incremental tree matches full rebuild
-PASS: rebuild with concurrent descendant update | rebuild
-PASS: rebuild with concurrent descendant update | incremental tree matches full rebuild
+PASS: append after trailing anonymous inline run | append whitespace | preserve
+PASS: append after trailing anonymous inline run | append whitespace | layout tree builds=1
+PASS: append after trailing anonymous inline run | append whitespace | incremental tree matches full rebuild
+PASS: append after trailing anonymous inline run | extend run | preserve
+PASS: append after trailing anonymous inline run | extend run | layout tree builds=1
+PASS: append after trailing anonymous inline run | extend run | incremental tree matches full rebuild
+PASS: insert within trailing anonymous inline run | insert before inline | preserve
+PASS: insert within trailing anonymous inline run | insert before inline | layout tree builds=1
+PASS: insert within trailing anonymous inline run | insert before inline | incremental tree matches full rebuild
+PASS: insert within trailing anonymous inline run | insert after inline | preserve
+PASS: insert within trailing anonymous inline run | insert after inline | layout tree builds=1
+PASS: insert within trailing anonymous inline run | insert after inline | incremental tree matches full rebuild
+PASS: insert in all-inline flow | prepend whitespace | preserve
+PASS: insert in all-inline flow | prepend whitespace | layout tree builds=1
+PASS: insert in all-inline flow | prepend whitespace | incremental tree matches full rebuild
+PASS: insert in all-inline flow | insert middle whitespace | preserve
+PASS: insert in all-inline flow | insert middle whitespace | layout tree builds=1
+PASS: insert in all-inline flow | insert middle whitespace | incremental tree matches full rebuild
+PASS: insert in all-inline flow | append whitespace | preserve
+PASS: insert in all-inline flow | append whitespace | layout tree builds=1
+PASS: insert in all-inline flow | append whitespace | incremental tree matches full rebuild
+PASS: insert in inline flow | prepend whitespace | preserve
+PASS: insert in inline flow | prepend whitespace | layout tree builds=1
+PASS: insert in inline flow | prepend whitespace | incremental tree matches full rebuild
+PASS: insert in inline flow | insert middle whitespace | preserve
+PASS: insert in inline flow | insert middle whitespace | layout tree builds=1
+PASS: insert in inline flow | insert middle whitespace | incremental tree matches full rebuild
+PASS: insert in inline flow | append whitespace | preserve
+PASS: insert in inline flow | append whitespace | layout tree builds=1
+PASS: insert in inline flow | append whitespace | incremental tree matches full rebuild
+PASS: insert around block children | prepend whitespace | preserve
+PASS: insert around block children | prepend whitespace | layout tree builds=1
+PASS: insert around block children | prepend whitespace | incremental tree matches full rebuild
+PASS: insert around block children | insert whitespace between blocks | preserve
+PASS: insert around block children | insert whitespace between blocks | layout tree builds=1
+PASS: insert around block children | insert whitespace between blocks | incremental tree matches full rebuild
+PASS: insert around block children | append whitespace | preserve
+PASS: insert around block children | append whitespace | layout tree builds=1
+PASS: insert around block children | append whitespace | incremental tree matches full rebuild
+PASS: insert around flex items | prepend whitespace | preserve
+PASS: insert around flex items | prepend whitespace | layout tree builds=1
+PASS: insert around flex items | prepend whitespace | incremental tree matches full rebuild
+PASS: insert around flex items | insert whitespace between items | preserve
+PASS: insert around flex items | insert whitespace between items | layout tree builds=1
+PASS: insert around flex items | insert whitespace between items | incremental tree matches full rebuild
+PASS: insert around flex items | append whitespace | preserve
+PASS: insert around flex items | append whitespace | layout tree builds=1
+PASS: insert around flex items | append whitespace | incremental tree matches full rebuild
+PASS: insert around grid items | prepend whitespace | preserve
+PASS: insert around grid items | prepend whitespace | layout tree builds=1
+PASS: insert around grid items | prepend whitespace | incremental tree matches full rebuild
+PASS: insert around grid items | insert whitespace between items | preserve
+PASS: insert around grid items | insert whitespace between items | layout tree builds=1
+PASS: insert around grid items | insert whitespace between items | incremental tree matches full rebuild
+PASS: insert around grid items | append whitespace | preserve
+PASS: insert around grid items | append whitespace | layout tree builds=1
+PASS: insert around grid items | append whitespace | incremental tree matches full rebuild
+PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | preserve
+PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | layout tree builds=1
+PASS: insert whitespace with hidden siblings | insert whitespace and display-none element | incremental tree matches full rebuild
+PASS: insert multiple whitespace nodes | insert at supported positions | preserve
+PASS: insert multiple whitespace nodes | insert at supported positions | layout tree builds=1
+PASS: insert multiple whitespace nodes | insert at supported positions | incremental tree matches full rebuild
+PASS: mixed block and inline progression | rebuild before block after inline run | rebuild
+PASS: mixed block and inline progression | rebuild before block after inline run | layout tree builds=1
+PASS: mixed block and inline progression | rebuild before block after inline run | incremental tree matches full rebuild
+PASS: mixed block and inline progression | preserve after final block | preserve
+PASS: mixed block and inline progression | preserve after final block | layout tree builds=1
+PASS: mixed block and inline progression | preserve after final block | incremental tree matches full rebuild
+PASS: mixed block and inline progression | preserve in new trailing inline run | preserve
+PASS: mixed block and inline progression | preserve in new trailing inline run | layout tree builds=1
+PASS: mixed block and inline progression | preserve in new trailing inline run | incremental tree matches full rebuild
+PASS: mixed block and inline progression | rebuild beside non-trailing inline run | rebuild
+PASS: mixed block and inline progression | rebuild beside non-trailing inline run | layout tree builds=1
+PASS: mixed block and inline progression | rebuild beside non-trailing inline run | incremental tree matches full rebuild
+PASS: rebuild before block after inline run | insert whitespace | rebuild
+PASS: rebuild before block after inline run | insert whitespace | layout tree builds=1
+PASS: rebuild before block after inline run | insert whitespace | incremental tree matches full rebuild
+PASS: rebuild beside non-trailing inline run | insert whitespace after preceding block | rebuild
+PASS: rebuild beside non-trailing inline run | insert whitespace after preceding block | layout tree builds=1
+PASS: rebuild beside non-trailing inline run | insert whitespace after preceding block | incremental tree matches full rebuild
+PASS: flow-root mixed-content progression | rebuild before block after inline run | rebuild
+PASS: flow-root mixed-content progression | rebuild before block after inline run | layout tree builds=1
+PASS: flow-root mixed-content progression | rebuild before block after inline run | incremental tree matches full rebuild
+PASS: flow-root mixed-content progression | preserve after final block | preserve
+PASS: flow-root mixed-content progression | preserve after final block | layout tree builds=1
+PASS: flow-root mixed-content progression | preserve after final block | incremental tree matches full rebuild
+PASS: rebuild all positions when one needs an earlier inline run | insert safe and unsafe whitespace | rebuild
+PASS: rebuild all positions when one needs an earlier inline run | insert safe and unsafe whitespace | layout tree builds=1
+PASS: rebuild all positions when one needs an earlier inline run | insert safe and unsafe whitespace | incremental tree matches full rebuild
+PASS: flex raw-text progression | rebuild after raw text before item | rebuild
+PASS: flex raw-text progression | rebuild after raw text before item | layout tree builds=1
+PASS: flex raw-text progression | rebuild after raw text before item | incremental tree matches full rebuild
+PASS: flex raw-text progression | preserve after final item | preserve
+PASS: flex raw-text progression | preserve after final item | layout tree builds=1
+PASS: flex raw-text progression | preserve after final item | incremental tree matches full rebuild
+PASS: flex raw-text progression | preserve in trailing text item | preserve
+PASS: flex raw-text progression | preserve in trailing text item | layout tree builds=1
+PASS: flex raw-text progression | preserve in trailing text item | incremental tree matches full rebuild
+PASS: rebuild before non-trailing flex raw text | insert whitespace | rebuild
+PASS: rebuild before non-trailing flex raw text | insert whitespace | layout tree builds=1
+PASS: rebuild before non-trailing flex raw text | insert whitespace | incremental tree matches full rebuild
+PASS: join trailing flex raw text | insert before raw text | preserve
+PASS: join trailing flex raw text | insert before raw text | layout tree builds=1
+PASS: join trailing flex raw text | insert before raw text | incremental tree matches full rebuild
+PASS: join trailing flex raw text | append after raw text | preserve
+PASS: join trailing flex raw text | append after raw text | layout tree builds=1
+PASS: join trailing flex raw text | append after raw text | incremental tree matches full rebuild
+PASS: grid raw-text progression | rebuild before raw text | rebuild
+PASS: grid raw-text progression | rebuild before raw text | layout tree builds=1
+PASS: grid raw-text progression | rebuild before raw text | incremental tree matches full rebuild
+PASS: grid raw-text progression | rebuild after raw text before item | rebuild
+PASS: grid raw-text progression | rebuild after raw text before item | layout tree builds=1
+PASS: grid raw-text progression | rebuild after raw text before item | incremental tree matches full rebuild
+PASS: grid raw-text progression | preserve after final item | preserve
+PASS: grid raw-text progression | preserve after final item | layout tree builds=1
+PASS: grid raw-text progression | preserve after final item | incremental tree matches full rebuild
+PASS: join trailing grid raw text | insert before raw text | preserve
+PASS: join trailing grid raw text | insert before raw text | layout tree builds=1
+PASS: join trailing grid raw text | insert before raw text | incremental tree matches full rebuild
+PASS: join trailing grid raw text | append after raw text | preserve
+PASS: join trailing grid raw text | append after raw text | layout tree builds=1
+PASS: join trailing grid raw text | append after raw text | incremental tree matches full rebuild
+PASS: rebuild beside display-contents inline run | insert whitespace | rebuild
+PASS: rebuild beside display-contents inline run | insert whitespace | layout tree builds=1
+PASS: rebuild beside display-contents inline run | insert whitespace | incremental tree matches full rebuild
+PASS: table parent | append whitespace | rebuild
+PASS: table parent | append whitespace | layout tree builds=1
+PASS: table parent | append whitespace | incremental tree matches full rebuild
+PASS: insert in SVG parent | append whitespace | preserve
+PASS: insert in SVG parent | append whitespace | layout tree builds=1
+PASS: insert in SVG parent | append whitespace | incremental tree matches full rebuild
+PASS: rebuild for preserved whitespace | append whitespace | rebuild
+PASS: rebuild for preserved whitespace | append whitespace | layout tree builds=1
+PASS: rebuild for preserved whitespace | append whitespace | incremental tree matches full rebuild
+PASS: rebuild for non-ASCII whitespace | append no-break space | rebuild
+PASS: rebuild for non-ASCII whitespace | append no-break space | layout tree builds=1
+PASS: rebuild for non-ASCII whitespace | append no-break space | incremental tree matches full rebuild
+PASS: rebuild for non-whitespace text | append text | rebuild
+PASS: rebuild for non-whitespace text | append text | layout tree builds=1
+PASS: rebuild for non-whitespace text | append text | incremental tree matches full rebuild
+PASS: rebuild under first-letter | append whitespace | rebuild
+PASS: rebuild under first-letter | append whitespace | layout tree builds=1
+PASS: rebuild under first-letter | append whitespace | incremental tree matches full rebuild
+PASS: rebuild under ancestor first-letter | append whitespace | rebuild
+PASS: rebuild under ancestor first-letter | append whitespace | layout tree builds=1
+PASS: rebuild under ancestor first-letter | append whitespace | incremental tree matches full rebuild
+PASS: rebuild with concurrent descendant update | update descendant and append whitespace | rebuild
+PASS: rebuild with concurrent descendant update | update descendant and append whitespace | layout tree builds=1
+PASS: rebuild with concurrent descendant update | update descendant and append whitespace | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/input/css/animation-box-adjustment-skips-layout.html
+++ b/Tests/LibWeb/Text/input/css/animation-box-adjustment-skips-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div style="display: flex"><span id="target"></span></div>
+<script>
+    test(() => {
+        const target = document.getElementById("target");
+        const animation = target.animate(
+            { opacity: [0, 1] },
+            { duration: 1000, fill: "both" });
+        animation.pause();
+
+        animation.currentTime = 100;
+        target.offsetWidth;
+        const layoutsBefore = internals.fullLayoutCount();
+
+        for (const time of [200, 300, 400]) {
+            animation.currentTime = time;
+            target.offsetWidth;
+        }
+
+        println(`full layouts: ${internals.fullLayoutCount() - layoutsBefore}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/hidden-child-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/hidden-child-insertion-preservation.html
@@ -1,19 +1,29 @@
 <!doctype html>
 <script src="../include.js"></script>
 <div id="parent"><div id="before"></div><span>inline</span></div>
+<div id="transient-parent"><div id="transient-before"></div><span>inline</span></div>
 <script>
     test(() => {
         const parentElement = document.getElementById("parent");
         const beforeElement = document.getElementById("before");
+        const transientParent = document.getElementById("transient-parent");
+        const transientBefore = document.getElementById("transient-before");
         document.body.offsetWidth;
         const parentIdentity = internals.layoutNodeIdentity(parentElement);
         const beforeIdentity = internals.layoutNodeIdentity(beforeElement);
+        const transientParentIdentity = internals.layoutNodeIdentity(transientParent);
+        const transientBeforeIdentity = internals.layoutNodeIdentity(transientBefore);
 
         parentElement.insertAdjacentHTML("beforeend", '<script></' + 'script>');
+        const transientScript = document.createElement("script");
+        transientParent.append(transientScript);
+        transientScript.remove();
         document.body.offsetWidth;
 
         println(`parent preserved: ${internals.layoutNodeIdentity(parentElement) === parentIdentity}`);
         println(`child preserved: ${internals.layoutNodeIdentity(beforeElement) === beforeIdentity}`);
+        println(`transient parent preserved: ${internals.layoutNodeIdentity(transientParent) === transientParentIdentity}`);
+        println(`transient child preserved: ${internals.layoutNodeIdentity(transientBefore) === transientBeforeIdentity}`);
         println(`incremental tree matches: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/hidden-child-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/hidden-child-insertion-preservation.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<script src="../include.js"></script>
+<div id="parent"><div id="before"></div><span>inline</span></div>
+<script>
+    test(() => {
+        const parentElement = document.getElementById("parent");
+        const beforeElement = document.getElementById("before");
+        document.body.offsetWidth;
+        const parentIdentity = internals.layoutNodeIdentity(parentElement);
+        const beforeIdentity = internals.layoutNodeIdentity(beforeElement);
+
+        parentElement.insertAdjacentHTML("beforeend", '<script></' + 'script>');
+        document.body.offsetWidth;
+
+        println(`parent preserved: ${internals.layoutNodeIdentity(parentElement) === parentIdentity}`);
+        println(`child preserved: ${internals.layoutNodeIdentity(beforeElement) === beforeIdentity}`);
+        println(`incremental tree matches: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
@@ -3,6 +3,9 @@
 <style>
     .flex { display: flex; }
     .grid { display: grid; }
+    .flow-root { display: flow-root; }
+    .contents { display: contents; }
+    .hidden { display: none; }
     .preserve { white-space-collapse: preserve; }
     .first-letter::first-letter { color: red; }
 </style>
@@ -10,70 +13,278 @@
 <script>
     const cases = [
         {
-            name: "append beside anonymous inline run",
+            name: "append after trailing anonymous inline run",
             markup: '<div class="parent"><div class="tracked"></div><span>inline</span></div>',
-            mutate: parent => parent.append(" ", document.createElement("script")),
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+                { name: "extend run", mutate: parent => parent.append("\t\n") },
+            ],
         },
         {
-            name: "insert into anonymous inline run",
+            name: "insert within trailing anonymous inline run",
             markup: '<div class="parent"><div class="tracked"></div><span class="before">before</span><span class="after">after</span></div>',
-            mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")),
+            steps: [
+                { name: "insert before inline", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
+                { name: "insert after inline", mutate: parent => parent.querySelector(".after").after(" ") },
+            ],
         },
         {
-            name: "insert between block children",
+            name: "insert in all-inline flow",
+            markup: '<div class="parent"><span class="tracked">tracked</span><span class="after">after</span></div>',
+            steps: [
+                { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
+                { name: "insert middle whitespace", mutate: parent => parent.insertBefore(document.createTextNode("\n"), parent.querySelector(".after")) },
+                { name: "append whitespace", mutate: parent => parent.append("\t") },
+            ],
+        },
+        {
+            name: "insert in inline flow",
+            markup: '<span class="parent"><span class="tracked">tracked</span><span class="after">after</span></span>',
+            steps: [
+                { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
+                { name: "insert middle whitespace", mutate: parent => parent.querySelector(".after").before(" ") },
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "insert around block children",
             markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
-            mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")),
+            steps: [
+                { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
+                { name: "insert whitespace between blocks", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+            ],
         },
         {
-            name: "append to flex parent",
-            markup: '<div class="parent flex"><div class="tracked"></div></div>',
-            mutate: parent => parent.append(" "),
+            name: "insert around flex items",
+            markup: '<div class="parent flex"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
+                { name: "insert whitespace between items", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+            ],
         },
         {
-            name: "append to grid parent",
-            markup: '<div class="parent grid"><div class="tracked"></div></div>',
-            mutate: parent => parent.append(" "),
+            name: "insert around grid items",
+            markup: '<div class="parent grid"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
+                { name: "insert whitespace between items", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "insert whitespace with hidden siblings",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "insert whitespace and display-none element",
+                    mutate: parent => {
+                        const hidden = document.createElement("span");
+                        hidden.className = "hidden";
+                        parent.querySelector(".after").before(" ", hidden);
+                    },
+                },
+            ],
+        },
+        {
+            name: "insert multiple whitespace nodes",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "insert at supported positions",
+                    mutate: parent => {
+                        parent.prepend(" ");
+                        parent.querySelector(".after").before("\n");
+                        parent.append("\t");
+                    },
+                },
+            ],
+        },
+        {
+            name: "mixed block and inline progression",
+            markup: '<div class="parent"><div class="tracked"></div><span class="inline">inline</span><div class="after"></div></div>',
+            steps: [
+                { name: "rebuild before block after inline run", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+                { name: "preserve after final block", mutate: parent => parent.append(" ") },
+                { name: "preserve in new trailing inline run", mutate: parent => parent.append("\n") },
+                { name: "rebuild beside non-trailing inline run", mutate: parent => parent.querySelector(".inline").before(" "), preserve: false },
+            ],
+        },
+        {
+            name: "rebuild before block after inline run",
+            markup: '<div class="parent"><span>inline</span><div class="tracked"></div></div>',
+            steps: [
+                { name: "insert whitespace", mutate: parent => parent.querySelector(".tracked").before(" "), preserve: false },
+            ],
+        },
+        {
+            name: "rebuild beside non-trailing inline run",
+            markup: '<div class="parent"><div class="tracked"></div><span class="inline">inline</span><div class="after"></div></div>',
+            steps: [
+                { name: "insert whitespace after preceding block", mutate: parent => parent.querySelector(".inline").before(" "), preserve: false },
+            ],
+        },
+        {
+            name: "flow-root mixed-content progression",
+            markup: '<div class="parent flow-root"><div class="tracked"></div><span class="inline">inline</span><div class="after"></div></div>',
+            steps: [
+                { name: "rebuild before block after inline run", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+                { name: "preserve after final block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "rebuild all positions when one needs an earlier inline run",
+            markup: '<div class="parent"><span class="inline">inline</span><div class="tracked"></div></div>',
+            steps: [
+                {
+                    name: "insert safe and unsafe whitespace",
+                    mutate: parent => {
+                        parent.querySelector(".tracked").before(" ");
+                        parent.append(" ");
+                    },
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "flex raw-text progression",
+            markup: '<div class="parent flex">raw<div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild after raw text before item", mutate: parent => parent.querySelector(".tracked").before(" "), preserve: false },
+                { name: "preserve after final item", mutate: parent => parent.append(" ") },
+                { name: "preserve in trailing text item", mutate: parent => parent.append("\t") },
+            ],
+        },
+        {
+            name: "rebuild before non-trailing flex raw text",
+            markup: '<div class="parent flex"><div class="tracked"></div>raw<div class="after"></div></div>',
+            steps: [
+                { name: "insert whitespace", mutate: parent => parent.firstChild.after(" "), preserve: false },
+            ],
+        },
+        {
+            name: "join trailing flex raw text",
+            markup: '<div class="parent flex"><div class="tracked"></div>raw</div>',
+            steps: [
+                { name: "insert before raw text", mutate: parent => parent.lastChild.before(" ") },
+                { name: "append after raw text", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "grid raw-text progression",
+            markup: '<div class="parent grid">raw<div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild before raw text", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "rebuild after raw text before item", mutate: parent => parent.querySelector(".tracked").before(" "), preserve: false },
+                { name: "preserve after final item", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "join trailing grid raw text",
+            markup: '<div class="parent grid"><div class="tracked"></div>raw</div>',
+            steps: [
+                { name: "insert before raw text", mutate: parent => parent.lastChild.before(" ") },
+                { name: "append after raw text", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "rebuild beside display-contents inline run",
+            markup: '<div class="parent"><div class="tracked"></div><span class="contents"><span>inline</span></span><div class="after"></div></div>',
+            steps: [
+                { name: "insert whitespace", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+            ],
+        },
+        {
+            name: "table parent",
+            markup: '<table class="parent"><tbody class="tracked"><tr><td>cell</td></tr></tbody></table>',
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "insert in SVG parent",
+            markup: '<svg class="parent"><g class="tracked"></g></svg>',
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" ") },
+            ],
         },
         {
             name: "rebuild for preserved whitespace",
             markup: '<div class="parent preserve"><div class="tracked"></div><span>inline</span></div>',
-            mutate: parent => parent.append(" "),
-            preserve: false,
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "rebuild for non-ASCII whitespace",
+            markup: '<div class="parent"><div class="tracked"></div></div>',
+            steps: [
+                { name: "append no-break space", mutate: parent => parent.append("\u00a0"), preserve: false },
+            ],
+        },
+        {
+            name: "rebuild for non-whitespace text",
+            markup: '<div class="parent"><div class="tracked"></div></div>',
+            steps: [
+                { name: "append text", mutate: parent => parent.append("text"), preserve: false },
+            ],
         },
         {
             name: "rebuild under first-letter",
             markup: '<div class="parent first-letter"><div class="tracked"></div><span>inline</span></div>',
-            mutate: parent => parent.append(" "),
-            preserve: false,
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "rebuild under ancestor first-letter",
+            markup: '<div class="first-letter"><div class="parent"><div class="tracked"></div><span>inline</span></div></div>',
+            parentSelector: ".parent",
+            steps: [
+                { name: "append whitespace", mutate: parent => parent.append(" "), preserve: false },
+            ],
         },
         {
             name: "rebuild with concurrent descendant update",
             markup: '<div class="parent"><div class="tracked first-letter"><span>old</span></div></div>',
-            mutate: parent => {
-                parent.firstElementChild.firstElementChild.firstChild.data = "new";
-                parent.append(" ");
-            },
-            preserve: false,
+            steps: [
+                {
+                    name: "update descendant and append whitespace",
+                    mutate: parent => {
+                        parent.firstElementChild.firstElementChild.firstChild.data = "new";
+                        parent.append(" ");
+                    },
+                    preserve: false,
+                },
+            ],
         },
     ];
 
     test(() => {
         for (const case_ of cases) {
             fixture.innerHTML = case_.markup;
-            const parent = fixture.firstElementChild;
+            const parent = case_.parentSelector ? fixture.querySelector(case_.parentSelector) : fixture.firstElementChild;
             const tracked = parent.querySelector(".tracked");
             document.body.offsetWidth;
-            const parentIdentity = internals.layoutNodeIdentity(parent);
-            const trackedIdentity = internals.layoutNodeIdentity(tracked);
 
-            case_.mutate(parent);
-            document.body.offsetWidth;
+            for (const step of case_.steps) {
+                const parentIdentity = internals.layoutNodeIdentity(parent);
+                const trackedIdentity = internals.layoutNodeIdentity(tracked);
+                const buildsBefore = internals.layoutTreeBuildStats().builds;
 
-            const preserved = internals.layoutNodeIdentity(parent) === parentIdentity
-                && internals.layoutNodeIdentity(tracked) === trackedIdentity;
-            const expectedPreserved = case_.preserve !== false;
-            println(`${preserved === expectedPreserved ? "PASS" : "FAIL"}: ${case_.name} | ${expectedPreserved ? "preserve" : "rebuild"}`);
-            println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${case_.name} | incremental tree matches full rebuild`);
+                step.mutate(parent);
+                document.body.offsetWidth;
+
+                const preserved = internals.layoutNodeIdentity(parent) === parentIdentity
+                    && internals.layoutNodeIdentity(tracked) === trackedIdentity;
+                const expectedPreserved = step.preserve !== false;
+                const name = `${case_.name} | ${step.name}`;
+                println(`${preserved === expectedPreserved ? "PASS" : "FAIL"}: ${name} | ${expectedPreserved ? "preserve" : "rebuild"}`);
+                const builds = internals.layoutTreeBuildStats().builds - buildsBefore;
+                println(`${builds === 1 ? "PASS" : "FAIL"}: ${name} | layout tree builds=${builds}`);
+                println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${name} | incremental tree matches full rebuild`);
+            }
         }
     });
 </script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
@@ -8,6 +8,22 @@
     .hidden { display: none; }
     .preserve { white-space-collapse: preserve; }
     .first-letter::first-letter { color: red; }
+    .before-inline::before { content: "before"; }
+    .after-inline::after { content: "after"; }
+    .before-and-after-inline::before { content: "before"; }
+    .before-and-after-inline::after { content: "after"; }
+    .before-inline-block::before { content: "before"; display: inline-block; }
+    .before-block::before { content: "before"; display: block; }
+    .after-block::after { content: "after"; display: block; }
+    .before-contents::before { content: "before"; display: contents; }
+    .before-absolute::before { content: "before"; position: absolute; }
+    .after-absolute::after { content: "after"; position: absolute; }
+    .before-float::before { content: "before"; float: left; }
+    .after-float::after { content: "after"; float: left; }
+    .list-item { display: list-item; }
+    .list-item::marker { content: "marker"; }
+    .absolute { position: absolute; }
+    .float { float: left; }
 </style>
 <div id="fixture"></div>
 <script>
@@ -53,6 +69,7 @@
                 { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
                 { name: "insert whitespace between blocks", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
                 { name: "append whitespace", mutate: parent => parent.append(" ") },
+                { name: "rebuild before blocks with trailing run", mutate: parent => parent.prepend("\n"), preserve: false },
             ],
         },
         {
@@ -62,6 +79,7 @@
                 { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
                 { name: "insert whitespace between items", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
                 { name: "append whitespace", mutate: parent => parent.append(" ") },
+                { name: "rebuild before items with trailing text item", mutate: parent => parent.prepend("\n"), preserve: false },
             ],
         },
         {
@@ -71,6 +89,7 @@
                 { name: "prepend whitespace", mutate: parent => parent.prepend(" ") },
                 { name: "insert whitespace between items", mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")) },
                 { name: "append whitespace", mutate: parent => parent.append(" ") },
+                { name: "rebuild between items with trailing text item", mutate: parent => parent.querySelector(".after").before("\n"), preserve: false },
             ],
         },
         {
@@ -98,6 +117,321 @@
                         parent.querySelector(".after").before("\n");
                         parent.append("\t");
                     },
+                },
+            ],
+        },
+        {
+            name: "insert adjacent whitespace nodes between blocks",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "rebuild for adjacent spaces",
+                    mutate: parent => parent.querySelector(".after").before(" ", "\n", "\t"),
+                    preserve: false,
+                },
+                {
+                    name: "rebuild when extending the anonymous run",
+                    mutate: parent => parent.querySelector(".after").before("\r\n", " "),
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "insert adjacent whitespace nodes between flex items",
+            markup: '<div class="parent flex"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "rebuild for adjacent spaces",
+                    mutate: parent => parent.querySelector(".after").before(" ", "\n", "\t"),
+                    preserve: false,
+                },
+                {
+                    name: "rebuild when extending the anonymous item",
+                    mutate: parent => parent.querySelector(".after").before("\r\n", " "),
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "insert adjacent whitespace nodes between grid items",
+            markup: '<div class="parent grid"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "rebuild for adjacent spaces",
+                    mutate: parent => parent.querySelector(".after").before(" ", "\n", "\t"),
+                    preserve: false,
+                },
+                {
+                    name: "rebuild when extending the anonymous item",
+                    mutate: parent => parent.querySelector(".after").before("\r\n", " "),
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "insert whitespace interleaved with hidden nodes",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                {
+                    name: "rebuild for interleaved batch",
+                    mutate: parent => {
+                        const firstHidden = document.createElement("span");
+                        const secondHidden = document.createElement("span");
+                        firstHidden.className = "hidden";
+                        secondHidden.className = "hidden";
+                        parent.querySelector(".after").before(" ", firstHidden, "\n", secondHidden, "\t");
+                    },
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "trailing inline run changes block insertion",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                { name: "create trailing run", mutate: parent => parent.append(" ") },
+                { name: "rebuild for earlier new run", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+                { name: "rebuild beside non-trailing middle run", mutate: parent => parent.querySelector(".after").before("\n"), preserve: false },
+            ],
+        },
+        {
+            name: "trailing text item changes flex insertion",
+            markup: '<div class="parent flex"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                { name: "create trailing text item", mutate: parent => parent.append(" ") },
+                { name: "rebuild for earlier text item", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+                { name: "rebuild beside non-trailing middle item", mutate: parent => parent.querySelector(".after").before("\n"), preserve: false },
+            ],
+        },
+        {
+            name: "trailing text item changes grid insertion",
+            markup: '<div class="parent grid"><div class="tracked"></div><div class="after"></div></div>',
+            steps: [
+                { name: "create trailing text item", mutate: parent => parent.append(" ") },
+                { name: "rebuild for earlier text item", mutate: parent => parent.querySelector(".after").before(" "), preserve: false },
+                { name: "rebuild beside non-trailing middle item", mutate: parent => parent.querySelector(".after").before("\n"), preserve: false },
+            ],
+        },
+        {
+            name: "absolute before block progression",
+            markup: '<div class="parent"><div class="absolute"></div><div class="tracked"></div></div>',
+            steps: [
+                { name: "insert before absolute", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "insert between absolute and block", mutate: parent => parent.querySelector(".tracked").before(" "), preserve: false },
+                { name: "preserve after block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "absolute after block progression",
+            markup: '<div class="parent"><div class="tracked"></div><div class="absolute"></div></div>',
+            steps: [
+                { name: "insert after absolute", mutate: parent => parent.append(" ") },
+                { name: "insert before absolute", mutate: parent => parent.querySelector(".absolute").before(" "), preserve: false },
+                { name: "insert before block", mutate: parent => parent.prepend(" "), preserve: false },
+            ],
+        },
+        {
+            name: "float before block progression",
+            markup: '<div class="parent"><div class="float"></div><div class="tracked"></div></div>',
+            steps: [
+                { name: "insert before float", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "insert between float and block", mutate: parent => parent.querySelector(".tracked").before(" "), preserve: false },
+                { name: "preserve after block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "float after block progression",
+            markup: '<div class="parent"><div class="tracked"></div><div class="float"></div></div>',
+            steps: [
+                { name: "insert after float", mutate: parent => parent.append(" ") },
+                { name: "insert before float", mutate: parent => parent.querySelector(".float").before(" "), preserve: false },
+                { name: "insert before block", mutate: parent => parent.prepend(" "), preserve: false },
+            ],
+        },
+        {
+            name: "absolute before flex item progression",
+            markup: '<div class="parent flex"><div class="absolute"></div><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild before absolute", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "preserve after absolute", mutate: parent => parent.querySelector(".tracked").before(" ") },
+                { name: "preserve after final item", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "absolute after flex item progression",
+            markup: '<div class="parent flex"><div class="tracked"></div><div class="absolute"></div></div>',
+            steps: [
+                { name: "insert after absolute", mutate: parent => parent.append(" ") },
+                { name: "rebuild before absolute", mutate: parent => parent.querySelector(".absolute").before(" "), preserve: false },
+                { name: "rebuild before item", mutate: parent => parent.prepend(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated before inline progression",
+            markup: '<div class="parent before-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild between before and block", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "preserve after block", mutate: parent => parent.append(" ") },
+                { name: "preserve in trailing inline run", mutate: parent => parent.append("\n") },
+                { name: "rebuild beside before again", mutate: parent => parent.prepend("\t"), preserve: false },
+            ],
+        },
+        {
+            name: "generated after inline progression",
+            markup: '<div class="parent after-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild before block with trailing after run", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "rebuild before trailing after run", mutate: parent => parent.append(" "), preserve: false },
+                { name: "rebuild beside trailing after run", mutate: parent => parent.append("\n"), preserve: false },
+            ],
+        },
+        {
+            name: "generated before and after inline progression",
+            markup: '<div class="parent before-and-after-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild beside before", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "rebuild before trailing after run", mutate: parent => parent.append(" "), preserve: false },
+                { name: "rebuild beside before again", mutate: parent => parent.prepend("\n"), preserve: false },
+            ],
+        },
+        {
+            name: "generated inline in all-inline flow",
+            markup: '<div class="parent before-and-after-inline"><span class="tracked">inline</span></div>',
+            steps: [
+                { name: "insert after before", mutate: parent => parent.prepend(" ") },
+                { name: "insert before after", mutate: parent => parent.append(" ") },
+                { name: "insert beside DOM inline", mutate: parent => parent.firstChild.after("\n") },
+            ],
+        },
+        {
+            name: "generated before inline-block",
+            markup: '<div class="parent before-inline-block"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild between before and block", mutate: parent => parent.prepend(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated before display contents",
+            markup: '<div class="parent before-contents"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild between before and block", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "preserve after block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated before block progression",
+            markup: '<div class="parent before-block"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve between generated and DOM blocks", mutate: parent => parent.prepend(" ") },
+                { name: "preserve after DOM block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated after block progression",
+            markup: '<div class="parent after-block"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve before DOM block", mutate: parent => parent.prepend(" ") },
+                { name: "rebuild before generated block", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated before absolute progression",
+            markup: '<div class="parent before-absolute"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild after generated absolute", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "preserve after DOM block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated after absolute progression",
+            markup: '<div class="parent after-absolute"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve before DOM block", mutate: parent => parent.prepend(" ") },
+                { name: "rebuild before generated absolute", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated before float progression",
+            markup: '<div class="parent before-float"><div class="tracked"></div></div>',
+            steps: [
+                { name: "rebuild after generated float", mutate: parent => parent.prepend(" "), preserve: false },
+                { name: "preserve after DOM block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated after float progression",
+            markup: '<div class="parent after-float"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve before DOM block", mutate: parent => parent.prepend(" ") },
+                { name: "rebuild before generated float", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "list marker progression",
+            markup: '<div class="parent list-item"><div class="tracked"></div></div>',
+            steps: [
+                { name: "prepend after marker", mutate: parent => parent.prepend(" ") },
+                { name: "append after block", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated before inline in flex",
+            markup: '<div class="parent flex before-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve between before and item", mutate: parent => parent.prepend(" ") },
+                { name: "preserve after final item", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated before inline in grid",
+            markup: '<div class="parent grid before-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve between before and item", mutate: parent => parent.prepend(" ") },
+                { name: "preserve after final item", mutate: parent => parent.append(" ") },
+            ],
+        },
+        {
+            name: "generated after content in flex",
+            markup: '<div class="parent flex after-inline"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve before item", mutate: parent => parent.prepend(" ") },
+                { name: "rebuild before trailing after item", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated after block in grid",
+            markup: '<div class="parent grid after-block"><div class="tracked"></div></div>',
+            steps: [
+                { name: "preserve before DOM item", mutate: parent => parent.prepend(" ") },
+                { name: "rebuild before generated item", mutate: parent => parent.append(" "), preserve: false },
+            ],
+        },
+        {
+            name: "generated before inline with hidden insertion",
+            markup: '<div class="parent before-inline"><div class="tracked"></div></div>',
+            steps: [
+                {
+                    name: "rebuild for whitespace beside before",
+                    mutate: parent => {
+                        const hidden = document.createElement("span");
+                        hidden.className = "hidden";
+                        parent.prepend(hidden, " ");
+                    },
+                    preserve: false,
+                },
+            ],
+        },
+        {
+            name: "generated before inline with batched positions",
+            markup: '<div class="parent before-inline"><div class="tracked"></div></div>',
+            steps: [
+                {
+                    name: "rebuild all positions for unsafe leading whitespace",
+                    mutate: parent => {
+                        parent.prepend(" ");
+                        parent.append(" ");
+                    },
+                    preserve: false,
                 },
             ],
         },
@@ -169,6 +503,7 @@
             steps: [
                 { name: "insert before raw text", mutate: parent => parent.lastChild.before(" ") },
                 { name: "append after raw text", mutate: parent => parent.append(" ") },
+                { name: "rebuild before item with trailing text item", mutate: parent => parent.prepend(" "), preserve: false },
             ],
         },
         {
@@ -186,6 +521,7 @@
             steps: [
                 { name: "insert before raw text", mutate: parent => parent.lastChild.before(" ") },
                 { name: "append after raw text", mutate: parent => parent.append(" ") },
+                { name: "rebuild before item with trailing text item", mutate: parent => parent.prepend(" "), preserve: false },
             ],
         },
         {
@@ -235,6 +571,7 @@
             markup: '<div class="parent first-letter"><div class="tracked"></div><span>inline</span></div>',
             steps: [
                 { name: "append whitespace", mutate: parent => parent.append(" "), preserve: false },
+                { name: "append multiple whitespace nodes", mutate: parent => parent.append("\n", "\t", " "), preserve: false },
             ],
         },
         {

--- a/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/whitespace-child-insertion-preservation.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    .flex { display: flex; }
+    .grid { display: grid; }
+    .preserve { white-space-collapse: preserve; }
+    .first-letter::first-letter { color: red; }
+</style>
+<div id="fixture"></div>
+<script>
+    const cases = [
+        {
+            name: "append beside anonymous inline run",
+            markup: '<div class="parent"><div class="tracked"></div><span>inline</span></div>',
+            mutate: parent => parent.append(" ", document.createElement("script")),
+        },
+        {
+            name: "insert into anonymous inline run",
+            markup: '<div class="parent"><div class="tracked"></div><span class="before">before</span><span class="after">after</span></div>',
+            mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")),
+        },
+        {
+            name: "insert between block children",
+            markup: '<div class="parent"><div class="tracked"></div><div class="after"></div></div>',
+            mutate: parent => parent.insertBefore(document.createTextNode(" "), parent.querySelector(".after")),
+        },
+        {
+            name: "append to flex parent",
+            markup: '<div class="parent flex"><div class="tracked"></div></div>',
+            mutate: parent => parent.append(" "),
+        },
+        {
+            name: "append to grid parent",
+            markup: '<div class="parent grid"><div class="tracked"></div></div>',
+            mutate: parent => parent.append(" "),
+        },
+        {
+            name: "rebuild for preserved whitespace",
+            markup: '<div class="parent preserve"><div class="tracked"></div><span>inline</span></div>',
+            mutate: parent => parent.append(" "),
+            preserve: false,
+        },
+        {
+            name: "rebuild under first-letter",
+            markup: '<div class="parent first-letter"><div class="tracked"></div><span>inline</span></div>',
+            mutate: parent => parent.append(" "),
+            preserve: false,
+        },
+        {
+            name: "rebuild with concurrent descendant update",
+            markup: '<div class="parent"><div class="tracked first-letter"><span>old</span></div></div>',
+            mutate: parent => {
+                parent.firstElementChild.firstElementChild.firstChild.data = "new";
+                parent.append(" ");
+            },
+            preserve: false,
+        },
+    ];
+
+    test(() => {
+        for (const case_ of cases) {
+            fixture.innerHTML = case_.markup;
+            const parent = fixture.firstElementChild;
+            const tracked = parent.querySelector(".tracked");
+            document.body.offsetWidth;
+            const parentIdentity = internals.layoutNodeIdentity(parent);
+            const trackedIdentity = internals.layoutNodeIdentity(tracked);
+
+            case_.mutate(parent);
+            document.body.offsetWidth;
+
+            const preserved = internals.layoutNodeIdentity(parent) === parentIdentity
+                && internals.layoutNodeIdentity(tracked) === trackedIdentity;
+            const expectedPreserved = case_.preserve !== false;
+            println(`${preserved === expectedPreserved ? "PASS" : "FAIL"}: ${case_.name} | ${expectedPreserved ? "preserve" : "rebuild"}`);
+            println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${case_.name} | incremental tree matches full rebuild`);
+        }
+    });
+</script>


### PR DESCRIPTION
Preserve existing layout nodes when animation adjustments leave the effective display unchanged, inserted children generate no boxes, insertions are canceled before layout, or collapsing whitespace can be placed without changing the resulting tree.

Fall back to rebuilding when text changes affect ::first-letter, or when anonymous inline runs, generated content, and out-of-flow siblings prevent whitespace from being placed identically to a full rebuild.

Ensure `moveBefore()` destinations remain dirty so moves cannot be mistaken for canceled insertions.

Add progression-based partial layout-tree-update coverage for hidden and whitespace insertions. The whitespace matrix exercises 122 sequential mutations across inline, block, flex, grid, generated-content, out-of-flow, first-letter, mixed-update, and batched-update cases while checking retained identity, build counts, and full-rebuild equivalence after every step.