### PR TITLE
LibGfx+LibWeb: Use the first available font for metrics

### DIFF
--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -113,23 +113,19 @@ Gfx::Font const& FontCascadeList::first_available_font() const
     return *m_first_available_font_cache;
 }
 
-Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, TriggerPendingLoads trigger_pending_loads, EmojiPresentationResult emoji_presentation) const
+Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, EmojiPresentationResult emoji_presentation) const
 {
-    // Only the text-shaping paths pass TriggerPendingLoads::Yes. Probes that don't lead to a glyph being drawn skip
-    // this block so they can't initiate a download for a subset face that happens to cover the probe codepoint.
-    if (trigger_pending_loads == TriggerPendingLoads::Yes) {
-        // Walk pending entries first: if this codepoint falls in an unloaded face's unicode-range we kick off the
-        // fetch and drop the entry — a fallback font that happens to cover the codepoint shouldn't prevent the real
-        // face from loading. FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch completes,
-        // so later shapes pick up the loaded face. Run before the ASCII cache lookup so a previously-cached codepoint
-        // still triggers a newly-added face.
-        m_pending_faces.remove_all_matching([code_point](auto const& pending) {
-            if (!pending->covers(code_point))
-                return false;
-            pending->start_load();
-            return true;
-        });
-    }
+    // Walk pending entries first: if this codepoint falls in an unloaded face's unicode-range we kick off the fetch
+    // and drop the entry — a fallback font that happens to cover the codepoint shouldn't prevent the real face from
+    // loading. FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch completes, so later
+    // shapes pick up the loaded face. Run before the ASCII cache lookup so a previously-cached codepoint still
+    // triggers a newly-added face.
+    m_pending_faces.remove_all_matching([code_point](auto const& pending) {
+        if (!pending->covers(code_point))
+            return false;
+        pending->start_load();
+        return true;
+    });
 
     auto use_ascii_cache = code_point < m_ascii_cache.size() && emoji_presentation.presentation == EmojiPresentation::Text && emoji_presentation.forced == ForcedPresentation::No;
     if (use_ascii_cache) {
@@ -210,20 +206,19 @@ bool FontCascadeList::equals(FontCascadeList const& other) const
 }
 
 extern "C" {
-void const* ladybird_gfx_font_cascade_list_font_for_code_point(void const*, u32, bool, bool, bool);
+void const* ladybird_gfx_font_cascade_list_font_for_code_point(void const*, u32, bool, bool);
 void const* ladybird_gfx_font_cascade_list_first(void const*);
 void ladybird_gfx_font_cascade_list_ref(void const*);
 void ladybird_gfx_font_cascade_list_unref(void const*);
 u8 ladybird_gfx_emoji_presentation_for_code_point(u32, u32, bool);
 }
 
-extern "C" void const* ladybird_gfx_font_cascade_list_font_for_code_point(void const* list, u32 code_point, bool trigger_pending_loads, bool emoji_presentation, bool forced_presentation)
+extern "C" void const* ladybird_gfx_font_cascade_list_font_for_code_point(void const* list, u32 code_point, bool emoji_presentation, bool forced_presentation)
 {
     VERIFY(list);
     auto const& cascade_list = *static_cast<Gfx::FontCascadeList const*>(list);
     return &cascade_list.font_for_code_point(
         code_point,
-        trigger_pending_loads ? Gfx::FontCascadeList::TriggerPendingLoads::Yes : Gfx::FontCascadeList::TriggerPendingLoads::No,
         { emoji_presentation ? Gfx::EmojiPresentation::Emoji : Gfx::EmojiPresentation::Text,
             forced_presentation ? Gfx::ForcedPresentation::Yes : Gfx::ForcedPresentation::No });
 }

--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -25,11 +25,13 @@ EmojiPresentationResult emoji_presentation_for_code_point(u32 code_point, Option
 
 void FontCascadeList::add(NonnullRefPtr<Font const> font)
 {
+    m_first_available_font_cache = nullptr;
     m_fonts.append({ move(font), {} });
 }
 
 void FontCascadeList::add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> unicode_ranges)
 {
+    m_first_available_font_cache = nullptr;
     if (unicode_ranges.is_empty()) {
         m_fonts.append({ move(font), {} });
         return;
@@ -69,6 +71,7 @@ void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Func
 
 void FontCascadeList::extend(FontCascadeList const& other)
 {
+    m_first_available_font_cache = nullptr;
     m_fonts.extend(other.m_fonts);
     m_pending_faces.extend(other.m_pending_faces);
 }
@@ -78,20 +81,48 @@ void FontCascadeList::extend_fallback(FontCascadeList const& other)
     m_fallback_fonts.extend(other.m_fonts);
 }
 
+// https://drafts.csswg.org/css-fonts/#first-available-font
+Gfx::Font const& FontCascadeList::first_available_font() const
+{
+    if (m_first_available_font_cache)
+        return *m_first_available_font_cache;
+
+    // The first available font, used for example in the definition of font-relative lengths such as ex or in the
+    // definition of the line-height property, is defined to be the first font for which the character U+0020 (space)
+    // is not excluded by a unicode-range, given the font families in the font-family list (or a user agent’s default
+    // font if none are available).
+    static constexpr u32 space_code_point = 0x20;
+
+    for (auto const& entry : m_fonts) {
+        if (!entry.range_data.has_value()) {
+            m_first_available_font_cache = entry.font.ptr();
+            return *m_first_available_font_cache;
+        }
+        if (!entry.range_data->enclosing_range.contains(space_code_point))
+            continue;
+
+        for (auto const& range : entry.range_data->unicode_ranges) {
+            if (range.contains(space_code_point)) {
+                m_first_available_font_cache = entry.font.ptr();
+                return *m_first_available_font_cache;
+            }
+        }
+    }
+
+    m_first_available_font_cache = m_last_resort_font.ptr();
+    return *m_first_available_font_cache;
+}
+
 Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, TriggerPendingLoads trigger_pending_loads, EmojiPresentationResult emoji_presentation) const
 {
-    // Only the text-shaping paths pass TriggerPendingLoads::Yes. Probes that don't
-    // lead to a glyph being drawn (the U+0020 check used to compute first-available-
-    // font metrics, for instance) skip this block so they can't initiate a download
-    // for a subset face that happens to cover the probe codepoint.
+    // Only the text-shaping paths pass TriggerPendingLoads::Yes. Probes that don't lead to a glyph being drawn skip
+    // this block so they can't initiate a download for a subset face that happens to cover the probe codepoint.
     if (trigger_pending_loads == TriggerPendingLoads::Yes) {
-        // Walk pending entries first: if this codepoint falls in an unloaded face's
-        // unicode-range we kick off the fetch and drop the entry — a fallback font
-        // that happens to cover the codepoint shouldn't prevent the real face from
-        // loading. FontComputer::clear_computed_font_cache() rebuilds the cascade
-        // once the fetch completes, so later shapes pick up the loaded face. Run
-        // before the ASCII cache lookup so a previously-cached codepoint still
-        // triggers a newly-added face.
+        // Walk pending entries first: if this codepoint falls in an unloaded face's unicode-range we kick off the
+        // fetch and drop the entry — a fallback font that happens to cover the codepoint shouldn't prevent the real
+        // face from loading. FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch completes,
+        // so later shapes pick up the loaded face. Run before the ASCII cache lookup so a previously-cached codepoint
+        // still triggers a newly-added face.
         m_pending_faces.remove_all_matching([code_point](auto const& pending) {
             if (!pending->covers(code_point))
                 return false;

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -62,15 +62,7 @@ public:
     void extend_fallback(FontCascadeList const& other);
 
     Gfx::Font const& first_available_font() const;
-
-    // A pending-face fetch should only be initiated for codepoints that are actually being shaped into glyph runs.
-    // Callers that merely probe the cascade pass TriggerPendingLoads::No so that probing does not kick off downloads
-    // for subset faces that cover the point.
-    enum class TriggerPendingLoads : u8 {
-        No,
-        Yes,
-    };
-    Gfx::Font const& font_for_code_point(u32 code_point, TriggerPendingLoads = TriggerPendingLoads::No, EmojiPresentationResult = {}) const;
+    Gfx::Font const& font_for_code_point(u32 code_point, EmojiPresentationResult = {}) const;
 
     bool equals(FontCascadeList const& other) const;
 

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -61,10 +61,11 @@ public:
 
     void extend_fallback(FontCascadeList const& other);
 
-    // A pending-face fetch should only be initiated for codepoints that are actually
-    // being shaped into glyph runs. Callers that merely probe the cascade (e.g. the
-    // U+0020 check in "first available font" metrics) pass No so that probing does
-    // not kick off downloads for subset faces that happen to cover the probe point.
+    Gfx::Font const& first_available_font() const;
+
+    // A pending-face fetch should only be initiated for codepoints that are actually being shaped into glyph runs.
+    // Callers that merely probe the cascade pass TriggerPendingLoads::No so that probing does not kick off downloads
+    // for subset faces that cover the point.
     enum class TriggerPendingLoads : u8 {
         No,
         Yes,
@@ -112,7 +113,11 @@ public:
         Function<void()> m_start_load;
     };
 
-    void set_last_resort_font(NonnullRefPtr<Font> font) { m_last_resort_font = move(font); }
+    void set_last_resort_font(NonnullRefPtr<Font> font)
+    {
+        m_first_available_font_cache = nullptr;
+        m_last_resort_font = move(font);
+    }
     void set_system_font_fallback_callback(SystemFontFallbackCallback callback) { m_system_font_fallback_callback = move(callback); }
 
 private:
@@ -125,6 +130,9 @@ private:
     // OPTIMIZATION: Cache of resolved fonts for ASCII code points. Since m_fonts only grows and the cascade returns
     //               the first matching font, a cached hit can never become stale.
     mutable Array<Font const*, 128> m_ascii_cache {};
+
+    // This cannot share m_ascii_cache because the first available font does not need to contain a space glyph.
+    mutable Font const* m_first_available_font_cache { nullptr };
 };
 
 }

--- a/Libraries/LibGfx/Rust/src/font.rs
+++ b/Libraries/LibGfx/Rust/src/font.rs
@@ -19,7 +19,6 @@ unsafe extern "C" {
     fn ladybird_gfx_font_cascade_list_font_for_code_point(
         list: *const c_void,
         code_point: u32,
-        trigger_pending_loads: bool,
         emoji_presentation: bool,
         forced_presentation: bool,
     ) -> *const c_void;
@@ -164,12 +163,7 @@ impl<'a> FontCascadeListRef<'a> {
         }
     }
 
-    pub fn font_for_code_point(
-        self,
-        code_point: u32,
-        trigger_pending_loads: bool,
-        presentation: EmojiPresentation,
-    ) -> FontRef<'a> {
+    pub fn font_for_code_point(self, code_point: u32, presentation: EmojiPresentation) -> FontRef<'a> {
         // SAFETY: The constructor requires the Gfx::FontCascadeList to remain
         // live for this reference's lifetime, and the fonts it resolves are
         // owned by it.
@@ -177,7 +171,6 @@ impl<'a> FontCascadeListRef<'a> {
             FontRef::from_raw(ladybird_gfx_font_cascade_list_font_for_code_point(
                 self.raw.as_ptr(),
                 code_point,
-                trigger_pending_loads,
                 presentation.is_emoji,
                 presentation.forced,
             ))

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -406,7 +406,7 @@ Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View 
 
     auto it = string.begin();
     auto substring_begin_offset = string.iterator_offset(it);
-    Font const* last_font = &font_cascade_list.font_for_code_point(*it, FontCascadeList::TriggerPendingLoads::Yes);
+    Font const* last_font = &font_cascade_list.font_for_code_point(*it);
     FloatPoint last_position = baseline_start;
 
     auto add_run = [&runs, &last_position, letter_spacing](Utf16View const& string, Font const& font) {
@@ -417,7 +417,7 @@ Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View 
 
     while (it != string.end()) {
         auto code_point = *it;
-        auto const* font = &font_cascade_list.font_for_code_point(code_point, FontCascadeList::TriggerPendingLoads::Yes);
+        auto const* font = &font_cascade_list.font_for_code_point(code_point);
         if (font != last_font) {
             auto substring = string.substring_view(substring_begin_offset, string.iterator_offset(it) - substring_begin_offset);
             add_run(substring, *last_font);

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -1283,12 +1283,8 @@ ValueComparingNonnullRefPtr<Gfx::FontCascadeList const> ComputedStyleWorkingSet:
 
 ValueComparingNonnullRefPtr<Gfx::Font const> ComputedStyleWorkingSet::first_available_computed_font(FontComputer const& font_computer) const
 {
-    if (!m_cached_first_available_computed_font) {
-        // https://drafts.csswg.org/css-fonts/#first-available-font
-        // First font for which the character U+0020 (space) is not excluded by a unicode-range
-        m_cached_first_available_computed_font = computed_font_list(font_computer)->font_for_code_point(' ');
-    }
-
+    if (!m_cached_first_available_computed_font)
+        m_cached_first_available_computed_font = computed_font_list(font_computer)->first_available_font();
     return *m_cached_first_available_computed_font;
 }
 

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -1630,7 +1630,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create_internal(ComputedStyl
     if (applies(StyleGroupIndex::FontValues)) {
         auto font_list = computed_style.computed_font_list(document.font_computer());
         document.font_computer().pin_font_list_for_style_record(font_list);
-        auto const& first_available_font = font_list->font_for_code_point(' ');
+        auto const& first_available_font = font_list->first_available_font();
         auto const metrics = first_available_font.pixel_metrics();
         auto math_shift = keyword_to_math_shift(computed_style.property(PropertyID::MathShift).to_keyword()).release_value();
         auto math_style = keyword_to_math_style(computed_style.property(PropertyID::MathStyle).to_keyword()).release_value();

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -219,8 +219,8 @@ Length::ResolutionContext Length::ResolutionContext::for_element(DOM::AbstractEl
 
     return Length::ResolutionContext {
         .viewport_rect = element.element().navigable()->viewport_rect(),
-        .font_metrics = { computed_values.font_size(), computed_values.font_list().font_for_code_point(' ').pixel_metrics(), computed_values.line_height() },
-        .root_font_metrics = { root_computed_values->font_size(), root_computed_values->font_list().font_for_code_point(' ').pixel_metrics(), root_computed_values->line_height() },
+        .font_metrics = { computed_values.font_size(), computed_values.font_list().first_available_font().pixel_metrics(), computed_values.line_height() },
+        .root_font_metrics = { root_computed_values->font_size(), root_computed_values->font_list().first_available_font().pixel_metrics(), root_computed_values->line_height() },
         .font_metrics_depend_on_viewport_metrics = computed_values.font_metrics_depend_on_viewport_metrics(),
         .root_font_metrics_depend_on_viewport_metrics = root_computed_values->font_metrics_depend_on_viewport_metrics(),
         .subject_inline_axis_is_horizontal = inline_axis_is_horizontal(computed_values.writing_mode()),

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.cpp
@@ -62,7 +62,7 @@ CSS::ComputationContext CanvasState::computation_context_for_drawing_state() con
         }
 
         VERIFY(m_drawing_state.current_font_cascade_list);
-        auto const& first_font = m_drawing_state.current_font_cascade_list->font_for_code_point(' ');
+        auto const& first_font = m_drawing_state.current_font_cascade_list->first_available_font();
         auto const& font_size = m_drawing_state.font_style_value->as_shorthand().longhand(CSS::PropertyID::FontSize)->as_length().length().absolute_length_to_px();
 
         return CSS::Length::FontMetrics { font_size, first_font.pixel_metrics(), CSS::InitialValues::line_height() };

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -784,9 +784,7 @@ inline NodeWithStyle* Node::parent()
 
 inline Gfx::Font const& NodeWithStyle::first_available_font() const
 {
-    // https://drafts.csswg.org/css-fonts/#first-available-font
-    // First font for which the character U+0020 (space) is not excluded by a unicode-range
-    return font_list().font_for_code_point(' ');
+    return font_list().first_available_font();
 }
 
 bool overflow_value_makes_box_a_scroll_container(CSS::Overflow overflow);

--- a/Libraries/LibWeb/Rust/src/layout/text_chunker.rs
+++ b/Libraries/LibWeb/Rust/src/layout/text_chunker.rs
@@ -353,7 +353,7 @@ impl<'text> TextChunker<'text> {
             if !is_interword_space(code_point) && code_point != '\t' as u32 && code_point != '\n' as u32 {
                 let font =
                     self.font_cascade_list
-                        .font_for_code_point(code_point, true, self.emoji_presentation_at(i, code_point));
+                        .font_for_code_point(code_point, self.emoji_presentation_at(i, code_point));
                 if !font.is_emoji_font() && has_glyph(font) {
                     return font;
                 }
@@ -366,7 +366,6 @@ impl<'text> TextChunker<'text> {
         // 3. No text around (leading/trailing/all spaces) — pick a font with the glyph from the cascade.
         self.font_cascade_list.font_for_code_point(
             space_code_point,
-            true,
             EmojiPresentation {
                 is_emoji: false,
                 forced: false,
@@ -380,7 +379,6 @@ impl<'text> TextChunker<'text> {
         } else {
             self.font_cascade_list.font_for_code_point(
                 code_point,
-                true,
                 self.emoji_presentation_at(self.current_index, code_point),
             )
         }

--- a/Tests/LibWeb/Layout/expected/first-available-font-can-lack-space-glyph.txt
+++ b/Tests/LibWeb/Layout/expected/first-available-font-can-lack-space-glyph.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 74.03125 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 74.03125 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <div#test> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [0,0 16x20] baseline: 16
+            "A"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,20] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <div#fallback> at [0,20] [0+0+0 800 0+0+0] [0+0+0 27.015625 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [0,20 17.828125x27] baseline: 21.265625
+            "A"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,47.015625] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <div#subset> at [0,47.015625] [0+0+0 800 0+0+0] [0+0+0 27.015625 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [0,47.015625 16x27] baseline: 21.265625
+            "A"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,74.03125] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x74.03125]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x74.03125]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#test) [0,0 800x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
+      PaintableWithLines (BlockContainer<DIV>#fallback) [0,20 800x27.015625]
+      PaintableWithLines (BlockContainer(anonymous)) [0,47.015625 800x0]
+      PaintableWithLines (BlockContainer<DIV>#subset) [0,47.015625 800x27.015625]
+      PaintableWithLines (BlockContainer(anonymous)) [0,74.03125 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x74.03125] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/first-available-font-can-lack-space-glyph.html
+++ b/Tests/LibWeb/Layout/input/first-available-font-can-lack-space-glyph.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+    <head>
+        <style>
+            @font-face {
+                font-family: NoSpace;
+                src: url("../../Assets/HashSansNoSpace.woff");
+            }
+            @font-face {
+                font-family: TallMetrics;
+                src: url("../../Assets/NotoSansEthiopic.woff2");
+            }
+            @font-face {
+                font-family: LettersOnly;
+                src: url("../../Assets/HashSans.woff");
+                unicode-range: U+0041-005A;
+            }
+            body {
+                margin: 0;
+            }
+            #test {
+                font-family: NoSpace, TallMetrics;
+                font-size: 20px;
+                line-height: normal;
+            }
+            #fallback {
+                font-family: TallMetrics;
+                font-size: 20px;
+                line-height: normal;
+            }
+            #subset {
+                font-family: LettersOnly, TallMetrics;
+                font-size: 20px;
+                line-height: normal;
+            }
+        </style>
+    </head>
+    <body>
+        <!-- NoSpace's default unicode-range includes U+0020, so it supplies this
+             line's metrics even though it does not contain a space glyph. -->
+        <div id="test">A</div>
+        <!-- If the first font were incorrectly skipped due to its missing space glyph,
+             the test line would instead have the same tall metrics as this line. -->
+        <div id="fallback">A</div>
+        <!-- LettersOnly supplies the A glyph, but its unicode-range excludes U+0020,
+             so TallMetrics must supply the line metrics. -->
+        <div id="subset">A</div>
+    </body>
+</html>


### PR DESCRIPTION
Choose the first font whose `unicode-range` includes U+0020 when computing font metrics, even when the font has no space glyph. This prevents fallback metrics from shifting icon font glyphs vertically.

claude.ai uses a web font without a space glyph for many of its icons. Using the declared font's metrics keeps those glyphs vertically centered beside their labels.

| Before | After |
|--|--|
| <img width="1658" height="1200" alt="before" src="https://github.com/user-attachments/assets/a008f75f-146e-4df6-a06a-a22dfb68692d" /> | <img width="1658" height="1200" alt="after" src="https://github.com/user-attachments/assets/36ddabc2-4f33-4198-84c0-bd73743a2fa8" /> |


