### PR TITLE
LibWeb: Narrow invalidation after web font changes

### DIFF
--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -41,6 +41,7 @@ public:
     }
 
     bool is_empty() const { return m_fonts.is_empty() && m_pending_faces.is_empty() && !m_last_resort_font; }
+    bool has_pending_faces() const { return !m_pending_faces.is_empty(); }
     Font const& first() const { return !m_fonts.is_empty() ? *m_fonts.first().font : *m_last_resort_font; }
 
     template<typename Callback>

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -222,12 +222,12 @@ void FontLoader::start_loading_next_url()
 
 void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
 {
-    if (typeface) {
+    if (typeface)
         m_typeface = typeface.release_nonnull();
-        m_font_computer->clear_computed_font_cache(m_family_name);
-    }
     m_has_completed = true;
     m_document_load_event_delayer.clear();
+    // Each subscriber publishes its now-loaded FontFace to FontComputer. The face's complete
+    // descriptors are needed to compare the old and new selections, so invalidation happens there.
     for (auto& callback : m_subscribers)
         callback->function()(m_typeface);
     m_subscribers.clear();
@@ -853,6 +853,55 @@ void FontComputer::did_load_font(Utf16FlyString const& family_name)
     clear_computed_font_cache(family_name);
 }
 
+void FontComputer::did_load_font(FontFaceKey const& changed_face)
+{
+    if (m_font_face_change_batch_depth > 0) {
+        did_load_font(changed_face.family_name);
+        return;
+    }
+
+    m_document->bump_style_environment_version();
+    // A family can contain many faces, but one face becoming available changes only the cached
+    // selections which now resolve to it. Compare those selections before discarding their cache
+    // entries, then find the elements holding the discarded cascade identities.
+    HashTable<Gfx::FontCascadeList const*> invalidated_font_lists;
+    m_computed_font_cache.remove_all_matching([&](auto const& key, auto const& font_list) {
+        if (!any_of(key.font_families, [&](ComputedFontFamily const& family) {
+                return family.has<ComputedFontFamilyName>()
+                    && family.get<ComputedFontFamilyName>().name.equals_ignoring_ascii_case(changed_face.family_name);
+            }))
+            return false;
+        auto updated_font_list = compute_font_for_style_values_impl(key.font_families, key.font_size, key.font_slope, key.font_weight, key.font_width, key.font_optical_sizing, key.font_variation_settings, key.font_feature_data);
+        if (!font_list->has_pending_faces() && font_list->equals(*updated_font_list))
+            return false;
+        invalidated_font_lists.set(font_list.ptr());
+        return true;
+    });
+    if (invalidated_font_lists.is_empty())
+        return;
+
+    document().for_each_shadow_including_inclusive_descendant([&](DOM::Node& node) {
+        auto* element = as_if<DOM::Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+        auto uses_invalidated_font_list = [&](Optional<CSS::PseudoElement> pseudo_element = {}) {
+            auto const* values = element->style_group<ComputedValues::FontValues>(pseudo_element);
+            return values && invalidated_font_lists.contains(&values->font_list_value());
+        };
+        bool should_recompute = uses_invalidated_font_list();
+        element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element, DOM::SyntheticPseudoElement const&) {
+            if (uses_invalidated_font_list(pseudo_element)) {
+                should_recompute = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        if (should_recompute)
+            element->document().style_computer().style_engine().record_element_style_input_change(element->style_node_id());
+        return TraversalDecision::Continue;
+    });
+}
+
 void FontComputer::begin_font_face_change_batch()
 {
     ++m_font_face_change_batch_depth;
@@ -886,7 +935,7 @@ void FontComputer::register_font_face(GC::Ref<FontFace> face)
     auto& faces = m_font_faces.ensure(key);
     if (!faces.contains_slow(face))
         faces.append(face);
-    did_load_font(key.family_name);
+    did_load_font(key);
 }
 
 void FontComputer::unregister_font_face(GC::Ref<FontFace> face)
@@ -904,7 +953,7 @@ void FontComputer::unregister_font_face(GC::Ref<FontFace> face)
         if (it->value.is_empty())
             m_font_faces.remove(it);
     }
-    did_load_font(key.family_name);
+    did_load_font(key);
 }
 
 void FontComputer::synchronize_font_face_order(Vector<GC::Ref<FontFace>> const& font_source_order)

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -134,6 +134,7 @@ public:
     void clear_computed_font_cache(Utf16FlyString const& family_name);
     void clear_font_feature_values_cache(Utf16FlyString const& family_name);
     void did_load_font(Utf16FlyString const& family_name);
+    void did_load_font(FontFaceKey const&);
 
     void register_font_face(GC::Ref<FontFace>);
     void unregister_font_face(GC::Ref<FontFace>);

--- a/Tests/LibWeb/Text/expected/css/font-face-weight-specific-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-weight-specific-invalidation.txt
@@ -1,0 +1,3 @@
+affected weight recomputed: true
+unaffected weights skipped: true
+regular face loaded: loaded

--- a/Tests/LibWeb/Text/input/css/font-face-weight-specific-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/font-face-weight-specific-invalidation.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #container > span {
+        font-family: "WeightSpecific", serif;
+    }
+
+    .regular {
+        font-weight: 400;
+    }
+
+    .bold {
+        font-weight: 700;
+    }
+</style>
+<div id="container"></div>
+<script>
+    promiseTest(async () => {
+        const boldFace = new FontFace("WeightSpecific", 'url("../../../Assets/HashSans.woff")', { weight: "700" });
+        document.fonts.add(boldFace);
+        await boldFace.load();
+
+        const container = document.getElementById("container");
+        container.appendChild(document.createElement("span")).className = "regular";
+        for (let index = 0; index < 100; ++index)
+            container.appendChild(document.createElement("span")).className = "bold";
+        internals.updateStyle();
+
+        internals.resetStyleInvalidationCounters();
+        const regularFace = new FontFace("WeightSpecific", 'url("../../../Assets/HashSansNoSpace.woff")', { weight: "400" });
+        document.fonts.add(regularFace);
+        await regularFace.load();
+        internals.updateStyle();
+
+        const counters = internals.getStyleInvalidationCounters();
+        println(`affected weight recomputed: ${counters.elementStyleRecomputations > 0}`);
+        println(`unaffected weights skipped: ${counters.elementStyleRecomputations < 10}`);
+        println(`regular face loaded: ${regularFace.status}`);
+    });
+</script>


### PR DESCRIPTION
Loading a web font currently clears every cached selection for its family, causing elements using unaffected weights and styles to be recomputed.

This compares cached font selections after the FontFace descriptors are final and invalidates only elements whose selected cascade changed or still contains pending faces.

Work towards #11355