### PR TITLE
Reuse cached layout work across unobserved block-size changes

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -720,6 +720,11 @@ WebIDL::UnsignedLongLong Internals::table_cell_measurement_cache_miss_count()
     return window().associated_document().layout_node_arena().table_cell_measurement_cache_miss_count();
 }
 
+WebIDL::UnsignedLongLong Internals::intrinsic_measurement_count()
+{
+    return window().associated_document().layout_node_arena().intrinsic_measurement_count();
+}
+
 WebIDL::UnsignedLongLong Internals::accumulated_visual_context_tree_build_count()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -119,6 +119,7 @@ public:
     WebIDL::UnsignedLongLong full_layout_count();
     WebIDL::UnsignedLongLong layout_run_cache_hit_count();
     WebIDL::UnsignedLongLong table_cell_measurement_cache_miss_count();
+    WebIDL::UnsignedLongLong intrinsic_measurement_count();
     WebIDL::UnsignedLongLong accumulated_visual_context_tree_build_count();
     void set_autoplay_policy(Utf16String const& policy);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -98,6 +98,7 @@ interface Internals {
     unsigned long long fullLayoutCount();
     unsigned long long layoutRunCacheHitCount();
     unsigned long long tableCellMeasurementCacheMissCount();
+    unsigned long long intrinsicMeasurementCount();
     unsigned long long accumulatedVisualContextTreeBuildCount();
     undefined setAutoplayPolicy(Utf16DOMString policy);
 

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -45,6 +45,11 @@ u64 NodeArena::table_cell_measurement_cache_miss_count() const
     return RustFFI::layout_arena_table_cell_measurement_cache_miss_count(m_handle);
 }
 
+u64 NodeArena::intrinsic_measurement_count() const
+{
+    return RustFFI::layout_arena_intrinsic_measurement_count(m_handle);
+}
+
 void NodeArena::drop_intrinsic_size_cache(RustFFI::NodeData const& node_data) const
 {
     RustFFI::layout_arena_drop_intrinsic_size_cache(m_handle, &node_data);

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -37,6 +37,7 @@ public:
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
     u64 table_cell_measurement_cache_miss_count() const;
+    u64 intrinsic_measurement_count() const;
     void drop_intrinsic_size_cache(RustFFI::NodeData const&) const;
 
     void enroll_text_node_for_content_sync(TextNode const&);

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1654,6 +1654,12 @@ impl BlockFormattingContext {
             // Keep the C++ behavior: diagnose and skip this unsupported box after its
             // vertical metrics have been resolved.
             eprintln!("FIXME: Block-level box is not BlockContainer but does not create formatting context");
+            crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+                &run.records,
+                &self.callbacks,
+                node,
+                self.sizing().resolve_percentage_block_size_dependency(node),
+            );
             return;
         }
 
@@ -1919,6 +1925,16 @@ impl BlockFormattingContext {
                 node,
                 inline_space_used_before_children_formatted,
                 list_item_first_baseline,
+            );
+        }
+
+        let dependency_was_not_reported_by_a_child_run = !has_independent_formatting_context;
+        if dependency_was_not_reported_by_a_child_run {
+            crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+                &run.records,
+                &self.callbacks,
+                node,
+                self.sizing().resolve_percentage_block_size_dependency(node),
             );
         }
 

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -449,6 +449,10 @@ impl FcRunCacheAttempt {
 
 fn verify_cached_entry_against_fresh_run(root_slot: u32, cached: &FcRunCacheEntry, fresh: &FcRunCacheEntry) {
     assert!(
+        cached.outputs.result.depends_on_percentage_block_size == fresh.outputs.result.depends_on_percentage_block_size,
+        "run cache shadow: percentage block-size dependency diverged for slot {root_slot}"
+    );
+    assert!(
         cached.outputs.result == fresh.outputs.result,
         "run cache shadow: child layout result diverged for slot {root_slot}"
     );

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -39,6 +39,78 @@ struct FcRunCacheKey {
     root_cells: UsedValuesCellState,
 }
 
+impl FcRunCacheKey {
+    fn matches(&self, probe: &Self, entry_depends_on_percentage_block_size: bool) -> bool {
+        if self == probe {
+            return true;
+        }
+        if entry_depends_on_percentage_block_size {
+            return false;
+        }
+        self.fc_type == probe.fc_type
+            && self.root_cells == probe.root_cells
+            && layout_inputs_match_ignoring_percentage_block_size(&self.input, &probe.input)
+    }
+}
+
+fn available_block_sizes_are_interchangeable(a: AvailableSize, b: AvailableSize) -> bool {
+    let is_definite_or_indefinite = |size: AvailableSize| matches!(size, AvailableSize::Definite(_) | AvailableSize::Indefinite);
+    a == b || (is_definite_or_indefinite(a) && is_definite_or_indefinite(b))
+}
+
+fn layout_inputs_match_ignoring_percentage_block_size(a: &LayoutInput, b: &LayoutInput) -> bool {
+    let LayoutInput {
+        available_space,
+        containing_block_constraints,
+        content_box_position_in_bfc_root,
+        sizing,
+        participation,
+    } = *a;
+    let ContainingBlockConstraints {
+        percentage_basis_inline_size,
+        percentage_basis_block_size: _,
+        quirks_mode_percentage_basis_block_size: _,
+    } = containing_block_constraints;
+    available_space.inline_size == b.available_space.inline_size
+        && available_block_sizes_are_interchangeable(available_space.block_size, b.available_space.block_size)
+        && percentage_basis_inline_size == b.containing_block_constraints.percentage_basis_inline_size
+        && content_box_position_in_bfc_root == b.content_box_position_in_bfc_root
+        && participation == b.participation
+        && sizing_directives_match_ignoring_percentage_block_size(&sizing, &b.sizing)
+}
+
+fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectives, b: &RootSizingDirectives) -> bool {
+    let RootSizingDirectives {
+        forced_content_inline_size,
+        forced_content_block_size,
+        forced_min_border_box_block_size,
+        table_cell_intrinsic_block_padding,
+        table_box_content_block_offset_in_wrapper,
+        adopt_automatic_content_block_size,
+        flex_self_block_size_resolution_space,
+        float_avoidance_inline_size,
+        outer_float_intrusion_before_list_item_children,
+        treat_block_axis_percentage_insets_as_auto_beyond_root,
+    } = *a;
+    forced_content_inline_size == b.forced_content_inline_size
+        && forced_content_block_size == b.forced_content_block_size
+        && forced_min_border_box_block_size == b.forced_min_border_box_block_size
+        && table_cell_intrinsic_block_padding == b.table_cell_intrinsic_block_padding
+        && table_box_content_block_offset_in_wrapper == b.table_box_content_block_offset_in_wrapper
+        && adopt_automatic_content_block_size == b.adopt_automatic_content_block_size
+        && float_avoidance_inline_size == b.float_avoidance_inline_size
+        && outer_float_intrusion_before_list_item_children == b.outer_float_intrusion_before_list_item_children
+        && treat_block_axis_percentage_insets_as_auto_beyond_root == b.treat_block_axis_percentage_insets_as_auto_beyond_root
+        && match (flex_self_block_size_resolution_space, b.flex_self_block_size_resolution_space) {
+            (None, None) => true,
+            (Some(a_space), Some(b_space)) => {
+                a_space.inline_size == b_space.inline_size
+                    && available_block_sizes_are_interchangeable(a_space.block_size, b_space.block_size)
+            }
+            _ => false,
+        }
+}
+
 /// What must still be true for a stored entry to be replayed: the slot
 /// holds the same box (generation), nothing in its subtree was invalidated
 /// (the fragment cache epoch, whose bump walk has no propagation boundary).
@@ -179,7 +251,7 @@ impl FcRunCacheArenaStore {
         if entry.validity != validity {
             return None;
         }
-        if entry.key != *key {
+        if !entry.key.matches(key, entry.outputs.result.depends_on_percentage_block_size) {
             return None;
         }
         Some(entry.clone())
@@ -198,7 +270,7 @@ impl FcRunCacheArenaStore {
         let entries = self.entries.borrow();
         let entry = entries.get(slot as usize)?.as_ref()?;
         if entry.validity.slot_generation != validity.slot_generation
-            || entry.key != *key
+            || !entry.key.matches(key, entry.outputs.result.depends_on_percentage_block_size)
             // Each child-list edit bumps once when topology changes and once
             // when the parent is marked for layout-tree-update layout.
             || validity

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -769,6 +769,7 @@ pub(crate) struct ChildLayoutResult {
     pub automatic_content_block_size: CssPixels,
     pub baselines: DerivedBaselines,
     pub table_box_in_wrapper_border_box_block_size: Option<CssPixels>,
+    pub depends_on_percentage_block_size: bool,
 }
 
 #[derive(Clone)]
@@ -1650,7 +1651,7 @@ fn execute_formatting_context_run(
         None
     };
     let mut implementation = None;
-    let result = if let Some((cached_block_size, cached_baselines)) = cached_atomic_block_size {
+    let mut result = if let Some((cached_block_size, cached_baselines)) = cached_atomic_block_size {
         ChildLayoutResult {
             automatic_content_block_size: cached_block_size,
             baselines: cached_baselines,
@@ -1679,6 +1680,7 @@ fn execute_formatting_context_run(
                     automatic_content_block_size: context.automatic_content_block_size(),
                     baselines,
                     table_box_in_wrapper_border_box_block_size: context.table_box_in_wrapper_border_box_block_size(),
+                    depends_on_percentage_block_size: false,
                 }
             }
             FormattingContextImplementation::Flex(context) => {
@@ -1759,6 +1761,7 @@ fn execute_formatting_context_run(
         }
         ParticipationInParentFormattingContext::Root => {}
     }
+    result.depends_on_percentage_block_size = run.sizing().resolve_percentage_block_size_dependency(run.box_);
 
     let take_run_fragments = || {
         run.fragments
@@ -1842,6 +1845,38 @@ fn finalize_atomic_root_block_size(
     }
 }
 
+pub(crate) fn propagate_percentage_block_size_dependency_to_containing_block(
+    records: &RunRecords,
+    callbacks: &FfiLayoutFcCallbacks,
+    child: Node,
+    child_depends_on_percentage_block_size: bool,
+) {
+    let run_root_reports_its_dependency_through_its_run_result = child == records.root();
+    if run_root_reports_its_dependency_through_its_run_result {
+        return;
+    }
+    let facts = NodeFacts::new(callbacks, child);
+    let resolves_against_containing_blocks_final_size = facts.is_absolutely_positioned();
+    if resolves_against_containing_blocks_final_size {
+        return;
+    }
+    let relative_block_insets_resolve_against_containing_block = facts.is_relatively_positioned() && {
+        let style = StyleValues::for_node(callbacks, child);
+        style.inset_top().contains_percentage() || style.inset_bottom().contains_percentage()
+    };
+    if !child_depends_on_percentage_block_size && !relative_block_insets_resolve_against_containing_block {
+        return;
+    }
+    let containing_block = callbacks.containing_block(child);
+    let containing_block_record_or_run_root_that_forwarded_the_basis = (!containing_block.is_invalid())
+        .then(|| records.used_values_if_owned(containing_block))
+        .flatten()
+        .unwrap_or_else(|| records.used_values(records.root()));
+    containing_block_record_or_run_root_that_forwarded_the_basis
+        .has_descendant_that_depends_on_percentage_block_size
+        .set(true);
+}
+
 pub(crate) fn layout_inside_child(
     run: &FormattingContextRun,
     parent_block: Option<&BlockFormattingContext>,
@@ -1859,6 +1894,14 @@ pub(crate) fn layout_inside_child(
         used.padding_top.set(used.padding_top.get() + padding_top);
         used.padding_bottom.set(used.padding_bottom.get() + padding_bottom);
     }
+    let note_skipped_child_dependency = || {
+        propagate_percentage_block_size_dependency_to_containing_block(
+            &run.records,
+            &run.callbacks,
+            child,
+            run.sizing().skipped_child_depends_on_percentage_block_size(child),
+        );
+    };
     if !force_independent_context_run
         && layout_mode == LayoutMode::IntrinsicSizing
         && matches!(input.participation, ParticipationInParentFormattingContext::AtomicInline)
@@ -1881,6 +1924,7 @@ pub(crate) fn layout_inside_child(
             Some(CssPixels::default()),
             || unreachable!("an empty atomic block has a zero automatic content block size"),
         );
+        note_skipped_child_dependency();
         return ChildLayoutOutcome::Skipped;
     }
     if !force_independent_context_run
@@ -1892,6 +1936,7 @@ pub(crate) fn layout_inside_child(
         && used.has_definite_block_size()
     {
         size_skipped_independent_root(run, parent_block, child, &input);
+        note_skipped_child_dependency();
         return ChildLayoutOutcome::Skipped;
     }
     let creates_replaced_context = matches!(
@@ -1900,6 +1945,7 @@ pub(crate) fn layout_inside_child(
     );
     if !facts.can_have_children() && !creates_replaced_context {
         size_skipped_independent_root(run, parent_block, child, &input);
+        note_skipped_child_dependency();
         return ChildLayoutOutcome::Skipped;
     }
 
@@ -1908,6 +1954,7 @@ pub(crate) fn layout_inside_child(
     });
     let Some(fc_type) = fc_type else {
         if force_independent_context_run {
+            note_skipped_child_dependency();
             return ChildLayoutOutcome::Skipped;
         }
         return ChildLayoutOutcome::ReenterCurrent;
@@ -1926,7 +1973,7 @@ pub(crate) fn layout_inside_child(
         &input,
         layout_mode == LayoutMode::Normal && !run.purpose.is_measurement(),
     );
-    ChildLayoutOutcome::Created(run_formatting_context(
+    let result = run_formatting_context(
         run.purpose,
         run.fragments.as_deref(),
         &used,
@@ -1938,7 +1985,14 @@ pub(crate) fn layout_inside_child(
         run.callbacks,
         input,
         parent_block,
-    ))
+    );
+    propagate_percentage_block_size_dependency_to_containing_block(
+        &run.records,
+        &run.callbacks,
+        child,
+        result.depends_on_percentage_block_size,
+    );
+    ChildLayoutOutcome::Created(result)
 }
 
 fn absorb_run_outputs(

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -61,39 +61,77 @@ impl IntrinsicSizeCacheKey {
             ..self
         }
     }
+
+    fn with_percentage_inline_basis_masked(self) -> Self {
+        Self {
+            percentage_basis_inline_size: None,
+            ..self
+        }
+    }
+
+    fn masked_for(self, dependencies: IntrinsicMeasurementDependencies) -> Self {
+        let mut key = self;
+        if !dependencies.percentage_block_size {
+            key = key.with_percentage_block_bases_masked();
+        }
+        if !dependencies.percentage_inline_basis {
+            key = key.with_percentage_inline_basis_masked();
+        }
+        key
+    }
 }
 
-// Independent measurements are stored under the masked key. A masked probe must skip dependent
-// entries: a dependent measurement made without a basis shares the masked key's shape.
-fn intrinsic_cache_lookup<V: Copy>(
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct IntrinsicMeasurementDependencies {
+    pub(crate) percentage_block_size: bool,
+    pub(crate) percentage_inline_basis: bool,
+}
+
+pub(crate) trait IntrinsicMeasurement: Copy {
+    fn dependencies(&self) -> IntrinsicMeasurementDependencies;
+}
+
+// Measurements are stored under their key with every basis they never observed masked out. A
+// probe that had to mask a basis must skip entries that observed it: a measurement made without
+// that basis shares the masked key's shape.
+fn intrinsic_cache_lookup<V: IntrinsicMeasurement>(
     map: &HashMap<IntrinsicSizeCacheKey, V>,
     key: IntrinsicSizeCacheKey,
-    depends_on_percentage_block_size: impl Fn(&V) -> bool,
 ) -> Option<V> {
     if let Some(value) = map.get(&key) {
         return Some(*value);
     }
-    let masked_key = key.with_percentage_block_bases_masked();
-    if masked_key == key {
-        return None;
-    }
-    map.get(&masked_key)
-        .copied()
-        .filter(|value| !depends_on_percentage_block_size(value))
+    let block_masked = key.with_percentage_block_bases_masked();
+    let inline_masked = key.with_percentage_inline_basis_masked();
+    let masking_block_changes_key = block_masked != key;
+    let masking_inline_changes_key = inline_masked != key;
+    let candidates = [
+        (block_masked, masking_block_changes_key, true, false),
+        (inline_masked, masking_inline_changes_key, false, true),
+        (
+            block_masked.with_percentage_inline_basis_masked(),
+            masking_block_changes_key && masking_inline_changes_key,
+            true,
+            true,
+        ),
+    ];
+    candidates.into_iter().filter(|(_, applies, _, _)| *applies).find_map(
+        |(candidate, _, block_was_masked, inline_was_masked)| {
+            let value = *map.get(&candidate)?;
+            let dependencies = value.dependencies();
+            let observed_a_masked_basis = (block_was_masked && dependencies.percentage_block_size)
+                || (inline_was_masked && dependencies.percentage_inline_basis);
+            (!observed_a_masked_basis).then_some(value)
+        },
+    )
 }
 
-fn intrinsic_cache_store<V>(
+fn intrinsic_cache_store<V: IntrinsicMeasurement>(
     map: &mut HashMap<IntrinsicSizeCacheKey, V>,
     key: IntrinsicSizeCacheKey,
     value: V,
-    depends_on_percentage_block_size: bool,
 ) {
-    let key = if depends_on_percentage_block_size {
-        key
-    } else {
-        key.with_percentage_block_bases_masked()
-    };
-    map.insert(key, value);
+    map.insert(key.masked_for(value.dependencies()), value);
 }
 
 impl Hash for IntrinsicSizeCacheKey {
@@ -186,12 +224,32 @@ pub(crate) struct IntrinsicInlineSizeMeasurement {
     pub(crate) has_last_baseline: bool,
     pub(crate) last_baseline: CssPixels,
     pub(crate) depends_on_percentage_block_size: bool,
+    pub(crate) depends_on_percentage_inline_basis: bool,
+}
+
+impl IntrinsicMeasurement for IntrinsicInlineSizeMeasurement {
+    fn dependencies(&self) -> IntrinsicMeasurementDependencies {
+        IntrinsicMeasurementDependencies {
+            percentage_block_size: self.depends_on_percentage_block_size,
+            percentage_inline_basis: self.depends_on_percentage_inline_basis,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct IntrinsicBlockSizeMeasurement {
     pub(crate) size: CssPixels,
     pub(crate) depends_on_percentage_block_size: bool,
+    pub(crate) depends_on_percentage_inline_basis: bool,
+}
+
+impl IntrinsicMeasurement for IntrinsicBlockSizeMeasurement {
+    fn dependencies(&self) -> IntrinsicMeasurementDependencies {
+        IntrinsicMeasurementDependencies {
+            percentage_block_size: self.depends_on_percentage_block_size,
+            percentage_inline_basis: self.depends_on_percentage_inline_basis,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -993,7 +1051,7 @@ impl LayoutNodeArena {
             .as_ref()?
             .block_sizes(kind)
             .expect("block size cache kind must use the block axis");
-        intrinsic_cache_lookup(map, key, |measurement| measurement.depends_on_percentage_block_size)
+        intrinsic_cache_lookup(map, key)
     }
 
     fn with_intrinsic_size_maps_mut(&self, data: &NodeData, callback: impl FnOnce(&mut IntrinsicSizeMaps)) {
@@ -1024,7 +1082,7 @@ impl LayoutNodeArena {
             let map = maps
                 .block_sizes_mut(kind)
                 .expect("block size cache kind must use the block axis");
-            intrinsic_cache_store(map, key, value, value.depends_on_percentage_block_size);
+            intrinsic_cache_store(map, key, value);
         });
     }
 
@@ -1053,7 +1111,7 @@ impl LayoutNodeArena {
             .as_ref()?
             .inline_measurements(kind)
             .expect("inline measurement cache kind must use the inline axis");
-        intrinsic_cache_lookup(map, key, |measurement| measurement.depends_on_percentage_block_size)
+        intrinsic_cache_lookup(map, key)
     }
 
     pub(crate) fn intrinsic_inline_size_depends_on_block_size(
@@ -1094,7 +1152,7 @@ impl LayoutNodeArena {
             let map = maps
                 .inline_measurements_mut(kind)
                 .expect("inline measurement cache kind must use the inline axis");
-            intrinsic_cache_store(map, key, value, value.depends_on_percentage_block_size);
+            intrinsic_cache_store(map, key, value);
         });
     }
 
@@ -2257,6 +2315,7 @@ mod tests {
         let value = IntrinsicBlockSizeMeasurement {
             size: CssPixels::from_raw(128),
             depends_on_percentage_block_size: false,
+            depends_on_percentage_inline_basis: false,
         };
         let inline_measurement = IntrinsicInlineSizeMeasurement {
             automatic_content_inline_size: CssPixels::from_raw(192),
@@ -2271,6 +2330,7 @@ mod tests {
             has_last_baseline: true,
             last_baseline: CssPixels::from_raw(128),
             depends_on_percentage_block_size: false,
+            depends_on_percentage_inline_basis: false,
         };
         let dependency_computations = Cell::new(0);
 
@@ -2364,6 +2424,7 @@ mod tests {
         let independent = IntrinsicBlockSizeMeasurement {
             size: CssPixels::from_raw(128),
             depends_on_percentage_block_size: false,
+            depends_on_percentage_inline_basis: false,
         };
         arena.intrinsic_block_size_cache_put(data, max_content, key_with_basis(100), independent);
         assert_eq!(
@@ -2382,6 +2443,7 @@ mod tests {
         let dependent = IntrinsicBlockSizeMeasurement {
             size: CssPixels::from_raw(256),
             depends_on_percentage_block_size: true,
+            depends_on_percentage_inline_basis: false,
         };
         arena.intrinsic_block_size_cache_put(data, min_content, key_without_basis, dependent);
         assert_eq!(
@@ -2399,6 +2461,42 @@ mod tests {
         );
         assert_eq!(
             arena.intrinsic_block_size_cache_get(data, min_content, key_with_basis(200)),
+            None
+        );
+
+        let key_at_another_inline_size_with_inline_basis = |basis: i32| IntrinsicSizeCacheKey {
+            measured_at_inline_size: Some(CssPixels::from_raw(96)),
+            percentage_basis_inline_size: Some(CssPixels::from_raw(basis)),
+            ..key_with_basis(100)
+        };
+        let observes_inline_basis = IntrinsicBlockSizeMeasurement {
+            size: CssPixels::from_raw(512),
+            depends_on_percentage_block_size: false,
+            depends_on_percentage_inline_basis: true,
+        };
+        arena.intrinsic_block_size_cache_put(
+            data,
+            max_content,
+            key_at_another_inline_size_with_inline_basis(300),
+            observes_inline_basis,
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, max_content, key_at_another_inline_size_with_inline_basis(300)),
+            Some(observes_inline_basis)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(
+                data,
+                max_content,
+                IntrinsicSizeCacheKey {
+                    percentage_basis_block_size: Some(CssPixels::from_raw(200)),
+                    ..key_at_another_inline_size_with_inline_basis(300)
+                }
+            ),
+            Some(observes_inline_basis)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, max_content, key_at_another_inline_size_with_inline_basis(400)),
             None
         );
         arena.free(allocation.slot, allocation.generation);

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -53,6 +53,49 @@ pub(crate) struct IntrinsicSizeCacheKey {
     pub(crate) quirks_mode_percentage_basis_block_size: Option<CssPixels>,
 }
 
+impl IntrinsicSizeCacheKey {
+    fn with_percentage_block_bases_masked(self) -> Self {
+        Self {
+            percentage_basis_block_size: None,
+            quirks_mode_percentage_basis_block_size: None,
+            ..self
+        }
+    }
+}
+
+// Independent measurements are stored under the masked key. A masked probe must skip dependent
+// entries: a dependent measurement made without a basis shares the masked key's shape.
+fn intrinsic_cache_lookup<V: Copy>(
+    map: &HashMap<IntrinsicSizeCacheKey, V>,
+    key: IntrinsicSizeCacheKey,
+    depends_on_percentage_block_size: impl Fn(&V) -> bool,
+) -> Option<V> {
+    if let Some(value) = map.get(&key) {
+        return Some(*value);
+    }
+    let masked_key = key.with_percentage_block_bases_masked();
+    if masked_key == key {
+        return None;
+    }
+    map.get(&masked_key)
+        .copied()
+        .filter(|value| !depends_on_percentage_block_size(value))
+}
+
+fn intrinsic_cache_store<V>(
+    map: &mut HashMap<IntrinsicSizeCacheKey, V>,
+    key: IntrinsicSizeCacheKey,
+    value: V,
+    depends_on_percentage_block_size: bool,
+) {
+    let key = if depends_on_percentage_block_size {
+        key
+    } else {
+        key.with_percentage_block_bases_masked()
+    };
+    map.insert(key, value);
+}
+
 impl Hash for IntrinsicSizeCacheKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         fn hash_optional<H: Hasher>(value: Option<CssPixels>, state: &mut H) {
@@ -319,6 +362,7 @@ pub(crate) struct LayoutNodeArena {
     live_count: u32,
     intrinsic_size_caches: RefCell<Vec<IntrinsicSizeCacheSlot>>,
     table_cell_measurement_cache_misses: Cell<u64>,
+    intrinsic_measurements: Cell<u64>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
@@ -344,6 +388,7 @@ impl LayoutNodeArena {
             live_count: 0,
             intrinsic_size_caches: RefCell::new(Vec::new()),
             table_cell_measurement_cache_misses: Cell::new(0),
+            intrinsic_measurements: Cell::new(0),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
@@ -943,12 +988,12 @@ impl LayoutNodeArena {
         if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
             return None;
         }
-        slot.sizes
+        let map = slot
+            .sizes
             .as_ref()?
             .block_sizes(kind)
-            .expect("block size cache kind must use the block axis")
-            .get(&key)
-            .copied()
+            .expect("block size cache kind must use the block axis");
+        intrinsic_cache_lookup(map, key, |measurement| measurement.depends_on_percentage_block_size)
     }
 
     fn with_intrinsic_size_maps_mut(&self, data: &NodeData, callback: impl FnOnce(&mut IntrinsicSizeMaps)) {
@@ -976,9 +1021,10 @@ impl LayoutNodeArena {
         value: IntrinsicBlockSizeMeasurement,
     ) {
         self.with_intrinsic_size_maps_mut(data, |maps| {
-            maps.block_sizes_mut(kind)
-                .expect("block size cache kind must use the block axis")
-                .insert(key, value);
+            let map = maps
+                .block_sizes_mut(kind)
+                .expect("block size cache kind must use the block axis");
+            intrinsic_cache_store(map, key, value, value.depends_on_percentage_block_size);
         });
     }
 
@@ -1002,12 +1048,12 @@ impl LayoutNodeArena {
         if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
             return None;
         }
-        slot.sizes
+        let map = slot
+            .sizes
             .as_ref()?
             .inline_measurements(kind)
-            .expect("inline measurement cache kind must use the inline axis")
-            .get(&key)
-            .copied()
+            .expect("inline measurement cache kind must use the inline axis");
+        intrinsic_cache_lookup(map, key, |measurement| measurement.depends_on_percentage_block_size)
     }
 
     pub(crate) fn intrinsic_inline_size_depends_on_block_size(
@@ -1045,9 +1091,10 @@ impl LayoutNodeArena {
         value: IntrinsicInlineSizeMeasurement,
     ) {
         self.with_intrinsic_size_maps_mut(data, |maps| {
-            maps.inline_measurements_mut(kind)
-                .expect("inline measurement cache kind must use the inline axis")
-                .insert(key, value);
+            let map = maps
+                .inline_measurements_mut(kind)
+                .expect("inline measurement cache kind must use the inline axis");
+            intrinsic_cache_store(map, key, value, value.depends_on_percentage_block_size);
         });
     }
 
@@ -1083,6 +1130,14 @@ impl LayoutNodeArena {
 
     pub(crate) fn table_cell_measurement_cache_miss_count(&self) -> u64 {
         self.table_cell_measurement_cache_misses.get()
+    }
+
+    pub(crate) fn note_intrinsic_measurement(&self) {
+        self.intrinsic_measurements.set(self.intrinsic_measurements.get() + 1);
+    }
+
+    pub(crate) fn intrinsic_measurement_count(&self) -> u64 {
+        self.intrinsic_measurements.get()
     }
 
     pub(crate) fn saved_abspos_layout_inputs(&self, data: *const NodeData) -> Option<AbsposLayoutInputs> {
@@ -1841,6 +1896,19 @@ pub unsafe extern "C" fn layout_arena_table_cell_measurement_cache_miss_count(ar
 
 /// # Safety
 ///
+/// The arena must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_intrinsic_measurement_count(arena: *mut c_void) -> u64 {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &*arena.cast::<LayoutNodeArena>() }.intrinsic_measurement_count()
+    })
+}
+
+/// # Safety
+///
 /// The arena must remain valid for the duration of the call, and `id` must
 /// name a live node in this arena.
 #[unsafe(no_mangle)]
@@ -2272,6 +2340,68 @@ mod tests {
             None
         );
         arena.free(second.slot, second.generation);
+    }
+
+    #[test]
+    fn intrinsic_size_cache_answers_masked_probes_only_from_independent_measurements() {
+        let mut arena = LayoutNodeArena::new();
+        let allocation = arena.allocate();
+        // SAFETY: The allocation remains live until it is explicitly freed below.
+        let data = unsafe { &mut *allocation.data };
+        let key_with_basis = |basis: i32| IntrinsicSizeCacheKey {
+            measured_at_inline_size: Some(CssPixels::from_raw(64)),
+            percentage_basis_block_size: Some(CssPixels::from_raw(basis)),
+            quirks_mode_percentage_basis_block_size: Some(CssPixels::from_raw(basis)),
+            ..Default::default()
+        };
+        let key_without_basis = IntrinsicSizeCacheKey {
+            measured_at_inline_size: Some(CssPixels::from_raw(64)),
+            ..Default::default()
+        };
+        let max_content = IntrinsicSizeCacheKind::MaxContentBlock;
+        let min_content = IntrinsicSizeCacheKind::MinContentBlock;
+
+        let independent = IntrinsicBlockSizeMeasurement {
+            size: CssPixels::from_raw(128),
+            depends_on_percentage_block_size: false,
+        };
+        arena.intrinsic_block_size_cache_put(data, max_content, key_with_basis(100), independent);
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, max_content, key_with_basis(100)),
+            Some(independent)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, max_content, key_with_basis(200)),
+            Some(independent)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, max_content, key_without_basis),
+            Some(independent)
+        );
+
+        let dependent = IntrinsicBlockSizeMeasurement {
+            size: CssPixels::from_raw(256),
+            depends_on_percentage_block_size: true,
+        };
+        arena.intrinsic_block_size_cache_put(data, min_content, key_without_basis, dependent);
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, min_content, key_without_basis),
+            Some(dependent)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, min_content, key_with_basis(100)),
+            None
+        );
+        arena.intrinsic_block_size_cache_put(data, min_content, key_with_basis(100), dependent);
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, min_content, key_with_basis(100)),
+            Some(dependent)
+        );
+        assert_eq!(
+            arena.intrinsic_block_size_cache_get(data, min_content, key_with_basis(200)),
+            None
+        );
+        arena.free(allocation.slot, allocation.generation);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -142,6 +142,13 @@ pub(crate) struct IntrinsicInlineSizeMeasurement {
     pub(crate) first_baseline: CssPixels,
     pub(crate) has_last_baseline: bool,
     pub(crate) last_baseline: CssPixels,
+    pub(crate) depends_on_percentage_block_size: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IntrinsicBlockSizeMeasurement {
+    pub(crate) size: CssPixels,
+    pub(crate) depends_on_percentage_block_size: bool,
 }
 
 #[derive(Default)]
@@ -150,13 +157,16 @@ struct IntrinsicSizeMaps {
     inline_size_depends_on_block_size: Option<bool>,
     min_content_inline_size: HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>,
     max_content_inline_size: HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>,
-    min_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
-    max_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
+    min_content_block_size: HashMap<IntrinsicSizeCacheKey, IntrinsicBlockSizeMeasurement>,
+    max_content_block_size: HashMap<IntrinsicSizeCacheKey, IntrinsicBlockSizeMeasurement>,
     table_cell_measurements: HashMap<TableCellMeasurementKey, TableCellMeasurement>,
 }
 
 impl IntrinsicSizeMaps {
-    fn block_sizes(&self, kind: IntrinsicSizeCacheKind) -> Option<&HashMap<IntrinsicSizeCacheKey, CssPixels>> {
+    fn block_sizes(
+        &self,
+        kind: IntrinsicSizeCacheKind,
+    ) -> Option<&HashMap<IntrinsicSizeCacheKey, IntrinsicBlockSizeMeasurement>> {
         match kind {
             IntrinsicSizeCacheKind::MinContentInline | IntrinsicSizeCacheKind::MaxContentInline => None,
             IntrinsicSizeCacheKind::MinContentBlock => Some(&self.min_content_block_size),
@@ -167,7 +177,7 @@ impl IntrinsicSizeMaps {
     fn block_sizes_mut(
         &mut self,
         kind: IntrinsicSizeCacheKind,
-    ) -> Option<&mut HashMap<IntrinsicSizeCacheKey, CssPixels>> {
+    ) -> Option<&mut HashMap<IntrinsicSizeCacheKey, IntrinsicBlockSizeMeasurement>> {
         match kind {
             IntrinsicSizeCacheKind::MinContentInline | IntrinsicSizeCacheKind::MaxContentInline => None,
             IntrinsicSizeCacheKind::MinContentBlock => Some(&mut self.min_content_block_size),
@@ -918,7 +928,7 @@ impl LayoutNodeArena {
         data: &NodeData,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
-    ) -> Option<CssPixels> {
+    ) -> Option<IntrinsicBlockSizeMeasurement> {
         assert!(
             matches!(
                 kind,
@@ -963,7 +973,7 @@ impl LayoutNodeArena {
         data: &NodeData,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
-        value: CssPixels,
+        value: IntrinsicBlockSizeMeasurement,
     ) {
         self.with_intrinsic_size_maps_mut(data, |maps| {
             maps.block_sizes_mut(kind)
@@ -1989,8 +1999,8 @@ mod tests {
     use std::cell::Cell;
 
     use crate::layout::layout_node_arena::{
-        Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
-        SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
+        Chunk, IntrinsicBlockSizeMeasurement, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey,
+        IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
     };
     use crate::layout::node_data::{NodeFlag, NodeSlotId};
     use crate::layout::{
@@ -2176,7 +2186,10 @@ mod tests {
             measured_at_inline_size: Some(CssPixels::from_raw(64)),
             ..Default::default()
         };
-        let value = CssPixels::from_raw(128);
+        let value = IntrinsicBlockSizeMeasurement {
+            size: CssPixels::from_raw(128),
+            depends_on_percentage_block_size: false,
+        };
         let inline_measurement = IntrinsicInlineSizeMeasurement {
             automatic_content_inline_size: CssPixels::from_raw(192),
             min_content_inline_size_from_max_content_layout: Some(CssPixels::from_raw(96)),
@@ -2189,6 +2202,7 @@ mod tests {
             first_baseline: CssPixels::from_raw(64),
             has_last_baseline: true,
             last_baseline: CssPixels::from_raw(128),
+            depends_on_percentage_block_size: false,
         };
         let dependency_computations = Cell::new(0);
 

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -46,6 +46,7 @@ mod tree_builder;
 
 include!("used_values.rs");
 
+use crate::layout::layout_node_arena::IntrinsicBlockSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKind;

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -66,6 +66,12 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         },
         None,
     );
+    crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+        &run.records,
+        &run.callbacks,
+        wrapper,
+        wrapper_result.depends_on_percentage_block_size,
+    );
     crate::layout::place_child(run, wrapper, FfiCssPixelPoint::default(), None);
 
     ChildLayoutResult {

--- a/Libraries/LibWeb/Rust/src/layout/run_records.rs
+++ b/Libraries/LibWeb/Rust/src/layout/run_records.rs
@@ -83,6 +83,10 @@ impl RunRecords {
     pub(crate) fn used_values_if_owned(&self, node: Node) -> Option<std::rc::Rc<UsedValues>> {
         self.arena().run_record(node.slot_index(), self.nonce)
     }
+
+    pub(crate) fn root(&self) -> Node {
+        self.root
+    }
 }
 
 impl Drop for RunRecords {

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -872,6 +872,27 @@ impl SizingContext {
             || unvisited_content_below_a_forwarding_box_is_assumed_dependent
     }
 
+    // Descendants resolve percentages against the measured box itself, so only the box's own style
+    // can reach its containing block's inline basis.
+    fn measurement_root_observes_percentage_inline_basis(&self, node: Node) -> bool {
+        let facts = self.facts(node);
+        if facts.is_anonymous() || facts.is_replaced_box() || facts.has_auto_content_box_size() {
+            return true;
+        }
+        let style = self.style(node);
+        style.width().contains_percentage()
+            || style.min_width().contains_percentage()
+            || style.max_width().contains_percentage()
+            || style.padding_left().contains_percentage()
+            || style.padding_right().contains_percentage()
+            || style.padding_top().contains_percentage()
+            || style.padding_bottom().contains_percentage()
+            || style.margin_left().contains_percentage()
+            || style.margin_right().contains_percentage()
+            || style.margin_top().contains_percentage()
+            || style.margin_bottom().contains_percentage()
+    }
+
     pub(crate) fn charge_measurement_dependency_to_measured_box_and_containing_block(
         &self,
         node: Node,
@@ -1465,6 +1486,7 @@ impl SizingContext {
                 has_last_baseline: used.has_last_baseline.get(),
                 last_baseline: used.last_baseline.get(),
                 depends_on_percentage_block_size: result.depends_on_percentage_block_size,
+                depends_on_percentage_inline_basis: self.measurement_root_observes_percentage_inline_basis(node),
             },
         );
     }
@@ -1944,6 +1966,7 @@ impl SizingContext {
             IntrinsicBlockSizeMeasurement {
                 size: value,
                 depends_on_percentage_block_size: result.depends_on_percentage_block_size,
+                depends_on_percentage_inline_basis: self.measurement_root_observes_percentage_inline_basis(node),
             },
         );
         value

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -779,11 +779,111 @@ impl SizingContext {
             constraints.quirks_mode_percentage_basis_block_size
         };
 
+        let forwarded_a_block_basis = (!used.has_definite_block_size()
+            && should_forward_indefinite_basis
+            && constraints.percentage_basis_block_size.is_some())
+            || (quirks_block.is_some()
+                && quirks_block == constraints.quirks_mode_percentage_basis_block_size
+                && facts.document_in_quirks_mode()
+                && !facts.is_viewport()
+                && !facts.is_table_cell()
+                && style.height().is_auto()
+                && !facts.is_absolutely_positioned()
+                && facts.is_block_container()
+                && !facts.is_table_wrapper());
+        debug_assert!(
+            !forwarded_a_block_basis || self.passes_percentage_block_size_through_to_children(containing_block),
+            "a containing block that forwards a percentage block basis must report it to dependency tracking"
+        );
+
         ContainingBlockConstraints {
             percentage_basis_inline_size: inline,
             percentage_basis_block_size: block,
             quirks_mode_percentage_basis_block_size: quirks_block,
         }
+    }
+
+    pub(crate) fn own_style_depends_on_percentage_block_size(&self, node: Node) -> bool {
+        let facts = self.facts(node);
+        if facts.is_text_node() {
+            return false;
+        }
+        let style = self.style(node);
+        let size_reads_block_axis_input = |size: &ComputedSize| size.contains_percentage() || size.is_fit_content();
+        let quirks_fill_viewport_rule_reads_block_basis = facts.document_in_quirks_mode()
+            && style.height().is_auto()
+            && (facts.is_html_html_element() || facts.is_html_body_element());
+        let table_cell_vertical_padding_resolves_against_block_basis = facts.is_table_cell()
+            && (style.padding_top().contains_percentage() || style.padding_bottom().contains_percentage());
+        size_reads_block_axis_input(style.height())
+            || size_reads_block_axis_input(style.min_height())
+            || size_reads_block_axis_input(style.max_height())
+            || quirks_fill_viewport_rule_reads_block_basis
+            || table_cell_vertical_padding_resolves_against_block_basis
+    }
+
+    pub(crate) fn passes_percentage_block_size_through_to_children(&self, node: Node) -> bool {
+        let facts = self.facts(node);
+        if facts.is_text_node() {
+            return false;
+        }
+        let table_formatting_context_resolves_participants_against_its_input_basis =
+            facts.is_table_wrapper() || facts.is_table_box();
+        if table_formatting_context_resolves_participants_against_its_input_basis {
+            return true;
+        }
+        let style = self.style(node);
+        let in_quirks_mode = facts.document_in_quirks_mode();
+        let svg_root_forwards_quirks_basis = facts.is_svg_svg_box() && in_quirks_mode;
+        let forwards_block_basis_as_anonymous_box = facts.is_box()
+            && facts.is_anonymous()
+            && !facts.is_table_cell()
+            && !facts.has_auto_content_box_size()
+            && self.records.used_values_if_owned(node).is_some_and(|used| {
+                used.inline_size_constraint.get() == SizeConstraint::None
+                    && used.block_size_constraint.get() == SizeConstraint::None
+            });
+        let forwards_quirks_basis_as_auto_height_block_container = in_quirks_mode
+            && !facts.is_viewport()
+            && !facts.is_table_cell()
+            && style.height().is_auto()
+            && !facts.is_absolutely_positioned()
+            && facts.is_block_container()
+            && !facts.is_table_wrapper();
+        svg_root_forwards_quirks_basis
+            || forwards_block_basis_as_anonymous_box
+            || forwards_quirks_basis_as_auto_height_block_container
+    }
+
+    pub(crate) fn resolve_percentage_block_size_dependency(&self, node: Node) -> bool {
+        let used = self.used(node);
+        let depends_on_percentage_block_size = used.depends_on_percentage_block_size.get()
+            || self.own_style_depends_on_percentage_block_size(node)
+            || (used.has_descendant_that_depends_on_percentage_block_size.get()
+                && self.passes_percentage_block_size_through_to_children(node));
+        used.depends_on_percentage_block_size.set(depends_on_percentage_block_size);
+        depends_on_percentage_block_size
+    }
+
+    pub(crate) fn skipped_child_depends_on_percentage_block_size(&self, node: Node) -> bool {
+        let unvisited_content_below_a_forwarding_box_is_assumed_dependent =
+            self.has_children(node) && self.passes_percentage_block_size_through_to_children(node);
+        self.own_style_depends_on_percentage_block_size(node)
+            || unvisited_content_below_a_forwarding_box_is_assumed_dependent
+    }
+
+    pub(crate) fn charge_measurement_dependency_to_measured_box_and_containing_block(
+        &self,
+        node: Node,
+        depends_on_percentage_block_size: bool,
+    ) {
+        if !depends_on_percentage_block_size {
+            return;
+        }
+        if let Some(record) = self.records.used_values_if_owned(node) {
+            record.depends_on_percentage_block_size.set(true);
+        }
+        propagate_percentage_block_size_dependency_to_containing_block(&self.records, &self.callbacks, node, true);
     }
 
     pub(crate) fn should_treat_inline_size_as_auto(&self, node: Node, available_space: AvailableSpace) -> bool {
@@ -1279,10 +1379,16 @@ impl SizingContext {
         node: Node,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
-    ) -> Option<CssPixels> {
-        self.callbacks
+    ) -> Option<IntrinsicBlockSizeMeasurement> {
+        let measurement = self
+            .callbacks
             .arena()
-            .intrinsic_block_size_cache_get(self.callbacks.node_data(node), kind, key)
+            .intrinsic_block_size_cache_get(self.callbacks.node_data(node), kind, key)?;
+        self.charge_measurement_dependency_to_measured_box_and_containing_block(
+            node,
+            measurement.depends_on_percentage_block_size,
+        );
+        Some(measurement)
     }
 
     fn intrinsic_block_cache_put(
@@ -1290,7 +1396,7 @@ impl SizingContext {
         node: Node,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
-        value: CssPixels,
+        value: IntrinsicBlockSizeMeasurement,
     ) {
         self.callbacks
             .arena()
@@ -1303,11 +1409,16 @@ impl SizingContext {
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
     ) -> Option<IntrinsicInlineSizeMeasurement> {
-        self.callbacks.arena().intrinsic_inline_size_measurement_cache_get(
+        let measurement = self.callbacks.arena().intrinsic_inline_size_measurement_cache_get(
             self.callbacks.node_data(node),
             kind,
             key,
-        )
+        )?;
+        self.charge_measurement_dependency_to_measured_box_and_containing_block(
+            node,
+            measurement.depends_on_percentage_block_size,
+        );
+        Some(measurement)
     }
 
     fn intrinsic_inline_measurement_cache_put(
@@ -1353,6 +1464,7 @@ impl SizingContext {
                 first_baseline: used.first_baseline.get(),
                 has_last_baseline: used.has_last_baseline.get(),
                 last_baseline: used.last_baseline.get(),
+                depends_on_percentage_block_size: result.depends_on_percentage_block_size,
             },
         );
     }
@@ -1775,6 +1887,10 @@ impl SizingContext {
             .min_content_inline_size_from_max_content_layout
             .map(clamp_to_max_dimension_value);
         let value = result.automatic_content_inline_size;
+        self.charge_measurement_dependency_to_measured_box_and_containing_block(
+            node,
+            result.depends_on_percentage_block_size,
+        );
         self.cache_intrinsic_inline_measurement(node, kind, key, &root, result, block_size);
         value
     }
@@ -1794,7 +1910,7 @@ impl SizingContext {
         };
         let key = cache_key(Some(inline_size), None, constraints);
         if let Some(cached) = self.intrinsic_block_cache_get(node, kind, key) {
-            return cached;
+            return cached.size;
         }
 
         let measurement = MeasurementState::create(self.callbacks);
@@ -1815,7 +1931,19 @@ impl SizingContext {
             ),
         );
         let value = clamp_to_max_dimension_value(result.automatic_content_block_size);
-        self.intrinsic_block_cache_put(node, kind, key, value);
+        self.charge_measurement_dependency_to_measured_box_and_containing_block(
+            node,
+            result.depends_on_percentage_block_size,
+        );
+        self.intrinsic_block_cache_put(
+            node,
+            kind,
+            key,
+            IntrinsicBlockSizeMeasurement {
+                size: value,
+                depends_on_percentage_block_size: result.depends_on_percentage_block_size,
+            },
+        );
         value
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -763,7 +763,9 @@ impl SizingContext {
         // 5. Jump to the first step.
         // NOTE: Evaluated incrementally: in-flow auto-height block containers pass the basis they
         //       inherited from their own containing block through to their children.
-        let quirks_block = if facts.is_viewport() {
+        let quirks_block = if !facts.document_in_quirks_mode() {
+            None
+        } else if facts.is_viewport() {
             Some(used.content_block_size.get())
         } else if facts.is_table_cell() {
             Some(CssPixels::default())

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1854,6 +1854,7 @@ impl SizingContext {
             return cached.automatic_content_inline_size;
         }
 
+        self.callbacks.arena().note_intrinsic_measurement();
         let measurement = MeasurementState::create(self.callbacks);
         let root = measurement.create_used_values(node, constraints);
         // NB: A parent layout can assign a definite block size that is not present in computed style,
@@ -1913,6 +1914,7 @@ impl SizingContext {
             return cached.size;
         }
 
+        self.callbacks.arena().note_intrinsic_measurement();
         let measurement = MeasurementState::create(self.callbacks);
         let root = measurement.create_used_values(node, constraints);
         root.block_size_constraint.set(size_constraint);

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -1146,15 +1146,24 @@ impl TableFormattingContext {
             }));
     }
 
+    // Participants resolve percentages against the table's input basis inside this context, so
+    // their dependency is charged here rather than through child runs.
     fn seed_table_participant_used_values(&mut self) {
-        for group in self.matching_children(self.table_box, |display| display.is_table_row_group_kind()) {
-            self.create_used_values(group, self.participant_constraints);
-        }
-        for row in &self.rows {
-            self.create_used_values(row.box_, self.participant_constraints);
-        }
-        for cell in &self.cells {
-            self.create_used_values(cell.box_, self.participant_constraints);
+        let participants: Vec<Node> = self
+            .matching_children(self.table_box, |display| display.is_table_row_group_kind())
+            .into_iter()
+            .chain(self.rows.iter().map(|row| row.box_))
+            .chain(self.cells.iter().map(|cell| cell.box_))
+            .collect();
+        let sizing = self.sizing();
+        let table_record = self.used_values(self.table_box);
+        for participant in participants {
+            self.create_used_values(participant, self.participant_constraints);
+            if sizing.own_style_depends_on_percentage_block_size(participant) {
+                table_record
+                    .has_descendant_that_depends_on_percentage_block_size
+                    .set(true);
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -289,6 +289,9 @@ pub(crate) struct UsedValues {
     pub has_last_baseline: Cell<bool>,
     pub last_baseline: Cell<CssPixels>,
 
+    // Layout outputs, deliberately outside the cell state.
+    pub depends_on_percentage_block_size: Cell<bool>,
+    pub has_descendant_that_depends_on_percentage_block_size: Cell<bool>,
 
     pub(crate) line_data: LazyRefCell<std::rc::Rc<LineData>>,
     pub(crate) rare_data: LazyRefCell<UsedValuesRareData>,
@@ -327,6 +330,8 @@ impl Default for UsedValues {
             first_baseline: Cell::new(zero),
             has_last_baseline: Cell::new(false),
             last_baseline: Cell::new(zero),
+            depends_on_percentage_block_size: Cell::new(false),
+            has_descendant_that_depends_on_percentage_block_size: Cell::new(false),
             line_data: LazyRefCell::new(),
             rare_data: LazyRefCell::new(),
         }

--- a/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-block-size-independent.txt
+++ b/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-block-size-independent.txt
@@ -1,0 +1,2 @@
+measurement delta: 0
+first item height: 26

--- a/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-inline-basis-independent.txt
+++ b/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-inline-basis-independent.txt
@@ -1,0 +1,2 @@
+measurement delta: 0
+inner width: 154.6875

--- a/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-min-height-dependent.txt
+++ b/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-min-height-dependent.txt
@@ -1,0 +1,2 @@
+measured again: true
+dependent item height: 50 -> 100

--- a/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-padding-dependent.txt
+++ b/Tests/LibWeb/Text/expected/intrinsic-measurement-cache-percentage-padding-dependent.txt
@@ -1,0 +1,2 @@
+measured again: true
+inner width: 184.6875 -> 194.6875

--- a/Tests/LibWeb/Text/expected/layout-run-cache-anonymous-flex-item-forwards-percentage-height.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-anonymous-flex-item-forwards-percentage-height.txt
@@ -1,0 +1,2 @@
+hit delta: 1
+inline-block height: 50 -> 100

--- a/Tests/LibWeb/Text/expected/layout-run-cache-percentage-block-size-independent-hits.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-percentage-block-size-independent-hits.txt
@@ -1,0 +1,2 @@
+hit delta: 1
+cached height: 40

--- a/Tests/LibWeb/Text/expected/layout-run-cache-percentage-min-height-root-misses.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-percentage-min-height-root-misses.txt
@@ -1,0 +1,2 @@
+hit delta: 0
+cached height: 50 -> 100

--- a/Tests/LibWeb/Text/expected/layout-run-cache-quirks-percentage-height-chain-misses.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-quirks-percentage-height-chain-misses.txt
@@ -1,0 +1,3 @@
+compat mode: BackCompat
+hit delta: 0
+inner height: 50 -> 100

--- a/Tests/LibWeb/Text/expected/layout-run-cache-standards-percentage-height-absorbed-hits.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-standards-percentage-height-absorbed-hits.txt
@@ -1,0 +1,2 @@
+hit delta: 1
+inner height: 0 -> 0

--- a/Tests/LibWeb/Text/expected/layout-run-cache-table-percentage-cell-height-misses.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-table-percentage-cell-height-misses.txt
@@ -1,0 +1,3 @@
+fixed table replayed: true
+percentage table height: 50 -> 100
+fixed table height: 20

--- a/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-block-size-independent.html
+++ b/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-block-size-independent.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #flex { display: flex; align-items: flex-start; width: 300px; height: 100px; }
+    .item { padding: 5px; }
+</style>
+<div id="flex"><div class="item">alpha beta</div><div class="item">gamma</div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const measurementsBefore = internals.intrinsicMeasurementCount();
+
+        // The items' intrinsic sizes were measured with the container's old height as their
+        // percentage basis; nothing in them observed it, so the cached measurements still answer.
+        document.getElementById("flex").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`measurement delta: ${internals.intrinsicMeasurementCount() - measurementsBefore}`);
+        println(`first item height: ${document.querySelector(".item").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-inline-basis-independent.html
+++ b/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-inline-basis-independent.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #outer { display: flex; width: 300px; }
+    #inner { display: flex; flex: none; }
+    .item { padding: 5px; }
+</style>
+<div id="outer"><div id="inner"><div class="item">alpha beta</div><div class="item">gamma</div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const measurementsBefore = internals.intrinsicMeasurementCount();
+
+        // #inner's intrinsic sizes were measured with #outer's width as their inline percentage
+        // basis; nothing in #inner resolves against it, so the cached measurements still answer.
+        document.getElementById("outer").style.width = "400px";
+        document.body.offsetHeight;
+
+        println(`measurement delta: ${internals.intrinsicMeasurementCount() - measurementsBefore}`);
+        println(`inner width: ${document.getElementById("inner").getBoundingClientRect().width}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-min-height-dependent.html
+++ b/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-min-height-dependent.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #flex { display: flex; align-items: flex-start; width: 300px; height: 100px; }
+    .item { padding: 5px; }
+    #dependent { min-height: 50%; box-sizing: border-box; }
+</style>
+<div id="flex"><div class="item">alpha beta</div><div class="item" id="dependent">gamma</div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const heightBefore = document.getElementById("dependent").getBoundingClientRect().height;
+        const measurementsBefore = internals.intrinsicMeasurementCount();
+
+        // The dependent item's percentage min-height observes the container's height, so its
+        // measurements are keyed on that basis and must be redone.
+        document.getElementById("flex").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`measured again: ${internals.intrinsicMeasurementCount() > measurementsBefore}`);
+        println(`dependent item height: ${heightBefore} -> ${document.getElementById("dependent").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-padding-dependent.html
+++ b/Tests/LibWeb/Text/input/intrinsic-measurement-cache-percentage-padding-dependent.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #outer { display: flex; width: 300px; }
+    #inner { display: flex; flex: none; padding-left: 10%; }
+    .item { padding: 5px; }
+</style>
+<div id="outer"><div id="inner"><div class="item">alpha beta</div><div class="item">gamma</div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const widthBefore = document.getElementById("inner").getBoundingClientRect().width;
+        const measurementsBefore = internals.intrinsicMeasurementCount();
+
+        // #inner's percentage padding resolves against #outer's width, so its measurements are keyed
+        // on that basis and must be redone.
+        document.getElementById("outer").style.width = "400px";
+        document.body.offsetHeight;
+
+        println(`measured again: ${internals.intrinsicMeasurementCount() > measurementsBefore}`);
+        println(`inner width: ${widthBefore} -> ${document.getElementById("inner").getBoundingClientRect().width}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-anonymous-flex-item-forwards-percentage-height.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-anonymous-flex-item-forwards-percentage-height.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #flex { display: flex; align-items: flex-start; width: 300px; height: 100px; }
+    #inline-block { display: inline-block; width: 20px; height: 50%; }
+    #plain { width: 50px; }
+    #plain div { height: 30px; }
+</style>
+<div id="flex">
+    x<span id="inline-block"></span>
+    <div id="plain"><div></div></div>
+</div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const inlineBlockHeightBefore = document.getElementById("inline-block").getBoundingClientRect().height;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // The anonymous flex item around the inline content forwards the container's block size to
+        // the inline-block's percentage height, so its run depends on that size and misses, while
+        // #plain is replayed.
+        document.getElementById("flex").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`inline-block height: ${inlineBlockHeightBefore} -> ${document.getElementById("inline-block").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-percentage-block-size-independent-hits.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-percentage-block-size-independent-hits.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #container { width: 300px; height: 100px; }
+    #cached { width: 200px; overflow: hidden; }
+    #inner { width: 100px; height: 40px; }
+</style>
+<div id="container"><div id="cached"><div id="inner"></div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // Nothing inside #cached resolves a percentage against #container's height, so its run
+        // is replayed even though its available and percentage block sizes changed.
+        document.getElementById("container").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`cached height: ${document.getElementById("cached").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-percentage-min-height-root-misses.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-percentage-min-height-root-misses.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #container { width: 300px; height: 100px; }
+    #cached { width: 200px; overflow: hidden; min-height: 50%; }
+    #inner { width: 100px; height: 40px; }
+</style>
+<div id="container"><div id="cached"><div id="inner"></div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const heightBefore = document.getElementById("cached").getBoundingClientRect().height;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // The root's own min-height is a percentage of #container's height, which is not part of
+        // the run's assigned cells, so the stored run must not be replayed.
+        document.getElementById("container").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`cached height: ${heightBefore} -> ${document.getElementById("cached").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-quirks-percentage-height-chain-misses.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-quirks-percentage-height-chain-misses.html
@@ -1,0 +1,25 @@
+<!DOCTYPE quirks>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #container { width: 300px; height: 100px; }
+    #cached { width: 200px; overflow: hidden; }
+    #inner { width: 100px; height: 50%; }
+</style>
+<div id="container"><div id="cached"><div id="inner"></div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const innerHeightBefore = document.getElementById("inner").getBoundingClientRect().height;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // In quirks mode the auto-height #cached passes #container's height through to #inner's
+        // percentage height, so #cached's run depends on it and must not be replayed.
+        document.getElementById("container").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`compat mode: ${document.compatMode}`);
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`inner height: ${innerHeightBefore} -> ${document.getElementById("inner").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-standards-percentage-height-absorbed-hits.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-standards-percentage-height-absorbed-hits.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #container { width: 300px; height: 100px; }
+    #cached { width: 200px; overflow: hidden; }
+    #inner { width: 100px; height: 50%; }
+</style>
+<div id="container"><div id="cached"><div id="inner"></div></div></div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const innerHeightBefore = document.getElementById("inner").getBoundingClientRect().height;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // In standards mode #inner's percentage resolves against the auto-height #cached and
+        // behaves as auto, so #cached's run does not depend on #container's height.
+        document.getElementById("container").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`inner height: ${innerHeightBefore} -> ${document.getElementById("inner").getBoundingClientRect().height}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-table-percentage-cell-height-misses.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-table-percentage-cell-height-misses.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #container { width: 300px; height: 100px; }
+    table { border-spacing: 0; width: 100px; }
+    td { padding: 0; }
+    #percentage-cell { height: 50%; }
+    #fixed-cell { height: 20px; }
+</style>
+<div id="container">
+    <table id="percentage-table"><tr><td id="percentage-cell">x</td></tr></table>
+    <table id="fixed-table"><tr><td id="fixed-cell">x</td></tr></table>
+</div>
+<script>
+    test(() => {
+        document.body.offsetHeight;
+        const percentageHeightBefore = document.getElementById("percentage-table").getBoundingClientRect().height;
+        const hitsBefore = internals.layoutRunCacheHitCount();
+
+        // Table cells resolve percentage heights against the basis the table forwards from its
+        // containing block, so only the table with fixed cell heights is replayed. The shadow run
+        // cache oracle also probes the runs nested inside a replayed table, so the exact hit count
+        // is not stable; the percentage table's geometry shows that it was laid out again.
+        document.getElementById("container").style.height = "200px";
+        document.body.offsetHeight;
+
+        println(`fixed table replayed: ${internals.layoutRunCacheHitCount() - hitsBefore >= 1}`);
+        println(`percentage table height: ${percentageHeightBefore} -> ${document.getElementById("percentage-table").getBoundingClientRect().height}`);
+        println(`fixed table height: ${document.getElementById("fixed-table").getBoundingClientRect().height}`);
+    });
+</script>


### PR DESCRIPTION
The layout caches keyed on every block-axis input a run received (the
available block size, the percentage block basis, the quirks basis), so
any ancestor resolving its height threw away all cached layout below it,
even though most content never reads those values. On nested flex pages
one leaf could be measured 29 times in a single layout.

This series records during layout whether a box, or an in-flow descendant
whose basis it forwards, actually resolved something against the
percentage block size, stores that bit with each cached run and intrinsic
measurement, and lets the caches ignore the block-axis inputs when nothing
depended on them. The last commit applies the same idea to the inline
basis of intrinsic measurements, which content measured under an
intrinsic constraint cannot observe either.

```
| Benchmark                                | master  | branch  | Change                       |
|------------------------------------------|---------|---------|------------------------------|
| Speedometer3 (total time)                | 6.03 s  | 5.58 s  | -7.5% (score 4.4 -> 4.6)     |
| StyleBench                               | 2.61 s  | 2.34 s  | -10.4% (score 99.9 -> 111.7) |
| StyleBenchConservative                   | 3.11 s  | 2.87 s  | -7.8% (score 79.9 -> 86.6)   |
| WebKitDOM                                | 2.65 s  | 2.48 s  | -6.4%                        |
| Speedometer3 NewsSite-Next/NavigateToUS  | 322 ms  | 240 ms  | -26%                         |
| Speedometer3 Editor-CodeMirror/Long      | 66 ms   | 52 ms   | -21%                         |
```