### PR TITLE
LibWeb: Speed up form selector state collection

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -357,12 +357,13 @@ ValidityState element_validity_state(DOM::Element const& target)
     if (!form_element && !is<HTML::HTMLFieldSetElement>(target))
         return ValidityState::NotApplicable;
 
+    if (form_element)
+        return form_element->has_invalid_associated_element() ? ValidityState::Invalid : ValidityState::Valid;
+
     bool has_invalid_elements = false;
     target.for_each_in_subtree([&](auto& node) {
         auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(&node);
         if (!form_associated_element)
-            return TraversalDecision::Continue;
-        if (form_element && form_associated_element->form() != form_element)
             return TraversalDecision::Continue;
         if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
             has_invalid_elements = true;

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -362,7 +362,10 @@ ValidityState element_validity_state(DOM::Element const& target)
 
     bool has_invalid_elements = false;
     target.for_each_in_subtree([&](auto& node) {
-        auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(&node);
+        auto const* element = as_if<DOM::Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+        auto const* form_associated_element = as_form_associated_element(*element);
         if (!form_associated_element)
             return TraversalDecision::Continue;
         if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -1220,20 +1220,25 @@ FormAssociatedElement* HTMLFormElement::default_button() const
     // A form element's default button is the first submit button in tree order whose form owner is that form element.
     FormAssociatedElement* default_button = nullptr;
 
-    root().for_each_in_subtree([&](auto& node) {
-        auto* form_associated_element = const_cast<FormAssociatedElement*>(as_if<FormAssociatedElement>(node));
-        if (!form_associated_element)
-            return TraversalDecision::Continue;
-
-        if (form_associated_element->form() == this && form_associated_element->is_submit_button()) {
-            default_button = form_associated_element;
-            return TraversalDecision::Break;
-        }
-
-        return TraversalDecision::Continue;
-    });
+    for (auto const& element : m_associated_elements) {
+        auto& form_associated_element = as<FormAssociatedElement>(*element);
+        if (!form_associated_element.is_submit_button())
+            continue;
+        if (!default_button || element->is_before(default_button->form_associated_element_to_html_element()))
+            default_button = &form_associated_element;
+    }
 
     return default_button;
+}
+
+bool HTMLFormElement::has_invalid_associated_element() const
+{
+    for (auto const& element : m_associated_elements) {
+        auto const& form_associated_element = as<FormAssociatedElement>(*element);
+        if (form_associated_element.is_candidate_for_constraint_validation() && !form_associated_element.satisfies_its_constraints())
+            return true;
+    }
+    return false;
 }
 
 void HTMLFormElement::default_button_state_maybe_changed()

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -108,6 +108,7 @@ public:
     void set_action(Utf16View);
 
     FormAssociatedElement* default_button() const;
+    bool has_invalid_associated_element() const;
     void default_button_state_maybe_changed();
     void default_button_state_maybe_changed(DOM::Element&, bool was_default);
 

--- a/Tests/LibWeb/Text/expected/css/style-engine/validity-attribute-mutations.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/validity-attribute-mutations.txt
@@ -5,5 +5,7 @@ enabled input form: rgb(255, 0, 0) valid=false invalid=true
 disabled fieldset input: rgb(0, 0, 0) valid=false invalid=false
 disabled fieldset: rgb(0, 128, 0) valid=true invalid=false
 disabled fieldset form: rgb(0, 128, 0) valid=true invalid=false
+external input: rgb(255, 0, 0) valid=false invalid=true
+external input form: rgb(255, 0, 0) valid=false invalid=true
 disabled custom control: rgb(0, 0, 0) valid=false invalid=false
 disabled custom control form: rgb(0, 128, 0) valid=true invalid=false

--- a/Tests/LibWeb/Text/input/css/style-engine/validity-attribute-mutations.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/validity-attribute-mutations.html
@@ -10,6 +10,8 @@
 <form id="fieldset-form">
     <fieldset id="disabled-fieldset"><input id="fieldset-input" required></fieldset>
 </form>
+<form id="external-form"></form>
+<input id="external-input" form="external-form" required>
 <script>
     class FormAssociatedElement extends HTMLElement {
         static formAssociated = true;
@@ -52,6 +54,11 @@
         println(`disabled fieldset input: ${state(fieldsetInput)}`);
         println(`disabled fieldset: ${state(disabledFieldset)}`);
         println(`disabled fieldset form: ${state(fieldsetForm)}`);
+
+        const externalForm = document.getElementById("external-form");
+        const externalInput = document.getElementById("external-input");
+        println(`external input: ${state(externalInput)}`);
+        println(`external input form: ${state(externalForm)}`);
 
         const customForm = document.createElement("form");
         const customControl = document.createElement("form-associated");


### PR DESCRIPTION
Form selector state collection repeatedly walks DOM subtrees to derive validity and the default submit button, while forms already maintain their associated controls.

This uses the associated-control collection, including controls connected through the form attribute, and avoids RTTI when deriving fieldset validity from form-associated descendants.

Work towards #11355