### PR TITLE
UI/Qt: Route Vulkan window pointer events through QWidget

### DIFF
--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -943,7 +943,7 @@ void WebContentView::set_vertical_tab_overlay_insets([[maybe_unused]] int left, 
     m_vertical_tab_overlay_left = left;
     m_vertical_tab_overlay_right = right;
 
-    update_vulkan_window_input_region();
+    update_vulkan_window_mask();
     schedule_repaint();
 #endif
 }

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -234,7 +234,7 @@ private:
 
     void create_vulkan_window();
     void destroy_vulkan_window();
-    void update_vulkan_window_input_region();
+    void update_vulkan_window_mask();
     void update_vulkan_alpha_blending_support();
     bool current_paintable_can_use_vulkan_window() const;
     void schedule_vulkan_window_update();

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -1024,27 +1024,32 @@ void WebContentView::update_vulkan_window_geometry()
 {
     if (m_vulkan_window_container)
         m_vulkan_window_container->setGeometry(rect());
-    update_vulkan_window_input_region();
+    update_vulkan_window_mask();
 }
 
-void WebContentView::update_vulkan_window_input_region()
+void WebContentView::update_vulkan_window_mask()
 {
     if (!m_vulkan_window || !m_vulkan_window_container)
         return;
 
-    // The strips overlaid by hover-expanded vertical tabs are painted transparent, but this native window still captures
-    // the pointer there. Exclude those strips from the input region so clicks fall through to the tab column beneath.
+    // Match the native window mask to the strips painted transparent for hover-expanded vertical tabs. On X11, the mask
+    // clips the window's bounding shape; on Wayland, it excludes those strips from the window's input region.
     auto size = m_vulkan_window_container->size();
-    QRegion input_region { QRect { QPoint { 0, 0 }, size } };
+    QRegion window_mask { QRect { QPoint { 0, 0 }, size } };
 
     if (m_vulkan_window_supports_alpha_blending.value_or(false)) {
         if (m_vertical_tab_overlay_left > 0)
-            input_region -= QRect { 0, 0, m_vertical_tab_overlay_left, size.height() };
+            window_mask -= QRect { 0, 0, m_vertical_tab_overlay_left, size.height() };
         if (m_vertical_tab_overlay_right > 0)
-            input_region -= QRect { size.width() - m_vertical_tab_overlay_right, 0, m_vertical_tab_overlay_right, size.height() };
+            window_mask -= QRect { size.width() - m_vertical_tab_overlay_right, 0, m_vertical_tab_overlay_right, size.height() };
     }
 
-    m_vulkan_window->setMask(input_region);
+    // QWindow interprets an empty mask as clearing the mask. Use a non-empty region outside the window to produce an
+    // empty effective bounding shape when the overlay strips cover the entire window.
+    if (window_mask.isEmpty() && !size.isEmpty())
+        window_mask += QRect { size.width(), size.height(), 1, 1 };
+
+    m_vulkan_window->setMask(window_mask);
 }
 
 void WebContentView::update_vulkan_alpha_blending_support()
@@ -1074,8 +1079,8 @@ void WebContentView::update_vulkan_alpha_blending_support()
     static constexpr auto blending_modes = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
     m_vulkan_window_supports_alpha_blending = (capabilities.supportedCompositeAlpha & blending_modes) != 0;
 
-    // The input mask was computed while support was still unknown; refresh it now that any stored insets can apply.
-    update_vulkan_window_input_region();
+    // The window mask was computed while support was still unknown; refresh it now that any stored insets can apply.
+    update_vulkan_window_mask();
 }
 
 void WebContentView::set_vulkan_window_cursor(QCursor const& cursor)

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -1034,8 +1034,8 @@ void WebContentView::update_vulkan_window_mask()
     if (!m_vulkan_window || !m_vulkan_window_container)
         return;
 
-    // Match the native window mask to the strips painted transparent for hover-expanded vertical tabs. On X11, the mask
-    // clips the window's bounding shape; on Wayland, it excludes those strips from the window's input region.
+    // On X11, the native window's bounding shape exposes the strips painted transparent for hover-expanded vertical
+    // tabs. Wayland instead uses the renderer's alpha output and empties the native window's input region separately.
     auto size = m_vulkan_window_container->size();
     QRegion window_mask { QRect { QPoint { 0, 0 }, size } };
 
@@ -1085,6 +1085,10 @@ void WebContentView::update_vulkan_alpha_blending_support()
         blending_modes |= VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
 
     m_vulkan_window_supports_alpha_blending = color_format_has_alpha && (capabilities.supportedCompositeAlpha & blending_modes) != 0;
+
+    // Route pointer input through QWidget when it can also display widgets beneath the Vulkan surface. QWidget's
+    // implicit mouse capture then preserves move and release events while the pointer is outside the browser window.
+    m_vulkan_window->setFlag(Qt::WindowTransparentForInput, *m_vulkan_window_supports_alpha_blending);
 
     // The window mask was computed while support was still unknown; refresh it now that any stored insets can apply.
     update_vulkan_window_mask();

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -773,11 +773,13 @@ struct WebContentView::VulkanWindowRenderer final : public QVulkanWindowRenderer
 
     virtual void releaseSwapChainResources() override
     {
+        m_view.m_vulkan_window_supports_alpha_blending.clear();
         m_renderer.release_pipeline();
     }
 
     virtual void releaseResources() override
     {
+        m_view.m_vulkan_window_supports_alpha_blending.clear();
         m_renderer.release();
     }
 
@@ -1072,12 +1074,17 @@ void WebContentView::update_vulkan_alpha_blending_support()
     if (vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device, surface, &capabilities) != VK_SUCCESS)
         return;
 
-    // Our transparent tab-column holes only reach the screen if the surface is blended per-pixel. QVulkanWindow (given
-    // our alpha format) picks a pre/post-multiplied mode when offered (the Wayland case), otherwise INHERIT, which
-    // blends against the window's ARGB visual on X11 while a compositor runs. If only OPAQUE is offered there is no
-    // blending at all, so the feature stays disabled.
-    static constexpr auto blending_modes = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
-    m_vulkan_window_supports_alpha_blending = (capabilities.supportedCompositeAlpha & blending_modes) != 0;
+    // Our transparent tab-column holes only reach the screen if the resolved swapchain format has alpha and the surface
+    // supports per-pixel blending. QVulkanWindow picks a pre/post-multiplied mode when offered. On X11 it may instead
+    // select INHERIT, where the window's ARGB visual and bounding mask provide the native compositing mechanism.
+    auto color_format = m_vulkan_window->colorFormat();
+    bool color_format_has_alpha = color_format == VK_FORMAT_B8G8R8A8_UNORM || color_format == VK_FORMAT_R8G8B8A8_UNORM;
+
+    VkCompositeAlphaFlagsKHR blending_modes = VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR | VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR;
+    if (QGuiApplication::platformName() == "xcb")
+        blending_modes |= VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
+
+    m_vulkan_window_supports_alpha_blending = color_format_has_alpha && (capabilities.supportedCompositeAlpha & blending_modes) != 0;
 
     // The window mask was computed while support was still unknown; refresh it now that any stored insets can apply.
     update_vulkan_window_mask();


### PR DESCRIPTION
The embedded `QVulkanWindow` does not receive a mouse release when a scrollbar drag leaves the browser window. When alpha blending is available, mark it as output-only so pointer events are delivered through the `QWidget` container instead.

`QWidget` then applies its implicit mouse grab for the duration of the press, preserving motion and release events outside the browser window. Only enable this when overlaid widgets can also be displayed, keeping input stacking consistent with the rendered content.

Pointer events being dropped was noticed, for example, while dragging the viewport scroll bar and moving the mouse outside of the browser window. With this patch, mouse move and release events while scrolling are handled again (as they are on macOS, and before we used the Vulkan window on Linux).