### PR TITLE
LibWeb: Update SVG presentation styles incrementally

### DIFF
--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/DOM/Document.h>
@@ -163,46 +164,104 @@ bool SVGElement::is_presentational_hint(Utf16FlyString const& name) const
 void SVGElement::apply_presentational_hints(Vector<CSS::StyleProperty>& properties) const
 {
     Base::apply_presentational_hints(properties);
-    CSS::Parser::ParsingParams parsing_context { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
-    for_each_attribute([&](Utf16FlyString const& name, Utf16View const& value) {
-        if (auto property_id = property_id_for_presentational_attribute(name, local_name()); property_id.has_value()) {
-            auto style_value = [&]() -> RefPtr<CSS::StyleValue const> {
-                // NB: <path>'s `d` presentational attribute is a special case - the attribute and the CSS properties
-                //     syntaxes differ with the attribute being a raw path string but the CSS property only accepting a
-                //     path() function. To account for this we wrap the attribute value in a path function before parsing.
-                if (property_id == CSS::PropertyID::D)
-                    return parse_css_value(parsing_context, Utf16String::formatted("path({})", CSS::serialize_a_string(value)), property_id.value());
 
-                // NB: The transform, gradientTransform, and patternTransform attributes use the SVG
-                //     transform-list grammar (optional commas, unitless values, three-argument
-                //     rotate), which the CSS transform property doesn't accept - so parse the SVG
-                //     grammar and re-express the resulting matrix as a single-function transform
-                //     list, the shape the CSS parser produces for the transform property.
-                if (property_id == CSS::PropertyID::Transform) {
-                    auto transform_list = AttributeParser::parse_transform(Utf16String::from_utf16(value));
-                    if (!transform_list.has_value())
-                        return {};
-                    auto matrix = transform_from_transform_list(*transform_list);
-                    CSS::StyleValueVector matrix_parameters {
-                        CSS::NumberStyleValue::create(matrix.a()),
-                        CSS::NumberStyleValue::create(matrix.b()),
-                        CSS::NumberStyleValue::create(matrix.c()),
-                        CSS::NumberStyleValue::create(matrix.d()),
-                        CSS::NumberStyleValue::create(matrix.e()),
-                        CSS::NumberStyleValue::create(matrix.f()),
-                    };
-                    return CSS::StyleValueList::create(
-                        CSS::StyleValueVector { CSS::TransformationStyleValue::create(CSS::PropertyID::Transform, CSS::TransformFunction::Matrix, move(matrix_parameters)) },
-                        CSS::StyleValueList::Separator::Space);
-                }
+    if (m_presentation_attribute_style.has_value()) {
+        properties.extend(*m_presentation_attribute_style);
+        return;
+    }
 
-                return parse_css_value(parsing_context, value, property_id.value());
-            }();
-
+    Vector<CSS::StyleProperty> presentation_attribute_style;
+    for_each_attribute([&](DOM::QualifiedName const& name, Utf16View const& value) {
+        if (name.namespace_().has_value())
+            return;
+        if (auto property_id = property_id_for_presentational_attribute(name.as_string(), local_name()); property_id.has_value()) {
+            auto style_value = parse_presentation_attribute(*property_id, value);
             if (style_value)
-                properties.append({ .property_id = property_id.value(), .value = style_value.release_nonnull() });
+                presentation_attribute_style.append({ .property_id = *property_id, .value = style_value.release_nonnull() });
         }
     });
+    m_presentation_attribute_style = move(presentation_attribute_style);
+    properties.extend(*m_presentation_attribute_style);
+}
+
+RefPtr<CSS::StyleValue const> SVGElement::parse_presentation_attribute(CSS::PropertyID property_id, Utf16View value) const
+{
+    CSS::Parser::ParsingParams parsing_context { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
+    // NB: <path>'s `d` presentational attribute is a special case - the attribute and the CSS properties
+    //     syntaxes differ with the attribute being a raw path string but the CSS property only accepting a
+    //     path() function. To account for this we wrap the attribute value in a path function before parsing.
+    if (property_id == CSS::PropertyID::D) {
+        return parse_css_value(parsing_context, Utf16String::formatted("path({})", CSS::serialize_a_string(value)), property_id);
+    }
+
+    // NB: The transform, gradientTransform, and patternTransform attributes use the SVG
+    //     transform-list grammar (optional commas, unitless values, three-argument
+    //     rotate), which the CSS transform property doesn't accept - so parse the SVG
+    //     grammar and re-express the resulting matrix as a single-function transform
+    //     list, the shape the CSS parser produces for the transform property.
+    if (property_id == CSS::PropertyID::Transform) {
+        auto transform_list = AttributeParser::parse_transform(Utf16String::from_utf16(value));
+        if (!transform_list.has_value())
+            return {};
+        auto matrix = transform_from_transform_list(*transform_list);
+        CSS::StyleValueVector matrix_parameters {
+            CSS::NumberStyleValue::create(matrix.a()),
+            CSS::NumberStyleValue::create(matrix.b()),
+            CSS::NumberStyleValue::create(matrix.c()),
+            CSS::NumberStyleValue::create(matrix.d()),
+            CSS::NumberStyleValue::create(matrix.e()),
+            CSS::NumberStyleValue::create(matrix.f()),
+        };
+        return CSS::StyleValueList::create(
+            CSS::StyleValueVector { CSS::TransformationStyleValue::create(CSS::PropertyID::Transform, CSS::TransformFunction::Matrix, move(matrix_parameters)) },
+            CSS::StyleValueList::Separator::Space);
+    }
+
+    return parse_css_value(parsing_context, value, property_id);
+}
+
+void SVGElement::update_presentation_attribute_style(Utf16FlyString const& name, Optional<Utf16FlyString> const& namespace_)
+{
+    if (!m_presentation_attribute_style.has_value() || namespace_.has_value())
+        return;
+
+    auto property_id = property_id_for_presentational_attribute(name, local_name());
+    if (!property_id.has_value())
+        return;
+
+    m_presentation_attribute_style->remove_all_matching([&](auto const& property) {
+        return property.property_id == property_id;
+    });
+
+    for_each_attribute([&](DOM::QualifiedName const& attribute_name, Utf16View const& attribute_value) {
+        if (attribute_name.namespace_().has_value())
+            return;
+        if (property_id_for_presentational_attribute(attribute_name.as_string(), local_name()) != property_id)
+            return;
+        if (auto style_value = parse_presentation_attribute(*property_id, attribute_value); style_value)
+            m_presentation_attribute_style->append({ .property_id = *property_id, .value = style_value.release_nonnull() });
+    });
+
+    publish_presentation_attribute_style();
+}
+
+void SVGElement::publish_presentation_attribute_style()
+{
+    document().flush_deferred_style_change_event();
+
+    Vector<CSS::StyleProperty> properties;
+    Base::apply_presentational_hints(properties);
+    properties.extend(*m_presentation_attribute_style);
+
+    HashTable<CSS::PropertyID> seen_properties;
+    for (size_t i = properties.size(); i > 0; --i) {
+        if (seen_properties.set(properties[i - 1].property_id) != AK::HashSetResult::InsertedNewEntry)
+            properties.remove(i - 1);
+    }
+
+    if (presentational_hint_properties_need_publication(properties)
+        && CSS::record_element_presentational_hint_properties(*this, properties))
+        did_publish_presentational_hint_properties(properties);
 }
 
 bool SVGElement::should_include_in_accessibility_tree() const
@@ -255,7 +314,15 @@ void SVGElement::attribute_changed(Utf16FlyString const& local_name, Optional<Ut
     Base::attribute_changed(local_name, old_value, value, namespace_);
     HTMLOrSVGOrMathMLElement::attribute_changed(local_name, old_value, value, namespace_);
 
+    if (old_value != value)
+        update_presentation_attribute_style(local_name, namespace_);
     update_use_elements_that_reference_this();
+}
+
+void SVGElement::adopted_from(DOM::Document& old_document)
+{
+    Base::adopted_from(old_document);
+    m_presentation_attribute_style.clear();
 }
 
 WebIDL::ExceptionOr<void> SVGElement::cloned(DOM::Node& copy, bool clone_children) const

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -56,6 +56,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
+    virtual void adopted_from(DOM::Document&) override;
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
@@ -70,7 +71,13 @@ private:
 
     virtual bool is_svg_element() const final { return true; }
 
+    RefPtr<CSS::StyleValue const> parse_presentation_attribute(CSS::PropertyID, Utf16View) const;
+    void update_presentation_attribute_style(Utf16FlyString const&, Optional<Utf16FlyString> const& namespace_);
+    void publish_presentation_attribute_style();
+
     GC::Ptr<SVGAnimatedString> m_class_name_animated_string;
+
+    mutable Optional<Vector<CSS::StyleProperty>> m_presentation_attribute_style;
 
     // Many reflecting attributes are marked as SameObject so we cache the objects we create here.
     HashMap<Utf16FlyString, GC::Ref<SVGAnimatedLength>> m_reflected_attribute_cache;

--- a/Tests/LibWeb/Text/expected/SVG/svg-presentation-attribute-style-update.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-presentation-attribute-style-update.txt
@@ -1,0 +1,12 @@
+matrix(1, 0, 0, 1, 10, 20)
+matrix(1, 0, 0, 1, 30, 40)
+none
+matrix(1, 0, 0, 1, 50, 60)
+none
+rgb(255, 0, 0)
+rgb(255, 0, 0)
+rgb(255, 0, 0)
+rgb(0, 0, 255)
+rgb(0, 128, 0)
+rgb(255, 0, 0)
+consecutive mutations preserved the transition start style: true

--- a/Tests/LibWeb/Text/input/SVG/svg-presentation-attribute-style-update.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-presentation-attribute-style-update.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg>
+    <rect id="target" width="10" height="10" transform="translate(10 20)"/>
+</svg>
+<script>
+test(() => {
+    const target = document.getElementById("target");
+    println(getComputedStyle(target).transform);
+
+    target.setAttribute("transform", "translate(30 40)");
+    println(getComputedStyle(target).transform);
+
+    target.setAttribute("transform", "invalid");
+    println(getComputedStyle(target).transform);
+
+    target.setAttribute("transform", "translate(50 60)");
+    println(getComputedStyle(target).transform);
+
+    target.removeAttribute("transform");
+    println(getComputedStyle(target).transform);
+
+    const namespacedTarget = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    namespacedTarget.setAttribute("fill", "red");
+    document.body.appendChild(namespacedTarget);
+
+    println(getComputedStyle(namespacedTarget).fill);
+    namespacedTarget.setAttributeNS("urn:test", "x:fill", "blue");
+    println(getComputedStyle(namespacedTarget).fill);
+    namespacedTarget.removeAttributeNS("urn:test", "fill");
+    println(getComputedStyle(namespacedTarget).fill);
+
+    const duplicateTarget = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    duplicateTarget.setAttribute("fill", "red");
+    duplicateTarget.setAttribute("FILL", "blue");
+    document.body.appendChild(duplicateTarget);
+
+    println(getComputedStyle(duplicateTarget).fill);
+    duplicateTarget.setAttribute("FILL", "green");
+    println(getComputedStyle(duplicateTarget).fill);
+    duplicateTarget.removeAttribute("FILL");
+    println(getComputedStyle(duplicateTarget).fill);
+
+    const transitionStyle = document.createElement("style");
+    transitionStyle.textContent = ".transition { transition: fill 1000s linear; }";
+    document.head.appendChild(transitionStyle);
+
+    const transitionTarget = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    transitionTarget.setAttribute("fill", "red");
+    document.querySelector("svg").appendChild(transitionTarget);
+    getComputedStyle(transitionTarget).fill;
+
+    transitionTarget.setAttribute("fill", "green");
+    transitionTarget.getBoundingClientRect();
+    transitionTarget.classList.add("transition");
+    transitionTarget.setAttribute("fill", "blue");
+
+    const transition = transitionTarget.getAnimations()[0];
+    if (transition)
+        transition.currentTime = 0;
+    println(`consecutive mutations preserved the transition start style: ${transition !== undefined
+        && getComputedStyle(transitionTarget).fill === "rgb(0, 128, 0)"}`);
+});
+</script>


### PR DESCRIPTION
Keep the parsed presentation-attribute declaration on each SVG element after style resolution. Flush deferred styles before replacing the published declaration so CSS transitions preserve their starting styles across consecutive mutations.

Ignore namespaced attribute changes. Rebuild an affected property from current attributes so case variants preserve cascade order. Publish the updated declaration directly into style-engine inputs.