### PR TITLE
LibWeb: Index attribute values for selector queries

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -720,6 +720,34 @@ Optional<bool> StyleEngine::selector_query_matches_without_document_root(void co
     return result != 0;
 }
 
+bool StyleEngine::selector_query_all(void* query, StyleNodeID root, bool include_root, StyleNodeID scope_root, StyleNodeID shadow_root, bool has_document_root, Vector<StyleNodeID>& matches)
+{
+    matches.resize(16);
+    auto read = [&] {
+        return StyleEngineFFI::style_engine_selector_query_all(
+            m_impl,
+            query,
+            root.value(),
+            include_root,
+            scope_root.value(),
+            shadow_root.value(),
+            has_document_root,
+            reinterpret_cast<u32*>(matches.data()),
+            matches.size());
+    };
+    auto count = read();
+    if (count == NumericLimits<size_t>::max())
+        return false;
+    if (count > matches.size()) {
+        matches.resize(count);
+        count = read();
+        if (count == NumericLimits<size_t>::max() || count > matches.size())
+            return false;
+    }
+    matches.shrink(count);
+    return true;
+}
+
 bool StyleEngine::counter(size_t index, StringView& out_name, u64& out_value) const
 {
     size_t name_length = 0;

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -245,6 +245,7 @@ public:
     void prepare_selector_query();
     Optional<bool> selector_query_matches(void const* query, StyleNodeID node, StyleNodeID scope_root, StyleNodeID shadow_root);
     Optional<bool> selector_query_matches_without_document_root(void const* query, StyleNodeID node, StyleNodeID scope_root, StyleNodeID shadow_root);
+    bool selector_query_all(void* query, StyleNodeID root, bool include_root, StyleNodeID scope_root, StyleNodeID shadow_root, bool has_document_root, Vector<StyleNodeID>& matches);
 
     // Enumerates the engine's counters. Returns false once index is past the last counter.
     bool counter(size_t index, StringView& out_name, u64& out_value) const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10143,8 +10143,14 @@ RefPtr<SelectorQuery const> Document::selector_query_for(Utf16View selector_text
 {
     static constexpr size_t MAX_SELECTOR_QUERY_CACHE_SIZE = 512;
 
-    if (auto it = m_selector_query_cache.find(selector_text); it != m_selector_query_cache.end())
+    if (m_last_selector_query_text.has_value() && selector_text == *m_last_selector_query_text)
+        return m_last_selector_query;
+
+    if (auto it = m_selector_query_cache.find(selector_text); it != m_selector_query_cache.end()) {
+        m_last_selector_query_text = it->key;
+        m_last_selector_query = it->value;
         return it->value;
+    }
 
     auto maybe_selectors = parse_selector(CSS::Parser::ParsingParams { *this }, selector_text);
 
@@ -10159,7 +10165,10 @@ RefPtr<SelectorQuery const> Document::selector_query_for(Utf16View selector_text
     if (m_selector_query_cache.size() >= MAX_SELECTOR_QUERY_CACHE_SIZE)
         m_selector_query_cache.remove(m_selector_query_cache.begin());
 
-    m_selector_query_cache.set(Utf16String::from_utf16(selector_text), query);
+    auto selector_text_copy = Utf16String::from_utf16(selector_text);
+    m_last_selector_query_text = selector_text_copy;
+    m_last_selector_query = query;
+    m_selector_query_cache.set(move(selector_text_copy), query);
     return query;
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1988,6 +1988,8 @@ private:
     // Cache of parsed selector queries for querySelectorAll/querySelector/matches/closest.
     // A null value means the selector string failed to parse.
     mutable HashMap<Utf16String, RefPtr<SelectorQuery const>> m_selector_query_cache;
+    mutable Optional<Utf16String> m_last_selector_query_text;
+    mutable RefPtr<SelectorQuery const> m_last_selector_query;
 
     // Cache of querySelectorAll results, validated lazily against dom_tree_version/character_data_version.
     OwnPtr<QuerySelectorResultCache> m_query_selector_result_cache;

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -408,7 +408,36 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
         }
     } else {
         settle_connected_selector_query(document);
-        collect_matches(root, [&](auto& element) { return matches_in_style_engine(element, root); }, elements);
+        CSS::StyleNodeID query_root;
+        bool include_root = false;
+        CSS::StyleNodeID scope_root;
+        if (GC::Ptr<Element const> scope_element = as_if<Element>(root)) {
+            query_root = scope_element->style_node_id();
+            scope_root = scope_element->style_node_id();
+        } else if (GC::Ptr<ShadowRoot const> shadow = as_if<ShadowRoot>(root)) {
+            query_root = shadow->style_node_id();
+        } else {
+            auto const* document_element = document.document_element();
+            if (!document_element)
+                return create_node_list(elements);
+            query_root = document_element->style_node_id();
+            include_root = true;
+        }
+        CSS::StyleNodeID shadow_root;
+        if (GC::Ptr<ShadowRoot const> tree_root = as_if<ShadowRoot>(root.root()))
+            shadow_root = tree_root->style_node_id();
+
+        Vector<CSS::StyleNodeID> matches;
+        if (!document.style_computer().style_engine().selector_query_all(m_engine_query, query_root, include_root, scope_root, shadow_root, true, matches)) {
+            collect_matches(root, [&](auto& element) { return matches_in_style_engine(element, root); }, elements);
+        } else {
+            elements.ensure_capacity(matches.size());
+            for (auto node : matches) {
+                auto element = document.style_computer().element_for_style_node(node);
+                VERIFY(element);
+                elements.unchecked_append(*element);
+            }
+        }
     }
 
     auto node_list = create_node_list(elements);

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -41,6 +41,7 @@ use super::compiler::ScopeChain;
 use super::index::FeatureValue;
 use super::index::LocalFeatureKey;
 use super::index::StyleAtomID;
+use super::matching::{SelectorQueryCache, SelectorQueryContext};
 use super::memory::DeviceClass;
 #[cfg(feature = "style-recording")]
 use super::memory::MEMORY_CATEGORIES;
@@ -270,8 +271,19 @@ pub struct FfiStyleRecordView {
 
 struct SelectorQuery {
     program: SelectorProgram,
+    cache: SelectorQueryCache,
     _atoms: PinnedAtoms,
     _memory: MemoryLease,
+}
+
+impl SelectorQuery {
+    #[must_use]
+    fn capacity_bytes(&self) -> u64 {
+        self.program
+            .capacity_bytes()
+            .saturating_add(self.cache.capacity_bytes())
+            .saturating_add(std::mem::size_of::<Self>() as u64)
+    }
 }
 
 impl FfiStyleRecordView {
@@ -1467,6 +1479,7 @@ pub unsafe extern "C" fn style_engine_compile_selector_query(
         memory.resize_required_to(&mut engine.memory, bytes);
         Box::into_raw(Box::new(SelectorQuery {
             program,
+            cache: SelectorQueryCache::default(),
             _atoms: atoms,
             _memory: memory,
         }))
@@ -1514,6 +1527,60 @@ pub unsafe extern "C" fn style_engine_selector_query_matches_without_document_ro
     shadow_root: u32,
 ) -> u8 {
     unsafe { selector_query_matches_impl(engine, query, node, scope_root, shadow_root, false) }
+}
+
+/// Matches a selector query against one resident subtree in one operation.
+///
+/// Returns the required result capacity without writing when `capacity` is too small, and
+/// `usize::MAX` when resident facts do not cover the query.
+///
+/// # Safety
+/// `engine` and `query` must be live and belong to the same document. `matches` must point at
+/// `capacity` writable node identities when `capacity` is nonzero.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn style_engine_selector_query_all(
+    engine: *mut c_void,
+    query: *mut c_void,
+    root: u32,
+    include_root: bool,
+    scope_root: u32,
+    shadow_root: u32,
+    has_document_root: bool,
+    matches: *mut u32,
+    capacity: usize,
+) -> usize {
+    abort_on_panic(|| {
+        let Some(root) = StyleNodeID::from_raw(root) else {
+            return usize::MAX;
+        };
+        if query.is_null() || (capacity != 0 && matches.is_null()) {
+            return usize::MAX;
+        }
+        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+        let query = unsafe { &mut *query.cast::<SelectorQuery>() };
+        let result = engine.selector_query_all(
+            &query.program,
+            &mut query.cache,
+            SelectorQueryContext {
+                root,
+                include_root,
+                scope_root: StyleNodeID::from_raw(scope_root),
+                shadow_root: StyleNodeID::from_raw(shadow_root),
+                has_document_root,
+            },
+        );
+        let query_bytes = query.capacity_bytes();
+        query._memory.resize_required_to(&mut engine.memory, query_bytes);
+        let Ok(result) = result else {
+            return usize::MAX;
+        };
+        if result.len() <= capacity {
+            for (index, node) in result.iter().enumerate() {
+                unsafe { matches.add(index).write(node.raw()) };
+            }
+        }
+        result.len()
+    })
 }
 
 unsafe fn selector_query_matches_impl(

--- a/Libraries/LibWeb/Rust/src/css/style/compiler.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/compiler.rs
@@ -904,8 +904,9 @@ impl<'a> SelectorCompiler<'a> {
         // An exact case-sensitive test is an identity question, and the DOM publishes each attribute
         // value under the same text key, so both sides can answer it by comparing two integers -
         // and the dispatch can reject a rule whose value the element does not hold without
-        // evaluating anything. Any other operator or case reads the literal.
+        // evaluating anything. Other value tests read the literal for their exact comparison.
         let value_atom = match (operator, case) {
+            (AttributeOperator::Presence, _) => StyleAtomID::NONE,
             (AttributeOperator::Exact, AttributeCase::Sensitive) => match &attribute.value_identity {
                 Some(identity) => (self.intern)(identity.raw(), None),
                 None => self.intern_text(&attribute.value),

--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -46,6 +46,9 @@ use super::program::DeclaredProperty;
 use super::program::EntryID;
 use super::program::RuleID;
 use super::program::SelectorProgramID;
+use super::selector::AttributeCase;
+use super::selector::AttributeOperator;
+use super::selector::AttributeTest;
 use super::transaction::ElementDeclarationKind;
 use super::transaction::StateFact;
 use super::tree::StyleNodeID;
@@ -63,6 +66,53 @@ impl StyleAtomID {
     #[must_use]
     pub fn is_none(self) -> bool {
         self == Self::NONE
+    }
+}
+
+fn attribute_value_equals(value: &[u16], literal: &[u16], insensitive: bool) -> bool {
+    value.len() == literal.len()
+        && value.iter().zip(literal).all(|(&left, &right)| {
+            left == right
+                || (insensitive
+                    && match (u8::try_from(left), u8::try_from(right)) {
+                        (Ok(left), Ok(right)) => left.eq_ignore_ascii_case(&right),
+                        _ => false,
+                    })
+        })
+}
+
+fn attribute_value_starts_with(value: &[u16], literal: &[u16], insensitive: bool) -> bool {
+    value.len() >= literal.len() && attribute_value_equals(&value[..literal.len()], literal, insensitive)
+}
+
+fn attribute_value_may_match(value: &[u16], literal: &[u16], operator: AttributeOperator, insensitive: bool) -> bool {
+    match operator {
+        AttributeOperator::Presence => true,
+        AttributeOperator::Exact => attribute_value_equals(value, literal, insensitive),
+        AttributeOperator::Includes => {
+            !literal.is_empty()
+                && value
+                    .split(|unit| matches!(unit, 0x20 | 0x09 | 0x0A | 0x0C | 0x0D))
+                    .any(|token| attribute_value_equals(token, literal, insensitive))
+        }
+        AttributeOperator::DashMatch => {
+            attribute_value_equals(value, literal, insensitive)
+                || (value.len() > literal.len()
+                    && attribute_value_starts_with(value, literal, insensitive)
+                    && value[literal.len()] == u16::from(b'-'))
+        }
+        AttributeOperator::Prefix => !literal.is_empty() && attribute_value_starts_with(value, literal, insensitive),
+        AttributeOperator::Suffix => {
+            !literal.is_empty()
+                && value.len() >= literal.len()
+                && attribute_value_equals(&value[value.len() - literal.len()..], literal, insensitive)
+        }
+        AttributeOperator::Substring => {
+            !literal.is_empty()
+                && value.len() >= literal.len()
+                && (0..=value.len() - literal.len())
+                    .any(|start| attribute_value_equals(&value[start..start + literal.len()], literal, insensitive))
+        }
     }
 }
 
@@ -292,6 +342,10 @@ impl<T: Clone + Default> PagedOwnedColumn<T> {
 
     fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.values.iter_mut()
+    }
+
+    fn indexed_iter(&self) -> impl Iterator<Item = (usize, &T)> {
+        self.indices.iter().copied().zip(self.values.iter())
     }
 
     fn indexed_iter_mut(&mut self) -> impl Iterator<Item = (usize, &mut T)> {
@@ -1493,6 +1547,9 @@ pub enum FeatureKey {
     Id(StyleAtomID),
     Class(StyleAtomID),
     AttributeName(StyleAtomID),
+    /// The complete interned value of an attribute. This is query acceleration rather than a CSS
+    /// dispatch key: attribute value queries use it to reach only values that can match.
+    AttributeValue(StyleAtomID),
     Directionality(StyleAtomID),
     Root,
     State(StateFact),
@@ -1538,6 +1595,7 @@ impl FeatureKey {
                 | Self::Id(_)
                 | Self::Class(_)
                 | Self::AttributeName(_)
+                | Self::AttributeValue(_)
                 | Self::Directionality(_)
         )
     }
@@ -1550,6 +1608,7 @@ impl FeatureKey {
             | Self::Id(atom)
             | Self::Class(atom)
             | Self::AttributeName(atom)
+            | Self::AttributeValue(atom)
             | Self::Directionality(atom)
             | Self::AnimationName(atom) => Some(atom),
             Self::Root
@@ -3278,6 +3337,8 @@ pub struct ElementFactStore {
     language_live_counts: PagedCopyColumn<u32>,
     attribute_name_live_counts: PagedCopyColumn<u32>,
     attribute_value_live_counts: PagedCopyColumn<u32>,
+    /// Changes whenever a newly published value can change an attribute-value query plan.
+    attribute_value_catalog_version: u64,
     custom_property_set_live_counts: Vec<u64>,
     /// Attribute-name forms and value text shared by the primary and each bounded fact batch.
     ///
@@ -3659,6 +3720,7 @@ impl Default for ElementFactStore {
             language_live_counts: PagedCopyColumn::default(),
             attribute_name_live_counts: PagedCopyColumn::default(),
             attribute_value_live_counts: PagedCopyColumn::default(),
+            attribute_value_catalog_version: 1,
             custom_property_set_live_counts: vec![0],
             element_declared_properties: ElementDeclarationRows::default(),
         };
@@ -3898,6 +3960,12 @@ impl ElementFactStore {
             for attribute in self.rows.attributes_of(row) {
                 for name in self.attribute_name_keys(attribute.name) {
                     let key = SelectorPostingKey::AttributeName(name);
+                    if !self.rebuild_missing_posting(&mut rebuilt, key, node, memory) {
+                        return None;
+                    }
+                }
+                if !attribute.value.is_none() {
+                    let key = SelectorPostingKey::AttributeValue(attribute.value);
                     if !self.rebuild_missing_posting(&mut rebuilt, key, node, memory) {
                         return None;
                     }
@@ -4158,6 +4226,12 @@ impl ElementFactStore {
                         || forms.folded_name == name
                         || forms.folded_local == name
                 })
+            }),
+            DispatchKey::AttributeValue(value) => row.is_some_and(|row| {
+                self.rows
+                    .attributes_of(row)
+                    .iter()
+                    .any(|attribute| attribute.value == value)
             }),
             DispatchKey::TagName(tag) => {
                 row.is_some_and(|row| self.rows.tag_of(row) == tag || self.rows.folded_tag_of(row) == tag)
@@ -4505,6 +4579,21 @@ impl ElementFactStore {
         // names are postings rather than facts, so they say only that at least one attribute of the
         // element answers to them.
         let keys = self.attribute_name_keys(name);
+        let old_value = self
+            .staging
+            .get(node)
+            .and_then(|facts| {
+                facts
+                    .attributes
+                    .binary_search_by_key(&name, |entry| entry.0)
+                    .ok()
+                    .map(|index| facts.attributes[index].1)
+            })
+            .or_else(|| {
+                let attributes = self.rows.attributes_of(self.rows.row_of(node)?);
+                let index = attributes.binary_search_by_key(&name, |entry| entry.name).ok()?;
+                Some(attributes[index].value)
+            });
         let changed = self.edit_staged_row(node, |facts| {
             let found = facts.attributes.binary_search_by_key(&name, |entry| entry.0);
             match (present, found) {
@@ -4537,6 +4626,62 @@ impl ElementFactStore {
                 }
             }
         }
+        if old_value != Some(value) {
+            if let Some(old_value) = old_value {
+                let old_value_is_still_present = self
+                    .staging
+                    .get(node)
+                    .is_some_and(|facts| facts.attributes.iter().any(|&(_, candidate)| candidate == old_value));
+                if !old_value.is_none() && !old_value_is_still_present {
+                    self.postings
+                        .remove(SelectorPostingKey::AttributeValue(old_value), node);
+                }
+            }
+            if present && !value.is_none() {
+                self.postings
+                    .insert(SelectorPostingKey::AttributeValue(value), node, memory);
+            }
+        }
+    }
+
+    pub(super) fn matching_attribute_values(&self, test: AttributeTest, literal: &[u16]) -> Vec<StyleAtomID> {
+        if test.operator == AttributeOperator::Exact
+            && test.case == AttributeCase::Sensitive
+            && !test.value_atom.is_none()
+        {
+            return vec![test.value_atom];
+        }
+
+        let insensitive = test.case != AttributeCase::Sensitive;
+        let mut values = Vec::new();
+        for (index, text) in self.attribute_catalogs.value_texts.indexed_iter() {
+            let Some(text) = text else {
+                continue;
+            };
+            if !attribute_value_may_match(text, literal, test.operator, insensitive) {
+                continue;
+            }
+            let value = StyleAtomID(u32::try_from(index).expect("attribute-value atom index exceeds u32"));
+            values.push(value);
+        }
+        values
+    }
+
+    pub(super) fn attribute_value_candidates(&self, values: &[StyleAtomID]) -> Option<Vec<StyleNodeID>> {
+        let mut candidates = Vec::new();
+        for &value in values {
+            match self.postings.lookup(SelectorPostingKey::AttributeValue(value)) {
+                Lookup::Known(posting) => candidates.extend(posting.candidates()),
+                Lookup::KnownAbsent => {}
+                Lookup::Missing(_) => return None,
+            }
+        }
+        Some(candidates)
+    }
+
+    #[must_use]
+    pub(super) fn attribute_value_catalog_version(&self) -> u64 {
+        self.attribute_value_catalog_version
     }
 
     /// Whether any attribute the node still carries is indexed under `key`.
@@ -4618,6 +4763,10 @@ impl ElementFactStore {
         self.attribute_catalogs_mut()
             .value_texts
             .insert(index, Some(text.to_vec()));
+        self.attribute_value_catalog_version = self
+            .attribute_value_catalog_version
+            .checked_add(1)
+            .expect("attribute-value catalog version overflow");
     }
 
     #[must_use]
@@ -4710,9 +4859,12 @@ impl ElementFactStore {
         for state in facts.custom_states {
             self.postings.remove(SelectorPostingKey::CustomState(state), node);
         }
-        for (name, _) in facts.attributes {
+        for (name, value) in facts.attributes {
             for key in self.attribute_name_keys(name) {
                 self.postings.remove(SelectorPostingKey::AttributeName(key), node);
+            }
+            if !value.is_none() {
+                self.postings.remove(SelectorPostingKey::AttributeValue(value), node);
             }
         }
         if let Some(metadata) = node

--- a/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/instrumentation.rs
@@ -79,6 +79,13 @@ define_counters! {
     StructuralTests => "structuralTests",
     RelationalTests => "relationalTests",
 
+    // DOM selector queries. Candidate rows are the elements admitted by the query plan, while
+    // evaluations are the rows that reached the exact matcher after selector-list deduplication.
+    SelectorQueryCandidateRows => "selectorQueryCandidateRows",
+    SelectorQueryEvaluations => "selectorQueryEvaluations",
+    SelectorQueryAttributeValuePlanHits => "selectorQueryAttributeValuePlanHits",
+    SelectorQueryAttributeValueCatalogScans => "selectorQueryAttributeValueCatalogScans",
+
     // Candidate enumeration and cold evaluation.
     ColdMatchingBatchMissingRows => "coldMatchingBatchMissingRows",
     ColdMatchingBatchRows => "coldMatchingBatchRows",

--- a/Libraries/LibWeb/Rust/src/css/style/matching.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/matching.rs
@@ -5,9 +5,37 @@
  */
 
 use super::batch_matcher::{append_selector_truth_matches, insert_scope_rule};
+use super::selector::{AttributeCase, AttributeOperator};
 use super::*;
 
 const MIN_SHARED_CASCADE_COMPLETION_SAVINGS: usize = 8;
+
+#[derive(Default)]
+pub(crate) struct SelectorQueryCache {
+    attribute_value_catalog_version: u64,
+    attribute_values: Vec<Option<Vec<StyleAtomID>>>,
+}
+
+pub(crate) struct SelectorQueryContext {
+    pub(crate) root: StyleNodeID,
+    pub(crate) include_root: bool,
+    pub(crate) scope_root: Option<StyleNodeID>,
+    pub(crate) shadow_root: Option<StyleNodeID>,
+    pub(crate) has_document_root: bool,
+}
+
+impl SelectorQueryCache {
+    #[must_use]
+    pub(crate) fn capacity_bytes(&self) -> u64 {
+        (self.attribute_values.capacity() * size_of::<Option<Vec<StyleAtomID>>>()
+            + self
+                .attribute_values
+                .iter()
+                .flatten()
+                .map(|values| values.capacity() * size_of::<StyleAtomID>())
+                .sum::<usize>()) as u64
+    }
+}
 
 fn verify_match_answer_against_cold(
     engine: &mut StyleEngine,
@@ -117,6 +145,130 @@ impl StyleEngine {
             }
         }
         Ok(false)
+    }
+
+    pub(crate) fn selector_query_all(
+        &mut self,
+        program: &SelectorProgram,
+        cache: &mut SelectorQueryCache,
+        context: SelectorQueryContext,
+    ) -> Result<Vec<StyleNodeID>, Incomplete> {
+        let attribute_value_catalog_version = self.facts.attribute_value_catalog_version();
+        if cache.attribute_value_catalog_version != attribute_value_catalog_version
+            || cache.attribute_values.len() != program.entries().len()
+        {
+            cache.attribute_values.clear();
+            cache.attribute_values.reserve(program.entries().len());
+            for entry_index in 0..program.entries().len() {
+                let values = program
+                    .subject_attribute_value_test(entry_index)
+                    .filter(|test| test.operator != AttributeOperator::Presence)
+                    .map(|test| {
+                        if test.operator != AttributeOperator::Exact || test.case != AttributeCase::Sensitive {
+                            self.counters.bump(Counter::SelectorQueryAttributeValueCatalogScans);
+                        }
+                        self.facts
+                            .matching_attribute_values(test, program.literal(test.value_offset, test.value_length))
+                    });
+                cache.attribute_values.push(values);
+            }
+            cache.attribute_value_catalog_version = attribute_value_catalog_version;
+        } else {
+            self.counters.add(
+                Counter::SelectorQueryAttributeValuePlanHits,
+                u64::try_from(cache.attribute_values.iter().flatten().count()).unwrap_or(u64::MAX),
+            );
+        }
+
+        let mut matches = HashSet::default();
+        let mut evaluator = MatchEvaluator::new(&self.tree, self.facts.primary());
+        if !context.has_document_root {
+            evaluator = evaluator.without_document_root();
+        }
+        if let Some(scope_root) = context.scope_root {
+            evaluator = evaluator.with_scope_root(scope_root);
+        }
+        if let Some(shadow_root) = context.shadow_root {
+            evaluator = evaluator.in_shadow_tree(shadow_root);
+        }
+
+        for (entry_index, entry) in program.entries().iter().enumerate() {
+            if entry.pseudo_element.is_some() {
+                continue;
+            }
+
+            let dispatch_keys = program.subject_dispatch_keys(entry_index);
+            let mut candidates = Vec::new();
+            let mut used_attribute_value_posting = false;
+            if let Some(values) = &cache.attribute_values[entry_index]
+                && let Some(value_candidates) = self.facts.attribute_value_candidates(values)
+            {
+                candidates.extend(value_candidates);
+                used_attribute_value_posting = true;
+            }
+            let mut use_all_nodes = !used_attribute_value_posting && dispatch_keys.is_empty();
+            if !used_attribute_value_posting && !use_all_nodes {
+                for &key in dispatch_keys {
+                    if !key.has_selector_posting() {
+                        use_all_nodes = true;
+                        break;
+                    }
+                    match self.facts.postings().lookup(key) {
+                        Lookup::Known(posting) => {
+                            candidates.extend(posting.candidates());
+                        }
+                        Lookup::KnownAbsent => {}
+                        Lookup::Missing(_) => {
+                            use_all_nodes = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if use_all_nodes {
+                candidates.clear();
+                candidates.extend(
+                    self.tree
+                        .preorder(context.root)
+                        .filter(|&node| context.include_root || node != context.root),
+                );
+            }
+            candidates.retain(|&node| {
+                (context.include_root || node != context.root) && self.tree.is_in_subtree_of(node, context.root)
+            });
+            candidates.sort_unstable();
+            candidates.dedup();
+            self.counters.add(
+                Counter::SelectorQueryCandidateRows,
+                u64::try_from(candidates.len()).unwrap_or(u64::MAX),
+            );
+
+            for node in candidates {
+                if matches.contains(&node) {
+                    continue;
+                }
+                self.counters.bump(Counter::SelectorQueryEvaluations);
+                if evaluator.matches_entry(program, entry, node, &mut self.counters)? {
+                    matches.insert(node);
+                }
+            }
+        }
+        if matches.len() <= 1 {
+            return Ok(matches.into_iter().collect());
+        }
+
+        let match_count = matches.len();
+        let mut ordered_matches = Vec::with_capacity(match_count);
+        for node in self.tree.preorder(context.root) {
+            if matches.contains(&node) {
+                ordered_matches.push(node);
+                if ordered_matches.len() == match_count {
+                    break;
+                }
+            }
+        }
+        debug_assert_eq!(ordered_matches.len(), match_count);
+        Ok(ordered_matches)
     }
 
     pub(super) fn materialize_cold_matching_batch(

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -730,7 +730,9 @@ impl SelectorProgram {
                 let SelectorOp::Feature(FeatureTest::Attribute(test)) = node else {
                     return None;
                 };
-                (test.operator != AttributeOperator::Presence && test.value_atom.is_none()).then_some(test)
+                (test.operator != AttributeOperator::Presence
+                    && (test.operator != AttributeOperator::Exact || test.case != AttributeCase::Sensitive))
+                    .then_some(test)
             })
             .flat_map(|test| {
                 [Some(test.name), (test.folded != test.name).then_some(test.folded)]
@@ -1536,6 +1538,24 @@ impl SelectorProgram {
     #[must_use]
     pub fn subject_dispatch_keys(&self, entry: usize) -> &[DispatchKey] {
         &self.dispatch_metadata.0[entry].subject_dispatch_keys
+    }
+
+    pub(super) fn subject_attribute_value_test(&self, entry: usize) -> Option<AttributeTest> {
+        self.attribute_value_test_of(self.entries()[entry].root)
+    }
+
+    fn attribute_value_test_of(&self, id: SelectorNodeID) -> Option<AttributeTest> {
+        match self.node(id) {
+            SelectorOp::Feature(FeatureTest::Attribute(test)) if test.operator != AttributeOperator::Presence => {
+                Some(test)
+            }
+            SelectorOp::And { first, count } => self
+                .operands(first, count)
+                .iter()
+                .find_map(|&operand| self.attribute_value_test_of(operand)),
+            SelectorOp::Where(inner) => self.attribute_value_test_of(inner),
+            _ => None,
+        }
     }
 
     fn compute_subject_dispatch_keys(&self, entry: usize) -> Vec<DispatchKey> {

--- a/Tests/LibWeb/Text/expected/css/style-engine/query-selector-all-attribute-value-index.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/query-selector-all-attribute-value-index.txt
@@ -1,0 +1,25 @@
+exact: true
+exact is selective: true
+includes: true
+includes is selective: true
+dash match: true
+dash match is selective: true
+prefix: true
+prefix is selective: true
+suffix: true
+suffix is selective: true
+substring: true
+substring is selective: true
+ASCII insensitive: true
+ASCII insensitive is selective: true
+attribute value plan is reused: true
+attribute value catalog is not rescanned: true
+new value refreshes plan: true
+document includes query root: true
+selector-list results use tree order: true
+moved results use tree order: true
+old value removed from index: true
+new value added to index: true
+old value posting is removed: true
+shared value remains indexed: true
+shadow-root query stays scoped: true

--- a/Tests/LibWeb/Text/input/css/style-engine/query-selector-all-attribute-value-index.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/query-selector-all-attribute-value-index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<div id="root" data-exact="alpha">
+    <span id="exact" data-exact="alpha"></span>
+    <span id="includes" data-includes="zero needle one"></span>
+    <span id="dash" data-dash="en-US"></span>
+    <span id="prefix" data-prefix="prefix-rest"></span>
+    <span id="suffix" data-suffix="rest-suffix"></span>
+    <span id="substring" data-substring="around-middle-around"></span>
+    <span id="insensitive" data-insensitive="MiXeD"></span>
+</div>
+<script>
+    test(() => {
+        const root = document.getElementById("root");
+        for (let i = 0; i < 1000; ++i) {
+            const distractor = document.createElement("i");
+            distractor.setAttribute("data-noise", `unrelated-${i}`);
+            root.appendChild(distractor);
+        }
+        internals.updateStyle();
+
+        const check = (description, selector, expectedId) => {
+            const before = internals.styleEngineCounters().selectorQueryEvaluations;
+            const results = root.querySelectorAll(selector);
+            const after = internals.styleEngineCounters().selectorQueryEvaluations;
+            println(`${description}: ${results.length === 1 && results[0].id === expectedId}`);
+            println(`${description} is selective: ${after - before < 10}`);
+        };
+
+        check("exact", '[data-exact="alpha"]', "exact");
+        check("includes", '[data-includes~="needle"]', "includes");
+        check("dash match", '[data-dash|="en"]', "dash");
+        check("prefix", '[data-prefix^="prefix"]', "prefix");
+        check("suffix", '[data-suffix$="suffix"]', "suffix");
+        check("substring", '[data-substring*="middle"]', "substring");
+        check("ASCII insensitive", '[data-insensitive="mixed" i]', "insensitive");
+
+        const planBefore = internals.styleEngineCounters();
+        for (let i = 0; i < 10; ++i) {
+            root.className = `query-cache-${i}`;
+            root.querySelectorAll('[data-includes~="needle"]');
+        }
+        const planAfter = internals.styleEngineCounters();
+        println(`attribute value plan is reused: ${planAfter.selectorQueryAttributeValuePlanHits - planBefore.selectorQueryAttributeValuePlanHits >= 9}`);
+        println(`attribute value catalog is not rescanned: ${planAfter.selectorQueryAttributeValueCatalogScans - planBefore.selectorQueryAttributeValueCatalogScans <= 1}`);
+
+        const freshValue = document.createElement("span");
+        freshValue.setAttribute("data-includes", "fresh needle");
+        root.appendChild(freshValue);
+        const refreshBefore = internals.styleEngineCounters().selectorQueryAttributeValueCatalogScans;
+        const refreshedResults = root.querySelectorAll('[data-includes~="needle"]');
+        const refreshAfter = internals.styleEngineCounters().selectorQueryAttributeValueCatalogScans;
+        println(`new value refreshes plan: ${refreshedResults.length === 2 && refreshAfter - refreshBefore === 1}`);
+
+        const documentResults = document.querySelectorAll('[data-exact="alpha"]');
+        println(`document includes query root: ${documentResults.length === 2 && documentResults[0] === root && documentResults[1].id === "exact"}`);
+
+        const ordered = root.querySelectorAll('[data-suffix$="suffix"], [data-exact="alpha"]');
+        println(`selector-list results use tree order: ${ordered.length === 2 && ordered[0].id === "exact" && ordered[1].id === "suffix"}`);
+
+        const reorderedNodes = [];
+        for (let i = 0; i < 64; ++i) {
+            const node = document.createElement("b");
+            node.dataset.queryOrder = i;
+            root.prepend(node);
+            reorderedNodes.unshift(node);
+        }
+        const reorderedResults = root.querySelectorAll('[data-query-order]');
+        println(`moved results use tree order: ${reorderedResults.length === reorderedNodes.length && Array.from(reorderedResults).every((node, index) => node === reorderedNodes[index])}`);
+
+        const mutation = document.getElementById("exact");
+        mutation.setAttribute("data-exact", "beta");
+        println(`old value removed from index: ${root.querySelectorAll('[data-exact="alpha"]').length === 0}`);
+        println(`new value added to index: ${root.querySelectorAll('[data-exact="beta"]')[0] === mutation}`);
+
+        const staleCandidates = [];
+        for (let i = 0; i < 64; ++i) {
+            const candidate = document.createElement("span");
+            candidate.setAttribute("data-stale-value", "old");
+            root.appendChild(candidate);
+            staleCandidates.push(candidate);
+        }
+        internals.updateStyle();
+        for (const candidate of staleCandidates)
+            candidate.setAttribute("data-stale-value", "new");
+        const staleBefore = internals.styleEngineCounters().selectorQueryEvaluations;
+        const staleResults = root.querySelectorAll('[data-stale-value="old"]');
+        const staleAfter = internals.styleEngineCounters().selectorQueryEvaluations;
+        println(`old value posting is removed: ${staleResults.length === 0 && staleAfter === staleBefore}`);
+
+        const shared = document.createElement("span");
+        shared.setAttribute("data-first", "shared");
+        shared.setAttribute("data-second", "shared");
+        root.appendChild(shared);
+        shared.removeAttribute("data-first");
+        println(`shared value remains indexed: ${root.querySelectorAll('[data-second="shared"]')[0] === shared}`);
+
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const outside = document.createElement("span");
+        outside.setAttribute("data-shadow", "outside");
+        document.body.appendChild(outside);
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = '<span id="shadow-outside" data-shadow="outside"></span><span id="shadow" data-shadow="inside"></span>';
+        const shadowResults = shadowRoot.querySelectorAll('[data-shadow$="side"]');
+        println(`shadow-root query stays scoped: ${shadowResults.length === 2 && shadowResults[0].id === "shadow-outside" && shadowResults[1].id === "shadow"}`);
+    });
+</script>


### PR DESCRIPTION
Connected querySelectorAll calls currently walk the full DOM through C++ and cross into the style engine for every element. This routes the whole query through the resident style graph and uses indexed candidates for every attribute value operator before exact matching.

It also caches attribute value plans until the document's value catalog changes, preserves tree-order results and fallback behavior, retains more stable query results, and adds a one-entry parsed-selector front cache.

Work towards #11355