### PR TITLE
LibWeb: Use shared ABI types across the painting FFI

### DIFF
--- a/Libraries/LibGfx/Matrix.h
+++ b/Libraries/LibGfx/Matrix.h
@@ -39,26 +39,8 @@ public:
     {
     }
 
-    constexpr Matrix(Matrix const& other)
-    {
-        *this = other;
-    }
-
-    constexpr Matrix& operator=(Matrix const& other)
-    {
-#ifndef __clang__
-        if consteval {
-            for (size_t i = 0; i < N; i++) {
-                for (size_t j = 0; j < N; j++) {
-                    (*this)[i, j] = other[i, j];
-                }
-            }
-            return *this;
-        }
-#endif
-        __builtin_memcpy(m_elements, other.elements(), sizeof(T) * N * N);
-        return *this;
-    }
+    constexpr Matrix(Matrix const&) = default;
+    constexpr Matrix& operator=(Matrix const&) = default;
 
     constexpr auto elements() const { return m_elements; }
     constexpr auto elements() { return m_elements; }

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1206,7 +1206,7 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
             return line_height;
         auto const* font_values = element.style_group<ComputedValues::FontValues>(pseudo_element);
         VERIFY(font_values);
-        return LengthStyleValue::create(Length::make_px(CSSPixels::from_raw(font_values->line_height_used)));
+        return LengthStyleValue::create(Length::make_px(font_values->line_height_used));
     }
 
         // -> block-size

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1395,13 +1395,13 @@ public:
     Optional<CSSPixels> perspective() const { return m_noninherited.transform->perspective_value(); }
 
     Gfx::FontCascadeList const& font_list() const { return m_inherited.font->font_list_value(); }
-    CSSPixels font_size() const { return CSSPixels::from_raw(m_inherited.font->font_size); }
+    CSSPixels font_size() const { return m_inherited.font->font_size; }
     double font_weight() const { return m_inherited.font->font_weight; }
-    CSSPixels line_height() const { return CSSPixels::from_raw(m_inherited.font->line_height_used); }
+    CSSPixels line_height() const { return m_inherited.font->line_height_used; }
 
     Color outline_color() const { return Color::from_bgra(m_noninherited.misc->outline_color); }
     OutlineStyle outline_style() const { return static_cast<OutlineStyle>(m_noninherited.misc->outline_style); }
-    CSSPixels outline_width() const { return CSSPixels::from_raw(m_noninherited.misc->outline_width); }
+    CSSPixels outline_width() const { return m_noninherited.misc->outline_width; }
 
     QuotesData quotes() const { return m_inherited.list->quotes_value(); }
 
@@ -1599,7 +1599,7 @@ public:
 
         TextAlign text_align_value() const { return static_cast<TextAlign>(text_align); }
         WhiteSpaceCollapse white_space_collapse_value() const { return static_cast<WhiteSpaceCollapse>(white_space_collapse); }
-        CSSPixels letter_spacing_value() const { return CSSPixels::from_raw(letter_spacing); }
+        CSSPixels letter_spacing_value() const { return letter_spacing; }
         Color color_value() const { return Color::from_bgra(color); }
         Color webkit_text_fill_color_value() const { return Color::from_bgra(webkit_text_fill_color); }
         ReadonlySpan<ShadowData> text_shadow_span() const
@@ -2354,7 +2354,7 @@ public:
     {
         if (m_values.m_inherited.text->letter_spacing_value() == value)
             return;
-        m_values.m_inherited.text.access().letter_spacing = value.raw_value();
+        m_values.m_inherited.text.access().letter_spacing = value;
     }
     void set_width(Size value) { set_size(&ComputedValuesFFI::SizingValues::width, move(value)); }
     void set_height(Size value) { set_size(&ComputedValuesFFI::SizingValues::height, move(value)); }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8923,7 +8923,7 @@ Optional<CSSPixelRect> Document::current_caret_rect()
             auto result = Layout::RustFFI::layout_arena_text_caret_rect_in_dom_range(
                 layout_node->arena_handle(), text_slots.data(), text_slots.size(), position->offset());
             if (result.has_value)
-                return to_viewport_rect(Painting::from_ffi_css_pixel_rect(result.rect));
+                return to_viewport_rect(result.rect);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1304,8 +1304,7 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             Layout::RustFFI::layout_arena_text_range_rects(
                 mapping.primary()->arena_handle(), text_slots.data(), text_slots.size(),
                 to_underlying(selection_state), start_offset(), end_offset(), filter_dom_start, filter_dom_end,
-                &rects, [](void* context, Layout::RustFFI::FfiCssPixelRect ffi_rect) {
-                    auto rect = Painting::from_ffi_css_pixel_rect(ffi_rect);
+                &rects, [](void* context, CSSPixelRect rect) {
                     static_cast<Vector<GC::Root<Geometry::DOMRect>>*>(context)->append(Geometry::DOMRect::create(rect.to_type<float>()));
                 });
         }

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -278,12 +278,12 @@ RustFFI::FfiReplacedContentFacts Box::build_replaced_content_facts_for_arena() c
     RustFFI::FfiReplacedContentFacts facts {};
     auto auto_content_size = auto_content_box_size();
     facts.has_auto_content_width = auto_content_size.has_width();
-    facts.auto_content_width = auto_content_size.width.value_or(0).raw_value();
+    facts.auto_content_width = auto_content_size.width.value_or(0);
     facts.has_auto_content_height = auto_content_size.has_height();
-    facts.auto_content_height = auto_content_size.height.value_or(0).raw_value();
+    facts.auto_content_height = auto_content_size.height.value_or(0);
     if (auto_content_size.aspect_ratio.has_value()) {
-        facts.auto_content_aspect_ratio_numerator = auto_content_size.aspect_ratio->numerator().raw_value();
-        facts.auto_content_aspect_ratio_denominator = auto_content_size.aspect_ratio->denominator().raw_value();
+        facts.auto_content_aspect_ratio_numerator = auto_content_size.aspect_ratio->numerator();
+        facts.auto_content_aspect_ratio_denominator = auto_content_size.aspect_ratio->denominator();
     }
     if (appearance() == CSS::Appearance::None) {
         if (auto const* input = as_if<HTML::HTMLInputElement>(dom_node())) {
@@ -297,9 +297,9 @@ RustFFI::FfiReplacedContentFacts Box::build_replaced_content_facts_for_arena() c
             case HTML::HTMLInputElement::TypeAttributeState::Number: {
                 auto default_preferred_size = default_preferred_size_for_text_control(*input, *this);
                 facts.has_default_preferred_width = default_preferred_size.has_width();
-                facts.default_preferred_width = default_preferred_size.width.value_or(0).raw_value();
+                facts.default_preferred_width = default_preferred_size.width.value_or(0);
                 facts.has_default_preferred_height = default_preferred_size.has_height();
-                facts.default_preferred_height = default_preferred_size.height.value_or(0).raw_value();
+                facts.default_preferred_height = default_preferred_size.height.value_or(0);
                 break;
             }
             default:

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -81,7 +81,7 @@ Painting::UsedGridTrackList build_used_grid_track_list(RustFFI::FfiUsedGridTrack
         result.lines.unchecked_append(move(line_names));
 
         if (line_index < list.track_count)
-            result.track_sizes.unchecked_append(CSSPixels::from_raw(list.track_sizes[line_index]));
+            result.track_sizes.unchecked_append(list.track_sizes[line_index]);
     }
     return result;
 }
@@ -302,8 +302,8 @@ static RustFFI::FfiSvgPathResult compute_svg_path(NodeWithStyle const& node, Rus
 {
     auto const& graphics_box = as<Box>(node);
     CSSPixelSize viewport_size {
-        CSSPixels::from_raw(request.viewport_width),
-        CSSPixels::from_raw(request.viewport_height),
+        request.viewport_width,
+        request.viewport_height,
     };
     Gfx::FloatPoint text_position {
         request.current_text_position.x,
@@ -524,12 +524,12 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
 {
     return {
         .context = this,
-        .content_size_changed = [](void*, void* layout_node_shell, RustFFI::FfiCssPixelSize old_size, RustFFI::FfiCssPixelSize new_size) {
+        .content_size_changed = [](void*, void* layout_node_shell, CSSPixelSize old_size, CSSPixelSize new_size) {
             auto& layout_node = *static_cast<Node*>(layout_node_shell);
             invalidate_descendant_styles_for_container_query_size_change(
                 layout_node.dom_node(),
-                { CSSPixels::from_raw(old_size.width), CSSPixels::from_raw(old_size.height) },
-                { CSSPixels::from_raw(new_size.width), CSSPixels::from_raw(new_size.height) }); },
+                old_size,
+                new_size); },
         .finish_commit = [](void*, void* const* viewport_shells, size_t viewport_count) {
             for (size_t index = 0; index < viewport_count; ++index)
                 as<Box>(*static_cast<Node*>(viewport_shells[index])).notify_content_navigable_of_committed_viewport(); },
@@ -584,7 +584,7 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
     return {
         .context = this,
         .arena = m_commit_root->arena_handle(),
-        .initial_containing_block_inline_size = m_commit_root->document().viewport_rect().width().raw_value(),
+        .initial_containing_block_inline_size = m_commit_root->document().viewport_rect().width(),
         .document_in_quirks_mode = m_commit_root->document().in_quirks_mode(),
         .report_unexpected_fragmented_inline = [](void*, void* node) {
             auto const& box = *static_cast<Box const*>(node);
@@ -598,11 +598,11 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
             VERIFY(node_with_style);
             return compute_svg_path(*node_with_style, request); },
-        .svg_image_bounding_box = [](void*, void* node, i32 viewport_width, i32 viewport_height) {
+        .svg_image_bounding_box = [](void*, void* node, CSSPixels viewport_width, CSSPixels viewport_height) {
             auto const& image_element = as<SVG::SVGImageElement>(*static_cast<Node const*>(node)->dom_node());
             auto bounding_box = image_element.bounding_box({
-                CSSPixels::from_raw(viewport_width),
-                CSSPixels::from_raw(viewport_height),
+                viewport_width,
+                viewport_height,
             });
             return RustFFI::FfiFloatRect {
                 .x = bounding_box.x(),

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -559,9 +559,9 @@ public:
     CSS::WillChange will_change() const { return style_group<CSS::ComputedValues::MiscResetValues>().will_change_value(); }
     Optional<Utf16FlyString> view_transition_name() const { return style_group<CSS::ComputedValues::MiscResetValues>().view_transition_name_value(); }
     Color outline_color() const { return Color::from_bgra(style_group<CSS::ComputedValues::MiscResetValues>().outline_color); }
-    CSSPixels outline_offset() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::MiscResetValues>().outline_offset); }
+    CSSPixels outline_offset() const { return style_group<CSS::ComputedValues::MiscResetValues>().outline_offset; }
     CSS::OutlineStyle outline_style() const { return static_cast<CSS::OutlineStyle>(style_group<CSS::ComputedValues::MiscResetValues>().outline_style); }
-    CSSPixels outline_width() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::MiscResetValues>().outline_width); }
+    CSSPixels outline_width() const { return style_group<CSS::ComputedValues::MiscResetValues>().outline_width; }
     Color background_color() const { return style_group<CSS::ComputedValues::BackgroundValues>().background_color_value(); }
     Vector<CSS::BackgroundLayerData> const& background_layers() const
     {
@@ -615,8 +615,8 @@ public:
     CSS::WhiteSpaceCollapse white_space_collapse() const { return style_group<CSS::ComputedValues::InheritedTextValues>().white_space_collapse_value(); }
     Color text_decoration_color() const { return Color::from_bgra(style_group<CSS::ComputedValues::TextResetValues>().text_decoration_color); }
     Optional<CSS::ContentData> const& content() const { return m_content; }
-    CSSPixels line_height() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::FontValues>().line_height_used); }
-    CSSPixels font_size() const { return CSSPixels::from_raw(style_group<CSS::ComputedValues::FontValues>().font_size); }
+    CSSPixels line_height() const { return style_group<CSS::ComputedValues::FontValues>().line_height_used; }
+    CSSPixels font_size() const { return style_group<CSS::ComputedValues::FontValues>().font_size; }
     Gfx::FontCascadeList const& font_list() const { return style_group<CSS::ComputedValues::FontValues>().font_list_value(); }
     CSS::FlexDirection flex_direction() const { return static_cast<CSS::FlexDirection>(style_group<CSS::ComputedValues::AlignmentValues>().flex_direction); }
     CSS::AlignSelf align_self() const { return static_cast<CSS::AlignSelf>(style_group<CSS::ComputedValues::AlignmentValues>().align_self); }

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -188,22 +188,22 @@ Layout::Node* layout_node_for_committed_slot(Layout::NodeArena& arena, Layout::R
 
 static PixelBox pixel_box_from_ffi(Layout::RustFFI::FfiPixelBox const& box)
 {
-    return { CSSPixels::from_raw(box.top), CSSPixels::from_raw(box.right), CSSPixels::from_raw(box.bottom), CSSPixels::from_raw(box.left) };
+    return { box.top, box.right, box.bottom, box.left };
 }
 
 CSSPixelRect absolute_rect(Layout::Node const& node)
 {
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_rect(node.arena_handle(), committed_row_slot(node)));
+    return Layout::RustFFI::layout_arena_paintable_absolute_rect(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelRect absolute_padding_box_rect(Layout::Node const& node)
 {
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_padding_box_rect(node.arena_handle(), committed_row_slot(node)));
+    return Layout::RustFFI::layout_arena_paintable_absolute_padding_box_rect(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelRect absolute_border_box_rect(Layout::Node const& node)
 {
-    return from_ffi_css_pixel_rect(Layout::RustFFI::layout_arena_paintable_absolute_border_box_rect(node.arena_handle(), committed_row_slot(node)));
+    return Layout::RustFFI::layout_arena_paintable_absolute_border_box_rect(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelPoint absolute_position(Layout::Node const& node)
@@ -213,14 +213,12 @@ CSSPixelPoint absolute_position(Layout::Node const& node)
 
 CSSPixelPoint offset(Layout::Node const& node)
 {
-    auto offset = Layout::RustFFI::layout_arena_paintable_offset(node.arena_handle(), committed_row_slot(node));
-    return { CSSPixels::from_raw(offset.x), CSSPixels::from_raw(offset.y) };
+    return Layout::RustFFI::layout_arena_paintable_offset(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelSize content_size(Layout::Node const& node)
 {
-    auto size = Layout::RustFFI::layout_arena_paintable_content_size(node.arena_handle(), committed_row_slot(node));
-    return { CSSPixels::from_raw(size.width), CSSPixels::from_raw(size.height) };
+    return Layout::RustFFI::layout_arena_paintable_content_size(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixels content_width(Layout::Node const& node)
@@ -261,7 +259,7 @@ Optional<OverflowData> overflow_data(Layout::Node const& node)
     auto const* row = committed_row(node);
     if (!row || !row->overflow_measured_this_commit)
         return {};
-    return OverflowData { from_ffi_css_pixel_rect(row->overflow_relative_to_padding_box.rect), row->overflow_relative_to_padding_box.has_scrollable_overflow };
+    return OverflowData { row->overflow_relative_to_padding_box.rect, row->overflow_relative_to_padding_box.has_scrollable_overflow };
 }
 
 static void measure_scrollable_overflow_if_missing(Layout::Node const& node, Layout::RustFFI::PaintableData const& row)
@@ -289,7 +287,7 @@ Optional<CSSPixelRect> scrollable_overflow_rect(Layout::Node const& node)
     measure_scrollable_overflow_if_missing(node, *row);
     if (!row->overflow_measured_this_commit && !row->overflow_valid_across_recommits)
         return {};
-    auto rect = from_ffi_css_pixel_rect(row->overflow_relative_to_padding_box.rect);
+    auto rect = row->overflow_relative_to_padding_box.rect;
     rect.translate_by(absolute_padding_box_rect(node).location());
     return rect;
 }
@@ -530,8 +528,7 @@ Gfx::Path const* committed_svg_path(Layout::Node const& node)
 
 CSSPixelSize svg_viewport_size(Layout::Node const& node)
 {
-    auto size = Layout::RustFFI::layout_arena_paintable_svg_viewport_size(node.arena_handle(), committed_row_slot(node));
-    return { CSSPixels::from_raw(size.width), CSSPixels::from_raw(size.height) };
+    return Layout::RustFFI::layout_arena_paintable_svg_viewport_size(node.arena_handle(), committed_row_slot(node));
 }
 
 Optional<Gfx::AffineTransform> svg_viewport_transform(Layout::Node const& node)
@@ -571,7 +568,7 @@ CSSPixelPoint box_type_agnostic_position(Layout::Node const& node)
     if (row->kind == Layout::RustFFI::PaintableKind::InlinePaintable) {
         auto result = Layout::RustFFI::layout_arena_inline_paintable_first_piece_position(node.arena_handle(), committed_row_slot(node));
         if (result.has_value)
-            return { CSSPixels::from_raw(result.x), CSSPixels::from_raw(result.y) };
+            return { result.x, result.y };
     }
     return absolute_position(node);
 }
@@ -596,10 +593,10 @@ StickyInsets sticky_insets(Layout::Node const& node)
         return {};
     VERIFY(row->has_sticky_insets);
     auto const& insets = row->sticky_insets;
-    auto side = [](i32 raw, bool present) -> Optional<CSSPixels> {
+    auto side = [](CSSPixels value, bool present) -> Optional<CSSPixels> {
         if (!present)
             return {};
-        return CSSPixels::from_raw(raw);
+        return value;
     };
     return { side(insets.top, insets.has_top), side(insets.right, insets.has_right), side(insets.bottom, insets.has_bottom), side(insets.left, insets.has_left) };
 }
@@ -670,7 +667,7 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
         if (previous_layout_node && previous_layout_node->is_atomic_inline()) {
             auto result = Layout::RustFFI::layout_arena_paintable_first_fragment_rect_for_node(block.arena_handle(), committed_row_slot(block), Layout::Node::slot_id(previous_layout_node));
             if (result.has_value) {
-                auto fragment_rect = from_ffi_css_pixel_rect(result.rect);
+                auto fragment_rect = result.rect;
                 if (styled_block.writing_mode() == CSS::WritingMode::HorizontalTb)
                     rect.set_x(styled_block.inline_axis_is_reverse() ? fragment_rect.left() : fragment_rect.right());
                 else
@@ -693,13 +690,13 @@ CSSPixelRect caret_rect_for_child_offset(Layout::Node const& block, size_t offse
     } preceding_context { const_cast<DOM::Node&>(*child), {} };
     Layout::RustFFI::layout_arena_for_each_subtree_fragment_rect(
         block.arena_handle(), committed_row_slot(block), &preceding_context,
-        [](void* context_pointer, void* fragment_layout_node_shell, Layout::RustFFI::FfiCssPixelRect rect) {
+        [](void* context_pointer, void* fragment_layout_node_shell, CSSPixelRect rect) {
             auto& context = *static_cast<PrecedingContentContext*>(context_pointer);
             auto const* fragment_layout_node = static_cast<Layout::Node const*>(fragment_layout_node_shell);
             auto* fragment_dom_node = fragment_layout_node ? const_cast<DOM::Node*>(fragment_layout_node->dom_node()) : nullptr;
             if (!fragment_dom_node || !(context.child->compare_document_position(fragment_dom_node) & DOM::Node::DOCUMENT_POSITION_PRECEDING))
                 return;
-            auto bottom = CSSPixels::from_raw(rect.y) + CSSPixels::from_raw(rect.height);
+            auto bottom = rect.bottom();
             if (!context.preceding_content_bottom.has_value() || bottom > *context.preceding_content_bottom)
                 context.preceding_content_bottom = bottom;
         });
@@ -750,7 +747,7 @@ Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node
             auto const* style_source = static_cast<Layout::NodeWithStyle const*>(result.style_source);
             if (!style_source || !layout_node_is_visible(*style_source))
                 return {};
-            return CaretPaint { from_ffi_css_pixel_rect(result.rect), style_source->caret_color() };
+            return CaretPaint { result.rect, style_source->caret_color() };
         }
         if (result.found) {
             return {};
@@ -773,7 +770,7 @@ Optional<CaretPaint> resolve_caret_paint(Layout::Node const& block, Layout::Node
             auto const* style_source = static_cast<Layout::NodeWithStyle const*>(empty_line.style_source);
             if (!style_source)
                 return {};
-            auto empty_line_rect = from_ffi_css_pixel_rect(empty_line.rect);
+            auto empty_line_rect = empty_line.rect;
             CSSPixelRect cursor_rect { empty_line_rect.x(), empty_line_rect.y(), 1, empty_line_rect.height() };
             return CaretPaint { cursor_rect, style_source->caret_color() };
         }
@@ -1145,9 +1142,9 @@ void set_sticky_insets(Layout::Node const& node, OwnPtr<StickyInsets> sticky_ins
 {
     Layout::RustFFI::FfiStickyInsets ffi_insets {};
     if (sticky_insets) {
-        auto pack = [](Optional<CSSPixels> const& value, i32& raw, bool& present) {
+        auto pack = [](Optional<CSSPixels> const& value, CSSPixels& output, bool& present) {
             present = value.has_value();
-            raw = value.has_value() ? value->raw_value() : 0;
+            output = value.value_or({});
         };
         pack(sticky_insets->top, ffi_insets.top, ffi_insets.has_top);
         pack(sticky_insets->right, ffi_insets.right, ffi_insets.has_right);
@@ -1169,13 +1166,8 @@ void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect
 {
     Layout::RustFFI::layout_arena_inline_paintable_piece_border_box_rects(
         node.arena_handle(), committed_row_slot(node), &rects,
-        [](void* context, Layout::RustFFI::FfiCssPixelRect rect) {
-            static_cast<Vector<CSSPixelRect>*>(context)->append({
-                CSSPixels::from_raw(rect.x),
-                CSSPixels::from_raw(rect.y),
-                CSSPixels::from_raw(rect.width),
-                CSSPixels::from_raw(rect.height),
-            });
+        [](void* context, CSSPixelRect rect) {
+            static_cast<Vector<CSSPixelRect>*>(context)->append(rect);
         });
 }
 

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -104,11 +104,11 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
             .kind = static_cast<ItemKind>(exported.kind),
             .box = exported.paintable,
             .chrome_widget_kind = static_cast<ChromeWidgetKind>(exported.chrome_widget_kind),
-            .text_fragment_index = exported.has_text_fragment_index ? Optional<u32> { exported.text_fragment_index } : Optional<u32> {},
+            .text_fragment_index = exported.text_fragment_index,
             .caret_node = exported.caret_node_shell ? static_cast<Layout::Node const*>(exported.caret_node_shell)->dom_node() : nullptr,
             .caret_offset = exported.caret_offset,
-            .rect = from_ffi_css_pixel_rect(exported.rect),
-            .caret_rect = from_ffi_css_pixel_rect(exported.caret_rect),
+            .rect = exported.rect,
+            .caret_rect = exported.caret_rect,
             .visual_context_index = VisualContextIndex { exported.visual_context_index },
         });
     }
@@ -151,7 +151,7 @@ void HitTestDisplayList::ensure_caret_lines() const
     for (size_t index = 0; index < line_count; ++index) {
         auto exported = Layout::RustFFI::layout_arena_hit_test_caret_line(arena, index);
         m_caret_lines.unchecked_append(CaretLine {
-            .rect = from_ffi_css_pixel_rect(exported.rect),
+            .rect = exported.rect,
             .visual_context_index = VisualContextIndex { exported.visual_context_index },
             .first_caret_item_index = exported.first_caret_item_index,
             .last_caret_item_index = exported.last_caret_item_index,
@@ -203,23 +203,21 @@ struct HitTestDisplayList::QueryContext {
     {
         return {
             .context = this,
-            .local_point_for_visual_context = [](void* context_pointer, size_t index, i32 x_raw, i32 y_raw, bool respect_clip, float* out) -> bool {
+            .local_point_for_visual_context = [](void* context_pointer, size_t index, CSSPixelPoint point, bool respect_clip, Gfx::FloatPoint* out) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
                 VERIFY(context.document);
                 auto clip_behavior = respect_clip ? AccumulatedVisualContextTree::ClipBehavior::Respect : AccumulatedVisualContextTree::ClipBehavior::Ignore;
-                auto local_point = local_float_point_for_visual_context(VisualContextIndex { index }, { CSSPixels::from_raw(x_raw), CSSPixels::from_raw(y_raw) }, *context.document, context.device_pixels_per_css_pixel, clip_behavior);
+                auto local_point = local_float_point_for_visual_context(VisualContextIndex { index }, point, *context.document, context.device_pixels_per_css_pixel, clip_behavior);
                 if (!local_point.has_value())
                     return false;
-                out[0] = local_point->x();
-                out[1] = local_point->y();
+                *out = *local_point;
                 return true;
             },
-            .chrome_widget_contains = [](void* context_pointer, void* layout_node_shell, u8 kind, i32 x_raw, i32 y_raw) -> bool {
+            .chrome_widget_contains = [](void* context_pointer, void* layout_node_shell, u8 kind, CSSPixelPoint local_point) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
                 VERIFY(context.chrome_metrics);
                 auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
                 auto paintable_slot = committed_row_slot(layout_node);
-                CSSPixelPoint local_point { CSSPixels::from_raw(x_raw), CSSPixels::from_raw(y_raw) };
                 auto contains = [&](auto widget) { return widget && widget->contains(local_point, *context.chrome_metrics); };
                 switch (static_cast<ChromeWidgetKind>(kind)) {
                 case ChromeWidgetKind::None:
@@ -247,7 +245,7 @@ struct HitTestDisplayList::QueryContext {
                 *out = sorting_contexts.outermost_context_of(sorting_contexts.context_by_node[index]).value();
                 return true;
             },
-            .plane_depth_key = [](void* context_pointer, size_t index, i32 x_raw, i32 y_raw, i64* out) -> bool {
+            .plane_depth_key = [](void* context_pointer, size_t index, CSSPixelPoint point, i64* out) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
                 VERIFY(context.document);
                 auto const& sorting_contexts = context.list.ensure_sorting_contexts(*context.document);
@@ -258,7 +256,6 @@ struct HitTestDisplayList::QueryContext {
                     return false;
                 // The plane's depth is the same for every query against one point, so it is resolved once.
                 auto depth_key = context.depth_key_by_plane.ensure(leaf.value(), [&]() -> Optional<i64> {
-                    CSSPixelPoint point { CSSPixels::from_raw(x_raw), CSSPixels::from_raw(y_raw) };
                     auto device_point = point.to_type<float>() * static_cast<float>(context.device_pixels_per_css_pixel);
                     auto depth = context.document->visual_context_tree().plane_depth_at_point_for_hit_test(leaf, device_point, context.document->scroll_state_snapshot());
                     if (!depth.has_value())
@@ -279,19 +276,19 @@ Optional<HitTestDisplayList::TopmostItem> HitTestDisplayList::topmost_item_from(
 {
     if (!item.has_item)
         return {};
-    return TopmostItem { item.index, { CSSPixels::from_raw(item.local_x), CSSPixels::from_raw(item.local_y) } };
+    return TopmostItem { item.index, item.local };
 }
 
 Optional<HitTestDisplayList::TopmostItem> HitTestDisplayList::find_topmost_item(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics) const
 {
     QueryContext context { *this, &document, device_pixels_per_css_pixel, &chrome_metrics, nullptr };
-    return topmost_item_from(Layout::RustFFI::layout_arena_hit_test_find_topmost_item(m_arena->handle(), context.callbacks(), point.x().raw_value(), point.y().raw_value()));
+    return topmost_item_from(Layout::RustFFI::layout_arena_hit_test_find_topmost_item(m_arena->handle(), context.callbacks(), point));
 }
 
 void HitTestDisplayList::find_topmost_items_for_caret(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics, Optional<TopmostItem>& caret_item, Optional<TopmostItem>& hit_item) const
 {
     QueryContext context { *this, &document, device_pixels_per_css_pixel, &chrome_metrics, nullptr };
-    auto items = Layout::RustFFI::layout_arena_hit_test_find_topmost_items_for_caret(m_arena->handle(), context.callbacks(), point.x().raw_value(), point.y().raw_value());
+    auto items = Layout::RustFFI::layout_arena_hit_test_find_topmost_items_for_caret(m_arena->handle(), context.callbacks(), point);
     caret_item = topmost_item_from(items.caret_item);
     hit_item = topmost_item_from(items.hit_item);
 }
@@ -300,7 +297,7 @@ Vector<size_t> HitTestDisplayList::hit_item_indices_topmost_first(CSSPixelPoint 
 {
     QueryContext context { *this, &document, device_pixels_per_css_pixel, &chrome_metrics, nullptr };
     Vector<size_t> indices;
-    Layout::RustFFI::layout_arena_hit_test_all(m_arena->handle(), context.callbacks(), point.x().raw_value(), point.y().raw_value(), &indices, [](void* sink, size_t index) {
+    Layout::RustFFI::layout_arena_hit_test_all(m_arena->handle(), context.callbacks(), point, &indices, [](void* sink, size_t index) {
         static_cast<Vector<size_t>*>(sink)->append(index);
     });
     return indices;
@@ -313,7 +310,7 @@ size_t HitTestDisplayList::item_index_at_line_edge(size_t line_index, CaretPosit
 
 Optional<HitTestDisplayList::CaretItemForLine> HitTestDisplayList::caret_item_for_line(size_t line_index, CSSPixelPoint local_point, CaretPositionMode mode) const
 {
-    auto result = Layout::RustFFI::layout_arena_hit_test_caret_item_for_line(m_arena->handle(), line_index, local_point.x().raw_value(), local_point.y().raw_value(), to_underlying(mode));
+    auto result = Layout::RustFFI::layout_arena_hit_test_caret_item_for_line(m_arena->handle(), line_index, local_point, to_underlying(mode));
     if (!result.has_item)
         return {};
     return CaretItemForLine { result.item_index, static_cast<CaretPositionType>(result.position_type) };
@@ -327,7 +324,7 @@ bool HitTestDisplayList::item_is_inline_adjacent_to_line(size_t item_index, size
 HitTestDisplayList::ClosestLine HitTestDisplayList::find_closest_line(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, CaretPositionMode mode, DOM::Node const* scope_dom_node, AccumulatedVisualContextTree::ClipBehavior clip_behavior) const
 {
     QueryContext context { *this, &document, device_pixels_per_css_pixel, nullptr, scope_dom_node };
-    auto result = Layout::RustFFI::layout_arena_hit_test_find_closest_line(m_arena->handle(), context.callbacks(), point.x().raw_value(), point.y().raw_value(), to_underlying(mode), scope_dom_node != nullptr, clip_behavior == AccumulatedVisualContextTree::ClipBehavior::Respect);
+    auto result = Layout::RustFFI::layout_arena_hit_test_find_closest_line(m_arena->handle(), context.callbacks(), point, to_underlying(mode), scope_dom_node != nullptr, clip_behavior == AccumulatedVisualContextTree::ClipBehavior::Respect);
     ClosestLine closest_line;
     if (result.has_index)
         closest_line.index = result.index;
@@ -495,7 +492,7 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
             .arena = *m_arena,
             .index_in_node = Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
                 m_arena->handle(), item.box, *item.text_fragment_index,
-                local_point.x().raw_value(), local_point.y().raw_value()),
+                local_point.x(), local_point.y()),
             .is_text_fragment = true,
         };
     }
@@ -544,7 +541,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             case CaretPositionType::Closest:
                 return Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
                     m_arena->handle(), item.box, *item.text_fragment_index,
-                    local_point.x().raw_value(), local_point.y().raw_value());
+                    local_point.x(), local_point.y());
             }
             VERIFY_NOT_REACHED();
         }();
@@ -562,7 +559,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             .arena = *m_arena,
             .boundary = { const_cast<DOM::Node&>(*fragment_dom_node), static_cast<WebIDL::UnsignedLong>(index_in_node) },
             .affinity = affinity,
-            .debug_rect = from_ffi_css_pixel_rect(debug_rect),
+            .debug_rect = debug_rect,
         };
     }
     case ItemKind::EmptyLine: {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -225,27 +225,81 @@ static_assert(alignof(RustFFI::OptionalAffineTransform) == alignof(Optional<Gfx:
 
 namespace {
 
-void write_matrix(Gfx::FloatMatrix4x4 const& matrix, float (&out)[16])
-{
-    auto const& elements = matrix.elements();
-    for (size_t row = 0; row < 4; ++row) {
-        for (size_t column = 0; column < 4; ++column)
-            out[row * 4 + column] = elements[row][column];
-    }
+template<typename T>
+struct RustOptionalLayout {
+    T value;
+    bool has_value;
+};
+
 }
 
-void write_rect(Gfx::IntRect const& rect, i32 (&out)[4])
-{
-    out[0] = rect.x();
-    out[1] = rect.y();
-    out[2] = rect.width();
-    out[3] = rect.height();
-}
+static_assert(sizeof(CSSPixelRect) == 16);
 
-void write_rect(DevicePixelRect const& rect, i32 (&out)[4])
-{
-    write_rect(rect.to_type<int>(), out);
-}
+static_assert(sizeof(RustOptionalLayout<CSSPixels>) == sizeof(Optional<CSSPixels>));
+static_assert(alignof(RustOptionalLayout<CSSPixels>) == alignof(Optional<CSSPixels>));
+static_assert(sizeof(RustOptionalLayout<CSSPixelRect>) == sizeof(Optional<CSSPixelRect>));
+static_assert(alignof(RustOptionalLayout<CSSPixelRect>) == alignof(Optional<CSSPixelRect>));
+static_assert(sizeof(RustOptionalLayout<Gfx::IntRect>) == sizeof(Optional<Gfx::IntRect>));
+static_assert(alignof(RustOptionalLayout<Gfx::IntRect>) == alignof(Optional<Gfx::IntRect>));
+static_assert(sizeof(RustOptionalLayout<Gfx::FloatPoint>) == sizeof(Optional<Gfx::FloatPoint>));
+static_assert(alignof(RustOptionalLayout<Gfx::FloatPoint>) == alignof(Optional<Gfx::FloatPoint>));
+static_assert(sizeof(RustOptionalLayout<Gfx::FloatSize>) == sizeof(Optional<Gfx::FloatSize>));
+static_assert(alignof(RustOptionalLayout<Gfx::FloatSize>) == alignof(Optional<Gfx::FloatSize>));
+static_assert(sizeof(RustOptionalLayout<i64>) == sizeof(Optional<i64>));
+static_assert(alignof(RustOptionalLayout<i64>) == alignof(Optional<i64>));
+static_assert(sizeof(RustOptionalLayout<size_t>) == sizeof(Optional<size_t>));
+static_assert(alignof(RustOptionalLayout<size_t>) == alignof(Optional<size_t>));
+
+static_assert(sizeof(Optional<CSSPixels>) == 8);
+static_assert(alignof(Optional<CSSPixels>) == 4);
+
+static_assert(sizeof(TransformDataRole) == sizeof(u8));
+static_assert(to_underlying(TransformDataRole::CssTransform) == 0);
+static_assert(to_underlying(TransformDataRole::SvgViewportTransform) == 1);
+static_assert(sizeof(MaskLayerOrigin) == sizeof(u8));
+static_assert(to_underlying(MaskLayerOrigin::CssMaskLayers) == 0);
+static_assert(to_underlying(MaskLayerOrigin::SvgMask) == 1);
+static_assert(to_underlying(MaskLayerOrigin::SvgClip) == 2);
+
+#define VERIFY_SHARED_FFI_TYPE(type) static_assert(IsTriviallyCopyable<type>)
+VERIFY_SHARED_FFI_TYPE(CSSPixels);
+VERIFY_SHARED_FFI_TYPE(CSSPixelPoint);
+VERIFY_SHARED_FFI_TYPE(CSSPixelSize);
+VERIFY_SHARED_FFI_TYPE(CSSPixelRect);
+VERIFY_SHARED_FFI_TYPE(Gfx::IntPoint);
+VERIFY_SHARED_FFI_TYPE(Gfx::FloatPoint);
+VERIFY_SHARED_FFI_TYPE(Gfx::IntSize);
+VERIFY_SHARED_FFI_TYPE(Gfx::FloatSize);
+VERIFY_SHARED_FFI_TYPE(Gfx::IntRect);
+VERIFY_SHARED_FFI_TYPE(Gfx::FloatRect);
+VERIFY_SHARED_FFI_TYPE(Gfx::Color);
+VERIFY_SHARED_FFI_TYPE(Gfx::AffineTransform);
+VERIFY_SHARED_FFI_TYPE(Gfx::FloatMatrix4x4);
+VERIFY_SHARED_FFI_TYPE(Gfx::CornerRadius);
+VERIFY_SHARED_FFI_TYPE(Gfx::CornerRadii);
+VERIFY_SHARED_FFI_TYPE(Gfx::GradientInterpolationMethod);
+VERIFY_SHARED_FFI_TYPE(Gfx::WindingRule);
+VERIFY_SHARED_FFI_TYPE(Gfx::MaskKind);
+VERIFY_SHARED_FFI_TYPE(Gfx::CompositingAndBlendingOperator);
+VERIFY_SHARED_FFI_TYPE(Gfx::ScalingMode);
+VERIFY_SHARED_FFI_TYPE(Gfx::InterpolationColorSpace);
+VERIFY_SHARED_FFI_TYPE(TransformDataRole);
+VERIFY_SHARED_FFI_TYPE(MaskLayerOrigin);
+VERIFY_SHARED_FFI_TYPE(Optional<CSSPixels>);
+VERIFY_SHARED_FFI_TYPE(Optional<CSSPixelRect>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::IntRect>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::FloatPoint>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::FloatSize>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::FloatRect>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::Color>);
+VERIFY_SHARED_FFI_TYPE(Optional<Gfx::AffineTransform>);
+VERIFY_SHARED_FFI_TYPE(Optional<i64>);
+VERIFY_SHARED_FFI_TYPE(Optional<size_t>);
+VERIFY_SHARED_FFI_TYPE(Optional<u32>);
+VERIFY_SHARED_FFI_TYPE(Optional<float>);
+#undef VERIFY_SHARED_FFI_TYPE
+
+namespace {
 
 static bool rust_painting_timing_enabled()
 {
@@ -256,45 +310,36 @@ static bool rust_painting_timing_enabled()
     return enabled;
 }
 
-static Gfx::FloatMatrix4x4 matrix_from_export(float const (&values)[16])
-{
-    Gfx::FloatMatrix4x4 matrix;
-    for (size_t row = 0; row < 4; ++row)
-        for (size_t column = 0; column < 4; ++column)
-            matrix.elements()[row][column] = values[row * 4 + column];
-    return matrix;
-}
-
 static TransformData transform_data_from_export(Layout::RustFFI::FfiVisualContextNodeExport const& node)
 {
     return TransformData {
-        .matrix = matrix_from_export(node.matrix),
-        .origin = { node.origin[0], node.origin[1] },
+        .matrix = node.matrix,
+        .origin = node.origin,
         .sorting_context_root_index = node.has_sorting_context_root ? Optional<VisualContextIndex> { VisualContextIndex { node.index_value } } : OptionalNone {},
         .flattens_inherited_transform = node.flattens_inherited_transform,
-        .role = static_cast<TransformDataRole>(node.transform_role),
+        .role = node.transform_role,
         .synthetic_plane = node.synthetic_plane,
     };
 }
 
 static VisualContextData visual_context_data_from_export(Layout::RustFFI::FfiVisualContextNodeExport const& node)
 {
-    auto rect = [&] { return DevicePixelRect { node.rect[0], node.rect[1], node.rect[2], node.rect[3] }; };
+    auto rect = [&] { return node.rect.to_type<DevicePixels>(); };
     switch (node.kind) {
     case Layout::RustFFI::FfiVisualContextNodeKind::Scroll:
         return ScrollData { .is_sticky = node.is_sticky, .state_slot = static_cast<ScrollStateSlot>(node.state_slot) };
     case Layout::RustFFI::FfiVisualContextNodeKind::Clip:
-        return ClipData { rect(), Gfx::CornerRadii { { node.corner_radii[0], node.corner_radii[1] }, { node.corner_radii[2], node.corner_radii[3] }, { node.corner_radii[4], node.corner_radii[5] }, { node.corner_radii[6], node.corner_radii[7] } } };
+        return ClipData { rect(), node.corner_radii };
     case Layout::RustFFI::FfiVisualContextNodeKind::Transform:
         return transform_data_from_export(node);
     case Layout::RustFFI::FfiVisualContextNodeKind::Perspective:
-        return PerspectiveData { .matrix = matrix_from_export(node.matrix), .flattens_inherited_transform = node.flattens_inherited_transform };
+        return PerspectiveData { .matrix = node.matrix, .flattens_inherited_transform = node.flattens_inherited_transform };
     case Layout::RustFFI::FfiVisualContextNodeKind::BackfaceVisibility:
         return BackfaceVisibilityData { .plane_root_index = VisualContextIndex { node.index_value }, .flattens_inherited_transform = node.flattens_inherited_transform };
     case Layout::RustFFI::FfiVisualContextNodeKind::ClipPath:
-        return ClipPathData { .path = *static_cast<Gfx::Path const*>(node.path), .bounding_rect = rect(), .fill_rule = static_cast<Gfx::WindingRule>(node.winding_rule) };
+        return ClipPathData { .path = *static_cast<Gfx::Path const*>(node.path), .bounding_rect = rect(), .fill_rule = node.winding_rule };
     case Layout::RustFFI::FfiVisualContextNodeKind::Effects: {
-        EffectsData effects { .opacity = node.opacity, .blend_mode = static_cast<Gfx::CompositingAndBlendingOperator>(node.blend_mode), .gfx_filter = {} };
+        EffectsData effects { .opacity = node.opacity, .blend_mode = node.blend_mode, .gfx_filter = {} };
         if (node.filter)
             effects.gfx_filter = *static_cast<Gfx::Filter const*>(node.filter);
         return effects;
@@ -304,7 +349,7 @@ static VisualContextData visual_context_data_from_export(Layout::RustFFI::FfiVis
     case Layout::RustFFI::FfiVisualContextNodeKind::AnchorScrollShift:
         return AnchorScrollShift { .scroll_node_index = VisualContextIndex { node.index_value }, .negate = node.negate, .compensate_horizontal_scroll = node.compensate_horizontal_scroll, .compensate_vertical_scroll = node.compensate_vertical_scroll };
     case Layout::RustFFI::FfiVisualContextNodeKind::Mask:
-        return MaskData { .rect = rect(), .kind = static_cast<Gfx::MaskKind>(node.mask_kind), .origin = static_cast<MaskLayerOrigin>(node.mask_origin) };
+        return MaskData { .rect = rect(), .kind = node.mask_kind, .origin = node.mask_origin };
     }
     VERIFY_NOT_REACHED();
 }
@@ -389,31 +434,23 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             inputs.may_have_default_scroll_shift_anchor = document.may_have_default_scroll_shift_anchor();
             return inputs;
         },
-        .scroll_offset = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiCssPixelPoint {
-            auto offset = scroll_offset(*static_cast<Layout::Node const*>(layout_node_shell));
-            return { offset.x().raw_value(), offset.y().raw_value() };
+        .scroll_offset = [](void*, void* layout_node_shell) -> CSSPixelPoint {
+            return scroll_offset(*static_cast<Layout::Node const*>(layout_node_shell));
         },
-        .svg_transform_view_box_rect = [](void*, void* layout_node_shell, Layout::RustFFI::FfiCssPixelRect* out_rect) -> bool {
+        .svg_transform_view_box_rect = [](void*, void* layout_node_shell, CSSPixelRect* out) -> bool {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* viewport_paintable = nearest_svg_viewport_of(layout_node);
             if (!viewport_paintable)
                 return false;
-            auto rect = svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
-            *out_rect = to_ffi_css_pixel_rect(rect);
+            *out = svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
             return true;
         },
-        .svg_additional_element_transform = [](void*, void* layout_node_shell, float* out_values) -> bool {
+        .svg_additional_element_transform = [](void*, void* layout_node_shell, Gfx::AffineTransform* out) -> bool {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(layout_node.dom_node());
             if (!graphics_element)
                 return false;
-            auto transform = graphics_element->additional_element_transform();
-            out_values[0] = transform.a();
-            out_values[1] = transform.b();
-            out_values[2] = transform.c();
-            out_values[3] = transform.d();
-            out_values[4] = transform.e();
-            out_values[5] = transform.f();
+            *out = graphics_element->additional_element_transform();
             return true;
         },
         .root_background_source = [](void* context) -> Layout::RustFFI::FfiRootBackgroundSource {
@@ -424,14 +461,10 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             Layout::RustFFI::FfiSvgMaskFacts facts {};
             if (auto area = mask_area(layout_node); area.has_value()) {
-                facts.has_mask_area = true;
-                facts.mask_area = to_ffi_css_pixel_rect(*area);
-                facts.mask_kind = to_underlying(mask_type(layout_node).value_or(Gfx::MaskKind::Alpha));
+                facts.mask_area = *area;
+                facts.mask_kind = mask_type(layout_node).value_or(Gfx::MaskKind::Alpha);
             }
-            if (auto area = clip_area(layout_node); area.has_value()) {
-                facts.has_clip_area = true;
-                facts.clip_area = to_ffi_css_pixel_rect(*area);
-            }
+            facts.clip_area = clip_area(layout_node);
             return facts;
         },
         .resolve_effects_filter = [](void* context, void* layout_node_shell) -> Layout::RustFFI::FfiResolvedEffectsFilter {
@@ -441,10 +474,7 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             ResolvedCSSFilter resolved_filter;
             if (style_source.filter().has_filters())
                 resolved_filter = resolve_css_filter(style_source.filter(), style_source);
-            if (resolved_filter.svg_filter_bounds.has_value()) {
-                result.has_svg_filter_bounds = true;
-                result.svg_filter_bounds = to_ffi_css_pixel_rect(*resolved_filter.svg_filter_bounds);
-            }
+            result.svg_filter_bounds = resolved_filter.svg_filter_bounds;
             if (!resolved_filter.has_filters())
                 return result;
             auto pixel_ratio = document.page().client().device_pixels_per_css_pixel();
@@ -536,26 +566,21 @@ CSS::ResolvedImage rust_resolve_gradient_for_size(CSS::StyleValue const& gradien
 
     Layout::RustFFI::FfiResolvedGradientPaint resolved {};
     ColorStopData color_stops;
-    auto append_stop = [](void* stop_context, u32 color, float position) {
+    auto append_stop = [](void* stop_context, Gfx::Color color, float position) {
         auto& color_stops = *static_cast<ColorStopData*>(stop_context);
-        color_stops.colors.append(Color::from_bgra(color));
+        color_stops.colors.append(color);
         color_stops.positions.append(position);
     };
     Layout::RustFFI::layout_arena_resolve_gradient_paint_for_size(
         gradient_style_value.rust_style_value_data(),
-        layout_node.color().value(),
+        layout_node.color(),
         current_color_value,
         static_cast<u8>(to_underlying(layout_node.color_scheme())),
-        size.width().raw_value(), size.height().raw_value(),
+        size,
         &resolved, &color_stops, append_stop);
     color_stops.repeating = resolved.color_stops_repeating;
 
-    Gfx::GradientInterpolationMethod interpolation_method {
-        .type = static_cast<Gfx::GradientInterpolationMethod::Type>(resolved.interpolation_method[0]),
-        .rectangular_color_space = static_cast<Gfx::RectangularColorSpace>(resolved.interpolation_method[1]),
-        .polar_color_space = static_cast<Gfx::PolarColorSpace>(resolved.interpolation_method[2]),
-        .hue_interpolation_method = static_cast<Gfx::HueInterpolationMethod>(resolved.interpolation_method[3]),
-    };
+    auto interpolation_method = resolved.interpolation_method;
     switch (resolved.kind) {
     case Layout::RustFFI::FfiResolvedGradientPaintKind::None:
         break;
@@ -564,13 +589,13 @@ CSS::ResolvedImage rust_resolve_gradient_for_size(CSS::StyleValue const& gradien
     case Layout::RustFFI::FfiResolvedGradientPaintKind::Radial:
         return ResolvedRadialGradient {
             RadialGradientData { move(color_stops), interpolation_method },
-            { CSSPixels::from_raw(resolved.size.width), CSSPixels::from_raw(resolved.size.height) },
-            { CSSPixels::from_raw(resolved.center.x), CSSPixels::from_raw(resolved.center.y) },
+            resolved.size,
+            resolved.center,
         };
     case Layout::RustFFI::FfiResolvedGradientPaintKind::Conic:
         return ResolvedConicGradient {
             ConicGradientData { resolved.gradient_angle, move(color_stops), interpolation_method },
-            { CSSPixels::from_raw(resolved.center.x), CSSPixels::from_raw(resolved.center.y) },
+            resolved.center,
         };
     }
     VERIFY_NOT_REACHED();
@@ -590,21 +615,19 @@ ScrollStateSnapshot rust_scroll_state_snapshot(DOM::Document& document)
 {
     auto* arena = layout_arena_handle(document);
     auto count = Layout::RustFFI::layout_arena_scroll_state_snapshot(arena, nullptr, 0);
-    Vector<float> values;
+    Vector<Gfx::FloatPoint> values;
     values.resize(count);
     if (count > 0)
         Layout::RustFFI::layout_arena_scroll_state_snapshot(arena, values.data(), values.size());
     ScrollStateSnapshot snapshot;
-    for (size_t index = 0; index * 2 + 1 < values.size(); ++index)
-        snapshot.set_device_offset_for_index(VisualContextIndex { index }, { values[index * 2], values[index * 2 + 1] });
+    for (size_t index = 0; index < values.size(); ++index)
+        snapshot.set_device_offset_for_index(VisualContextIndex { index }, values[index]);
     return snapshot;
 }
 
 CSSPixelPoint rust_cumulative_scroll_offset_for_node(DOM::Document const& document, VisualContextIndex scroll_node_index)
 {
-    i32 raw[2] = { 0, 0 };
-    Layout::RustFFI::layout_arena_cumulative_scroll_offset_for_node(layout_arena_handle(document), scroll_node_index.value(), raw);
-    return { CSSPixels::from_raw(raw[0]), CSSPixels::from_raw(raw[1]) };
+    return Layout::RustFFI::layout_arena_cumulative_scroll_offset_for_node(layout_arena_handle(document), scroll_node_index.value());
 }
 
 void mirror_rust_refresh_sticky_constraints(DOM::Document& document)
@@ -689,8 +712,8 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
                 auto const& graphics_element = as<SVG::SVGGraphicsElement>(*dom_node);
                 facts.svg_path_has_fill = graphics_element.fill_color().has_value();
                 facts.svg_path_winding_rule = graphics_element.fill_rule().value_or(SVG::FillRule::Nonzero) == SVG::FillRule::Evenodd
-                    ? to_underlying(Gfx::WindingRule::EvenOdd)
-                    : to_underlying(Gfx::WindingRule::Nonzero);
+                    ? Gfx::WindingRule::EvenOdd
+                    : Gfx::WindingRule::Nonzero;
             }
             if (auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(dom_node); graphics_element && graphics_element->unsafe_layout_node()) {
                 for (auto child = graphics_element->unsafe_layout_node()->first_child(); child; child = child->next_sibling()) {
@@ -724,7 +747,7 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
                     continue;
                 Layout::RustFFI::FfiLineBreakCaretTarget target {};
                 target.caret_offset = br->index();
-                target.rect = to_ffi_css_pixel_rect(caret_rect_for_child_offset(layout_node, br->index()));
+                target.rect = caret_rect_for_child_offset(layout_node, br->index());
                 Layout::RustFFI::layout_arena_hit_test_push_line_break_caret_target(sink, target);
             } },
     };
@@ -733,11 +756,6 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
 }
 
 namespace {
-
-void write_css_rect(CSSPixelRect const& rect, Layout::RustFFI::FfiCssPixelRect& out)
-{
-    out = to_ffi_css_pixel_rect(rect);
-}
 
 struct PaintHostContext {
     DisplayListResourceStorage& resource_storage;
@@ -801,14 +819,14 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                     auto expanded_scrollbar_data = compute_scrollbar_data(layout_node, direction, metrics, nullptr, ScrollbarSizing::Enlarged);
                     VERIFY(expanded_scrollbar_data.has_value());
                     out.present = true;
-                    write_css_rect(scrollbar_data->gutter_rect, out.gutter_rect);
-                    write_css_rect(scrollbar_data->thumb_rect, out.thumb_rect);
-                    write_css_rect(expanded_scrollbar_data->gutter_rect, out.expanded_gutter_rect);
-                    write_css_rect(expanded_scrollbar_data->thumb_rect, out.expanded_thumb_rect);
+                    out.gutter_rect = scrollbar_data->gutter_rect;
+                    out.thumb_rect = scrollbar_data->thumb_rect;
+                    out.expanded_gutter_rect = expanded_scrollbar_data->gutter_rect;
+                    out.expanded_thumb_rect = expanded_scrollbar_data->thumb_rect;
                     out.scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
                     out.expanded_scroll_size = expanded_scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
-                    out.thumb_color = scrollbar_colors.thumb_color.value();
-                    out.track_color = scrollbar_colors.track_color.value();
+                    out.thumb_color = scrollbar_colors.thumb_color;
+                    out.track_color = scrollbar_colors.track_color;
                 }
             }
             return facts;
@@ -822,8 +840,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 && layout_node.scrollbar_width() != CSS::ScrollbarWidth::None;
             if (facts.paints_scrollbars) {
                 auto scrollbar_colors = scrollbar_colors_for_paint(layout_node);
-                facts.thumb_color = scrollbar_colors.thumb_color.value();
-                facts.track_color = scrollbar_colors.track_color.value();
+                facts.thumb_color = scrollbar_colors.thumb_color;
+                facts.track_color = scrollbar_colors.track_color;
                 size_t index = 0;
                 for (auto direction : { ScrollDirection::Vertical, ScrollDirection::Horizontal }) {
                     auto& out = facts.scrollbars[index++];
@@ -833,23 +851,21 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                     if (!scrollbar_data.has_value())
                         continue;
                     out.present = true;
-                    write_css_rect(scrollbar_data->gutter_rect, out.gutter_rect);
-                    write_css_rect(scrollbar_data->thumb_rect, out.thumb_rect);
-                    write_css_rect(scrollbar_data->track_rect, out.track_rect);
+                    out.gutter_rect = scrollbar_data->gutter_rect;
+                    out.thumb_rect = scrollbar_data->thumb_rect;
+                    out.track_rect = scrollbar_data->track_rect;
                     out.thumb_travel_to_scroll_ratio = scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
                 }
             }
             if (auto resizer_rect = absolute_resizer_rect(layout_node, metrics); resizer_rect.has_value()) {
-                facts.has_resizer_rect = true;
-                write_css_rect(*resizer_rect, facts.resizer_rect);
-                facts.resize_gripper_padding = metrics.resize_gripper_padding.raw_value();
+                facts.resizer_rect = *resizer_rect;
+                facts.resize_gripper_padding = metrics.resize_gripper_padding;
             }
             if (is_viewport_paintable(layout_node)) {
                 if (auto navigable = document.navigable()) {
                     if (auto handler = navigable->event_handler().middle_button_scroll_handler(); handler.has_value()) {
                         facts.middle_button_scroll_active = true;
-                        facts.middle_button_scroll_origin.x = handler->origin().x().raw_value();
-                        facts.middle_button_scroll_origin.y = handler->origin().y().raw_value();
+                        facts.middle_button_scroll_origin = handler->origin();
                     }
                 }
             }
@@ -867,8 +883,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                             if (auto path = area_element->shape_path(absolute_rect(layout_node).size()); path.has_value()) {
                                 facts.paints_focused_area_outline = true;
                                 facts.focused_area_path = new Gfx::Path(path.release_value());
-                                facts.focused_area_color = outline_data->color.value();
-                                facts.focused_area_width = outline_data->width.raw_value();
+                                facts.focused_area_color = outline_data->color;
+                                facts.focused_area_width = outline_data->width;
                             }
                         }
                     }
@@ -884,18 +900,12 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (!image)
                 return facts;
             facts.is_paintable = image->is_paintable(document);
-            if (auto width = image->natural_width(document); width.has_value()) {
-                facts.has_natural_width = true;
-                facts.natural_width = width->raw_value();
-            }
-            if (auto height = image->natural_height(document); height.has_value()) {
-                facts.has_natural_height = true;
-                facts.natural_height = height->raw_value();
-            }
+            facts.natural_width = image->natural_width(document);
+            facts.natural_height = image->natural_height(document);
             if (auto aspect_ratio = image->natural_aspect_ratio(document); aspect_ratio.has_value()) {
                 facts.has_natural_aspect_ratio = true;
-                facts.natural_aspect_ratio_numerator = aspect_ratio->numerator().raw_value();
-                facts.natural_aspect_ratio_denominator = aspect_ratio->denominator().raw_value();
+                facts.natural_aspect_ratio_numerator = aspect_ratio->numerator();
+                facts.natural_aspect_ratio_denominator = aspect_ratio->denominator();
             }
             if (auto const* image_set = as_if<CSS::ImageSetStyleValue>(*image)) {
                 if (auto const* selected_image = image_set->selected_image()) {
@@ -934,15 +944,12 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (!text_node)
                 return facts;
             auto style = selection_style_for_node(*text_node, text_node->dom_text());
-            facts.background_color = style.background_color.value();
-            if (style.text_color.has_value()) {
-                facts.has_text_color = true;
-                facts.text_color = style.text_color->value();
-            }
+            facts.background_color = style.background_color;
+            facts.text_color = style.text_color;
             if (style.text_shadow.has_value()) {
                 facts.has_text_shadow = true;
                 for (auto const& layer : *style.text_shadow)
-                    Layout::RustFFI::layout_arena_paint_push_selection_shadow(shadow_sink, layer.color.value(), layer.offset_x.raw_value(), layer.offset_y.raw_value(), layer.blur_radius.raw_value());
+                    Layout::RustFFI::layout_arena_paint_push_selection_shadow(shadow_sink, layer.color, layer.offset_x, layer.offset_y, layer.blur_radius);
             }
             if (style.text_decoration.has_value()) {
                 facts.has_text_decoration = true;
@@ -950,7 +957,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 for (size_t i = 0; i < facts.text_decoration_line_count; ++i)
                     facts.text_decoration_lines[i] = to_underlying(style.text_decoration->line[i]);
                 facts.text_decoration_style = to_underlying(style.text_decoration->style);
-                facts.text_decoration_color = style.text_decoration->color.value();
+                facts.text_decoration_color = style.text_decoration->color;
             }
             return facts;
         },
@@ -974,8 +981,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (!caret.has_value())
                 return facts;
             facts.paints = true;
-            write_css_rect(caret->rect, facts.rect);
-            facts.color = caret->color.value();
+            facts.rect = caret->rect;
+            facts.color = caret->color;
             return facts;
         },
         .layer_image_prepare = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiLayerImagePrepareFacts {
@@ -985,20 +992,17 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (!image)
                 return facts;
             facts.is_image_style_value = is<CSS::ImageStyleValue>(*image);
-            if (auto color = image->color_if_single_pixel_bitmap(layout_node.document()); color.has_value()) {
-                facts.has_single_pixel_color = true;
-                facts.single_pixel_color = color->value();
-            }
+            facts.single_pixel_color = image->color_if_single_pixel_bitmap(layout_node.document());
             return facts;
         },
-        .layer_image_nested_display_list = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, i32 const* dest) -> Layout::RustFFI::FfiLayerImageNestedDisplayListFacts {
+        .layer_image_nested_display_list = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, Gfx::IntRect dest) -> Layout::RustFFI::FfiLayerImageNestedDisplayListFacts {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiLayerImageNestedDisplayListFacts facts {};
             auto const* image = layer_image_for(layout_node, list, computed_index);
             if (!image || !is<CSS::ImageStyleValue>(*image))
                 return facts;
-            DevicePixelRect dest_rect { DevicePixels(dest[0]), DevicePixels(dest[1]), DevicePixels(dest[2]), DevicePixels(dest[3]) };
+            auto dest_rect = dest.to_type<DevicePixels>();
             auto color_scheme = layout_node.color_scheme();
             if (auto display_list = static_cast<CSS::ImageStyleValue const&>(*image).record_display_list(context.resource_storage, layout_node.document(), dest_rect, color_scheme); display_list.has_value()) {
                 facts.has_nested_display_list = true;
@@ -1006,14 +1010,14 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             }
             return facts;
         },
-        .layer_image_current_frame = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, i32 const* dest) -> Layout::RustFFI::FfiLayerImageFrameFacts {
+        .layer_image_current_frame = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, Gfx::IntRect dest) -> Layout::RustFFI::FfiLayerImageFrameFacts {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiLayerImageFrameFacts facts {};
             auto const* image = layer_image_for(layout_node, list, computed_index);
             if (!image || !is<CSS::ImageStyleValue>(*image))
                 return facts;
-            DevicePixelRect dest_rect { DevicePixels(dest[0]), DevicePixels(dest[1]), DevicePixels(dest[2]), DevicePixels(dest[3]) };
+            auto dest_rect = dest.to_type<DevicePixels>();
             if (auto frame = static_cast<CSS::ImageStyleValue const&>(*image).current_frame(layout_node.document(), dest_rect); frame.has_value()) {
                 facts.has_frame = true;
                 facts.frame_id = context.resource_storage.add_image_frame(*frame).value();
@@ -1022,7 +1026,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             }
             return facts;
         },
-        .layer_image_paint = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, float const* dest, i32 const* css_size_raw, u8 image_rendering_raw, float const* accumulated_scale_raw) -> Layout::RustFFI::FfiImagePaintFacts {
+        .layer_image_paint = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, Gfx::FloatRect dest_rect, CSSPixelSize css_size, u8 image_rendering_raw, Gfx::FloatSize accumulated_scale) -> Layout::RustFFI::FfiImagePaintFacts {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiImagePaintFacts facts {};
@@ -1030,8 +1034,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (!image_pointer)
                 return facts;
             auto const& image = *image_pointer;
-            Gfx::FloatRect dest_rect { dest[0], dest[1], dest[2], dest[3] };
-            Gfx::FloatSize accumulated_scale { accumulated_scale_raw[0], accumulated_scale_raw[1] };
             ImagePaintRequest request {
                 .document = layout_node.document(),
                 .dest_rect = dest_rect,
@@ -1040,7 +1042,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 .accumulated_scale = accumulated_scale,
                 .resource_storage = context.resource_storage,
             };
-            CSSPixelSize css_size { CSSPixels::from_raw(css_size_raw[0]), CSSPixels::from_raw(css_size_raw[1]) };
             auto paint = image.image_paint(request, image.resolve_for_size(layout_node, css_size));
             if (paint.has_value())
                 write_image_paint_facts(*paint, context, facts);
@@ -1056,21 +1057,15 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             if (kind == Layout::RustFFI::PaintableKind::ImagePaintable) {
                 auto const& image_provider = static_cast<Layout::Box const&>(layout_node).image_provider();
                 facts.has_decoded_image_data = image_provider.decoded_image_data() != nullptr;
-                if (auto width = image_provider.intrinsic_width(); width.has_value()) {
-                    facts.has_natural_width = true;
-                    facts.natural_width = width->raw_value();
-                }
-                if (auto height = image_provider.intrinsic_height(); height.has_value()) {
-                    facts.has_natural_height = true;
-                    facts.natural_height = height->raw_value();
-                }
+                facts.natural_width = image_provider.intrinsic_width();
+                facts.natural_height = image_provider.intrinsic_height();
                 if (auto aspect_ratio = image_provider.intrinsic_aspect_ratio(); aspect_ratio.has_value()) {
                     facts.has_natural_aspect_ratio = true;
-                    facts.natural_aspect_ratio_numerator = aspect_ratio->numerator().raw_value();
-                    facts.natural_aspect_ratio_denominator = aspect_ratio->denominator().raw_value();
+                    facts.natural_aspect_ratio_numerator = aspect_ratio->numerator();
+                    facts.natural_aspect_ratio_denominator = aspect_ratio->denominator();
                 }
                 if (selection_state(layout_node) != SelectionState::None)
-                    facts.selection_background_color = selection_style(layout_node).background_color.value();
+                    facts.selection_background_color = selection_style(layout_node).background_color;
             } else if (kind == Layout::RustFFI::PaintableKind::CanvasPaintable) {
                 auto& canvas_element = as<HTML::HTMLCanvasElement>(*layout_node.dom_node());
                 if (auto content_size = canvas_element.canvas_surface_content_size(); content_size.has_value()) {
@@ -1135,13 +1130,13 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 facts.indeterminate = input.indeterminate();
                 facts.being_activated = input.is_being_activated();
                 auto color_scheme = layout_node.color_scheme();
-                facts.canvas_color = CSS::SystemColor::canvas(color_scheme).value();
-                facts.canvas_text_color = CSS::SystemColor::canvas_text(color_scheme).value();
-                facts.accent_color = layout_node.accent_color().value_or(CSS::SystemColor::accent_color(color_scheme)).value();
+                facts.canvas_color = CSS::SystemColor::canvas(color_scheme);
+                facts.canvas_text_color = CSS::SystemColor::canvas_text(color_scheme);
+                facts.accent_color = layout_node.accent_color().value_or(CSS::SystemColor::accent_color(color_scheme));
             }
             return facts;
         },
-        .replaced_image_paint = [](void* context_pointer, void* layout_node_shell, float const* dest, float const* accumulated_scale_raw) -> Layout::RustFFI::FfiImagePaintFacts {
+        .replaced_image_paint = [](void* context_pointer, void* layout_node_shell, Gfx::FloatRect dest_rect, Gfx::FloatSize accumulated_scale) -> Layout::RustFFI::FfiImagePaintFacts {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             auto const* row = committed_row(layout_node);
@@ -1156,8 +1151,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             }
             if (!decoded_image_data)
                 return facts;
-            Gfx::FloatRect dest_rect { dest[0], dest[1], dest[2], dest[3] };
-            Gfx::FloatSize accumulated_scale { accumulated_scale_raw[0], accumulated_scale_raw[1] };
             ImagePaintRequest request {
                 .document = layout_node.document(),
                 .dest_rect = dest_rect,
@@ -1187,9 +1180,9 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             Layout::RustFFI::layout_arena_paint_push_bytes(sink, filter_data.data(), filter_data.size());
             return true;
         },
-        .nested_display_list_from_bytes = [](void* context_pointer, u8 const* bytes, size_t length, i32 content_offset_x, i32 content_offset_y) -> u64 {
+        .nested_display_list_from_bytes = [](void* context_pointer, u8 const* bytes, size_t length, Gfx::IntPoint content_offset) -> u64 {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
-            auto visual_context_tree = AccumulatedVisualContextTree::create_with_content_offset({ content_offset_x, content_offset_y });
+            auto visual_context_tree = AccumulatedVisualContextTree::create_with_content_offset(content_offset);
             auto command_bytes = MUST(ByteBuffer::copy(bytes, length));
             auto display_list = DisplayList::create_from_command_bytes(visual_context_tree, move(command_bytes));
             return context.resource_storage.add_display_list(move(display_list), visual_context_tree).value();
@@ -1200,24 +1193,15 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             VERIFY(row);
             Layout::RustFFI::FfiSvgHostFacts facts {};
             if (is_svg_path_paintable(layout_node)) {
-                facts.percentage_basis = as<SVG::SVGGraphicsElement>(*layout_node.dom_node()).viewport_percentage_basis().raw_value();
-                if (auto const* viewport_paintable = nearest_svg_viewport_of(layout_node)) {
-                    facts.has_viewport = true;
-                    auto viewport = svg_viewport_user_rect(*viewport_paintable);
-                    facts.viewport[0] = viewport.x();
-                    facts.viewport[1] = viewport.y();
-                    facts.viewport[2] = viewport.width();
-                    facts.viewport[3] = viewport.height();
-                }
+                facts.percentage_basis = as<SVG::SVGGraphicsElement>(*layout_node.dom_node()).viewport_percentage_basis();
+                if (auto const* viewport_paintable = nearest_svg_viewport_of(layout_node))
+                    facts.viewport = svg_viewport_user_rect(*viewport_paintable);
             }
             if (row->kind == Layout::RustFFI::PaintableKind::SVGImagePaintable) {
                 auto const& image_provider = as<SVG::SVGImageElement>(*layout_node.dom_node());
                 facts.has_decoded_image_data = image_provider.decoded_image_data() != nullptr;
-                if (auto natural_size = image_provider.intrinsic_size(); natural_size.has_value()) {
-                    facts.has_natural_size = true;
-                    facts.natural_width = natural_size->width().to_float();
-                    facts.natural_height = natural_size->height().to_float();
-                }
+                if (auto natural_size = image_provider.intrinsic_size(); natural_size.has_value())
+                    facts.natural_size = natural_size->to_type<float>();
             }
             return facts;
         },
@@ -1225,39 +1209,24 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             Layout::RustFFI::FfiSvgPaintStyle style {};
-            auto const& viewport = ffi_paint_context->viewport;
-            auto const& path_bounding_box = ffi_paint_context->path_bounding_box;
-            auto const& paint_transform = ffi_paint_context->paint_transform;
-            auto const& content_scale = ffi_paint_context->content_scale;
             SVG::SVGPaintContext paint_context {
-                .viewport = { viewport[0], viewport[1], viewport[2], viewport[3] },
-                .path_bounding_box = { path_bounding_box[0], path_bounding_box[1], path_bounding_box[2], path_bounding_box[3] },
-                .paint_transform = Gfx::AffineTransform { paint_transform[0], paint_transform[1], paint_transform[2], paint_transform[3], paint_transform[4], paint_transform[5] },
-                .content_scale = { content_scale[0], content_scale[1] },
+                .viewport = ffi_paint_context->viewport,
+                .path_bounding_box = ffi_paint_context->path_bounding_box,
+                .paint_transform = ffi_paint_context->paint_transform,
+                .content_scale = ffi_paint_context->content_scale,
             };
             auto const& graphics_element = as<SVG::SVGGraphicsElement>(*layout_node.dom_node());
             auto paint_server = is_stroke ? graphics_element.stroke_paint_server(paint_context, context.device_pixels_per_css_pixel) : graphics_element.fill_paint_server(paint_context, context.device_pixels_per_css_pixel);
             if (!paint_server.has_value())
                 return style;
-            auto write_transform = [](Gfx::AffineTransform const& transform, float (&out)[6]) {
-                out[0] = transform.a();
-                out[1] = transform.b();
-                out[2] = transform.c();
-                out[3] = transform.d();
-                out[4] = transform.e();
-                out[5] = transform.f();
-            };
             auto write_gradient = [&](GradientPaintStyle const& gradient) {
-                if (auto const& transform = gradient.gradient_transform(); transform.has_value()) {
-                    style.has_gradient_transform = true;
-                    write_transform(*transform, style.gradient_transform);
-                }
+                style.gradient_transform = gradient.gradient_transform();
                 style.spread_method = static_cast<Layout::RustFFI::FfiSvgGradientSpreadMethod>(to_underlying(gradient.spread_method()));
-                style.color_space = to_underlying(gradient.color_space());
+                style.color_space = gradient.color_space();
                 auto colors = gradient.color_stop_colors();
                 auto positions = gradient.color_stop_positions();
                 for (size_t i = 0; i < colors.size(); ++i)
-                    Layout::RustFFI::layout_arena_paint_push_color_stop(sink, colors[i].value(), positions[i]);
+                    Layout::RustFFI::layout_arena_paint_push_color_stop(sink, colors[i], positions[i]);
             };
             paint_server->visit(
                 [&](PaintStyle const& paint_style) {
@@ -1265,19 +1234,15 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                         [&](LinearGradientPaintStyle const& linear) {
                             style.kind = Layout::RustFFI::FfiSvgPaintStyleKind::LinearGradient;
                             write_gradient(linear);
-                            style.start[0] = linear.start_point().x();
-                            style.start[1] = linear.start_point().y();
-                            style.end[0] = linear.end_point().x();
-                            style.end[1] = linear.end_point().y();
+                            style.start = linear.start_point();
+                            style.end = linear.end_point();
                         },
                         [&](RadialGradientPaintStyle const& radial) {
                             style.kind = Layout::RustFFI::FfiSvgPaintStyleKind::RadialGradient;
                             write_gradient(radial);
-                            style.start[0] = radial.start_center().x();
-                            style.start[1] = radial.start_center().y();
+                            style.start = radial.start_center();
                             style.start_radius = radial.start_radius();
-                            style.end[0] = radial.end_center().x();
-                            style.end[1] = radial.end_center().y();
+                            style.end = radial.end_center();
                             style.end_radius = radial.end_radius();
                         },
                         [&](PatternPaintStyle const&) {
@@ -1287,27 +1252,20 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 [&](SVG::SVGGraphicsElement::PatternPaintServer const& pattern) {
                     style.kind = Layout::RustFFI::FfiSvgPaintStyleKind::Pattern;
                     style.pattern_paintable = committed_row_slot(*pattern.pattern_layout_node);
-                    write_matrix(pattern.tile_content_transform.matrix, style.tile_content_transform);
-                    style.tile_rect[0] = pattern.tile_rect.x();
-                    style.tile_rect[1] = pattern.tile_rect.y();
-                    style.tile_rect[2] = pattern.tile_rect.width();
-                    style.tile_rect[3] = pattern.tile_rect.height();
-                    style.content_scale[0] = pattern.content_scale.width();
-                    style.content_scale[1] = pattern.content_scale.height();
-                    if (pattern.device_pattern_transform.has_value()) {
-                        style.has_pattern_transform = true;
-                        write_transform(*pattern.device_pattern_transform, style.pattern_transform);
-                    }
+                    style.tile_content_transform = pattern.tile_content_transform.matrix;
+                    style.tile_rect = pattern.tile_rect;
+                    style.content_scale = pattern.content_scale;
+                    style.pattern_transform = pattern.device_pattern_transform;
                 });
             return style;
         },
-        .accumulated_2d_scale = [](void* context_pointer, void const* rust_visual_context_tree, size_t visual_context_index, float* out) {
+        .accumulated_2d_scale = [](void* context_pointer, void const* rust_visual_context_tree, size_t visual_context_index) -> Gfx::FloatSize {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto scale = rust_visual_context_tree
                 ? materialize_rust_visual_context_tree(rust_visual_context_tree).accumulated_2d_scale(VisualContextIndex { visual_context_index }, ScrollStateSnapshot {}, AccumulatedVisualContextTree::IncludeVisualViewportTransform::No)
                 : context.document->visual_context_tree().accumulated_2d_scale(VisualContextIndex { visual_context_index }, ScrollStateSnapshot {}, AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-            out[0] = scale.width();
-            out[1] = scale.height(); },
+            return scale;
+        },
         .materialize_visual_context_tree = [](void*, void const* tree) -> void* {
             return new AccumulatedVisualContextTree(materialize_rust_visual_context_tree(tree));
         },
@@ -1349,7 +1307,7 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 .device_glyph_width = glyph_run->width(),
                 .device_ascent = metrics.ascent,
                 .device_descent = metrics.descent,
-                .blob_bounds = { bounds.x(), bounds.y(), bounds.width(), bounds.height() },
+                .blob_bounds = bounds,
             };
         },
     };
@@ -1370,9 +1328,9 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
         inputs.has_inspector_highlight = true;
         inputs.inspector_highlight_paintable = committed_row_slot(*overlay_inputs.highlighted_layout_node);
     }
-    inputs.tooltip_color = overlay_inputs.tooltip_color.value();
-    inputs.tooltip_text_color = overlay_inputs.tooltip_text_color.value();
-    inputs.tooltip_border_color = overlay_inputs.tooltip_border_color.value();
+    inputs.tooltip_color = overlay_inputs.tooltip_color;
+    inputs.tooltip_text_color = overlay_inputs.tooltip_text_color;
+    inputs.tooltip_border_color = overlay_inputs.tooltip_border_color;
     Vector<Layout::RustFFI::FfiGridOverlayInput> ffi_grid_overlays;
     auto grid_label_css_pixel_size = overlay_inputs.grid_highlights.is_empty()
         ? 0.0f
@@ -1380,8 +1338,8 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     for (auto const& highlight : overlay_inputs.grid_highlights) {
         ffi_grid_overlays.append({
             .paintable = committed_row_slot(*highlight.layout_node),
-            .color = highlight.options.color.value(),
-            .label_foreground_color = highlight.options.color.with_alpha(235).suggested_foreground_color().value(),
+            .color = highlight.options.color,
+            .label_foreground_color = highlight.options.color.with_alpha(235).suggested_foreground_color(),
             .label_css_pixel_size = grid_label_css_pixel_size,
             .show_area_names = highlight.options.show_area_names,
             .show_line_numbers = highlight.options.show_line_numbers,
@@ -1395,19 +1353,16 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     for (auto const& highlight : overlay_inputs.flex_highlights) {
         ffi_flex_overlays.append({
             .paintable = committed_row_slot(*highlight.layout_node),
-            .color = highlight.options.color.value(),
+            .color = highlight.options.color,
         });
     }
     inputs.flex_overlays = ffi_flex_overlays.data();
     inputs.flex_overlay_count = ffi_flex_overlays.size();
-    if (overlay_inputs.caret_debug_rect.has_value()) {
-        inputs.has_caret_debug_rect = true;
-        inputs.caret_debug_rect = to_ffi_css_pixel_rect(*overlay_inputs.caret_debug_rect);
-    }
+    inputs.caret_debug_rect = overlay_inputs.caret_debug_rect;
     inputs.device_pixels_per_css_pixel = device_pixels_per_css_pixel;
-    write_rect(device_viewport_rect, inputs.device_viewport_rect);
+    inputs.device_viewport_rect = device_viewport_rect.to_type<int>();
     if (auto navigable = document.navigable())
-        write_css_rect(navigable->viewport_rect(), inputs.css_viewport_rect);
+        inputs.css_viewport_rect = navigable->viewport_rect();
     inputs.should_show_line_box_borders = config.should_show_line_box_borders;
     inputs.should_paint_overlay = config.paint_overlay;
     inputs.is_recording_async_scrolling_metadata = true;
@@ -1418,7 +1373,7 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     {
         auto navigable = document.navigable();
         inputs.window_is_focused = navigable && navigable->is_focused();
-        inputs.outline_auto_color = CSS::SystemColor::accent_color(CSS::PreferredColorScheme::Auto).value();
+        inputs.outline_auto_color = CSS::SystemColor::accent_color(CSS::PreferredColorScheme::Auto);
     }
     {
         auto color_scheme = document.canvas_color_scheme();
@@ -1429,15 +1384,12 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
                 container_scheme = CSS::PreferredColorScheme::Light;
             opaque_canvas = container_scheme != color_scheme;
         }
-        if (config.canvas_fill_rect.has_value()) {
-            inputs.has_canvas_fill_rect = true;
-            write_rect(*config.canvas_fill_rect, inputs.canvas_fill_rect);
-        }
-        inputs.canvas_color = CSS::SystemColor::canvas(color_scheme).value();
+        inputs.canvas_fill_rect = config.canvas_fill_rect;
+        inputs.canvas_color = CSS::SystemColor::canvas(color_scheme);
         inputs.opaque_canvas = opaque_canvas;
         Gfx::IntRect bitmap_rect { {}, device_viewport_rect.size().to_type<int>() };
-        write_rect(bitmap_rect, inputs.bitmap_rect);
-        inputs.background_color = document.background_color().value();
+        inputs.bitmap_rect = bitmap_rect;
+        inputs.background_color = document.background_color();
     }
     PaintHostContext paint_host_context { resource_storage, document, paint_generation_id, device_pixels_per_css_pixel };
     auto rust_timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
@@ -1478,37 +1430,26 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
 NonnullRefPtr<DisplayList> record_image_paint_display_list(ImagePaint const& paint, Gfx::FloatRect dest_rect, CSS::ImageRendering image_rendering, double device_pixels_per_css_pixel, AccumulatedVisualContextTree const& visual_context_tree, DisplayListResourceStorage& resource_storage)
 {
     Layout::RustFFI::FfiImagePaintRecordInputs inputs {};
-    inputs.dest_rect[0] = dest_rect.x();
-    inputs.dest_rect[1] = dest_rect.y();
-    inputs.dest_rect[2] = dest_rect.width();
-    inputs.dest_rect[3] = dest_rect.height();
-    Vector<u32> color_stop_colors;
+    inputs.dest_rect = dest_rect;
+    Vector<Gfx::Color> color_stop_colors;
     auto write_color_stops = [&](ColorStopData const& color_stops) {
-        for (auto color : color_stops.colors)
-            color_stop_colors.append(color.value());
+        color_stop_colors = color_stops.colors;
         inputs.color_stop_colors = color_stop_colors.data();
         inputs.color_stop_positions = color_stops.positions.data();
         inputs.color_stop_count = color_stops.colors.size();
         inputs.color_stops_repeating = color_stops.repeating;
-    };
-    auto write_interpolation_method = [&](Gfx::GradientInterpolationMethod const& method) {
-        inputs.interpolation_type = to_underlying(method.type);
-        inputs.rectangular_color_space = to_underlying(method.rectangular_color_space);
-        inputs.polar_color_space = to_underlying(method.polar_color_space);
-        inputs.hue_interpolation_method = to_underlying(method.hue_interpolation_method);
     };
     inputs.device_pixels_per_css_pixel = device_pixels_per_css_pixel;
     paint.value.visit(
         [&](ImagePaint::DecodedFrame const& decoded_frame) {
             inputs.kind = Layout::RustFFI::FfiImagePaintRecordKind::DecodedFrame;
             inputs.frame_id = resource_storage.add_image_frame(decoded_frame.frame).value();
-            inputs.scaling_mode = to_underlying(CSS::to_gfx_scaling_mode(image_rendering, decoded_frame.natural_size, dest_rect.to_rounded<int>().size()));
+            inputs.scaling_mode = CSS::to_gfx_scaling_mode(image_rendering, decoded_frame.natural_size, dest_rect.to_rounded<int>().size());
         },
         [&](ImagePaint::NestedDisplayList const& nested) {
             inputs.kind = Layout::RustFFI::FfiImagePaintRecordKind::NestedDisplayList;
             inputs.nested_display_list_id = resource_storage.add_display_list(nested.resource.display_list, nested.resource.visual_context_tree).value();
-            inputs.nested_display_list_size[0] = nested.list_size.width();
-            inputs.nested_display_list_size[1] = nested.list_size.height();
+            inputs.nested_display_list_size = nested.list_size;
         },
         [&](LinearGradientData const& gradient) {
             inputs.kind = Layout::RustFFI::FfiImagePaintRecordKind::LinearGradient;
@@ -1516,21 +1457,21 @@ NonnullRefPtr<DisplayList> record_image_paint_display_list(ImagePaint const& pai
             inputs.first_stop_position = gradient.first_stop_position;
             inputs.repeat_length = gradient.repeat_length;
             write_color_stops(gradient.color_stops);
-            write_interpolation_method(gradient.interpolation_method);
+            inputs.interpolation_method = gradient.interpolation_method;
         },
         [&](ResolvedRadialGradient const& gradient) {
             inputs.kind = Layout::RustFFI::FfiImagePaintRecordKind::RadialGradient;
-            inputs.center = { gradient.center.x().raw_value(), gradient.center.y().raw_value() };
-            inputs.size = { gradient.gradient_size.width().raw_value(), gradient.gradient_size.height().raw_value() };
+            inputs.center = gradient.center;
+            inputs.size = gradient.gradient_size;
             write_color_stops(gradient.data.color_stops);
-            write_interpolation_method(gradient.data.interpolation_method);
+            inputs.interpolation_method = gradient.data.interpolation_method;
         },
         [&](ResolvedConicGradient const& gradient) {
             inputs.kind = Layout::RustFFI::FfiImagePaintRecordKind::ConicGradient;
             inputs.gradient_angle = gradient.data.start_angle;
-            inputs.position = { gradient.position.x().raw_value(), gradient.position.y().raw_value() };
+            inputs.position = gradient.position;
             write_color_stops(gradient.data.color_stops);
-            write_interpolation_method(gradient.data.interpolation_method);
+            inputs.interpolation_method = gradient.data.interpolation_method;
         });
     ByteBuffer command_bytes;
     Layout::RustFFI::ladybird_web_record_image_paint_display_list(&inputs, &command_bytes,

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -21,16 +21,6 @@ namespace Web::Painting {
 
 struct ImagePaint;
 
-inline Layout::RustFFI::FfiCssPixelRect to_ffi_css_pixel_rect(CSSPixelRect const& rect)
-{
-    return { rect.x().raw_value(), rect.y().raw_value(), rect.width().raw_value(), rect.height().raw_value() };
-}
-
-inline CSSPixelRect from_ffi_css_pixel_rect(Layout::RustFFI::FfiCssPixelRect const& rect)
-{
-    return { CSSPixels::from_raw(rect.x), CSSPixels::from_raw(rect.y), CSSPixels::from_raw(rect.width), CSSPixels::from_raw(rect.height) };
-}
-
 WEB_API void rust_build_stacking_context_tree(DOM::Document&);
 WEB_API void dump_stacking_context_tree(StringBuilder&, DOM::Document const&);
 

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -357,7 +357,7 @@ void scroll_text_offset_into_view(DOM::Text const& text, size_t offset, TextAffi
         return;
     auto const& style_source = *style_source_pointer;
 
-    auto cursor_rect = from_ffi_css_pixel_rect(result.rect);
+    auto cursor_rect = result.rect;
     if (style_source.writing_mode() == CSS::WritingMode::HorizontalTb) {
         if (style_source.inline_axis_is_reverse())
             cursor_rect.set_x(cursor_rect.x() - 1);

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -2108,16 +2108,99 @@ fn generate_ffi_header(config: cbindgen::Config, sources: &[PathBuf], out_dir: &
     );
 }
 
-// CssPixels is a single i32 fixed-point value shared with the CSS module; C++
-// already has the matching CSSPixels class, so expose its raw representation in
-// the generated ABI rather than generating a second C++ pixel type in the
-// RustFFI namespace.
-fn expose_css_pixels_as_raw_i32(config: &mut cbindgen::Config) {
-    config.export.exclude.push("CssPixels".to_string());
-    config
-        .export
-        .rename
-        .insert("CssPixels".to_string(), "int32_t".to_string());
+fn expose_css_pixel_types_as_web_types(config: &mut cbindgen::Config) {
+    for (rust_name, cpp_name) in [
+        ("CssPixels", "Web::CSSPixels"),
+        ("FfiCssPixelPoint", "Web::CSSPixelPoint"),
+        ("FfiCssPixelSize", "Web::CSSPixelSize"),
+        ("FfiCssPixelRect", "Web::CSSPixelRect"),
+    ] {
+        config.export.exclude.push(rust_name.to_string());
+        config.export.rename.insert(rust_name.to_string(), cpp_name.to_string());
+    }
+    config.includes.push("LibWeb/PixelUnits.h".to_string());
+    config.after_includes = Some(
+        "#if defined(__clang__)\n#pragma clang diagnostic push\n#pragma clang diagnostic ignored \"-Wreturn-type-c-linkage\"\n#endif"
+            .to_string(),
+    );
+    config.trailer = Some("#if defined(__clang__)\n#pragma clang diagnostic pop\n#endif".to_string());
+}
+
+fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
+    config.export.exclude.extend(
+        [
+            "OptionalFloatRect",
+            "OptionalColor",
+            "OptionalU32",
+            "OptionalF32",
+            "OptionalAffineTransform",
+            "OptionalCssPixels",
+            "OptionalCssPixelRect",
+            "OptionalIntRect",
+            "OptionalFloatPoint",
+            "OptionalFloatSize",
+            "OptionalI64",
+            "OptionalUsize",
+            "MaskLayerOrigin",
+            "TransformDataRole",
+        ]
+        .map(String::from),
+    );
+    for (rust_name, cpp_name) in [
+        ("IntPoint", "Gfx::IntPoint"),
+        ("FloatPoint", "Gfx::FloatPoint"),
+        ("IntSize", "Gfx::IntSize"),
+        ("FloatSize", "Gfx::FloatSize"),
+        ("IntRect", "Gfx::IntRect"),
+        ("FloatRect", "Gfx::FloatRect"),
+        ("Color", "Gfx::Color"),
+        ("AffineTransform", "Gfx::AffineTransform"),
+        ("FloatMatrix4x4", "Gfx::FloatMatrix4x4"),
+        ("CornerRadius", "Gfx::CornerRadius"),
+        ("CornerRadii", "Gfx::CornerRadii"),
+        ("GradientInterpolationMethod", "Gfx::GradientInterpolationMethod"),
+        ("WindingRule", "Gfx::WindingRule"),
+        ("MaskKind", "Gfx::MaskKind"),
+        ("CompositingAndBlendingOperator", "Gfx::CompositingAndBlendingOperator"),
+        ("ScalingMode", "Gfx::ScalingMode"),
+        ("InterpolationColorSpace", "Gfx::InterpolationColorSpace"),
+        ("OptionalFloatRect", "Optional<Gfx::FloatRect>"),
+        ("OptionalColor", "Optional<Gfx::Color>"),
+        ("OptionalU32", "Optional<u32>"),
+        ("OptionalF32", "Optional<float>"),
+        ("OptionalAffineTransform", "Optional<Gfx::AffineTransform>"),
+        ("OptionalCssPixels", "Optional<Web::CSSPixels>"),
+        ("OptionalCssPixelRect", "Optional<Web::CSSPixelRect>"),
+        ("OptionalIntRect", "Optional<Gfx::IntRect>"),
+        ("OptionalFloatPoint", "Optional<Gfx::FloatPoint>"),
+        ("OptionalFloatSize", "Optional<Gfx::FloatSize>"),
+        ("OptionalI64", "Optional<i64>"),
+        ("OptionalUsize", "Optional<size_t>"),
+        ("MaskLayerOrigin", "Web::Painting::MaskLayerOrigin"),
+        ("TransformDataRole", "Web::Painting::TransformDataRole"),
+    ] {
+        config.export.rename.insert(rust_name.to_string(), cpp_name.to_string());
+    }
+
+    config.includes.extend(
+        [
+            "AK/Optional.h",
+            "LibGfx/AffineTransform.h",
+            "LibGfx/Color.h",
+            "LibGfx/CompositingAndBlendingOperator.h",
+            "LibGfx/CornerRadii.h",
+            "LibGfx/GradientInterpolation.h",
+            "LibGfx/InterpolationColorSpace.h",
+            "LibGfx/Matrix4x4.h",
+            "LibGfx/Point.h",
+            "LibGfx/Rect.h",
+            "LibGfx/ScalingMode.h",
+            "LibGfx/Size.h",
+            "LibGfx/WindingRule.h",
+            "LibWeb/Painting/AccumulatedVisualContext.h",
+        ]
+        .map(String::from),
+    );
 }
 
 fn public_type_names(path: &Path) -> Result<Vec<String>, Box<dyn Error>> {
@@ -2417,6 +2500,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "EFFECTIVE_LONGHAND_SOURCE_OVERLAY".to_string(),
         "EFFECTIVE_LONGHAND_SOURCE_SPECIFIED".to_string(),
     ];
+    expose_css_pixel_types_as_web_types(&mut computed_values_config);
 
     generate_ffi_header(
         computed_values_config,
@@ -2471,7 +2555,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "rust_calc_node_create_numeric_dimension".to_string(),
         "rust_calc_resolve".to_string(),
     ];
-    expose_css_pixels_as_raw_i32(&mut tree_builder_config);
+    expose_css_pixel_types_as_web_types(&mut tree_builder_config);
     generate_ffi_header(
         tree_builder_config,
         &[
@@ -2495,7 +2579,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         "rust_calc_external_resolutions".to_string(),
         "rust_calc_external_resolutions_release".to_string(),
     ];
-    expose_css_pixels_as_raw_i32(&mut layout_config);
+    expose_css_pixel_types_as_web_types(&mut layout_config);
+    expose_shared_abi_types_as_cpp_types(&mut layout_config);
     layout_config
         .includes
         .push("LibWeb/Layout/TreeBuilderRustFFI.h".to_string());
@@ -2534,7 +2619,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut painting_config = base_config.clone();
     painting_config.namespaces = Some(vec!["Web".to_string(), "Painting".to_string(), "RustFFI".to_string()]);
-    expose_css_pixels_as_raw_i32(&mut painting_config);
+    expose_css_pixel_types_as_web_types(&mut painting_config);
     let libgfx_src_dir = manifest_dir.join("../../LibGfx/Rust/src");
     let painting_sources = [
         libgfx_src_dir.join("geometry.rs"),

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -45,6 +45,118 @@ pub struct FfiCssPixelRect {
     pub height: CssPixels,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct OptionalCssPixels {
+    pub value: CssPixels,
+    pub has_value: bool,
+}
+
+impl From<Option<CssPixels>> for OptionalCssPixels {
+    fn from(value: Option<CssPixels>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct OptionalCssPixelRect {
+    pub value: FfiCssPixelRect,
+    pub has_value: bool,
+}
+
+impl From<Option<FfiCssPixelRect>> for OptionalCssPixelRect {
+    fn from(value: Option<FfiCssPixelRect>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct OptionalIntRect {
+    pub value: libgfx_rust::IntRect,
+    pub has_value: bool,
+}
+
+impl From<Option<libgfx_rust::IntRect>> for OptionalIntRect {
+    fn from(value: Option<libgfx_rust::IntRect>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct OptionalFloatPoint {
+    pub value: libgfx_rust::FloatPoint,
+    pub has_value: bool,
+}
+
+impl From<Option<libgfx_rust::FloatPoint>> for OptionalFloatPoint {
+    fn from(value: Option<libgfx_rust::FloatPoint>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct OptionalFloatSize {
+    pub value: libgfx_rust::FloatSize,
+    pub has_value: bool,
+}
+
+impl From<Option<libgfx_rust::FloatSize>> for OptionalFloatSize {
+    fn from(value: Option<libgfx_rust::FloatSize>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct OptionalI64 {
+    pub value: i64,
+    pub has_value: bool,
+}
+
+impl From<Option<i64>> for OptionalI64 {
+    fn from(value: Option<i64>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct OptionalUsize {
+    pub value: usize,
+    pub has_value: bool,
+}
+
+impl From<Option<usize>> for OptionalUsize {
+    fn from(value: Option<usize>) -> Self {
+        Self {
+            value: value.unwrap_or_default(),
+            has_value: value.is_some(),
+        }
+    }
+}
+
 impl From<FfiCssPixelPoint> for CssPixelPoint {
     fn from(point: FfiCssPixelPoint) -> Self {
         Self { x: point.x, y: point.y }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -847,7 +847,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paint_push_selection_shadow(
     sink: *mut c_void,
-    color: u32,
+    color: libgfx_rust::Color,
     offset_x: CssPixels,
     offset_y: CssPixels,
     blur_radius: CssPixels,
@@ -857,7 +857,7 @@ pub unsafe extern "C" fn layout_arena_paint_push_selection_shadow(
         // FfiPaintHostCallbacks::selection_style_facts.
         let shadows = unsafe { &mut *sink.cast::<Vec<crate::painting::record::paint::text::ShadowLayer>>() };
         shadows.push(crate::painting::record::paint::text::ShadowLayer {
-            color,
+            color: color.0,
             offset_x,
             offset_y,
             blur_radius,
@@ -869,7 +869,11 @@ pub unsafe extern "C" fn layout_arena_paint_push_selection_shadow(
 ///
 /// `sink` must be the pointer handed to the callback, used synchronously.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paint_push_color_stop(sink: *mut c_void, color: u32, position: f32) {
+pub unsafe extern "C" fn layout_arena_paint_push_color_stop(
+    sink: *mut c_void,
+    color: libgfx_rust::Color,
+    position: f32,
+) {
     abort_on_panic(|| {
         // SAFETY: `sink` is the ColorStopSink pointer handed out by FfiPaintHostCallbacks::background_layer_image.
         let sink = unsafe { &mut *sink.cast::<crate::painting::host::ColorStopSink>() };
@@ -893,22 +897,19 @@ pub enum FfiImagePaintRecordKind {
 pub struct FfiImagePaintRecordInputs {
     pub kind: FfiImagePaintRecordKind,
     pub device_pixels_per_css_pixel: f64,
-    pub dest_rect: [f32; 4],
+    pub dest_rect: libgfx_rust::FloatRect,
     pub frame_id: u64,
-    pub scaling_mode: i32,
+    pub scaling_mode: libgfx_rust::ScalingMode,
     pub nested_display_list_id: u64,
-    pub nested_display_list_size: [i32; 2],
+    pub nested_display_list_size: libgfx_rust::IntSize,
     pub gradient_angle: f32,
     pub first_stop_position: f32,
     pub repeat_length: f32,
-    pub interpolation_type: u8,
-    pub rectangular_color_space: u8,
-    pub polar_color_space: u8,
-    pub hue_interpolation_method: u8,
+    pub interpolation_method: libgfx_rust::GradientInterpolationMethod,
     pub center: crate::layout::FfiCssPixelPoint,
     pub size: crate::layout::FfiCssPixelSize,
     pub position: crate::layout::FfiCssPixelPoint,
-    pub color_stop_colors: *const u32,
+    pub color_stop_colors: *const libgfx_rust::Color,
     pub color_stop_positions: *const f32,
     pub color_stop_count: usize,
     pub color_stops_repeating: bool,
@@ -927,24 +928,16 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
     use crate::painting::display_list::recorder::{
         ColorStops, ConicGradientData, DisplayListRecorder, LinearGradientData, RadialGradientData,
     };
-    use libgfx_rust::{
-        CompositingAndBlendingOperator, FloatRect, GradientInterpolationMethod, GradientInterpolationType,
-        HueInterpolationMethod, IntRect, IntSize, PolarColorSpace, RectangularColorSpace, ScalingMode,
-    };
+    use libgfx_rust::{CompositingAndBlendingOperator, IntRect};
     abort_on_panic(|| {
         let inputs = unsafe { &*inputs };
         let mut recorder = DisplayListRecorder::new(Vec::new());
-        let dest_rect = FloatRect::new(
-            inputs.dest_rect[0],
-            inputs.dest_rect[1],
-            inputs.dest_rect[2],
-            inputs.dest_rect[3],
-        );
+        let dest_rect = inputs.dest_rect;
         let dest_int_rect = IntRect::new(
-            inputs.dest_rect[0] as i32,
-            inputs.dest_rect[1] as i32,
-            inputs.dest_rect[2] as i32,
-            inputs.dest_rect[3] as i32,
+            inputs.dest_rect.x as i32,
+            inputs.dest_rect.y as i32,
+            inputs.dest_rect.width as i32,
+            inputs.dest_rect.height as i32,
         );
         let color_stops = || {
             let count = inputs.color_stop_count;
@@ -954,10 +947,7 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
                 // SAFETY: the host borrows the stop arrays for the duration of the call.
                 unsafe {
                     (
-                        std::slice::from_raw_parts(inputs.color_stop_colors, count)
-                            .iter()
-                            .map(|value| libgfx_rust::Color(*value))
-                            .collect(),
+                        std::slice::from_raw_parts(inputs.color_stop_colors, count).to_vec(),
                         std::slice::from_raw_parts(inputs.color_stop_positions, count).to_vec(),
                     )
                 }
@@ -968,28 +958,20 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
                 repeating: inputs.color_stops_repeating,
             }
         };
-        let interpolation_method = GradientInterpolationMethod {
-            interpolation_type: GradientInterpolationType::from_u8(inputs.interpolation_type),
-            rectangular_color_space: RectangularColorSpace::from_u8(inputs.rectangular_color_space),
-            polar_color_space: PolarColorSpace::from_u8(inputs.polar_color_space),
-            hue_interpolation_method: HueInterpolationMethod::from_u8(inputs.hue_interpolation_method),
-        };
+        let interpolation_method = inputs.interpolation_method;
         match inputs.kind {
             FfiImagePaintRecordKind::DecodedFrame => recorder.draw_scaled_decoded_image_frame(
                 dest_rect,
                 None,
                 ImageFrameResourceId(inputs.frame_id),
-                ScalingMode::from_raw(inputs.scaling_mode),
+                inputs.scaling_mode,
                 CompositingAndBlendingOperator::Normal,
                 None,
             ),
             FfiImagePaintRecordKind::NestedDisplayList => recorder.paint_nested_display_list(
                 DisplayListResourceId(inputs.nested_display_list_id),
                 dest_rect,
-                IntSize {
-                    width: inputs.nested_display_list_size[0],
-                    height: inputs.nested_display_list_size[1],
-                },
+                inputs.nested_display_list_size,
             ),
             FfiImagePaintRecordKind::LinearGradient => recorder.fill_rect_with_linear_gradient(
                 dest_int_rect,
@@ -2069,28 +2051,25 @@ pub unsafe extern "C" fn layout_arena_main_visual_context_tree(arena: *mut c_voi
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread; `out`
-/// must have room for `capacity` floats.
+/// must have room for `capacity` points.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_scroll_state_snapshot(
     arena: *mut c_void,
-    out: *mut f32,
+    out: *mut libgfx_rust::FloatPoint,
     capacity: usize,
 ) -> usize {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let paint_state = arena.paint_state().borrow();
         let snapshot = &paint_state.visual_context.scroll_state_snapshot;
-        let needed = snapshot.len() * 2;
+        let needed = snapshot.len();
         if !out.is_null() {
             for (index, offset) in snapshot.iter().enumerate() {
-                if index * 2 + 1 >= capacity {
+                if index >= capacity {
                     break;
                 }
                 // SAFETY: within the caller's capacity.
-                unsafe {
-                    *out.add(index * 2) = offset.x;
-                    *out.add(index * 2 + 1) = offset.y;
-                }
+                unsafe { *out.add(index) = *offset };
             }
         }
         needed
@@ -2104,8 +2083,7 @@ pub unsafe extern "C" fn layout_arena_scroll_state_snapshot(
 pub unsafe extern "C" fn layout_arena_cumulative_scroll_offset_for_node(
     arena: *mut c_void,
     scroll_node_index: usize,
-    out_raw: *mut i32,
-) {
+) -> FfiCssPixelPoint {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let paint_state = arena.paint_state().borrow();
@@ -2115,12 +2093,8 @@ pub unsafe extern "C" fn layout_arena_cumulative_scroll_offset_for_node(
                 .scroll_state
                 .cumulative_offset(tree.scroll_state_slot_for_node(scroll_node_index))
         });
-        // SAFETY: the caller passes room for two values.
-        unsafe {
-            *out_raw = offset.x.raw_value();
-            *out_raw.add(1) = offset.y.raw_value();
-        }
-    });
+        offset.into()
+    })
 }
 
 /// # Safety
@@ -2166,8 +2140,7 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
                 kind: item.kind as u8,
                 paintable: item.paintable,
                 chrome_widget_kind: item.chrome_widget_kind,
-                has_text_fragment_index: item.text_fragment_index.is_some(),
-                text_fragment_index: item.text_fragment_index.unwrap_or(0),
+                text_fragment_index: item.text_fragment_index.into(),
                 caret_node_shell: arena.shell_if_live(item.caret_node),
                 caret_offset: item.caret_offset,
                 rect: rect(item.rect),
@@ -2392,17 +2365,12 @@ fn with_hit_test_list<R>(
     query(list, arena)
 }
 
-fn css_point(x_raw: i32, y_raw: i32) -> crate::css::css_pixels::CssPixelPoint {
-    crate::css::css_pixels::CssPixelPoint::new(CssPixels::from_raw(x_raw), CssPixels::from_raw(y_raw))
-}
-
 fn ffi_topmost(item: Option<crate::painting::hit_test::query::TopmostItem>) -> crate::painting::host::FfiTopmostItem {
     match item {
         Some(item) => crate::painting::host::FfiTopmostItem {
             has_item: true,
             index: item.index,
-            local_x: item.local_point.x.raw_value(),
-            local_y: item.local_point.y.raw_value(),
+            local: item.local_point.into(),
         },
         None => crate::painting::host::FfiTopmostItem::default(),
     }
@@ -2415,12 +2383,11 @@ fn ffi_topmost(item: Option<crate::painting::hit_test::query::TopmostItem>) -> c
 pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_item(
     arena: *mut c_void,
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
-    x_raw: i32,
-    y_raw: i32,
+    point: FfiCssPixelPoint,
 ) -> crate::painting::host::FfiTopmostItem {
     abort_on_panic(|| {
         with_hit_test_list(arena, Default::default(), |list, arena| {
-            ffi_topmost(list.find_topmost_item(arena, &callbacks, css_point(x_raw, y_raw)))
+            ffi_topmost(list.find_topmost_item(arena, &callbacks, point.into()))
         })
     })
 }
@@ -2432,12 +2399,11 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_item(
 pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_items_for_caret(
     arena: *mut c_void,
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
-    x_raw: i32,
-    y_raw: i32,
+    point: FfiCssPixelPoint,
 ) -> crate::painting::host::FfiTopmostItemsForCaret {
     abort_on_panic(|| {
         with_hit_test_list(arena, Default::default(), |list, arena| {
-            let (caret_item, hit_item) = list.find_topmost_items_for_caret(arena, &callbacks, css_point(x_raw, y_raw));
+            let (caret_item, hit_item) = list.find_topmost_items_for_caret(arena, &callbacks, point.into());
             crate::painting::host::FfiTopmostItemsForCaret {
                 caret_item: ffi_topmost(caret_item),
                 hit_item: ffi_topmost(hit_item),
@@ -2453,14 +2419,13 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_items_for_caret(
 pub unsafe extern "C" fn layout_arena_hit_test_all(
     arena: *mut c_void,
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
-    x_raw: i32,
-    y_raw: i32,
+    point: FfiCssPixelPoint,
     push_context: *mut c_void,
     push: unsafe extern "C" fn(*mut c_void, usize),
 ) {
     abort_on_panic(|| {
         let indices = with_hit_test_list(arena, Vec::new(), |list, arena| {
-            list.hit_test_all(arena, &callbacks, css_point(x_raw, y_raw))
+            list.hit_test_all(arena, &callbacks, point.into())
         });
         for index in indices {
             // SAFETY: The C++ sink consumes the index synchronously.
@@ -2493,15 +2458,14 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_at_line_edge(
 pub unsafe extern "C" fn layout_arena_hit_test_caret_item_for_line(
     arena: *mut c_void,
     line_index: usize,
-    x_raw: i32,
-    y_raw: i32,
+    point: FfiCssPixelPoint,
     mode: u8,
 ) -> crate::painting::host::FfiCaretItemForLine {
     abort_on_panic(|| {
         with_hit_test_list(arena, Default::default(), |list, _| {
             match list.caret_item_for_line(
                 line_index,
-                css_point(x_raw, y_raw),
+                point.into(),
                 crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
             ) {
                 Some((item_index, position_type)) => crate::painting::host::FfiCaretItemForLine {
@@ -2546,8 +2510,7 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_is_inline_adjacent_to_line(
 pub unsafe extern "C" fn layout_arena_hit_test_find_closest_line(
     arena: *mut c_void,
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
-    x_raw: i32,
-    y_raw: i32,
+    point: FfiCssPixelPoint,
     mode: u8,
     scoped: bool,
     respect_clip: bool,
@@ -2556,7 +2519,7 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_closest_line(
         with_hit_test_list(arena, Default::default(), |list, _| {
             let closest = list.find_closest_line(
                 &callbacks,
-                css_point(x_raw, y_raw),
+                point.into(),
                 crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
                 scoped,
                 respect_clip,
@@ -2569,8 +2532,7 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_closest_line(
                 block_distance: closest.block_distance.raw_value(),
                 block_start_distance: closest.block_start_distance.raw_value(),
                 inline_distance: closest.inline_distance.raw_value(),
-                has_block_container_margin_rect: closest.block_container_margin_rect.is_some(),
-                block_container_margin_rect: closest.block_container_margin_rect.unwrap_or_default().into(),
+                block_container_margin_rect: closest.block_container_margin_rect.map(Into::into).into(),
                 is_before_point: closest.is_before_point,
                 contains_point_in_block_axis: closest.contains_point_in_block_axis,
             }
@@ -2646,7 +2608,7 @@ pub struct FfiResolvedGradientPaint {
     pub first_stop_position: f32,
     pub repeat_length: f32,
     pub color_stops_repeating: bool,
-    pub interpolation_method: [u8; 4],
+    pub interpolation_method: libgfx_rust::GradientInterpolationMethod,
     pub center: FfiCssPixelPoint,
     pub size: crate::layout::FfiCssPixelSize,
 }
@@ -2659,14 +2621,13 @@ pub struct FfiResolvedGradientPaint {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_resolve_gradient_paint_for_size(
     gradient_value: *const c_void,
-    current_color: u32,
+    current_color: libgfx_rust::Color,
     current_color_value: *const c_void,
     color_scheme: u8,
-    size_width: CssPixels,
-    size_height: CssPixels,
+    size: FfiCssPixelSize,
     out: *mut FfiResolvedGradientPaint,
     stop_context: *mut c_void,
-    append_stop: unsafe extern "C" fn(*mut c_void, u32, f32),
+    append_stop: unsafe extern "C" fn(*mut c_void, libgfx_rust::Color, f32),
 ) {
     abort_on_panic(|| {
         use crate::painting::record::paint::gradient_resolution::{
@@ -2681,16 +2642,16 @@ pub unsafe extern "C" fn layout_arena_resolve_gradient_paint_for_size(
         let color_input = crate::css::color_resolution::ColorResolutionInput {
             scheme: Some(color_scheme),
             current_color: Some(crate::css::color_resolution::Rgba {
-                r: (current_color >> 16) as u8,
-                g: (current_color >> 8) as u8,
-                b: current_color as u8,
-                a: (current_color >> 24) as u8,
+                r: current_color.red(),
+                g: current_color.green(),
+                b: current_color.blue(),
+                a: current_color.alpha(),
             }),
             current_color_value,
             length: None,
             channels: None,
         };
-        let tile_size = crate::css::css_pixels::CssPixelSize::new(size_width, size_height);
+        let tile_size = size.into();
         let resolved = resolve_gradient_paint_with_input(gradient_value, tile_size, &color_input);
         let out = unsafe { &mut *out };
         let (data_stops, interpolation_method) = match &resolved {
@@ -2724,15 +2685,10 @@ pub unsafe extern "C" fn layout_arena_resolve_gradient_paint_for_size(
             }
         };
         out.color_stops_repeating = data_stops.repeating;
-        out.interpolation_method = [
-            interpolation_method.interpolation_type as u8,
-            interpolation_method.rectangular_color_space as u8,
-            interpolation_method.polar_color_space as u8,
-            interpolation_method.hue_interpolation_method as u8,
-        ];
+        out.interpolation_method = interpolation_method;
         for (color, position) in data_stops.colors.iter().zip(data_stops.positions.iter()) {
             // SAFETY: The C++ caller appends into its own storage synchronously.
-            unsafe { append_stop(stop_context, color.0, *position) };
+            unsafe { append_stop(stop_context, *color, *position) };
         }
     });
 }

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
@@ -291,12 +291,7 @@ pub(crate) fn local_float_point(
     // Returned in float local units: fixed-point CSSPixels quantization here would be magnified by the
     // accumulated transform for content in scaled-down local spaces, such as SVG user units under a
     // small viewBox.
-    callbacks.local_point_for_visual_context(
-        visual_context_index,
-        point.x.raw_value(),
-        point.y.raw_value(),
-        respect_clip,
-    )
+    callbacks.local_point_for_visual_context(visual_context_index, point.into(), respect_clip)
 }
 
 pub(crate) fn to_css_point(local: (f32, f32)) -> CssPixelPoint {

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::layout::OptionalCssPixelRect;
 use crate::layout::node_data::NodeSlotId;
+use crate::painting::display_list::commands::OptionalU32;
+use libgfx_rust::WindingRule;
 use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -18,7 +21,7 @@ pub struct FfiHitTestPaintableFacts {
     pub could_be_scrolled_horizontally: bool,
     pub could_be_scrolled_vertically: bool,
     pub svg_path_has_fill: bool,
-    pub svg_path_winding_rule: i32,
+    pub svg_path_winding_rule: WindingRule,
     pub svg_mask_content_units_object_bbox: bool,
     pub svg_clip_path_units_object_bbox: bool,
 }
@@ -68,27 +71,32 @@ impl FfiHitTestHostCallbacks {
 #[repr(C)]
 pub struct FfiHitTestQueryCallbacks {
     pub context: *mut c_void,
-    pub local_point_for_visual_context: unsafe extern "C" fn(*mut c_void, usize, i32, i32, bool, *mut f32) -> bool,
-    pub chrome_widget_contains: unsafe extern "C" fn(*mut c_void, *mut c_void, u8, i32, i32) -> bool,
+    pub local_point_for_visual_context: unsafe extern "C" fn(
+        *mut c_void,
+        usize,
+        crate::layout::FfiCssPixelPoint,
+        bool,
+        *mut libgfx_rust::FloatPoint,
+    ) -> bool,
+    pub chrome_widget_contains:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, u8, crate::layout::FfiCssPixelPoint) -> bool,
     pub line_in_scope: unsafe extern "C" fn(*mut c_void, usize) -> bool,
     pub sorting_context_group: unsafe extern "C" fn(*mut c_void, usize, *mut usize) -> bool,
-    pub plane_depth_key: unsafe extern "C" fn(*mut c_void, usize, i32, i32, *mut i64) -> bool,
+    pub plane_depth_key: unsafe extern "C" fn(*mut c_void, usize, crate::layout::FfiCssPixelPoint, *mut i64) -> bool,
 }
 
 impl FfiHitTestQueryCallbacks {
     pub(crate) fn local_point_for_visual_context(
         &self,
         index: usize,
-        x_raw: i32,
-        y_raw: i32,
+        point: crate::layout::FfiCssPixelPoint,
         respect_clip: bool,
     ) -> Option<(f32, f32)> {
-        let mut out = [0.0f32; 2];
-        // SAFETY: The C++ host writes two floats synchronously.
-        let inside = unsafe {
-            (self.local_point_for_visual_context)(self.context, index, x_raw, y_raw, respect_clip, out.as_mut_ptr())
-        };
-        inside.then_some((out[0], out[1]))
+        let mut local = libgfx_rust::FloatPoint::default();
+        // SAFETY: The C++ host writes the point synchronously when it returns true.
+        let has_local =
+            unsafe { (self.local_point_for_visual_context)(self.context, index, point, respect_clip, &raw mut local) };
+        has_local.then_some((local.x, local.y))
     }
     pub(crate) fn chrome_widget_contains(
         &self,
@@ -97,15 +105,7 @@ impl FfiHitTestQueryCallbacks {
         local_point: crate::css::css_pixels::CssPixelPoint,
     ) -> bool {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe {
-            (self.chrome_widget_contains)(
-                self.context,
-                layout_node_shell,
-                kind,
-                local_point.x.raw_value(),
-                local_point.y.raw_value(),
-            )
-        }
+        unsafe { (self.chrome_widget_contains)(self.context, layout_node_shell, kind, local_point.into()) }
     }
     pub(crate) fn line_in_scope(&self, line_index: usize) -> bool {
         // SAFETY: The C++ host answers synchronously.
@@ -114,9 +114,9 @@ impl FfiHitTestQueryCallbacks {
     // The outermost 3D rendering context sorting the plane the visual context node renders into.
     pub(crate) fn sorting_context_group(&self, visual_context_index: usize) -> Option<usize> {
         let mut group = 0usize;
-        // SAFETY: The C++ host writes the group index synchronously.
-        let in_context = unsafe { (self.sorting_context_group)(self.context, visual_context_index, &raw mut group) };
-        in_context.then_some(group)
+        // SAFETY: The C++ host writes the group synchronously when it returns true.
+        let has_group = unsafe { (self.sorting_context_group)(self.context, visual_context_index, &raw mut group) };
+        has_group.then_some(group)
     }
     // The depth of that plane at the queried point, quantized so coplanar planes compare equal.
     pub(crate) fn plane_depth_key(
@@ -125,16 +125,9 @@ impl FfiHitTestQueryCallbacks {
         point: crate::css::css_pixels::CssPixelPoint,
     ) -> Option<i64> {
         let mut depth = 0i64;
-        // SAFETY: The C++ host writes the depth key synchronously.
-        let has_depth = unsafe {
-            (self.plane_depth_key)(
-                self.context,
-                visual_context_index,
-                point.x.raw_value(),
-                point.y.raw_value(),
-                &raw mut depth,
-            )
-        };
+        // SAFETY: The C++ host writes the depth synchronously when it returns true.
+        let has_depth =
+            unsafe { (self.plane_depth_key)(self.context, visual_context_index, point.into(), &raw mut depth) };
         has_depth.then_some(depth)
     }
 }
@@ -144,8 +137,7 @@ impl FfiHitTestQueryCallbacks {
 pub struct FfiTopmostItem {
     pub has_item: bool,
     pub index: usize,
-    pub local_x: i32,
-    pub local_y: i32,
+    pub local: crate::layout::FfiCssPixelPoint,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -165,8 +157,7 @@ pub struct FfiClosestLine {
     pub block_distance: i32,
     pub block_start_distance: i32,
     pub inline_distance: i32,
-    pub has_block_container_margin_rect: bool,
-    pub block_container_margin_rect: crate::layout::FfiCssPixelRect,
+    pub block_container_margin_rect: OptionalCssPixelRect,
     pub is_before_point: bool,
     pub contains_point_in_block_axis: bool,
 }
@@ -194,8 +185,7 @@ pub struct FfiHitTestItemExport {
     pub kind: u8,
     pub paintable: NodeSlotId,
     pub chrome_widget_kind: u8,
-    pub has_text_fragment_index: bool,
-    pub text_fragment_index: u32,
+    pub text_fragment_index: OptionalU32,
     pub caret_node_shell: *mut c_void,
     pub caret_offset: usize,
     pub rect: crate::layout::FfiCssPixelRect,

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -5,48 +5,51 @@
  */
 
 use super::*;
+use crate::layout::{OptionalCssPixelRect, OptionalCssPixels, OptionalFloatSize, OptionalIntRect};
+use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor, OptionalFloatRect};
+use libgfx_rust::{
+    AffineTransform, Color, FloatMatrix4x4, FloatRect, FloatSize, IntPoint, IntRect, InterpolationColorSpace,
+};
 use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiRecordingInputs {
     pub device_pixels_per_css_pixel: f64,
-    pub device_viewport_rect: [i32; 4],
+    pub device_viewport_rect: IntRect,
     pub css_viewport_rect: crate::layout::FfiCssPixelRect,
     pub should_show_line_box_borders: bool,
     pub should_paint_overlay: bool,
     pub is_recording_async_scrolling_metadata: bool,
     pub document_id: i64,
     pub has_blocking_wheel_event_region_covering_viewport: bool,
-    pub has_canvas_fill_rect: bool,
-    pub canvas_fill_rect: [i32; 4],
-    pub canvas_color: u32,
+    pub canvas_fill_rect: OptionalIntRect,
+    pub canvas_color: Color,
     pub opaque_canvas: bool,
-    pub bitmap_rect: [i32; 4],
-    pub background_color: u32,
+    pub bitmap_rect: IntRect,
+    pub background_color: Color,
     pub paint_command_cache_read_write: bool,
     pub display_list_id: u64,
     pub window_is_focused: bool,
-    pub outline_auto_color: u32,
+    pub outline_auto_color: Color,
     pub has_inspector_highlight: bool,
     pub inspector_highlight_paintable: crate::layout::node_data::NodeSlotId,
-    pub tooltip_color: u32,
-    pub tooltip_text_color: u32,
-    pub tooltip_border_color: u32,
+    pub tooltip_color: Color,
+    pub tooltip_text_color: Color,
+    pub tooltip_border_color: Color,
     pub grid_overlays: *const FfiGridOverlayInput,
     pub grid_overlay_count: usize,
     pub flex_overlays: *const FfiFlexOverlayInput,
     pub flex_overlay_count: usize,
-    pub has_caret_debug_rect: bool,
-    pub caret_debug_rect: crate::layout::FfiCssPixelRect,
+    pub caret_debug_rect: OptionalCssPixelRect,
 }
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiGridOverlayInput {
     pub paintable: crate::layout::node_data::NodeSlotId,
-    pub color: u32,
-    pub label_foreground_color: u32,
+    pub color: Color,
+    pub label_foreground_color: Color,
     pub label_css_pixel_size: f32,
     pub show_area_names: bool,
     pub show_line_numbers: bool,
@@ -58,7 +61,7 @@ pub struct FfiGridOverlayInput {
 #[repr(C)]
 pub struct FfiFlexOverlayInput {
     pub paintable: crate::layout::node_data::NodeSlotId,
-    pub color: u32,
+    pub color: Color,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -70,20 +73,18 @@ pub struct FfiOverlayLabelFacts {
     pub device_glyph_width: f32,
     pub device_ascent: f32,
     pub device_descent: f32,
-    pub blob_bounds: [f32; 4],
+    pub blob_bounds: FloatRect,
 }
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiImageIntrinsicFacts {
     pub is_paintable: bool,
-    pub has_natural_width: bool,
-    pub natural_width: i32,
-    pub has_natural_height: bool,
-    pub natural_height: i32,
+    pub natural_width: OptionalCssPixels,
+    pub natural_height: OptionalCssPixels,
     pub has_natural_aspect_ratio: bool,
-    pub natural_aspect_ratio_numerator: i32,
-    pub natural_aspect_ratio_denominator: i32,
+    pub natural_aspect_ratio_numerator: crate::css::css_pixels::CssPixels,
+    pub natural_aspect_ratio_denominator: crate::css::css_pixels::CssPixels,
     pub has_selected_image_value: bool,
     pub selected_image_value: *const c_void,
 }
@@ -92,13 +93,11 @@ impl Default for FfiImageIntrinsicFacts {
     fn default() -> Self {
         Self {
             is_paintable: false,
-            has_natural_width: false,
-            natural_width: 0,
-            has_natural_height: false,
-            natural_height: 0,
+            natural_width: Default::default(),
+            natural_height: Default::default(),
             has_natural_aspect_ratio: false,
-            natural_aspect_ratio_numerator: 0,
-            natural_aspect_ratio_denominator: 0,
+            natural_aspect_ratio_numerator: Default::default(),
+            natural_aspect_ratio_denominator: Default::default(),
             has_selected_image_value: false,
             selected_image_value: std::ptr::null(),
         }
@@ -118,14 +117,12 @@ pub enum FfiVideoRepresentation {
 #[repr(C)]
 pub struct FfiReplacedPaintFacts {
     pub has_decoded_image_data: bool,
-    pub has_natural_width: bool,
-    pub natural_width: crate::css::css_pixels::CssPixels,
-    pub has_natural_height: bool,
-    pub natural_height: crate::css::css_pixels::CssPixels,
+    pub natural_width: OptionalCssPixels,
+    pub natural_height: OptionalCssPixels,
     pub has_natural_aspect_ratio: bool,
     pub natural_aspect_ratio_numerator: crate::css::css_pixels::CssPixels,
     pub natural_aspect_ratio_denominator: crate::css::css_pixels::CssPixels,
-    pub selection_background_color: u32,
+    pub selection_background_color: Color,
     pub has_canvas_content: bool,
     pub canvas_content_width: i32,
     pub canvas_content_height: i32,
@@ -146,30 +143,27 @@ pub struct FfiReplacedPaintFacts {
     pub checked: bool,
     pub indeterminate: bool,
     pub being_activated: bool,
-    pub canvas_color: u32,
-    pub canvas_text_color: u32,
-    pub accent_color: u32,
+    pub canvas_color: Color,
+    pub canvas_text_color: Color,
+    pub accent_color: Color,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiSvgHostFacts {
-    pub has_viewport: bool,
-    pub viewport: [f32; 4],
-    pub percentage_basis: i32,
+    pub viewport: OptionalFloatRect,
+    pub percentage_basis: crate::css::css_pixels::CssPixels,
     pub has_decoded_image_data: bool,
-    pub has_natural_size: bool,
-    pub natural_width: f32,
-    pub natural_height: f32,
+    pub natural_size: OptionalFloatSize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiSvgPaintContext {
-    pub viewport: [f32; 4],
-    pub path_bounding_box: [f32; 4],
-    pub paint_transform: [f32; 6],
-    pub content_scale: [f32; 2],
+    pub viewport: FloatRect,
+    pub path_bounding_box: FloatRect,
+    pub paint_transform: AffineTransform,
+    pub content_scale: FloatSize,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -195,20 +189,18 @@ pub enum FfiSvgGradientSpreadMethod {
 #[repr(C)]
 pub struct FfiSvgPaintStyle {
     pub kind: FfiSvgPaintStyleKind,
-    pub has_gradient_transform: bool,
-    pub gradient_transform: [f32; 6],
+    pub gradient_transform: OptionalAffineTransform,
     pub spread_method: FfiSvgGradientSpreadMethod,
-    pub color_space: u8,
-    pub start: [f32; 2],
-    pub end: [f32; 2],
+    pub color_space: InterpolationColorSpace,
+    pub start: libgfx_rust::FloatPoint,
+    pub end: libgfx_rust::FloatPoint,
     pub start_radius: f32,
     pub end_radius: f32,
     pub pattern_paintable: crate::layout::node_data::NodeSlotId,
-    pub tile_content_transform: [f32; 16],
-    pub tile_rect: [f32; 4],
-    pub content_scale: [f32; 2],
-    pub has_pattern_transform: bool,
-    pub pattern_transform: [f32; 6],
+    pub tile_content_transform: FloatMatrix4x4,
+    pub tile_rect: FloatRect,
+    pub content_scale: FloatSize,
+    pub pattern_transform: OptionalAffineTransform,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -231,8 +223,8 @@ pub struct FfiViewportScrollbarFacts {
     pub expanded_thumb_rect: crate::layout::FfiCssPixelRect,
     pub scroll_size: f64,
     pub expanded_scroll_size: f64,
-    pub thumb_color: u32,
-    pub track_color: u32,
+    pub thumb_color: Color,
+    pub track_color: Color,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -262,11 +254,10 @@ pub struct FfiScrollbarPaintFacts {
 pub struct FfiOverlayFacts {
     pub paints_scrollbars: bool,
     pub scrollbars: [FfiScrollbarPaintFacts; 2],
-    pub thumb_color: u32,
-    pub track_color: u32,
-    pub has_resizer_rect: bool,
-    pub resizer_rect: crate::layout::FfiCssPixelRect,
-    pub resize_gripper_padding: i32,
+    pub thumb_color: Color,
+    pub track_color: Color,
+    pub resizer_rect: OptionalCssPixelRect,
+    pub resize_gripper_padding: crate::css::css_pixels::CssPixels,
     pub middle_button_scroll_active: bool,
     pub middle_button_scroll_origin: crate::layout::FfiCssPixelPoint,
 }
@@ -276,7 +267,7 @@ pub struct FfiOverlayFacts {
 pub struct FfiOutlineFacts {
     pub paints_focused_area_outline: bool,
     pub focused_area_path: *mut c_void,
-    pub focused_area_color: u32,
+    pub focused_area_color: Color,
     pub focused_area_width: crate::css::css_pixels::CssPixels,
 }
 
@@ -291,15 +282,14 @@ pub struct FfiTextControlSelection {
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiSelectionStyleFacts {
-    pub background_color: u32,
-    pub has_text_color: bool,
-    pub text_color: u32,
+    pub background_color: Color,
+    pub text_color: OptionalColor,
     pub has_text_shadow: bool,
     pub has_text_decoration: bool,
     pub text_decoration_lines: [u8; 8],
     pub text_decoration_line_count: u32,
     pub text_decoration_style: u8,
-    pub text_decoration_color: u32,
+    pub text_decoration_color: Color,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -307,7 +297,7 @@ pub struct FfiSelectionStyleFacts {
 pub struct FfiCursorFacts {
     pub paints: bool,
     pub rect: crate::layout::FfiCssPixelRect,
-    pub color: u32,
+    pub color: Color,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -323,8 +313,7 @@ pub enum FfiLayerImageList {
 #[repr(C)]
 pub struct FfiLayerImagePrepareFacts {
     pub is_image_style_value: bool,
-    pub has_single_pixel_color: bool,
-    pub single_pixel_color: u32,
+    pub single_pixel_color: OptionalColor,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -401,25 +390,25 @@ pub struct FfiPaintHostCallbacks {
         *mut c_void,
         FfiLayerImageList,
         u32,
-        *const i32,
+        IntRect,
     ) -> FfiLayerImageNestedDisplayListFacts,
     pub layer_image_current_frame:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiLayerImageList, u32, *const i32) -> FfiLayerImageFrameFacts,
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiLayerImageList, u32, IntRect) -> FfiLayerImageFrameFacts,
     pub layer_image_paint: unsafe extern "C" fn(
         *mut c_void,
         *mut c_void,
         FfiLayerImageList,
         u32,
-        *const f32,
-        *const i32,
+        FloatRect,
+        crate::layout::FfiCssPixelSize,
         u8,
-        *const f32,
+        FloatSize,
     ) -> FfiImagePaintFacts,
     pub replaced_paint_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiReplacedPaintFacts,
     pub replaced_image_paint:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *const f32, *const f32) -> FfiImagePaintFacts,
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FloatRect, FloatSize) -> FfiImagePaintFacts,
     pub backdrop_filter_bytes: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> bool,
-    pub nested_display_list_from_bytes: unsafe extern "C" fn(*mut c_void, *const u8, usize, i32, i32) -> u64,
+    pub nested_display_list_from_bytes: unsafe extern "C" fn(*mut c_void, *const u8, usize, IntPoint) -> u64,
     pub svg_host_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgHostFacts,
     pub svg_paint_style: unsafe extern "C" fn(
         *mut c_void,
@@ -428,7 +417,7 @@ pub struct FfiPaintHostCallbacks {
         *const FfiSvgPaintContext,
         *mut c_void,
     ) -> FfiSvgPaintStyle,
-    pub accumulated_2d_scale: unsafe extern "C" fn(*mut c_void, *const c_void, usize, *mut f32),
+    pub accumulated_2d_scale: unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> FloatSize,
     pub materialize_visual_context_tree: unsafe extern "C" fn(*mut c_void, *const c_void) -> *mut c_void,
     pub nested_display_list_from_tree:
         unsafe extern "C" fn(*mut c_void, *const u8, usize, *mut c_void, *const u64, usize) -> u64,
@@ -445,7 +434,7 @@ pub struct FfiPaintHostCallbacks {
 
 #[derive(Default)]
 pub struct ColorStopSink {
-    pub colors: Vec<u32>,
+    pub colors: Vec<Color>,
     pub positions: Vec<f32>,
 }
 
@@ -533,15 +522,15 @@ impl FfiPaintHostCallbacks {
         computed_index: u32,
         device_dest_rect: libgfx_rust::IntRect,
     ) -> FfiLayerImageNestedDisplayListFacts {
-        let dest = [
-            device_dest_rect.x,
-            device_dest_rect.y,
-            device_dest_rect.width,
-            device_dest_rect.height,
-        ];
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe {
-            (self.layer_image_nested_display_list)(self.context, layout_node_shell, list, computed_index, dest.as_ptr())
+            (self.layer_image_nested_display_list)(
+                self.context,
+                layout_node_shell,
+                list,
+                computed_index,
+                device_dest_rect,
+            )
         }
     }
     pub(crate) fn layer_image_current_frame(
@@ -551,15 +540,9 @@ impl FfiPaintHostCallbacks {
         computed_index: u32,
         device_dest_rect: libgfx_rust::IntRect,
     ) -> FfiLayerImageFrameFacts {
-        let dest = [
-            device_dest_rect.x,
-            device_dest_rect.y,
-            device_dest_rect.width,
-            device_dest_rect.height,
-        ];
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe {
-            (self.layer_image_current_frame)(self.context, layout_node_shell, list, computed_index, dest.as_ptr())
+            (self.layer_image_current_frame)(self.context, layout_node_shell, list, computed_index, device_dest_rect)
         }
     }
     #[allow(clippy::too_many_arguments)]
@@ -568,8 +551,8 @@ impl FfiPaintHostCallbacks {
         layout_node_shell: *mut c_void,
         list: FfiLayerImageList,
         computed_index: u32,
-        dest: [f32; 4],
-        css_tile_size: [i32; 2],
+        dest: FloatRect,
+        css_tile_size: crate::layout::FfiCssPixelSize,
         image_rendering: u8,
         accumulated_scale: libgfx_rust::FloatSize,
     ) -> FfiImagePaintFacts {
@@ -580,10 +563,10 @@ impl FfiPaintHostCallbacks {
                 layout_node_shell,
                 list,
                 computed_index,
-                dest.as_ptr(),
-                css_tile_size.as_ptr(),
+                dest,
+                css_tile_size,
                 image_rendering,
-                [accumulated_scale.width, accumulated_scale.height].as_ptr(),
+                accumulated_scale,
             )
         }
     }
@@ -607,18 +590,11 @@ impl FfiPaintHostCallbacks {
     pub(crate) fn replaced_image_paint(
         &self,
         layout_node_shell: *mut c_void,
-        dest: [f32; 4],
+        dest: FloatRect,
         accumulated_scale: libgfx_rust::FloatSize,
     ) -> FfiImagePaintFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe {
-            (self.replaced_image_paint)(
-                self.context,
-                layout_node_shell,
-                dest.as_ptr(),
-                [accumulated_scale.width, accumulated_scale.height].as_ptr(),
-            )
-        }
+        unsafe { (self.replaced_image_paint)(self.context, layout_node_shell, dest, accumulated_scale) }
     }
     pub(crate) fn backdrop_filter_bytes(&self, layout_node_shell: *mut c_void) -> Option<Vec<u8>> {
         let mut bytes: Vec<u8> = Vec::new();
@@ -633,15 +609,8 @@ impl FfiPaintHostCallbacks {
         content_offset: libgfx_rust::IntPoint,
     ) -> crate::painting::display_list::commands::DisplayListResourceId {
         // SAFETY: The C++ host copies the bytes synchronously.
-        let id = unsafe {
-            (self.nested_display_list_from_bytes)(
-                self.context,
-                bytes.as_ptr(),
-                bytes.len(),
-                content_offset.x,
-                content_offset.y,
-            )
-        };
+        let id =
+            unsafe { (self.nested_display_list_from_bytes)(self.context, bytes.as_ptr(), bytes.len(), content_offset) };
         crate::painting::display_list::commands::DisplayListResourceId(id)
     }
     pub(crate) fn svg_host_facts(&self, layout_node_shell: *mut c_void) -> FfiSvgHostFacts {
@@ -672,14 +641,9 @@ impl FfiPaintHostCallbacks {
         visual_context_tree: Option<&crate::painting::visual_context::VisualContextTree>,
         visual_context_index: usize,
     ) -> libgfx_rust::FloatSize {
-        let mut out = [0f32; 2];
         let tree = visual_context_tree.map_or(std::ptr::null(), |tree| std::ptr::from_ref(tree).cast());
         // SAFETY: The C++ host answers synchronously and only borrows the optional tree.
-        unsafe { (self.accumulated_2d_scale)(self.context, tree, visual_context_index, out.as_mut_ptr()) };
-        libgfx_rust::FloatSize {
-            width: out[0],
-            height: out[1],
-        }
+        unsafe { (self.accumulated_2d_scale)(self.context, tree, visual_context_index) }
     }
     pub(crate) fn materialize_visual_context_tree(
         &self,

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -5,16 +5,19 @@
  */
 
 use super::*;
+use crate::layout::OptionalCssPixelRect;
+use crate::painting::visual_context::{MaskLayerOrigin, TransformDataRole};
+use libgfx_rust::{
+    CompositingAndBlendingOperator, CornerRadii, FloatMatrix4x4, FloatPoint, IntRect, MaskKind, WindingRule,
+};
 use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiSvgMaskFacts {
-    pub has_mask_area: bool,
-    pub mask_area: crate::layout::FfiCssPixelRect,
-    pub mask_kind: i32,
-    pub has_clip_area: bool,
-    pub clip_area: crate::layout::FfiCssPixelRect,
+    pub mask_area: OptionalCssPixelRect,
+    pub mask_kind: MaskKind,
+    pub clip_area: OptionalCssPixelRect,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -31,8 +34,7 @@ pub struct FfiVisualContextTreeInputs {
 #[repr(C)]
 pub struct FfiResolvedEffectsFilter {
     pub gfx_filter: *mut c_void,
-    pub has_svg_filter_bounds: bool,
-    pub svg_filter_bounds: crate::layout::FfiCssPixelRect,
+    pub svg_filter_bounds: OptionalCssPixelRect,
 }
 
 #[derive(Clone, Copy)]
@@ -43,7 +45,8 @@ pub struct FfiVisualContextHostCallbacks {
     pub scroll_offset: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiCssPixelPoint,
     pub svg_transform_view_box_rect:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut crate::layout::FfiCssPixelRect) -> bool,
-    pub svg_additional_element_transform: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut f32) -> bool,
+    pub svg_additional_element_transform:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut libgfx_rust::AffineTransform) -> bool,
     pub root_background_source: unsafe extern "C" fn(*mut c_void) -> FfiRootBackgroundSource,
     pub svg_mask_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgMaskFacts,
     pub resolve_effects_filter: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiResolvedEffectsFilter,
@@ -65,17 +68,19 @@ impl FfiVisualContextHostCallbacks {
         layout_node_shell: *mut c_void,
     ) -> Option<crate::layout::FfiCssPixelRect> {
         let mut rect = crate::layout::FfiCssPixelRect::default();
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.svg_transform_view_box_rect)(self.context, layout_node_shell, &raw mut rect) }.then_some(rect)
+        // SAFETY: The C++ host writes the rect synchronously when it returns true.
+        let has_rect = unsafe { (self.svg_transform_view_box_rect)(self.context, layout_node_shell, &raw mut rect) };
+        has_rect.then_some(rect)
     }
     pub(crate) fn svg_additional_element_transform(
         &self,
         layout_node_shell: *mut c_void,
     ) -> Option<libgfx_rust::AffineTransform> {
-        let mut values = [0.0f32; 6];
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.svg_additional_element_transform)(self.context, layout_node_shell, values.as_mut_ptr()) }
-            .then_some(libgfx_rust::AffineTransform { values })
+        let mut transform = libgfx_rust::AffineTransform::default();
+        // SAFETY: The C++ host writes the transform synchronously when it returns true.
+        let has_transform =
+            unsafe { (self.svg_additional_element_transform)(self.context, layout_node_shell, &raw mut transform) };
+        has_transform.then_some(transform)
     }
     pub(crate) fn root_background_source(&self) -> FfiRootBackgroundSource {
         // SAFETY: The C++ host answers synchronously.
@@ -118,21 +123,21 @@ pub enum FfiVisualContextNodeKind {
 pub struct FfiVisualContextNodeExport {
     pub kind: FfiVisualContextNodeKind,
     pub parent_index: usize,
-    pub matrix: [f32; 16],
-    pub origin: [f32; 2],
+    pub matrix: FloatMatrix4x4,
+    pub origin: FloatPoint,
     pub flattens_inherited_transform: bool,
-    pub transform_role: u8,
+    pub transform_role: TransformDataRole,
     pub has_sorting_context_root: bool,
     pub synthetic_plane: bool,
-    pub rect: [i32; 4],
-    pub corner_radii: [i32; 8],
+    pub rect: IntRect,
+    pub corner_radii: CornerRadii,
     pub opacity: f32,
-    pub blend_mode: i32,
+    pub blend_mode: CompositingAndBlendingOperator,
     pub filter: *mut c_void,
     pub path: *mut c_void,
-    pub winding_rule: i32,
-    pub mask_kind: i32,
-    pub mask_origin: u8,
+    pub winding_rule: WindingRule,
+    pub mask_kind: MaskKind,
+    pub mask_origin: MaskLayerOrigin,
     pub index_value: usize,
     pub is_sticky: bool,
     pub state_slot: usize,

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -242,8 +242,8 @@ impl PaintRecorder<'_> {
             IntRect::new(
                 0,
                 0,
-                self.inputs.device_viewport_rect[2],
-                self.inputs.device_viewport_rect[3],
+                self.inputs.device_viewport_rect.width,
+                self.inputs.device_viewport_rect.height,
             )
         } else {
             self.converter
@@ -315,8 +315,8 @@ impl PaintRecorder<'_> {
                     } else {
                         max_scroll_offset.x
                     },
-                    thumb_color: libgfx_rust::Color(scrollbar.thumb_color),
-                    track_color: libgfx_rust::Color(scrollbar.track_color),
+                    thumb_color: scrollbar.thumb_color,
+                    track_color: scrollbar.track_color,
                     vertical,
                 });
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -468,14 +468,14 @@ impl<'a> PaintRecorder<'a> {
         &mut self,
         target: NodeSlotId,
         path: Rc<libgfx_rust::path::OwnedPath>,
-        winding_rule: i32,
+        winding_rule: libgfx_rust::WindingRule,
         bounding_box: CssPixelRect,
         context: usize,
     ) {
         let item = HitTestItem {
             rect: bounding_box,
             path: Some(path),
-            winding_rule,
+            winding_rule: winding_rule as i32,
             ..self.base_hit_test_item(HitTestItemKind::SvgPath, target, context)
         };
         self.list.append(item);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -521,7 +521,7 @@ fn paint_image_layer(
         *applied = true;
     };
 
-    if prepare.has_single_pixel_color {
+    if prepare.single_pixel_color.has_value {
         apply_blend_layer(recorder, applied_blend_layer);
         // OPTIMIZATION: If the image is a single pixel, we can just fill the whole area with it.
         //               However, we must first figure out the real coverage area, taking repeat etc into account.
@@ -534,10 +534,9 @@ fn paint_image_layer(
                 Some(current) => current.united(image_device_rect),
             });
         }
-        recorder.recorder.fill_rect(
-            fill_rect.unwrap_or_default(),
-            libgfx_rust::Color(prepare.single_pixel_color),
-        );
+        recorder
+            .recorder
+            .fill_rect(fill_rect.unwrap_or_default(), prepare.single_pixel_color.value);
     } else if prepare.is_image_style_value
         && ((repeat_x || repeat_y) || compositing_and_blending_operator != CompositingAndBlendingOperator::Normal)
         && !repeat_x_has_gap
@@ -652,13 +651,8 @@ fn paint_image_layer(
                 shell,
                 image.list,
                 image.computed_index,
-                [
-                    tile_dest_rect.x,
-                    tile_dest_rect.y,
-                    tile_dest_rect.width,
-                    tile_dest_rect.height,
-                ],
-                [image_rect.width.raw_value(), image_rect.height.raw_value()],
+                tile_dest_rect,
+                image_rect.size().into(),
                 image_rendering,
                 libgfx_rust::FloatSize {
                     width: 1.0,
@@ -729,8 +723,8 @@ fn paint_image_layer(
                 shell,
                 image.list,
                 image.computed_index,
-                [dest_rect.x, dest_rect.y, dest_rect.width, dest_rect.height],
-                [image_rect.width.raw_value(), image_rect.height.raw_value()],
+                dest_rect,
+                image_rect.size().into(),
                 image_rendering,
                 accumulated_scale,
             );

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -492,15 +492,11 @@ fn image_intrinsic_facts<'a>(
             LayerImageIntrinsics {
                 is_paintable: facts.is_paintable,
                 natural: SizeWithAspectRatio {
-                    width: facts
-                        .has_natural_width
-                        .then(|| CssPixels::from_raw(facts.natural_width)),
-                    height: facts
-                        .has_natural_height
-                        .then(|| CssPixels::from_raw(facts.natural_height)),
-                    aspect_ratio: facts.has_natural_aspect_ratio.then(|| Fraction {
-                        numerator: CssPixels::from_raw(facts.natural_aspect_ratio_numerator),
-                        denominator: CssPixels::from_raw(facts.natural_aspect_ratio_denominator),
+                    width: facts.natural_width.has_value.then_some(facts.natural_width.value),
+                    height: facts.natural_height.has_value.then_some(facts.natural_height.value),
+                    aspect_ratio: facts.has_natural_aspect_ratio.then_some(Fraction {
+                        numerator: facts.natural_aspect_ratio_numerator,
+                        denominator: facts.natural_aspect_ratio_denominator,
                     }),
                 },
                 // SAFETY: The selected image's retained value is kept alive by the memoized

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/form_controls.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/form_controls.rs
@@ -43,9 +43,9 @@ impl InputColors {
 fn compute_input_colors(facts: &FfiReplacedPaintFacts) -> InputColors {
     // These shades have been picked to work well for all themes and have enough variation to paint
     // all input states (disabled, enabled, checked, etc).
-    let canvas = Color(facts.canvas_color);
-    let base_text_color = Color(facts.canvas_text_color);
-    let accent = Color(facts.accent_color);
+    let canvas = facts.canvas_color;
+    let base_text_color = facts.canvas_text_color;
+    let accent = facts.accent_color;
     let base = InputColors::get_shade(base_text_color.inverted(), 0.8, canvas);
     let dark_gray = InputColors::get_shade(base_text_color, 0.3, canvas);
     let gray = InputColors::get_shade(dark_gray, 0.4, canvas);
@@ -91,7 +91,7 @@ pub(crate) fn paint_check_box_foreground(recorder: &mut PaintRecorder<'_>, paint
         .paint_host
         .replaced_paint_facts(recorder.layout_node_shell(paintable));
     let enabled = facts.enabled;
-    let canvas_color = Color(facts.canvas_color);
+    let canvas_color = facts.canvas_color;
 
     // Keep checkboxes painted as square, centered within the space they occupy.
     let outer_rect = absolute_rect(recorder.layout_arena, paintable);
@@ -184,7 +184,7 @@ pub(crate) fn paint_radio_button_foreground(recorder: &mut PaintRecorder<'_>, pa
     let facts = recorder
         .paint_host
         .replaced_paint_facts(recorder.layout_node_shell(paintable));
-    let canvas_color = Color(facts.canvas_color);
+    let canvas_color = facts.canvas_color;
 
     let enabled = facts.enabled;
     let input_colors = compute_input_colors(&facts);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -161,7 +161,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
             recorder.layout_arena,
             node,
             recorder.inputs.window_is_focused,
-            recorder.inputs.outline_auto_color,
+            recorder.inputs.outline_auto_color.0,
         );
         let outline_offset = crate::painting::style_queries::outline_offset(recorder.layout_arena, node);
         for piece_index in piece_indices {
@@ -194,7 +194,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
                 recorder.layout_node_shell(paintable),
             );
             if cursor.paints {
-                let color = libgfx_rust::Color(cursor.color);
+                let color = cursor.color;
                 if color.alpha() != 0 {
                     let rect = recorder
                         .converter

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -49,8 +49,8 @@ pub(crate) fn record_inspector_overlays(recorder: &mut PaintRecorder<'_>) {
             paint_grid_overlay(recorder, paintable, input);
         });
     }
-    if inputs.has_caret_debug_rect {
-        paint_caret_debug_marker(recorder, CssPixelRect::from(inputs.caret_debug_rect));
+    if inputs.caret_debug_rect.has_value {
+        paint_caret_debug_marker(recorder, CssPixelRect::from(inputs.caret_debug_rect.value));
     }
 }
 
@@ -107,11 +107,11 @@ fn paint_box_model_highlight(recorder: &mut PaintRecorder<'_>, paintable: NodeSl
     size_text_rect.height = CssPixels::nearest_value_for_f32(facts.css_pixel_size) + CssPixels::from_integer(4);
     let device_rect = converter.enclosing_device_rect(size_text_rect);
     let inputs = recorder.inputs;
-    recorder.recorder.fill_rect(device_rect, Color(inputs.tooltip_color));
+    recorder.recorder.fill_rect(device_rect, inputs.tooltip_color);
     recorder
         .recorder
-        .draw_rect(device_rect, Color(inputs.tooltip_border_color), false);
-    draw_label(recorder, &facts, &glyphs, device_rect, Color(inputs.tooltip_text_color));
+        .draw_rect(device_rect, inputs.tooltip_border_color, false);
+    draw_label(recorder, &facts, &glyphs, device_rect, inputs.tooltip_text_color);
 }
 
 fn paint_flex_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, input: &FfiFlexOverlayInput) {
@@ -126,7 +126,7 @@ fn paint_flex_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
         y: content_rect.y,
     };
     let viewport_rect = CssPixelRect::from(recorder.inputs.css_viewport_rect);
-    let color = Color(input.color);
+    let color = input.color;
     let line_color = color.with_alpha(220);
     let container_fill_color = color.with_alpha(28);
     let line_fill_color = color.with_alpha(18);
@@ -258,7 +258,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
         y: content_rect.y,
     };
     let viewport_rect = CssPixelRect::from(recorder.inputs.css_viewport_rect);
-    let color = Color(input.color);
+    let color = input.color;
     let label_height = CssPixels::nearest_value_for_f32(input.label_css_pixel_size) + CssPixels::from_integer(4);
     let two = CssPixels::from_integer(2);
 
@@ -291,7 +291,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                 &facts,
                 &glyphs,
                 label_device_rect,
-                Color(input.label_foreground_color),
+                input.label_foreground_color,
             );
         };
     let paint_centered_label =
@@ -484,10 +484,10 @@ fn draw_label(
             + (rect.height as f32 - (facts.device_ascent + facts.device_descent)) / 2.0,
     };
     let glyph_bounding_rect = IntRect::new(
-        (facts.blob_bounds[0] + baseline_start.x).round_ties_even() as i32,
-        (facts.blob_bounds[1] + baseline_start.y).round_ties_even() as i32,
-        facts.blob_bounds[2].round_ties_even() as i32,
-        facts.blob_bounds[3].round_ties_even() as i32,
+        (facts.blob_bounds.x + baseline_start.x).round_ties_even() as i32,
+        (facts.blob_bounds.y + baseline_start.y).round_ties_even() as i32,
+        facts.blob_bounds.width.round_ties_even() as i32,
+        facts.blob_bounds.height.round_ties_even() as i32,
     );
     recorder.recorder.draw_glyph_run(
         baseline_start,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/outline.rs
@@ -19,7 +19,7 @@ pub(crate) fn paint_outline_phase(recorder: &mut PaintRecorder<'_>, paintable: N
         recorder.layout_arena,
         node,
         recorder.inputs.window_is_focused,
-        recorder.inputs.outline_auto_color,
+        recorder.inputs.outline_auto_color.0,
     );
     let outline_offset = crate::painting::style_queries::outline_offset(recorder.layout_arena, node);
     let border_box_rect = paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
@@ -123,7 +123,7 @@ fn paint_focused_area_outline(
         dash_offset: 0.0,
         path: &transformed,
         opacity: 1.0,
-        paint_style_or_color: PaintStyleOrColor::Color(Color(facts.focused_area_color)),
+        paint_style_or_color: PaintStyleOrColor::Color(facts.focused_area_color),
         thickness: facts.focused_area_width.to_double() as f32 * scale,
         should_anti_alias: ShouldAntiAlias::Yes,
     });

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
@@ -36,20 +36,20 @@ pub(crate) fn paint_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlo
                 converter.rounded_device_rect(CssPixelRect::from(scrollbar.thumb_rect)),
                 converter.rounded_device_rect(CssPixelRect::from(scrollbar.track_rect)),
                 scrollbar.thumb_travel_to_scroll_ratio,
-                Color(facts.thumb_color),
-                Color(facts.track_color),
+                facts.thumb_color,
+                facts.track_color,
                 index == 0,
             );
         }
     }
 
-    if facts.has_resizer_rect {
+    if facts.resizer_rect.has_value {
         let bottom_left_resizer = recorder.is_chrome_mirrored(paintable);
-        let padding = CssPixels::from_raw(facts.resize_gripper_padding);
+        let padding = facts.resize_gripper_padding;
         let two = CssPixels::from_integer(2);
         let half = padding.div_as_fraction(two);
         let negative_half = (-padding).div_as_fraction(two);
-        let mut css_rect = CssPixelRect::from(facts.resizer_rect);
+        let mut css_rect = CssPixelRect::from(facts.resizer_rect.value);
         css_rect.x += half;
         css_rect.width -= padding;
         css_rect.y += half;

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/replaced.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/replaced.rs
@@ -250,8 +250,8 @@ pub(crate) fn paint_image_foreground(recorder: &mut PaintRecorder<'_>, paintable
 
         // https://drafts.csswg.org/css-images/#the-object-fit
         let natural_size = SizeWithAspectRatio {
-            width: facts.has_natural_width.then_some(facts.natural_width),
-            height: facts.has_natural_height.then_some(facts.natural_height),
+            width: facts.natural_width.has_value.then_some(facts.natural_width.value),
+            height: facts.natural_height.has_value.then_some(facts.natural_height.value),
             aspect_ratio: facts.has_natural_aspect_ratio.then(|| {
                 Fraction::of(
                     facts.natural_aspect_ratio_numerator,
@@ -272,7 +272,7 @@ pub(crate) fn paint_image_foreground(recorder: &mut PaintRecorder<'_>, paintable
             let accumulated_scale = recorder.accumulated_2d_scale_at(recorder.recorder.accumulated_visual_context().0);
             let paint = recorder.paint_host.replaced_image_paint(
                 recorder.layout_node_shell(paintable),
-                [dest_rect.x, dest_rect.y, dest_rect.width, dest_rect.height],
+                dest_rect,
                 accumulated_scale,
             );
             if paint.image_paint_kind != crate::painting::host::FfiImagePaintKind::None {
@@ -286,7 +286,7 @@ pub(crate) fn paint_image_foreground(recorder: &mut PaintRecorder<'_>, paintable
     }
 
     if recorder.data(paintable).selection_state != 0 {
-        let selection_background_color = Color(facts.selection_background_color);
+        let selection_background_color = facts.selection_background_color;
         if selection_background_color.alpha() > 0 {
             recorder
                 .recorder

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
@@ -6,7 +6,7 @@
 
 use crate::css::css_enums::paint_order;
 use crate::layout::node_data::NodeSlotId;
-use crate::painting::display_list::commands::{DisplayListGradientSpreadMethod, OptionalAffineTransform};
+use crate::painting::display_list::commands::DisplayListGradientSpreadMethod;
 use crate::painting::display_list::recorder::{
     ColorStops, FillPathParams, PaintStyle, PaintStyleOrColor, StrokePathParams,
 };
@@ -14,10 +14,7 @@ use crate::painting::host::{FfiSvgGradientSpreadMethod, FfiSvgPaintStyle, FfiSvg
 use crate::painting::paintable_geometry::absolute_rect;
 use crate::painting::record::paint::background::paint_image;
 use crate::painting::record::{PaintPhase, PaintRecorder};
-use libgfx_rust::{
-    AffineTransform, CapStyle, Color, FloatRect, FloatSize, InterpolationColorSpace, JoinStyle, ShouldAntiAlias,
-    WindingRule,
-};
+use libgfx_rust::{AffineTransform, CapStyle, Color, FloatRect, JoinStyle, ShouldAntiAlias, WindingRule};
 
 #[derive(Clone, Copy, Default)]
 struct SvgPaintFacts {
@@ -61,12 +58,17 @@ fn svg_paint_facts(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) -> (
         .paint_host
         .svg_host_facts(recorder.layout_node_shell(paintable));
     let mut facts = SvgPaintFacts {
-        has_viewport: host.has_viewport,
-        viewport: host.viewport,
+        has_viewport: host.viewport.has_value,
+        viewport: [
+            host.viewport.value.x,
+            host.viewport.value.y,
+            host.viewport.value.width,
+            host.viewport.value.height,
+        ],
         has_decoded_image_data: host.has_decoded_image_data,
-        has_natural_size: host.has_natural_size,
-        natural_width: host.natural_width,
-        natural_height: host.natural_height,
+        has_natural_size: host.natural_size.has_value,
+        natural_width: host.natural_size.value.width,
+        natural_height: host.natural_size.value.height,
         ..SvgPaintFacts::default()
     };
     let layout_arena = recorder.layout_arena;
@@ -113,7 +115,7 @@ fn svg_paint_facts(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) -> (
         style.box_values().overflow_x == overflow::VISIBLE && style.box_values().overflow_y == overflow::VISIBLE;
     facts.image_rendering = style.image_rendering();
 
-    let basis = crate::css::css_pixels::CssPixels::from_raw(host.percentage_basis);
+    let basis = host.percentage_basis;
     let resolve = |handle: &crate::css::computed_value_types::ComputedStyleValueHandle, default: f32| {
         handle
             .length_percentage()
@@ -161,54 +163,34 @@ fn paint_style_from_ffi(
     stops: &crate::painting::host::ColorStopSink,
 ) -> Option<PaintStyle> {
     let color_stops = ColorStops {
-        colors: stops.colors.iter().map(|color| Color(*color)).collect(),
+        colors: stops.colors.clone(),
         positions: stops.positions.clone(),
         repeating: false,
     };
-    let gradient_transform = if style.has_gradient_transform {
-        OptionalAffineTransform::from(Some(affine(style.gradient_transform)))
-    } else {
-        OptionalAffineTransform::none()
-    };
+    let gradient_transform = style.gradient_transform;
     let spread_method = match style.spread_method {
         FfiSvgGradientSpreadMethod::Pad => DisplayListGradientSpreadMethod::Pad,
         FfiSvgGradientSpreadMethod::Repeat => DisplayListGradientSpreadMethod::Repeat,
         FfiSvgGradientSpreadMethod::Reflect => DisplayListGradientSpreadMethod::Reflect,
     };
-    let color_space = if style.color_space == 0 {
-        InterpolationColorSpace::LinearRGB
-    } else {
-        InterpolationColorSpace::SRGB
-    };
+    let color_space = style.color_space;
     match style.kind {
         FfiSvgPaintStyleKind::LinearGradient => Some(PaintStyle::LinearGradient {
             gradient_transform,
             spread_method,
             color_space,
             color_stops,
-            start_point: libgfx_rust::FloatPoint {
-                x: style.start[0],
-                y: style.start[1],
-            },
-            end_point: libgfx_rust::FloatPoint {
-                x: style.end[0],
-                y: style.end[1],
-            },
+            start_point: style.start,
+            end_point: style.end,
         }),
         FfiSvgPaintStyleKind::RadialGradient => Some(PaintStyle::RadialGradient {
             gradient_transform,
             spread_method,
             color_space,
             color_stops,
-            start_center: libgfx_rust::FloatPoint {
-                x: style.start[0],
-                y: style.start[1],
-            },
+            start_center: style.start,
             start_radius: style.start_radius,
-            end_center: libgfx_rust::FloatPoint {
-                x: style.end[0],
-                y: style.end[1],
-            },
+            end_center: style.end,
             end_radius: style.end_radius,
         }),
         FfiSvgPaintStyleKind::Pattern => Some(
@@ -242,10 +224,14 @@ pub(crate) fn record_pattern_paint_styles(recorder: &mut PaintRecorder<'_>, pain
     let paint_transform = [device_scale, 0.0, 0.0, device_scale, 0.0, 0.0];
     let content_scale = recorder.own_accumulated_2d_scale(paintable);
     let paint_context = crate::painting::host::FfiSvgPaintContext {
-        viewport: if facts.has_viewport { facts.viewport } else { [0.0; 4] },
-        path_bounding_box: computed_path.bounding_box(),
-        paint_transform,
-        content_scale: [content_scale.width, content_scale.height],
+        viewport: if facts.has_viewport {
+            FloatRect::from_array(facts.viewport)
+        } else {
+            FloatRect::default()
+        },
+        path_bounding_box: FloatRect::from_array(computed_path.bounding_box()),
+        paint_transform: affine(paint_transform),
+        content_scale,
     };
     for is_stroke in [false, true] {
         let (style, _stops) =
@@ -271,12 +257,8 @@ pub(crate) fn record_pattern_paint_styles(recorder: &mut PaintRecorder<'_>, pain
 }
 
 fn record_pattern_paint_style(recorder: &mut PaintRecorder<'_>, style: &FfiSvgPaintStyle) -> PaintStyle {
-    let mut elements = [[0.0f32; 4]; 4];
-    for (index, value) in style.tile_content_transform.into_iter().enumerate() {
-        elements[index / 4][index % 4] = value;
-    }
     let root_transform = crate::painting::visual_context::TransformData {
-        matrix: libgfx_rust::FloatMatrix4x4 { elements },
+        matrix: style.tile_content_transform,
         origin: libgfx_rust::FloatPoint::default(),
         sorting_context_root_index: None,
         flattens_inherited_transform: false,
@@ -289,16 +271,9 @@ fn record_pattern_paint_style(recorder: &mut PaintRecorder<'_>, style: &FfiSvgPa
         recorder.record_nested_svg_display_list(style.pattern_paintable, root_transform, false, false);
     PaintStyle::Pattern {
         tile_display_list_id,
-        tile_rect: FloatRect::from_array(style.tile_rect),
-        content_scale: FloatSize {
-            width: style.content_scale[0],
-            height: style.content_scale[1],
-        },
-        pattern_transform: if style.has_pattern_transform {
-            OptionalAffineTransform::from(Some(affine(style.pattern_transform)))
-        } else {
-            OptionalAffineTransform::none()
-        },
+        tile_rect: style.tile_rect,
+        content_scale: style.content_scale,
+        pattern_transform: style.pattern_transform,
     }
 }
 
@@ -343,13 +318,14 @@ pub(crate) fn paint_path(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId
     }
 
     let paint_context = crate::painting::host::FfiSvgPaintContext {
-        viewport: if facts.has_viewport { facts.viewport } else { [0.0; 4] },
-        path_bounding_box: computed_path.bounding_box(),
-        paint_transform,
-        content_scale: {
-            let scale = recorder.own_accumulated_2d_scale(paintable);
-            [scale.width, scale.height]
+        viewport: if facts.has_viewport {
+            FloatRect::from_array(facts.viewport)
+        } else {
+            FloatRect::default()
         },
+        path_bounding_box: FloatRect::from_array(computed_path.bounding_box()),
+        paint_transform: affine(paint_transform),
+        content_scale: recorder.own_accumulated_2d_scale(paintable),
     };
 
     for index in 0..facts.paint_order_count as usize {
@@ -498,11 +474,10 @@ pub(crate) fn paint_image_element(recorder: &mut PaintRecorder<'_>, paintable: N
     }
 
     let accumulated_scale = recorder.accumulated_2d_scale_at(recorder.recorder.accumulated_visual_context().0);
-    let paint = recorder.paint_host.replaced_image_paint(
-        recorder.layout_node_shell(paintable),
-        [draw_rect.x, draw_rect.y, draw_rect.width, draw_rect.height],
-        accumulated_scale,
-    );
+    let paint =
+        recorder
+            .paint_host
+            .replaced_image_paint(recorder.layout_node_shell(paintable), draw_rect, accumulated_scale);
     if paint.image_paint_kind != crate::painting::host::FfiImagePaintKind::None {
         paint_image(recorder, &paint, draw_rect, facts.image_rendering);
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -138,8 +138,8 @@ fn compute_render_spans(
         } = selection_offsets;
         let answer = recorder.selection_style(fragment.layout_node);
         let facts = &answer.facts;
-        let selection_text_color = if facts.has_text_color {
-            facts.text_color
+        let selection_text_color = if facts.text_color.has_value {
+            facts.text_color.value.0
         } else {
             text_color
         };
@@ -163,7 +163,7 @@ fn compute_render_spans(
                 start_code_unit: selection_start,
                 end_code_unit: selection_end,
                 text_color: selection_text_color,
-                background_color: facts.background_color,
+                background_color: facts.background_color.0,
                 shadow_layers: if facts.has_text_shadow {
                     answer.shadows.clone()
                 } else {
@@ -174,7 +174,7 @@ fn compute_render_spans(
                     lines: facts.text_decoration_lines,
                     line_count: facts.text_decoration_line_count,
                     style: facts.text_decoration_style,
-                    color: facts.text_decoration_color,
+                    color: facts.text_decoration_color.0,
                 }),
             });
         }
@@ -481,7 +481,7 @@ pub(crate) fn paint_cursor(recorder: &mut PaintRecorder<'_>, block: NodeSlotId, 
     if !facts.paints {
         return;
     }
-    let color = Color(facts.color);
+    let color = facts.color;
     if color.alpha() == 0 {
         return;
     }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -132,12 +132,10 @@ pub(crate) fn record_display_list(
         selection_style_cache: HashMap::new(),
         wheel_hit_test_target_cache: HashMap::new(),
     };
-    let int_rect = |values: [i32; 4]| libgfx_rust::IntRect::new(values[0], values[1], values[2], values[3]);
-    if inputs.has_canvas_fill_rect {
-        recorder.recorder.fill_rect(
-            int_rect(inputs.canvas_fill_rect),
-            libgfx_rust::Color(inputs.canvas_color),
-        );
+    if inputs.canvas_fill_rect.has_value {
+        recorder
+            .recorder
+            .fill_rect(inputs.canvas_fill_rect.value, inputs.canvas_color);
     }
     // .. in the case of embedded documents typically rendered over a transparent canvas
     // (such as provided via an HTML iframe element), if the used color scheme of the element
@@ -145,14 +143,9 @@ pub(crate) fn record_display_list(
     // then the UA must use an opaque canvas of the Canvas color appropriate to the
     // embedded document’s used color scheme instead of a transparent canvas.
     if inputs.opaque_canvas {
-        recorder
-            .recorder
-            .fill_rect(int_rect(inputs.bitmap_rect), libgfx_rust::Color(inputs.canvas_color));
+        recorder.recorder.fill_rect(inputs.bitmap_rect, inputs.canvas_color);
     }
-    recorder.recorder.fill_rect(
-        int_rect(inputs.bitmap_rect),
-        libgfx_rust::Color(inputs.background_color),
-    );
+    recorder.recorder.fill_rect(inputs.bitmap_rect, inputs.background_color);
     recorder.prerecord_nested_display_lists();
     if !stacking_contexts.nodes.is_empty() {
         recorder.recorder.save_layer();

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -287,21 +287,21 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
     let mut out = FfiVisualContextNodeExport {
         kind: node.data.kind(),
         parent_index: node.parent_index,
-        matrix: [0.0; 16],
-        origin: [0.0; 2],
+        matrix: FloatMatrix4x4::default(),
+        origin: FloatPoint::default(),
         flattens_inherited_transform: false,
-        transform_role: 0,
+        transform_role: TransformDataRole::CssTransform,
         has_sorting_context_root: false,
         synthetic_plane: false,
-        rect: [0; 4],
-        corner_radii: [0; 8],
+        rect: IntRect::default(),
+        corner_radii: CornerRadii::default(),
         opacity: 1.0,
-        blend_mode: 0,
+        blend_mode: CompositingAndBlendingOperator::Normal,
         filter: std::ptr::null_mut(),
         path: std::ptr::null_mut(),
-        winding_rule: 0,
-        mask_kind: 0,
-        mask_origin: 0,
+        winding_rule: WindingRule::Nonzero,
+        mask_kind: MaskKind::Alpha,
+        mask_origin: MaskLayerOrigin::CssMaskLayers,
         index_value: 0,
         is_sticky: false,
         state_slot: 0,
@@ -309,40 +309,20 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
         compensate_horizontal_scroll: false,
         compensate_vertical_scroll: false,
     };
-    let write_matrix = |matrix: &FloatMatrix4x4, out: &mut [f32; 16]| {
-        for (row, values) in matrix.elements.iter().enumerate() {
-            for (column, value) in values.iter().enumerate() {
-                out[row * 4 + column] = *value;
-            }
-        }
-    };
-    let write_rect = |rect: &IntRect, out: &mut [i32; 4]| {
-        *out = [rect.x, rect.y, rect.width, rect.height];
-    };
     match &node.data {
         VisualContextData::Scroll(scroll) => {
             out.is_sticky = scroll.is_sticky;
             out.state_slot = scroll.state_slot;
         }
         VisualContextData::Clip(clip) => {
-            write_rect(&clip.rect, &mut out.rect);
-            let radii = &clip.corner_radii;
-            out.corner_radii = [
-                radii.top_left.horizontal_radius,
-                radii.top_left.vertical_radius,
-                radii.top_right.horizontal_radius,
-                radii.top_right.vertical_radius,
-                radii.bottom_right.horizontal_radius,
-                radii.bottom_right.vertical_radius,
-                radii.bottom_left.horizontal_radius,
-                radii.bottom_left.vertical_radius,
-            ];
+            out.rect = clip.rect;
+            out.corner_radii = clip.corner_radii;
         }
         VisualContextData::Transform(transform) => {
-            write_matrix(&transform.matrix, &mut out.matrix);
-            out.origin = [transform.origin.x, transform.origin.y];
+            out.matrix = transform.matrix;
+            out.origin = transform.origin;
             out.flattens_inherited_transform = transform.flattens_inherited_transform;
-            out.transform_role = transform.role as u8;
+            out.transform_role = transform.role;
             if let Some(root) = transform.sorting_context_root_index {
                 out.has_sorting_context_root = true;
                 out.index_value = root;
@@ -350,7 +330,7 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
             out.synthetic_plane = transform.synthetic_plane;
         }
         VisualContextData::Perspective(perspective) => {
-            write_matrix(&perspective.matrix, &mut out.matrix);
+            out.matrix = perspective.matrix;
             out.flattens_inherited_transform = perspective.flattens_inherited_transform;
         }
         VisualContextData::BackfaceVisibility(backface) => {
@@ -359,12 +339,12 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
         }
         VisualContextData::ClipPath(clip_path) => {
             out.path = clip_path.path.as_raw();
-            write_rect(&clip_path.bounding_rect, &mut out.rect);
-            out.winding_rule = clip_path.fill_rule as i32;
+            out.rect = clip_path.bounding_rect;
+            out.winding_rule = clip_path.fill_rule;
         }
         VisualContextData::Effects(effects) => {
             out.opacity = effects.opacity;
-            out.blend_mode = effects.blend_mode as i32;
+            out.blend_mode = effects.blend_mode;
             out.filter = effects
                 .filter
                 .as_ref()
@@ -380,9 +360,9 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
             out.compensate_vertical_scroll = shift.compensate_vertical_scroll;
         }
         VisualContextData::Mask(mask) => {
-            write_rect(&mask.rect, &mut out.rect);
-            out.mask_kind = mask.kind as i32;
-            out.mask_origin = mask.origin as u8;
+            out.rect = mask.rect;
+            out.mask_kind = mask.kind;
+            out.mask_origin = mask.origin;
         }
     }
     out

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -512,8 +512,9 @@ pub(crate) fn compute_effects_data(
     let resolved_filter = callbacks.resolve_effects_filter(layout_arena.shell_if_live(slot));
     layout_arena.paintable_side_data(slot).svg_filter_bounds.set(
         resolved_filter
-            .has_svg_filter_bounds
-            .then_some(resolved_filter.svg_filter_bounds),
+            .svg_filter_bounds
+            .has_value
+            .then_some(resolved_filter.svg_filter_bounds.value),
     );
     let filter_raw = resolved_filter.gfx_filter;
     let filter = if filter_raw.is_null() {
@@ -633,15 +634,6 @@ fn kind_overrides_svg_mask_virtuals(kind: crate::painting::paintable_data::Paint
     )
 }
 
-fn mask_kind_from(value: i32) -> libgfx_rust::MaskKind {
-    use libgfx_rust::MaskKind;
-    if value == MaskKind::Luminance as i32 {
-        MaskKind::Luminance
-    } else {
-        MaskKind::Alpha
-    }
-}
-
 pub(crate) fn mask_layer_presence(
     layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
@@ -669,17 +661,17 @@ pub(crate) fn mask_layer_presence(
     }
     if kind_overrides_svg_mask_virtuals(data.kind) {
         let svg_facts = callbacks.svg_mask_facts(layout_arena.shell_if_live(slot));
-        if svg_facts.has_mask_area {
+        if svg_facts.mask_area.has_value {
             layers.push(MaskLayerPresenceEntry {
                 origin: MaskLayerOrigin::SvgMask,
-                area: CssPixelRect::from(svg_facts.mask_area),
-                kind: mask_kind_from(svg_facts.mask_kind),
+                area: CssPixelRect::from(svg_facts.mask_area.value),
+                kind: svg_facts.mask_kind,
             });
         }
-        if svg_facts.has_clip_area {
+        if svg_facts.clip_area.has_value {
             layers.push(MaskLayerPresenceEntry {
                 origin: MaskLayerOrigin::SvgClip,
-                area: CssPixelRect::from(svg_facts.clip_area),
+                area: CssPixelRect::from(svg_facts.clip_area.value),
                 kind: libgfx_rust::MaskKind::Alpha,
             });
         }

--- a/Libraries/LibWeb/VisualLines.cpp
+++ b/Libraries/LibWeb/VisualLines.cpp
@@ -122,7 +122,7 @@ static Optional<CSSPixels> caret_inline_coordinate(DOM::Text const& dom_node, Vi
         layout_node->arena_handle(), line.owner_paintable, line.line_index, slots.data(), slots.size(), offset);
     if (!result.has_value)
         return {};
-    return CSSPixels::from_raw(result.value);
+    return result.value;
 }
 
 static size_t offset_in_visual_line_closest_to_inline_coordinate(DOM::Text const& dom_node, VisualLine const& line, Optional<CSSPixels> inline_coordinate)
@@ -135,7 +135,7 @@ static size_t offset_in_visual_line_closest_to_inline_coordinate(DOM::Text const
     auto slots = Layout::TextOffsetMapping { dom_node }.slot_ids();
     return Layout::RustFFI::layout_arena_visual_line_offset_closest_to_inline_coordinate(
         layout_node->arena_handle(), line.owner_paintable, line.line_index, slots.data(), slots.size(),
-        inline_coordinate->raw_value(), line.start_offset);
+        *inline_coordinate, line.start_offset);
 }
 
 Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity)


### PR DESCRIPTION
The painting and hit-test bridges passed layout-identical CSS pixels,
geometry, colors, transforms, enums, and optionals as primitive fields
and arrays. Each callback reconstructed them in both languages, making
the API imprecise and scattering ABI assumptions across many helpers.

Teach cbindgen to name Web, Gfx, and Optional types directly. Give the
Rust host records matching repr(C) optional layouts. Retype painting
callbacks and CSS-pixel consumers, eliminating packing and fixed-point
extraction, integer color conversion, and array out-parameters in C++.

Add size, alignment, discriminant, and trivial-copy ABI assertions. The
generated layout and computed-value headers now use real C++ types while
retaining the display-list mirror checks.