### PR TITLE
LibWeb: Fast-path universal selector queries

### DIFF
--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -215,12 +215,15 @@ bool SelectorQuery::matches_simple_selector_in_dom(Element const& element) const
     }
 
     auto id = element.id().value_or({});
+    Utf16FlyString lowercase_id;
+    if (element.document().in_quirks_mode())
+        lowercase_id = id.to_ascii_lowercase();
     auto result = CSS::SelectorFFI::rust_selector_matches_simple_dom(
         &m_selectors.first()->rust_selector(),
         interned_name_identity(element.local_name()),
         interned_name_identity(element.lowercased_local_name()),
         interned_name_identity(id),
-        interned_name_identity(id.to_ascii_lowercase()),
+        interned_name_identity(lowercase_id),
         class_identities.data(),
         lowercase_class_identities.data(),
         class_identities.size(),

--- a/Libraries/LibWeb/Rust/src/css/selector_operations.rs
+++ b/Libraries/LibWeb/Rust/src/css/selector_operations.rs
@@ -179,7 +179,7 @@ fn supports_simple_dom_matching(selector: &CompiledSelector) -> bool {
     };
     !compound.simple_selectors.is_empty()
         && compound.simple_selectors.iter().all(|simple| match simple {
-            SimpleSelector::TagName(name) => matches!(
+            SimpleSelector::Universal(name) | SimpleSelector::TagName(name) => matches!(
                 name.namespace_type,
                 super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
             ),
@@ -324,6 +324,14 @@ pub unsafe extern "C" fn rust_selector_matches_simple_dom(
             };
             for simple in &compound.simple_selectors {
                 let matches = match simple {
+                    SimpleSelector::Universal(name)
+                        if matches!(
+                            name.namespace_type,
+                            super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
+                        ) =>
+                    {
+                        true
+                    }
                     SimpleSelector::TagName(name)
                         if matches!(
                             name.namespace_type,

--- a/Tests/LibWeb/Text/expected/DOM/query-selector-universal-fast-path-quirks.txt
+++ b/Tests/LibWeb/Text/expected/DOM/query-selector-universal-fast-path-quirks.txt
@@ -1,0 +1,11 @@
+mode: BackCompat
+document order: doc-html,doc-head,script,doc-body,root,first,icon,dot,second,outside,outside-child,runner,out
+document first: doc-html
+subtree order: first,icon,dot,second
+subtree first: first
+outside subtree: outside-child
+HTML element matches: true
+SVG element matches: true
+HTML closest: second
+SVG closest: dot
+combinator order: first,icon,dot,second

--- a/Tests/LibWeb/Text/expected/DOM/query-selector-universal-fast-path.txt
+++ b/Tests/LibWeb/Text/expected/DOM/query-selector-universal-fast-path.txt
@@ -1,0 +1,11 @@
+mode: CSS1Compat
+document order: doc-html,doc-head,script,doc-body,root,first,icon,dot,second,outside,outside-child,runner,out
+document first: doc-html
+subtree order: first,icon,dot,second
+subtree first: first
+outside subtree: outside-child
+HTML element matches: true
+SVG element matches: true
+HTML closest: second
+SVG closest: dot
+combinator order: first,icon,dot,second

--- a/Tests/LibWeb/Text/input/DOM/query-selector-universal-fast-path-quirks.html
+++ b/Tests/LibWeb/Text/input/DOM/query-selector-universal-fast-path-quirks.html
@@ -1,0 +1,29 @@
+<!DOCTYPE quirks>
+<html id="doc-html">
+<head id="doc-head">
+    <script src="../include.js"></script>
+</head>
+<body id="doc-body">
+    <div id="root"><section id="first"><svg id="icon"><circle id="dot"></circle></svg></section><p id="second"></p></div>
+    <aside id="outside"><em id="outside-child"></em></aside>
+    <script id="runner">
+        test(() => {
+            const root = document.querySelector("#root");
+            const outside = document.querySelector("#outside");
+            const dot = document.querySelector("#dot");
+
+            println(`mode: ${document.compatMode}`);
+            println(`document order: ${Array.from(document.querySelectorAll("*"), element => element.id || element.localName).join(",")}`);
+            println(`document first: ${document.querySelector("*").id}`);
+            println(`subtree order: ${Array.from(root.querySelectorAll("*"), element => element.id).join(",")}`);
+            println(`subtree first: ${root.querySelector("*").id}`);
+            println(`outside subtree: ${Array.from(outside.querySelectorAll("*"), element => element.id).join(",")}`);
+            println(`HTML element matches: ${root.matches("*")}`);
+            println(`SVG element matches: ${dot.matches("*")}`);
+            println(`HTML closest: ${document.querySelector("#second").closest("*").id}`);
+            println(`SVG closest: ${dot.closest("*").id}`);
+            println(`combinator order: ${Array.from(root.querySelectorAll("div *"), element => element.id).join(",")}`);
+        });
+    </script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/DOM/query-selector-universal-fast-path.html
+++ b/Tests/LibWeb/Text/input/DOM/query-selector-universal-fast-path.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html id="doc-html">
+<head id="doc-head">
+    <script src="../include.js"></script>
+</head>
+<body id="doc-body">
+    <div id="root"><section id="first"><svg id="icon"><circle id="dot"></circle></svg></section><p id="second"></p></div>
+    <aside id="outside"><em id="outside-child"></em></aside>
+    <script id="runner">
+        test(() => {
+            const root = document.querySelector("#root");
+            const outside = document.querySelector("#outside");
+            const dot = document.querySelector("#dot");
+
+            println(`mode: ${document.compatMode}`);
+            println(`document order: ${Array.from(document.querySelectorAll("*"), element => element.id || element.localName).join(",")}`);
+            println(`document first: ${document.querySelector("*").id}`);
+            println(`subtree order: ${Array.from(root.querySelectorAll("*"), element => element.id).join(",")}`);
+            println(`subtree first: ${root.querySelector("*").id}`);
+            println(`outside subtree: ${Array.from(outside.querySelectorAll("*"), element => element.id).join(",")}`);
+            println(`HTML element matches: ${root.matches("*")}`);
+            println(`SVG element matches: ${dot.matches("*")}`);
+            println(`HTML closest: ${document.querySelector("#second").closest("*").id}`);
+            println(`SVG closest: ${dot.closest("*").id}`);
+            println(`combinator order: ${Array.from(root.querySelectorAll("div *"), element => element.id).join(",")}`);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Match universal selectors directly from DOM data when their namespace is compatible with simple matching. Avoid lowercasing element IDs outside quirks mode. Cover document, subtree, namespace, and combinator cases.