### PR TITLE
Compositor+LibWeb: A couple minor scrollbar improvements

### DIFF
--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -39,12 +39,12 @@ bool Scrollbar::contains(CSSPixelPoint position, ChromeMetrics const& metrics) c
 
 MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position)
 {
-    if (type == UIEvents::EventNames::pointermove) {
+    if (type == UIEvents::EventNames::pointermove || type == UIEvents::EventNames::pointerup) {
         if (!m_thumb_grab_position.has_value())
             return MouseAction::None;
-    } else if (button != UIEvents::MouseButton::Primary) {
-        return MouseAction::None;
     }
+    if (type != UIEvents::EventNames::pointermove && button != UIEvents::MouseButton::Primary)
+        return MouseAction::None;
 
     auto* node = layout_node();
     if (!node) {

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -128,7 +128,7 @@ bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
     auto gutter_size = scrollbar_data->gutter_rect.primary_size_for_orientation(orientation);
     auto thumb_size = scrollbar_data->thumb_rect.primary_size_for_orientation(orientation);
 
-    if (gutter_size < thumb_size)
+    if (gutter_size <= thumb_size)
         return true;
 
     if (!m_thumb_grab_position.has_value()) {

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -132,7 +132,12 @@ bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
         return true;
 
     if (!m_thumb_grab_position.has_value()) {
-        m_thumb_grab_position = scrollbar_data->thumb_rect.contains(position)
+        auto primary_position = position.primary_offset_for_orientation(orientation);
+        auto position_is_along_thumb = orientation == Orientation::Vertical
+            ? scrollbar_data->thumb_rect.contains_vertically(primary_position)
+            : scrollbar_data->thumb_rect.contains_horizontally(primary_position);
+
+        m_thumb_grab_position = position_is_along_thumb
             ? (position - scrollbar_data->thumb_rect.location()).primary_offset_for_orientation(orientation)
             : max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
         if (auto navigable = node->document().navigable())

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -292,6 +292,11 @@ ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEve
             result.frame_to_present = *frame_to_present;
             result.should_request_rendering_update = true;
         }
+
+        auto hovered_scrollbar_index = m_viewport_scrollbar_controller.hit_test(m_async_scroll_tree, m_scroll_state_snapshot, position);
+        if (m_viewport_scrollbar_controller.set_hovered_scrollbar(hovered_scrollbar_index) && !m_async_scrolling_viewport_rect.is_empty())
+            result.frame_to_present = m_async_scrolling_viewport_rect;
+
         return result;
     }
     case Web::MouseEvent::Type::MouseLeave: {

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -280,6 +280,9 @@ ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEve
         };
     }
     case Web::MouseEvent::Type::MouseUp: {
+        if (event.button != Web::UIEvents::MouseButton::Primary)
+            return {};
+
         auto drag = m_viewport_scrollbar_controller.release_captured_drag(position);
         if (!drag.has_value())
             return {};

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -126,23 +126,29 @@ Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::begin_d
         auto scroll_offset = async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, scroll_state_snapshot);
         if (!scroll_offset.has_value())
             continue;
+        if (!scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position))
+            continue;
 
         auto expanded = is_expanded(i);
         auto orientation = orientation_for_scrollbar(scrollbar);
         auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
+        auto thumb_hit_rect = thumb_rect.to_type<float>();
+
         auto primary_position = position.primary_offset_for_orientation(orientation);
+        auto position_is_along_thumb = orientation == Gfx::Orientation::Vertical
+            ? thumb_hit_rect.contains_vertically(primary_position)
+            : thumb_hit_rect.contains_horizontally(primary_position);
+
         float thumb_grab_position = 0;
-        if (thumb_rect.to_type<float>().contains(position)) {
+        if (position_is_along_thumb) {
             thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
-        } else if (scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position)) {
+        } else {
             auto gutter_rect = scrollbar_gutter_rect(scrollbar, true);
             auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
             auto gutter_start = static_cast<float>(gutter_rect.primary_offset_for_orientation(orientation));
             auto gutter_size = static_cast<float>(gutter_rect.primary_size_for_orientation(orientation));
             auto offset_relative_to_gutter = primary_position - gutter_start;
             thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
-        } else {
-            continue;
         }
 
         m_captured_scrollbar_index = i;

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -129,8 +129,10 @@ Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::begin_d
     auto scroll_offset = async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, scroll_state_snapshot);
     VERIFY(scroll_offset.has_value());
 
-    auto expanded = is_expanded(*scrollbar_index);
     auto orientation = orientation_for_scrollbar(scrollbar);
+
+    // A successful press captures and expands the scrollbar before its drag delta is applied.
+    static constexpr auto expanded = true;
     auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
     auto thumb_hit_rect = thumb_rect.to_type<float>();
 

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -121,43 +121,40 @@ Optional<size_t> ViewportScrollbarController::hit_test(Web::Compositor::AsyncScr
 
 Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::begin_drag(Web::Compositor::AsyncScrollTree const& async_scroll_tree, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position)
 {
-    for (size_t i = 0; i < m_scrollbars.size(); ++i) {
-        auto const& scrollbar = m_scrollbars[i];
-        auto scroll_offset = async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, scroll_state_snapshot);
-        if (!scroll_offset.has_value())
-            continue;
-        if (!scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position))
-            continue;
+    auto scrollbar_index = hit_test(async_scroll_tree, scroll_state_snapshot, position);
+    if (!scrollbar_index.has_value())
+        return {};
 
-        auto expanded = is_expanded(i);
-        auto orientation = orientation_for_scrollbar(scrollbar);
-        auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
-        auto thumb_hit_rect = thumb_rect.to_type<float>();
+    auto const& scrollbar = m_scrollbars[*scrollbar_index];
+    auto scroll_offset = async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, scroll_state_snapshot);
+    VERIFY(scroll_offset.has_value());
 
-        auto primary_position = position.primary_offset_for_orientation(orientation);
-        auto position_is_along_thumb = orientation == Gfx::Orientation::Vertical
-            ? thumb_hit_rect.contains_vertically(primary_position)
-            : thumb_hit_rect.contains_horizontally(primary_position);
+    auto expanded = is_expanded(*scrollbar_index);
+    auto orientation = orientation_for_scrollbar(scrollbar);
+    auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
+    auto thumb_hit_rect = thumb_rect.to_type<float>();
 
-        float thumb_grab_position = 0;
-        if (position_is_along_thumb) {
-            thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
-        } else {
-            auto gutter_rect = scrollbar_gutter_rect(scrollbar, true);
-            auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
-            auto gutter_start = static_cast<float>(gutter_rect.primary_offset_for_orientation(orientation));
-            auto gutter_size = static_cast<float>(gutter_rect.primary_size_for_orientation(orientation));
-            auto offset_relative_to_gutter = primary_position - gutter_start;
-            thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
-        }
+    auto primary_position = position.primary_offset_for_orientation(orientation);
+    auto position_is_along_thumb = orientation == Gfx::Orientation::Vertical
+        ? thumb_hit_rect.contains_vertically(primary_position)
+        : thumb_hit_rect.contains_horizontally(primary_position);
 
-        m_captured_scrollbar_index = i;
-        m_hovered_scrollbar_index = i;
-        m_thumb_grab_position = thumb_grab_position;
-        return Drag { i, primary_position, thumb_grab_position };
+    float thumb_grab_position = 0;
+    if (position_is_along_thumb) {
+        thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
+    } else {
+        auto gutter_rect = scrollbar_gutter_rect(scrollbar, true);
+        auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
+        auto gutter_start = static_cast<float>(gutter_rect.primary_offset_for_orientation(orientation));
+        auto gutter_size = static_cast<float>(gutter_rect.primary_size_for_orientation(orientation));
+        auto offset_relative_to_gutter = primary_position - gutter_start;
+        thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
     }
 
-    return {};
+    m_captured_scrollbar_index = *scrollbar_index;
+    m_hovered_scrollbar_index = *scrollbar_index;
+    m_thumb_grab_position = thumb_grab_position;
+    return Drag { *scrollbar_index, primary_position, thumb_grab_position };
 }
 
 Optional<ViewportScrollbarController::Drag> ViewportScrollbarController::captured_drag(Gfx::FloatPoint position)

--- a/Tests/Compositor/CMakeLists.txt
+++ b/Tests/Compositor/CMakeLists.txt
@@ -1,1 +1,8 @@
-ladybird_test(TestContextState.cpp Compositor LIBS compositorservice LibGfx LibWeb)
+set(TEST_SOURCES
+    TestContextState.cpp
+    TestViewportScrollbarController.cpp
+)
+
+foreach(source IN LISTS TEST_SOURCES)
+    ladybird_test("${source}" Compositor LIBS compositorservice LibGfx LibWeb)
+endforeach()

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -207,3 +207,22 @@ TEST_CASE(viewport_scrollbar_collapses_when_drag_is_released_away_from_scrollbar
     EXPECT(!next_move_result.accepted);
     EXPECT(!next_move_result.frame_to_present.has_value());
 }
+
+TEST_CASE(viewport_scrollbar_drag_ignores_non_primary_mouse_up)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, true };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    context.install_display_list_update(make_display_list_with_viewport_scrollbar(visual_context_tree), visual_context_tree, {});
+
+    EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 98, 10)).accepted);
+    EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseDown, 98, 10, Web::UIEvents::MouseButton::Primary)).accepted);
+
+    auto secondary_release_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseUp, 50, 50, Web::UIEvents::MouseButton::Secondary));
+    EXPECT(!secondary_release_result.accepted);
+
+    // The primary-button drag remains captured after another button is released.
+    EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 50, 60)).accepted);
+    EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseUp, 50, 60, Web::UIEvents::MouseButton::Primary)).accepted);
+}

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -12,6 +12,7 @@
 #include <LibIPC/Encoder.h>
 #include <LibIPC/Message.h>
 #include <LibTest/TestCase.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 
 struct TestWebContentClient final : public Compositor::CompositorStateWebContentClient {
@@ -21,41 +22,118 @@ struct TestWebContentClient final : public Compositor::CompositorStateWebContent
     virtual void release_video_edge(Media::VideoSinkHandle) override { }
 };
 
-static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<Gfx::Color> color, Optional<Gfx::Color> surface_clear_color = {})
+template<Web::Painting::DisplayListCommand Command>
+static void append_display_list_command(ByteBuffer& command_bytes, Command const& command, bool context_geometry_only, Optional<Gfx::IntRect> bounding_rect = {})
 {
-    ByteBuffer command_bytes;
-    if (color.has_value()) {
-        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color };
-        auto payload = Web::Painting::display_list_object_bytes(command);
-        auto record_size = sizeof(Web::Painting::DisplayListCommandHeader) + payload.size();
-        auto payload_size = align_up_to(record_size, Web::Painting::DisplayList::command_alignment) - sizeof(Web::Painting::DisplayListCommandHeader);
-        Web::Painting::DisplayListCommandHeader header {
-            .command_type = Web::Painting::FillRect::command_type,
-            .payload_size = static_cast<u32>(payload_size),
-            .context_index = Web::Painting::VISUAL_VIEWPORT_NODE_INDEX,
-            .context_geometry_only = false,
-            .has_bounding_rect = true,
-            .is_clip = false,
-            .bounding_rect = command.rect,
-        };
-        command_bytes.append(Web::Painting::display_list_object_bytes(header));
-        command_bytes.append(payload);
-        command_bytes.resize(sizeof(header) + payload_size, ByteBuffer::ZeroFillNewElements::Yes);
-    }
+    auto payload = Web::Painting::display_list_object_bytes(command);
+    auto record_size = sizeof(Web::Painting::DisplayListCommandHeader) + payload.size();
+    auto payload_size = align_up_to(record_size, Web::Painting::DisplayList::command_alignment) - sizeof(Web::Painting::DisplayListCommandHeader);
+    Web::Painting::DisplayListCommandHeader header {
+        .command_type = Command::command_type,
+        .payload_size = static_cast<u32>(payload_size),
+        .context_index = Web::Painting::VISUAL_VIEWPORT_NODE_INDEX,
+        .context_geometry_only = context_geometry_only,
+        .has_bounding_rect = bounding_rect.has_value(),
+        .is_clip = false,
+        .bounding_rect = bounding_rect.value_or({}),
+    };
+    command_bytes.append(Web::Painting::display_list_object_bytes(header));
+    command_bytes.append(payload);
+    // Pad the record so the next command begins at an aligned offset.
+    command_bytes.resize(align_up_to(command_bytes.size(), Web::Painting::DisplayList::command_alignment), ByteBuffer::ZeroFillNewElements::Yes);
+}
 
+static NonnullRefPtr<Web::Painting::DisplayList> decode_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, ByteBuffer command_bytes, Optional<Gfx::Color> surface_clear_color = {}, Optional<Web::Painting::DisplayList::AsyncScrollingMetadata> async_scrolling_metadata = {})
+{
     IPC::MessageBuffer buffer;
     IPC::Encoder encoder { buffer };
     MUST(encoder.encode(static_cast<u64>(1)));
     MUST(encoder.encode(command_bytes));
     MUST(encoder.encode(visual_context_tree.version()));
     MUST(encoder.encode(surface_clear_color));
-    MUST(encoder.encode(Optional<Web::Painting::DisplayList::AsyncScrollingMetadata> {}));
+    MUST(encoder.encode(async_scrolling_metadata));
     MUST(encoder.encode(HashMap<Web::Painting::VisualContextIndex, Web::Painting::DisplayListResourceId> {}));
 
     FixedMemoryStream stream { buffer.data().span() };
     Queue<IPC::Attachment> attachments;
     IPC::Decoder decoder { stream, attachments };
     return MUST(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>());
+}
+
+static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<Gfx::Color> color, Optional<Gfx::Color> surface_clear_color = {})
+{
+    ByteBuffer command_bytes;
+    if (color.has_value()) {
+        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color };
+        append_display_list_command(command_bytes, command, false, command.rect);
+    }
+    return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color);
+}
+
+static NonnullRefPtr<Web::Painting::DisplayList> make_display_list_with_viewport_scrollbar(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree)
+{
+    ByteBuffer command_bytes;
+    Web::UniqueNodeID document_id { 1 };
+    Web::Painting::VisualContextIndex scroll_node_index { 1 };
+
+    append_display_list_command(
+        command_bytes,
+        Web::Painting::CompositorScrollNode {
+            .document_id = document_id,
+            .scrollable_node_id = Web::UniqueNodeID { 2 },
+            .scroll_node_index = scroll_node_index,
+            .parent_scroll_node_index = Web::Painting::VISUAL_VIEWPORT_NODE_INDEX,
+            .scrollport_rect = { 0, 0, 100, 100 },
+            .min_scroll_offset = { 0, 0 },
+            .max_scroll_offset = { 0, 100 },
+            .scroll_node_kind = Web::Painting::CompositorScrollNodeKind::Viewport,
+            .pseudo_element_type = 0,
+            .is_viewport = true,
+            .can_be_wheel_scrolled_horizontally = false,
+            .can_be_wheel_scrolled_vertically = true,
+        },
+        true);
+
+    append_display_list_command(
+        command_bytes,
+        Web::Painting::CompositorViewportScrollbar {
+            .document_id = document_id,
+            .scroll_node_index = scroll_node_index,
+            .gutter_rect = { 96, 0, 4, 100 },
+            .thumb_rect = { 98, 0, 2, 20 },
+            .expanded_gutter_rect = { 92, 0, 8, 100 },
+            .expanded_thumb_rect = { 94, 0, 6, 20 },
+            .scroll_size = 0.8,
+            .expanded_scroll_size = 0.8,
+            .min_scroll_offset = 0,
+            .max_scroll_offset = 100,
+            .thumb_color = Gfx::Color::Black,
+            .track_color = Gfx::Color::Transparent,
+            .vertical = true,
+        },
+        true);
+
+    return decode_display_list(visual_context_tree, move(command_bytes), {},
+        Web::Painting::DisplayList::AsyncScrollingMetadata {
+            .viewport_rect = { 0, 0, 100, 100 },
+        });
+}
+
+static Web::MouseEvent mouse_event(Web::MouseEvent::Type type, int x, int y, Web::UIEvents::MouseButton button = Web::UIEvents::MouseButton::None)
+{
+    return {
+        .type = type,
+        .position = { Web::DevicePixels { x }, Web::DevicePixels { y } },
+        .screen_position = {},
+        .button = button,
+        .buttons = Web::UIEvents::MouseButton::None,
+        .modifiers = Web::UIEvents::KeyModifier::Mod_None,
+        .wheel_delta_x = 0,
+        .wheel_delta_y = 0,
+        .click_count = 0,
+        .browser_data = nullptr,
+        .async_scroll_performed_default_action = false,
+    };
 }
 
 TEST_CASE(rasterization_clears_damaged_pixels_to_the_canvas_color_in_presentation_backing_stores)
@@ -101,4 +179,31 @@ TEST_CASE(oversized_backing_stores_are_rejected)
 
     EXPECT(!publication.has_value());
     EXPECT(!manager.is_valid());
+}
+
+TEST_CASE(viewport_scrollbar_collapses_when_drag_is_released_away_from_scrollbar)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, true };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    context.install_display_list_update(make_display_list_with_viewport_scrollbar(visual_context_tree), visual_context_tree, {});
+
+    auto hover_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 98, 10));
+    EXPECT(hover_result.accepted);
+    EXPECT(hover_result.frame_to_present.has_value());
+
+    auto press_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseDown, 98, 10, Web::UIEvents::MouseButton::Primary));
+    EXPECT(press_result.accepted);
+
+    auto drag_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 50, 50));
+    EXPECT(drag_result.accepted);
+
+    auto release_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseUp, 50, 50, Web::UIEvents::MouseButton::Primary));
+    EXPECT(release_result.accepted);
+
+    // Releasing the drag should have already cleared the hover state, so the next move must not trigger a delayed repaint.
+    auto next_move_result = context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 50, 50));
+    EXPECT(!next_move_result.accepted);
+    EXPECT(!next_move_result.frame_to_present.has_value());
 }

--- a/Tests/Compositor/TestViewportScrollbarController.cpp
+++ b/Tests/Compositor/TestViewportScrollbarController.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/ViewportScrollbarController.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+static Compositor::ViewportScrollbarController::Drag begin_scrollbar_drag(Gfx::Orientation orientation, Gfx::FloatPoint position)
+{
+    auto vertical = orientation == Gfx::Orientation::Vertical;
+    auto document_id = Web::UniqueNodeID { 1 };
+    auto scroll_node_index = Web::Painting::VisualContextIndex { 1 };
+    auto scroll_node_id = Web::Compositor::AsyncScrollNodeID {
+        .document_id = document_id,
+        .scroll_node_index = scroll_node_index,
+    };
+
+    Web::Compositor::AsyncScrollingState scrolling_state;
+    scrolling_state.scroll_nodes.append({
+        .node_id = scroll_node_id,
+        .stable_node_id = {
+            .node_id = Web::UniqueNodeID { 2 },
+            .kind = Web::Compositor::AsyncScrollNodeKind::Viewport,
+            .pseudo_element_type = 0,
+        },
+        .parent_node_id = {},
+        .scrollport_rect = { 0, 0, 100, 100 },
+        .min_scroll_offset = { 0, 0 },
+        .max_scroll_offset = { 100, 100 },
+        .is_viewport = true,
+        .can_be_wheel_scrolled_horizontally = true,
+        .can_be_wheel_scrolled_vertically = true,
+    });
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(scrolling_state));
+    Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
+
+    Vector<Web::Compositor::ViewportScrollbar> scrollbars;
+    scrollbars.append({
+        .scroll_node_id = scroll_node_id,
+        .scroll_node_index = scroll_node_index,
+        .gutter_rect = vertical ? Gfx::IntRect { 96, 0, 4, 100 } : Gfx::IntRect { 0, 96, 100, 4 },
+        .thumb_rect = vertical ? Gfx::IntRect { 98, 20, 2, 20 } : Gfx::IntRect { 20, 98, 20, 2 },
+        .expanded_gutter_rect = vertical ? Gfx::IntRect { 92, 0, 8, 100 } : Gfx::IntRect { 0, 92, 100, 8 },
+        .expanded_thumb_rect = vertical ? Gfx::IntRect { 94, 20, 6, 20 } : Gfx::IntRect { 20, 94, 20, 6 },
+        .scroll_size = 0.8,
+        .expanded_scroll_size = 0.8,
+        .min_scroll_offset = 0,
+        .max_scroll_offset = 100,
+        .thumb_color = Gfx::Color::Black,
+        .track_color = Gfx::Color::Transparent,
+        .vertical = vertical,
+    });
+
+    Compositor::ViewportScrollbarController controller;
+    controller.set_scrollbars(scrollbars);
+    auto drag = controller.begin_drag(scroll_tree, scroll_state_snapshot, position);
+    VERIFY(drag.has_value());
+    return drag.release_value();
+}
+
+TEST_CASE(clicking_scrollbar_beside_thumb_grabs_thumb_at_that_position)
+{
+    auto vertical_drag = begin_scrollbar_drag(Gfx::Orientation::Vertical, { 97, 25 });
+    EXPECT_EQ(vertical_drag.primary_position, 25);
+    EXPECT_EQ(vertical_drag.thumb_grab_position, 5);
+
+    auto horizontal_drag = begin_scrollbar_drag(Gfx::Orientation::Horizontal, { 25, 97 });
+    EXPECT_EQ(horizontal_drag.primary_position, 25);
+    EXPECT_EQ(horizontal_drag.thumb_grab_position, 5);
+}
+
+TEST_CASE(clicking_scrollbar_track_outside_thumb_grabs_thumb_at_center)
+{
+    auto vertical_drag = begin_scrollbar_drag(Gfx::Orientation::Vertical, { 97, 60 });
+    EXPECT_EQ(vertical_drag.primary_position, 60);
+    EXPECT_EQ(vertical_drag.thumb_grab_position, 10);
+
+    auto horizontal_drag = begin_scrollbar_drag(Gfx::Orientation::Horizontal, { 60, 97 });
+    EXPECT_EQ(horizontal_drag.primary_position, 60);
+    EXPECT_EQ(horizontal_drag.thumb_grab_position, 10);
+}

--- a/Tests/Compositor/TestViewportScrollbarController.cpp
+++ b/Tests/Compositor/TestViewportScrollbarController.cpp
@@ -9,7 +9,7 @@
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Painting/ScrollState.h>
 
-static Compositor::ViewportScrollbarController::Drag begin_scrollbar_drag(Gfx::Orientation orientation, Gfx::FloatPoint position)
+static Compositor::ViewportScrollbarController::Drag begin_scrollbar_drag(Gfx::Orientation orientation, Gfx::FloatPoint position, Optional<Gfx::IntRect> expanded_thumb_rect = {})
 {
     auto vertical = orientation == Gfx::Orientation::Vertical;
     auto document_id = Web::UniqueNodeID { 1 };
@@ -47,7 +47,7 @@ static Compositor::ViewportScrollbarController::Drag begin_scrollbar_drag(Gfx::O
         .gutter_rect = vertical ? Gfx::IntRect { 96, 0, 4, 100 } : Gfx::IntRect { 0, 96, 100, 4 },
         .thumb_rect = vertical ? Gfx::IntRect { 98, 20, 2, 20 } : Gfx::IntRect { 20, 98, 20, 2 },
         .expanded_gutter_rect = vertical ? Gfx::IntRect { 92, 0, 8, 100 } : Gfx::IntRect { 0, 92, 100, 8 },
-        .expanded_thumb_rect = vertical ? Gfx::IntRect { 94, 20, 6, 20 } : Gfx::IntRect { 20, 94, 20, 6 },
+        .expanded_thumb_rect = expanded_thumb_rect.value_or(vertical ? Gfx::IntRect { 94, 20, 6, 20 } : Gfx::IntRect { 20, 94, 20, 6 }),
         .scroll_size = 0.8,
         .expanded_scroll_size = 0.8,
         .min_scroll_offset = 0,
@@ -84,4 +84,13 @@ TEST_CASE(clicking_scrollbar_track_outside_thumb_grabs_thumb_at_center)
     auto horizontal_drag = begin_scrollbar_drag(Gfx::Orientation::Horizontal, { 60, 97 });
     EXPECT_EQ(horizontal_drag.primary_position, 60);
     EXPECT_EQ(horizontal_drag.thumb_grab_position, 10);
+}
+
+TEST_CASE(starting_scrollbar_drag_uses_expanded_thumb_geometry)
+{
+    auto vertical_drag = begin_scrollbar_drag(Gfx::Orientation::Vertical, { 97, 25 }, Gfx::IntRect { 94, 18, 6, 24 });
+    EXPECT_EQ(vertical_drag.thumb_grab_position, 7);
+
+    auto horizontal_drag = begin_scrollbar_drag(Gfx::Orientation::Horizontal, { 25, 97 }, Gfx::IntRect { 18, 94, 24, 6 });
+    EXPECT_EQ(horizontal_drag.thumb_grab_position, 7);
 }


### PR DESCRIPTION
* After clicking and dragging the scrollbar thumb, and releasing the mouse outside of the scrollbar area, ensure the scrollbar is marked unhovered (and therefore painted narrow)
* Treat clicking the scrollbar gutter just outside of the scrollbar thumb (horizontally for vertical scrollbars, vertically for horizontal scrollbars) as clicking the thumb itself, rather than jumping to that position
* A handful of other minor edge cases found in the process