### PR TITLE
LibWeb: Track transient mutation observer nodes

### DIFF
--- a/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -118,18 +118,7 @@ WebIDL::ExceptionOr<void> MutationObserver::observe(Node& target, MutationObserv
             updated_existing_observer = true;
 
             // 1. For each node of this’s node list, remove all transient registered observers whose source is registered from node’s registered observer list.
-            for (auto& node : m_node_list) {
-                // FIXME: Is this correct?
-                if (!node)
-                    continue;
-
-                if (node->registered_observer_list()) {
-                    node->registered_observer_list()->remove_all_matching([&registered_observer](RegisteredObserver& observer) {
-                        auto* transient = as_if<TransientRegisteredObserver>(observer);
-                        return transient && transient->source().ptr() == registered_observer.ptr();
-                    });
-                }
-            }
+            remove_transient_registered_observers(registered_observer.ptr());
 
             // 2. Set registered’s options to options.
             registered_observer->set_options(move(options));
@@ -171,6 +160,8 @@ void MutationObserver::disconnect()
         }
     }
 
+    remove_transient_registered_observers();
+
     // 2. Empty this’s record queue.
     m_record_queue.clear();
 }
@@ -188,6 +179,49 @@ Vector<GC::Root<MutationRecord>> MutationObserver::take_records()
 
     // 3. Return records.
     return records;
+}
+
+void MutationObserver::add_transient_registered_node(Badge<Node>, Node& node)
+{
+    for (auto& transient_registered_node : m_transient_registered_node_list) {
+        if (transient_registered_node.ptr().ptr() == &node)
+            return;
+    }
+    m_transient_registered_node_list.append(node);
+}
+
+void MutationObserver::remove_transient_registered_observers(RegisteredObserver const* source)
+{
+    for (auto& node : m_transient_registered_node_list) {
+        if (!node)
+            continue;
+
+        if (auto* registered_observer_list = node->registered_observer_list()) {
+            registered_observer_list->remove_all_matching([this, source](RegisteredObserver& registered_observer) {
+                auto* transient = as_if<TransientRegisteredObserver>(registered_observer);
+                return transient && transient->observer().ptr() == this && (!source || transient->source().ptr() == source);
+            });
+        }
+    }
+
+    if (!source) {
+        m_transient_registered_node_list.clear();
+        return;
+    }
+
+    m_transient_registered_node_list.remove_all_matching([this](GC::Weak<Node> const& node) {
+        if (!node)
+            return true;
+        auto const* registered_observer_list = node->registered_observer_list();
+        if (!registered_observer_list)
+            return true;
+        for (auto const& registered_observer : *registered_observer_list) {
+            auto const* transient = as_if<TransientRegisteredObserver>(*registered_observer);
+            if (transient && transient->observer().ptr() == this)
+                return false;
+        }
+        return true;
+    });
 }
 
 // https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask
@@ -222,17 +256,7 @@ void queue_mutation_observer_microtask(HTML::SimilarOriginWindowAgent& surroundi
 
             // 3. For each node of mo’s node list, remove all transient registered observers whose observer is mo from
             //    node’s registered observer list.
-            for (auto& node : mutation_observer->node_list()) {
-                // FIXME: Is this correct?
-                if (!node)
-                    continue;
-
-                if (node->registered_observer_list()) {
-                    node->registered_observer_list()->remove_all_matching([&mutation_observer](RegisteredObserver& registered_observer) {
-                        return is<TransientRegisteredObserver>(registered_observer) && static_cast<TransientRegisteredObserver&>(registered_observer).observer().ptr() == mutation_observer.ptr();
-                    });
-                }
-            }
+            mutation_observer->remove_transient_registered_observers();
 
             // 4. If records is not empty, then invoke mo’s callback with « records, mo » and "report", and with
             //    callback this value mo.

--- a/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Libraries/LibWeb/DOM/MutationObserver.h
@@ -26,6 +26,8 @@ struct SimilarOriginWindowAgent;
 
 namespace Web::DOM {
 
+class RegisteredObserver;
+
 struct MutationObserverOptions {
     Optional<Vector<Utf16FlyString>> attribute_filter;
     Optional<bool> attribute_old_value;
@@ -53,6 +55,9 @@ public:
     Vector<GC::Weak<Node>>& node_list() { return m_node_list; }
     Vector<GC::Weak<Node>> const& node_list() const { return m_node_list; }
 
+    void add_transient_registered_node(Badge<Node>, Node&);
+    void remove_transient_registered_observers(RegisteredObserver const* source = nullptr);
+
     WebIDL::CallbackType& callback() { return *m_callback; }
 
     void enqueue_record(Badge<Node>, GC::Ref<MutationRecord> mutation_record)
@@ -71,6 +76,9 @@ private:
     // https://dom.spec.whatwg.org/#mutationobserver-node-list
     // Registered observers in a node’s registered observer list have a weak reference to the node.
     Vector<GC::Weak<Node>> m_node_list;
+
+    // Nodes that currently have transient registered observers for this observer.
+    Vector<GC::Weak<Node>> m_transient_registered_node_list;
 
     // https://dom.spec.whatwg.org/#concept-mo-queue
     Vector<GC::Ref<MutationRecord>> m_record_queue;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1410,6 +1410,7 @@ void Node::remove(bool suppress_observers)
             if (registered->options().subtree) {
                 auto transient_observer = TransientRegisteredObserver::create(registered->observer(), registered->options(), registered);
                 add_registered_observer(move(transient_observer));
+                registered->observer()->add_transient_registered_node({}, *this);
             }
         }
     }

--- a/Tests/LibWeb/Text/expected/MutationObserver/transient-registered-observer-cleanup.txt
+++ b/Tests/LibWeb/Text/expected/MutationObserver/transient-registered-observer-cleanup.txt
@@ -1,0 +1,2 @@
+callbacks after removal: 1
+callbacks after detached mutation: 1

--- a/Tests/LibWeb/Text/input/MutationObserver/transient-registered-observer-cleanup.html
+++ b/Tests/LibWeb/Text/input/MutationObserver/transient-registered-observer-cleanup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const parent = document.createElement("div");
+        const child = document.createElement("div");
+        parent.append(child);
+
+        let callbacks = 0;
+        const observer = new MutationObserver(() => ++callbacks);
+        observer.observe(parent, { attributes: true, childList: true, subtree: true });
+
+        child.remove();
+        child.setAttribute("before-delivery", "");
+        await Promise.resolve();
+        println(`callbacks after removal: ${callbacks}`);
+
+        child.setAttribute("after-delivery", "");
+        await Promise.resolve();
+        println(`callbacks after detached mutation: ${callbacks}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Transient mutation observer registrations are installed on removed subtree roots, but cleanup currently scans the observer's permanent targets. This can both waste time and leave registrations attached after delivery.

This records the exact removed roots receiving transient registrations and removes those registrations directly after the mutation records are delivered.

Work towards #11355