### PR TITLE
Stop rasterizing pages whose window is hidden or occluded

### DIFF
--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -32,6 +32,11 @@ enum class WindowResizingInProgress : u8 {
     Yes,
 };
 
+enum class ContextVisibility : u8 {
+    Visible,
+    Hidden,
+};
+
 enum class PagePresentationRegistration {
     No,
     Yes,

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -183,6 +183,12 @@ void HTMLMediaElement::initialize_element()
         add_current_video_sink();
     });
 
+    m_document_observer->set_document_visibility_state_observer([this](VisibilityState visibility_state) {
+        auto sink_predicate_may_query_layout_node = visibility_state == VisibilityState::Hidden || document().layout_is_up_to_date();
+        if (sink_predicate_may_query_layout_node)
+            sync_video_sink_ticking();
+    });
+
     document().page().register_media_element({}, unique_id());
 }
 
@@ -1790,6 +1796,8 @@ void HTMLMediaElement::attach_selected_video_track_sink(Media::Track const& trac
     m_active_video_sink = make<ActiveVideoSink>(handle, Painting::allocate_video_sink_resource_id());
     m_video_sink_is_ticking = true;
     add_current_video_sink(handle);
+    if (document().hidden())
+        sync_video_sink_ticking();
 }
 
 void HTMLMediaElement::add_current_video_sink(Media::VideoSinkHandle handle)

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1133,6 +1133,11 @@ bool Internals::media_element_is_playing_audio(HTML::HTMLMediaElement& element)
     return element.is_playing_audio();
 }
 
+bool Internals::media_element_video_sink_is_ticking(HTML::HTMLMediaElement& element)
+{
+    return element.m_video_sink_is_ticking;
+}
+
 void Internals::set_media_element_ready_state(HTML::HTMLMediaElement& element, u16 ready_state)
 {
     if (ready_state > to_underlying(HTML::HTMLMediaElement::ReadyState::HaveEnoughData))

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -205,6 +205,7 @@ public:
     WebIDL::ExceptionOr<GC::Ref<JS::Object>> image_animation_state_for_url(Utf16String const& url);
     bool media_element_is_fetching(HTML::HTMLMediaElement&);
     bool media_element_is_playing_audio(HTML::HTMLMediaElement&);
+    bool media_element_video_sink_is_ticking(HTML::HTMLMediaElement&);
     void set_media_element_ready_state(HTML::HTMLMediaElement&, u16 ready_state);
     void set_media_element_paused(HTML::HTMLMediaElement&, bool paused);
     void set_media_element_seeking(HTML::HTMLMediaElement&, bool seeking);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -209,6 +209,7 @@ interface Internals {
     object imageAnimationStateForURL(Utf16USVString url);
     boolean mediaElementIsFetching(HTMLMediaElement element);
     boolean mediaElementIsPlayingAudio(HTMLMediaElement element);
+    boolean mediaElementVideoSinkIsTicking(HTMLMediaElement element);
     undefined setMediaElementReadyState(HTMLMediaElement element, unsigned short readyState);
     undefined setMediaElementPaused(HTMLMediaElement element, boolean paused);
     undefined setMediaElementSeeking(HTMLMediaElement element, boolean seeking);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1079,6 +1079,18 @@ void Application::update_compositor_display_metadata(Web::Compositor::Compositor
     m_compositor_client->async_set_display_metadata(context_id, display_id, sanitized_display_refresh_rate(refresh_rate));
 }
 
+void Application::update_compositor_context_visibility(Web::Compositor::CompositorContextId context_id, Web::HTML::VisibilityState visibility_state)
+{
+    if (!can_send_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    auto context_visibility = visibility_state == Web::HTML::VisibilityState::Visible
+        ? Web::Compositor::ContextVisibility::Visible
+        : Web::Compositor::ContextVisibility::Hidden;
+    m_compositor_client->async_set_context_visibility(context_id, context_visibility);
+}
+
 bool Application::send_async_scroll_to_compositor(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
     if (!can_send_compositor_process_ipc(m_compositor_client))

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -33,6 +33,7 @@
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/BrowserProcess.h>
 #include <LibWebView/DownloadStore.h>
@@ -177,6 +178,7 @@ public:
     ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id);
     void update_compositor_viewport(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress = Web::Compositor::WindowResizingInProgress::No);
     void update_compositor_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
+    void update_compositor_context_visibility(Web::Compositor::CompositorContextId, Web::HTML::VisibilityState);
     bool send_async_scroll_to_compositor(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     bool handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     bool handle_pinch_event_in_compositor(Web::Compositor::CompositorContextId, Web::PinchEvent const&);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -324,6 +324,7 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
             navigable.remote_host_client().async_set_system_visibility_state(navigable.remote_host_page_id(), visibility_state);
         return IterationDecision::Continue;
     });
+    Application::the().update_compositor_context_visibility(client().compositor_context_id_for_page(m_client_state.page_index), visibility_state);
 }
 
 void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)
@@ -1865,6 +1866,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
     client().async_set_system_visibility_state(m_client_state.page_index, m_top_level_traversable.system_visibility_state());
     auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
     Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
+    Application::the().update_compositor_context_visibility(compositor_context_id, m_top_level_traversable.system_visibility_state());
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);
 
     client().async_set_page_mute_state(m_client_state.page_index, m_mute_state);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -319,6 +319,11 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
 
     m_top_level_traversable.set_system_visibility_state(visibility_state);
     client().async_set_system_visibility_state(m_client_state.page_index, visibility_state);
+    m_top_level_traversable.for_each_in_subtree([&](CanonicalNavigable& navigable) {
+        if (navigable.has_remote_host())
+            navigable.remote_host_client().async_set_system_visibility_state(navigable.remote_host_page_id(), visibility_state);
+        return IterationDecision::Continue;
+    });
 }
 
 void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHistoryBehavior history_handling)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -539,7 +539,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
             child_frame->device_pixel_ratio(),
             Web::ViewportIsFullscreen::No);
     }
-    remote_client->async_set_system_visibility_state(remote_page_id, Web::HTML::VisibilityState::Visible);
+    remote_client->async_set_system_visibility_state(remote_page_id, child_frame->top_level_traversable().system_visibility_state());
     remote_client->async_load_url_with_document_resource(remote_page_id, url, move(document_resource), history_handling, move(source_snapshot));
 
     SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -376,6 +376,7 @@ void WebContentClient::replay_compositor_view_state_after_reconnect(Badge<Applic
             continue;
         Application::the().update_compositor_viewport(context_id, view->viewport_size().to_type<int>());
         Application::the().update_compositor_display_metadata(context_id, view->display_id(), view->maximum_frames_per_second());
+        Application::the().update_compositor_context_visibility(context_id, view->traversable().system_visibility_state());
     }
 }
 

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(Compositor PRIVATE compositorservice LibCore LibMain LibSa
 target_link_libraries(compositorservice PRIVATE LibCore LibGfx LibIPC LibMedia LibSync LibWeb ${ANGLE_TARGETS} skia)
 
 if (APPLE)
-    target_link_libraries(Compositor PRIVATE "-framework CoreGraphics" "-framework CoreVideo")
+    target_link_libraries(compositorservice PUBLIC "-framework CoreGraphics" "-framework CoreVideo")
 endif()
 
 if (WIN32)

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -22,5 +22,6 @@ endpoint CompositorControlServer
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
     presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id) =|
     set_client_gpu_presentation_capability(bool supported, u64 adapter_luid) =|
+    set_context_visibility(Web::Compositor::CompositorContextId context_id, Web::Compositor::ContextVisibility visibility) =|
     crash() =|
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -260,6 +260,8 @@ void CompositorState::present_contexts_drawing_video_sink(CompositorStateWebCont
         auto& context = *context_entry.value;
         if (&context.web_content_client() != &client)
             continue;
+        if (!context_is_effectively_visible(context))
+            continue;
         for (auto const& resource_entry : context.video_sink_handles()) {
             if (resource_entry.value == handle) {
                 if (auto rect = context.video_present_rect(); rect.has_value())
@@ -344,6 +346,8 @@ void CompositorState::update_video_sinks_for_display(Optional<u64> display_id)
         auto& context = *context_entry.value;
         if (display_id_for_context(context) != display_id)
             continue;
+        if (!context_is_effectively_visible(context))
+            continue;
         for (auto const& resource_entry : context.video_sink_handles()) {
             auto* sink_state = video_sink_state(context.web_content_client(), resource_entry.value);
             if (sink_state != nullptr && sink_state->requires_updates) {
@@ -366,6 +370,25 @@ Optional<u64> CompositorState::display_id_for_context(ContextState const& contex
         current_context = context_if_present(*parent_context_id);
     }
     return {};
+}
+
+ContextState const* CompositorState::root_context_of(ContextState const& context) const
+{
+    auto const* current_context = &context;
+    while (true) {
+        auto parent_context_id = current_context->parent_context_id();
+        if (!parent_context_id.has_value())
+            return current_context;
+        auto const* parent_context = context_if_present(*parent_context_id);
+        if (!parent_context)
+            return current_context;
+        current_context = parent_context;
+    }
+}
+
+bool CompositorState::context_is_effectively_visible(ContextState const& context) const
+{
+    return root_context_of(context)->visibility() == Web::Compositor::ContextVisibility::Visible;
 }
 
 double CompositorState::display_refresh_rate_for_context(ContextState const& context) const
@@ -502,6 +525,37 @@ void CompositorState::set_display_metadata(Web::Compositor::CompositorContextId 
     }
 }
 
+void CompositorState::set_context_visibility(Web::Compositor::CompositorContextId context_id, Web::Compositor::ContextVisibility visibility)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+    if (!context->set_visibility(visibility))
+        return;
+
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Context {} became {}", context_id, visibility == Web::Compositor::ContextVisibility::Visible ? "visible" : "hidden");
+
+    if (visibility == Web::Compositor::ContextVisibility::Visible)
+        resume_presentation_after_becoming_visible(context_id, *context);
+}
+
+void CompositorState::resume_presentation_after_becoming_visible(Web::Compositor::CompositorContextId root_context_id, ContextState& root_context)
+{
+    for (auto& context_entry : m_contexts) {
+        auto& context = *context_entry.value;
+        if (root_context_of(context) != &root_context)
+            continue;
+        if (context.has_active_smooth_scroll_animations())
+            vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
+    }
+
+    auto frame_rect_to_present = root_context.pending_present_frame_viewport_rect();
+    if (!frame_rect_to_present.has_value())
+        frame_rect_to_present = root_context.current_frame_rect_to_present();
+    if (frame_rect_to_present.has_value())
+        schedule_present_frame(root_context_id, root_context, *frame_rect_to_present);
+}
+
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
 {
     auto* context = context_if_present(context_id);
@@ -563,7 +617,7 @@ void CompositorState::schedule_pending_present_frame(Web::Compositor::Compositor
         // may already be up to date (and therefore not schedule a new present),
         // so explicitly keep the effective display's scheduler ticking while
         // a nested smooth scroll is active.
-        if (context.has_active_smooth_scroll_animations())
+        if (context.has_active_smooth_scroll_animations() && context_is_effectively_visible(context))
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
         return;
     }
@@ -573,6 +627,8 @@ void CompositorState::schedule_pending_present_frame(Web::Compositor::Compositor
 
 void CompositorState::schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState& context)
 {
+    if (!context_is_effectively_visible(context))
+        return;
     context.mark_pending_present_frame_scheduled();
     vsync_scheduler_for_display(context.display_id()).schedule(context.display_refresh_rate());
 }
@@ -613,6 +669,10 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
     for (auto& context_entry : m_contexts) {
         auto context_id = context_entry.key;
         auto& context = *context_entry.value;
+        if (!context_is_effectively_visible(context)) {
+            context.unschedule_pending_present_frame();
+            continue;
+        }
         auto has_active_smooth_scroll_animation_on_display = context.has_active_smooth_scroll_animations() && display_id_for_context(context) == display_id;
         if (!context.has_pending_present_frame_scheduled_on(display_id) && !has_active_smooth_scroll_animation_on_display)
             continue;

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -103,6 +103,7 @@ public:
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
+    void set_context_visibility(Web::Compositor::CompositorContextId, Web::Compositor::ContextVisibility);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
@@ -130,6 +131,9 @@ private:
     ContextState* context_if_present(Web::Compositor::CompositorContextId);
     ContextState const* context_if_present(Web::Compositor::CompositorContextId) const;
     Optional<u64> display_id_for_context(ContextState const&) const;
+    ContextState const* root_context_of(ContextState const&) const;
+    bool context_is_effectively_visible(ContextState const&) const;
+    void resume_presentation_after_becoming_visible(Web::Compositor::CompositorContextId root_context_id, ContextState& root_context);
     double display_refresh_rate_for_context(ContextState const&) const;
     void clear_parent_context(ContextState&);
     CompositedContextResolver resolver_for(Web::Compositor::CompositorContextId parent_context_id);

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -83,6 +83,11 @@ void ConnectionFromClient::set_display_metadata(Web::Compositor::CompositorConte
     m_compositor_state->set_display_metadata(context_id, display_id, refresh_rate);
 }
 
+void ConnectionFromClient::set_context_visibility(Web::Compositor::CompositorContextId context_id, Web::Compositor::ContextVisibility visibility)
+{
+    m_compositor_state->set_context_visibility(context_id, visibility);
+}
+
 Messages::CompositorControlServer::HandleMouseEventResponse ConnectionFromClient::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
 {
     return m_compositor_state->handle_mouse_event(context_id, event);

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -40,6 +40,7 @@ private:
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, i32 web_content_connection_id) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
     virtual void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64>, double) override;
+    virtual void set_context_visibility(Web::Compositor::CompositorContextId, Web::Compositor::ContextVisibility) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::HandlePinchEventResponse handle_pinch_event(Web::Compositor::CompositorContextId, Web::PinchEvent) override;

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -643,6 +643,21 @@ bool ContextState::set_display_metadata(Optional<u64> display_id, double refresh
     return m_pending_present_frame_scheduled;
 }
 
+bool ContextState::set_visibility(Web::Compositor::ContextVisibility visibility)
+{
+    if (m_visibility == visibility)
+        return false;
+    m_visibility = visibility;
+    return true;
+}
+
+Optional<Gfx::IntRect> ContextState::pending_present_frame_viewport_rect() const
+{
+    if (!m_pending_present_frame.has_value())
+        return {};
+    return m_pending_present_frame->viewport_rect;
+}
+
 void ContextState::queue_present_frame(PendingFrame pending_frame)
 {
     if (!m_pending_present_frame.has_value()) {

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -134,9 +134,13 @@ public:
     bool set_display_metadata(Optional<u64> display_id, double refresh_rate);
     Optional<u64> display_id() const { return m_display_id; }
     double display_refresh_rate() const { return m_display_refresh_rate; }
+    bool set_visibility(Web::Compositor::ContextVisibility);
+    Web::Compositor::ContextVisibility visibility() const { return m_visibility; }
 
     void queue_present_frame(PendingFrame);
+    Optional<Gfx::IntRect> pending_present_frame_viewport_rect() const;
     void mark_pending_present_frame_scheduled();
+    void unschedule_pending_present_frame() { m_pending_present_frame_scheduled = false; }
     bool has_pending_present_frame_scheduled_on(Optional<u64> display_id) const;
     bool can_schedule_pending_present_frame_if_unblocked() const;
     Optional<PendingFrame> take_pending_present_frame_if_unblocked();
@@ -216,6 +220,7 @@ private:
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
     Optional<u64> m_display_id;
     double m_display_refresh_rate { 60.0 };
+    Web::Compositor::ContextVisibility m_visibility { Web::Compositor::ContextVisibility::Visible };
 
     Optional<PendingFrame> m_pending_present_frame;
     bool m_pending_present_frame_scheduled { false };

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -8,6 +8,8 @@
 #include <AK/Queue.h>
 #include <AK/Stream.h>
 #include <Compositor/CompositorState.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/Message.h>
@@ -21,6 +23,36 @@ struct TestWebContentClient final : public Compositor::CompositorStateWebContent
     virtual void create_video_edge(Media::VideoSinkHandle) override { }
     virtual void release_video_edge(Media::VideoSinkHandle) override { }
 };
+
+struct TestCompositorClient final : public Compositor::CompositorStateClient {
+    struct PresentedFrame {
+        Gfx::IntRect content_rect;
+        Gfx::IntRect damage_rect;
+        i32 bitmap_id { 0 };
+    };
+
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage>&&) override
+    {
+        allocated_bitmap_ids = move(bitmap_ids);
+    }
+
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override
+    {
+        presented_frames.append({ content_rect, damage_rect, bitmap_id });
+    }
+
+    Vector<i32> allocated_bitmap_ids;
+    Vector<PresentedFrame> presented_frames;
+};
+
+static bool spin_event_loop_until(Core::EventLoop& event_loop, int timeout_in_milliseconds, Function<bool()> condition)
+{
+    bool timed_out = false;
+    auto timeout_timer = Core::Timer::create_single_shot(timeout_in_milliseconds, [&] { timed_out = true; });
+    timeout_timer->start();
+    event_loop.spin_until([&] { return timed_out || condition(); });
+    return !timed_out;
+}
 
 template<Web::Painting::DisplayListCommand Command>
 static void append_display_list_command(ByteBuffer& command_bytes, Command const& command, bool context_geometry_only, Optional<Gfx::IntRect> bounding_rect = {})
@@ -225,4 +257,59 @@ TEST_CASE(viewport_scrollbar_drag_ignores_non_primary_mouse_up)
     // The primary-button drag remains captured after another button is released.
     EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseMove, 50, 60)).accepted);
     EXPECT(context.handle_mouse_event(mouse_event(Web::MouseEvent::Type::MouseUp, 50, 60, Web::UIEvents::MouseButton::Primary)).accepted);
+}
+
+TEST_CASE(context_visibility_and_pending_frame_state)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 1, client, canvas_surface_registry, false };
+    auto viewport_rect = Gfx::IntRect { 0, 0, 4, 4 };
+
+    EXPECT(!context.set_visibility(Web::Compositor::ContextVisibility::Visible));
+    EXPECT(context.set_visibility(Web::Compositor::ContextVisibility::Hidden));
+    EXPECT(!context.set_visibility(Web::Compositor::ContextVisibility::Hidden));
+    EXPECT(context.set_visibility(Web::Compositor::ContextVisibility::Visible));
+    EXPECT(!context.pending_present_frame_viewport_rect().has_value());
+
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.queue_present_frame({ viewport_rect, { 0, 0, 2, 2 } });
+    EXPECT_EQ(context.pending_present_frame_viewport_rect(), viewport_rect);
+    EXPECT(context.can_schedule_pending_present_frame_if_unblocked());
+    context.mark_pending_present_frame_scheduled();
+    EXPECT(!context.can_schedule_pending_present_frame_if_unblocked());
+    context.unschedule_pending_present_frame();
+    EXPECT(context.can_schedule_pending_present_frame_if_unblocked());
+}
+
+TEST_CASE(hidden_context_coalesces_presents_and_presents_once_when_shown)
+{
+    Core::EventLoop event_loop;
+    TestCompositorClient compositor_client;
+    TestWebContentClient web_content_client;
+    auto compositor_state = Compositor::CompositorState::create({}, false);
+    compositor_state->set_client(compositor_client);
+
+    u64 page_id = 1;
+    auto context_id = Web::Compositor::compositor_context_id_for_page(page_id);
+    auto viewport_rect = Gfx::IntRect { 0, 0, 4, 4 };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+
+    compositor_state->create_context(context_id, page_id, web_content_client);
+    compositor_state->viewport_size_updated(context_id, viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    EXPECT(!compositor_client.allocated_bitmap_ids.is_empty());
+    compositor_state->update_display_list(context_id, make_display_list(visual_context_tree, Gfx::Color::Red), visual_context_tree, {}, {});
+
+    compositor_state->set_context_visibility(context_id, Web::Compositor::ContextVisibility::Hidden);
+    compositor_state->present_frame(context_id, viewport_rect, { 0, 0, 2, 2 });
+    compositor_state->present_frame(context_id, viewport_rect, { 2, 2, 2, 2 });
+    compositor_state->presented_bitmap_ready_to_paint(context_id, compositor_client.allocated_bitmap_ids[0]);
+    EXPECT(!spin_event_loop_until(event_loop, 100, [&] { return !compositor_client.presented_frames.is_empty(); }));
+
+    compositor_state->set_context_visibility(context_id, Web::Compositor::ContextVisibility::Visible);
+    EXPECT(spin_event_loop_until(event_loop, 2000, [&] { return !compositor_client.presented_frames.is_empty(); }));
+    EXPECT(!spin_event_loop_until(event_loop, 100, [&] { return compositor_client.presented_frames.size() > 1; }));
+    EXPECT_EQ(compositor_client.presented_frames.size(), 1u);
+    EXPECT_EQ(compositor_client.presented_frames[0].damage_rect, viewport_rect);
 }

--- a/Tests/LibWeb/Text/expected/HTML/video-sink-stops-ticking-when-page-hidden.txt
+++ b/Tests/LibWeb/Text/expected/HTML/video-sink-stops-ticking-when-page-hidden.txt
@@ -1,0 +1,6 @@
+ticking while visible: true
+document.hidden: true
+ticking while hidden: false
+ticking for a sink created while hidden: false
+ticking after becoming visible: true
+ticking for the late sink after two frames: true

--- a/Tests/LibWeb/Text/input/HTML/video-sink-stops-ticking-when-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-sink-stops-ticking-when-page-hidden.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<video id="video" muted loop></video>
+<script>
+    const video = document.getElementById("video");
+
+    function nextVisibilityChange() {
+        return new Promise(resolve => document.addEventListener("visibilitychange", resolve, { once: true }));
+    }
+
+    asyncTest(async done => {
+        video.src = "../../../Assets/test-webm.webm";
+        await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
+        await video.play();
+        await animationFrame();
+        println(`ticking while visible: ${internals.mediaElementVideoSinkIsTicking(video)}`);
+
+        let visibilityChanged = nextVisibilityChange();
+        internals.setSystemVisibilityState("hidden");
+        await visibilityChanged;
+        println(`document.hidden: ${document.hidden}`);
+        println(`ticking while hidden: ${internals.mediaElementVideoSinkIsTicking(video)}`);
+
+        const videoCreatedWhileHidden = document.createElement("video");
+        videoCreatedWhileHidden.muted = true;
+        videoCreatedWhileHidden.src = "../../../Assets/test-webm.webm";
+        await new Promise(resolve => videoCreatedWhileHidden.addEventListener("loadedmetadata", resolve, { once: true }));
+        println(`ticking for a sink created while hidden: ${internals.mediaElementVideoSinkIsTicking(videoCreatedWhileHidden)}`);
+
+        video.getBoundingClientRect();
+        visibilityChanged = nextVisibilityChange();
+        internals.setSystemVisibilityState("visible");
+        await visibilityChanged;
+        println(`ticking after becoming visible: ${internals.mediaElementVideoSinkIsTicking(video)}`);
+        document.body.appendChild(videoCreatedWhileHidden);
+        await animationFrame();
+        await animationFrame();
+        println(`ticking for the late sink after two frames: ${internals.mediaElementVideoSinkIsTicking(videoCreatedWhileHidden)}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
- LibWeb: re-evaluate video sink ticking when document visibility changes.
  The predicate already checked visibility but only ran from the rendering
  update, which hidden documents skip; sinks created in already-hidden
  documents also started ticking. Adds internals.mediaElementVideoSinkIsTicking()
  and a Text test.
- LibWebView: forward the system visibility state to out-of-process child
  frames instead of hardcoding them to Visible.
- Compositor: add a UI->Compositor per-context visibility bit, inherited
  through parent chains. Hidden contexts keep coalescing pending damage but
  never rasterize, advance smooth scrolling, keep vsync alive, or schedule
  presents for arriving video frames. The last point is why the WebContent
  fix alone is not enough: DisplayingVideoSink frame-arrival wakeups request
  presents regardless of the ticking flag. Showing a context schedules one
  full-damage present. Unit tests cover the state and the coalesce/show path.