### PR TITLE
LibWeb: Compare tree order by ancestor chain in is_following (MicroWeb 11.9x→1.4x boost)

### DIFF
--- a/Libraries/LibWeb/TreeNode.h
+++ b/Libraries/LibWeb/TreeNode.h
@@ -628,13 +628,10 @@ inline bool TreeNode<T>::is_inclusive_descendant_of(TreeNode<T> const& other) co
 template<typename T>
 inline bool TreeNode<T>::is_following(TreeNode const& other) const
 {
-    // An object A is following an object B if A and B are in the same tree and A comes after B in tree order.
-    for (auto* node = previous_in_pre_order(); node; node = node->previous_in_pre_order()) {
-        if (node == &other)
-            return true;
-    }
-
-    return false;
+    // An object A is following an object B if A and B are in the same tree, and A comes after B in tree order. That's
+    // exactly the order is_before() decides. So, ask is_before() — rather than scan the preorder all the way back to
+    // the start of the tree: The ancestor chains is_before() walks are depth-bounded — while the scan's document-sized.
+    return other.is_before(*this);
 }
 
 template<typename T>


### PR DESCRIPTION
Related to [`range-set-points`](https://github.com/LadybirdBrowser/web-benchmarks/blob/master/benchmarks/MicroWeb/edit/range-set-points.html) from [the MicroWeb suite](https://github.com/LadybirdBrowser/web-benchmarks).

Scanning the preorder backwards cost us the distance between the two nodes — and a negative answer cost a walk all the way to the start of the tree. A is following B exactly when B precedes A. So, we can just defer to `is_before()` — which already answers that (by comparing the two depth-bounded ancestor chains).

MicroWeb [`range-set-points`](https://github.com/LadybirdBrowser/web-benchmarks/blob/master/benchmarks/MicroWeb/edit/range-set-points.html), 5-iteration median:

| | Ladybird | Chromium jitless | ratio |
| --- | --- | --- | --- |
| Before | 62.1 ms | 5.2 ms | 11.9x |
| After | 6.7 ms | 4.9 ms | 1.4x |
