### PR TITLE
LibWeb: Ensure we read pointer-events from the element that was actually hit (fixes a vscode.dev crash)

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -205,6 +205,15 @@ static Layout::Node* layout_node_for_target(DOM::Document& document, Layout::Rus
     return Painting::layout_node_for_committed_slot(document.layout_node_arena(), box);
 }
 
+static CSS::PointerEvents pointer_events_for_hit_target(bool is_text_fragment, DOM::Node const* hit_dom_node, Layout::Node const& target_layout_node)
+{
+    if (is_text_fragment && hit_dom_node) {
+        if (auto const* text_layout_node = hit_dom_node->layout_node(); text_layout_node && text_layout_node->parent())
+            return text_layout_node->parent()->pointer_events();
+    }
+    return as<Layout::NodeWithStyle>(target_layout_node).pointer_events();
+}
+
 void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
 {
     if (m_mouse_selection_target)
@@ -315,9 +324,10 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     if (!target_layout_node)
         return EventResult::Dropped;
 
-    auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
+    auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
     // FIXME: Handle other values for pointer-events.
-    VERIFY(pointer_events != CSS::PointerEvents::None);
+    if (pointer_events == CSS::PointerEvents::None)
+        return EventResult::Cancelled;
 
     if (!node)
         return EventResult::Dropped;
@@ -501,6 +511,11 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         if (!target_layout_node)
             return EventResult::Dropped;
 
+        auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
+        // FIXME: Handle other values for pointer-events.
+        if (pointer_events == CSS::PointerEvents::None)
+            return EventResult::Cancelled;
+
         auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
             return event_handler.handle_mousemove(position, screen_position, buttons, modifiers);
         });
@@ -508,10 +523,6 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
             clear_cursor.disarm();
             return *dispath_result;
         }
-
-        auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
-        // FIXME: Handle other values for pointer-events.
-        VERIFY(pointer_events != CSS::PointerEvents::None);
 
         // NB: Search for the first parent of the hit target that's an element.
         //
@@ -632,7 +643,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     if (!target_layout_node)
         return EventResult::Dropped;
 
-    auto pointer_events = as<Layout::NodeWithStyle>(*target_layout_node).pointer_events();
+    auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
     if (pointer_events == CSS::PointerEvents::None)
         return EventResult::Cancelled;
 

--- a/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-iframe-mousemove.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-iframe-mousemove.txt
@@ -1,0 +1,1 @@
+mousemove delivered to: outer document

--- a/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-inline-island.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-inline-island.txt
@@ -1,0 +1,1 @@
+mousemove delivered to: island

--- a/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-iframe-mousemove.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-iframe-mousemove.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0 }
+    iframe { position: absolute; left: 0; top: 0; width: 300px; height: 200px; border: 0; pointer-events: none }
+</style>
+<iframe id="frame" srcdoc="<body style='margin: 0'>inner</body>"></iframe>
+<script>
+    asyncTest(done => {
+        // An iframe with pointer-events:none must not deliver pointer events to its own document.
+        const frame = document.getElementById('frame');
+        frame.onload = () => {
+            const received = [];
+            frame.contentDocument.addEventListener('mousemove', () => received.push('iframe document'));
+            document.addEventListener('mousemove', () => received.push('outer document'));
+
+            internals.mouseMove(100, 100);
+
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                println(received.length ? `mousemove delivered to: ${received.join(', ')}`
+                                        : 'mousemove delivered to nothing');
+                done();
+            }));
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-inline-island.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-inline-island.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0 }
+    #none { position: absolute; left: 0; top: 0; width: 300px; height: 100px; pointer-events: none; font: 40px/100px monospace }
+    #island { pointer-events: auto }
+</style>
+<div id="none"><span id="island">ISLAND</span></div>
+<script>
+    asyncTest(done => {
+        // A pointer-events:auto inline inside a pointer-events:none block must still receive mouse events. The hit-test
+        // item for the text carries the line-root block as its box — so reading pointer-events from that box would
+        // wrongly report none.
+        const seen = [];
+        document.addEventListener('mousemove', event => seen.push(event.target.id || event.target.nodeName), true);
+        internals.mouseMove(60, 50);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            println(`mousemove delivered to: ${seen.length ? seen.join(', ') : 'nothing'}`);
+            done();
+        }));
+    });
+</script>


### PR DESCRIPTION
**Problem:** `VERIFICATION FAILED: pointer_events != CSS::PointerEvents::None` crash when moving or pressing the mouse. Reported against https://vscode.dev — where it fires a second or two after opening a new file.

**Cause:** **_We read the `pointer-events` value off the wrong element._** A text fragment’s hit-test item carries the fragment-owning line-root ancestor as its box — while whether that text is hit-testable at all is decided from the text’s *parent*. See `text_node_facts()` in `PaintingRustBridge`. So, given markup like this:

```html
<div style="pointer-events: none"
  ><span style="pointer-events: auto">text</span></div>
```

…the span makes the text a legitimate hit — but the item’s box is the `div`. We read `pointer-events` from that box/`div` — which then reports `none`, tripping the assert.

**Fix:** Take the value from the same element the recording filter used — so an inline island of `pointer-events: auto` in a `pointer-events: none` block is read as `auto`. Such an island now receives mouse events. Otherwise, without this change, the assert aborted the process. And stop asserting on `none`. Not every route to a target consults the filter. `Document::hit_test()` has a body fallback that doesn’t. So, `handle_mousedown()` and `handle_mousemove()` now return `EventResult::Cancelled` — as `handle_mouseup()` already did. And `handle_mousemove()` now checks before dispatching into a nested navigable — which the other two already did. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11332.

> [!NOTE]
> ### Why this hits vscode.dev
> 
> The https://vscode.dev empty-editor hint uses exactly the shape described above. From [`emptyTextEditorHint.css`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.css):
>
> ```css
> .monaco-editor .contentWidgets .empty-editor-hint {
>	pointer-events: none;
> }
>
> .monaco-editor .contentWidgets .empty-editor-hint a {
>	pointer-events: auto;
>}
> ```
> 
> And the hint text in [`emptyTextEditorHint.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts) marks its links with `[[…]]`, which `renderFormattedText()` turns into inline `a` elements:
>
> ```
> '[[Generate code]] ({0}), or [[select a language]] ({1}). Start typing to dismiss or [[don\'t show]] this again.'
> ```
> 
> So the hint’s a `pointer-events: none` container holding one line of text with `pointer-events: auto` inline links. Being inline, those links own no line box of their own — the line root is the `none` container, which is the box the hit item carries. That hint appears right when you create a new file, and the pointer only has to cross one of the links.