### PR TITLE
Compute style- and geometry-derived paint facts in Rust

### DIFF
--- a/Libraries/LibGfx/Rust/src/color.rs
+++ b/Libraries/LibGfx/Rust/src/color.rs
@@ -31,6 +31,28 @@ impl Color {
     pub const fn with_alpha(self, alpha: u8) -> Self {
         Self((self.0 & 0x00ff_ffff) | (alpha as u32) << 24)
     }
+    pub fn blend(self, source: Self) -> Self {
+        if self.alpha() == 0 || source.alpha() == 255 {
+            return source;
+        }
+        if source.alpha() == 0 {
+            return self;
+        }
+
+        let destination_alpha = self.alpha() as u32;
+        let source_alpha = source.alpha() as u32;
+        let denominator = 255 * (destination_alpha + source_alpha) - destination_alpha * source_alpha;
+        let blend_channel = |destination: u8, source: u8| {
+            ((destination as u32 * destination_alpha * (255 - source_alpha) + source as u32 * 255 * source_alpha)
+                / denominator) as u8
+        };
+        Self::from_rgba(
+            blend_channel(self.red(), source.red()),
+            blend_channel(self.green(), source.green()),
+            blend_channel(self.blue(), source.blue()),
+            (denominator / 255) as u8,
+        )
+    }
     pub fn with_opacity(self, opacity: f32) -> Self {
         self.with_alpha((self.alpha() as f32 * opacity).round() as u8)
     }

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -128,9 +128,11 @@ static RustFFI::FfiSvgElementFacts build_svg_element_facts(NodeWithStyle const& 
 
     Gfx::AffineTransform element_transform;
     float visible_stroke_width = 0;
+    CSSPixels viewport_percentage_basis = 0;
     if (auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(*dom_node)) {
         element_transform = node.used_svg_element_transform();
         visible_stroke_width = graphics_element->visible_stroke_width();
+        viewport_percentage_basis = graphics_element->viewport_percentage_basis();
     }
 
     SVG::SVGUnits content_units {};
@@ -159,6 +161,7 @@ static RustFFI::FfiSvgElementFacts build_svg_element_facts(NodeWithStyle const& 
         .preserve_aspect_ratio_meet_or_slice = static_cast<u8>(to_underlying(preserve_aspect_ratio.meet_or_slice)),
         .element_transform = to_ffi_affine_transform(element_transform),
         .visible_stroke_width = visible_stroke_width,
+        .viewport_percentage_basis = viewport_percentage_basis,
         .content_units = static_cast<u8>(to_underlying(content_units)),
         .pattern_units = static_cast<u8>(to_underlying(pattern_units)),
         .pattern_width = {

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -26,8 +26,6 @@
 #include <LibWeb/Painting/DocumentPaintState.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/SVG/SVGFilterElement.h>
-#include <LibWeb/SVG/SVGFitToViewBox.h>
-#include <LibWeb/SVG/SVGSVGElement.h>
 
 namespace Web::Painting {
 
@@ -50,41 +48,6 @@ bool body_background_is_propagated_to_root(Layout::NodeWithStyle const& layout_n
     // Reachable at invalidation time, when the root element's layout node may already be detached.
     auto const* html_element = layout_node.document().html_element();
     return html_element && html_element->unsafe_layout_node() && html_element->should_use_body_background_properties();
-}
-
-Layout::Node const* nearest_svg_viewport_of(Layout::Node const& layout_node)
-{
-    for (auto const* ancestor = layout_node.parent(); ancestor; ancestor = ancestor->parent()) {
-        if (svg_viewport_transform(*ancestor).has_value())
-            return ancestor;
-    }
-    return nullptr;
-}
-
-// active_view_box covers <view> redirection and the svg-as-image fallback viewBox, which
-// layout used to build the geometry these callers interpret.
-static Gfx::FloatRect svg_svg_box_view_box_or_viewport_rect(Layout::Box const& svg_svg_box)
-{
-    if (auto view_box = as<SVG::SVGSVGElement>(*svg_svg_box.dom_node()).active_view_box(); view_box.has_value())
-        return { view_box->min_x, view_box->min_y, view_box->width, view_box->height };
-    if (has_committed_box(svg_svg_box)) {
-        auto size = svg_viewport_size(svg_svg_box);
-        return { {}, { size.width().to_float(), size.height().to_float() } };
-    }
-    return {};
-}
-
-Gfx::FloatRect svg_viewport_user_rect(Layout::Node const& viewport)
-{
-    if (viewport.is_svg_svg_box())
-        return svg_svg_box_view_box_or_viewport_rect(static_cast<Layout::Box const&>(viewport));
-    if (auto const* dom_node = viewport.dom_node()) {
-        if (auto const* fit_to_view_box = as_if<SVG::SVGFitToViewBox>(*dom_node)) {
-            if (auto view_box = fit_to_view_box->view_box(); view_box.has_value())
-                return { static_cast<float>(view_box->min_x), static_cast<float>(view_box->min_y), static_cast<float>(view_box->width), static_cast<float>(view_box->height) };
-        }
-    }
-    return { {}, absolute_rect(viewport).size().to_type<float>() };
 }
 
 ResolvedCSSFilter resolve_css_filter(CSS::ComputedFilterView computed_filter, Layout::NodeWithStyle const& layout_node)
@@ -118,8 +81,9 @@ ResolvedCSSFilter resolve_css_filter(CSS::ComputedFilterView computed_filter, La
                 // geometry of its own falls back to the whole enclosing viewport rect there.
                 auto bounds = absolute_border_box_rect(layout_node);
                 if (bounds.is_empty()) {
-                    if (auto const* viewport = nearest_svg_viewport_of(layout_node))
-                        result.svg_filter_bounds = svg_viewport_user_rect(*viewport).to_type<CSSPixels>();
+                    auto viewport_rect = Layout::RustFFI::layout_arena_paintable_svg_viewport_user_rect(layout_node.arena_handle(), committed_row_slot(layout_node));
+                    if (viewport_rect.has_value())
+                        result.svg_filter_bounds = viewport_rect.value();
                 }
                 if (!bounds.is_empty())
                     result.svg_filter_bounds = bounds;
@@ -845,71 +809,7 @@ CSSPixels outline_offset(Layout::Node const& node)
 
 CSSPixelRect transform_reference_box(Layout::Node const& node)
 {
-    if (!has_committed_box(node))
-        return {};
-
-    auto transform_box = as<Layout::NodeWithStyle>(node).transform_box();
-    // For SVG elements without associated CSS layout box, the used value for content-box is fill-box and for
-    // border-box is stroke-box.
-    // FIXME: This currently detects any SVG element except the <svg> one. Is that correct?
-    //        And is it correct to use `else` below?
-    if (is_svg_paintable(node)) {
-        switch (transform_box) {
-        case CSS::TransformBox::ContentBox:
-            transform_box = CSS::TransformBox::FillBox;
-            break;
-        case CSS::TransformBox::BorderBox:
-            transform_box = CSS::TransformBox::StrokeBox;
-            break;
-        default:
-            break;
-        }
-    }
-    // For elements with associated CSS layout box, the used value for fill-box is content-box and for
-    // stroke-box and view-box is border-box.
-    else {
-        switch (transform_box) {
-        case CSS::TransformBox::FillBox:
-            transform_box = CSS::TransformBox::ContentBox;
-            break;
-        case CSS::TransformBox::StrokeBox:
-        case CSS::TransformBox::ViewBox:
-            transform_box = CSS::TransformBox::BorderBox;
-            break;
-        default:
-            break;
-        }
-    }
-
-    switch (transform_box) {
-    case CSS::TransformBox::ContentBox:
-        // Uses the content box as reference box.
-        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
-        return absolute_rect(node);
-    case CSS::TransformBox::BorderBox:
-        // Uses the border box as reference box.
-        // FIXME: The reference box of a table is the border box of its table wrapper box, not its table box.
-        return absolute_border_box_rect(node);
-    case CSS::TransformBox::FillBox:
-        // Uses the object bounding box as reference box.
-        // FIXME: For now we're using the content rect as an approximation.
-        return absolute_rect(node);
-    case CSS::TransformBox::StrokeBox:
-        // Uses the stroke bounding box as reference box.
-        // FIXME: For now we're using the border rect as an approximation.
-        return absolute_border_box_rect(node);
-    case CSS::TransformBox::ViewBox: {
-        // Uses the nearest SVG viewport as reference box.
-        // FIXME: If a viewBox attribute is specified for the SVG viewport creating element:
-        //  - The reference box is positioned at the origin of the coordinate system established by the viewBox attribute.
-        //  - The dimension of the reference box is set to the width and height values of the viewBox attribute.
-        auto const* viewport_paintable = nearest_svg_viewport_of(node);
-        if (!viewport_paintable)
-            return absolute_border_box_rect(node);
-        return svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
-    }
-    }
-    VERIFY_NOT_REACHED();
+    return Layout::RustFFI::layout_arena_paintable_transform_reference_box(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -27,11 +27,6 @@ WEB_API void set_paint_viewport_scrollbars(bool enabled);
 bool should_paint_viewport_scrollbars();
 ResolvedCSSFilter resolve_css_filter(CSS::ComputedFilterView, Layout::NodeWithStyle const&);
 
-// Walks layout ancestors so it also covers content of unconnected resource subtrees.
-WEB_API Layout::Node const* nearest_svg_viewport_of(Layout::Node const&);
-// The viewport's rect in its own user units: the active viewBox rect, else {0,0} + the used size.
-WEB_API Gfx::FloatRect svg_viewport_user_rect(Layout::Node const& viewport);
-
 bool body_background_is_propagated_to_root(Layout::NodeWithStyle const&);
 
 Layout::RustFFI::NodeSlotId committed_row_slot(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/ChromeMetrics.h
+++ b/Libraries/LibWeb/Painting/ChromeMetrics.h
@@ -20,6 +20,7 @@ struct ChromeMetrics {
     static constexpr CSSPixels ZOOM_INVARIANT_RESIZE_GRIPPER_SIZE { 12 };
     static constexpr CSSPixels ZOOM_INVARIANT_RESIZE_GRIPPER_PADDING { 2 };
 
+    ChromeMetrics() = default;
     explicit ChromeMetrics(double zoom_factor)
     {
         VERIFY(zoom_factor > 0);

--- a/Libraries/LibWeb/Painting/ChromeWidget.cpp
+++ b/Libraries/LibWeb/Painting/ChromeWidget.cpp
@@ -96,278 +96,38 @@ Layout::Node* ChromeWidget::layout_node() const
 
 void ChromeWidget::detach(Badge<ChromeWidgetRegistry>)
 {
-    m_slot = Layout::RustFFI::NodeSlotId_INVALID;
     did_detach();
-}
-
-static bool is_canvas_background_source(Layout::NodeWithStyle const& layout_node)
-{
-    return layout_node.is_root_element() || body_background_is_propagated_to_root(layout_node);
-}
-
-static Color effective_scrollbar_background_color(Layout::NodeWithStyle const& layout_node)
-{
-    auto background_color = layout_node.document().canvas_background_color();
-
-    Vector<Layout::NodeWithStyle const*, 32> ancestors;
-    for (Layout::NodeWithStyle const* ancestor = &layout_node; ancestor; ancestor = ancestor->parent())
-        ancestors.append(ancestor);
-
-    for (auto const* ancestor : ancestors.in_reverse()) {
-        auto const& layout_node_with_style = *ancestor;
-        if (is_canvas_background_source(layout_node_with_style))
-            continue;
-
-        auto color = layout_node_with_style.background_color();
-        if (color.alpha() == 0)
-            continue;
-
-        background_color = background_color.blend(color);
-    }
-
-    return background_color;
-}
-
-static CSS::ScrollbarColorData automatic_scrollbar_colors(Layout::NodeWithStyle const& layout_node)
-{
-    auto background_color = effective_scrollbar_background_color(layout_node);
-    auto black_thumb = Color(Color::Black).with_alpha(128);
-    auto white_thumb = Color(Color::White).with_alpha(128);
-
-    auto black_thumb_contrast = background_color.contrast_ratio(background_color.blend(black_thumb));
-    auto white_thumb_contrast = background_color.contrast_ratio(background_color.blend(white_thumb));
-    auto thumb_color = black_thumb_contrast >= white_thumb_contrast ? black_thumb : white_thumb;
-
-    return {
-        .thumb_color = thumb_color,
-        .track_color = thumb_color.with_alpha(25),
-        .is_auto = true,
-    };
-}
-
-CSS::ScrollbarColorData scrollbar_colors_for_paint(Layout::NodeWithStyle const& layout_node)
-{
-    auto scrollbar_colors = layout_node.scrollbar_color();
-    if (!scrollbar_colors.is_auto)
-        return scrollbar_colors;
-
-    return automatic_scrollbar_colors(layout_node);
+    m_slot = Layout::RustFFI::NodeSlotId_INVALID;
 }
 
 PhysicalResizeAxes physical_resize_axes(Layout::Node const& node)
 {
-    auto const& style_source = as<Layout::NodeWithStyle>(node);
-
-    // https://drafts.csswg.org/css-ui/#resize
-    if (style_source.resize() == CSS::Resize::None)
-        return {};
-
-    // 4.1. ... The resize property applies to elements that are scroll containers. UAs may also apply it,
-    // regardless of the value of the overflow property, to:
-    // - Replaced elements representing images or videos, such as img, video, picture, svg, object, or canvas.
-    // - The <iframe> element.
-    if (style_source.display().is_inline_outside() && style_source.display().is_flow_inside())
-        return {};
-
-    bool horizontal_writing_mode = style_source.writing_mode() == CSS::WritingMode::HorizontalTb;
-
-    return {
-        .horizontal = style_source.overflow_x() != CSS::Overflow::Visible
-            && style_source.overflow_x() != CSS::Overflow::Clip
-            && (style_source.resize() == CSS::Resize::Both
-                || style_source.resize() == CSS::Resize::Horizontal
-                || (style_source.resize() == CSS::Resize::Inline && horizontal_writing_mode)
-                || (style_source.resize() == CSS::Resize::Block && !horizontal_writing_mode)),
-        .vertical = style_source.overflow_y() != CSS::Overflow::Visible
-            && style_source.overflow_y() != CSS::Overflow::Clip
-            && (style_source.resize() == CSS::Resize::Both
-                || style_source.resize() == CSS::Resize::Vertical
-                || (style_source.resize() == CSS::Resize::Inline && !horizontal_writing_mode)
-                || (style_source.resize() == CSS::Resize::Block && horizontal_writing_mode))
-    };
-}
-
-bool has_resizer(Layout::Node const& node)
-{
-    if (!has_committed_box(node))
-        return false;
-
-    // https://drafts.csswg.org/css-ui#resize
-    if (node.is_viewport())
-        return false;
-
-    // The effect of the resize property on generated content is undefined.
-    // Implementations should not apply the resize property to generated content.
-
-    if (node.generated_for_pseudo_element().has_value())
-        return false;
-
-    auto axes = physical_resize_axes(node);
-    return axes.horizontal || axes.vertical;
-}
-
-bool is_chrome_mirrored(Layout::Node const& node)
-{
-    auto const& style_source = as<Layout::NodeWithStyle>(node);
-    auto writing_mode = style_source.writing_mode();
-    return (writing_mode == CSS::WritingMode::HorizontalTb && style_source.direction() == CSS::Direction::Rtl)
-        || writing_mode == CSS::WritingMode::VerticalRl
-        || writing_mode == CSS::WritingMode::SidewaysRl;
-}
-
-Optional<CSSPixelRect> absolute_resizer_rect(Layout::Node const& node, ChromeMetrics const& metrics)
-{
-    if (!has_resizer(node))
-        return {};
-    auto padding_rect = absolute_padding_box_rect(node);
-    CSSPixels x = is_chrome_mirrored(node) ? padding_rect.x() : padding_rect.right() - metrics.resize_gripper_size;
-    CSSPixels y = padding_rect.bottom() - metrics.resize_gripper_size;
-    return CSSPixelRect { x, y, metrics.resize_gripper_size, metrics.resize_gripper_size };
-}
-
-bool resizer_contains(Layout::Node const& node, CSSPixelPoint adjusted_position, ChromeMetrics const& metrics)
-{
-    if (!has_committed_box(node))
-        return false;
-    auto handle_rect = absolute_resizer_rect(node, metrics);
-    if (!handle_rect.has_value())
-        return false;
-    bool bottom_left_resizer = is_chrome_mirrored(node);
-    auto model = box_model(node);
-    handle_rect->inflate(0, bottom_left_resizer ? 0 : model.border.right, model.border.bottom, bottom_left_resizer ? model.border.left : 0);
-
-    return handle_rect->contains(adjusted_position);
-}
-
-static CSSPixels available_scrollbar_length(Layout::Node const& node, ScrollDirection direction, ChromeMetrics const& metrics)
-{
-    if (!has_committed_box(node))
-        return {};
-    bool is_horizontal = direction == ScrollDirection::Horizontal;
-    auto padding_rect = absolute_padding_box_rect(node);
-    CSSPixels full_scrollport_length = is_horizontal ? padding_rect.width() : padding_rect.height();
-    if (has_resizer(node))
-        full_scrollport_length -= metrics.resize_gripper_size;
-    else {
-        if (is_horizontal && could_be_scrolled_by_wheel_event(node, ScrollDirection::Vertical))
-            full_scrollport_length -= metrics.scroll_gutter_thickness;
-        if (!is_horizontal && could_be_scrolled_by_wheel_event(node, ScrollDirection::Horizontal))
-            full_scrollport_length -= metrics.scroll_gutter_thickness;
-    }
-    return full_scrollport_length;
-}
-
-Optional<CSSPixelRect> absolute_scrollbar_rect(Layout::Node const& node, ScrollDirection direction, bool with_gutter, ChromeMetrics const& metrics)
-{
-    if (!has_committed_box(node))
-        return {};
-    if (!could_be_scrolled_by_wheel_event(node, direction))
-        return {};
-
-    if (as<Layout::NodeWithStyle>(node).scrollbar_width() == CSS::ScrollbarWidth::None)
-        return {};
-
-    bool is_horizontal = direction == ScrollDirection::Horizontal;
-    bool adjusting_for_resizer = has_resizer(node);
-
-    CSSPixels rect_thickness = with_gutter
-        ? metrics.scroll_gutter_thickness
-        : metrics.scroll_thumb_thickness_thin + metrics.scroll_thumb_padding_thin;
-    CSSPixelRect scrollbar_rect = absolute_padding_box_rect(node);
-
-    if (is_horizontal) {
-        if (!adjusting_for_resizer && could_be_scrolled_by_wheel_event(node, ScrollDirection::Vertical)) {
-            scrollbar_rect.set_width(max(CSSPixels { 0 }, scrollbar_rect.width() - metrics.scroll_gutter_thickness));
-            if (is_chrome_mirrored(node))
-                scrollbar_rect.set_x(scrollbar_rect.x() + metrics.scroll_gutter_thickness);
-        } else if (adjusting_for_resizer) {
-            scrollbar_rect.set_width(available_scrollbar_length(node, ScrollDirection::Horizontal, metrics));
-            if (is_chrome_mirrored(node))
-                scrollbar_rect.set_x(scrollbar_rect.x() + metrics.resize_gripper_size);
-        }
-        scrollbar_rect.set_y(max(CSSPixels { 0 }, scrollbar_rect.bottom() - rect_thickness));
-        scrollbar_rect.set_height(rect_thickness);
-    } else {
-        if (adjusting_for_resizer)
-            scrollbar_rect.set_height(available_scrollbar_length(node, ScrollDirection::Vertical, metrics));
-        if (!is_chrome_mirrored(node))
-            scrollbar_rect.set_x(max(CSSPixels { 0 }, scrollbar_rect.right() - rect_thickness));
-        scrollbar_rect.set_width(rect_thickness);
-    }
-    return scrollbar_rect;
+    auto axes = Layout::RustFFI::layout_arena_paintable_physical_resize_axes(node.arena_handle(), committed_row_slot(node));
+    return { axes.horizontal, axes.vertical };
 }
 
 Optional<ScrollbarData> compute_scrollbar_data(Layout::Node const& node, ScrollDirection direction, ChromeMetrics const& metrics, ScrollStateSnapshot const* scroll_state_snapshot, ScrollbarSizing scrollbar_sizing)
 {
-    if (!has_committed_box(node))
-        return {};
-    bool is_horizontal = direction == ScrollDirection::Horizontal;
-    auto orientation = is_horizontal ? Gfx::Orientation::Horizontal : Gfx::Orientation::Vertical;
-    auto const& style_source = as<Layout::NodeWithStyle>(node);
-    auto overflow = is_horizontal ? style_source.overflow_x() : style_source.overflow_y();
-
-    if (overflow != CSS::Overflow::Scroll && !could_be_scrolled_by_wheel_event(node, direction))
-        return {};
-
-    if (!own_scroll_node_index(node).value())
-        return {};
-
-    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(node);
-    if (!scrollable_overflow_rect.has_value())
-        return {};
-
-    CSSPixels scrollable_overflow_length = scrollable_overflow_rect->primary_size_for_orientation(orientation);
-    if (scrollable_overflow_length == 0)
-        return {};
-
-    bool with_gutter = [&] {
-        switch (scrollbar_sizing) {
-        case ScrollbarSizing::Regular:
-            return false;
-        case ScrollbarSizing::Enlarged:
-            return true;
-        }
-        VERIFY_NOT_REACHED();
-    }();
-    auto scrollbar_rect = absolute_scrollbar_rect(node, direction, with_gutter, metrics);
-    if (!scrollbar_rect.has_value())
-        return {};
-
-    CSSPixels thumb_thickness = metrics.scroll_thumb_thickness_thin;
-    CSSPixels thumb_margin = metrics.scroll_thumb_padding_thin;
-    if (with_gutter) {
-        thumb_thickness = metrics.scroll_thumb_thickness;
-        thumb_margin = CSSPixels { (metrics.scroll_gutter_thickness - metrics.scroll_thumb_thickness) / 2.0 };
-    }
-    CSSPixels scrollbar_length = scrollbar_rect->primary_size_for_orientation(orientation);
-    CSSPixels usable_scrollbar_length = max(CSSPixels { 0 }, scrollbar_length - (2 * thumb_margin));
-    CSSPixels scrollport_size = absolute_padding_box_rect(node).primary_size_for_orientation(orientation);
-    CSSPixels min_thumb_length = min(usable_scrollbar_length, metrics.scroll_thumb_min_length);
-    CSSPixels thumb_length = max(usable_scrollbar_length * (scrollport_size / scrollable_overflow_length), min_thumb_length);
-
-    ScrollbarData scrollbar_data = { .gutter_rect = {}, .thumb_rect = scrollbar_rect.value(), .track_rect = scrollbar_rect.value(), .thumb_travel_to_scroll_ratio = 0 };
-
-    if (scrollable_overflow_length > scrollport_size)
-        scrollbar_data.thumb_travel_to_scroll_ratio = (usable_scrollbar_length - thumb_length) / (scrollable_overflow_length - scrollport_size);
-
-    scrollbar_data.thumb_rect.set_primary_size_for_orientation(orientation, thumb_length);
-    scrollbar_data.thumb_rect.set_secondary_size_for_orientation(orientation, thumb_thickness);
-    auto minimum_offset = minimum_scroll_offset(node).primary_offset_for_orientation(orientation);
-    scrollbar_data.thumb_rect.translate_primary_offset_for_orientation(orientation, thumb_margin - minimum_offset * scrollbar_data.thumb_travel_to_scroll_ratio);
-    if (with_gutter || (!is_horizontal && is_chrome_mirrored(node)))
-        scrollbar_data.thumb_rect.translate_secondary_offset_for_orientation(orientation, thumb_margin);
-    if (with_gutter)
-        scrollbar_data.gutter_rect = scrollbar_rect.value();
-
+    auto& document = node.document();
+    auto overflow_x = overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal);
+    auto overflow_y = overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical);
+    float device_scroll_offset = 0;
     if (scroll_state_snapshot) {
         auto own_offset = scroll_state_snapshot->device_offset_for_index(own_scroll_node_index(node));
-        auto device_scroll_offset = is_horizontal ? -own_offset.x() : -own_offset.y();
-        auto device_pixels_per_css_pixel = static_cast<float>(node.document().page().client().device_pixels_per_css_pixel());
-        CSSPixels thumb_offset = CSSPixels::nearest_value_for(device_scroll_offset / device_pixels_per_css_pixel) * scrollbar_data.thumb_travel_to_scroll_ratio;
-        scrollbar_data.thumb_rect.translate_primary_offset_for_orientation(orientation, thumb_offset);
+        device_scroll_offset = direction == ScrollDirection::Horizontal ? -own_offset.x() : -own_offset.y();
     }
-
-    return scrollbar_data;
+    auto result = Layout::RustFFI::layout_arena_paintable_compute_scrollbar_data(
+        node.arena_handle(), committed_row_slot(node), static_cast<Layout::RustFFI::ScrollDirection>(direction),
+        metrics, to_underlying(overflow_x), to_underlying(overflow_y), scrollbar_sizing == ScrollbarSizing::Enlarged,
+        scroll_state_snapshot, device_scroll_offset, document.page().client().device_pixels_per_css_pixel());
+    if (!result.has_value)
+        return {};
+    return ScrollbarData {
+        .gutter_rect = result.value.gutter_rect,
+        .thumb_rect = result.value.thumb_rect,
+        .track_rect = result.value.track_rect,
+        .thumb_travel_to_scroll_ratio = result.value.thumb_travel_to_scroll_ratio,
+    };
 }
 
 }

--- a/Libraries/LibWeb/Painting/ChromeWidget.h
+++ b/Libraries/LibWeb/Painting/ChromeWidget.h
@@ -60,13 +60,7 @@ struct PhysicalResizeAxes {
     bool vertical;
 };
 
-CSS::ScrollbarColorData scrollbar_colors_for_paint(Layout::NodeWithStyle const&);
 Optional<ScrollbarData> compute_scrollbar_data(Layout::Node const&, ScrollDirection, ChromeMetrics const&, ScrollStateSnapshot const* = nullptr, ScrollbarSizing = ScrollbarSizing::Regular);
-Optional<CSSPixelRect> absolute_scrollbar_rect(Layout::Node const&, ScrollDirection, bool with_gutter, ChromeMetrics const&);
-bool resizer_contains(Layout::Node const&, CSSPixelPoint, ChromeMetrics const&);
-Optional<CSSPixelRect> absolute_resizer_rect(Layout::Node const&, ChromeMetrics const&);
-bool has_resizer(Layout::Node const&);
-bool is_chrome_mirrored(Layout::Node const&);
 PhysicalResizeAxes physical_resize_axes(Layout::Node const&);
 
 class Scrollbar;
@@ -100,7 +94,6 @@ class ChromeWidget
 public:
     virtual ~ChromeWidget() = default;
 
-    virtual bool contains(CSSPixelPoint, ChromeMetrics const&) const = 0;
     virtual MouseAction handle_pointer_event(Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position) = 0;
     virtual void mouse_enter() = 0;
     virtual void mouse_leave() = 0;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -12,11 +12,13 @@
 #include <LibWeb/Layout/LayoutRustFFI.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/BoxViews.h>
+#include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/Painting/ChromeWidget.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/PaintingRustBridge.h>
 #include <LibWeb/Painting/ResizeHandle.h>
 #include <LibWeb/Painting/Scrollbar.h>
+#include <LibWeb/Painting/Scrolling.h>
 
 namespace Web::Painting {
 
@@ -201,8 +203,12 @@ struct HitTestDisplayList::QueryContext {
 
     Layout::RustFFI::FfiHitTestQueryCallbacks callbacks()
     {
-        return {
+        Layout::RustFFI::FfiHitTestQueryCallbacks callbacks {
             .context = this,
+            .has_chrome_metrics = chrome_metrics != nullptr,
+            .chrome_metrics = {},
+            .viewport_wheel_overflow_x = 0,
+            .viewport_wheel_overflow_y = 0,
             .local_point_for_visual_context = [](void* context_pointer, size_t index, CSSPixelPoint point, bool respect_clip, Gfx::FloatPoint* out) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
                 VERIFY(context.document);
@@ -212,24 +218,6 @@ struct HitTestDisplayList::QueryContext {
                     return false;
                 *out = *local_point;
                 return true;
-            },
-            .chrome_widget_contains = [](void* context_pointer, void* layout_node_shell, u8 kind, CSSPixelPoint local_point) -> bool {
-                auto& context = *static_cast<QueryContext*>(context_pointer);
-                VERIFY(context.chrome_metrics);
-                auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
-                auto paintable_slot = committed_row_slot(layout_node);
-                auto contains = [&](auto widget) { return widget && widget->contains(local_point, *context.chrome_metrics); };
-                switch (static_cast<ChromeWidgetKind>(kind)) {
-                case ChromeWidgetKind::None:
-                    return false;
-                case ChromeWidgetKind::ResizeHandle:
-                    return contains(context.list.m_chrome_widget_registry->resize_handle(paintable_slot));
-                case ChromeWidgetKind::HorizontalScrollbar:
-                    return contains(context.list.m_chrome_widget_registry->scrollbar(paintable_slot, ScrollDirection::Horizontal));
-                case ChromeWidgetKind::VerticalScrollbar:
-                    return contains(context.list.m_chrome_widget_registry->scrollbar(paintable_slot, ScrollDirection::Vertical));
-                }
-                VERIFY_NOT_REACHED();
             },
             .line_in_scope = [](void* context_pointer, size_t line_index) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
@@ -269,6 +257,13 @@ struct HitTestDisplayList::QueryContext {
                 return true;
             },
         };
+        if (chrome_metrics)
+            callbacks.chrome_metrics = *chrome_metrics;
+        if (document) {
+            callbacks.viewport_wheel_overflow_x = to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(*document, ScrollDirection::Horizontal));
+            callbacks.viewport_wheel_overflow_y = to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(*document, ScrollDirection::Vertical));
+        }
+        return callbacks;
     }
 };
 

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/Environment.h>
 #include <LibGfx/CornerRadii.h>
 #include <LibGfx/Filter.h>
+#include <LibGfx/FilterImpl.h>
 #include <LibGfx/GradientInterpolation.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Path.h>
@@ -74,6 +75,27 @@ namespace Web::Painting {
 static_assert(sizeof(Layout::RustFFI::ScrollDirection) == sizeof(ScrollDirection));
 static_assert(to_underlying(Layout::RustFFI::ScrollDirection::Horizontal) == to_underlying(ScrollDirection::Horizontal));
 static_assert(to_underlying(Layout::RustFFI::ScrollDirection::Vertical) == to_underlying(ScrollDirection::Vertical));
+
+static_assert(sizeof(Layout::RustFFI::FilterOperationType) == sizeof(Gfx::FilterImpl::OperationType));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Arithmetic) == to_underlying(Gfx::FilterImpl::OperationType::Arithmetic));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Compose) == to_underlying(Gfx::FilterImpl::OperationType::Compose));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Blend) == to_underlying(Gfx::FilterImpl::OperationType::Blend));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Flood) == to_underlying(Gfx::FilterImpl::OperationType::Flood));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::DisplacementMap) == to_underlying(Gfx::FilterImpl::OperationType::DisplacementMap));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::DropShadow) == to_underlying(Gfx::FilterImpl::OperationType::DropShadow));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Blur) == to_underlying(Gfx::FilterImpl::OperationType::Blur));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::ColorFilter) == to_underlying(Gfx::FilterImpl::OperationType::ColorFilter));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::ColorMatrix) == to_underlying(Gfx::FilterImpl::OperationType::ColorMatrix));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::ColorTable) == to_underlying(Gfx::FilterImpl::OperationType::ColorTable));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Saturate) == to_underlying(Gfx::FilterImpl::OperationType::Saturate));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::HueRotate) == to_underlying(Gfx::FilterImpl::OperationType::HueRotate));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Image) == to_underlying(Gfx::FilterImpl::OperationType::Image));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Merge) == to_underlying(Gfx::FilterImpl::OperationType::Merge));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Offset) == to_underlying(Gfx::FilterImpl::OperationType::Offset));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Erode) == to_underlying(Gfx::FilterImpl::OperationType::Erode));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Dilate) == to_underlying(Gfx::FilterImpl::OperationType::Dilate));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::Turbulence) == to_underlying(Gfx::FilterImpl::OperationType::Turbulence));
+static_assert(to_underlying(Layout::RustFFI::FilterOperationType::ColorSpaceConversion) == to_underlying(Gfx::FilterImpl::OperationType::ColorSpaceConversion));
 
 static_assert(sizeof(RustFFI::IntPoint) == sizeof(Gfx::IntPoint));
 static_assert(alignof(RustFFI::IntPoint) == alignof(Gfx::IntPoint));
@@ -358,6 +380,8 @@ static VisualContextData visual_context_data_from_export(Layout::RustFFI::FfiVis
         EffectsData effects { .opacity = node.opacity, .blend_mode = node.blend_mode, .gfx_filter = {} };
         if (node.filter)
             effects.gfx_filter = *static_cast<Gfx::Filter const*>(node.filter);
+        else if (node.filter_bytes_length)
+            effects.gfx_filter = Gfx::deserialize_filter({ node.filter_bytes, node.filter_bytes_length }, [](u64) -> Gfx::DecodedImageFrame { VERIFY_NOT_REACHED(); });
         return effects;
     }
     case Layout::RustFFI::FfiVisualContextNodeKind::ScrollCompensation:

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/Blending.h>
 #include <LibWeb/Painting/BoxViews.h>
+#include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/Painting/ChromeWidget.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
@@ -69,6 +70,10 @@
 #include <LibWeb/SVG/SVGMaskElement.h>
 
 namespace Web::Painting {
+
+static_assert(sizeof(Layout::RustFFI::ScrollDirection) == sizeof(ScrollDirection));
+static_assert(to_underlying(Layout::RustFFI::ScrollDirection::Horizontal) == to_underlying(ScrollDirection::Horizontal));
+static_assert(to_underlying(Layout::RustFFI::ScrollDirection::Vertical) == to_underlying(ScrollDirection::Vertical));
 
 static_assert(sizeof(RustFFI::IntPoint) == sizeof(Gfx::IntPoint));
 static_assert(alignof(RustFFI::IntPoint) == alignof(Gfx::IntPoint));
@@ -287,6 +292,15 @@ VERIFY_SHARED_FFI_TYPE(Gfx::ScalingMode);
 VERIFY_SHARED_FFI_TYPE(Gfx::InterpolationColorSpace);
 VERIFY_SHARED_FFI_TYPE(TransformDataRole);
 VERIFY_SHARED_FFI_TYPE(MaskLayerOrigin);
+VERIFY_SHARED_FFI_TYPE(ChromeMetrics);
+static_assert(sizeof(ChromeMetrics) == 7 * sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, scroll_thumb_min_length) == 0);
+static_assert(offsetof(ChromeMetrics, scroll_thumb_padding_thin) == sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, scroll_thumb_thickness_thin) == 2 * sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, scroll_thumb_thickness) == 3 * sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, scroll_gutter_thickness) == 4 * sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, resize_gripper_size) == 5 * sizeof(CSSPixels));
+static_assert(offsetof(ChromeMetrics, resize_gripper_padding) == 6 * sizeof(CSSPixels));
 VERIFY_SHARED_FFI_TYPE(Optional<CSSPixels>);
 VERIFY_SHARED_FFI_TYPE(Optional<CSSPixelRect>);
 VERIFY_SHARED_FFI_TYPE(Optional<Gfx::IntRect>);
@@ -804,72 +818,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 facts.snaps_scroll_position_horizontally = snap_axes.x;
                 facts.snaps_scroll_position_vertically = snap_axes.y;
             }
-            facts.records_viewport_scrollbars = is_viewport_paintable(layout_node)
-                && layout_node.document().page().async_scrolling_enabled()
-                && should_paint_viewport_scrollbars()
-                && layout_node.scrollbar_width() != CSS::ScrollbarWidth::None;
-            if (facts.records_viewport_scrollbars) {
-                auto scrollbar_colors = scrollbar_colors_for_paint(layout_node);
-                auto const& metrics = layout_node.document().page().chrome_metrics();
-                size_t index = 0;
-                for (auto direction : { ScrollDirection::Vertical, ScrollDirection::Horizontal }) {
-                    auto& out = facts.viewport_scrollbars[index++];
-                    auto scrollbar_data = compute_scrollbar_data(layout_node, direction, metrics, nullptr, ScrollbarSizing::Regular);
-                    if (!scrollbar_data.has_value())
-                        continue;
-                    auto expanded_scrollbar_data = compute_scrollbar_data(layout_node, direction, metrics, nullptr, ScrollbarSizing::Enlarged);
-                    VERIFY(expanded_scrollbar_data.has_value());
-                    out.present = true;
-                    out.gutter_rect = scrollbar_data->gutter_rect;
-                    out.thumb_rect = scrollbar_data->thumb_rect;
-                    out.expanded_gutter_rect = expanded_scrollbar_data->gutter_rect;
-                    out.expanded_thumb_rect = expanded_scrollbar_data->thumb_rect;
-                    out.scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
-                    out.expanded_scroll_size = expanded_scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
-                    out.thumb_color = scrollbar_colors.thumb_color;
-                    out.track_color = scrollbar_colors.track_color;
-                }
-            }
-            return facts;
-        },
-        .overlay_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiOverlayFacts {
-            auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
-            auto const& document = layout_node.document();
-            auto const& metrics = document.page().chrome_metrics();
-            Layout::RustFFI::FfiOverlayFacts facts {};
-            facts.paints_scrollbars = ((should_paint_viewport_scrollbars() && !document.page().async_scrolling_enabled()) || !is_viewport_paintable(layout_node))
-                && layout_node.scrollbar_width() != CSS::ScrollbarWidth::None;
-            if (facts.paints_scrollbars) {
-                auto scrollbar_colors = scrollbar_colors_for_paint(layout_node);
-                facts.thumb_color = scrollbar_colors.thumb_color;
-                facts.track_color = scrollbar_colors.track_color;
-                size_t index = 0;
-                for (auto direction : { ScrollDirection::Vertical, ScrollDirection::Horizontal }) {
-                    auto& out = facts.scrollbars[index++];
-                    auto scrollbar = document.chrome_widget_registry().scrollbar(committed_row_slot(layout_node), direction);
-                    auto scrollbar_data = compute_scrollbar_data(layout_node, direction, metrics, nullptr,
-                        scrollbar && scrollbar->is_enlarged() ? ScrollbarSizing::Enlarged : ScrollbarSizing::Regular);
-                    if (!scrollbar_data.has_value())
-                        continue;
-                    out.present = true;
-                    out.gutter_rect = scrollbar_data->gutter_rect;
-                    out.thumb_rect = scrollbar_data->thumb_rect;
-                    out.track_rect = scrollbar_data->track_rect;
-                    out.thumb_travel_to_scroll_ratio = scrollbar_data->thumb_travel_to_scroll_ratio.to_double();
-                }
-            }
-            if (auto resizer_rect = absolute_resizer_rect(layout_node, metrics); resizer_rect.has_value()) {
-                facts.resizer_rect = *resizer_rect;
-                facts.resize_gripper_padding = metrics.resize_gripper_padding;
-            }
-            if (is_viewport_paintable(layout_node)) {
-                if (auto navigable = document.navigable()) {
-                    if (auto handler = navigable->event_handler().middle_button_scroll_handler(); handler.has_value()) {
-                        facts.middle_button_scroll_active = true;
-                        facts.middle_button_scroll_origin = handler->origin();
-                    }
-                }
-            }
             return facts;
         },
         .outline_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiOutlineFacts {
@@ -915,10 +863,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 }
             }
             return facts;
-        },
-        .root_background_source = [](void* context_pointer) -> Layout::RustFFI::FfiRootBackgroundSource {
-            auto& context = *static_cast<PaintHostContext*>(context_pointer);
-            return rust_root_background_source(context.document);
         },
         .text_control_selection = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiTextControlSelection {
             Layout::RustFFI::FfiTextControlSelection result {};
@@ -1365,6 +1309,16 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     inputs.has_blocking_wheel_event_region_covering_viewport = wheel_event_region_state.has_blocking_wheel_event_region_covering_viewport;
     inputs.viewport_wheel_overflow_x = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)));
     inputs.viewport_wheel_overflow_y = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)));
+    inputs.chrome_metrics = document.page().chrome_metrics();
+    inputs.root_background_source = rust_root_background_source(document);
+    inputs.paint_viewport_scrollbars = should_paint_viewport_scrollbars();
+    inputs.async_scrolling_enabled = document.page().async_scrolling_enabled();
+    if (auto navigable = document.navigable()) {
+        if (auto handler = navigable->event_handler().middle_button_scroll_handler(); handler.has_value()) {
+            inputs.middle_button_scroll_active = true;
+            inputs.middle_button_scroll_origin = handler->origin();
+        }
+    }
     inputs.paint_command_cache_read_write = cache_mode == PaintCommandCacheMode::ReadWrite;
     inputs.display_list_id = placeholder_display_list.id();
     {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -438,14 +438,6 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
         .scroll_offset = [](void*, void* layout_node_shell) -> CSSPixelPoint {
             return scroll_offset(*static_cast<Layout::Node const*>(layout_node_shell));
         },
-        .svg_transform_view_box_rect = [](void*, void* layout_node_shell, CSSPixelRect* out) -> bool {
-            auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
-            auto const* viewport_paintable = nearest_svg_viewport_of(layout_node);
-            if (!viewport_paintable)
-                return false;
-            *out = svg_viewport_user_rect(*viewport_paintable).to_type<CSSPixels>();
-            return true;
-        },
         .svg_additional_element_transform = [](void*, void* layout_node_shell, Gfx::AffineTransform* out) -> bool {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(layout_node.dom_node());
@@ -1210,22 +1202,16 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto display_list = DisplayList::create_from_command_bytes(visual_context_tree, move(command_bytes));
             return context.resource_storage.add_display_list(move(display_list), visual_context_tree).value();
         },
-        .svg_host_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiSvgHostFacts {
+        .svg_image_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiSvgImageFacts {
             auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
             auto const* row = committed_row(layout_node);
             VERIFY(row);
-            Layout::RustFFI::FfiSvgHostFacts facts {};
-            if (is_svg_path_paintable(layout_node)) {
-                facts.percentage_basis = as<SVG::SVGGraphicsElement>(*layout_node.dom_node()).viewport_percentage_basis();
-                if (auto const* viewport_paintable = nearest_svg_viewport_of(layout_node))
-                    facts.viewport = svg_viewport_user_rect(*viewport_paintable);
-            }
-            if (row->kind == Layout::RustFFI::PaintableKind::SVGImagePaintable) {
-                auto const& image_provider = as<SVG::SVGImageElement>(*layout_node.dom_node());
-                facts.has_decoded_image_data = image_provider.decoded_image_data() != nullptr;
-                if (auto natural_size = image_provider.intrinsic_size(); natural_size.has_value())
-                    facts.natural_size = natural_size->to_type<float>();
-            }
+            VERIFY(row->kind == Layout::RustFFI::PaintableKind::SVGImagePaintable);
+            Layout::RustFFI::FfiSvgImageFacts facts {};
+            auto const& image_provider = as<SVG::SVGImageElement>(*layout_node.dom_node());
+            facts.has_decoded_image_data = image_provider.decoded_image_data() != nullptr;
+            if (auto natural_size = image_provider.intrinsic_size(); natural_size.has_value())
+                facts.natural_size = natural_size->to_type<float>();
             return facts;
         },
         .svg_paint_style = [](void* context_pointer, void* layout_node_shell, bool is_stroke, Layout::RustFFI::FfiSvgPaintContext const* ffi_paint_context, void* sink) -> Layout::RustFFI::FfiSvgPaintStyle {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -58,6 +58,7 @@
 #include <LibWeb/Painting/ResolvedCSSFilter.h>
 #include <LibWeb/Painting/ScrollSnap.h>
 #include <LibWeb/Painting/Scrollbar.h>
+#include <LibWeb/Painting/Scrolling.h>
 #include <LibWeb/Painting/ShadowData.h>
 #include <LibWeb/Platform/FontPlugin.h>
 #include <LibWeb/SVG/AttributeParser.h>
@@ -709,22 +710,10 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
         .paintable_facts = [](void*, void* layout_node_shell) -> Layout::RustFFI::FfiHitTestPaintableFacts {
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiHitTestPaintableFacts facts {};
-            facts.opacity_is_zero = layout_node.opacity() == 0;
-            facts.visible_for_hit_testing = visible_for_hit_testing(layout_node);
             auto dom_node = layout_node.dom_node();
+            facts.is_inert = dom_node && dom_node->is_inert();
             facts.dom_node_has_parent = dom_node && dom_node->parent();
             facts.is_editable_or_editing_host = dom_node && dom_node->is_editable_or_editing_host();
-            facts.has_resizer = has_resizer(layout_node);
-            auto wheel_scrollable_axes = Painting::wheel_scrollable_axes(layout_node);
-            facts.could_be_scrolled_horizontally = wheel_scrollable_axes.horizontal;
-            facts.could_be_scrolled_vertically = wheel_scrollable_axes.vertical;
-            if (is_svg_path_paintable(layout_node)) {
-                auto const& graphics_element = as<SVG::SVGGraphicsElement>(*dom_node);
-                facts.svg_path_has_fill = graphics_element.fill_color().has_value();
-                facts.svg_path_winding_rule = graphics_element.fill_rule().value_or(SVG::FillRule::Nonzero) == SVG::FillRule::Evenodd
-                    ? Gfx::WindingRule::EvenOdd
-                    : Gfx::WindingRule::Nonzero;
-            }
             if (auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(dom_node); graphics_element && graphics_element->unsafe_layout_node()) {
                 for (auto child = graphics_element->unsafe_layout_node()->first_child(); child; child = child->next_sibling()) {
                     if (child->kind() == Layout::RustFFI::NodeKind::SVGMaskBox)
@@ -733,15 +722,13 @@ Layout::RustFFI::FfiHitTestHostCallbacks hit_test_host_callbacks()
                         facts.svg_clip_path_units_object_bbox = as<SVG::SVGClipPathElement>(*child->dom_node()).clip_path_units() == SVG::ClipPathUnits::ObjectBoundingBox;
                 }
             }
+            facts.inside_blocking_wheel_event_handler = dom_node && dom_node->inside_blocking_wheel_event_handler();
             return facts;
         },
         .text_node_facts = [](void*, void* node_shell) -> Layout::RustFFI::FfiHitTestTextNodeFacts {
             auto const& text_node = *static_cast<Layout::TextNode const*>(node_shell);
-            auto const& style_source = *text_node.parent();
             auto const* dom_text = text_node.dom_text();
             return {
-                .parent_opacity_is_zero = style_source.opacity() == 0,
-                .parent_pointer_events_none = style_source.pointer_events() == CSS::PointerEvents::None,
                 .is_inert = dom_text && dom_text->is_inert(),
             };
         },
@@ -817,7 +804,6 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 facts.snaps_scroll_position_horizontally = snap_axes.x;
                 facts.snaps_scroll_position_vertically = snap_axes.y;
             }
-            facts.inside_blocking_wheel_event_handler = dom_node && dom_node->inside_blocking_wheel_event_handler();
             facts.records_viewport_scrollbars = is_viewport_paintable(layout_node)
                 && layout_node.document().page().async_scrolling_enabled()
                 && should_paint_viewport_scrollbars()
@@ -1377,6 +1363,8 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     inputs.is_recording_async_scrolling_metadata = true;
     inputs.document_id = document.unique_id().value();
     inputs.has_blocking_wheel_event_region_covering_viewport = wheel_event_region_state.has_blocking_wheel_event_region_covering_viewport;
+    inputs.viewport_wheel_overflow_x = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)));
+    inputs.viewport_wheel_overflow_y = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)));
     inputs.paint_command_cache_read_write = cache_mode == PaintCommandCacheMode::ReadWrite;
     inputs.display_list_id = placeholder_display_list.id();
     {

--- a/Libraries/LibWeb/Painting/ResizeHandle.cpp
+++ b/Libraries/LibWeb/Painting/ResizeHandle.cpp
@@ -26,14 +26,6 @@ ResizeHandle::ResizeHandle(Layout::NodeArena& arena, Layout::RustFFI::NodeSlotId
 {
 }
 
-bool ResizeHandle::contains(CSSPixelPoint position, ChromeMetrics const& metrics) const
-{
-    auto* node = layout_node();
-    if (!node)
-        return false;
-    return resizer_contains(*node, position, metrics);
-}
-
 Optional<CSS::CursorPredefined> ResizeHandle::cursor() const
 {
     auto* node = layout_node();
@@ -42,7 +34,7 @@ Optional<CSS::CursorPredefined> ResizeHandle::cursor() const
     auto axes = physical_resize_axes(*node);
     if (axes.vertical) {
         if (axes.horizontal) {
-            if (is_chrome_mirrored(*node))
+            if (Layout::RustFFI::layout_arena_paintable_is_chrome_mirrored(node->arena_handle(), committed_row_slot(*node)))
                 return CSS::CursorPredefined::SwResize;
             return CSS::CursorPredefined::SeResize;
         }

--- a/Libraries/LibWeb/Painting/ResizeHandle.h
+++ b/Libraries/LibWeb/Painting/ResizeHandle.h
@@ -15,8 +15,6 @@ class ResizeHandle final : public ChromeWidget {
 public:
     static NonnullRefPtr<ResizeHandle> create(Layout::NodeArena&, Layout::RustFFI::NodeSlotId);
 
-    virtual bool contains(CSSPixelPoint position, ChromeMetrics const&) const override;
-
     virtual MouseAction handle_pointer_event(Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position) override;
     virtual void mouse_enter() override { }
     virtual void mouse_leave() override { }

--- a/Libraries/LibWeb/Painting/SVGMasking.cpp
+++ b/Libraries/LibWeb/Painting/SVGMasking.cpp
@@ -144,8 +144,9 @@ Optional<CSSPixelRect> mask_area(Layout::Node const& node)
     // computation stays in the target's user space: that is the coordinate space of the mask node
     // in the visual context tree.
     Gfx::FloatSize viewport_size {};
-    if (auto const* viewport_paintable = nearest_svg_viewport_of(*mask_box))
-        viewport_size = svg_viewport_user_rect(*viewport_paintable).size();
+    auto viewport_rect = Layout::RustFFI::layout_arena_paintable_svg_viewport_user_rect(mask_box->arena_handle(), committed_row_slot(*mask_box));
+    if (viewport_rect.has_value())
+        viewport_size = viewport_rect.value().size().to_type<float>();
 
     auto target_object_bounding_box = target_user_space_object_bounding_box(target);
     return as<SVG::SVGMaskElement>(*mask_box->dom_node()).resolve_masking_area(target_object_bounding_box, viewport_size, Gfx::AffineTransform {});

--- a/Libraries/LibWeb/Painting/Scrollbar.cpp
+++ b/Libraries/LibWeb/Painting/Scrollbar.cpp
@@ -27,16 +27,6 @@ Scrollbar::Scrollbar(Layout::NodeArena& arena, Layout::RustFFI::NodeSlotId slot,
 {
 }
 
-bool Scrollbar::contains(CSSPixelPoint position, ChromeMetrics const& metrics) const
-{
-    auto* node = layout_node();
-    if (!node)
-        return false;
-    if (auto rect = absolute_scrollbar_rect(*node, m_direction, is_enlarged(), metrics); rect.has_value())
-        return rect->contains(position);
-    return false;
-}
-
 MouseAction Scrollbar::handle_pointer_event(Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position)
 {
     if (type == UIEvents::EventNames::pointermove || type == UIEvents::EventNames::pointerup) {
@@ -90,6 +80,16 @@ void Scrollbar::release_thumb_grab()
 {
     m_thumb_grab_position.clear();
     m_thumb_grab_gesture_hold = nullptr;
+    push_enlarged_state();
+}
+
+void Scrollbar::push_enlarged_state()
+{
+    auto* node = layout_node();
+    if (!node)
+        return;
+    Layout::RustFFI::layout_arena_paintable_set_scrollbar_enlarged(
+        node->arena_handle(), committed_row_slot(*node), static_cast<Layout::RustFFI::ScrollDirection>(m_direction), is_enlarged());
 }
 
 void Scrollbar::mouse_enter()
@@ -97,6 +97,7 @@ void Scrollbar::mouse_enter()
     if (m_hovered)
         return;
     m_hovered = true;
+    push_enlarged_state();
     if (auto* node = layout_node())
         Painting::set_needs_repaint(*node);
 }
@@ -106,6 +107,7 @@ void Scrollbar::mouse_leave()
     if (!m_hovered)
         return;
     m_hovered = false;
+    push_enlarged_state();
     if (auto* node = layout_node())
         Painting::set_needs_repaint(*node);
 }
@@ -140,6 +142,7 @@ bool Scrollbar::scroll_to_mouse_position(CSSPixelPoint position)
         m_thumb_grab_position = position_is_along_thumb
             ? (position - scrollbar_data->thumb_rect.location()).primary_offset_for_orientation(orientation)
             : max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
+        push_enlarged_state();
         if (auto navigable = node->document().navigable())
             m_thumb_grab_gesture_hold = make<HTML::UserScrollGestureHold>(*navigable);
     }

--- a/Libraries/LibWeb/Painting/Scrollbar.h
+++ b/Libraries/LibWeb/Painting/Scrollbar.h
@@ -18,8 +18,6 @@ public:
     ScrollDirection direction() const { return m_direction; }
     bool is_enlarged() const { return m_hovered || m_thumb_grab_position.has_value(); }
 
-    virtual bool contains(CSSPixelPoint position, ChromeMetrics const&) const override;
-
     virtual MouseAction handle_pointer_event(Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position) override;
     virtual void mouse_enter() override;
     virtual void mouse_leave() override;
@@ -32,6 +30,7 @@ private:
     MouseAction mouse_up(CSSPixelPoint, unsigned button);
     bool scroll_to_mouse_position(CSSPixelPoint);
     void release_thumb_grab();
+    void push_enlarged_state();
     virtual void did_detach() override;
 
     ScrollDirection m_direction;

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -44,28 +44,12 @@ CSSPixelPoint scroll_offset(Layout::Node const& node)
 
 CSSPixelPoint minimum_scroll_offset(Layout::Node const& node)
 {
-    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(node);
-    if (!scrollable_overflow_rect.has_value())
-        return {};
-
-    auto scrollport_rect = absolute_padding_box_rect(node);
-    return {
-        min(scrollable_overflow_rect->left() - scrollport_rect.left(), CSSPixels(0)),
-        min(scrollable_overflow_rect->top() - scrollport_rect.top(), CSSPixels(0)),
-    };
+    return Layout::RustFFI::layout_arena_paintable_minimum_scroll_offset(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelPoint maximum_scroll_offset(Layout::Node const& node)
 {
-    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(node);
-    if (!scrollable_overflow_rect.has_value())
-        return {};
-
-    auto scrollport_rect = absolute_padding_box_rect(node);
-    return {
-        max(scrollable_overflow_rect->right() - scrollport_rect.right(), CSSPixels(0)),
-        max(scrollable_overflow_rect->bottom() - scrollport_rect.bottom(), CSSPixels(0)),
-    };
+    return Layout::RustFFI::layout_arena_paintable_maximum_scroll_offset(node.arena_handle(), committed_row_slot(node));
 }
 
 CSSPixelPoint clamp_scroll_offset(Layout::Node const& node, CSSPixelPoint offset)
@@ -150,34 +134,13 @@ CSS::Overflow overflow_value_applied_to_viewport_for_wheel_scrolling(DOM::Docume
     return overflow;
 }
 
-static bool overflow_allows_wheel_scrolling(Layout::NodeWithStyle const& node, ScrollDirection direction)
-{
-    auto overflow = direction == ScrollDirection::Horizontal ? node.overflow_x() : node.overflow_y();
-    if (node.is_viewport())
-        overflow = overflow_value_applied_to_viewport_for_wheel_scrolling(node.document(), direction);
-    return overflow == CSS::Overflow::Auto || overflow == CSS::Overflow::Scroll;
-}
-
 WheelScrollableAxes wheel_scrollable_axes(Layout::Node const& node)
 {
-    auto const* node_with_style = as_if<Layout::NodeWithStyle>(node);
-    if (!node_with_style)
-        return {};
-    WheelScrollableAxes axes {
-        .horizontal = overflow_allows_wheel_scrolling(*node_with_style, ScrollDirection::Horizontal),
-        .vertical = overflow_allows_wheel_scrolling(*node_with_style, ScrollDirection::Vertical),
-    };
-    if (!axes.horizontal && !axes.vertical)
-        return {};
-
-    auto scrollable_overflow_rect = Painting::scrollable_overflow_rect(node);
-    if (!scrollable_overflow_rect.has_value())
-        return {};
-
-    auto scrollport_rect = absolute_padding_box_rect(node);
-    axes.horizontal = axes.horizontal && scrollable_overflow_rect->width() > scrollport_rect.width();
-    axes.vertical = axes.vertical && scrollable_overflow_rect->height() > scrollport_rect.height();
-    return axes;
+    auto overflow_x = overflow_value_applied_to_viewport_for_wheel_scrolling(node.document(), ScrollDirection::Horizontal);
+    auto overflow_y = overflow_value_applied_to_viewport_for_wheel_scrolling(node.document(), ScrollDirection::Vertical);
+    auto axes = Layout::RustFFI::layout_arena_paintable_wheel_scrollable_axes(
+        node.arena_handle(), committed_row_slot(node), to_underlying(overflow_x), to_underlying(overflow_y));
+    return { axes.horizontal, axes.vertical };
 }
 
 bool could_be_scrolled_by_wheel_event(Layout::Node const& node, ScrollDirection direction)

--- a/Libraries/LibWeb/Painting/Scrolling.cpp
+++ b/Libraries/LibWeb/Painting/Scrolling.cpp
@@ -114,7 +114,7 @@ CSSPixelRect scroll_snapport_rect(Layout::Node const& node, CSSPixelRect scrollp
     return scrollport;
 }
 
-static CSS::Overflow overflow_value_applied_to_viewport_for_wheel_scrolling(DOM::Document const& document, ScrollDirection direction)
+CSS::Overflow overflow_value_applied_to_viewport_for_wheel_scrolling(DOM::Document const& document, ScrollDirection direction)
 {
     auto overflow_for_direction = [direction](CSS::ComputedValues::BoxValues const& style) {
         return direction == ScrollDirection::Horizontal

--- a/Libraries/LibWeb/Painting/Scrolling.h
+++ b/Libraries/LibWeb/Painting/Scrolling.h
@@ -34,6 +34,7 @@ CSSPixelPoint maximum_scroll_offset(Layout::Node const&);
 CSSPixelPoint clamp_scroll_offset(Layout::Node const&, CSSPixelPoint);
 CSSPixelRect scroll_snapport_rect(Layout::Node const&);
 CSSPixelRect scroll_snapport_rect(Layout::Node const&, CSSPixelRect scrollport);
+CSS::Overflow overflow_value_applied_to_viewport_for_wheel_scrolling(DOM::Document const&, ScrollDirection);
 struct WheelScrollableAxes {
     bool horizontal { false };
     bool vertical { false };

--- a/Libraries/LibWeb/Painting/Scrolling.h
+++ b/Libraries/LibWeb/Painting/Scrolling.h
@@ -13,7 +13,7 @@
 
 namespace Web::Painting {
 
-enum class ScrollDirection {
+enum class ScrollDirection : u8 {
     Horizontal,
     Vertical,
 };

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -2679,7 +2679,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     layout_config
         .includes
         .push("LibWeb/Layout/TreeBuilderRustFFI.h".to_string());
-    layout_config.export.include = vec!["FfiFormattingContextType".to_string()];
+    layout_config.export.include = vec![
+        "FfiFormattingContextType".to_string(),
+        "FilterOperationType".to_string(),
+    ];
     generate_ffi_header(
         layout_config,
         &[

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -2227,6 +2227,7 @@ fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
             "OptionalUsize",
             "MaskLayerOrigin",
             "TransformDataRole",
+            "FfiChromeMetrics",
         ]
         .map(String::from),
     );
@@ -2262,6 +2263,7 @@ fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
         ("OptionalUsize", "Optional<size_t>"),
         ("MaskLayerOrigin", "Web::Painting::MaskLayerOrigin"),
         ("TransformDataRole", "Web::Painting::TransformDataRole"),
+        ("FfiChromeMetrics", "Web::ChromeMetrics"),
     ] {
         config.export.rename.insert(rust_name.to_string(), cpp_name.to_string());
     }
@@ -2282,6 +2284,7 @@ fn expose_shared_abi_types_as_cpp_types(config: &mut cbindgen::Config) {
             "LibGfx/Size.h",
             "LibGfx/WindingRule.h",
             "LibWeb/Painting/AccumulatedVisualContext.h",
+            "LibWeb/Painting/ChromeMetrics.h",
         ]
         .map(String::from),
     );

--- a/Libraries/LibWeb/Rust/src/css/css_pixels.rs
+++ b/Libraries/LibWeb/Rust/src/css/css_pixels.rs
@@ -189,6 +189,13 @@ pub struct CssPixelFraction {
 }
 
 impl CssPixelFraction {
+    pub fn zero() -> Self {
+        Self {
+            numerator: CssPixels::from_raw(0),
+            denominator: CssPixels::from_integer(1),
+        }
+    }
+
     pub fn one() -> Self {
         Self {
             numerator: CssPixels::from_integer(1),
@@ -199,6 +206,10 @@ impl CssPixelFraction {
     pub fn ratio_of(numerator: CssPixels, denominator: CssPixels) -> Self {
         assert!(denominator.raw_value() != 0);
         Self { numerator, denominator }
+    }
+
+    pub fn to_double(self) -> f64 {
+        self.numerator.to_double() / self.denominator.to_double()
     }
 
     fn cross_products(self, other: Self) -> (i64, i64) {

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -567,6 +567,8 @@ macro_rules! shadow_comparable_rare_payloads {
         (
             $carrier.svg_viewport_transform,
             $carrier.svg_viewport_size,
+            $carrier.svg_view_box,
+            $carrier.svg_viewport_percentage_basis,
             &$carrier.computed_svg_path,
             &$carrier.grid_layout_data,
             &$carrier.flex_layout_data,

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -29,6 +29,8 @@ pub(crate) struct Fragment {
     pub(crate) used_grid_tracks: Option<std::rc::Rc<OwnedUsedGridTracks>>,
     pub(crate) svg_viewport_transform: Option<crate::layout::FfiAffineTransform>,
     pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
+    pub(crate) svg_view_box: Option<crate::layout::FfiSvgViewBox>,
+    pub(crate) svg_viewport_percentage_basis: CssPixels,
     pub(crate) computed_svg_path: Option<std::rc::Rc<libgfx_rust::path::OwnedPath>>,
     pub(crate) children: Vec<FragmentLink>,
 }
@@ -78,6 +80,8 @@ impl Fragment {
             && same_allocation(self.used_grid_tracks.as_ref(), previous.used_grid_tracks.as_ref())
             && self.svg_viewport_transform == previous.svg_viewport_transform
             && self.svg_viewport_size == previous.svg_viewport_size
+            && self.svg_view_box == previous.svg_view_box
+            && self.svg_viewport_percentage_basis == previous.svg_viewport_percentage_basis
             && same_allocation(self.computed_svg_path.as_ref(), previous.computed_svg_path.as_ref())
             && self.children.len() == previous.children.len()
             && self
@@ -241,6 +245,8 @@ fn snapshot_fragment(
             rare.used_grid_tracks.take(),
             rare.svg_viewport_transform,
             rare.svg_viewport_size,
+            rare.svg_view_box,
+            rare.svg_viewport_percentage_basis,
             rare.computed_svg_path.take(),
         )
     });
@@ -251,6 +257,8 @@ fn snapshot_fragment(
         used_grid_tracks,
         svg_viewport_transform,
         svg_viewport_size,
+        svg_view_box,
+        svg_viewport_percentage_basis,
         computed_svg_path,
     ) = rare_payloads.unwrap_or_default();
     let mut fragment = Fragment {
@@ -278,6 +286,8 @@ fn snapshot_fragment(
         used_grid_tracks,
         svg_viewport_transform,
         svg_viewport_size,
+        svg_view_box,
+        svg_viewport_percentage_basis,
         computed_svg_path,
         children,
     };

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -2160,6 +2160,8 @@ mod tests {
                 used_grid_tracks: None,
                 svg_viewport_transform: None,
                 svg_viewport_size: None,
+                svg_view_box: None,
+                svg_viewport_percentage_basis: CssPixels::default(),
                 computed_svg_path: None,
                 children: Vec::new(),
             }),

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -72,6 +72,7 @@ pub struct FfiSvgElementFacts {
     pub preserve_aspect_ratio_meet_or_slice: u8,
     pub element_transform: FfiAffineTransform,
     pub visible_stroke_width: f32,
+    pub viewport_percentage_basis: CssPixels,
     pub content_units: u8,
     pub pattern_units: u8,
     pub pattern_width: FfiSvgNumberPercentage,
@@ -466,6 +467,13 @@ impl SvgFormattingContext {
         self.used_values(node).rare_data_mut().svg_viewport_size = Some(viewport_size);
     }
 
+    fn commit_svg_element_facts(&self, node: Node, facts: FfiSvgElementFacts) {
+        let used = self.used_values(node);
+        let mut rare = used.rare_data_mut();
+        rare.svg_view_box = facts.has_active_view_box.then_some(facts.active_view_box);
+        rare.svg_viewport_percentage_basis = facts.viewport_percentage_basis;
+    }
+
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
         crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
     }
@@ -496,6 +504,7 @@ impl SvgFormattingContext {
         let facts = self.svg_facts(self.box_);
         let used_pointer = self.used_values(self.box_);
         let used = &used_pointer;
+        self.commit_svg_element_facts(self.box_, facts);
 
         if facts.is_document_element && !facts.document_is_decoded_svg && !used.has_content_offset.get() {
             // Overwrite the content width/height with the styled node width/height (from <svg width height ...>)
@@ -712,6 +721,8 @@ impl SvgFormattingContext {
 
     fn layout_graphics_element(&mut self, run: &FormattingContextRun, graphics_box: Node, input: LayoutInput) {
         self.create_used_values(graphics_box);
+        let facts = self.svg_facts(graphics_box);
+        self.commit_svg_element_facts(graphics_box, facts);
         let kind = self.node_kind(graphics_box);
 
         // https://svgwg.org/svg2-draft/struct.html#GroupsOverview
@@ -820,6 +831,7 @@ impl SvgFormattingContext {
         assert!(kind_is_svg_resource_box(kind));
         // FIXME: Somehow limit <clipPath> contents to: shape elements, <text>, and <use>.
         let used_pointer = self.create_used_values(resource);
+        self.commit_svg_element_facts(resource, facts);
 
         if kind == NodeKind::SVGPatternBox && facts.has_active_view_box {
             if facts.pattern_units == SVG_UNITS_USER_SPACE_ON_USE {

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -298,6 +298,8 @@ pub(crate) struct UsedValuesRareData {
     pub(crate) computed_svg_path: Option<std::rc::Rc<libgfx_rust::path::OwnedPath>>,
     pub(crate) svg_viewport_transform: Option<crate::layout::FfiAffineTransform>,
     pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
+    pub(crate) svg_view_box: Option<crate::layout::FfiSvgViewBox>,
+    pub(crate) svg_viewport_percentage_basis: CssPixels,
     pub(crate) grid_layout_data: Option<std::rc::Rc<GridLayoutData>>,
     pub(crate) flex_layout_data: Option<std::rc::Rc<FlexLayoutData>>,
     pub(crate) used_grid_tracks: Option<std::rc::Rc<OwnedUsedGridTracks>>,
@@ -311,6 +313,8 @@ impl UsedValuesRareData {
             computed_svg_path,
             svg_viewport_transform,
             svg_viewport_size,
+            svg_view_box,
+            svg_viewport_percentage_basis,
             grid_layout_data,
             flex_layout_data,
             used_grid_tracks,
@@ -324,6 +328,8 @@ impl UsedValuesRareData {
         if computed_svg_path.is_none()
             && svg_viewport_transform.is_none()
             && svg_viewport_size.is_none()
+            && svg_view_box.is_none()
+            && svg_viewport_percentage_basis == CssPixels::default()
             && grid_layout_data.is_none()
             && flex_layout_data.is_none()
             && used_grid_tracks.is_none()
@@ -341,6 +347,10 @@ impl UsedValuesRareData {
         if let Some(size) = svg_viewport_size {
             rare.svg_viewport_size = Some(size);
         }
+        if let Some(view_box) = svg_view_box {
+            rare.svg_view_box = Some(view_box);
+        }
+        rare.svg_viewport_percentage_basis = svg_viewport_percentage_basis;
         if let Some(data) = grid_layout_data {
             rare.grid_layout_data = Some(data);
         }

--- a/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
@@ -5,15 +5,90 @@
  */
 
 use crate::css::css_enums;
+use crate::css::css_pixels::{CssPixelFraction, CssPixelPoint, CssPixelRect, CssPixels};
 use crate::layout::node_data::NodeSlotId;
-use crate::painting::paintable_data::PaintableKind;
+use crate::painting::ffi::{FfiChromeMetrics, ScrollDirection};
+use crate::painting::host::{FfiHitTestQueryCallbacks, FfiRecordingInputs, FfiRootBackgroundSource};
+use crate::painting::paintable_data::{PaintableFlag, PaintableKind};
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::style_queries;
+use libgfx_rust::Color;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScrollbarData {
+    pub(crate) gutter_rect: CssPixelRect,
+    pub(crate) thumb_rect: CssPixelRect,
+    pub(crate) track_rect: CssPixelRect,
+    pub(crate) thumb_travel_to_scroll_ratio: CssPixelFraction,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScrollbarScrollState {
+    pub(crate) device_scroll_offset: f32,
+    pub(crate) device_pixels_per_css_pixel: f64,
+}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct PhysicalAxes {
     pub(crate) horizontal: bool,
     pub(crate) vertical: bool,
+}
+
+impl PhysicalAxes {
+    fn along(self, direction: ScrollDirection) -> bool {
+        match direction {
+            ScrollDirection::Horizontal => self.horizontal,
+            ScrollDirection::Vertical => self.vertical,
+        }
+    }
+}
+
+fn primary_size(rect: CssPixelRect, direction: ScrollDirection) -> CssPixels {
+    match direction {
+        ScrollDirection::Horizontal => rect.width,
+        ScrollDirection::Vertical => rect.height,
+    }
+}
+
+fn primary_offset(point: CssPixelPoint, direction: ScrollDirection) -> CssPixels {
+    match direction {
+        ScrollDirection::Horizontal => point.x,
+        ScrollDirection::Vertical => point.y,
+    }
+}
+
+struct AxisView<'r> {
+    primary_offset: &'r mut CssPixels,
+    primary_size: &'r mut CssPixels,
+    secondary_offset: &'r mut CssPixels,
+    secondary_size: &'r mut CssPixels,
+}
+
+fn axis_view(rect: &mut CssPixelRect, direction: ScrollDirection) -> AxisView<'_> {
+    match direction {
+        ScrollDirection::Horizontal => AxisView {
+            primary_offset: &mut rect.x,
+            primary_size: &mut rect.width,
+            secondary_offset: &mut rect.y,
+            secondary_size: &mut rect.height,
+        },
+        ScrollDirection::Vertical => AxisView {
+            primary_offset: &mut rect.y,
+            primary_size: &mut rect.height,
+            secondary_offset: &mut rect.x,
+            secondary_size: &mut rect.width,
+        },
+    }
+}
+
+pub(crate) fn is_chrome_mirrored(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
+    arena.node_style_if_live(slot).is_some_and(|style| {
+        let writing_mode = style.writing_mode();
+        (writing_mode == css_enums::writing_mode::HORIZONTAL_TB && style.direction() == css_enums::direction::RTL)
+            || writing_mode == css_enums::writing_mode::VERTICAL_RL
+            || writing_mode == css_enums::writing_mode::SIDEWAYS_RL
+    })
 }
 
 pub(crate) fn physical_resize_axes(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> PhysicalAxes {
@@ -59,23 +134,18 @@ pub(crate) fn has_resizer(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> b
 pub(crate) fn wheel_scrollable_axes(
     arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
-    viewport_overflow_x: u8,
-    viewport_overflow_y: u8,
+    viewport_wheel_overflow_x: u8,
+    viewport_wheel_overflow_y: u8,
 ) -> PhysicalAxes {
     let Some(style) = arena.node_style_if_live(slot) else {
         return PhysicalAxes::default();
     };
     let box_values = style.box_values();
     let is_viewport = arena.paintable_data(slot).kind == PaintableKind::ViewportPaintable;
-    let overflow_x = if is_viewport {
-        viewport_overflow_x
+    let (overflow_x, overflow_y) = if is_viewport {
+        (viewport_wheel_overflow_x, viewport_wheel_overflow_y)
     } else {
-        box_values.overflow_x
-    };
-    let overflow_y = if is_viewport {
-        viewport_overflow_y
-    } else {
-        box_values.overflow_y
+        (box_values.overflow_x, box_values.overflow_y)
     };
     let allows_wheel_scrolling =
         |overflow| overflow == css_enums::overflow::AUTO || overflow == css_enums::overflow::SCROLL;
@@ -94,4 +164,319 @@ pub(crate) fn wheel_scrollable_axes(
     axes.horizontal &= scrollable_overflow.width > scrollport.width;
     axes.vertical &= scrollable_overflow.height > scrollport.height;
     axes
+}
+
+pub(crate) fn minimum_scroll_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
+    let Some(overflow) = paintable_geometry::scrollable_overflow_rect(arena, slot) else {
+        return CssPixelPoint::default();
+    };
+    let scrollport = paintable_geometry::absolute_padding_box_rect(arena, slot);
+    let zero = CssPixels::from_raw(0);
+    CssPixelPoint::new(
+        (overflow.left() - scrollport.left()).min(zero),
+        (overflow.top() - scrollport.top()).min(zero),
+    )
+}
+
+pub(crate) fn maximum_scroll_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelPoint {
+    let Some(overflow) = paintable_geometry::scrollable_overflow_rect(arena, slot) else {
+        return CssPixelPoint::default();
+    };
+    let scrollport = paintable_geometry::absolute_padding_box_rect(arena, slot);
+    let zero = CssPixels::from_raw(0);
+    CssPixelPoint::new(
+        (overflow.right() - scrollport.right()).max(zero),
+        (overflow.bottom() - scrollport.bottom()).max(zero),
+    )
+}
+
+pub(crate) fn scrollbar_is_enlarged(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    direction: ScrollDirection,
+) -> bool {
+    let flag = match direction {
+        ScrollDirection::Horizontal => PaintableFlag::HorizontalScrollbarEnlarged,
+        ScrollDirection::Vertical => PaintableFlag::VerticalScrollbarEnlarged,
+    };
+    arena.paintable_data(slot).has_flag(flag)
+}
+
+pub(crate) struct ChromeGeometry<'a, Arena: PaintableRowsRead> {
+    pub(crate) arena: &'a Arena,
+    pub(crate) metrics: FfiChromeMetrics,
+    pub(crate) viewport_wheel_overflow_x: u8,
+    pub(crate) viewport_wheel_overflow_y: u8,
+}
+
+impl<'a, Arena: PaintableRowsRead> ChromeGeometry<'a, Arena> {
+    pub(crate) fn for_recording(arena: &'a Arena, inputs: &FfiRecordingInputs) -> Self {
+        Self {
+            arena,
+            metrics: inputs.chrome_metrics,
+            viewport_wheel_overflow_x: inputs.viewport_wheel_overflow_x,
+            viewport_wheel_overflow_y: inputs.viewport_wheel_overflow_y,
+        }
+    }
+
+    pub(crate) fn for_hit_test_query(arena: &'a Arena, callbacks: &FfiHitTestQueryCallbacks) -> Self {
+        Self {
+            arena,
+            metrics: callbacks.chrome_metrics,
+            viewport_wheel_overflow_x: callbacks.viewport_wheel_overflow_x,
+            viewport_wheel_overflow_y: callbacks.viewport_wheel_overflow_y,
+        }
+    }
+
+    fn wheel_scrollable_axes(&self, slot: NodeSlotId) -> PhysicalAxes {
+        wheel_scrollable_axes(
+            self.arena,
+            slot,
+            self.viewport_wheel_overflow_x,
+            self.viewport_wheel_overflow_y,
+        )
+    }
+
+    pub(crate) fn absolute_resizer_rect(&self, slot: NodeSlotId) -> Option<CssPixelRect> {
+        if !has_resizer(self.arena, slot) {
+            return None;
+        }
+        let padding_rect = paintable_geometry::absolute_padding_box_rect(self.arena, slot);
+        let gripper_size = self.metrics.resize_gripper_size;
+        let x = if is_chrome_mirrored(self.arena, slot) {
+            padding_rect.x
+        } else {
+            padding_rect.right() - gripper_size
+        };
+        Some(CssPixelRect::new(
+            x,
+            padding_rect.bottom() - gripper_size,
+            gripper_size,
+            gripper_size,
+        ))
+    }
+
+    pub(crate) fn resizer_contains(&self, slot: NodeSlotId, point: CssPixelPoint) -> bool {
+        if !self.arena.paintable_row_is_populated(slot) {
+            return false;
+        }
+        let Some(mut rect) = self.absolute_resizer_rect(slot) else {
+            return false;
+        };
+        let border = paintable_geometry::committed_border(self.arena, slot);
+        if is_chrome_mirrored(self.arena, slot) {
+            rect.x -= border.left;
+            rect.width += border.left;
+        } else {
+            rect.width += border.right;
+        }
+        rect.height += border.bottom;
+        rect.contains_point(point)
+    }
+
+    fn available_scrollbar_length(&self, slot: NodeSlotId, direction: ScrollDirection) -> CssPixels {
+        if !self.arena.paintable_row_is_populated(slot) {
+            return CssPixels::from_raw(0);
+        }
+        let mut length = primary_size(
+            paintable_geometry::absolute_padding_box_rect(self.arena, slot),
+            direction,
+        );
+        let axes = self.wheel_scrollable_axes(slot);
+        let other_axis_scrolls = match direction {
+            ScrollDirection::Horizontal => axes.vertical,
+            ScrollDirection::Vertical => axes.horizontal,
+        };
+        if has_resizer(self.arena, slot) {
+            length -= self.metrics.resize_gripper_size;
+        } else if other_axis_scrolls {
+            length -= self.metrics.scroll_gutter_thickness;
+        }
+        length
+    }
+
+    pub(crate) fn absolute_scrollbar_rect(
+        &self,
+        slot: NodeSlotId,
+        direction: ScrollDirection,
+        with_gutter: bool,
+    ) -> Option<CssPixelRect> {
+        if !self.arena.paintable_row_is_populated(slot) {
+            return None;
+        }
+        let axes = self.wheel_scrollable_axes(slot);
+        if !axes.along(direction) {
+            return None;
+        }
+        let style = self.arena.node_style_if_live(slot)?;
+        if style.misc_reset().scrollbar_width == css_enums::scrollbar_width::NONE {
+            return None;
+        }
+
+        let metrics = self.metrics;
+        let adjusting_for_resizer = has_resizer(self.arena, slot);
+        let mirrored = is_chrome_mirrored(self.arena, slot);
+        let rect_thickness = if with_gutter {
+            metrics.scroll_gutter_thickness
+        } else {
+            metrics.scroll_thumb_thickness_thin + metrics.scroll_thumb_padding_thin
+        };
+        let zero = CssPixels::from_raw(0);
+        let mut rect = paintable_geometry::absolute_padding_box_rect(self.arena, slot);
+        match direction {
+            ScrollDirection::Horizontal => {
+                if !adjusting_for_resizer && axes.vertical {
+                    rect.width = (rect.width - metrics.scroll_gutter_thickness).max(zero);
+                    if mirrored {
+                        rect.x += metrics.scroll_gutter_thickness;
+                    }
+                } else if adjusting_for_resizer {
+                    rect.width = self.available_scrollbar_length(slot, direction);
+                    if mirrored {
+                        rect.x += metrics.resize_gripper_size;
+                    }
+                }
+                rect.y = (rect.bottom() - rect_thickness).max(zero);
+                rect.height = rect_thickness;
+            }
+            ScrollDirection::Vertical => {
+                if adjusting_for_resizer {
+                    rect.height = self.available_scrollbar_length(slot, direction);
+                }
+                if !mirrored {
+                    rect.x = (rect.right() - rect_thickness).max(zero);
+                }
+                rect.width = rect_thickness;
+            }
+        }
+        Some(rect)
+    }
+
+    pub(crate) fn compute_scrollbar_data(
+        &self,
+        slot: NodeSlotId,
+        direction: ScrollDirection,
+        enlarged: bool,
+        scroll_state: Option<ScrollbarScrollState>,
+    ) -> Option<ScrollbarData> {
+        let arena = self.arena;
+        let metrics = self.metrics;
+        if !arena.paintable_row_is_populated(slot) {
+            return None;
+        }
+        let style = arena.node_style_if_live(slot)?;
+        let overflow = match direction {
+            ScrollDirection::Horizontal => style.box_values().overflow_x,
+            ScrollDirection::Vertical => style.box_values().overflow_y,
+        };
+        if overflow != css_enums::overflow::SCROLL && !self.wheel_scrollable_axes(slot).along(direction) {
+            return None;
+        }
+        if arena.paintable_data(slot).own_scroll_node_index == 0 {
+            return None;
+        }
+        let overflow_length = primary_size(paintable_geometry::scrollable_overflow_rect(arena, slot)?, direction);
+        if overflow_length == CssPixels::from_raw(0) {
+            return None;
+        }
+        let scrollbar_rect = self.absolute_scrollbar_rect(slot, direction, enlarged)?;
+        let (thumb_thickness, thumb_margin) = if enlarged {
+            (
+                metrics.scroll_thumb_thickness,
+                (metrics.scroll_gutter_thickness - metrics.scroll_thumb_thickness) / 2,
+            )
+        } else {
+            (metrics.scroll_thumb_thickness_thin, metrics.scroll_thumb_padding_thin)
+        };
+        let usable_length = (primary_size(scrollbar_rect, direction) - thumb_margin * 2).max(CssPixels::from_raw(0));
+        let scrollport_size = primary_size(paintable_geometry::absolute_padding_box_rect(arena, slot), direction);
+        let min_thumb_length = usable_length.min(metrics.scroll_thumb_min_length);
+        let thumb_length = usable_length
+            .mul_by_fraction(CssPixelFraction::ratio_of(scrollport_size, overflow_length))
+            .max(min_thumb_length);
+        let ratio = if overflow_length > scrollport_size {
+            CssPixelFraction::ratio_of(usable_length - thumb_length, overflow_length - scrollport_size)
+        } else {
+            CssPixelFraction::zero()
+        };
+        let mut thumb_rect = scrollbar_rect;
+        let thumb = axis_view(&mut thumb_rect, direction);
+        *thumb.primary_size = thumb_length;
+        *thumb.secondary_size = thumb_thickness;
+        let minimum_offset = primary_offset(minimum_scroll_offset(arena, slot), direction);
+        *thumb.primary_offset += thumb_margin - minimum_offset.mul_by_fraction(ratio);
+        if enlarged || (direction == ScrollDirection::Vertical && is_chrome_mirrored(arena, slot)) {
+            *thumb.secondary_offset += thumb_margin;
+        }
+        if let Some(scroll_state) = scroll_state {
+            let scroll_offset = CssPixels::nearest_value_for_f32(
+                scroll_state.device_scroll_offset / scroll_state.device_pixels_per_css_pixel as f32,
+            );
+            *thumb.primary_offset += scroll_offset.mul_by_fraction(ratio);
+        }
+        Some(ScrollbarData {
+            gutter_rect: if enlarged {
+                scrollbar_rect
+            } else {
+                CssPixelRect::default()
+            },
+            thumb_rect,
+            track_rect: scrollbar_rect,
+            thumb_travel_to_scroll_ratio: ratio,
+        })
+    }
+}
+
+fn is_canvas_background_source(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    root_background_source: FfiRootBackgroundSource,
+) -> bool {
+    style_queries::node_is_root_element(arena, slot)
+        || (root_background_source.use_body_background_properties && root_background_source.body_layout_node == slot)
+}
+
+pub(crate) fn scrollbar_colors_for_paint(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    root_background_source: FfiRootBackgroundSource,
+    canvas_background_color: Color,
+) -> (Color, Color) {
+    let Some(style) = arena.node_style_if_live(slot) else {
+        return (Color::TRANSPARENT, Color::TRANSPARENT);
+    };
+    let colors = style.inherited_ui().scrollbar_color;
+    if !colors.is_auto {
+        return (Color(colors.thumb_color), Color(colors.track_color));
+    }
+
+    let mut ancestors = Vec::new();
+    let mut current = Some(slot);
+    while let Some(ancestor) = current {
+        ancestors.push(ancestor);
+        current = arena.node_parent_if_live(ancestor);
+    }
+    let mut background_color = canvas_background_color;
+    for ancestor in ancestors.into_iter().rev() {
+        if is_canvas_background_source(arena, ancestor, root_background_source) {
+            continue;
+        }
+        let Some(style) = arena.node_style_if_live(ancestor) else {
+            continue;
+        };
+        let color = Color(style.background().background_color);
+        if color.alpha() != 0 {
+            background_color = background_color.blend(color);
+        }
+    }
+    let black_thumb = Color::from_rgb(0, 0, 0).with_alpha(128);
+    let white_thumb = Color::from_rgb(255, 255, 255).with_alpha(128);
+    let black_contrast = background_color.contrast_ratio(background_color.blend(black_thumb));
+    let white_contrast = background_color.contrast_ratio(background_color.blend(white_thumb));
+    let thumb = if black_contrast >= white_contrast {
+        black_thumb
+    } else {
+        white_thumb
+    };
+    (thumb, thumb.with_alpha(25))
 }

--- a/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/chrome_geometry.rs
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::css_enums;
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::paintable_data::PaintableKind;
+use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PhysicalAxes {
+    pub(crate) horizontal: bool,
+    pub(crate) vertical: bool,
+}
+
+pub(crate) fn physical_resize_axes(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> PhysicalAxes {
+    let Some(style) = arena.node_style_if_live(slot) else {
+        return PhysicalAxes::default();
+    };
+    let box_values = style.box_values();
+    if box_values.resize == css_enums::resize::NONE {
+        return PhysicalAxes::default();
+    }
+    if style.display().is_inline_outside() && style.display().is_flow_inside() {
+        return PhysicalAxes::default();
+    }
+
+    let horizontal_writing_mode = style.writing_mode() == css_enums::writing_mode::HORIZONTAL_TB;
+    let overflow_allows_resize =
+        |overflow| overflow != css_enums::overflow::VISIBLE && overflow != css_enums::overflow::CLIP;
+    PhysicalAxes {
+        horizontal: overflow_allows_resize(box_values.overflow_x)
+            && (box_values.resize == css_enums::resize::BOTH
+                || box_values.resize == css_enums::resize::HORIZONTAL
+                || (box_values.resize == css_enums::resize::INLINE && horizontal_writing_mode)
+                || (box_values.resize == css_enums::resize::BLOCK && !horizontal_writing_mode)),
+        vertical: overflow_allows_resize(box_values.overflow_y)
+            && (box_values.resize == css_enums::resize::BOTH
+                || box_values.resize == css_enums::resize::VERTICAL
+                || (box_values.resize == css_enums::resize::INLINE && !horizontal_writing_mode)
+                || (box_values.resize == css_enums::resize::BLOCK && horizontal_writing_mode)),
+    }
+}
+
+pub(crate) fn has_resizer(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
+    if !arena.paintable_row_is_populated(slot)
+        || arena.paintable_data(slot).kind == PaintableKind::ViewportPaintable
+        || arena.node_is_generated_for_pseudo_element(slot)
+    {
+        return false;
+    }
+    let axes = physical_resize_axes(arena, slot);
+    axes.horizontal || axes.vertical
+}
+
+pub(crate) fn wheel_scrollable_axes(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    viewport_overflow_x: u8,
+    viewport_overflow_y: u8,
+) -> PhysicalAxes {
+    let Some(style) = arena.node_style_if_live(slot) else {
+        return PhysicalAxes::default();
+    };
+    let box_values = style.box_values();
+    let is_viewport = arena.paintable_data(slot).kind == PaintableKind::ViewportPaintable;
+    let overflow_x = if is_viewport {
+        viewport_overflow_x
+    } else {
+        box_values.overflow_x
+    };
+    let overflow_y = if is_viewport {
+        viewport_overflow_y
+    } else {
+        box_values.overflow_y
+    };
+    let allows_wheel_scrolling =
+        |overflow| overflow == css_enums::overflow::AUTO || overflow == css_enums::overflow::SCROLL;
+    let mut axes = PhysicalAxes {
+        horizontal: allows_wheel_scrolling(overflow_x),
+        vertical: allows_wheel_scrolling(overflow_y),
+    };
+    if !axes.horizontal && !axes.vertical {
+        return axes;
+    }
+
+    let Some(scrollable_overflow) = paintable_geometry::scrollable_overflow_rect(arena, slot) else {
+        return PhysicalAxes::default();
+    };
+    let scrollport = paintable_geometry::absolute_padding_box_rect(arena, slot);
+    axes.horizontal &= scrollable_overflow.width > scrollport.width;
+    axes.vertical &= scrollable_overflow.height > scrollport.height;
+    axes
+}

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -35,6 +35,30 @@ pub enum ScrollDirection {
     Vertical,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FilterOperationType {
+    Arithmetic,
+    Compose,
+    Blend,
+    Flood,
+    DisplacementMap,
+    DropShadow,
+    Blur,
+    ColorFilter,
+    ColorMatrix,
+    ColorTable,
+    Saturate,
+    HueRotate,
+    Image,
+    Merge,
+    Offset,
+    Erode,
+    Dilate,
+    Turbulence,
+    ColorSpaceConversion,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiChromeMetrics {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -27,6 +27,204 @@ unsafe fn arena_from_handle_mut<'a>(arena: *mut c_void) -> &'a mut LayoutNodeAre
     unsafe { LayoutNodeArena::from_handle_mut(arena) }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ScrollDirection {
+    #[default]
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiChromeMetrics {
+    pub scroll_thumb_min_length: CssPixels,
+    pub scroll_thumb_padding_thin: CssPixels,
+    pub scroll_thumb_thickness_thin: CssPixels,
+    pub scroll_thumb_thickness: CssPixels,
+    pub scroll_gutter_thickness: CssPixels,
+    pub resize_gripper_size: CssPixels,
+    pub resize_gripper_padding: CssPixels,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiPhysicalResizeAxes {
+    pub horizontal: bool,
+    pub vertical: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiScrollbarData {
+    pub gutter_rect: FfiCssPixelRect,
+    pub thumb_rect: FfiCssPixelRect,
+    pub track_rect: FfiCssPixelRect,
+    pub thumb_travel_to_scroll_ratio: f64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiOptionalScrollbarData {
+    pub has_value: bool,
+    pub value: FfiScrollbarData,
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_set_scrollbar_enlarged(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    direction: ScrollDirection,
+    enlarged: bool,
+) {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        let mut rows = arena.paintable_rows_mut();
+        if !rows.paintable_row_is_populated(slot) {
+            return;
+        }
+        let flag = match direction {
+            ScrollDirection::Horizontal => PaintableFlag::HorizontalScrollbarEnlarged,
+            ScrollDirection::Vertical => PaintableFlag::VerticalScrollbarEnlarged,
+        };
+        rows.paintable_data_mut(slot).set_flag(flag, enlarged);
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_physical_resize_axes(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+) -> FfiPhysicalResizeAxes {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let axes = crate::painting::chrome_geometry::physical_resize_axes(&arena.paintable_rows(), slot);
+        FfiPhysicalResizeAxes {
+            horizontal: axes.horizontal,
+            vertical: axes.vertical,
+        }
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_is_chrome_mirrored(arena: *mut c_void, slot: NodeSlotId) -> bool {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        crate::painting::chrome_geometry::is_chrome_mirrored(&arena.paintable_rows(), slot)
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_compute_scrollbar_data(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    direction: ScrollDirection,
+    metrics: FfiChromeMetrics,
+    viewport_overflow_x: u8,
+    viewport_overflow_y: u8,
+    enlarged: bool,
+    has_device_scroll_offset: bool,
+    device_scroll_offset: f32,
+    device_pixels_per_css_pixel: f64,
+) -> FfiOptionalScrollbarData {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
+        let data = crate::painting::chrome_geometry::ChromeGeometry {
+            arena: &paintable_rows,
+            metrics,
+            viewport_wheel_overflow_x: viewport_overflow_x,
+            viewport_wheel_overflow_y: viewport_overflow_y,
+        }
+        .compute_scrollbar_data(
+            slot,
+            direction,
+            enlarged,
+            has_device_scroll_offset.then_some(crate::painting::chrome_geometry::ScrollbarScrollState {
+                device_scroll_offset,
+                device_pixels_per_css_pixel,
+            }),
+        );
+        let Some(data) = data else {
+            return FfiOptionalScrollbarData::default();
+        };
+        FfiOptionalScrollbarData {
+            has_value: true,
+            value: FfiScrollbarData {
+                gutter_rect: data.gutter_rect.into(),
+                thumb_rect: data.thumb_rect.into(),
+                track_rect: data.track_rect.into(),
+                thumb_travel_to_scroll_ratio: data.thumb_travel_to_scroll_ratio.to_double(),
+            },
+        }
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_minimum_scroll_offset(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+) -> FfiCssPixelPoint {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        crate::painting::chrome_geometry::minimum_scroll_offset(&arena.paintable_rows(), slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_maximum_scroll_offset(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+) -> FfiCssPixelPoint {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        crate::painting::chrome_geometry::maximum_scroll_offset(&arena.paintable_rows(), slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_wheel_scrollable_axes(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    viewport_overflow_x: u8,
+    viewport_overflow_y: u8,
+) -> FfiPhysicalResizeAxes {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let axes = crate::painting::chrome_geometry::wheel_scrollable_axes(
+            &arena.paintable_rows(),
+            slot,
+            viewport_overflow_x,
+            viewport_overflow_y,
+        );
+        FfiPhysicalResizeAxes {
+            horizontal: axes.horizontal,
+            vertical: axes.vertical,
+        }
+    })
+}
+
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -396,6 +396,52 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_transform(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_transform_reference_box(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+) -> FfiCssPixelRect {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        if !arena.paintable_row_is_populated(slot) {
+            return FfiCssPixelRect::default();
+        }
+        let Some(style) = arena.node_style_if_live(slot) else {
+            return FfiCssPixelRect::default();
+        };
+        let paintable_rows = arena.paintable_rows();
+        crate::painting::visual_context::node_values::transform_reference_box(style, &paintable_rows, slot).into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_user_rect(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+) -> crate::layout::OptionalCssPixelRect {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        if !arena.paintable_row_is_populated(slot) {
+            return None.into();
+        }
+        let paintable_rows = arena.paintable_rows();
+        crate::painting::svg_viewport::nearest_svg_viewport_user_rect(&paintable_rows, slot)
+            .map(|rect| crate::layout::FfiCssPixelRect {
+                x: crate::css::css_pixels::CssPixels::nearest_value_for(rect.x as f64),
+                y: crate::css::css_pixels::CssPixels::nearest_value_for(rect.y as f64),
+                width: crate::css::css_pixels::CssPixels::nearest_value_for(rect.width as f64),
+                height: crate::css::css_pixels::CssPixels::nearest_value_for(rect.height as f64),
+            })
+            .into()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_box_model(arena: *mut c_void, slot: NodeSlotId) -> FfiBoxModelMetrics {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };

--- a/Libraries/LibWeb/Rust/src/painting/filter_bytes.rs
+++ b/Libraries/LibWeb/Rust/src/painting/filter_bytes.rs
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::css::computed_value_types::{ComputedFilter, ComputedFilterOperation};
+use crate::css::css_pixels::CssPixels;
+use crate::painting::ffi::FilterOperationType;
+
+const FILTER_KIND_BLUR: u8 = 0;
+const FILTER_KIND_DROP_SHADOW: u8 = 1;
+const FILTER_KIND_HUE_ROTATE: u8 = 2;
+const FILTER_KIND_COLOR: u8 = 3;
+const FILTER_KIND_URL: u8 = 4;
+
+pub(crate) fn contains_url(filter: &ComputedFilter) -> bool {
+    filter
+        .operations
+        .as_slice()
+        .iter()
+        .any(|operation| operation.kind == FILTER_KIND_URL)
+}
+
+pub(crate) fn serialize_non_url_filter(filter: &ComputedFilter, device_pixels_per_css_pixel: f64) -> Option<Vec<u8>> {
+    let operations = filter.operations.as_slice();
+    if operations.is_empty() || operations.iter().any(|operation| operation.kind == FILTER_KIND_URL) {
+        return None;
+    }
+
+    let mut bytes = Vec::new();
+    encode_composed_filter(&mut bytes, operations, device_pixels_per_css_pixel);
+    Some(bytes)
+}
+
+fn encode_composed_filter(
+    bytes: &mut Vec<u8>,
+    operations: &[ComputedFilterOperation],
+    device_pixels_per_css_pixel: f64,
+) {
+    if let Some((last, previous)) = operations.split_last() {
+        if previous.is_empty() {
+            encode_operation(bytes, last, device_pixels_per_css_pixel);
+        } else {
+            write_u8(bytes, FilterOperationType::Compose as u8);
+            encode_operation(bytes, last, device_pixels_per_css_pixel);
+            encode_composed_filter(bytes, previous, device_pixels_per_css_pixel);
+        }
+    }
+}
+
+fn encode_operation(bytes: &mut Vec<u8>, operation: &ComputedFilterOperation, device_pixels_per_css_pixel: f64) {
+    match operation.kind {
+        FILTER_KIND_BLUR => {
+            write_u8(bytes, FilterOperationType::Blur as u8);
+            let radius =
+                (CssPixels::nearest_value_for_f32(operation.amount).to_double() * device_pixels_per_css_pixel) as f32;
+            write_f32(bytes, radius);
+            write_f32(bytes, radius);
+            write_bool(bytes, false);
+        }
+        FILTER_KIND_DROP_SHADOW => {
+            write_u8(bytes, FilterOperationType::DropShadow as u8);
+            let scale = |raw| (CssPixels::from_raw(raw).to_double() * device_pixels_per_css_pixel) as f32;
+            write_f32(bytes, scale(operation.shadow_offset_x));
+            write_f32(bytes, scale(operation.shadow_offset_y));
+            write_f32(bytes, scale(operation.shadow_radius));
+            write_u32(bytes, operation.shadow_color);
+            write_bool(bytes, false);
+        }
+        FILTER_KIND_COLOR => {
+            write_u8(bytes, FilterOperationType::ColorFilter as u8);
+            write_i32(bytes, i32::from(operation.color_operation));
+            write_f32(bytes, operation.amount);
+            write_bool(bytes, false);
+        }
+        FILTER_KIND_HUE_ROTATE => {
+            write_u8(bytes, FilterOperationType::HueRotate as u8);
+            write_f32(bytes, operation.amount);
+            write_bool(bytes, false);
+        }
+        _ => unreachable!("computed filter holds an unknown operation kind"),
+    }
+}
+
+fn write_bool(bytes: &mut Vec<u8>, value: bool) {
+    write_u8(bytes, value as u8);
+}
+
+fn write_u8(bytes: &mut Vec<u8>, value: u8) {
+    bytes.push(value);
+}
+
+fn write_i32(bytes: &mut Vec<u8>, value: i32) {
+    bytes.extend_from_slice(&value.to_ne_bytes());
+}
+
+fn write_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_ne_bytes());
+}
+
+fn write_f32(bytes: &mut Vec<u8>, value: f32) {
+    bytes.extend_from_slice(&value.to_ne_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::css::computed_value_types::ComputedStyleValueHandle;
+
+    fn operation(kind: u8) -> ComputedFilterOperation {
+        ComputedFilterOperation {
+            kind,
+            color_operation: 0,
+            amount: 0.0,
+            shadow_offset_x: 0,
+            shadow_offset_y: 0,
+            shadow_radius: 0,
+            shadow_color: 0,
+            url_value: ComputedStyleValueHandle {
+                pointer: std::ptr::null(),
+            },
+        }
+    }
+
+    #[test]
+    fn serializes_blur_with_css_pixel_rounding() {
+        let mut blur = operation(FILTER_KIND_BLUR);
+        blur.amount = 1.257;
+        let mut bytes = Vec::new();
+        encode_composed_filter(&mut bytes, &[blur], 2.0);
+
+        let radius = 2.5f32;
+        let mut expected = vec![FilterOperationType::Blur as u8];
+        expected.extend_from_slice(&radius.to_ne_bytes());
+        expected.extend_from_slice(&radius.to_ne_bytes());
+        expected.push(0);
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn composes_new_operations_outside_previous_operations() {
+        let mut color = operation(FILTER_KIND_COLOR);
+        color.color_operation = 5;
+        color.amount = 0.75;
+        let mut hue_rotate = operation(FILTER_KIND_HUE_ROTATE);
+        hue_rotate.amount = 90.0;
+        let mut bytes = Vec::new();
+        encode_composed_filter(&mut bytes, &[color, hue_rotate], 1.0);
+
+        assert_eq!(bytes[0], FilterOperationType::Compose as u8);
+        assert_eq!(bytes[1], FilterOperationType::HueRotate as u8);
+        assert_eq!(bytes[7], FilterOperationType::ColorFilter as u8);
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/query.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/query.rs
@@ -6,6 +6,8 @@
 
 use super::*;
 use crate::layout::LayoutNodeArena;
+use crate::painting::chrome_geometry::{ChromeGeometry, scrollbar_is_enlarged};
+use crate::painting::ffi::ScrollDirection;
 use crate::painting::host::FfiHitTestQueryCallbacks;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -54,8 +56,27 @@ impl HitTestList {
                 if !layout_arena.paintable_row_is_populated(item.paintable) {
                     return false;
                 }
+                assert!(
+                    callbacks.has_chrome_metrics,
+                    "chrome widget hit testing needs the chrome metrics"
+                );
                 let node = item.paintable;
-                callbacks.chrome_widget_contains(layout_arena.shell_if_live(node), item.chrome_widget_kind, local_point)
+                let rows = layout_arena.paintable_rows();
+                let chrome_geometry = ChromeGeometry::for_hit_test_query(&rows, callbacks);
+                match item.chrome_widget_kind {
+                    1 => chrome_geometry.resizer_contains(node, local_point),
+                    2 | 3 => {
+                        let direction = if item.chrome_widget_kind == 2 {
+                            ScrollDirection::Horizontal
+                        } else {
+                            ScrollDirection::Vertical
+                        };
+                        chrome_geometry
+                            .absolute_scrollbar_rect(node, direction, scrollbar_is_enlarged(&rows, node, direction))
+                            .is_some_and(|rect| rect.contains_point(local_point))
+                    }
+                    _ => false,
+                }
             }
         }
     }

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -63,6 +63,10 @@ impl FfiHitTestHostCallbacks {
 #[repr(C)]
 pub struct FfiHitTestQueryCallbacks {
     pub context: *mut c_void,
+    pub has_chrome_metrics: bool,
+    pub chrome_metrics: crate::painting::ffi::FfiChromeMetrics,
+    pub viewport_wheel_overflow_x: u8,
+    pub viewport_wheel_overflow_y: u8,
     pub local_point_for_visual_context: unsafe extern "C" fn(
         *mut c_void,
         usize,
@@ -70,8 +74,6 @@ pub struct FfiHitTestQueryCallbacks {
         bool,
         *mut libgfx_rust::FloatPoint,
     ) -> bool,
-    pub chrome_widget_contains:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, u8, crate::layout::FfiCssPixelPoint) -> bool,
     pub line_in_scope: unsafe extern "C" fn(*mut c_void, usize) -> bool,
     pub sorting_context_group: unsafe extern "C" fn(*mut c_void, usize, *mut usize) -> bool,
     pub plane_depth_key: unsafe extern "C" fn(*mut c_void, usize, crate::layout::FfiCssPixelPoint, *mut i64) -> bool,
@@ -89,15 +91,6 @@ impl FfiHitTestQueryCallbacks {
         let has_local =
             unsafe { (self.local_point_for_visual_context)(self.context, index, point, respect_clip, &raw mut local) };
         has_local.then_some((local.x, local.y))
-    }
-    pub(crate) fn chrome_widget_contains(
-        &self,
-        layout_node_shell: *mut c_void,
-        kind: u8,
-        local_point: crate::css::css_pixels::CssPixelPoint,
-    ) -> bool {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.chrome_widget_contains)(self.context, layout_node_shell, kind, local_point.into()) }
     }
     pub(crate) fn line_in_scope(&self, line_index: usize) -> bool {
         // SAFETY: The C++ host answers synchronously.

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -7,30 +7,22 @@
 use crate::layout::OptionalCssPixelRect;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::display_list::commands::OptionalU32;
-use libgfx_rust::WindingRule;
 use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiHitTestPaintableFacts {
-    pub opacity_is_zero: bool,
-    pub visible_for_hit_testing: bool,
+    pub is_inert: bool,
     pub dom_node_has_parent: bool,
     pub is_editable_or_editing_host: bool,
-    pub has_resizer: bool,
-    pub could_be_scrolled_horizontally: bool,
-    pub could_be_scrolled_vertically: bool,
-    pub svg_path_has_fill: bool,
-    pub svg_path_winding_rule: WindingRule,
     pub svg_mask_content_units_object_bbox: bool,
     pub svg_clip_path_units_object_bbox: bool,
+    pub inside_blocking_wheel_event_handler: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiHitTestTextNodeFacts {
-    pub parent_opacity_is_zero: bool,
-    pub parent_pointer_events_none: bool,
     pub is_inert: bool,
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -25,6 +25,12 @@ pub struct FfiRecordingInputs {
     pub has_blocking_wheel_event_region_covering_viewport: bool,
     pub viewport_wheel_overflow_x: u8,
     pub viewport_wheel_overflow_y: u8,
+    pub chrome_metrics: crate::painting::ffi::FfiChromeMetrics,
+    pub paint_viewport_scrollbars: bool,
+    pub async_scrolling_enabled: bool,
+    pub middle_button_scroll_active: bool,
+    pub middle_button_scroll_origin: crate::layout::FfiCssPixelPoint,
+    pub root_background_source: FfiRootBackgroundSource,
     pub canvas_fill_rect: OptionalIntRect,
     pub canvas_color: Color,
     pub opaque_canvas: bool,
@@ -215,20 +221,6 @@ pub enum FfiScrollNodeKind {
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
-pub struct FfiViewportScrollbarFacts {
-    pub present: bool,
-    pub gutter_rect: crate::layout::FfiCssPixelRect,
-    pub thumb_rect: crate::layout::FfiCssPixelRect,
-    pub expanded_gutter_rect: crate::layout::FfiCssPixelRect,
-    pub expanded_thumb_rect: crate::layout::FfiCssPixelRect,
-    pub scroll_size: f64,
-    pub expanded_scroll_size: f64,
-    pub thumb_color: Color,
-    pub track_color: Color,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
 pub struct FfiAsyncScrollFacts {
     pub is_nested_navigable_container: bool,
     pub scroll_node_kind: FfiScrollNodeKind,
@@ -236,31 +228,6 @@ pub struct FfiAsyncScrollFacts {
     pub pseudo_element_type: u8,
     pub snaps_scroll_position_horizontally: bool,
     pub snaps_scroll_position_vertically: bool,
-    pub records_viewport_scrollbars: bool,
-    pub viewport_scrollbars: [FfiViewportScrollbarFacts; 2],
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
-pub struct FfiScrollbarPaintFacts {
-    pub present: bool,
-    pub gutter_rect: crate::layout::FfiCssPixelRect,
-    pub thumb_rect: crate::layout::FfiCssPixelRect,
-    pub track_rect: crate::layout::FfiCssPixelRect,
-    pub thumb_travel_to_scroll_ratio: f64,
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
-pub struct FfiOverlayFacts {
-    pub paints_scrollbars: bool,
-    pub scrollbars: [FfiScrollbarPaintFacts; 2],
-    pub thumb_color: Color,
-    pub track_color: Color,
-    pub resizer_rect: OptionalCssPixelRect,
-    pub resize_gripper_padding: crate::css::css_pixels::CssPixels,
-    pub middle_button_scroll_active: bool,
-    pub middle_button_scroll_origin: crate::layout::FfiCssPixelPoint,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -375,11 +342,9 @@ pub struct FfiPaintTreeDumpEntry {
 pub struct FfiPaintHostCallbacks {
     pub context: *mut c_void,
     pub async_scroll_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAsyncScrollFacts,
-    pub overlay_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiOverlayFacts,
     pub outline_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiOutlineFacts,
     pub image_intrinsic_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiLayerImageList, u32) -> FfiImageIntrinsicFacts,
-    pub root_background_source: unsafe extern "C" fn(*mut c_void) -> FfiRootBackgroundSource,
     pub text_control_selection: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiTextControlSelection,
     pub selection_style_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiSelectionStyleFacts,
     pub register_font: unsafe extern "C" fn(*mut c_void, *const c_void) -> u64,
@@ -443,10 +408,6 @@ impl FfiPaintHostCallbacks {
     pub(crate) fn outline_facts(&self, layout_node_shell: *mut c_void) -> FfiOutlineFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.outline_facts)(self.context, layout_node_shell) }
-    }
-    pub(crate) fn overlay_facts(&self, layout_node_shell: *mut c_void) -> FfiOverlayFacts {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.overlay_facts)(self.context, layout_node_shell) }
     }
     pub(crate) fn async_scroll_facts(&self, layout_node_shell: *mut c_void) -> FfiAsyncScrollFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
@@ -579,10 +540,6 @@ impl FfiPaintHostCallbacks {
     ) -> FfiImageIntrinsicFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.image_intrinsic_facts)(self.context, layout_node_shell, list, computed_index) }
-    }
-    pub(crate) fn root_background_source(&self) -> FfiRootBackgroundSource {
-        // SAFETY: The C++ host answers synchronously.
-        unsafe { (self.root_background_source)(self.context) }
     }
     pub(crate) fn replaced_paint_facts(&self, layout_node_shell: *mut c_void) -> FfiReplacedPaintFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -6,7 +6,7 @@
 
 use super::*;
 use crate::layout::{OptionalCssPixelRect, OptionalCssPixels, OptionalFloatSize, OptionalIntRect};
-use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor, OptionalFloatRect};
+use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor};
 use libgfx_rust::{
     AffineTransform, Color, FloatMatrix4x4, FloatRect, FloatSize, IntPoint, IntRect, InterpolationColorSpace,
 };
@@ -150,9 +150,7 @@ pub struct FfiReplacedPaintFacts {
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
-pub struct FfiSvgHostFacts {
-    pub viewport: OptionalFloatRect,
-    pub percentage_basis: crate::css::css_pixels::CssPixels,
+pub struct FfiSvgImageFacts {
     pub has_decoded_image_data: bool,
     pub natural_size: OptionalFloatSize,
 }
@@ -411,7 +409,7 @@ pub struct FfiPaintHostCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, FloatRect, FloatSize) -> FfiImagePaintFacts,
     pub backdrop_filter_bytes: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> bool,
     pub nested_display_list_from_bytes: unsafe extern "C" fn(*mut c_void, *const u8, usize, IntPoint) -> u64,
-    pub svg_host_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgHostFacts,
+    pub svg_image_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgImageFacts,
     pub svg_paint_style: unsafe extern "C" fn(
         *mut c_void,
         *mut c_void,
@@ -615,9 +613,9 @@ impl FfiPaintHostCallbacks {
             unsafe { (self.nested_display_list_from_bytes)(self.context, bytes.as_ptr(), bytes.len(), content_offset) };
         crate::painting::display_list::commands::DisplayListResourceId(id)
     }
-    pub(crate) fn svg_host_facts(&self, layout_node_shell: *mut c_void) -> FfiSvgHostFacts {
+    pub(crate) fn svg_image_facts(&self, layout_node_shell: *mut c_void) -> FfiSvgImageFacts {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.svg_host_facts)(self.context, layout_node_shell) }
+        unsafe { (self.svg_image_facts)(self.context, layout_node_shell) }
     }
     pub(crate) fn svg_paint_style(
         &self,

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -23,6 +23,8 @@ pub struct FfiRecordingInputs {
     pub is_recording_async_scrolling_metadata: bool,
     pub document_id: i64,
     pub has_blocking_wheel_event_region_covering_viewport: bool,
+    pub viewport_wheel_overflow_x: u8,
+    pub viewport_wheel_overflow_y: u8,
     pub canvas_fill_rect: OptionalIntRect,
     pub canvas_color: Color,
     pub opaque_canvas: bool,
@@ -234,7 +236,6 @@ pub struct FfiAsyncScrollFacts {
     pub pseudo_element_type: u8,
     pub snaps_scroll_position_horizontally: bool,
     pub snaps_scroll_position_vertically: bool,
-    pub inside_blocking_wheel_event_handler: bool,
     pub records_viewport_scrollbars: bool,
     pub viewport_scrollbars: [FfiViewportScrollbarFacts; 2],
 }

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -123,6 +123,8 @@ pub struct FfiVisualContextNodeExport {
     pub opacity: f32,
     pub blend_mode: CompositingAndBlendingOperator,
     pub filter: *mut c_void,
+    pub filter_bytes: *const u8,
+    pub filter_bytes_length: usize,
     pub path: *mut c_void,
     pub winding_rule: WindingRule,
     pub mask_kind: MaskKind,

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -43,8 +43,6 @@ pub struct FfiVisualContextHostCallbacks {
     pub context: *mut c_void,
     pub tree_inputs: unsafe extern "C" fn(*mut c_void) -> FfiVisualContextTreeInputs,
     pub scroll_offset: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiCssPixelPoint,
-    pub svg_transform_view_box_rect:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut crate::layout::FfiCssPixelRect) -> bool,
     pub svg_additional_element_transform:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut libgfx_rust::AffineTransform) -> bool,
     pub root_background_source: unsafe extern "C" fn(*mut c_void) -> FfiRootBackgroundSource,
@@ -62,15 +60,6 @@ impl FfiVisualContextHostCallbacks {
     pub(crate) fn scroll_offset(&self, layout_node_shell: *mut c_void) -> crate::layout::FfiCssPixelPoint {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.scroll_offset)(self.context, layout_node_shell) }
-    }
-    pub(crate) fn svg_transform_view_box_rect(
-        &self,
-        layout_node_shell: *mut c_void,
-    ) -> Option<crate::layout::FfiCssPixelRect> {
-        let mut rect = crate::layout::FfiCssPixelRect::default();
-        // SAFETY: The C++ host writes the rect synchronously when it returns true.
-        let has_rect = unsafe { (self.svg_transform_view_box_rect)(self.context, layout_node_shell, &raw mut rect) };
-        has_rect.then_some(rect)
     }
     pub(crate) fn svg_additional_element_transform(
         &self,

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod border_radii;
 mod caret;
+pub(crate) mod chrome_geometry;
 mod devtools_layout;
 pub mod display_list;
 mod dump;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -11,6 +11,7 @@ mod devtools_layout;
 pub mod display_list;
 mod dump;
 pub mod ffi;
+pub(crate) mod filter_bytes;
 pub mod fragment_ownership;
 pub mod hit_test;
 pub mod host;

--- a/Libraries/LibWeb/Rust/src/painting/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/mod.rs
@@ -24,6 +24,7 @@ pub mod scrollable_overflow;
 pub mod selection;
 pub mod stacking_context;
 pub mod style_queries;
+pub(crate) mod svg_viewport;
 pub mod text_fragment;
 pub mod visual_context;
 pub(crate) mod visual_lines;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -86,6 +86,8 @@ impl PaintableKind {
 #[repr(u32)]
 pub enum PaintableFlag {
     HasNonInvertibleCssTransform = 1 << 0,
+    HorizontalScrollbarEnlarged = 1 << 1,
+    VerticalScrollbarEnlarged = 1 << 2,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -173,6 +173,19 @@ pub(crate) fn committed_svg_viewport_size(
     })
 }
 
+pub(crate) fn committed_svg_view_box(
+    arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+) -> Option<crate::layout::FfiSvgViewBox> {
+    arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.fragment.svg_view_box))
+}
+
+pub(crate) fn committed_svg_viewport_percentage_basis(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixels {
+    arena.with_committed_fragment_link(slot, |link| {
+        link.map_or_else(CssPixels::default, |link| link.fragment.svg_viewport_percentage_basis)
+    })
+}
+
 pub(crate) fn absolute_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
     if let Some(rect) = arena.memoized_absolute_rect(slot) {
         return rect;

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -187,18 +187,14 @@ impl PaintRecorder<'_> {
             });
     }
 
-    fn record_blocking_wheel_event_region(
-        &mut self,
-        paintable: NodeSlotId,
-        facts: &crate::painting::host::FfiAsyncScrollFacts,
-    ) {
+    fn record_blocking_wheel_event_region(&mut self, paintable: NodeSlotId) {
         if self.inputs.has_blocking_wheel_event_region_covering_viewport {
             return;
         }
         if !self.is_visible(paintable) || !self.visible_for_hit_testing(paintable) {
             return;
         }
-        if !facts.inside_blocking_wheel_event_handler {
+        if !self.hit_test_facts(paintable).inside_blocking_wheel_event_handler {
             return;
         }
         let rect = css_rect_to_device_rect(
@@ -331,7 +327,7 @@ impl PaintRecorder<'_> {
         let facts = self.paint_host.async_scroll_facts(self.layout_node_shell(paintable));
 
         self.record_wheel_hit_test_target(paintable);
-        self.record_blocking_wheel_event_region(paintable, &facts);
+        self.record_blocking_wheel_event_region(paintable);
 
         if facts.is_nested_navigable_container {
             self.record_main_thread_wheel_event_region(paintable);

--- a/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/async_scroll_metadata.rs
@@ -7,7 +7,11 @@
 use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixelSize};
 use crate::layout::node_data::NodeSlotId;
+use crate::painting::chrome_geometry::{
+    ChromeGeometry, maximum_scroll_offset, minimum_scroll_offset, scrollbar_colors_for_paint,
+};
 use crate::painting::display_list::commands::*;
+use crate::painting::ffi::ScrollDirection;
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
 use crate::painting::record::PaintRecorder;
@@ -64,30 +68,6 @@ impl PaintRecorder<'_> {
             candidate = self.data(candidate).containing_block;
         }
         None
-    }
-
-    fn minimum_scroll_offset(&self, paintable: NodeSlotId) -> CssPixelPoint {
-        let Some(overflow) = paintable_geometry::scrollable_overflow_rect(self.layout_arena, paintable) else {
-            return CssPixelPoint::default();
-        };
-        let scrollport = paintable_geometry::absolute_padding_box_rect(self.layout_arena, paintable);
-        let zero = CssPixels::from_raw(0);
-        CssPixelPoint::new(
-            (overflow.left() - scrollport.left()).min(zero),
-            (overflow.top() - scrollport.top()).min(zero),
-        )
-    }
-
-    fn maximum_scroll_offset(&self, paintable: NodeSlotId) -> CssPixelPoint {
-        let Some(overflow) = paintable_geometry::scrollable_overflow_rect(self.layout_arena, paintable) else {
-            return CssPixelPoint::default();
-        };
-        let scrollport = paintable_geometry::absolute_padding_box_rect(self.layout_arena, paintable);
-        let zero = CssPixels::from_raw(0);
-        CssPixelPoint::new(
-            (overflow.right() - scrollport.right()).max(zero),
-            (overflow.bottom() - scrollport.bottom()).max(zero),
-        )
     }
 
     fn wheel_hit_test_target_scroll_node_index_for(&mut self, paintable: NodeSlotId) -> usize {
@@ -256,8 +236,8 @@ impl PaintRecorder<'_> {
             scroll_node_index: VisualContextIndex(self.data(paintable).own_scroll_node_index),
             parent_scroll_node_index: VisualContextIndex(parent_scroll_node_index),
             scrollport_rect,
-            min_scroll_offset: css_point_to_device_point(self.minimum_scroll_offset(paintable), scale),
-            max_scroll_offset: css_point_to_device_point(self.maximum_scroll_offset(paintable), scale),
+            min_scroll_offset: css_point_to_device_point(minimum_scroll_offset(self.layout_arena, paintable), scale),
+            max_scroll_offset: css_point_to_device_point(maximum_scroll_offset(self.layout_arena, paintable), scale),
             scroll_node_kind,
             pseudo_element_type: facts.pseudo_element_type,
             is_viewport,
@@ -268,41 +248,45 @@ impl PaintRecorder<'_> {
         });
     }
 
-    fn record_viewport_scrollbar_state(
-        &mut self,
-        paintable: NodeSlotId,
-        facts: &crate::painting::host::FfiAsyncScrollFacts,
-    ) {
-        if !facts.records_viewport_scrollbars {
+    fn record_viewport_scrollbar_state(&mut self, paintable: NodeSlotId) {
+        let records_viewport_scrollbars = self.data(paintable).kind == PaintableKind::ViewportPaintable
+            && self.inputs.async_scrolling_enabled
+            && self.inputs.paint_viewport_scrollbars
+            && self.layout_arena.node_style_if_live(paintable).is_some_and(|style| {
+                style.misc_reset().scrollbar_width != crate::css::css_enums::scrollbar_width::NONE
+            });
+        if !records_viewport_scrollbars {
             return;
         }
         let scale = self.inputs.device_pixels_per_css_pixel;
-        let min_scroll_offset = css_point_to_device_point(self.minimum_scroll_offset(paintable), scale);
-        let max_scroll_offset = css_point_to_device_point(self.maximum_scroll_offset(paintable), scale);
+        let min_scroll_offset = css_point_to_device_point(minimum_scroll_offset(self.layout_arena, paintable), scale);
+        let max_scroll_offset = css_point_to_device_point(maximum_scroll_offset(self.layout_arena, paintable), scale);
         let scroll_node_index = VisualContextIndex(self.data(paintable).own_scroll_node_index);
-        for (index, scrollbar) in facts.viewport_scrollbars.iter().enumerate() {
-            if !scrollbar.present {
+        let (thumb_color, track_color) = scrollbar_colors_for_paint(
+            self.layout_arena,
+            paintable,
+            self.inputs.root_background_source,
+            self.inputs.canvas_color.blend(self.inputs.background_color),
+        );
+        let chrome_geometry = ChromeGeometry::for_recording(self.layout_arena, &self.inputs);
+        for direction in [ScrollDirection::Vertical, ScrollDirection::Horizontal] {
+            let Some(scrollbar) = chrome_geometry.compute_scrollbar_data(paintable, direction, false, None) else {
                 continue;
-            }
-            let vertical = index == 0;
+            };
+            let expanded = chrome_geometry
+                .compute_scrollbar_data(paintable, direction, true, None)
+                .expect("an enlarged scrollbar must exist when the regular scrollbar exists");
+            let vertical = direction == ScrollDirection::Vertical;
             self.recorder
                 .compositor_viewport_scrollbar(CompositorViewportScrollbar {
                     document_id: UniqueNodeId(self.inputs.document_id),
                     scroll_node_index,
-                    gutter_rect: self
-                        .converter
-                        .rounded_device_rect(CssPixelRect::from(scrollbar.gutter_rect)),
-                    thumb_rect: self
-                        .converter
-                        .rounded_device_rect(CssPixelRect::from(scrollbar.thumb_rect)),
-                    expanded_gutter_rect: self
-                        .converter
-                        .rounded_device_rect(CssPixelRect::from(scrollbar.expanded_gutter_rect)),
-                    expanded_thumb_rect: self
-                        .converter
-                        .rounded_device_rect(CssPixelRect::from(scrollbar.expanded_thumb_rect)),
-                    scroll_size: scrollbar.scroll_size,
-                    expanded_scroll_size: scrollbar.expanded_scroll_size,
+                    gutter_rect: self.converter.rounded_device_rect(scrollbar.gutter_rect),
+                    thumb_rect: self.converter.rounded_device_rect(scrollbar.thumb_rect),
+                    expanded_gutter_rect: self.converter.rounded_device_rect(expanded.gutter_rect),
+                    expanded_thumb_rect: self.converter.rounded_device_rect(expanded.thumb_rect),
+                    scroll_size: scrollbar.thumb_travel_to_scroll_ratio.to_double(),
+                    expanded_scroll_size: expanded.thumb_travel_to_scroll_ratio.to_double(),
                     min_scroll_offset: if vertical {
                         min_scroll_offset.y
                     } else {
@@ -313,8 +297,8 @@ impl PaintRecorder<'_> {
                     } else {
                         max_scroll_offset.x
                     },
-                    thumb_color: scrollbar.thumb_color,
-                    track_color: scrollbar.track_color,
+                    thumb_color,
+                    track_color,
                     vertical,
                 });
         }
@@ -334,7 +318,7 @@ impl PaintRecorder<'_> {
         } else if self.data(paintable).own_scroll_node_index != 0 && self.could_be_scrolled_by_wheel_event(paintable) {
             self.record_scroll_node(paintable, &facts);
         }
-        self.record_viewport_scrollbar_state(paintable, &facts);
+        self.record_viewport_scrollbar_state(paintable);
 
         let sticky_node_index = self.data(paintable).enclosing_scroll_node_index;
         if style_queries::is_sticky_position(self.layout_arena, paintable) && sticky_node_index != 0 {

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -14,7 +14,69 @@ use crate::painting::host::FfiHitTestTextNodeFacts;
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
 use crate::painting::text_fragment;
+use libgfx_rust::WindingRule;
 use std::rc::Rc;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct HitTestFacts {
+    pub(crate) visible_for_hit_testing: bool,
+    pub(crate) dom_node_has_parent: bool,
+    pub(crate) is_editable_or_editing_host: bool,
+    pub(crate) has_resizer: bool,
+    pub(crate) could_be_scrolled_horizontally: bool,
+    pub(crate) could_be_scrolled_vertically: bool,
+    pub(crate) svg_path_has_fill: bool,
+    pub(crate) svg_path_winding_rule: WindingRule,
+    pub(crate) svg_mask_content_units_object_bbox: bool,
+    pub(crate) svg_clip_path_units_object_bbox: bool,
+    pub(crate) inside_blocking_wheel_event_handler: bool,
+}
+
+pub(crate) fn hit_test_facts(
+    arena: &impl crate::painting::paintable_rows::PaintableRowsRead,
+    paintable: NodeSlotId,
+    inputs: &crate::painting::host::FfiRecordingInputs,
+    dom: crate::painting::host::FfiHitTestPaintableFacts,
+) -> HitTestFacts {
+    let Some(style) = arena.node_style_if_live(paintable) else {
+        return HitTestFacts {
+            dom_node_has_parent: dom.dom_node_has_parent,
+            is_editable_or_editing_host: dom.is_editable_or_editing_host,
+            svg_mask_content_units_object_bbox: dom.svg_mask_content_units_object_bbox,
+            svg_clip_path_units_object_bbox: dom.svg_clip_path_units_object_bbox,
+            inside_blocking_wheel_event_handler: dom.inside_blocking_wheel_event_handler,
+            ..HitTestFacts::default()
+        };
+    };
+    let wheel_axes = crate::painting::chrome_geometry::wheel_scrollable_axes(
+        arena,
+        paintable,
+        inputs.viewport_wheel_overflow_x,
+        inputs.viewport_wheel_overflow_y,
+    );
+    let kind = arena.paintable_data(paintable).kind;
+    let svg_path = kind == PaintableKind::SVGPathPaintable;
+    let svg = style.inherited_svg();
+    HitTestFacts {
+        visible_for_hit_testing: arena.paintable_row_is_populated(paintable)
+            && !dom.is_inert
+            && style.inherited_ui().pointer_events != css_enums::pointer_events::NONE,
+        dom_node_has_parent: dom.dom_node_has_parent,
+        is_editable_or_editing_host: dom.is_editable_or_editing_host,
+        has_resizer: crate::painting::chrome_geometry::has_resizer(arena, paintable),
+        could_be_scrolled_horizontally: wheel_axes.horizontal,
+        could_be_scrolled_vertically: wheel_axes.vertical,
+        svg_path_has_fill: svg_path && crate::painting::record::paint::svg::svg_paint_color(&svg.fill).is_some(),
+        svg_path_winding_rule: if svg_path && svg.fill_rule == css_enums::fill_rule::EVENODD {
+            WindingRule::EvenOdd
+        } else {
+            WindingRule::Nonzero
+        },
+        svg_mask_content_units_object_bbox: dom.svg_mask_content_units_object_bbox,
+        svg_clip_path_units_object_bbox: dom.svg_clip_path_units_object_bbox,
+        inside_blocking_wheel_event_handler: dom.inside_blocking_wheel_event_handler,
+    }
+}
 
 impl<'a> PaintRecorder<'a> {
     fn text_node_facts(&mut self, text_node: NodeSlotId) -> FfiHitTestTextNodeFacts {
@@ -314,14 +376,16 @@ impl<'a> PaintRecorder<'a> {
         if !parent_visible {
             return false;
         }
+        let Some(parent_style) = self.layout_arena.node_style_if_live(parent) else {
+            return false;
+        };
+        if parent_style.effects().opacity == 0.0
+            || parent_style.inherited_ui().pointer_events == css_enums::pointer_events::NONE
+        {
+            return false;
+        }
         let facts = self.text_node_facts(node);
-        if facts.parent_opacity_is_zero {
-            return false;
-        }
         if facts.is_inert {
-            return false;
-        }
-        if facts.parent_pointer_events_none {
             return false;
         }
         true

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -327,13 +327,4 @@ impl<'a> PaintRecorder<'a> {
     pub(crate) fn own_accumulated_2d_scale(&self, paintable: NodeSlotId) -> libgfx_rust::FloatSize {
         self.accumulated_2d_scale_at(self.own_context_index(paintable))
     }
-
-    pub(crate) fn is_chrome_mirrored(&self, paintable: NodeSlotId) -> bool {
-        self.layout_arena.node_style_if_live(paintable).is_some_and(|style| {
-            let writing_mode = style.writing_mode();
-            (writing_mode == css_enums::writing_mode::HORIZONTAL_TB && style.direction() == css_enums::direction::RTL)
-                || writing_mode == css_enums::writing_mode::VERTICAL_RL
-                || writing_mode == css_enums::writing_mode::SIDEWAYS_RL
-        })
-    }
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -19,8 +19,8 @@ use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::display_list::recorder::DisplayListRecorder;
 use crate::painting::hit_test::HitTestList;
 use crate::painting::host::{
-    FfiHitTestHostCallbacks, FfiHitTestPaintableFacts, FfiHitTestTextNodeFacts, FfiPaintHostCallbacks,
-    FfiRecordingInputs, FfiVisualContextHostCallbacks,
+    FfiHitTestHostCallbacks, FfiHitTestTextNodeFacts, FfiPaintHostCallbacks, FfiRecordingInputs,
+    FfiVisualContextHostCallbacks,
 };
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
 use crate::painting::paintable_rows::PaintableRowsRef;
@@ -84,7 +84,7 @@ pub struct PaintRecorder<'a> {
     uncacheable_paint_generation: u64,
     list: HitTestList,
     base_paint_facts_cache: Vec<Option<(NodeSlotId, BasePaintFacts)>>,
-    paintable_facts_cache: Vec<Option<(NodeSlotId, FfiHitTestPaintableFacts)>>,
+    paintable_facts_cache: Vec<Option<(NodeSlotId, hit_test_items::HitTestFacts)>>,
     pub(crate) absolute_position_cache: Vec<std::cell::Cell<Option<(NodeSlotId, crate::layout::FfiCssPixelPoint)>>>,
     // Validity checks must compare against this recording-start snapshot, not the live per-row
     // cell: the first phase that re-records a moved row updates the cell, and later phases
@@ -125,18 +125,19 @@ impl<'a> PaintRecorder<'a> {
         self.layout_arena.shell_if_live(paintable)
     }
 
-    pub(crate) fn hit_test_facts(&mut self, paintable: NodeSlotId) -> FfiHitTestPaintableFacts {
+    pub(crate) fn hit_test_facts(&mut self, paintable: NodeSlotId) -> hit_test_items::HitTestFacts {
         self.paintable_facts(paintable)
     }
 
-    fn paintable_facts(&mut self, paintable: NodeSlotId) -> FfiHitTestPaintableFacts {
+    fn paintable_facts(&mut self, paintable: NodeSlotId) -> hit_test_items::HitTestFacts {
         let index = paintable.slot_index() as usize;
         if let Some((memoized_id, facts)) = self.paintable_facts_cache[index]
             && memoized_id == paintable
         {
             return facts;
         }
-        let facts = self.host.paintable_facts(self.layout_node_shell(paintable));
+        let dom_facts = self.host.paintable_facts(self.layout_node_shell(paintable));
+        let facts = hit_test_items::hit_test_facts(self.layout_arena, paintable, &self.inputs, dom_facts);
         self.paintable_facts_cache[index] = Some((paintable, facts));
         facts
     }
@@ -299,7 +300,7 @@ impl<'a> PaintRecorder<'a> {
     }
 
     pub(crate) fn is_visible(&mut self, paintable: NodeSlotId) -> bool {
-        self.visibility_is_visible(paintable) && !self.paintable_facts(paintable).opacity_is_zero
+        self.base_paint_facts(paintable).is_visible
     }
 
     pub(crate) fn visible_for_hit_testing(&mut self, paintable: NodeSlotId) -> bool {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -564,18 +564,13 @@ pub(crate) fn resolve_background_for_paint<'a>(
     let node_flags = layout_arena.node_flags_if_live(node);
     let node_is_body = node_flags & crate::layout::node_data::NodeFlag::IsBody as u32 != 0;
     // If the body's background properties were propagated to the root element, do not re-paint the body's background.
-    if node_is_body
-        && recorder
-            .paint_host
-            .root_background_source()
-            .use_body_background_properties
-    {
+    if node_is_body && recorder.inputs.root_background_source.use_body_background_properties {
         return None;
     }
 
     // https://drafts.csswg.org/css-backgrounds/#root-background
     if style_queries::node_is_root_element(layout_arena, node) {
-        let root_background_source = recorder.paint_host.root_background_source();
+        let root_background_source = recorder.inputs.root_background_source;
         let background_rect =
             crate::painting::paintable_geometry::absolute_border_box_rect(recorder.layout_arena, paintable);
         let border_radii =

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inline_box.rs
@@ -37,10 +37,7 @@ pub(crate) fn paint(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, pha
         let background_is_propagated_to_root = {
             let node_flags = recorder.layout_arena.node_flags_if_live(paintable);
             node_flags & crate::layout::node_data::NodeFlag::IsBody as u32 != 0
-                && recorder
-                    .paint_host
-                    .root_background_source()
-                    .use_body_background_properties
+                && recorder.inputs.root_background_source.use_body_background_properties
         };
         let has_borders = {
             let style = recorder.layout_arena.node_style_if_live(paintable);

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/mod.rs
@@ -200,10 +200,20 @@ pub(crate) fn paint_backdrop_filter(
         &border_radii,
         libgfx_rust::CornerClip::Outside,
     );
-    if let Some(filter_bytes) = recorder
-        .paint_host
-        .backdrop_filter_bytes(recorder.layout_node_shell(paintable))
-    {
+    let filter_bytes = recorder.layout_arena.node_style_if_live(paintable).and_then(|style| {
+        let backdrop_filter = &style.effects().backdrop_filter;
+        if crate::painting::filter_bytes::contains_url(backdrop_filter) {
+            recorder
+                .paint_host
+                .backdrop_filter_bytes(recorder.layout_node_shell(paintable))
+        } else {
+            crate::painting::filter_bytes::serialize_non_url_filter(
+                backdrop_filter,
+                recorder.inputs.device_pixels_per_css_pixel,
+            )
+        }
+    });
+    if let Some(filter_bytes) = filter_bytes {
         let corner_radii = border_radii.as_corners(&recorder.converter);
         recorder
             .recorder

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/overlay.rs
@@ -4,52 +4,68 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
+use crate::painting::chrome_geometry::{
+    ChromeGeometry, is_chrome_mirrored, scrollbar_colors_for_paint, scrollbar_is_enlarged,
+};
 use crate::painting::display_list::commands::VisualContextIndex;
 use crate::painting::display_list::recorder::{FillPathParams, PaintStyleOrColor};
+use crate::painting::ffi::ScrollDirection;
 use crate::painting::paintable_data::PaintableKind;
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::{Color, FloatPoint, IntRect, LineStyle, ShouldAntiAlias, WindingRule};
 
 pub(crate) fn paint_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) {
-    let data = recorder.data(paintable);
-    if data.kind != PaintableKind::ViewportPaintable
-        && data.own_scroll_node_index == 0
+    let kind = recorder.data(paintable).kind;
+    let own_scroll_node_index = recorder.data(paintable).own_scroll_node_index;
+    if kind != PaintableKind::ViewportPaintable
+        && own_scroll_node_index == 0
         && !recorder.hit_test_facts(paintable).has_resizer
     {
         return;
     }
-    let facts = recorder.paint_host.overlay_facts(recorder.layout_node_shell(paintable));
     let converter = recorder.converter;
+    let chrome_geometry = ChromeGeometry::for_recording(recorder.layout_arena, &recorder.inputs);
+    let style = recorder.layout_arena.node_style_if_live(paintable);
+    let paints_scrollbars = style.is_some_and(|style| {
+        ((recorder.inputs.paint_viewport_scrollbars && !recorder.inputs.async_scrolling_enabled)
+            || kind != PaintableKind::ViewportPaintable)
+            && style.misc_reset().scrollbar_width != crate::css::css_enums::scrollbar_width::NONE
+    });
 
-    if facts.paints_scrollbars {
-        let own_scroll_node_index = VisualContextIndex(recorder.data(paintable).own_scroll_node_index);
-        for (index, scrollbar) in facts.scrollbars.iter().enumerate() {
-            if !scrollbar.present {
+    if paints_scrollbars {
+        let (thumb_color, track_color) = scrollbar_colors_for_paint(
+            recorder.layout_arena,
+            paintable,
+            recorder.inputs.root_background_source,
+            recorder.inputs.canvas_color.blend(recorder.inputs.background_color),
+        );
+        let scroll_node_index = VisualContextIndex(own_scroll_node_index);
+        for direction in [ScrollDirection::Vertical, ScrollDirection::Horizontal] {
+            let enlarged = scrollbar_is_enlarged(recorder.layout_arena, paintable, direction);
+            let Some(scrollbar) = chrome_geometry.compute_scrollbar_data(paintable, direction, enlarged, None) else {
                 continue;
-            }
+            };
             recorder.recorder.paint_scrollbar(
-                own_scroll_node_index,
-                converter.rounded_device_rect(CssPixelRect::from(scrollbar.gutter_rect)),
-                converter.rounded_device_rect(CssPixelRect::from(scrollbar.thumb_rect)),
-                converter.rounded_device_rect(CssPixelRect::from(scrollbar.track_rect)),
-                scrollbar.thumb_travel_to_scroll_ratio,
-                facts.thumb_color,
-                facts.track_color,
-                index == 0,
+                scroll_node_index,
+                converter.rounded_device_rect(scrollbar.gutter_rect),
+                converter.rounded_device_rect(scrollbar.thumb_rect),
+                converter.rounded_device_rect(scrollbar.track_rect),
+                scrollbar.thumb_travel_to_scroll_ratio.to_double(),
+                thumb_color,
+                track_color,
+                direction == ScrollDirection::Vertical,
             );
         }
     }
 
-    if facts.resizer_rect.has_value {
-        let bottom_left_resizer = recorder.is_chrome_mirrored(paintable);
-        let padding = facts.resize_gripper_padding;
+    if let Some(mut css_rect) = chrome_geometry.absolute_resizer_rect(paintable) {
+        let bottom_left_resizer = is_chrome_mirrored(recorder.layout_arena, paintable);
+        let padding = recorder.inputs.chrome_metrics.resize_gripper_padding;
         let two = CssPixels::from_integer(2);
         let half = padding.div_as_fraction(two);
         let negative_half = (-padding).div_as_fraction(two);
-        let mut css_rect = CssPixelRect::from(facts.resizer_rect.value);
         css_rect.x += half;
         css_rect.width -= padding;
         css_rect.y += half;
@@ -87,26 +103,23 @@ pub(crate) fn paint_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlo
         }
     }
 
-    paint_middle_button_scroll_indicator(recorder, paintable, &facts);
+    paint_middle_button_scroll_indicator(recorder, paintable);
 }
 
-fn paint_middle_button_scroll_indicator(
-    recorder: &mut PaintRecorder<'_>,
-    _paintable: NodeSlotId,
-    facts: &crate::painting::host::FfiOverlayFacts,
-) {
+fn paint_middle_button_scroll_indicator(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) {
     const CIRCLE_COLOR: Color = Color::from_rgba(255, 255, 255, 220);
     const ARROW_COLOR: Color = Color::from_rgb(64, 64, 64);
     const RADIUS: i32 = 16;
     const ARROW_SIZE: f32 = 6.0;
     const ARROW_OFFSET: f32 = 8.0;
 
-    if !facts.middle_button_scroll_active {
+    if recorder.data(paintable).kind != PaintableKind::ViewportPaintable || !recorder.inputs.middle_button_scroll_active
+    {
         return;
     }
     let device_origin = recorder
         .converter
-        .rounded_device_point(facts.middle_button_scroll_origin.into());
+        .rounded_device_point(recorder.inputs.middle_button_scroll_origin.into());
     let circle = IntRect::new(
         device_origin.x - RADIUS,
         device_origin.y - RADIUS,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/svg.rs
@@ -11,6 +11,7 @@ use crate::painting::display_list::recorder::{
     ColorStops, FillPathParams, PaintStyle, PaintStyleOrColor, StrokePathParams,
 };
 use crate::painting::host::{FfiSvgGradientSpreadMethod, FfiSvgPaintStyle, FfiSvgPaintStyleKind};
+use crate::painting::paintable_data::PaintableKind;
 use crate::painting::paintable_geometry::absolute_rect;
 use crate::painting::record::paint::background::paint_image;
 use crate::painting::record::{PaintPhase, PaintRecorder};
@@ -44,7 +45,7 @@ struct SvgPaintFacts {
     image_rendering: u8,
 }
 
-fn svg_paint_color(paint: &crate::css::computed_value_types::ComputedSvgPaint) -> Option<u32> {
+pub(crate) fn svg_paint_color(paint: &crate::css::computed_value_types::ComputedSvgPaint) -> Option<u32> {
     match paint.kind {
         0 => None,
         1 => Some(paint.color),
@@ -54,24 +55,25 @@ fn svg_paint_color(paint: &crate::css::computed_value_types::ComputedSvgPaint) -
 
 fn svg_paint_facts(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) -> (SvgPaintFacts, Vec<f32>) {
     use crate::css::css_enums::{fill_rule, overflow, stroke_linecap, stroke_linejoin, vector_effect};
-    let host = recorder
-        .paint_host
-        .svg_host_facts(recorder.layout_node_shell(paintable));
+    let layout_arena = recorder.layout_arena;
+    let kind = layout_arena.paintable_data(paintable).kind;
+    let viewport = (kind == PaintableKind::SVGPathPaintable)
+        .then(|| crate::painting::svg_viewport::nearest_svg_viewport_user_rect(layout_arena, paintable))
+        .flatten();
     let mut facts = SvgPaintFacts {
-        has_viewport: host.viewport.has_value,
-        viewport: [
-            host.viewport.value.x,
-            host.viewport.value.y,
-            host.viewport.value.width,
-            host.viewport.value.height,
-        ],
-        has_decoded_image_data: host.has_decoded_image_data,
-        has_natural_size: host.natural_size.has_value,
-        natural_width: host.natural_size.value.width,
-        natural_height: host.natural_size.value.height,
+        has_viewport: viewport.is_some(),
+        viewport: viewport.map_or([0.0; 4], |rect| [rect.x, rect.y, rect.width, rect.height]),
         ..SvgPaintFacts::default()
     };
-    let layout_arena = recorder.layout_arena;
+    if kind == PaintableKind::SVGImagePaintable {
+        let image = recorder
+            .paint_host
+            .svg_image_facts(recorder.layout_node_shell(paintable));
+        facts.has_decoded_image_data = image.has_decoded_image_data;
+        facts.has_natural_size = image.natural_size.has_value;
+        facts.natural_width = image.natural_size.value.width;
+        facts.natural_height = image.natural_size.value.height;
+    }
     let Some(style) = layout_arena.node_style_if_live(paintable) else {
         return (facts, Vec::new());
     };
@@ -115,7 +117,7 @@ fn svg_paint_facts(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId) -> (
         style.box_values().overflow_x == overflow::VISIBLE && style.box_values().overflow_y == overflow::VISIBLE;
     facts.image_rendering = style.image_rendering();
 
-    let basis = host.percentage_basis;
+    let basis = crate::painting::paintable_geometry::committed_svg_viewport_percentage_basis(layout_arena, paintable);
     let resolve = |handle: &crate::css::computed_value_types::ComputedStyleValueHandle, default: f32| {
         handle
             .length_percentage()

--- a/Libraries/LibWeb/Rust/src/painting/svg_viewport.rs
+++ b/Libraries/LibWeb/Rust/src/painting/svg_viewport.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::paintable_data::PaintableKind;
+use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::PaintableRowsRead;
+use libgfx_rust::FloatRect;
+
+pub(crate) fn nearest_svg_viewport_of(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<NodeSlotId> {
+    let mut ancestor = arena.node_parent_if_live(slot);
+    while let Some(node) = ancestor {
+        if paintable_geometry::committed_svg_viewport_transform(arena, node).is_some() {
+            return Some(node);
+        }
+        ancestor = arena.node_parent_if_live(node);
+    }
+    None
+}
+
+pub(crate) fn svg_viewport_user_rect(arena: &impl PaintableRowsRead, viewport: NodeSlotId) -> FloatRect {
+    if let Some(view_box) = paintable_geometry::committed_svg_view_box(arena, viewport) {
+        return FloatRect::new(
+            view_box.min_x as f32,
+            view_box.min_y as f32,
+            view_box.width as f32,
+            view_box.height as f32,
+        );
+    }
+
+    let size = if arena.paintable_data(viewport).kind == PaintableKind::SVGSVGPaintable {
+        let size = paintable_geometry::committed_svg_viewport_size(arena, viewport);
+        (size.width.to_float(), size.height.to_float())
+    } else {
+        let rect = paintable_geometry::absolute_rect(arena, viewport);
+        (rect.width.to_float(), rect.height.to_float())
+    };
+    FloatRect::new(0.0, 0.0, size.0, size.1)
+}
+
+pub(crate) fn nearest_svg_viewport_user_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> Option<FloatRect> {
+    nearest_svg_viewport_of(arena, slot).map(|viewport| svg_viewport_user_rect(arena, viewport))
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -169,7 +169,8 @@ impl BoxFacts {
             facts.transform_is_invertible = transform_is_invertible;
         }
         facts.perspective = super::node_values::compute_perspective_data(layout_arena, slot, pixel_ratio);
-        facts.effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot).map(std::rc::Rc::new);
+        facts.effects =
+            super::node_values::compute_effects_data(layout_arena, callbacks, slot, pixel_ratio).map(std::rc::Rc::new);
         facts.backface_hidden = super::node_values::backface_hidden(layout_arena, slot);
         let node = slot;
         facts.establishes_or_extends_3d_rendering_context =
@@ -985,7 +986,7 @@ pub(crate) fn update_visual_context_values(
         super::node_values::compute_transform(layout_arena, callbacks, slot, pixel_ratio);
     let transform = transform_with_invertibility.map(|(transform, _)| transform);
     let transform_is_invertible = transform_with_invertibility.is_some_and(|(_, invertible)| invertible);
-    let effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot);
+    let effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot, pixel_ratio);
     let perspective = super::node_values::compute_perspective_data(layout_arena, slot, pixel_ratio);
     let svg_viewport_transform_data = svg_viewport_transform_of(layout_arena, slot)
         .map(|transform| compute_svg_viewport_transform_data(layout_arena, slot, transform, pixel_ratio));

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -168,7 +168,7 @@ impl BoxFacts {
             facts.transform = Some(transform);
             facts.transform_is_invertible = transform_is_invertible;
         }
-        facts.perspective = super::node_values::compute_perspective_data(layout_arena, callbacks, slot, pixel_ratio);
+        facts.perspective = super::node_values::compute_perspective_data(layout_arena, slot, pixel_ratio);
         facts.effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot).map(std::rc::Rc::new);
         facts.backface_hidden = super::node_values::backface_hidden(layout_arena, slot);
         let node = slot;
@@ -986,7 +986,7 @@ pub(crate) fn update_visual_context_values(
     let transform = transform_with_invertibility.map(|(transform, _)| transform);
     let transform_is_invertible = transform_with_invertibility.is_some_and(|(_, invertible)| invertible);
     let effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot);
-    let perspective = super::node_values::compute_perspective_data(layout_arena, callbacks, slot, pixel_ratio);
+    let perspective = super::node_values::compute_perspective_data(layout_arena, slot, pixel_ratio);
     let svg_viewport_transform_data = svg_viewport_transform_of(layout_arena, slot)
         .map(|transform| compute_svg_viewport_transform_data(layout_arena, slot, transform, pixel_ratio));
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -91,7 +91,13 @@ pub struct ClipPathData {
 pub struct EffectsData {
     pub opacity: f32,
     pub blend_mode: CompositingAndBlendingOperator,
-    pub filter: Option<std::rc::Rc<FilterHandle>>,
+    pub filter: Option<EffectsFilter>,
+}
+
+#[derive(Clone)]
+pub enum EffectsFilter {
+    Bytes(std::rc::Rc<Vec<u8>>),
+    Host(std::rc::Rc<FilterHandle>),
 }
 
 impl EffectsData {
@@ -298,6 +304,8 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
         opacity: 1.0,
         blend_mode: CompositingAndBlendingOperator::Normal,
         filter: std::ptr::null_mut(),
+        filter_bytes: std::ptr::null(),
+        filter_bytes_length: 0,
         path: std::ptr::null_mut(),
         winding_rule: WindingRule::Nonzero,
         mask_kind: MaskKind::Alpha,
@@ -345,10 +353,15 @@ pub fn export_node(node: &VisualContextNode) -> crate::painting::host::FfiVisual
         VisualContextData::Effects(effects) => {
             out.opacity = effects.opacity;
             out.blend_mode = effects.blend_mode;
-            out.filter = effects
-                .filter
-                .as_ref()
-                .map_or(std::ptr::null_mut(), |filter| filter.as_raw());
+            if let Some(filter) = &effects.filter {
+                match filter {
+                    EffectsFilter::Bytes(bytes) => {
+                        out.filter_bytes = bytes.as_ptr();
+                        out.filter_bytes_length = bytes.len();
+                    }
+                    EffectsFilter::Host(filter) => out.filter = filter.as_raw(),
+                }
+            }
         }
         VisualContextData::ScrollCompensation(compensation) => {
             out.index_value = compensation.scroll_node_index;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -48,7 +48,6 @@ pub(crate) fn visual_viewport_transform_data(inputs: &FfiVisualContextTreeInputs
 pub(crate) fn transform_reference_box(
     style: ComputedValuesView<'_>,
     layout_arena: &impl PaintableRowsRead,
-    callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
 ) -> CssPixelRect {
     use css_enums::transform_box::{BORDER_BOX, CONTENT_BOX, FILL_BOX, STROKE_BOX, VIEW_BOX};
@@ -69,9 +68,15 @@ pub(crate) fn transform_reference_box(
     }
     match transform_box {
         CONTENT_BOX | FILL_BOX => paintable_geometry::absolute_rect(layout_arena, slot),
-        VIEW_BOX => callbacks
-            .svg_transform_view_box_rect(layout_arena.shell_if_live(slot))
-            .map(CssPixelRect::from)
+        VIEW_BOX => crate::painting::svg_viewport::nearest_svg_viewport_user_rect(layout_arena, slot)
+            .map(|rect| {
+                CssPixelRect::new(
+                    CssPixels::nearest_value_for(rect.x as f64),
+                    CssPixels::nearest_value_for(rect.y as f64),
+                    CssPixels::nearest_value_for(rect.width as f64),
+                    CssPixels::nearest_value_for(rect.height as f64),
+                )
+            })
             .unwrap_or_else(|| paintable_geometry::absolute_border_box_rect(layout_arena, slot)),
         _ => paintable_geometry::absolute_border_box_rect(layout_arena, slot),
     }
@@ -138,7 +143,7 @@ pub(crate) fn compute_transform(
 
     // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and
     // offset properties as follows:
-    let reference_box = transform_reference_box(style, layout_arena, callbacks, node);
+    let reference_box = transform_reference_box(style, layout_arena, node);
     let origin_lp = |handle: &ComputedStyleValueHandle| {
         handle
             .length_percentage()
@@ -201,7 +206,6 @@ pub(crate) fn compute_transform(
 // https://drafts.csswg.org/css-transforms-2/#perspective-matrix
 pub(crate) fn compute_perspective_data(
     layout_arena: &impl PaintableRowsRead,
-    callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
     pixel_ratio: f64,
 ) -> Option<PerspectiveData> {
@@ -218,7 +222,7 @@ pub(crate) fn compute_perspective_data(
     // 2. Translate by the computed X and Y values of 'perspective-origin'
     // https://drafts.csswg.org/css-transforms-2/#perspective-origin-property
     // Percentages: refer to the size of the reference box
-    let reference_box = transform_reference_box(style, layout_arena, callbacks, slot);
+    let reference_box = transform_reference_box(style, layout_arena, slot);
     let origin_x = transform_values
         .perspective_origin_x
         .length_percentage()

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use super::{ClipData, EffectsData, PerspectiveData, TransformData, TransformDataRole};
+use super::{ClipData, EffectsData, EffectsFilter, PerspectiveData, TransformData, TransformDataRole};
 use crate::css::computed_value_types::{ComputedClipEdge, ComputedStyleValueHandle};
 use crate::css::computed_value_views::{ComputedValuesView, LengthPercentageRef};
 use crate::css::css_enums;
@@ -511,24 +511,33 @@ pub(crate) fn compute_effects_data(
     layout_arena: &impl PaintableRowsRead,
     callbacks: &FfiVisualContextHostCallbacks,
     slot: NodeSlotId,
+    device_pixels_per_css_pixel: f64,
 ) -> Option<EffectsData> {
     use crate::css::css_enums::mix_blend_mode;
-    let resolved_filter = callbacks.resolve_effects_filter(layout_arena.shell_if_live(slot));
-    layout_arena.paintable_side_data(slot).svg_filter_bounds.set(
-        resolved_filter
-            .svg_filter_bounds
-            .has_value
-            .then_some(resolved_filter.svg_filter_bounds.value),
-    );
-    let filter_raw = resolved_filter.gfx_filter;
-    let filter = if filter_raw.is_null() {
-        None
-    } else {
-        // SAFETY: The host hands over a heap-allocated Gfx::Filter for us to own.
-        Some(std::rc::Rc::new(unsafe { super::FilterHandle::adopt(filter_raw) }))
-    };
     let style = layout_arena.node_style_if_live(slot)?;
     let effects_values = style.effects();
+    let filter = if crate::painting::filter_bytes::contains_url(&effects_values.filter) {
+        let resolved_filter = callbacks.resolve_effects_filter(layout_arena.shell_if_live(slot));
+        layout_arena.paintable_side_data(slot).svg_filter_bounds.set(
+            resolved_filter
+                .svg_filter_bounds
+                .has_value
+                .then_some(resolved_filter.svg_filter_bounds.value),
+        );
+        let filter_raw = resolved_filter.gfx_filter;
+        if filter_raw.is_null() {
+            None
+        } else {
+            // SAFETY: The host hands over a heap-allocated Gfx::Filter for us to own.
+            Some(EffectsFilter::Host(std::rc::Rc::new(unsafe {
+                super::FilterHandle::adopt(filter_raw)
+            })))
+        }
+    } else {
+        layout_arena.paintable_side_data(slot).svg_filter_bounds.set(None);
+        crate::painting::filter_bytes::serialize_non_url_filter(&effects_values.filter, device_pixels_per_css_pixel)
+            .map(|bytes| EffectsFilter::Bytes(std::rc::Rc::new(bytes)))
+    };
     if filter.is_none() && effects_values.opacity == 1.0 && effects_values.mix_blend_mode == mix_blend_mode::NORMAL {
         return None;
     }

--- a/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Libraries/LibWeb/SVG/AttributeParser.h
@@ -122,13 +122,6 @@ private:
     bool m_is_percentage { false };
 };
 
-enum class FillRule {
-    Nonzero,
-    Evenodd
-};
-
-using ClipRule = FillRule;
-
 enum class TextAnchor {
     Start,
     Middle,

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -184,47 +184,6 @@ Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> trans
     return affine_transform;
 }
 
-static FillRule to_svg_fill_rule(CSS::FillRule fill_rule)
-{
-    switch (fill_rule) {
-    case CSS::FillRule::Nonzero:
-        return FillRule::Nonzero;
-    case CSS::FillRule::Evenodd:
-        return FillRule::Evenodd;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-Optional<FillRule> SVGGraphicsElement::fill_rule() const
-{
-    if (!unsafe_layout_node())
-        return {};
-    return to_svg_fill_rule(unsafe_layout_node()->fill_rule());
-}
-
-Optional<ClipRule> SVGGraphicsElement::clip_rule() const
-{
-    if (!unsafe_layout_node())
-        return {};
-    return to_svg_fill_rule(unsafe_layout_node()->clip_rule());
-}
-
-Optional<Gfx::Color> SVGGraphicsElement::fill_color() const
-{
-    if (!unsafe_layout_node())
-        return {};
-
-    auto paint = unsafe_layout_node()->fill();
-    if (!paint.has_value())
-        return {};
-
-    if (paint->is_url())
-        return paint->fallback_color();
-
-    return paint->as_color();
-}
-
 Optional<Gfx::Color> SVGGraphicsElement::stroke_color() const
 {
     if (!unsafe_layout_node())

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -32,7 +32,6 @@ class WEB_API SVGGraphicsElement : public SVGElement {
     WEB_WRAPPABLE(SVGGraphicsElement, SVGElement);
 
 public:
-    Optional<Gfx::Color> fill_color() const;
     Optional<Gfx::Color> stroke_color() const;
     Vector<float> stroke_dasharray() const;
     Optional<float> stroke_dashoffset() const;
@@ -43,8 +42,6 @@ public:
     Optional<CSS::StrokeLinejoin> stroke_linejoin() const;
     Optional<double> stroke_miterlimit() const;
     Optional<float> stroke_opacity() const;
-    Optional<FillRule> fill_rule() const;
-    Optional<ClipRule> clip_rule() const;
 
     virtual Optional<ViewBox> active_view_box() const
     {


### PR DESCRIPTION
Most of the paint host callbacks were C++ reading computed style and committed geometry back out of the Rust arena and handing the result to Rust. Move those computations into Rust and delete the C++ behind them.