### PR TITLE
LibWeb: Reduce stylesheet replacement bookkeeping

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -295,7 +295,6 @@ impl StyleEngine {
         }
         let routing = Rc::get_mut(&mut self.routing).expect("routing program is shared outside a planning epoch");
         routing.add_rule(rule, program, &self.programs);
-        routing.settle_memory(&mut self.memory);
     }
 
     /// The process-global atom for one interned name identity.

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -373,8 +373,8 @@ impl StyleEngine {
         let previous_program = self
             .replacement_rule(rule)
             .and_then(|replacement| replacement.version.selector_program);
-        let (program, inserted) = self.programs.add_with_status(selector_program, &mut self.memory);
-        self.selector_programs_need_sweep |= inserted;
+        let (program, _) = self.programs.add_with_status(selector_program, &mut self.memory);
+        self.selector_programs_need_sweep |= previous_program.is_some();
         self.programs.settle_memory(&mut self.memory);
         if previous_program != Some(program) {
             self.add_routing_rule(rule, program);
@@ -388,8 +388,8 @@ impl StyleEngine {
 
     #[cfg(feature = "style-recording")]
     pub(crate) fn replace_replayed_style_rule_selectors(&mut self, rule: RuleID, selector_program: SelectorProgram) {
-        let (program, inserted) = self.programs.add_with_status(selector_program, &mut self.memory);
-        self.selector_programs_need_sweep |= inserted;
+        let (program, _) = self.programs.add_with_status(selector_program, &mut self.memory);
+        self.selector_programs_need_sweep = true;
         self.programs.settle_memory(&mut self.memory);
         self.add_routing_rule(rule, program);
         let mut version = self.current_rule_version(rule);
@@ -548,8 +548,8 @@ impl StyleEngine {
         {
             return reusable;
         }
-        let (program, inserted) = self.programs.add_with_status(compiled, &mut self.memory);
-        self.selector_programs_need_sweep |= inserted;
+        let (program, _) = self.programs.add_with_status(compiled, &mut self.memory);
+        self.selector_programs_need_sweep |= reusable.is_some();
         self.programs.settle_memory(&mut self.memory);
         program
     }

--- a/Libraries/LibWeb/Rust/src/css/style/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/mod.rs
@@ -517,39 +517,17 @@ fn for_each_matching_scope(
     Ok(())
 }
 
-trait DenseStagingID: Copy + Ord {
-    fn index(self) -> usize;
-}
-
-impl DenseStagingID for RuleID {
-    fn index(self) -> usize {
-        self.0 as usize
-    }
-}
-
-impl DenseStagingID for SheetID {
-    fn index(self) -> usize {
-        self.0 as usize
-    }
-}
-
-impl DenseStagingID for TreeScopeID {
-    fn index(self) -> usize {
-        self.0 as usize
-    }
-}
-
 struct StagedFieldRow<V> {
     before: V,
     after: V,
     dirty: bool,
 }
 
-/// Dense staging for one program field. The first write freezes `before`, later writes replace
+/// Sparse staging for one program field. The first write freezes `before`, later writes replace
 /// `after`, and `take_dirty()` applies only the last write while retaining both sides for
-/// `ProgramStaging::delta()`. `clear()` releases the dense columns after the transaction.
+/// `ProgramStaging::delta()`.
 struct StagedField<K, V> {
-    rows: Column<Option<StagedFieldRow<V>>>,
+    rows: HashMap<K, StagedFieldRow<V>>,
     touched: Vec<K>,
     dirty_count: usize,
 }
@@ -557,27 +535,24 @@ struct StagedField<K, V> {
 impl<K, V> Default for StagedField<K, V> {
     fn default() -> Self {
         Self {
-            rows: Column::default(),
+            rows: HashMap::default(),
             touched: Vec::new(),
             dirty_count: 0,
         }
     }
 }
 
-impl<K: DenseStagingID, V: Clone> StagedField<K, V> {
+impl<K: Copy + Eq + Hash + Ord, V: Clone> StagedField<K, V> {
     fn current(&self, key: K, committed: impl FnOnce() -> V) -> V {
         self.side(key, TransactionFactSide::After, committed)
     }
 
     fn after(&self, key: K) -> Option<&V> {
-        self.rows
-            .get(key.index())
-            .and_then(Option::as_ref)
-            .map(|row| &row.after)
+        self.rows.get(&key).map(|row| &row.after)
     }
 
     fn side(&self, key: K, side: TransactionFactSide, resident: impl FnOnce() -> V) -> V {
-        let row = self.rows.get(key.index()).and_then(Option::as_ref);
+        let row = self.rows.get(&key);
         match (side, row) {
             (TransactionFactSide::Before, Some(row)) => row.before.clone(),
             (TransactionFactSide::After, Some(row)) => row.after.clone(),
@@ -586,8 +561,7 @@ impl<K: DenseStagingID, V: Clone> StagedField<K, V> {
     }
 
     fn stage(&mut self, key: K, before: V, after: V) {
-        let slot = self.rows.entry(key.index());
-        if let Some(row) = slot {
+        if let Some(row) = self.rows.get_mut(&key) {
             row.after = after;
             if !row.dirty {
                 row.dirty = true;
@@ -595,11 +569,14 @@ impl<K: DenseStagingID, V: Clone> StagedField<K, V> {
             }
             return;
         }
-        *slot = Some(StagedFieldRow {
-            before,
-            after,
-            dirty: true,
-        });
+        self.rows.insert(
+            key,
+            StagedFieldRow {
+                before,
+                after,
+                dirty: true,
+            },
+        );
         self.touched.push(key);
         self.dirty_count += 1;
     }
@@ -607,7 +584,7 @@ impl<K: DenseStagingID, V: Clone> StagedField<K, V> {
     fn take_dirty(&mut self) -> Vec<(K, V)> {
         let mut dirty = Vec::with_capacity(self.dirty_count);
         for &key in &self.touched {
-            let row = self.rows[key.index()].as_mut().unwrap();
+            let row = self.rows.get_mut(&key).unwrap();
             if row.dirty {
                 dirty.push((key, row.after.clone()));
                 row.dirty = false;
@@ -623,20 +600,18 @@ impl<K: DenseStagingID, V: Clone> StagedField<K, V> {
     }
 
     fn clear(&mut self) {
-        self.rows = Column::default();
-        self.touched = Vec::new();
+        self.rows.clear();
+        self.touched.clear();
         self.dirty_count = 0;
     }
 
     fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
-        self.touched
-            .iter()
-            .map(|key| (key, &self.rows[key.index()].as_ref().unwrap().after))
+        self.touched.iter().map(|key| (key, &self.rows.get(key).unwrap().after))
     }
 
     fn pairs(&self) -> impl Iterator<Item = (K, &V, &V)> {
         self.touched.iter().map(|&key| {
-            let row = self.rows[key.index()].as_ref().unwrap();
+            let row = self.rows.get(&key).unwrap();
             (key, &row.before, &row.after)
         })
     }

--- a/Libraries/LibWeb/Rust/src/css/style/ordering.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/ordering.rs
@@ -1368,11 +1368,12 @@ impl StyleEngine {
             return;
         }
         self.routing_needs_detachment_sweep = false;
-        let live_rules = self.program.live_selector_programs().collect::<Vec<_>>();
         let mut excluded_sheets = BitColumn::default();
-        for &(rule, _) in &live_rules {
-            let sheet = self.program.rule_sheet(rule);
-            if !self.program.sheet_is_attached_somewhere(sheet) {
+        let mut attached_sheets = Vec::new();
+        for (sheet, attached) in self.program.sheets_with_attachment_state() {
+            if attached {
+                attached_sheets.push(sheet);
+            } else {
                 excluded_sheets.set(sheet.0 as usize, true);
             }
         }
@@ -1380,11 +1381,17 @@ impl StyleEngine {
             return;
         }
         let mut rebuilt_routing = RoutingRegistry::new();
-        for &(rule, program) in &live_rules {
-            if excluded_sheets.contains(self.program.rule_sheet(rule).0 as usize) {
-                continue;
+        for sheet in attached_sheets {
+            for rule in self
+                .program
+                .rules_in_sheet(sheet)
+                .into_iter()
+                .filter(|&rule| self.program.rule_is_live(rule))
+            {
+                if let Some(program) = self.program.rule_version(rule).selector_program {
+                    rebuilt_routing.add_rule(rule, program, &self.programs);
+                }
             }
-            rebuilt_routing.add_rule(rule, program, &self.programs);
         }
         let mut previous_routing = std::mem::replace(&mut self.routing, Rc::new(rebuilt_routing));
         Rc::get_mut(&mut previous_routing)

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -1075,7 +1075,9 @@ impl StyleSheetProgram {
         declared: Vec<DeclaredProperty>,
         declarations_are_complete: bool,
     ) {
-        self.invalidate_semantic_declarations();
+        if self.rules[rule.0 as usize].semantic_declaration != SemanticDeclarationID::default() {
+            self.invalidate_semantic_declarations();
+        }
         let entry = &mut self.rules[rule.0 as usize];
         let previous_capacity = (entry.declared_properties.capacity() * size_of::<DeclaredProperty>()) as u64;
         entry.declared_properties = declared;
@@ -1407,6 +1409,7 @@ mod tests {
         let first = program.append_rule(sheet, None, RuleKind::Style);
         let second = program.append_rule(sheet, None, RuleKind::Style);
         let third = program.append_rule(sheet, None, RuleKind::Style);
+        let never_interned = program.append_rule(sheet, None, RuleKind::Style);
         let declared = |value| DeclaredProperty {
             property: 1,
             important: false,
@@ -1424,6 +1427,9 @@ mod tests {
         assert_ne!(first_identity, SemanticDeclarationID::default());
         assert_eq!(first_identity, second_identity);
         assert_ne!(first_identity, third_identity);
+
+        program.set_rule_declared_properties(never_interned, vec![declared(30)], true);
+        assert_eq!(program.ensure_semantic_declaration(first), first_identity);
 
         program.set_rule_declared_properties(second, vec![declared(10)], false);
         assert_eq!(

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -758,6 +758,15 @@ impl StyleSheetProgram {
         !self.sheets[sheet.0 as usize].attachments.is_empty()
     }
 
+    pub fn sheets_with_attachment_state(&self) -> impl Iterator<Item = (SheetID, bool)> + '_ {
+        self.sheets.iter().enumerate().map(|(index, sheet)| {
+            (
+                SheetID(u32::try_from(index).expect("sheet identity space exhausted")),
+                !sheet.attachments.is_empty(),
+            )
+        })
+    }
+
     pub fn live_selector_programs(&self) -> impl Iterator<Item = (RuleID, SelectorProgramID)> + '_ {
         self.rules.iter().enumerate().filter_map(|(index, rule)| {
             let version = self.rule_versions[rule.version_slot as usize];

--- a/Libraries/LibWeb/Rust/src/css/style/program.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/program.rs
@@ -930,8 +930,20 @@ impl StyleSheetProgram {
     /// Every live style rule of a sheet, in cascade order within that sheet.
     #[must_use]
     pub fn rules_in_sheet(&self, sheet: SheetID) -> Vec<RuleID> {
+        let top_level_rules = &self.sheets[sheet.0 as usize].rules;
+        if top_level_rules
+            .iter()
+            .all(|rule| self.rules[rule.0 as usize].children.is_empty())
+        {
+            return top_level_rules
+                .iter()
+                .copied()
+                .filter(|rule| self.rules[rule.0 as usize].live)
+                .collect();
+        }
+
         let mut rules: Vec<RuleID> = Vec::new();
-        for &top_level in &self.sheets[sheet.0 as usize].rules {
+        for &top_level in top_level_rules {
             self.collect_live_subtree(top_level, &mut rules);
         }
         rules.sort_by(|first, second| {

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -20,7 +20,7 @@ use super::*;
 use crate::css::property_metadata::property_id;
 
 #[test]
-fn dense_program_staging_freezes_before_until_release() {
+fn sparse_program_staging_freezes_before_until_release() {
     let rule = RuleID(7);
     let mut staged = StagedField::default();
     staged.stage(rule, 10_u32, 20);
@@ -40,8 +40,8 @@ fn dense_program_staging_freezes_before_until_release() {
 
     staged.clear();
     assert_eq!(staged.current(rule, || 50), 50);
-    assert_eq!(staged.rows.capacity(), 0);
-    assert_eq!(staged.touched.capacity(), 0);
+    assert!(staged.rows.is_empty());
+    assert!(staged.touched.is_empty());
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -8134,6 +8134,43 @@ fn adding_a_live_selector_program_keeps_existing_routing() {
 }
 
 #[test]
+fn detachment_routing_rebuild_excludes_retired_rules() {
+    let mut engine = StyleEngine::new(DeviceClass::ForegroundDesktop);
+    let retained_sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    let detached_sheet = engine.add_sheet(StyleSheetObjectID(2), CascadeOrigin::Author);
+    engine.attach_sheet(retained_sheet, TreeScopeID::DOCUMENT);
+    engine.attach_sheet(detached_sheet, TreeScopeID::DOCUMENT);
+    let program = engine
+        .programs
+        .add(test_selector_program(".target", &[("target", StyleAtomID(1))]));
+
+    let retained_rule = engine.append_rule(retained_sheet, None, RuleKind::Style);
+    let group = engine.append_rule(retained_sheet, None, RuleKind::Media);
+    let retired_rule = engine.append_rule(retained_sheet, Some(group), RuleKind::Style);
+    let detached_rule = engine.append_rule(detached_sheet, None, RuleKind::Style);
+    for rule in [retained_rule, retired_rule, detached_rule] {
+        engine.add_routing_rule(rule, program);
+        let mut version = engine.program.rule_version(rule);
+        version.selector_program = Some(program);
+        engine.replace_rule_version(rule, version);
+    }
+    discard_transaction(&mut engine);
+    assert_eq!(engine.routing.len(), 3);
+
+    engine.remove_rule(group);
+    engine.detach_sheet(detached_sheet, TreeScopeID::DOCUMENT);
+    discard_transaction(&mut engine);
+
+    assert_eq!(engine.routing.len(), 1);
+    assert_eq!(
+        engine
+            .routing
+            .rule_of(engine.routing.routes_for(RoutingKey::Class(StyleAtomID(1)))[0]),
+        retained_rule
+    );
+}
+
+#[test]
 fn a_declaration_edit_journals_only_the_declaration_field() {
     let (mut engine, _, rule) = authoring_engine();
     let mut contents = engine.program().rule_version(rule);


### PR DESCRIPTION
Repeated stylesheet replacement performed work proportional to all rule IDs ever created, even after the corresponding stylesheets had been removed. This caused the cost of inserting an identical `<style>` element to grow over time.

Make transaction staging sparse, settle selector-routing memory once per transaction, and rebuild routing from currently attached stylesheets instead of every lifetime rule. Also avoid unnecessary selector-program and semantic-declaration sweeps, and skip sorting when a stylesheet contains only flat top-level rules.

These changes preserve separate CSSOM objects and existing invalidation behavior while removing bookkeeping unrelated to the active stylesheet set.

On MicroWeb/style/insert-style-500-rules.html, using two five-iteration runs:

- Ladybird improved from 114.10/116.10 ms to 94.80/94.70 ms.
- The mean median improved from 115.10 ms to 94.75 ms, a 17.7% reduction or 1.21x speedup.
- Chromium remained at approximately 6.8 ms.
- The Ladybird/Chromium ratio improved from approximately 16.9x to 13.8x.

Profiling also shows that repeated iterations now remain approximately flat instead of becoming progressively slower as dead rule IDs accumulate.

Note that Chromium (and WebKit) have string-to-style-sheet caches that allow them to skip parsing the same sheets repeatedly. That's why the difference is huge. We should probably do this as well, but that's a separate issue :)