### PR TITLE
LibJS: Enforce immutable Flap bindings

### DIFF
--- a/Libraries/LibJS/Flap/src/frontend/ast.rs
+++ b/Libraries/LibJS/Flap/src/frontend/ast.rs
@@ -136,6 +136,7 @@ pub(crate) enum Pattern {
     Binding {
         name: String,
         ty: Option<Type>,
+        mutable: bool,
     },
     Tuple(Vec<Pattern>),
     Wildcard,
@@ -231,6 +232,7 @@ pub(crate) struct ScalarMatchArm {
 pub(crate) struct ValueMatchArm {
     pub(crate) representation: String,
     pub(crate) binding: Option<String>,
+    pub(crate) binding_mutable: bool,
     pub(crate) temperature: BlockTemperature,
     pub(crate) body: Block,
 }

--- a/Libraries/LibJS/Flap/src/frontend/parser.rs
+++ b/Libraries/LibJS/Flap/src/frontend/parser.rs
@@ -632,13 +632,19 @@ impl<'a> Parser<'a> {
             self.advance();
             if self.at_keyword("let") {
                 self.advance();
+                let mutable = if self.at_keyword("mut") {
+                    self.advance();
+                    true
+                } else {
+                    false
+                };
                 if self.current().kind == TokenKind::LeftParen {
                     return self.error("tuple return bindings use '[...]'");
                 }
                 if self.at_keyword("Value") {
-                    return self.parse_value_refinement(start);
+                    return self.parse_value_refinement(start, mutable);
                 }
-                return self.parse_fallible_binding(start);
+                return self.parse_fallible_binding(start, mutable);
             }
             let condition = self.parse_expression()?;
             self.consume_keyword("else")?;
@@ -665,6 +671,12 @@ impl<'a> Parser<'a> {
         }
         if self.at_keyword("let") {
             self.advance();
+            let mutable = if self.at_keyword("mut") {
+                self.advance();
+                true
+            } else {
+                false
+            };
             if self.at_keyword("Value") {
                 return self.error("refutable bindings use 'guard let'");
             }
@@ -672,7 +684,7 @@ impl<'a> Parser<'a> {
                 return self.error("tuple return bindings use '[...]'");
             }
             if self.current().kind == TokenKind::LeftBracket {
-                let pattern = self.parse_tuple_pattern()?;
+                let pattern = self.parse_tuple_pattern(mutable)?;
                 self.consume(TokenKind::Equals, "'='")?;
                 let initializer = self.parse_expression()?;
                 let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
@@ -691,6 +703,9 @@ impl<'a> Parser<'a> {
                     .get(self.index + 1)
                     .is_some_and(|token| matches!(token.kind, TokenKind::DoublePipe | TokenKind::Pipe))
             {
+                if mutable {
+                    return self.error("a continuation binding cannot be mutable");
+                }
                 self.advance();
                 let parameters = if self.current().kind == TokenKind::DoublePipe {
                     self.advance();
@@ -751,7 +766,7 @@ impl<'a> Parser<'a> {
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
             return Ok(Statement::new(
                 StatementKind::Let {
-                    pattern: Pattern::Binding { name, ty },
+                    pattern: Pattern::Binding { name, ty, mutable },
                     initializer,
                 },
                 SourceSpan { start, end },
@@ -891,7 +906,7 @@ impl<'a> Parser<'a> {
         ))
     }
 
-    fn parse_tuple_pattern(&mut self) -> Result<Pattern, Diagnostic> {
+    fn parse_tuple_pattern(&mut self, mutable: bool) -> Result<Pattern, Diagnostic> {
         self.consume(TokenKind::LeftBracket, "'['")?;
         let mut patterns = Vec::new();
         loop {
@@ -899,7 +914,11 @@ impl<'a> Parser<'a> {
             patterns.push(if name == "_" {
                 Pattern::Wildcard
             } else {
-                Pattern::Binding { name, ty: None }
+                Pattern::Binding {
+                    name,
+                    ty: None,
+                    mutable,
+                }
             });
             if self.current().kind != TokenKind::Comma {
                 break;
@@ -913,9 +932,9 @@ impl<'a> Parser<'a> {
         Ok(Pattern::Tuple(patterns))
     }
 
-    fn parse_fallible_binding(&mut self, start: SourceLocation) -> Result<Statement, Diagnostic> {
+    fn parse_fallible_binding(&mut self, start: SourceLocation, mutable: bool) -> Result<Statement, Diagnostic> {
         let pattern = if self.current().kind == TokenKind::LeftBracket {
-            self.parse_tuple_pattern()?
+            self.parse_tuple_pattern(mutable)?
         } else {
             let (name, _) = self.consume_identifier("binding name")?;
             let ty = if self.current().kind == TokenKind::Colon {
@@ -924,7 +943,7 @@ impl<'a> Parser<'a> {
             } else {
                 None
             };
-            Pattern::Binding { name, ty }
+            Pattern::Binding { name, ty, mutable }
         };
         self.consume(TokenKind::Equals, "'='")?;
         let initializer = self.parse_expression()?;
@@ -967,7 +986,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_value_refinement(&mut self, start: SourceLocation) -> Result<Statement, Diagnostic> {
+    fn parse_value_refinement(&mut self, start: SourceLocation, mutable: bool) -> Result<Statement, Diagnostic> {
         self.consume_keyword("Value")?;
         self.consume(TokenKind::LeftAngle, "'<'")?;
         let (refined_type, _) = self.consume_identifier("refined Value type")?;
@@ -990,6 +1009,7 @@ impl<'a> Parser<'a> {
                     binding: Some(Box::new(Pattern::Binding {
                         name: binding,
                         ty: None,
+                        mutable,
                     })),
                 },
                 initializer: value,
@@ -1234,18 +1254,24 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_value_match_pattern(&mut self) -> Result<(String, Option<String>), Diagnostic> {
+    fn parse_value_match_pattern(&mut self) -> Result<(String, Option<String>, bool), Diagnostic> {
         self.consume_keyword("Value")?;
         self.consume(TokenKind::LeftAngle, "'<'")?;
         let (representation, _) = self.consume_identifier("Value representation")?;
         self.consume(TokenKind::RightAngle, "'>'")?;
         if self.current().kind != TokenKind::LeftParen {
-            return Ok((representation, None));
+            return Ok((representation, None, false));
         }
         self.consume(TokenKind::LeftParen, "'('")?;
+        let mutable = if self.at_keyword("mut") {
+            self.advance();
+            true
+        } else {
+            false
+        };
         let (binding, _) = self.consume_identifier("pattern binding")?;
         self.consume(TokenKind::RightParen, "')'")?;
-        Ok((representation, Some(binding)))
+        Ok((representation, Some(binding), mutable))
     }
 
     fn parse_value_match_arms(
@@ -1254,7 +1280,7 @@ impl<'a> Parser<'a> {
     ) -> Result<(Vec<ValueMatchArm>, ValueMatchFallback), Diagnostic> {
         let mut arms = Vec::new();
         while !self.at_keyword("_") {
-            let (representation, binding) = self.parse_value_match_pattern()?;
+            let (representation, binding, binding_mutable) = self.parse_value_match_pattern()?;
             self.consume(TokenKind::FatArrow, "'=>'")?;
             let temperature = self.parse_block_temperature()?;
             let body = if value_producing {
@@ -1265,6 +1291,7 @@ impl<'a> Parser<'a> {
             arms.push(ValueMatchArm {
                 representation,
                 binding,
+                binding_mutable,
                 temperature,
                 body,
             });
@@ -1671,6 +1698,27 @@ handler Mod(lhs: Value, rhs: Value) {
                 pattern: Pattern::ValueRepresentation { ref representation, .. },
                 ..
             } if representation == "i32"
+        ));
+    }
+
+    #[test]
+    fn parses_mutable_bindings() {
+        let handler = parse_handler(
+            "handler Mutate(value: i32) { let mut scalar = value; let mut [lhs, rhs] = pair(value); dispatch_next; }",
+        );
+        assert!(matches!(
+            handler.body.statements[0].kind,
+            StatementKind::Let {
+                pattern: Pattern::Binding { mutable: true, .. },
+                ..
+            }
+        ));
+        assert!(matches!(
+            handler.body.statements[1].kind,
+            StatementKind::Let {
+                pattern: Pattern::Tuple(ref patterns),
+                ..
+            } if patterns.iter().all(|pattern| matches!(pattern, Pattern::Binding { mutable: true, .. }))
         ));
     }
 

--- a/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
+++ b/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
@@ -71,6 +71,16 @@ fn check_definite_initialization_with_entry(
                 format!("binding '{}' is read before it is initialized", variables[id].name),
             ));
         }
+        if let Some(id) = definitions
+            .iter()
+            .find(|id| initialized.contains(id) && !variables[**id].mutable)
+        {
+            return Err(Diagnostic::new(
+                filename,
+                statement.span,
+                format!("cannot assign to immutable binding '{}'", variables[*id].name),
+            ));
+        }
         if let StatementKindIr::ValueMatch {
             tag, arms, fallback, ..
         } = &statement.kind

--- a/Libraries/LibJS/Flap/src/hir/definitions.rs
+++ b/Libraries/LibJS/Flap/src/hir/definitions.rs
@@ -49,6 +49,7 @@ pub(crate) struct Variable {
     pub(crate) name: String,
     pub(crate) ty: Type,
     pub(crate) parameter_mode: Option<ParameterMode>,
+    pub(crate) mutable: bool,
     pub(crate) span: SourceSpan,
 }
 

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -156,6 +156,28 @@ impl<'a> Checker<'a> {
         parameter_mode: Option<ParameterMode>,
         span: SourceSpan,
     ) -> Result<VariableId, Diagnostic> {
+        let mutable = matches!(parameter_mode, Some(ParameterMode::Out | ParameterMode::InOut));
+        self.declare_with_mutability(name, ty, parameter_mode, mutable, span)
+    }
+
+    fn declare_local(
+        &mut self,
+        name: &str,
+        ty: Type,
+        mutable: bool,
+        span: SourceSpan,
+    ) -> Result<VariableId, Diagnostic> {
+        self.declare_with_mutability(name, ty, None, mutable, span)
+    }
+
+    fn declare_with_mutability(
+        &mut self,
+        name: &str,
+        ty: Type,
+        parameter_mode: Option<ParameterMode>,
+        mutable: bool,
+        span: SourceSpan,
+    ) -> Result<VariableId, Diagnostic> {
         if self.scopes.last().unwrap().contains_key(name) {
             return self.error(span, format!("duplicate binding '{name}' in the same scope"));
         }
@@ -164,6 +186,7 @@ impl<'a> Checker<'a> {
             name: name.to_string(),
             ty: ty.clone(),
             parameter_mode,
+            mutable,
             span,
         });
         self.scopes
@@ -196,7 +219,12 @@ impl<'a> Checker<'a> {
                     }
                     continuation_parameters.push(ContinuationParameter {
                         name: parameter.name.clone(),
-                        id: self.declare_hidden(&parameter.name, parameter.ty.clone(), parameter.span),
+                        id: self.declare_hidden_with_mutability(
+                            &parameter.name,
+                            parameter.ty.clone(),
+                            false,
+                            parameter.span,
+                        ),
                         ty: parameter.ty.clone(),
                     });
                 }
@@ -356,7 +384,11 @@ impl<'a> Checker<'a> {
             .iter()
             .zip(element_types)
             .map(|(pattern, ty)| match pattern {
-                ast::Pattern::Binding { name, ty: None } => self.declare(name, ty, None, span),
+                ast::Pattern::Binding {
+                    name,
+                    ty: None,
+                    mutable,
+                } => self.declare_local(name, ty, *mutable, span),
                 ast::Pattern::Wildcard => Ok(self.declare_hidden("discard", ty, span)),
                 _ => self.error(span, "invalid tuple binding pattern"),
             })
@@ -376,6 +408,7 @@ impl<'a> Checker<'a> {
     fn check_bound_block(
         &mut self,
         binding: Option<&str>,
+        binding_mutable: bool,
         ty: Type,
         block: &ast::Block,
         span: SourceSpan,
@@ -383,7 +416,7 @@ impl<'a> Checker<'a> {
         let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let binding = binding
-            .map(|binding| self.declare(binding, ty, None, span))
+            .map(|binding| self.declare_local(binding, ty, binding_mutable, span))
             .transpose()?;
         let start = self.statements.len();
         let result = self.check_block(block, false);
@@ -397,6 +430,7 @@ impl<'a> Checker<'a> {
     fn check_bound_value_block(
         &mut self,
         binding: Option<&str>,
+        binding_mutable: bool,
         binding_type: Type,
         block: &ast::Block,
         expected: Option<&Type>,
@@ -405,7 +439,7 @@ impl<'a> Checker<'a> {
         let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let binding = binding
-            .map(|binding| self.declare(binding, binding_type, None, span))
+            .map(|binding| self.declare_local(binding, binding_type, binding_mutable, span))
             .transpose()?;
         let result = self.check_value_block(block, expected);
         self.scopes.pop();
@@ -474,6 +508,7 @@ impl<'a> Checker<'a> {
             let (binding, mut body, value) = if name.is_some() {
                 let (binding, body, value) = self.check_bound_value_block(
                     arm.binding.as_deref(),
+                    arm.binding_mutable,
                     binding_type,
                     &arm.body,
                     result_type.as_ref(),
@@ -497,8 +532,13 @@ impl<'a> Checker<'a> {
                 result_type = Some(arm_type);
                 (binding, body, Some(value))
             } else {
-                let (binding, body) =
-                    self.check_bound_block(arm.binding.as_deref(), binding_type, &arm.body, statement.span)?;
+                let (binding, body) = self.check_bound_block(
+                    arm.binding.as_deref(),
+                    arm.binding_mutable,
+                    binding_type,
+                    &arm.body,
+                    statement.span,
+                )?;
                 if !body.last().is_some_and(statement_is_terminal) {
                     return self.error(statement.span, "every match arm must terminate control flow");
                 }
@@ -728,6 +768,7 @@ impl<'a> Checker<'a> {
         let Some(ast::Pattern::Binding {
             name: binding,
             ty: None,
+            mutable,
         }) = binding.as_deref()
         else {
             return self.error(statement.span, "Value refinement requires an untyped binding");
@@ -767,7 +808,7 @@ impl<'a> Checker<'a> {
             self.ensure_writable(&binding_symbol, statement.span)?;
             binding_symbol.id
         } else {
-            self.declare(binding, binding_type, None, statement.span)?
+            self.declare_local(binding, binding_type, *mutable, statement.span)?
         };
         let value = self.check_materialized_value(value, &Type::Value)?;
         let failure = self.check_guard_continuation(failure, statement.span)?;
@@ -1001,12 +1042,14 @@ impl<'a> Checker<'a> {
     fn check_guard_let_binding_statement(
         &mut self,
         statement: &ast::Statement,
-        name: &str,
-        ty: &Option<Type>,
+        pattern: &ast::Pattern,
         callee: &str,
         arguments: &[ast::Expression],
         failure: &ast::ElseContinuation,
     ) -> Result<(), Diagnostic> {
+        let ast::Pattern::Binding { name, ty, mutable } = pattern else {
+            unreachable!()
+        };
         let outer_variable_count = self.variables.len();
         let failure = self.check_else_continuation(failure, statement.span)?;
         let structured_failure = resolve_intrinsic(callee, arguments.len()).is_some_and(|resolved| {
@@ -1040,7 +1083,7 @@ impl<'a> Checker<'a> {
                 format!("cannot initialize '{name}' of type {destination_type} with {return_type}"),
             );
         }
-        let destination = self.declare(name, destination_type, None, statement.span)?;
+        let destination = self.declare_local(name, destination_type, *mutable, statement.span)?;
         if let Some(failure) = failure {
             call.failure = Some(CallFailure {
                 captures: collect_captures(&failure.body, outer_variable_count),
@@ -1059,6 +1102,7 @@ impl<'a> Checker<'a> {
         statement: &ast::Statement,
         name: &str,
         ty: &Option<Type>,
+        mutable: bool,
         initializer: &Option<ast::Expression>,
     ) -> Result<(), Diagnostic> {
         if let Some(initializer) = initializer {
@@ -1082,17 +1126,17 @@ impl<'a> Checker<'a> {
                 );
             }
             let declared_type = ty.clone().unwrap_or(return_type);
-            let id = self.declare(name, declared_type.clone(), None, statement.span)?;
+            let id = self.declare_local(name, declared_type.clone(), mutable, statement.span)?;
             self.update_known_null_pointer(id, initializer, &declared_type);
             self.update_known_integer_literal(id, initializer, &declared_type);
             self.statements
                 .push(Statement::new(StatementKindIr::call([id], call), statement.span));
         } else {
-            self.declare(
+            self.declare_local(
                 name,
                 ty.clone()
                     .expect("parser rejects inferred declarations without initializers"),
-                None,
+                mutable,
                 statement.span,
             )?;
         }
@@ -1133,9 +1177,9 @@ impl<'a> Checker<'a> {
     fn check_statement(&mut self, statement: &ast::Statement) -> Result<(), Diagnostic> {
         match &statement.kind {
             StatementKind::Let {
-                pattern: ast::Pattern::Binding { name, ty },
+                pattern: ast::Pattern::Binding { name, ty, mutable },
                 initializer,
-            } => self.check_let_binding_statement(statement, name, ty, initializer)?,
+            } => self.check_let_binding_statement(statement, name, ty, *mutable, initializer)?,
             StatementKind::Let {
                 pattern: ast::Pattern::Tuple(patterns),
                 initializer: Some(initializer),
@@ -1151,14 +1195,14 @@ impl<'a> Checker<'a> {
                 failure,
             } => self.check_guard_let_tuple_statement(statement, patterns, callee, arguments, failure)?,
             StatementKind::GuardLet {
-                pattern: ast::Pattern::Binding { name, ty },
+                pattern: pattern @ ast::Pattern::Binding { .. },
                 initializer:
                     ast::Expression {
                         kind: ExpressionKind::Call { callee, arguments },
                         ..
                     },
                 failure,
-            } => self.check_guard_let_binding_statement(statement, name, ty, callee, arguments, failure)?,
+            } => self.check_guard_let_binding_statement(statement, pattern, callee, arguments, failure)?,
             StatementKind::Assign { name, initializer } => self.check_assign_statement(statement, name, initializer)?,
             StatementKind::IndexAssign { base, index, value } => {
                 let (base, element_type) = self.check_index_base(base)?;
@@ -1300,11 +1344,16 @@ impl<'a> Checker<'a> {
     }
 
     fn declare_hidden(&mut self, base: &str, ty: Type, span: SourceSpan) -> VariableId {
+        self.declare_hidden_with_mutability(base, ty, true, span)
+    }
+
+    fn declare_hidden_with_mutability(&mut self, base: &str, ty: Type, mutable: bool, span: SourceSpan) -> VariableId {
         let id = self.variables.len();
         self.variables.push(Variable {
             name: format!("{base}_{id}"),
             ty,
             parameter_mode: None,
+            mutable,
             span,
         });
         id
@@ -1474,6 +1523,12 @@ impl<'a> Checker<'a> {
                         parameter_mode: self.variables[*id].parameter_mode,
                     };
                     self.ensure_writable(&symbol, argument.span)?;
+                    if !self.variables[*id].mutable {
+                        return self.error(
+                            argument.span,
+                            format!("cannot assign to immutable binding '{}'", self.variables[*id].name),
+                        );
+                    }
                 } else if !matches!(value.kind, ValueKind::MachineRegister(_)) {
                     return self.error(argument.span, "an output argument must be a writable binding");
                 }
@@ -3815,6 +3870,149 @@ mod tests {
         };
     }
 
+    rejects!(
+        rejects_assignment_to_immutable_binding,
+        "handler Bad(value: i32) { let binding = value; binding = 1; dispatch_next; }",
+        "cannot assign to immutable binding 'binding'"
+    );
+
+    rejects!(
+        rejects_output_through_immutable_binding,
+        r#"
+inline fn initialize(value: out i32) {
+    value = 1;
+}
+handler Bad() {
+    let value: i32 = 0;
+    initialize(value);
+    dispatch_next;
+}
+"#,
+        "cannot assign to immutable binding 'value'"
+    );
+
+    rejects!(
+        rejects_initialization_through_immutable_output_binding,
+        r#"
+inline fn initialize(value: out i32) {
+    value = 1;
+}
+handler Bad() {
+    let value: i32;
+    initialize(value);
+    dispatch_next;
+}
+"#,
+        "cannot assign to immutable binding 'value'"
+    );
+
+    rejects!(
+        rejects_inout_through_immutable_binding,
+        r#"
+inline fn increment(value: inout i32) {
+    value = value + 1;
+}
+handler Bad() {
+    let value: i32 = 0;
+    increment(value);
+    dispatch_next;
+}
+"#,
+        "cannot assign to immutable binding 'value'"
+    );
+
+    rejects!(
+        rejects_uninitialized_mutable_inout_binding,
+        r#"
+inline fn increment(value: inout i32) {
+    value = value + 1;
+}
+handler Bad() {
+    let mut value: i32;
+    increment(value);
+    dispatch_next;
+}
+"#,
+        "binding 'value' is read before it is initialized"
+    );
+
+    accepts!(
+        accepts_initialization_through_mutable_output_binding,
+        r#"
+inline fn initialize(value: out i32) {
+    value = 1;
+}
+handler Good() {
+    let mut value: i32;
+    initialize(value);
+    assert_nonzero(value);
+    dispatch_next;
+}
+"#
+    );
+
+    accepts!(
+        accepts_inout_through_mutable_binding,
+        r#"
+inline fn increment(value: inout i32) {
+    value = value + 1;
+}
+handler Good() {
+    let mut value: i32 = 1;
+    increment(value);
+    assert_nonzero(value);
+    dispatch_next;
+}
+"#
+    );
+
+    accepts!(
+        accepts_assignment_to_mutable_binding,
+        "handler Good(value: i32) { let mut binding = value; binding = 1; dispatch_next; }"
+    );
+
+    accepts!(
+        accepts_single_initialization_of_immutable_binding,
+        "handler Good(value: i32) { let binding: i32; binding = value; assert_nonzero(binding); dispatch_next; }"
+    );
+
+    rejects!(
+        rejects_reinitialization_of_immutable_binding,
+        "handler Bad(value: i32) { let binding: i32; binding = value; binding = 1; dispatch_next; }",
+        "cannot assign to immutable binding 'binding'"
+    );
+
+    rejects!(
+        rejects_assignment_to_immutable_pattern_binding,
+        r#"
+handler Bad(value: Value) {
+    match value {
+        Value<i32>(integer) => {
+            integer = 1;
+            dispatch_next;
+        },
+        _ => { dispatch_next; },
+    }
+}
+"#,
+        "cannot assign to immutable binding 'integer'"
+    );
+
+    accepts!(
+        accepts_assignment_to_mutable_pattern_binding,
+        r#"
+handler Good(value: Value) {
+    match value {
+        Value<i32>(mut integer) => {
+            integer = 1;
+            dispatch_next;
+        },
+        _ => { dispatch_next; },
+    }
+}
+"#
+    );
+
     #[test]
     fn keeps_int32_refinement_in_typed_ir() {
         let program = check_source(
@@ -3872,7 +4070,7 @@ handler Read(src: in Operand) {
         let program = check_source(
             r#"
 inline fn apply(value: i32, operation: BinaryOperation<i32>) {
-    let result = value;
+    let mut result = value;
     operation(result, 1);
     dispatch_next;
 }
@@ -4004,7 +4202,7 @@ handler Dispatch(value: Value) {
         let program = check_source(
             r#"
 handler Add(lhs: i32, rhs: i32) {
-    let dst = box_i32(lhs);
+    let mut dst = box_i32(lhs);
     guard let sum = checked_add(lhs, rhs) else @cold {
         dst = box_i32(lhs);
         dispatch_next;
@@ -4082,7 +4280,7 @@ handler Check(value: i32) {
 handler Add() {
     let number: f64;
     if true {
-        let integer: i32;
+        let mut integer: i32;
         mov(integer, 0);
         let inner_number = to_f64(integer);
     }
@@ -4254,7 +4452,7 @@ handler StoreNull(address: u64, flag: u32) {
             r#"
 handler StoreShape(address: u64) {
     let object: Object = alias(address);
-    let shape: Shape = null;
+    let mut shape: Shape = null;
     shape = object.shape;
     object.shape = shape;
     dispatch_next;
@@ -4340,7 +4538,7 @@ handler Read(address: u64) {
         explicitly_widens_refined_values,
         r#"
 inline fn box(object: Object) -> Value<Object> {
-    let value: Value<Object>;
+    let mut value: Value<Object>;
     mov(value, object);
     value
 }
@@ -4382,7 +4580,7 @@ handler Box(dst: out Operand, value: bool) {
         rejects_aliasing_conditionally_assigned_integer_literals_to_pointer_types,
         r#"
 handler Bad(address: u64, flag: u32) {
-    let raw: u64 = 1;
+    let mut raw: u64 = 1;
     if load(flag) == 0 {
         raw = address;
     } else {
@@ -4398,7 +4596,7 @@ handler Bad(address: u64, flag: u32) {
         accepts_aliasing_reassigned_integer_variables_to_pointer_types,
         r#"
 handler Good(address: u64) {
-    let raw: u64 = 1;
+    let mut raw: u64 = 1;
     raw = address;
     let object: Object = alias(raw);
     assert_nonzero(object);
@@ -4423,7 +4621,7 @@ handler FrameSize(slot_count: u32) {
         checks_value_tag_bitwise_arithmetic,
         r#"
 handler Mask(value: Value) {
-    let tag = extract_tag(value);
+    let mut tag = extract_tag(value);
     tag = tag & NAN_BASE_TAG;
     dispatch_next;
 }
@@ -4521,7 +4719,7 @@ inline fn terminal(value: out Value, input: Value, slow: SlowPath) {
         r#"
 handler Jump(target: BytecodeOffset) {
     let take = || {
-        let target_offset: BytecodeOffset;
+        let mut target_offset: BytecodeOffset;
         load_label(target_offset, target);
         goto_handler(target_offset);
     };
@@ -4610,7 +4808,7 @@ inline fn recurse(lhs: inout i32, rhs: i32) {
 }
 
 handler Loop(lhs: i32, rhs: i32) {
-    let value = lhs;
+    let mut value = lhs;
     recurse(value, rhs);
     assert_nonzero(value);
     dispatch_next;
@@ -4783,7 +4981,7 @@ handler Bad() {
         treats_self_xor_as_initialization,
         r#"
 handler Zero() {
-    let value: u64;
+    let mut value: u64;
     xor(value, value);
     store64([values, 0], value);
     dispatch_next;

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -986,7 +986,7 @@ inline fn apply(
     value: i32,
     operation: CheckedBinaryOperation<i32>
 ) {
-    let result = value;
+    let mut result = value;
     operation(result, 1) else @cold {
         dispatch_next;
     };

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -30,23 +30,23 @@ inline fn check_tag_is_double(tag: inout ValueTag, else failure: Label) {
 }
 
 inline fn box_cell(cell: Environment) -> Value {
-    let bits: u64 = alias(cell);
+    let mut bits: u64 = alias(cell);
     bits = heap_region_offset(bits);
     bits = bits | SHIFTED_IS_CELL_PATTERN;
     # FIXME: Use a representation alias once it can coalesce with an inline
     #        function return without leaving its result uninitialized.
-    let value: Value;
+    let mut value: Value;
     mov(value, bits);
     value
 }
 
 inline fn box_object(object: Object) -> Value<Object> {
-    let pointer: u64 = alias(object);
+    let mut pointer: u64 = alias(object);
     pointer = heap_region_offset(pointer);
     pointer = pointer | OBJECT_TAG_SHIFTED;
     # FIXME: Use a representation alias once it can coalesce with an inline
     #        function return without leaving its result uninitialized.
-    let value: Value<Object>;
+    let mut value: Value<Object>;
     mov(value, pointer);
     value
 }
@@ -72,7 +72,7 @@ inline fn load_direct_getter_value(
 
     let result_implementation = implementation_words[direct_getter.implementation_value_word_offset];
     if result_implementation == 0 {
-        let null_value: Value;
+        let mut null_value: Value;
         mov(null_value, NULL_VALUE);
         null_value
     } else {
@@ -126,7 +126,7 @@ inline fn load_property_lookup_cache(
 ) -> PropertyLookupCache {
     let executable = exec_ctx.executable;
     assert_nonzero(executable);
-    let property_cache = executable.property_lookup_caches[load(cache)];
+    let mut property_cache = executable.property_lookup_caches[load(cache)];
     guard property_cache != 0 else fail;
     and(property_cache, PROPERTY_LOOKUP_CACHE_DATA_POINTER_MASK);
     assert_nonzero(property_cache);
@@ -163,9 +163,9 @@ inline fn walk_environment_chain(
     initial_environment: Environment,
     coordinate: EnvironmentCoordinate
 ) -> (DeclarativeEnvironment, u32) {
-    let environment = initial_environment;
+    let mut environment = initial_environment;
     let coordinate = &coordinate;
-    let hops = coordinate.hops;
+    let mut hops = coordinate.hops;
     let binding_index = coordinate.binding_index;
     assert_nonzero(environment);
     if hops != 0 {
@@ -198,8 +198,8 @@ inline fn walk_cached_environment_chain(
     initial_hops: u32,
     else failure: Label
 ) -> DeclarativeEnvironment {
-    let environment = initial_environment;
-    let hops = initial_hops;
+    let mut environment = initial_environment;
+    let mut hops = initial_hops;
     assert_nonzero(environment);
     if hops != 0 {
         do {
@@ -336,7 +336,7 @@ inline fn primitive_storage_cage_base() -> u64 {
 }
 
 inline fn normalize_completion_value(initial_value: Value) -> (Value, Value) {
-    let value = initial_value;
+    let mut value = initial_value;
     let empty_tag: Value = Value<Empty>;
     # FIXME: Use an immutable value-producing if once its result can coalesce
     #        with an inline function output on AArch64.
@@ -386,14 +386,14 @@ inline fn update_operand(
     slow_path: SlowPath
 ) {
     let value = load(operand);
-    guard let Value<i32>(integer) = value else slow;
+    guard let mut Value<i32>(integer) = value else slow;
     integer_operation(integer, 1) else overflow;
     store(operand, box_i32(integer));
     dispatch_next;
 
     let overflow = || @cold {
         let overflowed_integer = unbox_i32(load(operand));
-        let result = to_f64(overflowed_integer);
+        let mut result = to_f64(overflowed_integer);
         let one = unbox_f64(DOUBLE_ONE);
         float_operation(result, one);
         store(operand, box_f64(result));
@@ -412,7 +412,7 @@ inline fn post_update_operand(
     slow_path: SlowPath
 ) {
     let old = load(operand);
-    guard let Value<i32>(integer) = old else slow;
+    guard let mut Value<i32>(integer) = old else slow;
     store(dst, old);
     integer_operation(integer, 1) else overflow;
     store(operand, box_i32(integer));
@@ -420,7 +420,7 @@ inline fn post_update_operand(
 
     let overflow = || @cold {
         let overflowed_integer = unbox_i32(load(operand));
-        let result = to_f64(overflowed_integer);
+        let mut result = to_f64(overflowed_integer);
         let one = unbox_f64(DOUBLE_ONE);
         float_operation(result, one);
         store(operand, box_f64(result));
@@ -462,13 +462,13 @@ inline fn bitwise_binary(
     };
 
     let non_int32 = || @cold {
-        guard let lhs_integer = numeric_value_to_i32(lhs) else slow;
+        guard let mut lhs_integer = numeric_value_to_i32(lhs) else slow;
         guard let rhs_integer = numeric_value_to_i32(rhs) else slow;
         operation(lhs_integer, rhs_integer);
         store(dst, box_i32(lhs_integer));
         dispatch_next;
     };
-    guard let Value<i32>(lhs_integer) = lhs else non_int32;
+    guard let mut Value<i32>(lhs_integer) = lhs else non_int32;
     guard let Value<i32>(rhs_integer) = rhs else non_int32;
 
     operation(lhs_integer, rhs_integer);
@@ -487,8 +487,8 @@ inline fn signed_shift(
         call_binary_slow_path(slow_path, dst, lhs, rhs);
     };
 
-    guard let Value<i32>(integer) = lhs else slow;
-    guard let Value<i32>(count) = rhs else slow;
+    guard let mut Value<i32>(integer) = lhs else slow;
+    guard let mut Value<i32>(count) = rhs else slow;
     count = count & 31;
     operation(integer, count);
     store(dst, box_i32(integer));
@@ -577,9 +577,9 @@ inline fn strict_equality(
     not_equal: Label,
     else slow: Label
 ) {
-    let rhs_tag = extract_tag(rhs);
+    let mut rhs_tag = extract_tag(rhs);
     branch_eq(rhs_tag, INT32_TAG, rhs_i32);
-    let lhs_tag = extract_tag(lhs);
+    let mut lhs_tag = extract_tag(lhs);
     guard lhs_tag == rhs_tag else different_tags;
     equality_same_tag(lhs, rhs, lhs_tag, equal, not_equal, compare_f64) else slow;
 
@@ -627,9 +627,9 @@ inline fn loose_equality(
     not_equal: Label,
     else slow: Label
 ) {
-    let rhs_tag = extract_tag(rhs);
+    let mut rhs_tag = extract_tag(rhs);
     branch_eq(rhs_tag, INT32_TAG, rhs_i32);
-    let lhs_tag = extract_tag(lhs);
+    let mut lhs_tag = extract_tag(lhs);
     guard lhs_tag == rhs_tag else different_tags;
     equality_same_tag(lhs, rhs, lhs_tag, equal, not_equal, compare_f64) else slow;
 
@@ -1863,8 +1863,8 @@ handler BitwiseNot(
 ) {
     match load(src) {
         Value<i32>(integer) => {
-            integer = ~integer;
-            store(dst, box_i32(integer));
+            let result = ~integer;
+            store(dst, box_i32(result));
             dispatch_next;
         },
 
@@ -1911,8 +1911,8 @@ handler UnsignedRightShift(
     };
 
     guard let Value<i32>(integer) = lhs else slow;
-    guard let Value<i32>(count) = rhs else slow;
-    let value = u32(integer);
+    guard let mut Value<i32>(count) = rhs else slow;
+    let mut value = u32(integer);
     let as_double = || @cold {
         store(dst, box_f64(u32_to_f64(value)));
         dispatch_next;
@@ -2035,10 +2035,10 @@ handler UnaryMinus(
     dst: out Operand,
     src: in Operand
 ) {
-    let value = load(src);
+    let mut value = load(src);
 
     match value {
-        Value<i32>(integer) => {
+        Value<i32>(mut integer) => {
             let negative_zero = || @cold {
                 store(dst, Value<NegativeZero>);
                 dispatch_next;
@@ -2207,7 +2207,7 @@ handler PutByValue(
         }
     };
 
-    guard let Value<i32>(source_i32) = source else store_non_integer;
+    guard let mut Value<i32>(source_i32) = source else store_non_integer;
     match typed_array_kind {
         TYPED_ARRAY_KIND_UINT8 | TYPED_ARRAY_KIND_INT8 => {
             let values: Sequence<u8> = alias(
@@ -2382,7 +2382,7 @@ handler GetById(
         exec_ctx = native_frame;
         values = exec_ctx.slots;
         let native_function = native_function_entry.function;
-        let [native_return, variant] = call_raw_native(native_function);
+        let mut [native_return, variant] = call_raw_native(native_function);
         let native_payload = native_return;
         variant = variant & 255;
         assert_lt_unsigned(variant, 2);
@@ -2425,7 +2425,7 @@ handler GetById(
 
     # FIXME: Restore a value-producing if once SSA destruction can coalesce its
     #        holder phi with object without adding a hot-path jump.
-    let holder = object;
+    let mut holder = object;
     if cached_prototype != 0 {
         let prototype_chain_validity = property_cache.prototype_chain_validity;
         guard prototype_chain_validity != 0 else try_cache;
@@ -2793,7 +2793,7 @@ handler Call(
     let metadata = shared_data.asm_call_metadata;
     guard metadata has SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_CAN_INLINE_CALL else slow;
     guard metadata lacks SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_NEEDS_ENVIRONMENT_OR_THIS_VALUE_RESOLUTION else invoke_interp_inline;
-    let receiver: Value = Value<Empty>;
+    let mut receiver: Value = Value<Empty>;
     if metadata has SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_USES_THIS {
         receiver = load(this_value);
         if metadata lacks SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_STRICT {
@@ -2858,7 +2858,7 @@ handler Call(
     let [_, return_pc, return_destination] = call_site_info(length, dst);
     frame.caller_return_pc = return_pc;
     frame.caller_dst_raw = return_destination;
-    let slot_index: u64 = RESERVED_REGISTER_COUNT;
+    let mut slot_index: u64 = RESERVED_REGISTER_COUNT;
     while slot_index + 1 < alias(registers_and_locals_count) {
         let next_slot_index = slot_index + 1;
         frame_values[slot_index] = empty_tag;
@@ -2872,8 +2872,8 @@ handler Call(
     assert_nonzero(executable);
     let constant_count = executable.asm_constants_size;
     let constant_data = executable.asm_constants_data;
-    let write_index: u64 = alias(registers_and_locals_count);
-    let constant_index: u64 = 0;
+    let mut write_index: u64 = alias(registers_and_locals_count);
+    let mut constant_index: u64 = 0;
     while constant_index < alias(constant_count) {
         assert_nonzero(constant_data);
         frame_values[write_index] = constant_data[constant_index];
@@ -2885,7 +2885,7 @@ handler Call(
     write_index = alias(registers_and_locals_count) + alias(constant_count);
     let caller_values = exec_ctx.slots;
     let argument_operand_indices = &arguments;
-    let argument_index: u32 = 0;
+    let mut argument_index: u32 = 0;
     while argument_index < actual_argument_count {
         frame_values[write_index] = caller_values[argument_operand_indices[argument_index]];
         argument_index = argument_index + 1;
@@ -2976,7 +2976,7 @@ handler Call(
         let native_caller_values = exec_ctx.slots;
         let native_argument_operand_indices = &arguments;
         let native_frame_values = native_frame.slots;
-        let argument_index: u32 = 0;
+        let mut argument_index: u32 = 0;
         while argument_index < actual_argument_count {
             native_frame_values[argument_index] = native_caller_values[native_argument_operand_indices[argument_index]];
             argument_index = argument_index + 1;
@@ -2992,7 +2992,7 @@ handler Call(
         let native_function = native_function_entry.function;
         # FIXME: Bind native_payload directly once the allocator can keep the
         #        ABI-pinned result live alongside the native result variant.
-        let [native_return, variant] = call_raw_native(native_function);
+        let mut [native_return, variant] = call_raw_native(native_function);
         let native_payload = native_return;
         variant = variant & 255;
         assert_lt_unsigned(variant, 2);
@@ -3041,7 +3041,7 @@ handler CallBuiltinMathAbs(
     };
 
     validate_builtin(callee, BUILTIN_MATH_ABS) else slow;
-    let argument_value = load(argument);
+    let mut argument_value = load(argument);
     match argument_value {
         Value<f64> => {
             clear_bit(argument_value, 63);
@@ -3049,9 +3049,9 @@ handler CallBuiltinMathAbs(
             dispatch_next;
         },
 
-        Value<i32>(integer_value) => {
+        Value<i32>(mut integer_value) => {
             let overflow = || @cold {
-                let overflowed_integer = unbox_i32(argument_value);
+                let mut overflowed_integer = unbox_i32(argument_value);
                 neg(overflowed_integer);
                 let unsigned_integer: u32 = alias(overflowed_integer);
                 store(dst, box_f64(u32_to_f64(unsigned_integer)));
@@ -3283,7 +3283,7 @@ handler CallBuiltinStringFromCharCode(
     };
 
     validate_builtin(callee, BUILTIN_STRING_FROM_CHAR_CODE) else slow;
-    guard let Value<i32>(code_unit) = load(argument) else slow;
+    guard let mut Value<i32>(code_unit) = load(argument) else slow;
     let single_utf16_code_unit = || {
         assert_lt_unsigned(code_unit, 0x10000);
         let result: Value = call_helper(asm_helper_single_utf16_code_unit_string, code_unit);


### PR DESCRIPTION
Make local and pattern bindings immutable by default, and require the `mut` modifier before they can be reassigned or passed to an output parameter. Preserve one-time initialization of uninitialized bindings by performing the check alongside definite-initialization analysis.

Annotate the interpreter's mutable bindings and replace the unnecessary `BitwiseNot` reassignment with an immutable result. Keep generated x86-64 and AArch64 interpreter assembly byte-for-byte unchanged.