### PR TITLE
LibWeb: Discard capacity after publishing deferred style facts

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -73,14 +73,9 @@ void StyleEngine::allocate_style_nodes(Span<StyleNodeID> nodes)
     StyleEngineFFI::style_engine_allocate_style_nodes(m_impl, reinterpret_cast<u32*>(nodes.data()), nodes.size());
 }
 
-Vector<StyleNodeID> StyleEngine::take_deferred_element_initial_features()
+HashTable<StyleNodeID> StyleEngine::take_deferred_element_initial_features()
 {
-    Vector<StyleNodeID> nodes;
-    nodes.ensure_capacity(m_nodes_with_pending_initial_features.size());
-    for (auto node : m_nodes_with_pending_initial_features)
-        nodes.unchecked_append(node);
-    m_nodes_with_pending_initial_features.clear_with_capacity();
-    return nodes;
+    return move(m_nodes_with_pending_initial_features);
 }
 
 HashTable<StyleNodeID> StyleEngine::take_elements_awaiting_first_style_computation()

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -62,7 +62,7 @@ public:
         m_nodes_awaiting_first_style_computation.remove(style_node);
     }
     [[nodiscard]] bool has_deferred_element_initial_features(StyleNodeID style_node) const { return m_nodes_with_pending_initial_features.contains(style_node); }
-    Vector<StyleNodeID> take_deferred_element_initial_features();
+    HashTable<StyleNodeID> take_deferred_element_initial_features();
     HashTable<StyleNodeID> take_elements_awaiting_first_style_computation();
     void mark_style_node_preallocated(StyleNodeID style_node, TreeScopeID tree_scope) { m_preallocated_style_nodes.set(style_node, tree_scope); }
     Optional<TreeScopeID> consume_preallocated_style_node(StyleNodeID style_node) { return m_preallocated_style_nodes.take(style_node); }


### PR DESCRIPTION
Move the pending-element hash table out when its entries are consumed. Retaining peak capacity made each later style observation scan and clear the allocation, even when the current batch contained few elements.

Large pages that keep mutating their DOM could therefore spend most of their CPU time emptying a sparsely populated table. Let each new batch start with an empty table so publication work follows its current size.

Existing deferred-initial-feature coverage continues to exercise batch publication semantics.

Fixes #11355