### PR TITLE
LibWeb: Avoid redundant deferred style flushes

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineInput.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineInput.cpp
@@ -2011,7 +2011,6 @@ void record_stylesheet_attached(CSSStyleSheet& sheet, DOM::Node& document_or_sha
 // the set is compared by identity and re-attached whole when it differs.
 void record_non_author_stylesheets(DOM::Document& document)
 {
-    document.flush_deferred_style_change_event();
     auto& style_computer = document.style_computer();
     auto& style_scope = document.style_scope();
 
@@ -2027,13 +2026,21 @@ void record_non_author_stylesheets(DOM::Document& document)
     }
 
     auto& recorded = style_computer.non_author_style_sheets();
-    if (recorded.size() == sheets.size()) {
-        bool unchanged = true;
-        for (size_t index = 0; index < sheets.size(); ++index)
-            unchanged &= recorded[index].sheet == sheets[index];
-        if (unchanged)
-            return;
-    }
+    auto recorded_sheets_match = [&] {
+        if (recorded.size() != sheets.size())
+            return false;
+        for (size_t index = 0; index < sheets.size(); ++index) {
+            if (recorded[index].sheet != sheets[index])
+                return false;
+        }
+        return true;
+    };
+    if (recorded_sheets_match())
+        return;
+
+    document.flush_deferred_style_change_event();
+    if (recorded_sheets_match())
+        return;
 
     auto& style_engine = style_computer.style_engine();
     for (auto const& entry : recorded)

--- a/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/geometry-read-defers-paint-only-style.txt
@@ -8,3 +8,5 @@ layout offset size: 200x20
 layout style settled: true
 transformed geometry: 18
 visual geometry style settled: true
+merged deferred style is observable: rgb(0, 0, 255)
+deferred and current style used one transaction: true

--- a/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/geometry-read-defers-paint-only-style.html
@@ -8,6 +8,9 @@
     #target.paint-only {
         background-color: red;
     }
+    #target.paint-only-next {
+        background-color: blue;
+    }
     #target.layout {
         width: 200px;
         height: 20px;
@@ -55,5 +58,16 @@
         counters = internals.getStyleInvalidationCounters();
         println(`transformed geometry: ${transformedRect.x}`);
         println(`visual geometry style settled: ${counters.styleStabilizationEpochs === 1}`);
+
+        target.className = "";
+        target.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        target.className = "paint-only";
+        target.getBoundingClientRect();
+        target.className = "paint-only-next";
+        internals.updateStyle();
+        counters = internals.getStyleInvalidationCounters();
+        println(`merged deferred style is observable: ${getComputedStyle(target).backgroundColor}`);
+        println(`deferred and current style used one transaction: ${counters.styleEngineTransactionSetups === 1}`);
     });
 </script>


### PR DESCRIPTION
Flush a deferred geometry boundary only when the non-author sheet set changes, then recheck after the reentrant flush before mutating it. Unchanged sheets merge both journals in the normal drain.

Extend the paint-only geometry test to require one transaction setup while preserving the final computed style.