### PR TITLE
LibWeb: Cut editing resolved-value cost (MicroWeb 11.7x→3.5x boost)

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -746,11 +746,13 @@ static Optional<Layout::NodeWithStyle*> prepare_computed_style_and_layout_for_pr
     }
     // Ensure styles are up to date. update_layout()/update_style() skip display:none subtrees,
     // so the leaf and its inheritance ancestors may still be stale at this point.
-    auto current_style = abstract_element.computed_style();
+    // NB: Only the style record's presence and its display:none-subtree bit matter here — so, probe
+    //     those directly, instead of materializing a full style record view.
+    auto record_status = abstract_element.document().style_computer().style_record_status(abstract_element.style_record_identity());
     bool const style_is_in_display_none_subtree = !layout_node
-        && current_style
-        && current_style->in_display_none_subtree();
-    if (!current_style || style_is_in_display_none_subtree)
+        && record_status.present
+        && record_status.in_display_none_subtree;
+    if (!record_status.present || style_is_in_display_none_subtree)
         abstract_element.document().update_style_for_element(abstract_element);
     else
         abstract_element.document().update_style_for_element(abstract_element, DOM::Document::StyleUpdateMode::OnlyIfNeeded);
@@ -781,6 +783,38 @@ static Optional<Layout::NodeWithStyle*> prepare_computed_style_and_layout_for_pr
     }
 
     return layout_node;
+}
+
+Optional<RefPtr<StyleValue const>> CSSStyleProperties::resolved_value_read_from_computed_style(DOM::AbstractElement abstract_element, PropertyID property_id)
+{
+    // Only properties whose resolved value is the plain computed value qualify: no used-value substitution (see
+    // property_needs_layout_for_getcomputedstyle() and property_needs_layout_node_for_resolved_value()): No color or
+    // shadow resolution, no logical alias mapping, and no shorthand reconstruction. get_direct_property() and
+    // style_value_for_computed_property() enumerate the properties that need such treatment.
+    switch (property_id) {
+    case PropertyID::Display:
+    case PropertyID::FontFamily:
+    case PropertyID::FontSize:
+    case PropertyID::FontStyle:
+    case PropertyID::FontWeight:
+    case PropertyID::TextAlign:
+    case PropertyID::TextDecorationLine:
+    case PropertyID::WhiteSpaceCollapse:
+        break;
+    default:
+        return OptionalNone {};
+    }
+
+    auto prepared = prepare_computed_style_and_layout_for_property(abstract_element, property_id);
+    if (!prepared.has_value())
+        return RefPtr<StyleValue const> {};
+
+    if (auto style = abstract_element.computed_style())
+        return RefPtr<StyleValue const> { style->computed_style_value(property_id) };
+
+    // Only a synthetic pseudo-element with no matching rules lacks a style record after the preparation above; its
+    // transient style needs the full declaration path.
+    return OptionalNone {};
 }
 
 Optional<StyleProperty> CSSStyleProperties::get_direct_property(PropertyNameAndID const& property_name_and_id) const

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -33,6 +33,8 @@ public:
     virtual Utf16String item(size_t index) const override;
 
     Optional<StyleProperty> get_property(PropertyID) const;
+
+    [[nodiscard]] static Optional<RefPtr<StyleValue const>> resolved_value_read_from_computed_style(DOM::AbstractElement, PropertyID);
     Optional<StyleProperty const&> custom_property(Utf16FlyString const& custom_property_name) const;
 
     WebIDL::ExceptionOr<void> set_property(PropertyID, Utf16View css_text, Utf16View priority = u""sv);

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -914,9 +914,9 @@ ComputedStyleRecordView::ComputedStyleRecordView(StyleEngineFFI::FfiStyleRecordV
     m_values.m_property_inherited.copy_from({ view.property_inheritance, view.property_inheritance_count });
 
     m_values.m_pseudo_element_styles = view.pseudo_element_styles;
-    m_values.m_depends_on_viewport_metrics = view.dependency_flags & 1;
-    m_values.m_font_metrics_depend_on_viewport_metrics = view.dependency_flags & 2;
-    m_values.m_in_display_none_subtree = view.dependency_flags & 4;
+    m_values.m_depends_on_viewport_metrics = view.dependency_flags & to_underlying(StyleRecordDependencyFlag::DependsOnViewportMetrics);
+    m_values.m_font_metrics_depend_on_viewport_metrics = view.dependency_flags & to_underlying(StyleRecordDependencyFlag::FontMetricsDependOnViewportMetrics);
+    m_values.m_in_display_none_subtree = view.dependency_flags & to_underlying(StyleRecordDependencyFlag::InDisplayNoneSubtree);
     m_values.m_borrowed_raw_cascaded_font_size = static_cast<StyleValueFFI::StyleValueData const*>(view.raw_cascaded_font_size);
     m_values.m_borrowed_inheritance_dependent_values = { view.inheritance_dependent_values, view.inheritance_dependent_value_count };
     VERIFY(view.longhand_value_count == 0 || view.longhand_value_count == number_of_longhand_properties);

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -986,6 +986,13 @@ enum class StyleGroupIndex : size_t {
         Count,
 };
 
+// Bits of the dependency flags published alongside a style record's group payloads.
+enum class StyleRecordDependencyFlag : u8 {
+    DependsOnViewportMetrics = 1 << 0,
+    FontMetricsDependOnViewportMetrics = 1 << 1,
+    InDisplayNoneSubtree = 1 << 2,
+};
+
 // The box group payload stores display values in the Rust-defined explicit
 // form; these pins keep the tag discriminants aligned with Display::Type.
 inline ComputedValuesFFI::FfiDisplay to_ffi_display(Display const& display)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -409,6 +409,19 @@ ComputedStyleRecordView StyleComputer::computed_style_record_view(StyleRecordID 
     return ComputedStyleRecordView { view, *this, style_record_identity };
 }
 
+StyleComputer::StyleRecordStatus StyleComputer::style_record_status(StyleRecordID style_record_identity) const
+{
+    if (!style_record_identity)
+        return {};
+    auto view = m_style_engine.style_record_view(style_record_identity);
+    if (!view.present)
+        return {};
+    return {
+        .present = true,
+        .in_display_none_subtree = (view.dependency_flags & to_underlying(StyleRecordDependencyFlag::InDisplayNoneSubtree)) != 0,
+    };
+}
+
 void const* StyleComputer::style_record_payloads(StyleRecordID style_record_identity) const
 {
     if (!style_record_identity)
@@ -3905,9 +3918,9 @@ StyleEngine::StyleRecordDelta StyleComputer::record_computed_style_inputs(Option
     for (size_t index = 0; index < payloads.size(); ++index)
         payloads[index] = payload_source.style_group_payload(static_cast<StyleGroupIndex>(index));
     auto custom_property_environment = abstract_element.has_value() ? abstract_element->custom_property_data() : nullptr;
-    u8 dependency_flags = static_cast<u8>(base.depends_on_viewport_metrics())
-        | (static_cast<u8>(base.font_metrics_depend_on_viewport_metrics()) << 1)
-        | (static_cast<u8>(base.in_display_none_subtree()) << 2);
+    u8 dependency_flags = (base.depends_on_viewport_metrics() ? to_underlying(StyleRecordDependencyFlag::DependsOnViewportMetrics) : 0)
+        | (base.font_metrics_depend_on_viewport_metrics() ? to_underlying(StyleRecordDependencyFlag::FontMetricsDependOnViewportMetrics) : 0)
+        | (base.in_display_none_subtree() ? to_underlying(StyleRecordDependencyFlag::InDisplayNoneSubtree) : 0);
     if (abstract_element.has_value() && !abstract_element->pseudo_element().has_value()) {
         auto& element = abstract_element->element();
         bool const inherited_group_swap_eligible = element.style_input_record()

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -129,6 +129,14 @@ public:
     [[nodiscard]] RefPtr<ComputedValues const> inherited_style_group_swap(DOM::Element&, ComputedValues const& old_values, ComputedValues const& new_parent_values) const;
 
     [[nodiscard]] ComputedStyleRecordView computed_style_record_view(StyleRecordID) const;
+
+    // Presence and display:none-subtree placement of a style record, read without materializing a full style record view.
+    struct StyleRecordStatus {
+        bool present { false };
+        bool in_display_none_subtree { false };
+    };
+    [[nodiscard]] StyleRecordStatus style_record_status(StyleRecordID) const;
+
     [[nodiscard]] void const* style_record_payloads(StyleRecordID) const;
     void pin_style_record(StyleRecordID) const;
     void unpin_style_record(StyleRecordID) const;

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -623,6 +623,16 @@ bool StyleEngine::has_deferred_geometry_transaction() const
     return StyleEngineFFI::style_engine_has_deferred_geometry_transaction(m_impl);
 }
 
+bool StyleEngine::has_deferred_element_style_inputs() const
+{
+    return StyleEngineFFI::style_engine_has_deferred_element_style_inputs(m_impl);
+}
+
+bool StyleEngine::has_deferred_element_style_input(StyleNodeID style_node) const
+{
+    return StyleEngineFFI::style_engine_has_deferred_element_style_input(m_impl, style_node.value());
+}
+
 bool StyleEngine::defer_pending_transaction_for_geometry_read()
 {
     submit_recorded_input();

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -190,6 +190,8 @@ public:
     [[nodiscard]] bool has_recorded_input() const;
     [[nodiscard]] bool has_pending_transaction() const;
     [[nodiscard]] bool has_deferred_geometry_transaction() const;
+    [[nodiscard]] bool has_deferred_element_style_inputs() const;
+    [[nodiscard]] bool has_deferred_element_style_input(StyleNodeID style_node) const;
     [[nodiscard]] bool pending_transaction_may_affect_layout_geometry();
     [[nodiscard]] bool defer_pending_transaction_for_geometry_read();
     [[nodiscard]] bool begin_deferred_geometry_transaction_flush();

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -700,10 +700,57 @@ static RequiredInvalidationAfterStyleChange materialize_style_for_targeted_updat
     return {};
 }
 
+// A targeted style update has nothing to do when every source of style work in the document is settled: A full style
+// update has completed, no style engine transaction or recorded input is pending, no media rule evaluation is queued,
+// and no animated style refresh is due.
+static bool document_has_no_pending_style_work(DOM::Document const& document)
+{
+    // A rootless flush drains the journal but preserves element style inputs for the first transaction with a document
+    // root — so has_pending_transaction() alone would report a settled engine still owing an element its recomputation.
+    return document.has_completed_style_update()
+        && !document.style_computer().style_engine().has_pending_transaction()
+        && !document.style_computer().style_engine().has_deferred_element_style_inputs()
+        && !document.needs_media_rule_evaluation()
+        && !document.needs_animated_style_update();
+}
+
+// Whether every embedding document up the container chain needs no style or layout work — so, bringing the embedding
+// chain up to date couldn't invalidate anything in this document.
+static bool embedding_document_chain_has_no_pending_style_or_layout_work(DOM::Document const& document)
+{
+    auto const* embedded_document = &document;
+    while (auto navigable = embedded_document->navigable()) {
+        auto container = navigable->container();
+        if (!container || &container->document() == embedded_document)
+            return true;
+        auto& embedding_document = container->document();
+        if (!document_has_no_pending_style_work(embedding_document)
+            || !embedding_document.layout_is_up_to_date()
+            || !container->has_style())
+            return false;
+        embedded_document = &embedding_document;
+    }
+    return true;
+}
+
 static bool update_style_for_element(DOM::Document& document, DOM::AbstractElement const& abstract_element, StyleUpdateMode mode)
 {
     if (!abstract_element.element().is_connected())
         return false;
+
+    // OPTIMIZATION: When nothing style-related is pending anywhere that could affect this document, the only question
+    // left is, if the element's inheritance chain already has style. If it does, the walk below would conclude there's
+    // nothing to recompute. So answer that directly — without constructing a style record view for every ancestor.
+    if (mode == StyleUpdateMode::OnlyIfNeeded
+        && !abstract_element.pseudo_element().has_value()
+        && document_has_no_pending_style_work(document)
+        && embedding_document_chain_has_no_pending_style_or_layout_work(document)) {
+        bool inheritance_chain_has_style = abstract_element.element().has_style();
+        for (auto cursor = abstract_element.element_to_inherit_style_from(); inheritance_chain_has_style && cursor.has_value(); cursor = cursor->element_to_inherit_style_from())
+            inheritance_chain_has_style = cursor->element().has_style();
+        if (inheritance_chain_has_style)
+            return true;
+    }
 
     StyleValueFFI::rust_style_ffi_complete_style_update_begin();
     ScopeGuard leave_complete_style_update = finish_complete_style_update;
@@ -792,6 +839,7 @@ static bool update_style_for_element(DOM::Document& document, DOM::AbstractEleme
         auto& ancestor = inheritance_chain[i - 1];
         if (!topmost_element_requiring_style.has_value()
             && (document.style_computer().style_engine().has_recorded_element_style_input_change(ancestor->style_node_id())
+                || document.style_computer().style_engine().has_deferred_element_style_input(ancestor->style_node_id())
                 || !ancestor->has_style())) {
             topmost_element_requiring_style = i - 1;
         }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -1969,8 +1969,10 @@ bool is_block_end_point(DOM::BoundaryPoint boundary_point)
         return true;
 
     // or node has a child with index offset, and that child is a visible block node.
+    // AD-HOC: Test block-ness first. Both conditions are side-effect free, and is_visible_node() resolves style for
+    //         every inclusive ancestor, while is_block_node() rejects a non-Element outright.
     auto offset_child = boundary_point.node->child_at_index(boundary_point.offset);
-    return offset_child && is_visible_node(*offset_child) && is_block_node(*offset_child);
+    return offset_child && is_block_node(*offset_child) && is_visible_node(*offset_child);
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#block-node
@@ -1999,9 +2001,11 @@ bool is_block_start_point(DOM::BoundaryPoint boundary_point)
         return true;
 
     // or node has a child with index offset − 1, and that child is either a visible block node or a visible br.
+    // AD-HOC: Test block-ness first, as in is_block_end_point().
     auto offset_minus_one_child = boundary_point.node->child_at_index(boundary_point.offset - 1);
-    return offset_minus_one_child && is_visible_node(*offset_minus_one_child)
-        && (is_block_node(*offset_minus_one_child) || is<HTML::HTMLBRElement>(*offset_minus_one_child));
+    return offset_minus_one_child
+        && (is_block_node(*offset_minus_one_child) || is<HTML::HTMLBRElement>(*offset_minus_one_child))
+        && is_visible_node(*offset_minus_one_child);
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#collapsed-block-prop

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -1975,6 +1975,15 @@ bool is_block_end_point(DOM::BoundaryPoint boundary_point)
     return offset_child && is_block_node(*offset_child) && is_visible_node(*offset_child);
 }
 
+// Whether a resolved display qualifies an Element as a block node; see is_block_node() below.
+static bool is_block_display(Optional<CSS::Display> const& display)
+{
+    if (!display.has_value())
+        return true;
+    return !(display->is_inline_outside() && (display->is_flow_inside() || display->is_flow_root_inside() || display->is_table_inside()))
+        && !display->is_none();
+}
+
 // https://w3c.github.io/editing/docs/execCommand/#block-node
 bool is_block_node(GC::Ref<DOM::Node> node)
 {
@@ -1986,11 +1995,7 @@ bool is_block_node(GC::Ref<DOM::Node> node)
     if (!is<DOM::Element>(*node))
         return false;
 
-    auto display = resolved_display(node);
-    if (!display.has_value())
-        return true;
-    return !(display->is_inline_outside() && (display->is_flow_inside() || display->is_flow_root_inside() || display->is_table_inside()))
-        && !display->is_none();
+    return is_block_display(resolved_display(node));
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#block-start-point
@@ -2654,9 +2659,18 @@ bool is_visible_node(GC::Ref<DOM::Node> node)
 {
     // excluding any node with an inclusive ancestor Element whose "display" property has resolved
     // value "none".
+    // NB: Only Elements have a display of their own; on any other node, resolved_display() answers
+    //     with the nearest inclusive ancestor Element's display. So, walking the ancestor Elements
+    //     covers every node in between. The display of node itself also feeds the block-node check
+    //     below. So, it's resolved once here — rather than a second time there.
+    Optional<CSS::Display> node_display;
     bool has_display_none = false;
-    node->for_each_inclusive_ancestor([&has_display_none](GC::Ref<DOM::Node> ancestor) {
+    node->for_each_inclusive_ancestor([&](GC::Ref<DOM::Node> ancestor) {
+        if (!is<DOM::Element>(*ancestor))
+            return IterationDecision::Continue;
         auto display = resolved_display(ancestor);
+        if (ancestor.ptr() == node.ptr())
+            node_display = display;
         if (display.has_value() && display->is_none()) {
             has_display_none = true;
             return IterationDecision::Break;
@@ -2667,7 +2681,7 @@ bool is_visible_node(GC::Ref<DOM::Node> node)
         return false;
 
     // Something is visible if it is a node that either is a block node,
-    if (is_block_node(node))
+    if (is<DOM::Element>(*node) ? is_block_display(node_display) : is_block_node(node))
         return true;
 
     // or a Text node that is not a collapsed whitespace node,
@@ -4941,9 +4955,15 @@ RefPtr<CSS::StyleValue const> resolved_value(GC::Ref<DOM::Node> node, CSS::Prope
         element = element->parent();
     if (!element)
         return {};
+    DOM::AbstractElement abstract_element { static_cast<DOM::Element&>(*element) };
+
+    // OPTIMIZATION: For properties whose resolved value is the plain computed value, read it straight off the element's
+    // computed style — instead of materializing a whole resolved-style declaration just to extract a single property.
+    if (auto fast_value = CSS::CSSStyleProperties::resolved_value_read_from_computed_style(abstract_element, property_id); fast_value.has_value())
+        return fast_value.release_value();
 
     // Retrieve resolved style value
-    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(DOM::AbstractElement { static_cast<DOM::Element&>(*element) });
+    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(abstract_element);
     auto optional_style_property = resolved_css_style_declaration->get_property(property_id);
     if (!optional_style_property.has_value())
         return {};

--- a/Libraries/LibWeb/Rust/StyleEngineBoundary.json
+++ b/Libraries/LibWeb/Rust/StyleEngineBoundary.json
@@ -87,7 +87,9 @@
     [84, "DeferPendingTransactionForGeometryRead"],
     [85, "BeginDeferredGeometryTransactionFlush"],
     [86, "EndDeferredGeometryTransactionFlush"],
-    [87, "HasDeferredGeometryTransaction"]
+    [87, "HasDeferredGeometryTransaction"],
+    [88, "HasDeferredElementStyleInputs"],
+    [89, "HasDeferredElementStyleInput"]
   ],
   "operations": [
     { "event": "SetFoldIdAndClassNameCase", "ffi": "style_engine_set_fold_id_and_class_name_case", "cpp": "set_fold_id_and_class_name_case", "return": "void", "args": [["fold", "bool"]], "body": "engine.set_fold_id_and_class_name_case(fold);" },
@@ -114,6 +116,8 @@
     { "event": "BeginDeferredGeometryTransactionFlush", "ffi": "style_engine_begin_deferred_geometry_transaction_flush", "return": "bool", "replay": false, "args": [], "body": "let result = engine.begin_deferred_geometry_transaction_flush();" },
     { "event": "EndDeferredGeometryTransactionFlush", "ffi": "style_engine_end_deferred_geometry_transaction_flush", "return": "void", "replay": false, "args": [], "body": "engine.end_deferred_geometry_transaction_flush();" },
     { "event": "HasDeferredGeometryTransaction", "ffi": "style_engine_has_deferred_geometry_transaction", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.has_deferred_geometry_transaction();" },
+    { "event": "HasDeferredElementStyleInputs", "ffi": "style_engine_has_deferred_element_style_inputs", "return": "bool", "receiver": "const", "replay": false, "args": [], "body": "let result = engine.has_deferred_element_style_inputs();" },
+    { "event": "HasDeferredElementStyleInput", "ffi": "style_engine_has_deferred_element_style_input", "return": "bool", "receiver": "const", "replay": false, "args": [["node", "style_node"]], "body": "let Some(node) = StyleNodeID::from_raw(node) else { return false; }; let result = engine.has_deferred_element_style_input(node);" },
     { "event": "MatchDocument", "ffi": "style_engine_match_document", "cpp": "match_document", "return": "usize_u64", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return usize::MAX; }; let result = engine.match_document(root).unwrap_or(usize::MAX);" },
     { "event": "BeginColdMatchingBatch", "ffi": "style_engine_begin_cold_matching_batch", "cpp": "begin_cold_matching_batch", "return": "bool", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return false; }; let result = engine.begin_cold_matching_batch(root);" },
     { "event": "BeginAdaptiveColdMatchingBatch", "ffi": "style_engine_begin_adaptive_cold_matching_batch", "cpp": "begin_adaptive_cold_matching_batch", "return": "void", "replay": false, "args": [["root", "style_node"]], "body": "let Some(root) = StyleNodeID::from_raw(root) else { return; }; engine.begin_adaptive_cold_matching_batch(root);" },

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -712,6 +712,23 @@ impl StyleEngine {
         !self.flushing_deferred_geometry_journal && !self.deferred_geometry_journal.is_empty()
     }
 
+    /// Whether any element style input is still deferred, waiting for the first transaction with a
+    /// document root. A rootless flush drains the journal but preserves these — so an engine that
+    /// reports no pending transaction can still owe an element its recomputation.
+    #[must_use]
+    pub fn has_deferred_element_style_inputs(&self) -> bool {
+        !self.deferred_element_style_inputs.is_empty()
+    }
+
+    /// Whether one element still owes a deferred style input, asked per node the way the recorded
+    /// batch is. The deferred inputs are kept sorted by key, so this is a binary search.
+    #[must_use]
+    pub fn has_deferred_element_style_input(&self, node: StyleNodeID) -> bool {
+        self.deferred_element_style_inputs
+            .binary_search_by_key(&InputKey::ElementStyleInput(node), |pending| pending.key)
+            .is_ok()
+    }
+
     /// Whether settling the pending selector inputs can change geometry derived from the committed
     /// layout. This is deliberately a proof of independence rather than a list of properties which
     /// usually avoid layout: anything not explicitly known to preserve geometry remains observable.


### PR DESCRIPTION
This contains two commits for speedups on [`exec-insert-text`](https://github.com/LadybirdBrowser/web-benchmarks/blob/master/benchmarks/MicroWeb/edit/exec-insert-text.html) from [the MicroWeb suite](https://github.com/LadybirdBrowser/web-benchmarks).

### Avoid resolving style for non-block boundary children

A relatively modest speedup — but also a relatively simple change, and easy-ish review.

`is_block_start_point()` and `is_block_end_point()` checked whether a child was visible before asking whether it was a block node. Visibility does a costly style resolution for every inclusive ancestor, while block-ness checking cheaply rejects a non-Element outright. So whenever that cheap check was false, the costly check decided nothing.

Both conditions are side-effect free, so testing for a block node first returns the same answer. The text nodes these boundary points walk across now resolve no style at all.

MicroWeb [`exec-insert-text`](https://github.com/LadybirdBrowser/web-benchmarks/blob/master/benchmarks/MicroWeb/edit/exec-insert-text.html), 5-iteration median:

| | Ladybird | Chromium jitless | ratio |
| --- | --- | --- | --- |
| Before | 28.0 ms | 2.4 ms | 11.7x |
| After | 19.1 ms | 2.3 ms | 8.3x |

### Read editing resolved values straight off computed style

A heftier speedup — but also a hefty set of changes, and so a heft(ier)-ish review.

The editing algorithms’ `resolved_value()` materialized a whole resolved-style `CSSStyleProperties` declaration just to read one property — and the visibility checks behind `execCommand` call it for every inclusive ancestor of every node they inspect. Most of that usually concluded that nothing was stale — and just handed back the computed value unchanged:

- `update_style_for_element()` in `OnlyIfNeeded` mode walked the whole inheritance chain, and built a full style record view per ancestor — even when the document had no pending style work at all.
- Preparing computed style built another full record view — only to ask if the element’s record exists and sits in a `display:none` subtree.
- `is_visible_node()` resolved the display of the node itself twice, and of text nodes’ parents twice.

And so, this commit includes the following changes:

- Give targeted style updates a settled fast path that answers from the pending-work flags and a has-style walk over the inheritance chain.
- Probe record presence and `display:none` placement through a lightweight status query instead of a full view.
- Read resolved values that are plain computed values straight off the element’s computed style after the same style preparation.
- Resolve each display once in `is_visible_node()`.

A rootless flush drains the input journal but preserves element style inputs for the first transaction with a document root — so the settled check asks for those too: `has_pending_transaction()` alone would report a settled engine that still owed an element its recomputation.

The ancestor walk that the fast path falls back to reads the recorded batch — which a rootless flush clears. So, an already-styled ancestor owing a deferred input went unmarked — and its recomputation never ran. Ask for deferred inputs per node there too — the way recorded ones are.

MicroWeb [`exec-insert-text`](https://github.com/LadybirdBrowser/web-benchmarks/blob/master/benchmarks/MicroWeb/edit/exec-insert-text.html), 5-iteration median:

| | Ladybird | Chromium jitless | ratio |
| --- | --- | --- | --- |
| Before | 19.1 ms | 2.3 ms | 8.3x |
| After | 8.5 ms | 2.4 ms | 3.5x |


