### PR TITLE
Keep sibling layout subtrees when an element's box is toggled

### DIFF
--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -355,6 +355,18 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     if (AK::first_is_one_of(property_id, CSS::PropertyID::Content, CSS::PropertyID::ContentVisibility, CSS::PropertyID::TextTransform))
         return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::Self);
 
+    // A box that appears or disappears leaves every sibling box intact, so the parent can treat the
+    // change like a child-list mutation instead of rebuilding its whole subtree.
+    if (property_id == CSS::PropertyID::Display) {
+        auto old_display = old_computed_values.display();
+        auto new_display = new_computed_values.display();
+        if (old_display.is_none() != new_display.is_none()) {
+            auto const& box_display = old_display.is_none() ? new_display : old_display;
+            if (box_display.is_outside_and_inside())
+                return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::BoxPresenceChange);
+        }
+    }
+
     // NB: Other display, float, or position changes have to rebuild from the parent.
     if (AK::first_is_one_of(property_id, CSS::PropertyID::Display, CSS::PropertyID::Float, CSS::PropertyID::Position)) {
         return RequiredInvalidationAfterStyleChange::full();

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -29,6 +29,9 @@ enum class AccumulatedVisualContextInvalidation : u8 {
 enum class LayoutTreeRebuildRoot : u8 {
     Self,
     SelfUnlessDocumentElementOrBody,
+    // The element's principal box appears or disappears while every sibling box keeps its kind.
+    // The parent absorbs that as a child-list change where it can, and rebuilds otherwise.
+    BoxPresenceChange,
     Parent,
 };
 
@@ -58,6 +61,11 @@ struct RequiredInvalidationAfterStyleChange {
     {
         VERIFY(needs_layout_tree_rebuild());
         return m_layout_tree_rebuild_root;
+    }
+    void set_layout_tree_rebuild_root(LayoutTreeRebuildRoot rebuild_root)
+    {
+        VERIFY(needs_layout_tree_rebuild());
+        m_layout_tree_rebuild_root = rebuild_root;
     }
     [[nodiscard]] bool needs_stacking_context_tree_rebuild() const { return m_rebuild_stacking_context_tree; }
     // NB: A pending relayout re-measures all scrollable overflow anyway, so this reports true only

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -34,8 +34,10 @@
 #include <LibWeb/CSS/CSSStyleProperties.h>
 #include <LibWeb/CSS/ComputedStyleWorkingSet.h>
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/CounterStyle.h>
 #include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/CustomPropertyData.h>
+#include <LibWeb/CSS/GeneratedContent.h>
 #include <LibWeb/CSS/Invalidation/AttributeInvalidator.h>
 #include <LibWeb/CSS/Invalidation/CustomElementInvalidator.h>
 #include <LibWeb/CSS/Invalidation/ElementStateInvalidator.h>
@@ -141,6 +143,7 @@
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/SVG/SVGAElement.h>
+#include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
 #include <LibWeb/Selection/Selection.h>
@@ -1547,17 +1550,19 @@ static void add_element_dependent_invalidation(CSS::RequiredInvalidationAfterSty
 {
     // NB: Even if the computed value hasn't changed the resolved counter style may have (e.g. if the relevant
     //     @counter-style rule was modified, or a new rule with the same name took precedence over the old one).
+    // Generated content and the marker live inside the element's own layout subtree, so, like a
+    // 'content' change, they rebuild from the element rather than its parent.
     auto compare = [&](Optional<Vector<ValueComparingRefPtr<CSS::CounterStyle const>>> const& old_content_dependencies, Optional<ValueComparingRefPtr<CSS::CounterStyle const>> const& old_list_counter_style) {
         if (old_content_dependencies.has_value()
             && *old_content_dependencies != new_computed_values.resolved_content(abstract_element, 0).content_data.counter_style_dependencies)
-            invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
+            invalidation |= CSS::RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(CSS::LayoutTreeRebuildRoot::Self);
 
         if (old_list_counter_style.has_value()) {
             auto new_list_style_type = new_computed_values.list_style_type(abstract_element.style_scope());
             if (new_list_style_type.has<RefPtr<CSS::CounterStyle const>>()) {
                 ValueComparingRefPtr<CSS::CounterStyle const> new_counter_style = new_list_style_type.get<RefPtr<CSS::CounterStyle const>>();
                 if (*old_list_counter_style != new_counter_style)
-                    invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
+                    invalidation |= CSS::RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(CSS::LayoutTreeRebuildRoot::Self);
             }
         }
     };
@@ -1701,6 +1706,16 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
             return !pseudo_display.is_none() && !pseudo_display.is_contents() && !pseudo_display.is_inline_outside();
         };
 
+        // A marker box is always attached inside the originating box, as is a ::before or ::after
+        // box that cannot escape it, so replacing that box in place creates, removes, or rebuilds
+        // the pseudo-element box along with it.
+        auto pseudo_box_stays_inside_originating_box = [&](CSS::ComputedValues const* new_style) {
+            return pseudo_element == CSS::PseudoElement::Marker
+                || (first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
+                    && !pseudo_style_can_escape_originating_element(pseudo_element_values)
+                    && !pseudo_style_can_escape_originating_element(new_style));
+        };
+
         if (pseudo_element_values && new_pseudo_element_style) {
             DOM::AbstractElement abstract_element { *this, pseudo_element };
             auto result = compute_required_invalidation_with_cache(style_computer, *pseudo_element_values, *new_pseudo_element_style, old_state, abstract_element, style_record_delta);
@@ -1716,20 +1731,18 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
                 result.invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
             }
             if (result.invalidation.needs_layout_tree_rebuild()
-                && result.invalidation.layout_tree_rebuild_root() != CSS::LayoutTreeRebuildRoot::Parent
-                && (!first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
-                    || pseudo_style_can_escape_originating_element(pseudo_element_values)
-                    || pseudo_style_can_escape_originating_element(new_pseudo_element_style.ptr()))) {
-                result.invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
+                && result.invalidation.layout_tree_rebuild_root() != CSS::LayoutTreeRebuildRoot::Parent) {
+                if (!pseudo_box_stays_inside_originating_box(new_pseudo_element_style.ptr()))
+                    result.invalidation.ensure_at_least(CSS::InvalidationLevel::RebuildLayoutTree);
+                else if (result.invalidation.layout_tree_rebuild_root() == CSS::LayoutTreeRebuildRoot::BoxPresenceChange)
+                    result.invalidation.set_layout_tree_rebuild_root(CSS::LayoutTreeRebuildRoot::Self);
             }
             if (result.any_computed_value_changed)
                 document().style_invalidation_counters().element_computed_style_changes++;
             invalidation |= result.invalidation;
         } else if (pseudo_element_values || new_pseudo_element_style) {
             document().style_invalidation_counters().element_computed_style_changes++;
-            auto rebuild_root = first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
-                    && !pseudo_style_can_escape_originating_element(pseudo_element_values)
-                    && !pseudo_style_can_escape_originating_element(new_pseudo_element_style.ptr())
+            auto rebuild_root = pseudo_box_stays_inside_originating_box(new_pseudo_element_style.ptr())
                 ? CSS::LayoutTreeRebuildRoot::Self
                 : CSS::LayoutTreeRebuildRoot::Parent;
             invalidation |= CSS::RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(rebuild_root);
@@ -1798,6 +1811,8 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
     // the insertion-specific invalidation on its parent instead of widening it to StyleChange.
     if (!layout_node && may_reuse_layout_node_for_child_list_insertion())
         return;
+    if (rebuild_root == CSS::LayoutTreeRebuildRoot::BoxPresenceChange && apply_box_presence_change_in_place(reason))
+        return;
     bool can_rebuild_from_self = rebuild_root == CSS::LayoutTreeRebuildRoot::Self
         || (rebuild_root == CSS::LayoutTreeRebuildRoot::SelfUnlessDocumentElementOrBody
             && !is_html_html_element() && !is_html_body_element());
@@ -1809,6 +1824,189 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
         parent->set_needs_layout_tree_update(true, reason);
     else
         set_needs_layout_tree_update(true, reason);
+}
+
+static bool content_displays_a_counter(CSS::ComputedContentData const& content)
+{
+    return any_of(content.items, [](CSS::ComputedContentItem const& item) {
+        return item.has<CSS::ComputedContentCounter>();
+    });
+}
+
+// A marker whose text is the same for every counter value (disc, circle, square, ...) does not
+// reveal renumbering.
+static bool counter_style_representation_depends_on_value(CSS::CounterStyle const& counter_style)
+{
+    auto first = counter_style.generate_an_initial_representation_for_the_counter_value(1);
+    auto second = counter_style.generate_an_initial_representation_for_the_counter_value(2);
+    auto third = counter_style.generate_an_initial_representation_for_the_counter_value(3);
+    return first != second || second != third;
+}
+
+static bool pseudo_element_content_displays_a_counter(Element const& element, CSS::PseudoElement pseudo_element)
+{
+    if (!element.has_style(pseudo_element))
+        return false;
+    auto const* content = element.style_group<CSS::ComputedValues::ContentValues>(pseudo_element);
+    return content && content_displays_a_counter(content->computed_content_value());
+}
+
+// NB: Reads style groups directly; this runs over every element after the list item, and
+//     materializing a ComputedValues per element would cost more than the relayout it saves.
+static bool element_displays_a_list_item_counter_value(Element const& element)
+{
+    if (!element.has_style())
+        return false;
+    for (auto pseudo_element : { CSS::PseudoElement::Before, CSS::PseudoElement::After, CSS::PseudoElement::Marker }) {
+        if (pseudo_element_content_displays_a_counter(element, pseudo_element))
+            return true;
+    }
+    if (!CSS::display_from_ffi_display(element.style_group<CSS::ComputedValues::BoxValues>()->display).is_list_item())
+        return false;
+    auto list_style_type = element.style_group<CSS::ComputedValues::InheritedListValues>()->list_style_type_value(element.style_scope());
+    return list_style_type.visit(
+        [](Empty const&) {
+            return false;
+        },
+        [](RefPtr<CSS::CounterStyle const> const& counter_style) {
+            return !counter_style || counter_style_representation_depends_on_value(*counter_style);
+        },
+        [](Utf16String const&) {
+            return false;
+        },
+        [](Utf16FlyString const&) {
+            return true;
+        },
+        [](CSS::ListStyleSymbols const& symbols) {
+            return counter_style_representation_depends_on_value(*symbols.counter_style);
+        });
+}
+
+// A list item box that appears or disappears renumbers the list-item counter for everything after
+// it in the list. That only matters when some later content would display the counter value.
+static bool list_item_box_change_is_observable(Element const& list_item, Element const& list_owner)
+{
+    if (!Node::list_item_box_change_renumbers_list(list_item))
+        return false;
+    if (pseudo_element_content_displays_a_counter(list_owner, CSS::PseudoElement::After))
+        return true;
+    for (auto const* sibling = list_item.next_element_sibling(); sibling; sibling = sibling->next_element_sibling()) {
+        bool observable = false;
+        sibling->for_each_in_inclusive_subtree([&](Node const& descendant) {
+            auto const* element = as_if<Element>(descendant);
+            if (element && element_displays_a_list_item_counter_value(*element)) {
+                observable = true;
+                return TraversalDecision::Break;
+            }
+            return TraversalDecision::Continue;
+        });
+        if (observable)
+            return true;
+    }
+    return false;
+}
+
+static bool dom_subtree_generates_list_item_boxes(Element const& element)
+{
+    bool generates_list_item_boxes = false;
+    element.for_each_in_inclusive_subtree([&](Node const& descendant) {
+        auto const* descendant_element = as_if<Element>(descendant);
+        if (!descendant_element)
+            return TraversalDecision::Continue;
+        if (descendant_element->is_html_li_element()
+            || (descendant_element->has_style() && CSS::display_from_ffi_display(descendant_element->style_group<CSS::ComputedValues::BoxValues>()->display).is_list_item())) {
+            generates_list_item_boxes = true;
+            return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    });
+    return generates_list_item_boxes;
+}
+
+// NB: Reads box kinds rather than styles: the element whose box is going away already carries
+//     its display: none style.
+static bool layout_subtree_contains_list_item_boxes(Layout::Node const& layout_node)
+{
+    bool contains_list_item_boxes = false;
+    layout_node.for_each_in_inclusive_subtree([&](Layout::Node const& descendant) {
+        if (descendant.kind() == Layout::RustFFI::NodeKind::ListItemBox) {
+            contains_list_item_boxes = true;
+            return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    });
+    return contains_list_item_boxes;
+}
+
+// The element's box stopped or started existing (display: none <-> a box display). Instead of
+// rebuilding the parent's whole layout subtree, schedule the element alone for a rebuild that
+// drops its box, or a DOM-order insertion of its new box into the parent's existing box, when the
+// surrounding structure is unaffected. Returns false when the parent has to be rebuilt after all.
+// NB: Only schedules; the layout tree update removes the box. Style updates must not free layout
+//     nodes, as callers keep layout node pointers across them (e.g. getComputedStyle()).
+bool Element::apply_box_presence_change_in_place(SetNeedsLayoutTreeUpdateReason reason)
+{
+    if (is_html_html_element() || is_html_body_element() || rendered_in_top_layer() || is<SVG::SVGElement>(*this))
+        return false;
+    GC::Ptr<Element> parent = parent_element();
+    if (!parent || parent->shadow_root() || assigned_slot() || is<HTML::HTMLSlotElement>(*parent))
+        return false;
+    auto* parent_layout_node = parent->unsafe_layout_node();
+    if (!parent_layout_node)
+        return false;
+    if (first_letter_owner_for_layout_subtree_from(*parent))
+        return false;
+    if (CSS::subtree_affects_generated_content_state(*this))
+        return false;
+
+    auto style = computed_style();
+    VERIFY(style);
+    auto display = style->display();
+
+    if (display.is_none()) {
+        auto* layout_node = unsafe_layout_node();
+        if (!layout_node)
+            return false;
+        // The box's own style already says display: none, so its level comes from where it sits: a
+        // block container with block-level children holds block-level boxes directly, one with
+        // inline-level children holds inline-level boxes. Only atomic inlines detach from an inline
+        // run; an inline box may have been split around block-level descendants.
+        bool box_is_block_level = !parent_layout_node->children_are_inline();
+        if (!box_is_block_level && layout_node->kind() == Layout::RustFFI::NodeKind::InlineNode)
+            return false;
+        if (!Node::can_detach_layout_subtree_in_place(*this, *parent, box_is_block_level))
+            return false;
+        if (layout_subtree_contains_list_item_boxes(*layout_node) && list_item_box_change_is_observable(*this, *parent))
+            return false;
+
+        // Rebuilding the element in place with display: none clears its stale box out of the
+        // retained parent.
+        set_needs_layout_tree_update(true, reason);
+        return true;
+    }
+
+    if (unsafe_layout_node())
+        return false;
+    if (style->position() == CSS::Positioning::Absolute || style->position() == CSS::Positioning::Fixed || style->float_() != CSS::Float::None)
+        return false;
+
+    auto parent_display = parent_layout_node->display();
+    bool parent_is_block_container = (parent_display.is_flow_inside() || parent_display.is_flow_root_inside()) && !parent_display.is_inline_outside();
+    bool can_insert_in_place = false;
+    if (parent_display.is_flex_inside() || parent_display.is_grid_inside())
+        can_insert_in_place = true;
+    else if (parent_is_block_container && display.is_block_outside())
+        can_insert_in_place = !parent_layout_node->children_are_inline() || !parent_layout_node->has_children();
+    else if (parent_is_block_container && display.is_inline_outside())
+        can_insert_in_place = parent_layout_node->children_are_inline() && parent_layout_node->has_children();
+    if (!can_insert_in_place)
+        return false;
+    if (dom_subtree_generates_list_item_boxes(*this) && list_item_box_change_is_observable(*this, *parent))
+        return false;
+
+    parent->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeInsertBefore);
+    set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeInsertBefore);
+    return true;
 }
 
 void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -341,6 +341,7 @@ public:
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>);
 
     void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason, CSS::LayoutTreeRebuildRoot);
+    bool apply_box_presence_change_in_place(SetNeedsLayoutTreeUpdateReason);
 
     Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element() const;
     void set_associated_shadow_host_pseudo_element(CSS::PseudoElement pseudo_element);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1126,7 +1126,15 @@ static bool node_contributes_to_layout_tree(Node const& node)
         && CSS::display_from_ffi_display(element->style_group<CSS::ComputedValues::BoxValues>()->display).is_contents();
 }
 
-static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& parent)
+// Which kind of box a detached child is. DOM removal reads it from the child's style; a style
+// change that stopped generating the box has already swapped the style, so it names the level.
+enum class DetachedBoxLevel {
+    FromStyle,
+    Block,
+    AtomicInline,
+};
+
+static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& parent, DetachedBoxLevel box_level = DetachedBoxLevel::FromStyle)
 {
     auto const* layout_node = as_if<Layout::NodeWithStyle>(node.unsafe_layout_node());
     auto const* parent_layout_node = parent.unsafe_layout_node();
@@ -1166,9 +1174,36 @@ static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& 
             if (auto next_layout_sibling = layout_node->next_sibling(); next_layout_sibling && next_layout_sibling->is_anonymous())
                 return false;
         }
-        return layout_node->display().is_block_outside();
+        // Once only anonymous wrappers would remain, a full rebuild would place their inline
+        // content directly in the parent instead.
+        bool a_non_anonymous_sibling_remains = false;
+        for (auto sibling = parent_layout_node->first_child(); sibling; sibling = sibling->next_sibling()) {
+            if (sibling.ptr() != layout_node && !sibling->is_anonymous()) {
+                a_non_anonymous_sibling_remains = true;
+                break;
+            }
+        }
+        if (!a_non_anonymous_sibling_remains && parent_layout_node->first_child().ptr() != layout_node)
+            return false;
+        if (box_level == DetachedBoxLevel::FromStyle)
+            return layout_node->display().is_block_outside();
+        return box_level == DetachedBoxLevel::Block;
     }
-    return parent_layout_node->children_are_inline() && layout_node->is_inline_block() && !layout_node->is_out_of_flow();
+    if (!parent_layout_node->children_are_inline())
+        return false;
+    if (box_level == DetachedBoxLevel::FromStyle)
+        return layout_node->is_inline_block();
+    return box_level == DetachedBoxLevel::AtomicInline;
+}
+
+bool Node::can_detach_layout_subtree_in_place(Node const& node, Node const& parent, bool box_is_block_level)
+{
+    return can_detach_layout_subtree_for_removal(node, parent, box_is_block_level ? DetachedBoxLevel::Block : DetachedBoxLevel::AtomicInline);
+}
+
+bool Node::list_item_box_change_renumbers_list(Element const& list_item)
+{
+    return !final_direct_list_item_does_not_renumber_existing_content(list_item);
 }
 
 class RemovalStyleRecordPins {

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -394,6 +394,13 @@ public:
     void set_needs_layout_update(SetNeedsLayoutReason);
     void set_needs_layout_update(SetNeedsLayoutReason, Layout::LayoutUpdatePropagation);
 
+    // Whether the node's layout subtree can leave the parent's box without restructuring the
+    // anonymous boxes around it, so the parent's subtree keeps its layout tree.
+    static bool can_detach_layout_subtree_in_place(Node const& node, Node const& parent, bool box_is_block_level);
+    // Whether a list item's box appearing or disappearing changes the list-item counter value of
+    // some item that stays in the list.
+    static bool list_item_box_change_renumbers_list(Element const& list_item);
+
     void clear_layout_node(Badge<Document>);
     void set_layout_node(Badge<Layout::Node>, Layout::Node&);
     void detach_layout_node(Badge<Layout::LayoutTreeBuilderAccess>);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -877,8 +877,14 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node
     if (layout_node)
         layout_node->clear_committed_box();
     LayoutTreeBuilderAccess::detach_layout_node(node);
-    if (layout_node && layout_node->parent())
+    if (layout_node && layout_node->parent()) {
+        // The parent may keep its subtree (a child lost its box in place); an emptied container
+        // reads as having block-level children, like a freshly built one.
+        auto* parent = layout_node->parent();
         layout_node->remove();
+        if (!parent->has_children())
+            parent->set_children_are_inline(false);
+    }
 
     if (is<DOM::Element>(node))
         LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(static_cast<DOM::Element&>(node));

--- a/Tests/LibWeb/Layout/expected/list-item-hidden-renumbers-markers.txt
+++ b/Tests/LibWeb/Layout/expected/list-item-hidden-renumbers-markers.txt
@@ -1,0 +1,51 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] children: not-inline
+      BlockContainer <ol> at [40,0] [0+0+40 760 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        ListItemBox <li> at [40,0] [0+0+0 760 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [40,0 28.6875x16] baseline: 12.796875
+              "one"
+          ListItemMarkerBox <(anonymous)> at [21,0] [0+0+0 18.6875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from GeneratedTextNode start: 0, length: 3, rect: [21,0 18.6875x16] baseline: 12.796875
+                "1. "
+            GeneratedTextNode <(anonymous)> (not painted)
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [40,16] [0+0+0 760 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [40,16 42.421875x16] baseline: 12.796875
+              "three"
+          ListItemMarkerBox <(anonymous)> at [19,16] [0+0+0 21.15625 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from GeneratedTextNode start: 0, length: 3, rect: [19,16 21.15625x16] baseline: 12.796875
+                "2. "
+            GeneratedTextNode <(anonymous)> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,32] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <ul> at [40,32] [0+0+40 760 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        ListItemBox <li> at [40,32] [0+0+0 760 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [40,32 28.6875x16] baseline: 12.796875
+              "one"
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [40,48] [0+0+0 760 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [40,48 42.421875x16] baseline: 12.796875
+              "three"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,64] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x64]
+      PaintableWithLines (BlockContainer<OL>) [0,0 800x32]
+        PaintableWithLines (ListItemBox<LI>) [40,0 760x16]
+          PaintableWithLines (ListItemMarkerBox(anonymous)) [21,0 18.6875x16]
+        PaintableWithLines (ListItemBox<LI>) [40,16 760x16]
+          PaintableWithLines (ListItemMarkerBox(anonymous)) [19,16 21.15625x16]
+      PaintableWithLines (BlockContainer(anonymous)) [0,32 800x0]
+      PaintableWithLines (BlockContainer<UL>) [0,32 800x32]
+        PaintableWithLines (ListItemBox<LI>) [40,32 760x16]
+        PaintableWithLines (ListItemBox<LI>) [40,48 760x16]
+      PaintableWithLines (BlockContainer(anonymous)) [0,64 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x64] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/list-item-hidden-renumbers-markers.html
+++ b/Tests/LibWeb/Layout/input/list-item-hidden-renumbers-markers.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+    ol, ul { margin: 0; }
+    ul { list-style: none; }
+</style>
+<ol><li>one</li><li id="hidden-ordered">two</li><li>three</li></ol>
+<ul><li>one</li><li id="hidden-unordered">two</li><li>three</li></ul>
+<script>
+    document.body.offsetHeight;
+    // Hiding an item renumbers the markers after it; the unordered list has no markers to update.
+    document.getElementById("hidden-ordered").hidden = true;
+    document.getElementById("hidden-unordered").hidden = true;
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-1.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-1.txt
@@ -118,16 +118,16 @@ RECREATED: display contents -> block flow list-item in contents | following sibl
 RECREATED: display contents -> block flow list-item in contents | following sibling descendant
 STATS: display contents -> block flow list-item in contents | rebuilt subtree roots=1, escaped=false
 PASS: display contents -> block flow list-item in contents | incremental tree matches full rebuild
-RECREATED: display block -> list-item in inline-flex | fixture ancestor
-RECREATED: display block -> list-item in inline-flex | distant sibling
-RECREATED: display block -> list-item in inline-flex | distant sibling descendant
-RECREATED: display block -> list-item in inline-flex | DOM parent
-RECREATED: display block -> list-item in inline-flex | preceding sibling
-RECREATED: display block -> list-item in inline-flex | preceding sibling descendant
+PRESERVED: display block -> list-item in inline-flex | fixture ancestor
+PRESERVED: display block -> list-item in inline-flex | distant sibling
+PRESERVED: display block -> list-item in inline-flex | distant sibling descendant
+PRESERVED: display block -> list-item in inline-flex | DOM parent
+PRESERVED: display block -> list-item in inline-flex | preceding sibling
+PRESERVED: display block -> list-item in inline-flex | preceding sibling descendant
 RECREATED: display block -> list-item in inline-flex | target
 RECREATED: display block -> list-item in inline-flex | target descendant
-RECREATED: display block -> list-item in inline-flex | following sibling
-RECREATED: display block -> list-item in inline-flex | following sibling descendant
+PRESERVED: display block -> list-item in inline-flex | following sibling
+PRESERVED: display block -> list-item in inline-flex | following sibling descendant
 STATS: display block -> list-item in inline-flex | rebuilt subtree roots=1, escaped=false
 PASS: display block -> list-item in inline-flex | incremental tree matches full rebuild
 RECREATED: display block -> math in table-row-group | fixture ancestor
@@ -445,14 +445,14 @@ PASS: display list-item -> block flex in contents | incremental tree matches ful
 PRESERVED: display inline list-item -> none in flex | fixture ancestor
 PRESERVED: display inline list-item -> none in flex | distant sibling
 PRESERVED: display inline list-item -> none in flex | distant sibling descendant
-RECREATED: display inline list-item -> none in flex | DOM parent
-RECREATED: display inline list-item -> none in flex | preceding sibling
-RECREATED: display inline list-item -> none in flex | preceding sibling descendant
+PRESERVED: display inline list-item -> none in flex | DOM parent
+PRESERVED: display inline list-item -> none in flex | preceding sibling
+PRESERVED: display inline list-item -> none in flex | preceding sibling descendant
 REMOVED: display inline list-item -> none in flex | target
 REMOVED: display inline list-item -> none in flex | target descendant
-RECREATED: display inline list-item -> none in flex | following sibling
-RECREATED: display inline list-item -> none in flex | following sibling descendant
-STATS: display inline list-item -> none in flex | rebuilt subtree roots=1, escaped=false
+PRESERVED: display inline list-item -> none in flex | following sibling
+PRESERVED: display inline list-item -> none in flex | following sibling descendant
+STATS: display inline list-item -> none in flex | rebuilt subtree roots=0, escaped=false
 PASS: display inline list-item -> none in flex | incremental tree matches full rebuild
 RECREATED: display inline list-item -> flex in table-row-group | fixture ancestor
 RECREATED: display inline list-item -> flex in table-row-group | distant sibling
@@ -553,13 +553,13 @@ PASS: display flex -> block flow-root in contents | incremental tree matches ful
 PRESERVED: display flex -> block flow list-item in flex | fixture ancestor
 PRESERVED: display flex -> block flow list-item in flex | distant sibling
 PRESERVED: display flex -> block flow list-item in flex | distant sibling descendant
-RECREATED: display flex -> block flow list-item in flex | DOM parent
-RECREATED: display flex -> block flow list-item in flex | preceding sibling
-RECREATED: display flex -> block flow list-item in flex | preceding sibling descendant
+PRESERVED: display flex -> block flow list-item in flex | DOM parent
+PRESERVED: display flex -> block flow list-item in flex | preceding sibling
+PRESERVED: display flex -> block flow list-item in flex | preceding sibling descendant
 RECREATED: display flex -> block flow list-item in flex | target
 RECREATED: display flex -> block flow list-item in flex | target descendant
-RECREATED: display flex -> block flow list-item in flex | following sibling
-RECREATED: display flex -> block flow list-item in flex | following sibling descendant
+PRESERVED: display flex -> block flow list-item in flex | following sibling
+PRESERVED: display flex -> block flow list-item in flex | following sibling descendant
 STATS: display flex -> block flow list-item in flex | rebuilt subtree roots=1, escaped=false
 PASS: display flex -> block flow list-item in flex | incremental tree matches full rebuild
 PRESERVED: display inline-flex -> run-in in -webkit-inline-box | fixture ancestor
@@ -886,17 +886,17 @@ PRESERVED: display math -> block flex in flex | following sibling
 PRESERVED: display math -> block flex in flex | following sibling descendant
 STATS: display math -> block flex in flex | rebuilt subtree roots=1, escaped=false
 PASS: display math -> block flex in flex | incremental tree matches full rebuild
-RECREATED: display -webkit-box -> none in -webkit-inline-box | fixture ancestor
-RECREATED: display -webkit-box -> none in -webkit-inline-box | distant sibling
-RECREATED: display -webkit-box -> none in -webkit-inline-box | distant sibling descendant
-RECREATED: display -webkit-box -> none in -webkit-inline-box | DOM parent
-RECREATED: display -webkit-box -> none in -webkit-inline-box | preceding sibling
-RECREATED: display -webkit-box -> none in -webkit-inline-box | preceding sibling descendant
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | fixture ancestor
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | distant sibling
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | distant sibling descendant
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | DOM parent
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | preceding sibling
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | preceding sibling descendant
 REMOVED: display -webkit-box -> none in -webkit-inline-box | target
 REMOVED: display -webkit-box -> none in -webkit-inline-box | target descendant
-RECREATED: display -webkit-box -> none in -webkit-inline-box | following sibling
-RECREATED: display -webkit-box -> none in -webkit-inline-box | following sibling descendant
-STATS: display -webkit-box -> none in -webkit-inline-box | rebuilt subtree roots=1, escaped=false
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | following sibling
+PRESERVED: display -webkit-box -> none in -webkit-inline-box | following sibling descendant
+STATS: display -webkit-box -> none in -webkit-inline-box | rebuilt subtree roots=0, escaped=false
 PASS: display -webkit-box -> none in -webkit-inline-box | incremental tree matches full rebuild
 RECREATED: display -webkit-box -> inline list-item in table-caption | fixture ancestor
 RECREATED: display -webkit-box -> inline list-item in table-caption | distant sibling
@@ -994,16 +994,16 @@ PRESERVED: display -webkit-inline-box -> block flow-root in flex | following sib
 PRESERVED: display -webkit-inline-box -> block flow-root in flex | following sibling descendant
 STATS: display -webkit-inline-box -> block flow-root in flex | rebuilt subtree roots=1, escaped=false
 PASS: display -webkit-inline-box -> block flow-root in flex | incremental tree matches full rebuild
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | fixture ancestor
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | distant sibling
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | distant sibling descendant
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | DOM parent
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | preceding sibling
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | preceding sibling descendant
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | fixture ancestor
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | distant sibling
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | distant sibling descendant
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | DOM parent
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | preceding sibling
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | preceding sibling descendant
 RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | target
 RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | target descendant
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | following sibling
-RECREATED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | following sibling descendant
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | following sibling
+PRESERVED: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | following sibling descendant
 STATS: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | rebuilt subtree roots=1, escaped=false
 PASS: display -webkit-inline-box -> block flow list-item in -webkit-inline-box | incremental tree matches full rebuild
 RECREATED: display table-row-group -> run-in in table-caption | fixture ancestor
@@ -1342,16 +1342,16 @@ RECREATED: display table-column -> none in table-caption | following sibling
 RECREATED: display table-column -> none in table-caption | following sibling descendant
 STATS: display table-column -> none in table-caption | rebuilt subtree roots=1, escaped=false
 PASS: display table-column -> none in table-caption | incremental tree matches full rebuild
-RECREATED: display table-column -> inline list-item in inline grid | fixture ancestor
-RECREATED: display table-column -> inline list-item in inline grid | distant sibling
-RECREATED: display table-column -> inline list-item in inline grid | distant sibling descendant
-RECREATED: display table-column -> inline list-item in inline grid | DOM parent
-RECREATED: display table-column -> inline list-item in inline grid | preceding sibling
-RECREATED: display table-column -> inline list-item in inline grid | preceding sibling descendant
+PRESERVED: display table-column -> inline list-item in inline grid | fixture ancestor
+PRESERVED: display table-column -> inline list-item in inline grid | distant sibling
+PRESERVED: display table-column -> inline list-item in inline grid | distant sibling descendant
+PRESERVED: display table-column -> inline list-item in inline grid | DOM parent
+PRESERVED: display table-column -> inline list-item in inline grid | preceding sibling
+PRESERVED: display table-column -> inline list-item in inline grid | preceding sibling descendant
 RECREATED: display table-column -> inline list-item in inline grid | target
 RECREATED: display table-column -> inline list-item in inline grid | target descendant
-RECREATED: display table-column -> inline list-item in inline grid | following sibling
-RECREATED: display table-column -> inline list-item in inline grid | following sibling descendant
+PRESERVED: display table-column -> inline list-item in inline grid | following sibling
+PRESERVED: display table-column -> inline list-item in inline grid | following sibling descendant
 STATS: display table-column -> inline list-item in inline grid | rebuilt subtree roots=1, escaped=false
 PASS: display table-column -> inline list-item in inline grid | incremental tree matches full rebuild
 PRESERVED: display table-column -> -webkit-box in flow-root | fixture ancestor
@@ -1774,17 +1774,17 @@ ABSENT: display inline flex -> inline flow-root in table-column | following sibl
 ABSENT: display inline flex -> inline flow-root in table-column | following sibling descendant
 STATS: display inline flex -> inline flow-root in table-column | rebuilt subtree roots=0, escaped=true
 PASS: display inline flex -> inline flow-root in table-column | incremental tree matches full rebuild
-RECREATED: display block grid -> none in inline grid | fixture ancestor
-RECREATED: display block grid -> none in inline grid | distant sibling
-RECREATED: display block grid -> none in inline grid | distant sibling descendant
-RECREATED: display block grid -> none in inline grid | DOM parent
-RECREATED: display block grid -> none in inline grid | preceding sibling
-RECREATED: display block grid -> none in inline grid | preceding sibling descendant
+PRESERVED: display block grid -> none in inline grid | fixture ancestor
+PRESERVED: display block grid -> none in inline grid | distant sibling
+PRESERVED: display block grid -> none in inline grid | distant sibling descendant
+PRESERVED: display block grid -> none in inline grid | DOM parent
+PRESERVED: display block grid -> none in inline grid | preceding sibling
+PRESERVED: display block grid -> none in inline grid | preceding sibling descendant
 REMOVED: display block grid -> none in inline grid | target
 REMOVED: display block grid -> none in inline grid | target descendant
-RECREATED: display block grid -> none in inline grid | following sibling
-RECREATED: display block grid -> none in inline grid | following sibling descendant
-STATS: display block grid -> none in inline grid | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block grid -> none in inline grid | following sibling
+PRESERVED: display block grid -> none in inline grid | following sibling descendant
+STATS: display block grid -> none in inline grid | rebuilt subtree roots=0, escaped=false
 PASS: display block grid -> none in inline grid | incremental tree matches full rebuild
 PRESERVED: display block grid -> inline list-item in flow-root | fixture ancestor
 PRESERVED: display block grid -> inline list-item in flow-root | distant sibling
@@ -1882,16 +1882,16 @@ ABSENT: display inline grid -> inline flow in table-column | following sibling
 ABSENT: display inline grid -> inline flow in table-column | following sibling descendant
 STATS: display inline grid -> inline flow in table-column | rebuilt subtree roots=0, escaped=true
 PASS: display inline grid -> inline flow in table-column | incremental tree matches full rebuild
-RECREATED: display inline grid -> block flow list-item in inline grid | fixture ancestor
-RECREATED: display inline grid -> block flow list-item in inline grid | distant sibling
-RECREATED: display inline grid -> block flow list-item in inline grid | distant sibling descendant
-RECREATED: display inline grid -> block flow list-item in inline grid | DOM parent
-RECREATED: display inline grid -> block flow list-item in inline grid | preceding sibling
-RECREATED: display inline grid -> block flow list-item in inline grid | preceding sibling descendant
+PRESERVED: display inline grid -> block flow list-item in inline grid | fixture ancestor
+PRESERVED: display inline grid -> block flow list-item in inline grid | distant sibling
+PRESERVED: display inline grid -> block flow list-item in inline grid | distant sibling descendant
+PRESERVED: display inline grid -> block flow list-item in inline grid | DOM parent
+PRESERVED: display inline grid -> block flow list-item in inline grid | preceding sibling
+PRESERVED: display inline grid -> block flow list-item in inline grid | preceding sibling descendant
 RECREATED: display inline grid -> block flow list-item in inline grid | target
 RECREATED: display inline grid -> block flow list-item in inline grid | target descendant
-RECREATED: display inline grid -> block flow list-item in inline grid | following sibling
-RECREATED: display inline grid -> block flow list-item in inline grid | following sibling descendant
+PRESERVED: display inline grid -> block flow list-item in inline grid | following sibling
+PRESERVED: display inline grid -> block flow list-item in inline grid | following sibling descendant
 STATS: display inline grid -> block flow list-item in inline grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline grid -> block flow list-item in inline grid | incremental tree matches full rebuild
 PRESERVED: display block table -> run-in in flow-root | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-2.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-2.txt
@@ -13,13 +13,13 @@ PASS: display none -> block in inline | incremental tree matches full rebuild
 PRESERVED: display none -> inline-flex in grid | fixture ancestor
 PRESERVED: display none -> inline-flex in grid | distant sibling
 PRESERVED: display none -> inline-flex in grid | distant sibling descendant
-RECREATED: display none -> inline-flex in grid | DOM parent
-RECREATED: display none -> inline-flex in grid | preceding sibling
-RECREATED: display none -> inline-flex in grid | preceding sibling descendant
+PRESERVED: display none -> inline-flex in grid | DOM parent
+PRESERVED: display none -> inline-flex in grid | preceding sibling
+PRESERVED: display none -> inline-flex in grid | preceding sibling descendant
 CREATED: display none -> inline-flex in grid | target
 CREATED: display none -> inline-flex in grid | target descendant
-RECREATED: display none -> inline-flex in grid | following sibling
-RECREATED: display none -> inline-flex in grid | following sibling descendant
+PRESERVED: display none -> inline-flex in grid | following sibling
+PRESERVED: display none -> inline-flex in grid | following sibling descendant
 STATS: display none -> inline-flex in grid | rebuilt subtree roots=1, escaped=false
 PASS: display none -> inline-flex in grid | incremental tree matches full rebuild
 RECREATED: display none -> table-row-group in table-header-group | fixture ancestor
@@ -121,13 +121,13 @@ PASS: display contents -> inline flow list-item in block | incremental tree matc
 PRESERVED: display block -> inline list-item in grid | fixture ancestor
 PRESERVED: display block -> inline list-item in grid | distant sibling
 PRESERVED: display block -> inline list-item in grid | distant sibling descendant
-RECREATED: display block -> inline list-item in grid | DOM parent
-RECREATED: display block -> inline list-item in grid | preceding sibling
-RECREATED: display block -> inline list-item in grid | preceding sibling descendant
+PRESERVED: display block -> inline list-item in grid | DOM parent
+PRESERVED: display block -> inline list-item in grid | preceding sibling
+PRESERVED: display block -> inline list-item in grid | preceding sibling descendant
 RECREATED: display block -> inline list-item in grid | target
 RECREATED: display block -> inline list-item in grid | target descendant
-RECREATED: display block -> inline list-item in grid | following sibling
-RECREATED: display block -> inline list-item in grid | following sibling descendant
+PRESERVED: display block -> inline list-item in grid | following sibling
+PRESERVED: display block -> inline list-item in grid | following sibling descendant
 STATS: display block -> inline list-item in grid | rebuilt subtree roots=1, escaped=false
 PASS: display block -> inline list-item in grid | incremental tree matches full rebuild
 RECREATED: display block -> -webkit-box in table-header-group | fixture ancestor
@@ -550,16 +550,16 @@ RECREATED: display flex -> inline flow-root in block | following sibling
 RECREATED: display flex -> inline flow-root in block | following sibling descendant
 STATS: display flex -> inline flow-root in block | rebuilt subtree roots=1, escaped=false
 PASS: display flex -> inline flow-root in block | incremental tree matches full rebuild
-RECREATED: display flex -> inline flow list-item in inline-flex | fixture ancestor
-RECREATED: display flex -> inline flow list-item in inline-flex | distant sibling
-RECREATED: display flex -> inline flow list-item in inline-flex | distant sibling descendant
-RECREATED: display flex -> inline flow list-item in inline-flex | DOM parent
-RECREATED: display flex -> inline flow list-item in inline-flex | preceding sibling
-RECREATED: display flex -> inline flow list-item in inline-flex | preceding sibling descendant
+PRESERVED: display flex -> inline flow list-item in inline-flex | fixture ancestor
+PRESERVED: display flex -> inline flow list-item in inline-flex | distant sibling
+PRESERVED: display flex -> inline flow list-item in inline-flex | distant sibling descendant
+PRESERVED: display flex -> inline flow list-item in inline-flex | DOM parent
+PRESERVED: display flex -> inline flow list-item in inline-flex | preceding sibling
+PRESERVED: display flex -> inline flow list-item in inline-flex | preceding sibling descendant
 RECREATED: display flex -> inline flow list-item in inline-flex | target
 RECREATED: display flex -> inline flow list-item in inline-flex | target descendant
-RECREATED: display flex -> inline flow list-item in inline-flex | following sibling
-RECREATED: display flex -> inline flow list-item in inline-flex | following sibling descendant
+PRESERVED: display flex -> inline flow list-item in inline-flex | following sibling
+PRESERVED: display flex -> inline flow list-item in inline-flex | following sibling descendant
 STATS: display flex -> inline flow list-item in inline-flex | rebuilt subtree roots=1, escaped=false
 PASS: display flex -> inline flow list-item in inline-flex | incremental tree matches full rebuild
 RECREATED: display inline-flex -> list-item in table-row-group | fixture ancestor
@@ -1177,13 +1177,13 @@ PASS: display table-row -> none in table-cell | incremental tree matches full re
 PRESERVED: display table-row -> inline list-item in block flex | fixture ancestor
 PRESERVED: display table-row -> inline list-item in block flex | distant sibling
 PRESERVED: display table-row -> inline list-item in block flex | distant sibling descendant
-RECREATED: display table-row -> inline list-item in block flex | DOM parent
-RECREATED: display table-row -> inline list-item in block flex | preceding sibling
-RECREATED: display table-row -> inline list-item in block flex | preceding sibling descendant
+PRESERVED: display table-row -> inline list-item in block flex | DOM parent
+PRESERVED: display table-row -> inline list-item in block flex | preceding sibling
+PRESERVED: display table-row -> inline list-item in block flex | preceding sibling descendant
 RECREATED: display table-row -> inline list-item in block flex | target
 RECREATED: display table-row -> inline list-item in block flex | target descendant
-RECREATED: display table-row -> inline list-item in block flex | following sibling
-RECREATED: display table-row -> inline list-item in block flex | following sibling descendant
+PRESERVED: display table-row -> inline list-item in block flex | following sibling
+PRESERVED: display table-row -> inline list-item in block flex | following sibling descendant
 STATS: display table-row -> inline list-item in block flex | rebuilt subtree roots=1, escaped=false
 PASS: display table-row -> inline list-item in block flex | incremental tree matches full rebuild
 RECREATED: display table-row -> -webkit-box in contents | fixture ancestor
@@ -1609,14 +1609,14 @@ PASS: display block flow-root -> block flex in table-cell | incremental tree mat
 PRESERVED: display inline flow-root -> none in block flex | fixture ancestor
 PRESERVED: display inline flow-root -> none in block flex | distant sibling
 PRESERVED: display inline flow-root -> none in block flex | distant sibling descendant
-RECREATED: display inline flow-root -> none in block flex | DOM parent
-RECREATED: display inline flow-root -> none in block flex | preceding sibling
-RECREATED: display inline flow-root -> none in block flex | preceding sibling descendant
+PRESERVED: display inline flow-root -> none in block flex | DOM parent
+PRESERVED: display inline flow-root -> none in block flex | preceding sibling
+PRESERVED: display inline flow-root -> none in block flex | preceding sibling descendant
 REMOVED: display inline flow-root -> none in block flex | target
 REMOVED: display inline flow-root -> none in block flex | target descendant
-RECREATED: display inline flow-root -> none in block flex | following sibling
-RECREATED: display inline flow-root -> none in block flex | following sibling descendant
-STATS: display inline flow-root -> none in block flex | rebuilt subtree roots=1, escaped=false
+PRESERVED: display inline flow-root -> none in block flex | following sibling
+PRESERVED: display inline flow-root -> none in block flex | following sibling descendant
+STATS: display inline flow-root -> none in block flex | rebuilt subtree roots=0, escaped=false
 PASS: display inline flow-root -> none in block flex | incremental tree matches full rebuild
 RECREATED: display inline flow-root -> inline list-item in contents | fixture ancestor
 RECREATED: display inline flow-root -> inline list-item in contents | distant sibling
@@ -1717,13 +1717,13 @@ PASS: display block flex -> inline flow in table-row | incremental tree matches 
 PRESERVED: display block flex -> block flow list-item in block flex | fixture ancestor
 PRESERVED: display block flex -> block flow list-item in block flex | distant sibling
 PRESERVED: display block flex -> block flow list-item in block flex | distant sibling descendant
-RECREATED: display block flex -> block flow list-item in block flex | DOM parent
-RECREATED: display block flex -> block flow list-item in block flex | preceding sibling
-RECREATED: display block flex -> block flow list-item in block flex | preceding sibling descendant
+PRESERVED: display block flex -> block flow list-item in block flex | DOM parent
+PRESERVED: display block flex -> block flow list-item in block flex | preceding sibling
+PRESERVED: display block flex -> block flow list-item in block flex | preceding sibling descendant
 RECREATED: display block flex -> block flow list-item in block flex | target
 RECREATED: display block flex -> block flow list-item in block flex | target descendant
-RECREATED: display block flex -> block flow list-item in block flex | following sibling
-RECREATED: display block flex -> block flow list-item in block flex | following sibling descendant
+PRESERVED: display block flex -> block flow list-item in block flex | following sibling
+PRESERVED: display block flex -> block flow list-item in block flex | following sibling descendant
 STATS: display block flex -> block flow list-item in block flex | rebuilt subtree roots=1, escaped=false
 PASS: display block flex -> block flow list-item in block flex | incremental tree matches full rebuild
 RECREATED: display inline flex -> run-in in contents | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-3.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-3.txt
@@ -106,17 +106,17 @@ RECREATED: display contents -> block flex in block grid | following sibling
 RECREATED: display contents -> block flex in block grid | following sibling descendant
 STATS: display contents -> block flex in block grid | rebuilt subtree roots=1, escaped=false
 PASS: display contents -> block flex in block grid | incremental tree matches full rebuild
-RECREATED: display block -> none in inline | fixture ancestor
-RECREATED: display block -> none in inline | distant sibling
-RECREATED: display block -> none in inline | distant sibling descendant
-RECREATED: display block -> none in inline | DOM parent
-RECREATED: display block -> none in inline | preceding sibling
-RECREATED: display block -> none in inline | preceding sibling descendant
+PRESERVED: display block -> none in inline | fixture ancestor
+PRESERVED: display block -> none in inline | distant sibling
+PRESERVED: display block -> none in inline | distant sibling descendant
+PRESERVED: display block -> none in inline | DOM parent
+PRESERVED: display block -> none in inline | preceding sibling
+PRESERVED: display block -> none in inline | preceding sibling descendant
 REMOVED: display block -> none in inline | target
 REMOVED: display block -> none in inline | target descendant
-RECREATED: display block -> none in inline | following sibling
-RECREATED: display block -> none in inline | following sibling descendant
-STATS: display block -> none in inline | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block -> none in inline | following sibling
+PRESERVED: display block -> none in inline | following sibling descendant
+STATS: display block -> none in inline | rebuilt subtree roots=0, escaped=false
 PASS: display block -> none in inline | incremental tree matches full rebuild
 PRESERVED: display block -> flex in inline-grid | fixture ancestor
 PRESERVED: display block -> flex in inline-grid | distant sibling
@@ -226,16 +226,16 @@ RECREATED: display inline -> block flow list-item in inline | following sibling
 RECREATED: display inline -> block flow list-item in inline | following sibling descendant
 STATS: display inline -> block flow list-item in inline | rebuilt subtree roots=1, escaped=false
 PASS: display inline -> block flow list-item in inline | incremental tree matches full rebuild
-RECREATED: display flow-root -> list-item in inline-grid | fixture ancestor
-RECREATED: display flow-root -> list-item in inline-grid | distant sibling
-RECREATED: display flow-root -> list-item in inline-grid | distant sibling descendant
-RECREATED: display flow-root -> list-item in inline-grid | DOM parent
-RECREATED: display flow-root -> list-item in inline-grid | preceding sibling
-RECREATED: display flow-root -> list-item in inline-grid | preceding sibling descendant
+PRESERVED: display flow-root -> list-item in inline-grid | fixture ancestor
+PRESERVED: display flow-root -> list-item in inline-grid | distant sibling
+PRESERVED: display flow-root -> list-item in inline-grid | distant sibling descendant
+PRESERVED: display flow-root -> list-item in inline-grid | DOM parent
+PRESERVED: display flow-root -> list-item in inline-grid | preceding sibling
+PRESERVED: display flow-root -> list-item in inline-grid | preceding sibling descendant
 RECREATED: display flow-root -> list-item in inline-grid | target
 RECREATED: display flow-root -> list-item in inline-grid | target descendant
-RECREATED: display flow-root -> list-item in inline-grid | following sibling
-RECREATED: display flow-root -> list-item in inline-grid | following sibling descendant
+PRESERVED: display flow-root -> list-item in inline-grid | following sibling
+PRESERVED: display flow-root -> list-item in inline-grid | following sibling descendant
 STATS: display flow-root -> list-item in inline-grid | rebuilt subtree roots=1, escaped=false
 PASS: display flow-root -> list-item in inline-grid | incremental tree matches full rebuild
 RECREATED: display flow-root -> math in table-footer-group | fixture ancestor
@@ -553,14 +553,14 @@ PASS: display flex -> block flex in inline | incremental tree matches full rebui
 PRESERVED: display inline-flex -> none in grid | fixture ancestor
 PRESERVED: display inline-flex -> none in grid | distant sibling
 PRESERVED: display inline-flex -> none in grid | distant sibling descendant
-RECREATED: display inline-flex -> none in grid | DOM parent
-RECREATED: display inline-flex -> none in grid | preceding sibling
-RECREATED: display inline-flex -> none in grid | preceding sibling descendant
+PRESERVED: display inline-flex -> none in grid | DOM parent
+PRESERVED: display inline-flex -> none in grid | preceding sibling
+PRESERVED: display inline-flex -> none in grid | preceding sibling descendant
 REMOVED: display inline-flex -> none in grid | target
 REMOVED: display inline-flex -> none in grid | target descendant
-RECREATED: display inline-flex -> none in grid | following sibling
-RECREATED: display inline-flex -> none in grid | following sibling descendant
-STATS: display inline-flex -> none in grid | rebuilt subtree roots=1, escaped=false
+PRESERVED: display inline-flex -> none in grid | following sibling
+PRESERVED: display inline-flex -> none in grid | following sibling descendant
+STATS: display inline-flex -> none in grid | rebuilt subtree roots=0, escaped=false
 PASS: display inline-flex -> none in grid | incremental tree matches full rebuild
 RECREATED: display inline-flex -> inline list-item in table-header-group | fixture ancestor
 RECREATED: display inline-flex -> inline list-item in table-header-group | distant sibling
@@ -661,13 +661,13 @@ PASS: display grid -> block flow-root in inline | incremental tree matches full 
 PRESERVED: display grid -> block flow list-item in grid | fixture ancestor
 PRESERVED: display grid -> block flow list-item in grid | distant sibling
 PRESERVED: display grid -> block flow list-item in grid | distant sibling descendant
-RECREATED: display grid -> block flow list-item in grid | DOM parent
-RECREATED: display grid -> block flow list-item in grid | preceding sibling
-RECREATED: display grid -> block flow list-item in grid | preceding sibling descendant
+PRESERVED: display grid -> block flow list-item in grid | DOM parent
+PRESERVED: display grid -> block flow list-item in grid | preceding sibling
+PRESERVED: display grid -> block flow list-item in grid | preceding sibling descendant
 RECREATED: display grid -> block flow list-item in grid | target
 RECREATED: display grid -> block flow list-item in grid | target descendant
-RECREATED: display grid -> block flow list-item in grid | following sibling
-RECREATED: display grid -> block flow list-item in grid | following sibling descendant
+PRESERVED: display grid -> block flow list-item in grid | following sibling
+PRESERVED: display grid -> block flow list-item in grid | following sibling descendant
 STATS: display grid -> block flow list-item in grid | rebuilt subtree roots=1, escaped=false
 PASS: display grid -> block flow list-item in grid | incremental tree matches full rebuild
 RECREATED: display inline-grid -> run-in in table-header-group | fixture ancestor
@@ -1438,17 +1438,17 @@ RECREATED: display table-caption -> block flex in table-header-group | following
 RECREATED: display table-caption -> block flex in table-header-group | following sibling descendant
 STATS: display table-caption -> block flex in table-header-group | rebuilt subtree roots=1, escaped=false
 PASS: display table-caption -> block flex in table-header-group | incremental tree matches full rebuild
-RECREATED: display block flow -> none in inline flow | fixture ancestor
-RECREATED: display block flow -> none in inline flow | distant sibling
-RECREATED: display block flow -> none in inline flow | distant sibling descendant
-RECREATED: display block flow -> none in inline flow | DOM parent
-RECREATED: display block flow -> none in inline flow | preceding sibling
-RECREATED: display block flow -> none in inline flow | preceding sibling descendant
+PRESERVED: display block flow -> none in inline flow | fixture ancestor
+PRESERVED: display block flow -> none in inline flow | distant sibling
+PRESERVED: display block flow -> none in inline flow | distant sibling descendant
+PRESERVED: display block flow -> none in inline flow | DOM parent
+PRESERVED: display block flow -> none in inline flow | preceding sibling
+PRESERVED: display block flow -> none in inline flow | preceding sibling descendant
 REMOVED: display block flow -> none in inline flow | target
 REMOVED: display block flow -> none in inline flow | target descendant
-RECREATED: display block flow -> none in inline flow | following sibling
-RECREATED: display block flow -> none in inline flow | following sibling descendant
-STATS: display block flow -> none in inline flow | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block flow -> none in inline flow | following sibling
+PRESERVED: display block flow -> none in inline flow | following sibling descendant
+STATS: display block flow -> none in inline flow | rebuilt subtree roots=0, escaped=false
 PASS: display block flow -> none in inline flow | incremental tree matches full rebuild
 RECREATED: display block flow -> inline list-item in inline table | fixture ancestor
 RECREATED: display block flow -> inline list-item in inline table | distant sibling
@@ -1714,16 +1714,16 @@ PRESERVED: display block flex -> block flow-root in table-cell | following sibli
 PRESERVED: display block flex -> block flow-root in table-cell | following sibling descendant
 STATS: display block flex -> block flow-root in table-cell | rebuilt subtree roots=1, escaped=false
 PASS: display block flex -> block flow-root in table-cell | incremental tree matches full rebuild
-RECREATED: display block flex -> inline flow list-item in inline flex | fixture ancestor
-RECREATED: display block flex -> inline flow list-item in inline flex | distant sibling
-RECREATED: display block flex -> inline flow list-item in inline flex | distant sibling descendant
-RECREATED: display block flex -> inline flow list-item in inline flex | DOM parent
-RECREATED: display block flex -> inline flow list-item in inline flex | preceding sibling
-RECREATED: display block flex -> inline flow list-item in inline flex | preceding sibling descendant
+PRESERVED: display block flex -> inline flow list-item in inline flex | fixture ancestor
+PRESERVED: display block flex -> inline flow list-item in inline flex | distant sibling
+PRESERVED: display block flex -> inline flow list-item in inline flex | distant sibling descendant
+PRESERVED: display block flex -> inline flow list-item in inline flex | DOM parent
+PRESERVED: display block flex -> inline flow list-item in inline flex | preceding sibling
+PRESERVED: display block flex -> inline flow list-item in inline flex | preceding sibling descendant
 RECREATED: display block flex -> inline flow list-item in inline flex | target
 RECREATED: display block flex -> inline flow list-item in inline flex | target descendant
-RECREATED: display block flex -> inline flow list-item in inline flex | following sibling
-RECREATED: display block flex -> inline flow list-item in inline flex | following sibling descendant
+PRESERVED: display block flex -> inline flow list-item in inline flex | following sibling
+PRESERVED: display block flex -> inline flow list-item in inline flex | following sibling descendant
 STATS: display block flex -> inline flow list-item in inline flex | rebuilt subtree roots=1, escaped=false
 PASS: display block flex -> inline flow list-item in inline flex | incremental tree matches full rebuild
 PRESERVED: display inline flex -> list-item in block | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-4.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-4.txt
@@ -382,17 +382,17 @@ RECREATED: display run-in -> block flex in inline flow list-item | following sib
 RECREATED: display run-in -> block flex in inline flow list-item | following sibling descendant
 STATS: display run-in -> block flex in inline flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: display run-in -> block flex in inline flow list-item | incremental tree matches full rebuild
-RECREATED: display list-item -> none in inline list-item | fixture ancestor
-RECREATED: display list-item -> none in inline list-item | distant sibling
-RECREATED: display list-item -> none in inline list-item | distant sibling descendant
-RECREATED: display list-item -> none in inline list-item | DOM parent
-RECREATED: display list-item -> none in inline list-item | preceding sibling
-RECREATED: display list-item -> none in inline list-item | preceding sibling descendant
+PRESERVED: display list-item -> none in inline list-item | fixture ancestor
+PRESERVED: display list-item -> none in inline list-item | distant sibling
+PRESERVED: display list-item -> none in inline list-item | distant sibling descendant
+PRESERVED: display list-item -> none in inline list-item | DOM parent
+PRESERVED: display list-item -> none in inline list-item | preceding sibling
+PRESERVED: display list-item -> none in inline list-item | preceding sibling descendant
 REMOVED: display list-item -> none in inline list-item | target
 REMOVED: display list-item -> none in inline list-item | target descendant
-RECREATED: display list-item -> none in inline list-item | following sibling
-RECREATED: display list-item -> none in inline list-item | following sibling descendant
-STATS: display list-item -> none in inline list-item | rebuilt subtree roots=1, escaped=false
+PRESERVED: display list-item -> none in inline list-item | following sibling
+PRESERVED: display list-item -> none in inline list-item | following sibling descendant
+STATS: display list-item -> none in inline list-item | rebuilt subtree roots=0, escaped=false
 PASS: display list-item -> none in inline list-item | incremental tree matches full rebuild
 RECREATED: display list-item -> flex in -webkit-inline-box | fixture ancestor
 RECREATED: display list-item -> flex in -webkit-inline-box | distant sibling
@@ -658,16 +658,16 @@ RECREATED: display grid -> inline flow-root in flow-root | following sibling
 RECREATED: display grid -> inline flow-root in flow-root | following sibling descendant
 STATS: display grid -> inline flow-root in flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display grid -> inline flow-root in flow-root | incremental tree matches full rebuild
-RECREATED: display grid -> inline flow list-item in inline-grid | fixture ancestor
-RECREATED: display grid -> inline flow list-item in inline-grid | distant sibling
-RECREATED: display grid -> inline flow list-item in inline-grid | distant sibling descendant
-RECREATED: display grid -> inline flow list-item in inline-grid | DOM parent
-RECREATED: display grid -> inline flow list-item in inline-grid | preceding sibling
-RECREATED: display grid -> inline flow list-item in inline-grid | preceding sibling descendant
+PRESERVED: display grid -> inline flow list-item in inline-grid | fixture ancestor
+PRESERVED: display grid -> inline flow list-item in inline-grid | distant sibling
+PRESERVED: display grid -> inline flow list-item in inline-grid | distant sibling descendant
+PRESERVED: display grid -> inline flow list-item in inline-grid | DOM parent
+PRESERVED: display grid -> inline flow list-item in inline-grid | preceding sibling
+PRESERVED: display grid -> inline flow list-item in inline-grid | preceding sibling descendant
 RECREATED: display grid -> inline flow list-item in inline-grid | target
 RECREATED: display grid -> inline flow list-item in inline-grid | target descendant
-RECREATED: display grid -> inline flow list-item in inline-grid | following sibling
-RECREATED: display grid -> inline flow list-item in inline-grid | following sibling descendant
+PRESERVED: display grid -> inline flow list-item in inline-grid | following sibling
+PRESERVED: display grid -> inline flow list-item in inline-grid | following sibling descendant
 STATS: display grid -> inline flow list-item in inline-grid | rebuilt subtree roots=1, escaped=false
 PASS: display grid -> inline flow list-item in inline-grid | incremental tree matches full rebuild
 RECREATED: display inline-grid -> list-item in table-footer-group | fixture ancestor
@@ -829,26 +829,26 @@ PASS: display inline-table -> block flex in inline list-item | incremental tree 
 PRESERVED: display math -> none in -webkit-box | fixture ancestor
 PRESERVED: display math -> none in -webkit-box | distant sibling
 PRESERVED: display math -> none in -webkit-box | distant sibling descendant
-RECREATED: display math -> none in -webkit-box | DOM parent
-RECREATED: display math -> none in -webkit-box | preceding sibling
-RECREATED: display math -> none in -webkit-box | preceding sibling descendant
+PRESERVED: display math -> none in -webkit-box | DOM parent
+PRESERVED: display math -> none in -webkit-box | preceding sibling
+PRESERVED: display math -> none in -webkit-box | preceding sibling descendant
 REMOVED: display math -> none in -webkit-box | target
 REMOVED: display math -> none in -webkit-box | target descendant
-RECREATED: display math -> none in -webkit-box | following sibling
-RECREATED: display math -> none in -webkit-box | following sibling descendant
-STATS: display math -> none in -webkit-box | rebuilt subtree roots=1, escaped=false
+PRESERVED: display math -> none in -webkit-box | following sibling
+PRESERVED: display math -> none in -webkit-box | following sibling descendant
+STATS: display math -> none in -webkit-box | rebuilt subtree roots=0, escaped=false
 PASS: display math -> none in -webkit-box | incremental tree matches full rebuild
-RECREATED: display math -> inline list-item in table-column | fixture ancestor
-RECREATED: display math -> inline list-item in table-column | distant sibling
-RECREATED: display math -> inline list-item in table-column | distant sibling descendant
-RECREATED: display math -> inline list-item in table-column | DOM parent
+PRESERVED: display math -> inline list-item in table-column | fixture ancestor
+PRESERVED: display math -> inline list-item in table-column | distant sibling
+PRESERVED: display math -> inline list-item in table-column | distant sibling descendant
+PRESERVED: display math -> inline list-item in table-column | DOM parent
 ABSENT: display math -> inline list-item in table-column | preceding sibling
 ABSENT: display math -> inline list-item in table-column | preceding sibling descendant
 ABSENT: display math -> inline list-item in table-column | target
 ABSENT: display math -> inline list-item in table-column | target descendant
 ABSENT: display math -> inline list-item in table-column | following sibling
 ABSENT: display math -> inline list-item in table-column | following sibling descendant
-STATS: display math -> inline list-item in table-column | rebuilt subtree roots=1, escaped=false
+STATS: display math -> inline list-item in table-column | rebuilt subtree roots=0, escaped=true
 PASS: display math -> inline list-item in table-column | incremental tree matches full rebuild
 PRESERVED: display math -> -webkit-inline-box in inline grid | fixture ancestor
 PRESERVED: display math -> -webkit-inline-box in inline grid | distant sibling
@@ -937,13 +937,13 @@ PASS: display -webkit-box -> block flow-root in inline list-item | incremental t
 PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | fixture ancestor
 PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | distant sibling
 PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | distant sibling descendant
-RECREATED: display -webkit-box -> block flow list-item in -webkit-box | DOM parent
-RECREATED: display -webkit-box -> block flow list-item in -webkit-box | preceding sibling
-RECREATED: display -webkit-box -> block flow list-item in -webkit-box | preceding sibling descendant
+PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | DOM parent
+PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | preceding sibling
+PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | preceding sibling descendant
 RECREATED: display -webkit-box -> block flow list-item in -webkit-box | target
 RECREATED: display -webkit-box -> block flow list-item in -webkit-box | target descendant
-RECREATED: display -webkit-box -> block flow list-item in -webkit-box | following sibling
-RECREATED: display -webkit-box -> block flow list-item in -webkit-box | following sibling descendant
+PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | following sibling
+PRESERVED: display -webkit-box -> block flow list-item in -webkit-box | following sibling descendant
 STATS: display -webkit-box -> block flow list-item in -webkit-box | rebuilt subtree roots=1, escaped=false
 PASS: display -webkit-box -> block flow list-item in -webkit-box | incremental tree matches full rebuild
 RECREATED: display -webkit-inline-box -> run-in in table-column | fixture ancestor
@@ -1561,13 +1561,13 @@ PASS: display inline flow -> inline flow list-item in block flow-root | incremen
 PRESERVED: display block flow-root -> list-item in block flow list-item | fixture ancestor
 PRESERVED: display block flow-root -> list-item in block flow list-item | distant sibling
 PRESERVED: display block flow-root -> list-item in block flow list-item | distant sibling descendant
-RECREATED: display block flow-root -> list-item in block flow list-item | DOM parent
-RECREATED: display block flow-root -> list-item in block flow list-item | preceding sibling
-RECREATED: display block flow-root -> list-item in block flow list-item | preceding sibling descendant
+PRESERVED: display block flow-root -> list-item in block flow list-item | DOM parent
+PRESERVED: display block flow-root -> list-item in block flow list-item | preceding sibling
+PRESERVED: display block flow-root -> list-item in block flow list-item | preceding sibling descendant
 RECREATED: display block flow-root -> list-item in block flow list-item | target
 RECREATED: display block flow-root -> list-item in block flow list-item | target descendant
-RECREATED: display block flow-root -> list-item in block flow list-item | following sibling
-RECREATED: display block flow-root -> list-item in block flow list-item | following sibling descendant
+PRESERVED: display block flow-root -> list-item in block flow list-item | following sibling
+PRESERVED: display block flow-root -> list-item in block flow list-item | following sibling descendant
 STATS: display block flow-root -> list-item in block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: display block flow-root -> list-item in block flow list-item | incremental tree matches full rebuild
 PRESERVED: display block flow-root -> math in list-item | fixture ancestor
@@ -1717,25 +1717,25 @@ PASS: display block flex -> inline flow-root in table-column-group | incremental
 PRESERVED: display inline flex -> none in block grid | fixture ancestor
 PRESERVED: display inline flex -> none in block grid | distant sibling
 PRESERVED: display inline flex -> none in block grid | distant sibling descendant
-RECREATED: display inline flex -> none in block grid | DOM parent
-RECREATED: display inline flex -> none in block grid | preceding sibling
-RECREATED: display inline flex -> none in block grid | preceding sibling descendant
+PRESERVED: display inline flex -> none in block grid | DOM parent
+PRESERVED: display inline flex -> none in block grid | preceding sibling
+PRESERVED: display inline flex -> none in block grid | preceding sibling descendant
 REMOVED: display inline flex -> none in block grid | target
 REMOVED: display inline flex -> none in block grid | target descendant
-RECREATED: display inline flex -> none in block grid | following sibling
-RECREATED: display inline flex -> none in block grid | following sibling descendant
-STATS: display inline flex -> none in block grid | rebuilt subtree roots=1, escaped=false
+PRESERVED: display inline flex -> none in block grid | following sibling
+PRESERVED: display inline flex -> none in block grid | following sibling descendant
+STATS: display inline flex -> none in block grid | rebuilt subtree roots=0, escaped=false
 PASS: display inline flex -> none in block grid | incremental tree matches full rebuild
-RECREATED: display inline flex -> inline list-item in inline | fixture ancestor
-RECREATED: display inline flex -> inline list-item in inline | distant sibling
-RECREATED: display inline flex -> inline list-item in inline | distant sibling descendant
-RECREATED: display inline flex -> inline list-item in inline | DOM parent
-RECREATED: display inline flex -> inline list-item in inline | preceding sibling
-RECREATED: display inline flex -> inline list-item in inline | preceding sibling descendant
+PRESERVED: display inline flex -> inline list-item in inline | fixture ancestor
+PRESERVED: display inline flex -> inline list-item in inline | distant sibling
+PRESERVED: display inline flex -> inline list-item in inline | distant sibling descendant
+PRESERVED: display inline flex -> inline list-item in inline | DOM parent
+PRESERVED: display inline flex -> inline list-item in inline | preceding sibling
+PRESERVED: display inline flex -> inline list-item in inline | preceding sibling descendant
 RECREATED: display inline flex -> inline list-item in inline | target
 RECREATED: display inline flex -> inline list-item in inline | target descendant
-RECREATED: display inline flex -> inline list-item in inline | following sibling
-RECREATED: display inline flex -> inline list-item in inline | following sibling descendant
+PRESERVED: display inline flex -> inline list-item in inline | following sibling
+PRESERVED: display inline flex -> inline list-item in inline | following sibling descendant
 STATS: display inline flex -> inline list-item in inline | rebuilt subtree roots=1, escaped=false
 PASS: display inline flex -> inline list-item in inline | incremental tree matches full rebuild
 PRESERVED: display inline flex -> -webkit-box in grid | fixture ancestor
@@ -1825,13 +1825,13 @@ PASS: display block grid -> inline flow in table-column-group | incremental tree
 PRESERVED: display block grid -> block flow list-item in block grid | fixture ancestor
 PRESERVED: display block grid -> block flow list-item in block grid | distant sibling
 PRESERVED: display block grid -> block flow list-item in block grid | distant sibling descendant
-RECREATED: display block grid -> block flow list-item in block grid | DOM parent
-RECREATED: display block grid -> block flow list-item in block grid | preceding sibling
-RECREATED: display block grid -> block flow list-item in block grid | preceding sibling descendant
+PRESERVED: display block grid -> block flow list-item in block grid | DOM parent
+PRESERVED: display block grid -> block flow list-item in block grid | preceding sibling
+PRESERVED: display block grid -> block flow list-item in block grid | preceding sibling descendant
 RECREATED: display block grid -> block flow list-item in block grid | target
 RECREATED: display block grid -> block flow list-item in block grid | target descendant
-RECREATED: display block grid -> block flow list-item in block grid | following sibling
-RECREATED: display block grid -> block flow list-item in block grid | following sibling descendant
+PRESERVED: display block grid -> block flow list-item in block grid | following sibling
+PRESERVED: display block grid -> block flow list-item in block grid | following sibling descendant
 STATS: display block grid -> block flow list-item in block grid | rebuilt subtree roots=1, escaped=false
 PASS: display block grid -> block flow list-item in block grid | incremental tree matches full rebuild
 RECREATED: display inline grid -> run-in in inline | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-5.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-5.txt
@@ -37,13 +37,13 @@ PASS: display none -> table-row in table-cell | incremental tree matches full re
 PRESERVED: display none -> inline flow-root in block flex | fixture ancestor
 PRESERVED: display none -> inline flow-root in block flex | distant sibling
 PRESERVED: display none -> inline flow-root in block flex | distant sibling descendant
-RECREATED: display none -> inline flow-root in block flex | DOM parent
-RECREATED: display none -> inline flow-root in block flex | preceding sibling
-RECREATED: display none -> inline flow-root in block flex | preceding sibling descendant
+PRESERVED: display none -> inline flow-root in block flex | DOM parent
+PRESERVED: display none -> inline flow-root in block flex | preceding sibling
+PRESERVED: display none -> inline flow-root in block flex | preceding sibling descendant
 CREATED: display none -> inline flow-root in block flex | target
 CREATED: display none -> inline flow-root in block flex | target descendant
-RECREATED: display none -> inline flow-root in block flex | following sibling
-RECREATED: display none -> inline flow-root in block flex | following sibling descendant
+PRESERVED: display none -> inline flow-root in block flex | following sibling
+PRESERVED: display none -> inline flow-root in block flex | following sibling descendant
 STATS: display none -> inline flow-root in block flex | rebuilt subtree roots=1, escaped=false
 PASS: display none -> inline flow-root in block flex | incremental tree matches full rebuild
 RECREATED: display none -> inline flow list-item in contents | fixture ancestor
@@ -214,17 +214,17 @@ RECREATED: display inline -> block flex in block table | following sibling
 RECREATED: display inline -> block flex in block table | following sibling descendant
 STATS: display inline -> block flex in block table | rebuilt subtree roots=1, escaped=false
 PASS: display inline -> block flex in block table | incremental tree matches full rebuild
-RECREATED: display flow-root -> none in inline-block | fixture ancestor
-RECREATED: display flow-root -> none in inline-block | distant sibling
-RECREATED: display flow-root -> none in inline-block | distant sibling descendant
-RECREATED: display flow-root -> none in inline-block | DOM parent
-RECREATED: display flow-root -> none in inline-block | preceding sibling
-RECREATED: display flow-root -> none in inline-block | preceding sibling descendant
+PRESERVED: display flow-root -> none in inline-block | fixture ancestor
+PRESERVED: display flow-root -> none in inline-block | distant sibling
+PRESERVED: display flow-root -> none in inline-block | distant sibling descendant
+PRESERVED: display flow-root -> none in inline-block | DOM parent
+PRESERVED: display flow-root -> none in inline-block | preceding sibling
+PRESERVED: display flow-root -> none in inline-block | preceding sibling descendant
 REMOVED: display flow-root -> none in inline-block | target
 REMOVED: display flow-root -> none in inline-block | target descendant
-RECREATED: display flow-root -> none in inline-block | following sibling
-RECREATED: display flow-root -> none in inline-block | following sibling descendant
-STATS: display flow-root -> none in inline-block | rebuilt subtree roots=1, escaped=false
+PRESERVED: display flow-root -> none in inline-block | following sibling
+PRESERVED: display flow-root -> none in inline-block | following sibling descendant
+STATS: display flow-root -> none in inline-block | rebuilt subtree roots=0, escaped=false
 PASS: display flow-root -> none in inline-block | incremental tree matches full rebuild
 RECREATED: display flow-root -> flex in inline-table | fixture ancestor
 RECREATED: display flow-root -> flex in inline-table | distant sibling
@@ -502,16 +502,16 @@ PRESERVED: display inline list-item -> inline flow list-item in flex | following
 PRESERVED: display inline list-item -> inline flow list-item in flex | following sibling descendant
 STATS: display inline list-item -> inline flow list-item in flex | no layout tree build
 PASS: display inline list-item -> inline flow list-item in flex | incremental tree matches full rebuild
-RECREATED: display flex -> list-item in -webkit-inline-box | fixture ancestor
-RECREATED: display flex -> list-item in -webkit-inline-box | distant sibling
-RECREATED: display flex -> list-item in -webkit-inline-box | distant sibling descendant
-RECREATED: display flex -> list-item in -webkit-inline-box | DOM parent
-RECREATED: display flex -> list-item in -webkit-inline-box | preceding sibling
-RECREATED: display flex -> list-item in -webkit-inline-box | preceding sibling descendant
+PRESERVED: display flex -> list-item in -webkit-inline-box | fixture ancestor
+PRESERVED: display flex -> list-item in -webkit-inline-box | distant sibling
+PRESERVED: display flex -> list-item in -webkit-inline-box | distant sibling descendant
+PRESERVED: display flex -> list-item in -webkit-inline-box | DOM parent
+PRESERVED: display flex -> list-item in -webkit-inline-box | preceding sibling
+PRESERVED: display flex -> list-item in -webkit-inline-box | preceding sibling descendant
 RECREATED: display flex -> list-item in -webkit-inline-box | target
 RECREATED: display flex -> list-item in -webkit-inline-box | target descendant
-RECREATED: display flex -> list-item in -webkit-inline-box | following sibling
-RECREATED: display flex -> list-item in -webkit-inline-box | following sibling descendant
+PRESERVED: display flex -> list-item in -webkit-inline-box | following sibling
+PRESERVED: display flex -> list-item in -webkit-inline-box | following sibling descendant
 STATS: display flex -> list-item in -webkit-inline-box | rebuilt subtree roots=1, escaped=false
 PASS: display flex -> list-item in -webkit-inline-box | incremental tree matches full rebuild
 PRESERVED: display flex -> -webkit-box in block flow | fixture ancestor
@@ -934,16 +934,16 @@ PRESERVED: display -webkit-box -> inline flow-root in flex | following sibling
 PRESERVED: display -webkit-box -> inline flow-root in flex | following sibling descendant
 STATS: display -webkit-box -> inline flow-root in flex | rebuilt subtree roots=1, escaped=false
 PASS: display -webkit-box -> inline flow-root in flex | incremental tree matches full rebuild
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | fixture ancestor
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | distant sibling
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | distant sibling descendant
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | DOM parent
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | preceding sibling
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | preceding sibling descendant
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | fixture ancestor
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | distant sibling
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | distant sibling descendant
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | DOM parent
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | preceding sibling
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | preceding sibling descendant
 RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | target
 RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | target descendant
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | following sibling
-RECREATED: display -webkit-box -> inline flow list-item in -webkit-inline-box | following sibling descendant
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | following sibling
+PRESERVED: display -webkit-box -> inline flow list-item in -webkit-inline-box | following sibling descendant
 STATS: display -webkit-box -> inline flow list-item in -webkit-inline-box | rebuilt subtree roots=1, escaped=false
 PASS: display -webkit-box -> inline flow list-item in -webkit-inline-box | incremental tree matches full rebuild
 RECREATED: display -webkit-inline-box -> list-item in table-caption | fixture ancestor
@@ -1546,17 +1546,17 @@ RECREATED: display inline flow -> block flex in table-row | following sibling
 RECREATED: display inline flow -> block flex in table-row | following sibling descendant
 STATS: display inline flow -> block flex in table-row | rebuilt subtree roots=1, escaped=false
 PASS: display inline flow -> block flex in table-row | incremental tree matches full rebuild
-RECREATED: display block flow-root -> none in inline flow-root | fixture ancestor
-RECREATED: display block flow-root -> none in inline flow-root | distant sibling
-RECREATED: display block flow-root -> none in inline flow-root | distant sibling descendant
-RECREATED: display block flow-root -> none in inline flow-root | DOM parent
-RECREATED: display block flow-root -> none in inline flow-root | preceding sibling
-RECREATED: display block flow-root -> none in inline flow-root | preceding sibling descendant
+PRESERVED: display block flow-root -> none in inline flow-root | fixture ancestor
+PRESERVED: display block flow-root -> none in inline flow-root | distant sibling
+PRESERVED: display block flow-root -> none in inline flow-root | distant sibling descendant
+PRESERVED: display block flow-root -> none in inline flow-root | DOM parent
+PRESERVED: display block flow-root -> none in inline flow-root | preceding sibling
+PRESERVED: display block flow-root -> none in inline flow-root | preceding sibling descendant
 REMOVED: display block flow-root -> none in inline flow-root | target
 REMOVED: display block flow-root -> none in inline flow-root | target descendant
-RECREATED: display block flow-root -> none in inline flow-root | following sibling
-RECREATED: display block flow-root -> none in inline flow-root | following sibling descendant
-STATS: display block flow-root -> none in inline flow-root | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block flow-root -> none in inline flow-root | following sibling
+PRESERVED: display block flow-root -> none in inline flow-root | following sibling descendant
+STATS: display block flow-root -> none in inline flow-root | rebuilt subtree roots=0, escaped=false
 PASS: display block flow-root -> none in inline flow-root | incremental tree matches full rebuild
 RECREATED: display block flow-root -> inline list-item in inline flow list-item | fixture ancestor
 RECREATED: display block flow-root -> inline list-item in inline flow list-item | distant sibling
@@ -1822,16 +1822,16 @@ ABSENT: display block grid -> block flow-root in table-column | following siblin
 ABSENT: display block grid -> block flow-root in table-column | following sibling descendant
 STATS: display block grid -> block flow-root in table-column | rebuilt subtree roots=0, escaped=true
 PASS: display block grid -> block flow-root in table-column | incremental tree matches full rebuild
-RECREATED: display block grid -> inline flow list-item in inline grid | fixture ancestor
-RECREATED: display block grid -> inline flow list-item in inline grid | distant sibling
-RECREATED: display block grid -> inline flow list-item in inline grid | distant sibling descendant
-RECREATED: display block grid -> inline flow list-item in inline grid | DOM parent
-RECREATED: display block grid -> inline flow list-item in inline grid | preceding sibling
-RECREATED: display block grid -> inline flow list-item in inline grid | preceding sibling descendant
+PRESERVED: display block grid -> inline flow list-item in inline grid | fixture ancestor
+PRESERVED: display block grid -> inline flow list-item in inline grid | distant sibling
+PRESERVED: display block grid -> inline flow list-item in inline grid | distant sibling descendant
+PRESERVED: display block grid -> inline flow list-item in inline grid | DOM parent
+PRESERVED: display block grid -> inline flow list-item in inline grid | preceding sibling
+PRESERVED: display block grid -> inline flow list-item in inline grid | preceding sibling descendant
 RECREATED: display block grid -> inline flow list-item in inline grid | target
 RECREATED: display block grid -> inline flow list-item in inline grid | target descendant
-RECREATED: display block grid -> inline flow list-item in inline grid | following sibling
-RECREATED: display block grid -> inline flow list-item in inline grid | following sibling descendant
+PRESERVED: display block grid -> inline flow list-item in inline grid | following sibling
+PRESERVED: display block grid -> inline flow list-item in inline grid | following sibling descendant
 STATS: display block grid -> inline flow list-item in inline grid | rebuilt subtree roots=1, escaped=false
 PASS: display block grid -> inline flow list-item in inline grid | incremental tree matches full rebuild
 PRESERVED: display inline grid -> list-item in flow-root | fixture ancestor
@@ -1990,17 +1990,17 @@ RECREATED: display inline table -> inline flow-root in block flow-root | followi
 RECREATED: display inline table -> inline flow-root in block flow-root | following sibling descendant
 STATS: display inline table -> inline flow-root in block flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display inline table -> inline flow-root in block flow-root | incremental tree matches full rebuild
-RECREATED: display block flow list-item -> none in inline flow list-item | fixture ancestor
-RECREATED: display block flow list-item -> none in inline flow list-item | distant sibling
-RECREATED: display block flow list-item -> none in inline flow list-item | distant sibling descendant
-RECREATED: display block flow list-item -> none in inline flow list-item | DOM parent
-RECREATED: display block flow list-item -> none in inline flow list-item | preceding sibling
-RECREATED: display block flow list-item -> none in inline flow list-item | preceding sibling descendant
+PRESERVED: display block flow list-item -> none in inline flow list-item | fixture ancestor
+PRESERVED: display block flow list-item -> none in inline flow list-item | distant sibling
+PRESERVED: display block flow list-item -> none in inline flow list-item | distant sibling descendant
+PRESERVED: display block flow list-item -> none in inline flow list-item | DOM parent
+PRESERVED: display block flow list-item -> none in inline flow list-item | preceding sibling
+PRESERVED: display block flow list-item -> none in inline flow list-item | preceding sibling descendant
 REMOVED: display block flow list-item -> none in inline flow list-item | target
 REMOVED: display block flow list-item -> none in inline flow list-item | target descendant
-RECREATED: display block flow list-item -> none in inline flow list-item | following sibling
-RECREATED: display block flow list-item -> none in inline flow list-item | following sibling descendant
-STATS: display block flow list-item -> none in inline flow list-item | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block flow list-item -> none in inline flow list-item | following sibling
+PRESERVED: display block flow list-item -> none in inline flow list-item | following sibling descendant
+STATS: display block flow list-item -> none in inline flow list-item | rebuilt subtree roots=0, escaped=false
 PASS: display block flow list-item -> none in inline flow list-item | incremental tree matches full rebuild
 RECREATED: display block flow list-item -> inline list-item in inline list-item | fixture ancestor
 RECREATED: display block flow list-item -> inline list-item in inline list-item | distant sibling

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-6.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-6.txt
@@ -157,25 +157,25 @@ PASS: display block -> block flow-root in inline flex | incremental tree matches
 PRESERVED: display block -> block flow list-item in block | fixture ancestor
 PRESERVED: display block -> block flow list-item in block | distant sibling
 PRESERVED: display block -> block flow list-item in block | distant sibling descendant
-RECREATED: display block -> block flow list-item in block | DOM parent
-RECREATED: display block -> block flow list-item in block | preceding sibling
-RECREATED: display block -> block flow list-item in block | preceding sibling descendant
+PRESERVED: display block -> block flow list-item in block | DOM parent
+PRESERVED: display block -> block flow list-item in block | preceding sibling
+PRESERVED: display block -> block flow list-item in block | preceding sibling descendant
 RECREATED: display block -> block flow list-item in block | target
 RECREATED: display block -> block flow list-item in block | target descendant
-RECREATED: display block -> block flow list-item in block | following sibling
-RECREATED: display block -> block flow list-item in block | following sibling descendant
+PRESERVED: display block -> block flow list-item in block | following sibling
+PRESERVED: display block -> block flow list-item in block | following sibling descendant
 STATS: display block -> block flow list-item in block | rebuilt subtree roots=1, escaped=false
 PASS: display block -> block flow list-item in block | incremental tree matches full rebuild
 PRESERVED: display inline -> list-item in grid | fixture ancestor
 PRESERVED: display inline -> list-item in grid | distant sibling
 PRESERVED: display inline -> list-item in grid | distant sibling descendant
-RECREATED: display inline -> list-item in grid | DOM parent
-RECREATED: display inline -> list-item in grid | preceding sibling
-RECREATED: display inline -> list-item in grid | preceding sibling descendant
+PRESERVED: display inline -> list-item in grid | DOM parent
+PRESERVED: display inline -> list-item in grid | preceding sibling
+PRESERVED: display inline -> list-item in grid | preceding sibling descendant
 RECREATED: display inline -> list-item in grid | target
 RECREATED: display inline -> list-item in grid | target descendant
-RECREATED: display inline -> list-item in grid | following sibling
-RECREATED: display inline -> list-item in grid | following sibling descendant
+PRESERVED: display inline -> list-item in grid | following sibling
+PRESERVED: display inline -> list-item in grid | following sibling descendant
 STATS: display inline -> list-item in grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline -> list-item in grid | incremental tree matches full rebuild
 PRESERVED: display inline -> math in table-header-group | fixture ancestor
@@ -490,17 +490,17 @@ RECREATED: display inline list-item -> block flex in block | following sibling
 RECREATED: display inline list-item -> block flex in block | following sibling descendant
 STATS: display inline list-item -> block flex in block | rebuilt subtree roots=1, escaped=false
 PASS: display inline list-item -> block flex in block | incremental tree matches full rebuild
-RECREATED: display flex -> none in inline-flex | fixture ancestor
-RECREATED: display flex -> none in inline-flex | distant sibling
-RECREATED: display flex -> none in inline-flex | distant sibling descendant
-RECREATED: display flex -> none in inline-flex | DOM parent
-RECREATED: display flex -> none in inline-flex | preceding sibling
-RECREATED: display flex -> none in inline-flex | preceding sibling descendant
+PRESERVED: display flex -> none in inline-flex | fixture ancestor
+PRESERVED: display flex -> none in inline-flex | distant sibling
+PRESERVED: display flex -> none in inline-flex | distant sibling descendant
+PRESERVED: display flex -> none in inline-flex | DOM parent
+PRESERVED: display flex -> none in inline-flex | preceding sibling
+PRESERVED: display flex -> none in inline-flex | preceding sibling descendant
 REMOVED: display flex -> none in inline-flex | target
 REMOVED: display flex -> none in inline-flex | target descendant
-RECREATED: display flex -> none in inline-flex | following sibling
-RECREATED: display flex -> none in inline-flex | following sibling descendant
-STATS: display flex -> none in inline-flex | rebuilt subtree roots=1, escaped=false
+PRESERVED: display flex -> none in inline-flex | following sibling
+PRESERVED: display flex -> none in inline-flex | following sibling descendant
+STATS: display flex -> none in inline-flex | rebuilt subtree roots=0, escaped=false
 PASS: display flex -> none in inline-flex | incremental tree matches full rebuild
 RECREATED: display flex -> inline list-item in table-row-group | fixture ancestor
 RECREATED: display flex -> inline list-item in table-row-group | distant sibling
@@ -598,16 +598,16 @@ RECREATED: display inline-flex -> block flow-root in block | following sibling
 RECREATED: display inline-flex -> block flow-root in block | following sibling descendant
 STATS: display inline-flex -> block flow-root in block | rebuilt subtree roots=1, escaped=false
 PASS: display inline-flex -> block flow-root in block | incremental tree matches full rebuild
-RECREATED: display inline-flex -> block flow list-item in inline-flex | fixture ancestor
-RECREATED: display inline-flex -> block flow list-item in inline-flex | distant sibling
-RECREATED: display inline-flex -> block flow list-item in inline-flex | distant sibling descendant
-RECREATED: display inline-flex -> block flow list-item in inline-flex | DOM parent
-RECREATED: display inline-flex -> block flow list-item in inline-flex | preceding sibling
-RECREATED: display inline-flex -> block flow list-item in inline-flex | preceding sibling descendant
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | fixture ancestor
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | distant sibling
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | distant sibling descendant
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | DOM parent
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | preceding sibling
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | preceding sibling descendant
 RECREATED: display inline-flex -> block flow list-item in inline-flex | target
 RECREATED: display inline-flex -> block flow list-item in inline-flex | target descendant
-RECREATED: display inline-flex -> block flow list-item in inline-flex | following sibling
-RECREATED: display inline-flex -> block flow list-item in inline-flex | following sibling descendant
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | following sibling
+PRESERVED: display inline-flex -> block flow list-item in inline-flex | following sibling descendant
 STATS: display inline-flex -> block flow list-item in inline-flex | rebuilt subtree roots=1, escaped=false
 PASS: display inline-flex -> block flow list-item in inline-flex | incremental tree matches full rebuild
 RECREATED: display grid -> run-in in table-row-group | fixture ancestor
@@ -1225,13 +1225,13 @@ PASS: display table-row -> inline flow list-item in table-cell | incremental tre
 PRESERVED: display table-cell -> list-item in block flex | fixture ancestor
 PRESERVED: display table-cell -> list-item in block flex | distant sibling
 PRESERVED: display table-cell -> list-item in block flex | distant sibling descendant
-RECREATED: display table-cell -> list-item in block flex | DOM parent
-RECREATED: display table-cell -> list-item in block flex | preceding sibling
-RECREATED: display table-cell -> list-item in block flex | preceding sibling descendant
+PRESERVED: display table-cell -> list-item in block flex | DOM parent
+PRESERVED: display table-cell -> list-item in block flex | preceding sibling
+PRESERVED: display table-cell -> list-item in block flex | preceding sibling descendant
 RECREATED: display table-cell -> list-item in block flex | target
 RECREATED: display table-cell -> list-item in block flex | target descendant
-RECREATED: display table-cell -> list-item in block flex | following sibling
-RECREATED: display table-cell -> list-item in block flex | following sibling descendant
+PRESERVED: display table-cell -> list-item in block flex | following sibling
+PRESERVED: display table-cell -> list-item in block flex | following sibling descendant
 STATS: display table-cell -> list-item in block flex | rebuilt subtree roots=1, escaped=false
 PASS: display table-cell -> list-item in block flex | incremental tree matches full rebuild
 RECREATED: display table-cell -> math in contents | fixture ancestor
@@ -1489,13 +1489,13 @@ PASS: display block flow -> block flow-root in table-row-group | incremental tre
 PRESERVED: display block flow -> block flow list-item in block flow | fixture ancestor
 PRESERVED: display block flow -> block flow list-item in block flow | distant sibling
 PRESERVED: display block flow -> block flow list-item in block flow | distant sibling descendant
-RECREATED: display block flow -> block flow list-item in block flow | DOM parent
-RECREATED: display block flow -> block flow list-item in block flow | preceding sibling
-RECREATED: display block flow -> block flow list-item in block flow | preceding sibling descendant
+PRESERVED: display block flow -> block flow list-item in block flow | DOM parent
+PRESERVED: display block flow -> block flow list-item in block flow | preceding sibling
+PRESERVED: display block flow -> block flow list-item in block flow | preceding sibling descendant
 RECREATED: display block flow -> block flow list-item in block flow | target
 RECREATED: display block flow -> block flow list-item in block flow | target descendant
-RECREATED: display block flow -> block flow list-item in block flow | following sibling
-RECREATED: display block flow -> block flow list-item in block flow | following sibling descendant
+PRESERVED: display block flow -> block flow list-item in block flow | following sibling
+PRESERVED: display block flow -> block flow list-item in block flow | following sibling descendant
 STATS: display block flow -> block flow list-item in block flow | rebuilt subtree roots=1, escaped=false
 PASS: display block flow -> block flow list-item in block flow | incremental tree matches full rebuild
 RECREATED: display inline flow -> run-in in block table | fixture ancestor
@@ -1657,25 +1657,25 @@ PASS: display inline flow-root -> block flow-root in table-row | incremental tre
 PRESERVED: display inline flow-root -> inline flow list-item in block flex | fixture ancestor
 PRESERVED: display inline flow-root -> inline flow list-item in block flex | distant sibling
 PRESERVED: display inline flow-root -> inline flow list-item in block flex | distant sibling descendant
-RECREATED: display inline flow-root -> inline flow list-item in block flex | DOM parent
-RECREATED: display inline flow-root -> inline flow list-item in block flex | preceding sibling
-RECREATED: display inline flow-root -> inline flow list-item in block flex | preceding sibling descendant
+PRESERVED: display inline flow-root -> inline flow list-item in block flex | DOM parent
+PRESERVED: display inline flow-root -> inline flow list-item in block flex | preceding sibling
+PRESERVED: display inline flow-root -> inline flow list-item in block flex | preceding sibling descendant
 RECREATED: display inline flow-root -> inline flow list-item in block flex | target
 RECREATED: display inline flow-root -> inline flow list-item in block flex | target descendant
-RECREATED: display inline flow-root -> inline flow list-item in block flex | following sibling
-RECREATED: display inline flow-root -> inline flow list-item in block flex | following sibling descendant
+PRESERVED: display inline flow-root -> inline flow list-item in block flex | following sibling
+PRESERVED: display inline flow-root -> inline flow list-item in block flex | following sibling descendant
 STATS: display inline flow-root -> inline flow list-item in block flex | rebuilt subtree roots=1, escaped=false
 PASS: display inline flow-root -> inline flow list-item in block flex | incremental tree matches full rebuild
-RECREATED: display block flex -> list-item in contents | fixture ancestor
-RECREATED: display block flex -> list-item in contents | distant sibling
-RECREATED: display block flex -> list-item in contents | distant sibling descendant
+PRESERVED: display block flex -> list-item in contents | fixture ancestor
+PRESERVED: display block flex -> list-item in contents | distant sibling
+PRESERVED: display block flex -> list-item in contents | distant sibling descendant
 ABSENT: display block flex -> list-item in contents | DOM parent
-RECREATED: display block flex -> list-item in contents | preceding sibling
-RECREATED: display block flex -> list-item in contents | preceding sibling descendant
+PRESERVED: display block flex -> list-item in contents | preceding sibling
+PRESERVED: display block flex -> list-item in contents | preceding sibling descendant
 RECREATED: display block flex -> list-item in contents | target
 RECREATED: display block flex -> list-item in contents | target descendant
-RECREATED: display block flex -> list-item in contents | following sibling
-RECREATED: display block flex -> list-item in contents | following sibling descendant
+PRESERVED: display block flex -> list-item in contents | following sibling
+PRESERVED: display block flex -> list-item in contents | following sibling descendant
 STATS: display block flex -> list-item in contents | rebuilt subtree roots=1, escaped=false
 PASS: display block flex -> list-item in contents | incremental tree matches full rebuild
 PRESERVED: display block flex -> math in flex | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-7.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-7.txt
@@ -13,13 +13,13 @@ PASS: display none -> list-item in inline list-item | incremental tree matches f
 PRESERVED: display none -> math in -webkit-box | fixture ancestor
 PRESERVED: display none -> math in -webkit-box | distant sibling
 PRESERVED: display none -> math in -webkit-box | distant sibling descendant
-RECREATED: display none -> math in -webkit-box | DOM parent
-RECREATED: display none -> math in -webkit-box | preceding sibling
-RECREATED: display none -> math in -webkit-box | preceding sibling descendant
+PRESERVED: display none -> math in -webkit-box | DOM parent
+PRESERVED: display none -> math in -webkit-box | preceding sibling
+PRESERVED: display none -> math in -webkit-box | preceding sibling descendant
 CREATED: display none -> math in -webkit-box | target
 CREATED: display none -> math in -webkit-box | target descendant
-RECREATED: display none -> math in -webkit-box | following sibling
-RECREATED: display none -> math in -webkit-box | following sibling descendant
+PRESERVED: display none -> math in -webkit-box | following sibling
+PRESERVED: display none -> math in -webkit-box | following sibling descendant
 STATS: display none -> math in -webkit-box | rebuilt subtree roots=1, escaped=false
 PASS: display none -> math in -webkit-box | incremental tree matches full rebuild
 RECREATED: display none -> table-column-group in table-column | fixture ancestor
@@ -37,13 +37,13 @@ PASS: display none -> table-column-group in table-column | incremental tree matc
 PRESERVED: display none -> inline flex in block grid | fixture ancestor
 PRESERVED: display none -> inline flex in block grid | distant sibling
 PRESERVED: display none -> inline flex in block grid | distant sibling descendant
-RECREATED: display none -> inline flex in block grid | DOM parent
-RECREATED: display none -> inline flex in block grid | preceding sibling
-RECREATED: display none -> inline flex in block grid | preceding sibling descendant
+PRESERVED: display none -> inline flex in block grid | DOM parent
+PRESERVED: display none -> inline flex in block grid | preceding sibling
+PRESERVED: display none -> inline flex in block grid | preceding sibling descendant
 CREATED: display none -> inline flex in block grid | target
 CREATED: display none -> inline flex in block grid | target descendant
-RECREATED: display none -> inline flex in block grid | following sibling
-RECREATED: display none -> inline flex in block grid | following sibling descendant
+PRESERVED: display none -> inline flex in block grid | following sibling
+PRESERVED: display none -> inline flex in block grid | following sibling descendant
 STATS: display none -> inline flex in block grid | rebuilt subtree roots=1, escaped=false
 PASS: display none -> inline flex in block grid | incremental tree matches full rebuild
 PRESERVED: display contents -> block in flow-root | fixture ancestor
@@ -166,16 +166,16 @@ RECREATED: display block -> inline flow list-item in inline | following sibling
 RECREATED: display block -> inline flow list-item in inline | following sibling descendant
 STATS: display block -> inline flow list-item in inline | rebuilt subtree roots=1, escaped=false
 PASS: display block -> inline flow list-item in inline | incremental tree matches full rebuild
-RECREATED: display inline -> inline list-item in inline-grid | fixture ancestor
-RECREATED: display inline -> inline list-item in inline-grid | distant sibling
-RECREATED: display inline -> inline list-item in inline-grid | distant sibling descendant
-RECREATED: display inline -> inline list-item in inline-grid | DOM parent
-RECREATED: display inline -> inline list-item in inline-grid | preceding sibling
-RECREATED: display inline -> inline list-item in inline-grid | preceding sibling descendant
+PRESERVED: display inline -> inline list-item in inline-grid | fixture ancestor
+PRESERVED: display inline -> inline list-item in inline-grid | distant sibling
+PRESERVED: display inline -> inline list-item in inline-grid | distant sibling descendant
+PRESERVED: display inline -> inline list-item in inline-grid | DOM parent
+PRESERVED: display inline -> inline list-item in inline-grid | preceding sibling
+PRESERVED: display inline -> inline list-item in inline-grid | preceding sibling descendant
 RECREATED: display inline -> inline list-item in inline-grid | target
 RECREATED: display inline -> inline list-item in inline-grid | target descendant
-RECREATED: display inline -> inline list-item in inline-grid | following sibling
-RECREATED: display inline -> inline list-item in inline-grid | following sibling descendant
+PRESERVED: display inline -> inline list-item in inline-grid | following sibling
+PRESERVED: display inline -> inline list-item in inline-grid | following sibling descendant
 STATS: display inline -> inline list-item in inline-grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline -> inline list-item in inline-grid | incremental tree matches full rebuild
 RECREATED: display inline -> -webkit-box in table-footer-group | fixture ancestor
@@ -325,14 +325,14 @@ PASS: display inline-block -> block flex in block flow list-item | incremental t
 PRESERVED: display run-in -> none in list-item | fixture ancestor
 PRESERVED: display run-in -> none in list-item | distant sibling
 PRESERVED: display run-in -> none in list-item | distant sibling descendant
-RECREATED: display run-in -> none in list-item | DOM parent
-RECREATED: display run-in -> none in list-item | preceding sibling
-RECREATED: display run-in -> none in list-item | preceding sibling descendant
+PRESERVED: display run-in -> none in list-item | DOM parent
+PRESERVED: display run-in -> none in list-item | preceding sibling
+PRESERVED: display run-in -> none in list-item | preceding sibling descendant
 REMOVED: display run-in -> none in list-item | target
 REMOVED: display run-in -> none in list-item | target descendant
-RECREATED: display run-in -> none in list-item | following sibling
-RECREATED: display run-in -> none in list-item | following sibling descendant
-STATS: display run-in -> none in list-item | rebuilt subtree roots=1, escaped=false
+PRESERVED: display run-in -> none in list-item | following sibling
+PRESERVED: display run-in -> none in list-item | following sibling descendant
+STATS: display run-in -> none in list-item | rebuilt subtree roots=0, escaped=false
 PASS: display run-in -> none in list-item | incremental tree matches full rebuild
 PRESERVED: display run-in -> flex in -webkit-box | fixture ancestor
 PRESERVED: display run-in -> flex in -webkit-box | distant sibling
@@ -601,13 +601,13 @@ PASS: display inline-flex -> inline flow-root in inline | incremental tree match
 PRESERVED: display inline-flex -> inline flow list-item in grid | fixture ancestor
 PRESERVED: display inline-flex -> inline flow list-item in grid | distant sibling
 PRESERVED: display inline-flex -> inline flow list-item in grid | distant sibling descendant
-RECREATED: display inline-flex -> inline flow list-item in grid | DOM parent
-RECREATED: display inline-flex -> inline flow list-item in grid | preceding sibling
-RECREATED: display inline-flex -> inline flow list-item in grid | preceding sibling descendant
+PRESERVED: display inline-flex -> inline flow list-item in grid | DOM parent
+PRESERVED: display inline-flex -> inline flow list-item in grid | preceding sibling
+PRESERVED: display inline-flex -> inline flow list-item in grid | preceding sibling descendant
 RECREATED: display inline-flex -> inline flow list-item in grid | target
 RECREATED: display inline-flex -> inline flow list-item in grid | target descendant
-RECREATED: display inline-flex -> inline flow list-item in grid | following sibling
-RECREATED: display inline-flex -> inline flow list-item in grid | following sibling descendant
+PRESERVED: display inline-flex -> inline flow list-item in grid | following sibling
+PRESERVED: display inline-flex -> inline flow list-item in grid | following sibling descendant
 STATS: display inline-flex -> inline flow list-item in grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline-flex -> inline flow list-item in grid | incremental tree matches full rebuild
 RECREATED: display grid -> list-item in table-header-group | fixture ancestor
@@ -778,17 +778,17 @@ RECREATED: display inline-table -> none in math | following sibling
 RECREATED: display inline-table -> none in math | following sibling descendant
 STATS: display inline-table -> none in math | rebuilt subtree roots=1, escaped=false
 PASS: display inline-table -> none in math | incremental tree matches full rebuild
-RECREATED: display inline-table -> inline list-item in table-column-group | fixture ancestor
-RECREATED: display inline-table -> inline list-item in table-column-group | distant sibling
-RECREATED: display inline-table -> inline list-item in table-column-group | distant sibling descendant
-RECREATED: display inline-table -> inline list-item in table-column-group | DOM parent
+PRESERVED: display inline-table -> inline list-item in table-column-group | fixture ancestor
+PRESERVED: display inline-table -> inline list-item in table-column-group | distant sibling
+PRESERVED: display inline-table -> inline list-item in table-column-group | distant sibling descendant
+PRESERVED: display inline-table -> inline list-item in table-column-group | DOM parent
 ABSENT: display inline-table -> inline list-item in table-column-group | preceding sibling
 ABSENT: display inline-table -> inline list-item in table-column-group | preceding sibling descendant
 ABSENT: display inline-table -> inline list-item in table-column-group | target
 ABSENT: display inline-table -> inline list-item in table-column-group | target descendant
 ABSENT: display inline-table -> inline list-item in table-column-group | following sibling
 ABSENT: display inline-table -> inline list-item in table-column-group | following sibling descendant
-STATS: display inline-table -> inline list-item in table-column-group | rebuilt subtree roots=1, escaped=false
+STATS: display inline-table -> inline list-item in table-column-group | rebuilt subtree roots=0, escaped=true
 PASS: display inline-table -> inline list-item in table-column-group | incremental tree matches full rebuild
 PRESERVED: display inline-table -> -webkit-inline-box in block grid | fixture ancestor
 PRESERVED: display inline-table -> -webkit-inline-box in block grid | distant sibling
@@ -1222,16 +1222,16 @@ ABSENT: display table-cell -> none in table-column-group | following sibling
 ABSENT: display table-cell -> none in table-column-group | following sibling descendant
 STATS: display table-cell -> none in table-column-group | rebuilt subtree roots=1, escaped=false
 PASS: display table-cell -> none in table-column-group | incremental tree matches full rebuild
-RECREATED: display table-cell -> inline list-item in inline flex | fixture ancestor
-RECREATED: display table-cell -> inline list-item in inline flex | distant sibling
-RECREATED: display table-cell -> inline list-item in inline flex | distant sibling descendant
-RECREATED: display table-cell -> inline list-item in inline flex | DOM parent
-RECREATED: display table-cell -> inline list-item in inline flex | preceding sibling
-RECREATED: display table-cell -> inline list-item in inline flex | preceding sibling descendant
+PRESERVED: display table-cell -> inline list-item in inline flex | fixture ancestor
+PRESERVED: display table-cell -> inline list-item in inline flex | distant sibling
+PRESERVED: display table-cell -> inline list-item in inline flex | distant sibling descendant
+PRESERVED: display table-cell -> inline list-item in inline flex | DOM parent
+PRESERVED: display table-cell -> inline list-item in inline flex | preceding sibling
+PRESERVED: display table-cell -> inline list-item in inline flex | preceding sibling descendant
 RECREATED: display table-cell -> inline list-item in inline flex | target
 RECREATED: display table-cell -> inline list-item in inline flex | target descendant
-RECREATED: display table-cell -> inline list-item in inline flex | following sibling
-RECREATED: display table-cell -> inline list-item in inline flex | following sibling descendant
+PRESERVED: display table-cell -> inline list-item in inline flex | following sibling
+PRESERVED: display table-cell -> inline list-item in inline flex | following sibling descendant
 STATS: display table-cell -> inline list-item in inline flex | rebuilt subtree roots=1, escaped=false
 PASS: display table-cell -> inline list-item in inline flex | incremental tree matches full rebuild
 PRESERVED: display table-cell -> -webkit-box in block | fixture ancestor
@@ -1654,17 +1654,17 @@ ABSENT: display inline flow-root -> block flex in table-column-group | following
 ABSENT: display inline flow-root -> block flex in table-column-group | following sibling descendant
 STATS: display inline flow-root -> block flex in table-column-group | rebuilt subtree roots=1, escaped=false
 PASS: display inline flow-root -> block flex in table-column-group | incremental tree matches full rebuild
-RECREATED: display block flex -> none in inline flex | fixture ancestor
-RECREATED: display block flex -> none in inline flex | distant sibling
-RECREATED: display block flex -> none in inline flex | distant sibling descendant
-RECREATED: display block flex -> none in inline flex | DOM parent
-RECREATED: display block flex -> none in inline flex | preceding sibling
-RECREATED: display block flex -> none in inline flex | preceding sibling descendant
+PRESERVED: display block flex -> none in inline flex | fixture ancestor
+PRESERVED: display block flex -> none in inline flex | distant sibling
+PRESERVED: display block flex -> none in inline flex | distant sibling descendant
+PRESERVED: display block flex -> none in inline flex | DOM parent
+PRESERVED: display block flex -> none in inline flex | preceding sibling
+PRESERVED: display block flex -> none in inline flex | preceding sibling descendant
 REMOVED: display block flex -> none in inline flex | target
 REMOVED: display block flex -> none in inline flex | target descendant
-RECREATED: display block flex -> none in inline flex | following sibling
-RECREATED: display block flex -> none in inline flex | following sibling descendant
-STATS: display block flex -> none in inline flex | rebuilt subtree roots=1, escaped=false
+PRESERVED: display block flex -> none in inline flex | following sibling
+PRESERVED: display block flex -> none in inline flex | following sibling descendant
+STATS: display block flex -> none in inline flex | rebuilt subtree roots=0, escaped=false
 PASS: display block flex -> none in inline flex | incremental tree matches full rebuild
 PRESERVED: display block flex -> inline list-item in block | fixture ancestor
 PRESERVED: display block flex -> inline list-item in block | distant sibling
@@ -1762,16 +1762,16 @@ RECREATED: display inline flex -> inline flow in table-cell | following sibling
 RECREATED: display inline flex -> inline flow in table-cell | following sibling descendant
 STATS: display inline flex -> inline flow in table-cell | rebuilt subtree roots=1, escaped=false
 PASS: display inline flex -> inline flow in table-cell | incremental tree matches full rebuild
-RECREATED: display inline flex -> block flow list-item in inline flex | fixture ancestor
-RECREATED: display inline flex -> block flow list-item in inline flex | distant sibling
-RECREATED: display inline flex -> block flow list-item in inline flex | distant sibling descendant
-RECREATED: display inline flex -> block flow list-item in inline flex | DOM parent
-RECREATED: display inline flex -> block flow list-item in inline flex | preceding sibling
-RECREATED: display inline flex -> block flow list-item in inline flex | preceding sibling descendant
+PRESERVED: display inline flex -> block flow list-item in inline flex | fixture ancestor
+PRESERVED: display inline flex -> block flow list-item in inline flex | distant sibling
+PRESERVED: display inline flex -> block flow list-item in inline flex | distant sibling descendant
+PRESERVED: display inline flex -> block flow list-item in inline flex | DOM parent
+PRESERVED: display inline flex -> block flow list-item in inline flex | preceding sibling
+PRESERVED: display inline flex -> block flow list-item in inline flex | preceding sibling descendant
 RECREATED: display inline flex -> block flow list-item in inline flex | target
 RECREATED: display inline flex -> block flow list-item in inline flex | target descendant
-RECREATED: display inline flex -> block flow list-item in inline flex | following sibling
-RECREATED: display inline flex -> block flow list-item in inline flex | following sibling descendant
+PRESERVED: display inline flex -> block flow list-item in inline flex | following sibling
+PRESERVED: display inline flex -> block flow list-item in inline flex | following sibling descendant
 STATS: display inline flex -> block flow list-item in inline flex | rebuilt subtree roots=1, escaped=false
 PASS: display inline flex -> block flow list-item in inline flex | incremental tree matches full rebuild
 PRESERVED: display block grid -> run-in in block | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-8.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-display-8.txt
@@ -1,13 +1,13 @@
 PRESERVED: display none -> inline list-item in flex | fixture ancestor
 PRESERVED: display none -> inline list-item in flex | distant sibling
 PRESERVED: display none -> inline list-item in flex | distant sibling descendant
-RECREATED: display none -> inline list-item in flex | DOM parent
-RECREATED: display none -> inline list-item in flex | preceding sibling
-RECREATED: display none -> inline list-item in flex | preceding sibling descendant
+PRESERVED: display none -> inline list-item in flex | DOM parent
+PRESERVED: display none -> inline list-item in flex | preceding sibling
+PRESERVED: display none -> inline list-item in flex | preceding sibling descendant
 CREATED: display none -> inline list-item in flex | target
 CREATED: display none -> inline list-item in flex | target descendant
-RECREATED: display none -> inline list-item in flex | following sibling
-RECREATED: display none -> inline list-item in flex | following sibling descendant
+PRESERVED: display none -> inline list-item in flex | following sibling
+PRESERVED: display none -> inline list-item in flex | following sibling descendant
 STATS: display none -> inline list-item in flex | rebuilt subtree roots=1, escaped=false
 PASS: display none -> inline list-item in flex | incremental tree matches full rebuild
 RECREATED: display none -> -webkit-box in -webkit-inline-box | fixture ancestor
@@ -265,13 +265,13 @@ PASS: display flow-root -> block flow-root in inline grid | incremental tree mat
 PRESERVED: display flow-root -> block flow list-item in flow-root | fixture ancestor
 PRESERVED: display flow-root -> block flow list-item in flow-root | distant sibling
 PRESERVED: display flow-root -> block flow list-item in flow-root | distant sibling descendant
-RECREATED: display flow-root -> block flow list-item in flow-root | DOM parent
-RECREATED: display flow-root -> block flow list-item in flow-root | preceding sibling
-RECREATED: display flow-root -> block flow list-item in flow-root | preceding sibling descendant
+PRESERVED: display flow-root -> block flow list-item in flow-root | DOM parent
+PRESERVED: display flow-root -> block flow list-item in flow-root | preceding sibling
+PRESERVED: display flow-root -> block flow list-item in flow-root | preceding sibling descendant
 RECREATED: display flow-root -> block flow list-item in flow-root | target
 RECREATED: display flow-root -> block flow list-item in flow-root | target descendant
-RECREATED: display flow-root -> block flow list-item in flow-root | following sibling
-RECREATED: display flow-root -> block flow list-item in flow-root | following sibling descendant
+PRESERVED: display flow-root -> block flow list-item in flow-root | following sibling
+PRESERVED: display flow-root -> block flow list-item in flow-root | following sibling descendant
 STATS: display flow-root -> block flow list-item in flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display flow-root -> block flow list-item in flow-root | incremental tree matches full rebuild
 RECREATED: display inline-block -> list-item in table | fixture ancestor
@@ -598,17 +598,17 @@ RECREATED: display inline-flex -> block flex in flow-root | following sibling
 RECREATED: display inline-flex -> block flex in flow-root | following sibling descendant
 STATS: display inline-flex -> block flex in flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display inline-flex -> block flex in flow-root | incremental tree matches full rebuild
-RECREATED: display grid -> none in inline-grid | fixture ancestor
-RECREATED: display grid -> none in inline-grid | distant sibling
-RECREATED: display grid -> none in inline-grid | distant sibling descendant
-RECREATED: display grid -> none in inline-grid | DOM parent
-RECREATED: display grid -> none in inline-grid | preceding sibling
-RECREATED: display grid -> none in inline-grid | preceding sibling descendant
+PRESERVED: display grid -> none in inline-grid | fixture ancestor
+PRESERVED: display grid -> none in inline-grid | distant sibling
+PRESERVED: display grid -> none in inline-grid | distant sibling descendant
+PRESERVED: display grid -> none in inline-grid | DOM parent
+PRESERVED: display grid -> none in inline-grid | preceding sibling
+PRESERVED: display grid -> none in inline-grid | preceding sibling descendant
 REMOVED: display grid -> none in inline-grid | target
 REMOVED: display grid -> none in inline-grid | target descendant
-RECREATED: display grid -> none in inline-grid | following sibling
-RECREATED: display grid -> none in inline-grid | following sibling descendant
-STATS: display grid -> none in inline-grid | rebuilt subtree roots=1, escaped=false
+PRESERVED: display grid -> none in inline-grid | following sibling
+PRESERVED: display grid -> none in inline-grid | following sibling descendant
+STATS: display grid -> none in inline-grid | rebuilt subtree roots=0, escaped=false
 PASS: display grid -> none in inline-grid | incremental tree matches full rebuild
 RECREATED: display grid -> inline list-item in table-footer-group | fixture ancestor
 RECREATED: display grid -> inline list-item in table-footer-group | distant sibling
@@ -706,16 +706,16 @@ RECREATED: display inline-grid -> block flow-root in flow-root | following sibli
 RECREATED: display inline-grid -> block flow-root in flow-root | following sibling descendant
 STATS: display inline-grid -> block flow-root in flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display inline-grid -> block flow-root in flow-root | incremental tree matches full rebuild
-RECREATED: display inline-grid -> block flow list-item in inline-grid | fixture ancestor
-RECREATED: display inline-grid -> block flow list-item in inline-grid | distant sibling
-RECREATED: display inline-grid -> block flow list-item in inline-grid | distant sibling descendant
-RECREATED: display inline-grid -> block flow list-item in inline-grid | DOM parent
-RECREATED: display inline-grid -> block flow list-item in inline-grid | preceding sibling
-RECREATED: display inline-grid -> block flow list-item in inline-grid | preceding sibling descendant
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | fixture ancestor
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | distant sibling
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | distant sibling descendant
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | DOM parent
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | preceding sibling
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | preceding sibling descendant
 RECREATED: display inline-grid -> block flow list-item in inline-grid | target
 RECREATED: display inline-grid -> block flow list-item in inline-grid | target descendant
-RECREATED: display inline-grid -> block flow list-item in inline-grid | following sibling
-RECREATED: display inline-grid -> block flow list-item in inline-grid | following sibling descendant
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | following sibling
+PRESERVED: display inline-grid -> block flow list-item in inline-grid | following sibling descendant
 STATS: display inline-grid -> block flow list-item in inline-grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline-grid -> block flow list-item in inline-grid | incremental tree matches full rebuild
 RECREATED: display table -> run-in in table-footer-group | fixture ancestor
@@ -877,26 +877,26 @@ PASS: display math -> inline flow-root in inline list-item | incremental tree ma
 PRESERVED: display math -> inline flow list-item in -webkit-box | fixture ancestor
 PRESERVED: display math -> inline flow list-item in -webkit-box | distant sibling
 PRESERVED: display math -> inline flow list-item in -webkit-box | distant sibling descendant
-RECREATED: display math -> inline flow list-item in -webkit-box | DOM parent
-RECREATED: display math -> inline flow list-item in -webkit-box | preceding sibling
-RECREATED: display math -> inline flow list-item in -webkit-box | preceding sibling descendant
+PRESERVED: display math -> inline flow list-item in -webkit-box | DOM parent
+PRESERVED: display math -> inline flow list-item in -webkit-box | preceding sibling
+PRESERVED: display math -> inline flow list-item in -webkit-box | preceding sibling descendant
 RECREATED: display math -> inline flow list-item in -webkit-box | target
 RECREATED: display math -> inline flow list-item in -webkit-box | target descendant
-RECREATED: display math -> inline flow list-item in -webkit-box | following sibling
-RECREATED: display math -> inline flow list-item in -webkit-box | following sibling descendant
+PRESERVED: display math -> inline flow list-item in -webkit-box | following sibling
+PRESERVED: display math -> inline flow list-item in -webkit-box | following sibling descendant
 STATS: display math -> inline flow list-item in -webkit-box | rebuilt subtree roots=1, escaped=false
 PASS: display math -> inline flow list-item in -webkit-box | incremental tree matches full rebuild
-RECREATED: display -webkit-box -> list-item in table-column | fixture ancestor
-RECREATED: display -webkit-box -> list-item in table-column | distant sibling
-RECREATED: display -webkit-box -> list-item in table-column | distant sibling descendant
-RECREATED: display -webkit-box -> list-item in table-column | DOM parent
+PRESERVED: display -webkit-box -> list-item in table-column | fixture ancestor
+PRESERVED: display -webkit-box -> list-item in table-column | distant sibling
+PRESERVED: display -webkit-box -> list-item in table-column | distant sibling descendant
+PRESERVED: display -webkit-box -> list-item in table-column | DOM parent
 ABSENT: display -webkit-box -> list-item in table-column | preceding sibling
 ABSENT: display -webkit-box -> list-item in table-column | preceding sibling descendant
 ABSENT: display -webkit-box -> list-item in table-column | target
 ABSENT: display -webkit-box -> list-item in table-column | target descendant
 ABSENT: display -webkit-box -> list-item in table-column | following sibling
 ABSENT: display -webkit-box -> list-item in table-column | following sibling descendant
-STATS: display -webkit-box -> list-item in table-column | rebuilt subtree roots=1, escaped=false
+STATS: display -webkit-box -> list-item in table-column | rebuilt subtree roots=0, escaped=true
 PASS: display -webkit-box -> list-item in table-column | incremental tree matches full rebuild
 PRESERVED: display -webkit-box -> math in block grid | fixture ancestor
 PRESERVED: display -webkit-box -> math in block grid | distant sibling
@@ -1333,13 +1333,13 @@ PASS: display table-column-group -> inline flow list-item in table-column | incr
 PRESERVED: display table-column -> list-item in block grid | fixture ancestor
 PRESERVED: display table-column -> list-item in block grid | distant sibling
 PRESERVED: display table-column -> list-item in block grid | distant sibling descendant
-RECREATED: display table-column -> list-item in block grid | DOM parent
-RECREATED: display table-column -> list-item in block grid | preceding sibling
-RECREATED: display table-column -> list-item in block grid | preceding sibling descendant
+PRESERVED: display table-column -> list-item in block grid | DOM parent
+PRESERVED: display table-column -> list-item in block grid | preceding sibling
+PRESERVED: display table-column -> list-item in block grid | preceding sibling descendant
 RECREATED: display table-column -> list-item in block grid | target
 RECREATED: display table-column -> list-item in block grid | target descendant
-RECREATED: display table-column -> list-item in block grid | following sibling
-RECREATED: display table-column -> list-item in block grid | following sibling descendant
+PRESERVED: display table-column -> list-item in block grid | following sibling
+PRESERVED: display table-column -> list-item in block grid | following sibling descendant
 STATS: display table-column -> list-item in block grid | rebuilt subtree roots=1, escaped=false
 PASS: display table-column -> list-item in block grid | incremental tree matches full rebuild
 RECREATED: display table-column -> math in inline | fixture ancestor
@@ -1597,13 +1597,13 @@ PASS: display block flow-root -> inline flow in table-header-group | incremental
 PRESERVED: display block flow-root -> block flow list-item in block flow-root | fixture ancestor
 PRESERVED: display block flow-root -> block flow list-item in block flow-root | distant sibling
 PRESERVED: display block flow-root -> block flow list-item in block flow-root | distant sibling descendant
-RECREATED: display block flow-root -> block flow list-item in block flow-root | DOM parent
-RECREATED: display block flow-root -> block flow list-item in block flow-root | preceding sibling
-RECREATED: display block flow-root -> block flow list-item in block flow-root | preceding sibling descendant
+PRESERVED: display block flow-root -> block flow list-item in block flow-root | DOM parent
+PRESERVED: display block flow-root -> block flow list-item in block flow-root | preceding sibling
+PRESERVED: display block flow-root -> block flow list-item in block flow-root | preceding sibling descendant
 RECREATED: display block flow-root -> block flow list-item in block flow-root | target
 RECREATED: display block flow-root -> block flow list-item in block flow-root | target descendant
-RECREATED: display block flow-root -> block flow list-item in block flow-root | following sibling
-RECREATED: display block flow-root -> block flow list-item in block flow-root | following sibling descendant
+PRESERVED: display block flow-root -> block flow list-item in block flow-root | following sibling
+PRESERVED: display block flow-root -> block flow list-item in block flow-root | following sibling descendant
 STATS: display block flow-root -> block flow list-item in block flow-root | rebuilt subtree roots=1, escaped=false
 PASS: display block flow-root -> block flow list-item in block flow-root | incremental tree matches full rebuild
 PRESERVED: display inline flow-root -> run-in in block flow list-item | fixture ancestor
@@ -1765,25 +1765,25 @@ PASS: display inline flex -> block flow-root in table-column-group | incremental
 PRESERVED: display inline flex -> inline flow list-item in block grid | fixture ancestor
 PRESERVED: display inline flex -> inline flow list-item in block grid | distant sibling
 PRESERVED: display inline flex -> inline flow list-item in block grid | distant sibling descendant
-RECREATED: display inline flex -> inline flow list-item in block grid | DOM parent
-RECREATED: display inline flex -> inline flow list-item in block grid | preceding sibling
-RECREATED: display inline flex -> inline flow list-item in block grid | preceding sibling descendant
+PRESERVED: display inline flex -> inline flow list-item in block grid | DOM parent
+PRESERVED: display inline flex -> inline flow list-item in block grid | preceding sibling
+PRESERVED: display inline flex -> inline flow list-item in block grid | preceding sibling descendant
 RECREATED: display inline flex -> inline flow list-item in block grid | target
 RECREATED: display inline flex -> inline flow list-item in block grid | target descendant
-RECREATED: display inline flex -> inline flow list-item in block grid | following sibling
-RECREATED: display inline flex -> inline flow list-item in block grid | following sibling descendant
+PRESERVED: display inline flex -> inline flow list-item in block grid | following sibling
+PRESERVED: display inline flex -> inline flow list-item in block grid | following sibling descendant
 STATS: display inline flex -> inline flow list-item in block grid | rebuilt subtree roots=1, escaped=false
 PASS: display inline flex -> inline flow list-item in block grid | incremental tree matches full rebuild
-RECREATED: display block grid -> list-item in inline | fixture ancestor
-RECREATED: display block grid -> list-item in inline | distant sibling
-RECREATED: display block grid -> list-item in inline | distant sibling descendant
-RECREATED: display block grid -> list-item in inline | DOM parent
-RECREATED: display block grid -> list-item in inline | preceding sibling
-RECREATED: display block grid -> list-item in inline | preceding sibling descendant
+PRESERVED: display block grid -> list-item in inline | fixture ancestor
+PRESERVED: display block grid -> list-item in inline | distant sibling
+PRESERVED: display block grid -> list-item in inline | distant sibling descendant
+PRESERVED: display block grid -> list-item in inline | DOM parent
+PRESERVED: display block grid -> list-item in inline | preceding sibling
+PRESERVED: display block grid -> list-item in inline | preceding sibling descendant
 RECREATED: display block grid -> list-item in inline | target
 RECREATED: display block grid -> list-item in inline | target descendant
-RECREATED: display block grid -> list-item in inline | following sibling
-RECREATED: display block grid -> list-item in inline | following sibling descendant
+PRESERVED: display block grid -> list-item in inline | following sibling
+PRESERVED: display block grid -> list-item in inline | following sibling descendant
 STATS: display block grid -> list-item in inline | rebuilt subtree roots=1, escaped=false
 PASS: display block grid -> list-item in inline | incremental tree matches full rebuild
 PRESERVED: display block grid -> math in grid | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-1.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-1.txt
@@ -13,13 +13,13 @@ PASS: assigned slottable display none -> contents | incremental tree matches ful
 PRESERVED: direct shadow child display none -> flex | fixture ancestor
 PRESERVED: direct shadow child display none -> flex | distant sibling
 PRESERVED: direct shadow child display none -> flex | shadow host
-RECREATED: direct shadow child display none -> flex | shadow container
-RECREATED: direct shadow child display none -> flex | preceding flat-tree sibling
-RECREATED: direct shadow child display none -> flex | preceding sibling descendant
+PRESERVED: direct shadow child display none -> flex | shadow container
+PRESERVED: direct shadow child display none -> flex | preceding flat-tree sibling
+PRESERVED: direct shadow child display none -> flex | preceding sibling descendant
 CREATED: direct shadow child display none -> flex | target
 CREATED: direct shadow child display none -> flex | target descendant
-RECREATED: direct shadow child display none -> flex | following flat-tree sibling
-RECREATED: direct shadow child display none -> flex | following sibling descendant
+PRESERVED: direct shadow child display none -> flex | following flat-tree sibling
+PRESERVED: direct shadow child display none -> flex | following sibling descendant
 STATS: direct shadow child display none -> flex | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display none -> flex | incremental tree matches full rebuild
 PRESERVED: slot fallback child display none -> -webkit-inline-box | fixture ancestor
@@ -121,13 +121,13 @@ PASS: assigned slottable display contents -> block flow list-item | incremental 
 PRESERVED: direct shadow child display block -> list-item | fixture ancestor
 PRESERVED: direct shadow child display block -> list-item | distant sibling
 PRESERVED: direct shadow child display block -> list-item | shadow host
-RECREATED: direct shadow child display block -> list-item | shadow container
-RECREATED: direct shadow child display block -> list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display block -> list-item | preceding sibling descendant
+PRESERVED: direct shadow child display block -> list-item | shadow container
+PRESERVED: direct shadow child display block -> list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display block -> list-item | preceding sibling descendant
 RECREATED: direct shadow child display block -> list-item | target
 RECREATED: direct shadow child display block -> list-item | target descendant
-RECREATED: direct shadow child display block -> list-item | following flat-tree sibling
-RECREATED: direct shadow child display block -> list-item | following sibling descendant
+PRESERVED: direct shadow child display block -> list-item | following flat-tree sibling
+PRESERVED: direct shadow child display block -> list-item | following sibling descendant
 STATS: direct shadow child display block -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display block -> list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display block -> math | fixture ancestor
@@ -288,7 +288,7 @@ STATS: slot fallback child display flow-root -> inline flow list-item | rebuilt 
 PASS: slot fallback child display flow-root -> inline flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline-block -> inline list-item | fixture ancestor
 PRESERVED: assigned slottable display inline-block -> inline list-item | distant sibling
-RECREATED: assigned slottable display inline-block -> inline list-item | shadow host
+PRESERVED: assigned slottable display inline-block -> inline list-item | shadow host
 RECREATED: assigned slottable display inline-block -> inline list-item | shadow container
 RECREATED: assigned slottable display inline-block -> inline list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline-block -> inline list-item | preceding sibling descendant
@@ -553,13 +553,13 @@ PASS: assigned slottable display flex -> block flow-root | incremental tree matc
 PRESERVED: direct shadow child display flex -> block flow list-item | fixture ancestor
 PRESERVED: direct shadow child display flex -> block flow list-item | distant sibling
 PRESERVED: direct shadow child display flex -> block flow list-item | shadow host
-RECREATED: direct shadow child display flex -> block flow list-item | shadow container
-RECREATED: direct shadow child display flex -> block flow list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display flex -> block flow list-item | preceding sibling descendant
+PRESERVED: direct shadow child display flex -> block flow list-item | shadow container
+PRESERVED: direct shadow child display flex -> block flow list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display flex -> block flow list-item | preceding sibling descendant
 RECREATED: direct shadow child display flex -> block flow list-item | target
 RECREATED: direct shadow child display flex -> block flow list-item | target descendant
-RECREATED: direct shadow child display flex -> block flow list-item | following flat-tree sibling
-RECREATED: direct shadow child display flex -> block flow list-item | following sibling descendant
+PRESERVED: direct shadow child display flex -> block flow list-item | following flat-tree sibling
+PRESERVED: direct shadow child display flex -> block flow list-item | following sibling descendant
 STATS: direct shadow child display flex -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display flex -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline-flex -> run-in | fixture ancestor
@@ -720,7 +720,7 @@ STATS: slot fallback child display inline-grid -> inline flow-root | rebuilt sub
 PASS: slot fallback child display inline-grid -> inline flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline-grid -> inline flow list-item | fixture ancestor
 PRESERVED: assigned slottable display inline-grid -> inline flow list-item | distant sibling
-RECREATED: assigned slottable display inline-grid -> inline flow list-item | shadow host
+PRESERVED: assigned slottable display inline-grid -> inline flow list-item | shadow host
 RECREATED: assigned slottable display inline-grid -> inline flow list-item | shadow container
 RECREATED: assigned slottable display inline-grid -> inline flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline-grid -> inline flow list-item | preceding sibling descendant

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-2.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-2.txt
@@ -1453,13 +1453,13 @@ PASS: slot fallback child display table-caption -> inline flow list-item | incre
 PRESERVED: direct shadow child display block flow -> list-item | fixture ancestor
 PRESERVED: direct shadow child display block flow -> list-item | distant sibling
 PRESERVED: direct shadow child display block flow -> list-item | shadow host
-RECREATED: direct shadow child display block flow -> list-item | shadow container
-RECREATED: direct shadow child display block flow -> list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display block flow -> list-item | preceding sibling descendant
+PRESERVED: direct shadow child display block flow -> list-item | shadow container
+PRESERVED: direct shadow child display block flow -> list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display block flow -> list-item | preceding sibling descendant
 RECREATED: direct shadow child display block flow -> list-item | target
 RECREATED: direct shadow child display block flow -> list-item | target descendant
-RECREATED: direct shadow child display block flow -> list-item | following flat-tree sibling
-RECREATED: direct shadow child display block flow -> list-item | following sibling descendant
+PRESERVED: direct shadow child display block flow -> list-item | following flat-tree sibling
+PRESERVED: direct shadow child display block flow -> list-item | following sibling descendant
 STATS: direct shadow child display block flow -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display block flow -> list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display block flow -> math | fixture ancestor
@@ -1620,7 +1620,7 @@ STATS: slot fallback child display inline flow-root -> none | rebuilt subtree ro
 PASS: slot fallback child display inline flow-root -> none | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline flow-root -> inline list-item | fixture ancestor
 PRESERVED: assigned slottable display inline flow-root -> inline list-item | distant sibling
-RECREATED: assigned slottable display inline flow-root -> inline list-item | shadow host
+PRESERVED: assigned slottable display inline flow-root -> inline list-item | shadow host
 RECREATED: assigned slottable display inline flow-root -> inline list-item | shadow container
 RECREATED: assigned slottable display inline flow-root -> inline list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline flow-root -> inline list-item | preceding sibling descendant
@@ -1717,13 +1717,13 @@ PASS: direct shadow child display block flex -> inline flow | incremental tree m
 PRESERVED: direct shadow child display block flex -> block flow list-item | fixture ancestor
 PRESERVED: direct shadow child display block flex -> block flow list-item | distant sibling
 PRESERVED: direct shadow child display block flex -> block flow list-item | shadow host
-RECREATED: direct shadow child display block flex -> block flow list-item | shadow container
-RECREATED: direct shadow child display block flex -> block flow list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display block flex -> block flow list-item | preceding sibling descendant
+PRESERVED: direct shadow child display block flex -> block flow list-item | shadow container
+PRESERVED: direct shadow child display block flex -> block flow list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display block flex -> block flow list-item | preceding sibling descendant
 RECREATED: direct shadow child display block flex -> block flow list-item | target
 RECREATED: direct shadow child display block flex -> block flow list-item | target descendant
-RECREATED: direct shadow child display block flex -> block flow list-item | following flat-tree sibling
-RECREATED: direct shadow child display block flex -> block flow list-item | following sibling descendant
+PRESERVED: direct shadow child display block flex -> block flow list-item | following flat-tree sibling
+PRESERVED: direct shadow child display block flex -> block flow list-item | following sibling descendant
 STATS: direct shadow child display block flex -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display block flex -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline flex -> run-in | fixture ancestor
@@ -1884,7 +1884,7 @@ STATS: assigned slottable display inline grid -> block flow-root | rebuilt subtr
 PASS: assigned slottable display inline grid -> block flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline grid -> inline flow list-item | fixture ancestor
 PRESERVED: assigned slottable display inline grid -> inline flow list-item | distant sibling
-RECREATED: assigned slottable display inline grid -> inline flow list-item | shadow host
+PRESERVED: assigned slottable display inline grid -> inline flow list-item | shadow host
 RECREATED: assigned slottable display inline grid -> inline flow list-item | shadow container
 RECREATED: assigned slottable display inline grid -> inline flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline grid -> inline flow list-item | preceding sibling descendant

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-3.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-3.txt
@@ -229,13 +229,13 @@ PASS: direct shadow child display inline -> block flow list-item | incremental t
 PRESERVED: slot fallback child display flow-root -> list-item | fixture ancestor
 PRESERVED: slot fallback child display flow-root -> list-item | distant sibling
 PRESERVED: slot fallback child display flow-root -> list-item | shadow host
-RECREATED: slot fallback child display flow-root -> list-item | shadow container
-RECREATED: slot fallback child display flow-root -> list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display flow-root -> list-item | preceding sibling descendant
+PRESERVED: slot fallback child display flow-root -> list-item | shadow container
+PRESERVED: slot fallback child display flow-root -> list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display flow-root -> list-item | preceding sibling descendant
 RECREATED: slot fallback child display flow-root -> list-item | target
 RECREATED: slot fallback child display flow-root -> list-item | target descendant
-RECREATED: slot fallback child display flow-root -> list-item | following flat-tree sibling
-RECREATED: slot fallback child display flow-root -> list-item | following sibling descendant
+PRESERVED: slot fallback child display flow-root -> list-item | following flat-tree sibling
+PRESERVED: slot fallback child display flow-root -> list-item | following sibling descendant
 STATS: slot fallback child display flow-root -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display flow-root -> list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display flow-root -> math | fixture ancestor
@@ -661,13 +661,13 @@ PASS: direct shadow child display grid -> block flow-root | incremental tree mat
 PRESERVED: slot fallback child display grid -> block flow list-item | fixture ancestor
 PRESERVED: slot fallback child display grid -> block flow list-item | distant sibling
 PRESERVED: slot fallback child display grid -> block flow list-item | shadow host
-RECREATED: slot fallback child display grid -> block flow list-item | shadow container
-RECREATED: slot fallback child display grid -> block flow list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display grid -> block flow list-item | preceding sibling descendant
+PRESERVED: slot fallback child display grid -> block flow list-item | shadow container
+PRESERVED: slot fallback child display grid -> block flow list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display grid -> block flow list-item | preceding sibling descendant
 RECREATED: slot fallback child display grid -> block flow list-item | target
 RECREATED: slot fallback child display grid -> block flow list-item | target descendant
-RECREATED: slot fallback child display grid -> block flow list-item | following flat-tree sibling
-RECREATED: slot fallback child display grid -> block flow list-item | following sibling descendant
+PRESERVED: slot fallback child display grid -> block flow list-item | following flat-tree sibling
+PRESERVED: slot fallback child display grid -> block flow list-item | following sibling descendant
 STATS: slot fallback child display grid -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display grid -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display inline-grid -> run-in | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-4.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-4.txt
@@ -49,13 +49,13 @@ PASS: assigned slottable display none -> block flow-root | incremental tree matc
 PRESERVED: direct shadow child display none -> block flow list-item | fixture ancestor
 PRESERVED: direct shadow child display none -> block flow list-item | distant sibling
 PRESERVED: direct shadow child display none -> block flow list-item | shadow host
-RECREATED: direct shadow child display none -> block flow list-item | shadow container
-RECREATED: direct shadow child display none -> block flow list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display none -> block flow list-item | preceding sibling descendant
+PRESERVED: direct shadow child display none -> block flow list-item | shadow container
+PRESERVED: direct shadow child display none -> block flow list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display none -> block flow list-item | preceding sibling descendant
 CREATED: direct shadow child display none -> block flow list-item | target
 CREATED: direct shadow child display none -> block flow list-item | target descendant
-RECREATED: direct shadow child display none -> block flow list-item | following flat-tree sibling
-RECREATED: direct shadow child display none -> block flow list-item | following sibling descendant
+PRESERVED: direct shadow child display none -> block flow list-item | following flat-tree sibling
+PRESERVED: direct shadow child display none -> block flow list-item | following sibling descendant
 STATS: direct shadow child display none -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display none -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display contents -> list-item | fixture ancestor
@@ -216,7 +216,7 @@ STATS: slot fallback child display inline -> inline flow-root | rebuilt subtree 
 PASS: slot fallback child display inline -> inline flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline -> inline flow list-item | fixture ancestor
 PRESERVED: assigned slottable display inline -> inline flow list-item | distant sibling
-RECREATED: assigned slottable display inline -> inline flow list-item | shadow host
+PRESERVED: assigned slottable display inline -> inline flow list-item | shadow host
 RECREATED: assigned slottable display inline -> inline flow list-item | shadow container
 RECREATED: assigned slottable display inline -> inline flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline -> inline flow list-item | preceding sibling descendant
@@ -936,14 +936,14 @@ STATS: slot fallback child display -webkit-box -> block flow-root | rebuilt subt
 PASS: slot fallback child display -webkit-box -> block flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display -webkit-box -> block flow list-item | fixture ancestor
 PRESERVED: assigned slottable display -webkit-box -> block flow list-item | distant sibling
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | shadow host
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | shadow container
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | preceding flat-tree sibling
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | preceding sibling descendant
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | shadow host
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | shadow container
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | preceding flat-tree sibling
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | preceding sibling descendant
 RECREATED: assigned slottable display -webkit-box -> block flow list-item | target
 RECREATED: assigned slottable display -webkit-box -> block flow list-item | target descendant
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | following flat-tree sibling
-RECREATED: assigned slottable display -webkit-box -> block flow list-item | following sibling descendant
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | following flat-tree sibling
+PRESERVED: assigned slottable display -webkit-box -> block flow list-item | following sibling descendant
 STATS: assigned slottable display -webkit-box -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: assigned slottable display -webkit-box -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display -webkit-inline-box -> run-in | fixture ancestor
@@ -1548,7 +1548,7 @@ STATS: slot fallback child display inline flow -> inline flow-root | rebuilt sub
 PASS: slot fallback child display inline flow -> inline flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline flow -> inline flow list-item | fixture ancestor
 PRESERVED: assigned slottable display inline flow -> inline flow list-item | distant sibling
-RECREATED: assigned slottable display inline flow -> inline flow list-item | shadow host
+PRESERVED: assigned slottable display inline flow -> inline flow list-item | shadow host
 RECREATED: assigned slottable display inline flow -> inline flow list-item | shadow container
 RECREATED: assigned slottable display inline flow -> inline flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline flow -> inline flow list-item | preceding sibling descendant
@@ -1561,13 +1561,13 @@ PASS: assigned slottable display inline flow -> inline flow list-item | incremen
 PRESERVED: slot fallback child display block flow-root -> list-item | fixture ancestor
 PRESERVED: slot fallback child display block flow-root -> list-item | distant sibling
 PRESERVED: slot fallback child display block flow-root -> list-item | shadow host
-RECREATED: slot fallback child display block flow-root -> list-item | shadow container
-RECREATED: slot fallback child display block flow-root -> list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display block flow-root -> list-item | preceding sibling descendant
+PRESERVED: slot fallback child display block flow-root -> list-item | shadow container
+PRESERVED: slot fallback child display block flow-root -> list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display block flow-root -> list-item | preceding sibling descendant
 RECREATED: slot fallback child display block flow-root -> list-item | target
 RECREATED: slot fallback child display block flow-root -> list-item | target descendant
-RECREATED: slot fallback child display block flow-root -> list-item | following flat-tree sibling
-RECREATED: slot fallback child display block flow-root -> list-item | following sibling descendant
+PRESERVED: slot fallback child display block flow-root -> list-item | following flat-tree sibling
+PRESERVED: slot fallback child display block flow-root -> list-item | following sibling descendant
 STATS: slot fallback child display block flow-root -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display block flow-root -> list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display block flow-root -> math | fixture ancestor
@@ -1825,13 +1825,13 @@ PASS: slot fallback child display block grid -> inline flow | incremental tree m
 PRESERVED: slot fallback child display block grid -> block flow list-item | fixture ancestor
 PRESERVED: slot fallback child display block grid -> block flow list-item | distant sibling
 PRESERVED: slot fallback child display block grid -> block flow list-item | shadow host
-RECREATED: slot fallback child display block grid -> block flow list-item | shadow container
-RECREATED: slot fallback child display block grid -> block flow list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display block grid -> block flow list-item | preceding sibling descendant
+PRESERVED: slot fallback child display block grid -> block flow list-item | shadow container
+PRESERVED: slot fallback child display block grid -> block flow list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display block grid -> block flow list-item | preceding sibling descendant
 RECREATED: slot fallback child display block grid -> block flow list-item | target
 RECREATED: slot fallback child display block grid -> block flow list-item | target descendant
-RECREATED: slot fallback child display block grid -> block flow list-item | following flat-tree sibling
-RECREATED: slot fallback child display block grid -> block flow list-item | following sibling descendant
+PRESERVED: slot fallback child display block grid -> block flow list-item | following flat-tree sibling
+PRESERVED: slot fallback child display block grid -> block flow list-item | following sibling descendant
 STATS: slot fallback child display block grid -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display block grid -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display inline grid -> run-in | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-5.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-5.txt
@@ -504,14 +504,14 @@ STATS: direct shadow child display inline list-item -> inline flow list-item | n
 PASS: direct shadow child display inline list-item -> inline flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display flex -> list-item | fixture ancestor
 PRESERVED: assigned slottable display flex -> list-item | distant sibling
-RECREATED: assigned slottable display flex -> list-item | shadow host
-RECREATED: assigned slottable display flex -> list-item | shadow container
-RECREATED: assigned slottable display flex -> list-item | preceding flat-tree sibling
-RECREATED: assigned slottable display flex -> list-item | preceding sibling descendant
+PRESERVED: assigned slottable display flex -> list-item | shadow host
+PRESERVED: assigned slottable display flex -> list-item | shadow container
+PRESERVED: assigned slottable display flex -> list-item | preceding flat-tree sibling
+PRESERVED: assigned slottable display flex -> list-item | preceding sibling descendant
 RECREATED: assigned slottable display flex -> list-item | target
 RECREATED: assigned slottable display flex -> list-item | target descendant
-RECREATED: assigned slottable display flex -> list-item | following flat-tree sibling
-RECREATED: assigned slottable display flex -> list-item | following sibling descendant
+PRESERVED: assigned slottable display flex -> list-item | following flat-tree sibling
+PRESERVED: assigned slottable display flex -> list-item | following sibling descendant
 STATS: assigned slottable display flex -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: assigned slottable display flex -> list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display flex -> -webkit-box | fixture ancestor
@@ -768,7 +768,7 @@ STATS: slot fallback child display table -> block flow-root | rebuilt subtree ro
 PASS: slot fallback child display table -> block flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display table -> block flow list-item | fixture ancestor
 PRESERVED: assigned slottable display table -> block flow list-item | distant sibling
-RECREATED: assigned slottable display table -> block flow list-item | shadow host
+PRESERVED: assigned slottable display table -> block flow list-item | shadow host
 RECREATED: assigned slottable display table -> block flow list-item | shadow container
 RECREATED: assigned slottable display table -> block flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display table -> block flow list-item | preceding sibling descendant
@@ -1993,14 +1993,14 @@ PASS: assigned slottable display inline table -> inline flow-root | incremental 
 PRESERVED: direct shadow child display block flow list-item -> none | fixture ancestor
 PRESERVED: direct shadow child display block flow list-item -> none | distant sibling
 PRESERVED: direct shadow child display block flow list-item -> none | shadow host
-RECREATED: direct shadow child display block flow list-item -> none | shadow container
-RECREATED: direct shadow child display block flow list-item -> none | preceding flat-tree sibling
-RECREATED: direct shadow child display block flow list-item -> none | preceding sibling descendant
+PRESERVED: direct shadow child display block flow list-item -> none | shadow container
+PRESERVED: direct shadow child display block flow list-item -> none | preceding flat-tree sibling
+PRESERVED: direct shadow child display block flow list-item -> none | preceding sibling descendant
 REMOVED: direct shadow child display block flow list-item -> none | target
 REMOVED: direct shadow child display block flow list-item -> none | target descendant
-RECREATED: direct shadow child display block flow list-item -> none | following flat-tree sibling
-RECREATED: direct shadow child display block flow list-item -> none | following sibling descendant
-STATS: direct shadow child display block flow list-item -> none | rebuilt subtree roots=1, escaped=false
+PRESERVED: direct shadow child display block flow list-item -> none | following flat-tree sibling
+PRESERVED: direct shadow child display block flow list-item -> none | following sibling descendant
+STATS: direct shadow child display block flow list-item -> none | rebuilt subtree roots=0, escaped=false
 PASS: direct shadow child display block flow list-item -> none | incremental tree matches full rebuild
 PRESERVED: slot fallback child display block flow list-item -> inline list-item | fixture ancestor
 PRESERVED: slot fallback child display block flow list-item -> inline list-item | distant sibling

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-6.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-6.txt
@@ -37,13 +37,13 @@ PASS: assigned slottable display none -> table-cell | incremental tree matches f
 PRESERVED: direct shadow child display none -> block flex | fixture ancestor
 PRESERVED: direct shadow child display none -> block flex | distant sibling
 PRESERVED: direct shadow child display none -> block flex | shadow host
-RECREATED: direct shadow child display none -> block flex | shadow container
-RECREATED: direct shadow child display none -> block flex | preceding flat-tree sibling
-RECREATED: direct shadow child display none -> block flex | preceding sibling descendant
+PRESERVED: direct shadow child display none -> block flex | shadow container
+PRESERVED: direct shadow child display none -> block flex | preceding flat-tree sibling
+PRESERVED: direct shadow child display none -> block flex | preceding sibling descendant
 CREATED: direct shadow child display none -> block flex | target
 CREATED: direct shadow child display none -> block flex | target descendant
-RECREATED: direct shadow child display none -> block flex | following flat-tree sibling
-RECREATED: direct shadow child display none -> block flex | following sibling descendant
+PRESERVED: direct shadow child display none -> block flex | following flat-tree sibling
+PRESERVED: direct shadow child display none -> block flex | following sibling descendant
 STATS: direct shadow child display none -> block flex | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display none -> block flex | incremental tree matches full rebuild
 PRESERVED: assigned slottable display contents -> none | fixture ancestor
@@ -157,13 +157,13 @@ PASS: direct shadow child display block -> block flow-root | incremental tree ma
 PRESERVED: slot fallback child display block -> block flow list-item | fixture ancestor
 PRESERVED: slot fallback child display block -> block flow list-item | distant sibling
 PRESERVED: slot fallback child display block -> block flow list-item | shadow host
-RECREATED: slot fallback child display block -> block flow list-item | shadow container
-RECREATED: slot fallback child display block -> block flow list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display block -> block flow list-item | preceding sibling descendant
+PRESERVED: slot fallback child display block -> block flow list-item | shadow container
+PRESERVED: slot fallback child display block -> block flow list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display block -> block flow list-item | preceding sibling descendant
 RECREATED: slot fallback child display block -> block flow list-item | target
 RECREATED: slot fallback child display block -> block flow list-item | target descendant
-RECREATED: slot fallback child display block -> block flow list-item | following flat-tree sibling
-RECREATED: slot fallback child display block -> block flow list-item | following sibling descendant
+PRESERVED: slot fallback child display block -> block flow list-item | following flat-tree sibling
+PRESERVED: slot fallback child display block -> block flow list-item | following sibling descendant
 STATS: slot fallback child display block -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display block -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline -> list-item | fixture ancestor
@@ -493,14 +493,14 @@ PASS: slot fallback child display inline list-item -> block flex | incremental t
 PRESERVED: direct shadow child display flex -> none | fixture ancestor
 PRESERVED: direct shadow child display flex -> none | distant sibling
 PRESERVED: direct shadow child display flex -> none | shadow host
-RECREATED: direct shadow child display flex -> none | shadow container
-RECREATED: direct shadow child display flex -> none | preceding flat-tree sibling
-RECREATED: direct shadow child display flex -> none | preceding sibling descendant
+PRESERVED: direct shadow child display flex -> none | shadow container
+PRESERVED: direct shadow child display flex -> none | preceding flat-tree sibling
+PRESERVED: direct shadow child display flex -> none | preceding sibling descendant
 REMOVED: direct shadow child display flex -> none | target
 REMOVED: direct shadow child display flex -> none | target descendant
-RECREATED: direct shadow child display flex -> none | following flat-tree sibling
-RECREATED: direct shadow child display flex -> none | following sibling descendant
-STATS: direct shadow child display flex -> none | rebuilt subtree roots=1, escaped=false
+PRESERVED: direct shadow child display flex -> none | following flat-tree sibling
+PRESERVED: direct shadow child display flex -> none | following sibling descendant
+STATS: direct shadow child display flex -> none | rebuilt subtree roots=0, escaped=false
 PASS: direct shadow child display flex -> none | incremental tree matches full rebuild
 PRESERVED: slot fallback child display flex -> inline list-item | fixture ancestor
 PRESERVED: slot fallback child display flex -> inline list-item | distant sibling
@@ -948,7 +948,7 @@ STATS: slot fallback child display -webkit-inline-box -> none | rebuilt subtree 
 PASS: slot fallback child display -webkit-inline-box -> none | incremental tree matches full rebuild
 PRESERVED: assigned slottable display -webkit-inline-box -> inline list-item | fixture ancestor
 PRESERVED: assigned slottable display -webkit-inline-box -> inline list-item | distant sibling
-RECREATED: assigned slottable display -webkit-inline-box -> inline list-item | shadow host
+PRESERVED: assigned slottable display -webkit-inline-box -> inline list-item | shadow host
 RECREATED: assigned slottable display -webkit-inline-box -> inline list-item | shadow container
 RECREATED: assigned slottable display -webkit-inline-box -> inline list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display -webkit-inline-box -> inline list-item | preceding sibling descendant
@@ -1489,13 +1489,13 @@ PASS: direct shadow child display block flow -> block flow-root | incremental tr
 PRESERVED: slot fallback child display block flow -> block flow list-item | fixture ancestor
 PRESERVED: slot fallback child display block flow -> block flow list-item | distant sibling
 PRESERVED: slot fallback child display block flow -> block flow list-item | shadow host
-RECREATED: slot fallback child display block flow -> block flow list-item | shadow container
-RECREATED: slot fallback child display block flow -> block flow list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display block flow -> block flow list-item | preceding sibling descendant
+PRESERVED: slot fallback child display block flow -> block flow list-item | shadow container
+PRESERVED: slot fallback child display block flow -> block flow list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display block flow -> block flow list-item | preceding sibling descendant
 RECREATED: slot fallback child display block flow -> block flow list-item | target
 RECREATED: slot fallback child display block flow -> block flow list-item | target descendant
-RECREATED: slot fallback child display block flow -> block flow list-item | following flat-tree sibling
-RECREATED: slot fallback child display block flow -> block flow list-item | following sibling descendant
+PRESERVED: slot fallback child display block flow -> block flow list-item | following flat-tree sibling
+PRESERVED: slot fallback child display block flow -> block flow list-item | following sibling descendant
 STATS: slot fallback child display block flow -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display block flow -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display inline flow -> run-in | fixture ancestor
@@ -1668,14 +1668,14 @@ STATS: direct shadow child display inline flow-root -> inline flow list-item | r
 PASS: direct shadow child display inline flow-root -> inline flow list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display block flex -> list-item | fixture ancestor
 PRESERVED: assigned slottable display block flex -> list-item | distant sibling
-RECREATED: assigned slottable display block flex -> list-item | shadow host
-RECREATED: assigned slottable display block flex -> list-item | shadow container
-RECREATED: assigned slottable display block flex -> list-item | preceding flat-tree sibling
-RECREATED: assigned slottable display block flex -> list-item | preceding sibling descendant
+PRESERVED: assigned slottable display block flex -> list-item | shadow host
+PRESERVED: assigned slottable display block flex -> list-item | shadow container
+PRESERVED: assigned slottable display block flex -> list-item | preceding flat-tree sibling
+PRESERVED: assigned slottable display block flex -> list-item | preceding sibling descendant
 RECREATED: assigned slottable display block flex -> list-item | target
 RECREATED: assigned slottable display block flex -> list-item | target descendant
-RECREATED: assigned slottable display block flex -> list-item | following flat-tree sibling
-RECREATED: assigned slottable display block flex -> list-item | following sibling descendant
+PRESERVED: assigned slottable display block flex -> list-item | following flat-tree sibling
+PRESERVED: assigned slottable display block flex -> list-item | following sibling descendant
 STATS: assigned slottable display block flex -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: assigned slottable display block flex -> list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display block flex -> math | fixture ancestor
@@ -1932,7 +1932,7 @@ STATS: assigned slottable display block table -> inline flow | rebuilt subtree r
 PASS: assigned slottable display block table -> inline flow | incremental tree matches full rebuild
 PRESERVED: assigned slottable display block table -> block flow list-item | fixture ancestor
 PRESERVED: assigned slottable display block table -> block flow list-item | distant sibling
-RECREATED: assigned slottable display block table -> block flow list-item | shadow host
+PRESERVED: assigned slottable display block table -> block flow list-item | shadow host
 RECREATED: assigned slottable display block table -> block flow list-item | shadow container
 RECREATED: assigned slottable display block table -> block flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display block table -> block flow list-item | preceding sibling descendant

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-7.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-7.txt
@@ -325,14 +325,14 @@ PASS: slot fallback child display inline-block -> block flex | incremental tree 
 PRESERVED: direct shadow child display run-in -> none | fixture ancestor
 PRESERVED: direct shadow child display run-in -> none | distant sibling
 PRESERVED: direct shadow child display run-in -> none | shadow host
-RECREATED: direct shadow child display run-in -> none | shadow container
-RECREATED: direct shadow child display run-in -> none | preceding flat-tree sibling
-RECREATED: direct shadow child display run-in -> none | preceding sibling descendant
+PRESERVED: direct shadow child display run-in -> none | shadow container
+PRESERVED: direct shadow child display run-in -> none | preceding flat-tree sibling
+PRESERVED: direct shadow child display run-in -> none | preceding sibling descendant
 REMOVED: direct shadow child display run-in -> none | target
 REMOVED: direct shadow child display run-in -> none | target descendant
-RECREATED: direct shadow child display run-in -> none | following flat-tree sibling
-RECREATED: direct shadow child display run-in -> none | following sibling descendant
-STATS: direct shadow child display run-in -> none | rebuilt subtree roots=1, escaped=false
+PRESERVED: direct shadow child display run-in -> none | following flat-tree sibling
+PRESERVED: direct shadow child display run-in -> none | following sibling descendant
+STATS: direct shadow child display run-in -> none | rebuilt subtree roots=0, escaped=false
 PASS: direct shadow child display run-in -> none | incremental tree matches full rebuild
 PRESERVED: direct shadow child display run-in -> flex | fixture ancestor
 PRESERVED: direct shadow child display run-in -> flex | distant sibling
@@ -613,13 +613,13 @@ PASS: slot fallback child display inline-flex -> inline flow list-item | increme
 PRESERVED: direct shadow child display grid -> list-item | fixture ancestor
 PRESERVED: direct shadow child display grid -> list-item | distant sibling
 PRESERVED: direct shadow child display grid -> list-item | shadow host
-RECREATED: direct shadow child display grid -> list-item | shadow container
-RECREATED: direct shadow child display grid -> list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display grid -> list-item | preceding sibling descendant
+PRESERVED: direct shadow child display grid -> list-item | shadow container
+PRESERVED: direct shadow child display grid -> list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display grid -> list-item | preceding sibling descendant
 RECREATED: direct shadow child display grid -> list-item | target
 RECREATED: direct shadow child display grid -> list-item | target descendant
-RECREATED: direct shadow child display grid -> list-item | following flat-tree sibling
-RECREATED: direct shadow child display grid -> list-item | following sibling descendant
+PRESERVED: direct shadow child display grid -> list-item | following flat-tree sibling
+PRESERVED: direct shadow child display grid -> list-item | following sibling descendant
 STATS: direct shadow child display grid -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display grid -> list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display grid -> -webkit-box | fixture ancestor
@@ -780,7 +780,7 @@ STATS: slot fallback child display inline-table -> none | rebuilt subtree roots=
 PASS: slot fallback child display inline-table -> none | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline-table -> inline list-item | fixture ancestor
 PRESERVED: assigned slottable display inline-table -> inline list-item | distant sibling
-RECREATED: assigned slottable display inline-table -> inline list-item | shadow host
+PRESERVED: assigned slottable display inline-table -> inline list-item | shadow host
 RECREATED: assigned slottable display inline-table -> inline list-item | shadow container
 RECREATED: assigned slottable display inline-table -> inline list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline-table -> inline list-item | preceding sibling descendant
@@ -1657,14 +1657,14 @@ PASS: slot fallback child display inline flow-root -> block flex | incremental t
 PRESERVED: direct shadow child display block flex -> none | fixture ancestor
 PRESERVED: direct shadow child display block flex -> none | distant sibling
 PRESERVED: direct shadow child display block flex -> none | shadow host
-RECREATED: direct shadow child display block flex -> none | shadow container
-RECREATED: direct shadow child display block flex -> none | preceding flat-tree sibling
-RECREATED: direct shadow child display block flex -> none | preceding sibling descendant
+PRESERVED: direct shadow child display block flex -> none | shadow container
+PRESERVED: direct shadow child display block flex -> none | preceding flat-tree sibling
+PRESERVED: direct shadow child display block flex -> none | preceding sibling descendant
 REMOVED: direct shadow child display block flex -> none | target
 REMOVED: direct shadow child display block flex -> none | target descendant
-RECREATED: direct shadow child display block flex -> none | following flat-tree sibling
-RECREATED: direct shadow child display block flex -> none | following sibling descendant
-STATS: direct shadow child display block flex -> none | rebuilt subtree roots=1, escaped=false
+PRESERVED: direct shadow child display block flex -> none | following flat-tree sibling
+PRESERVED: direct shadow child display block flex -> none | following sibling descendant
+STATS: direct shadow child display block flex -> none | rebuilt subtree roots=0, escaped=false
 PASS: direct shadow child display block flex -> none | incremental tree matches full rebuild
 PRESERVED: slot fallback child display block flex -> inline list-item | fixture ancestor
 PRESERVED: slot fallback child display block flex -> inline list-item | distant sibling

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-8.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-flat-tree-8.txt
@@ -264,14 +264,14 @@ STATS: slot fallback child display flow-root -> block flow-root | no layout tree
 PASS: slot fallback child display flow-root -> block flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display flow-root -> block flow list-item | fixture ancestor
 PRESERVED: assigned slottable display flow-root -> block flow list-item | distant sibling
-RECREATED: assigned slottable display flow-root -> block flow list-item | shadow host
-RECREATED: assigned slottable display flow-root -> block flow list-item | shadow container
-RECREATED: assigned slottable display flow-root -> block flow list-item | preceding flat-tree sibling
-RECREATED: assigned slottable display flow-root -> block flow list-item | preceding sibling descendant
+PRESERVED: assigned slottable display flow-root -> block flow list-item | shadow host
+PRESERVED: assigned slottable display flow-root -> block flow list-item | shadow container
+PRESERVED: assigned slottable display flow-root -> block flow list-item | preceding flat-tree sibling
+PRESERVED: assigned slottable display flow-root -> block flow list-item | preceding sibling descendant
 RECREATED: assigned slottable display flow-root -> block flow list-item | target
 RECREATED: assigned slottable display flow-root -> block flow list-item | target descendant
-RECREATED: assigned slottable display flow-root -> block flow list-item | following flat-tree sibling
-RECREATED: assigned slottable display flow-root -> block flow list-item | following sibling descendant
+PRESERVED: assigned slottable display flow-root -> block flow list-item | following flat-tree sibling
+PRESERVED: assigned slottable display flow-root -> block flow list-item | following sibling descendant
 STATS: assigned slottable display flow-root -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: assigned slottable display flow-root -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: direct shadow child display inline-block -> list-item | fixture ancestor
@@ -876,7 +876,7 @@ STATS: slot fallback child display math -> inline flow-root | rebuilt subtree ro
 PASS: slot fallback child display math -> inline flow-root | incremental tree matches full rebuild
 PRESERVED: assigned slottable display math -> inline flow list-item | fixture ancestor
 PRESERVED: assigned slottable display math -> inline flow list-item | distant sibling
-RECREATED: assigned slottable display math -> inline flow list-item | shadow host
+PRESERVED: assigned slottable display math -> inline flow list-item | shadow host
 RECREATED: assigned slottable display math -> inline flow list-item | shadow container
 RECREATED: assigned slottable display math -> inline flow list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display math -> inline flow list-item | preceding sibling descendant
@@ -889,13 +889,13 @@ PASS: assigned slottable display math -> inline flow list-item | incremental tre
 PRESERVED: slot fallback child display -webkit-box -> list-item | fixture ancestor
 PRESERVED: slot fallback child display -webkit-box -> list-item | distant sibling
 PRESERVED: slot fallback child display -webkit-box -> list-item | shadow host
-RECREATED: slot fallback child display -webkit-box -> list-item | shadow container
-RECREATED: slot fallback child display -webkit-box -> list-item | preceding flat-tree sibling
-RECREATED: slot fallback child display -webkit-box -> list-item | preceding sibling descendant
+PRESERVED: slot fallback child display -webkit-box -> list-item | shadow container
+PRESERVED: slot fallback child display -webkit-box -> list-item | preceding flat-tree sibling
+PRESERVED: slot fallback child display -webkit-box -> list-item | preceding sibling descendant
 RECREATED: slot fallback child display -webkit-box -> list-item | target
 RECREATED: slot fallback child display -webkit-box -> list-item | target descendant
-RECREATED: slot fallback child display -webkit-box -> list-item | following flat-tree sibling
-RECREATED: slot fallback child display -webkit-box -> list-item | following sibling descendant
+PRESERVED: slot fallback child display -webkit-box -> list-item | following flat-tree sibling
+PRESERVED: slot fallback child display -webkit-box -> list-item | following sibling descendant
 STATS: slot fallback child display -webkit-box -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: slot fallback child display -webkit-box -> list-item | incremental tree matches full rebuild
 PRESERVED: assigned slottable display -webkit-box -> math | fixture ancestor
@@ -1596,14 +1596,14 @@ STATS: assigned slottable display block flow-root -> inline flow | rebuilt subtr
 PASS: assigned slottable display block flow-root -> inline flow | incremental tree matches full rebuild
 PRESERVED: assigned slottable display block flow-root -> block flow list-item | fixture ancestor
 PRESERVED: assigned slottable display block flow-root -> block flow list-item | distant sibling
-RECREATED: assigned slottable display block flow-root -> block flow list-item | shadow host
-RECREATED: assigned slottable display block flow-root -> block flow list-item | shadow container
-RECREATED: assigned slottable display block flow-root -> block flow list-item | preceding flat-tree sibling
-RECREATED: assigned slottable display block flow-root -> block flow list-item | preceding sibling descendant
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | shadow host
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | shadow container
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | preceding flat-tree sibling
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | preceding sibling descendant
 RECREATED: assigned slottable display block flow-root -> block flow list-item | target
 RECREATED: assigned slottable display block flow-root -> block flow list-item | target descendant
-RECREATED: assigned slottable display block flow-root -> block flow list-item | following flat-tree sibling
-RECREATED: assigned slottable display block flow-root -> block flow list-item | following sibling descendant
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | following flat-tree sibling
+PRESERVED: assigned slottable display block flow-root -> block flow list-item | following sibling descendant
 STATS: assigned slottable display block flow-root -> block flow list-item | rebuilt subtree roots=1, escaped=false
 PASS: assigned slottable display block flow-root -> block flow list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display inline flow-root -> run-in | fixture ancestor
@@ -1777,13 +1777,13 @@ PASS: slot fallback child display inline flex -> inline flow list-item | increme
 PRESERVED: direct shadow child display block grid -> list-item | fixture ancestor
 PRESERVED: direct shadow child display block grid -> list-item | distant sibling
 PRESERVED: direct shadow child display block grid -> list-item | shadow host
-RECREATED: direct shadow child display block grid -> list-item | shadow container
-RECREATED: direct shadow child display block grid -> list-item | preceding flat-tree sibling
-RECREATED: direct shadow child display block grid -> list-item | preceding sibling descendant
+PRESERVED: direct shadow child display block grid -> list-item | shadow container
+PRESERVED: direct shadow child display block grid -> list-item | preceding flat-tree sibling
+PRESERVED: direct shadow child display block grid -> list-item | preceding sibling descendant
 RECREATED: direct shadow child display block grid -> list-item | target
 RECREATED: direct shadow child display block grid -> list-item | target descendant
-RECREATED: direct shadow child display block grid -> list-item | following flat-tree sibling
-RECREATED: direct shadow child display block grid -> list-item | following sibling descendant
+PRESERVED: direct shadow child display block grid -> list-item | following flat-tree sibling
+PRESERVED: direct shadow child display block grid -> list-item | following sibling descendant
 STATS: direct shadow child display block grid -> list-item | rebuilt subtree roots=1, escaped=false
 PASS: direct shadow child display block grid -> list-item | incremental tree matches full rebuild
 PRESERVED: slot fallback child display block grid -> math | fixture ancestor
@@ -1944,7 +1944,7 @@ STATS: slot fallback child display inline table -> none | rebuilt subtree roots=
 PASS: slot fallback child display inline table -> none | incremental tree matches full rebuild
 PRESERVED: assigned slottable display inline table -> inline list-item | fixture ancestor
 PRESERVED: assigned slottable display inline table -> inline list-item | distant sibling
-RECREATED: assigned slottable display inline table -> inline list-item | shadow host
+PRESERVED: assigned slottable display inline table -> inline list-item | shadow host
 RECREATED: assigned slottable display inline table -> inline list-item | shadow container
 RECREATED: assigned slottable display inline table -> inline list-item | preceding flat-tree sibling
 RECREATED: assigned slottable display inline table -> inline list-item | preceding sibling descendant

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-list-item.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-list-item.txt
@@ -1,0 +1,81 @@
+PRESERVED: hide li in ul list-style none | list
+PRESERVED: hide li in ul list-style none | preceding item
+PRESERVED: hide li in ul list-style none | preceding item descendant
+REMOVED: hide li in ul list-style none | target
+PRESERVED: hide li in ul list-style none | following item
+PRESERVED: hide li in ul list-style none | following item descendant
+STATS: hide li in ul list-style none | rebuilt subtree roots=0, escaped=false
+PASS: hide li in ul list-style none | incremental tree matches full rebuild
+PRESERVED: show li in ul list-style none | list
+PRESERVED: show li in ul list-style none | preceding item
+PRESERVED: show li in ul list-style none | preceding item descendant
+CREATED: show li in ul list-style none | target
+PRESERVED: show li in ul list-style none | following item
+PRESERVED: show li in ul list-style none | following item descendant
+STATS: show li in ul list-style none | rebuilt subtree roots=1, escaped=false
+PASS: show li in ul list-style none | incremental tree matches full rebuild
+PRESERVED: hide li in ul disc | list
+PRESERVED: hide li in ul disc | preceding item
+PRESERVED: hide li in ul disc | preceding item descendant
+REMOVED: hide li in ul disc | target
+PRESERVED: hide li in ul disc | following item
+PRESERVED: hide li in ul disc | following item descendant
+STATS: hide li in ul disc | rebuilt subtree roots=0, escaped=false
+PASS: hide li in ul disc | incremental tree matches full rebuild
+PRESERVED: show li in ul disc | list
+PRESERVED: show li in ul disc | preceding item
+PRESERVED: show li in ul disc | preceding item descendant
+CREATED: show li in ul disc | target
+PRESERVED: show li in ul disc | following item
+PRESERVED: show li in ul disc | following item descendant
+STATS: show li in ul disc | rebuilt subtree roots=1, escaped=false
+PASS: show li in ul disc | incremental tree matches full rebuild
+RECREATED: hide li in ol decimal | list
+RECREATED: hide li in ol decimal | preceding item
+RECREATED: hide li in ol decimal | preceding item descendant
+REMOVED: hide li in ol decimal | target
+RECREATED: hide li in ol decimal | following item
+RECREATED: hide li in ol decimal | following item descendant
+STATS: hide li in ol decimal | rebuilt subtree roots=1, escaped=false
+PASS: hide li in ol decimal | incremental tree matches full rebuild
+RECREATED: show li in ol decimal | list
+RECREATED: show li in ol decimal | preceding item
+RECREATED: show li in ol decimal | preceding item descendant
+CREATED: show li in ol decimal | target
+RECREATED: show li in ol decimal | following item
+RECREATED: show li in ol decimal | following item descendant
+STATS: show li in ol decimal | rebuilt subtree roots=1, escaped=false
+PASS: show li in ol decimal | incremental tree matches full rebuild
+PRESERVED: hide last li in ol decimal | list
+PRESERVED: hide last li in ol decimal | preceding item
+PRESERVED: hide last li in ol decimal | preceding item descendant
+REMOVED: hide last li in ol decimal | target
+PRESERVED: hide last li in ol decimal | following item
+PRESERVED: hide last li in ol decimal | following item descendant
+STATS: hide last li in ol decimal | rebuilt subtree roots=0, escaped=false
+PASS: hide last li in ol decimal | incremental tree matches full rebuild
+RECREATED: hide li in ul none with counter in ::before | list
+RECREATED: hide li in ul none with counter in ::before | preceding item
+RECREATED: hide li in ul none with counter in ::before | preceding item descendant
+REMOVED: hide li in ul none with counter in ::before | target
+RECREATED: hide li in ul none with counter in ::before | following item
+RECREATED: hide li in ul none with counter in ::before | following item descendant
+STATS: hide li in ul none with counter in ::before | rebuilt subtree roots=1, escaped=false
+PASS: hide li in ul none with counter in ::before | incremental tree matches full rebuild
+RECREATED: hide li in ul none with counter in descendant ::after | list
+RECREATED: hide li in ul none with counter in descendant ::after | preceding item
+RECREATED: hide li in ul none with counter in descendant ::after | preceding item descendant
+REMOVED: hide li in ul none with counter in descendant ::after | target
+RECREATED: hide li in ul none with counter in descendant ::after | following item
+RECREATED: hide li in ul none with counter in descendant ::after | following item descendant
+STATS: hide li in ul none with counter in descendant ::after | rebuilt subtree roots=1, escaped=false
+PASS: hide li in ul none with counter in descendant ::after | incremental tree matches full rebuild
+RECREATED: hide li in ul none with counter in list ::after | list
+RECREATED: hide li in ul none with counter in list ::after | preceding item
+RECREATED: hide li in ul none with counter in list ::after | preceding item descendant
+REMOVED: hide li in ul none with counter in list ::after | target
+RECREATED: hide li in ul none with counter in list ::after | following item
+RECREATED: hide li in ul none with counter in list ::after | following item descendant
+STATS: hide li in ul none with counter in list ::after | rebuilt subtree roots=1, escaped=false
+PASS: hide li in ul none with counter in list ::after | incremental tree matches full rebuild
+10 cases; 10 matched; 0 mismatched

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-pseudo-elements-4.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-pseudo-elements-4.txt
@@ -73,14 +73,14 @@ PASS: ::after change display table-caption on none in inline flow | incremental 
 PRESERVED: ::after change display inline flow list-item on none in block | fixture ancestor
 PRESERVED: ::after change display inline flow list-item on none in block | distant sibling
 PRESERVED: ::after change display inline flow list-item on none in block | distant sibling descendant
-RECREATED: ::after change display inline flow list-item on none in block | DOM parent
-RECREATED: ::after change display inline flow list-item on none in block | preceding sibling
-RECREATED: ::after change display inline flow list-item on none in block | preceding sibling descendant
+PRESERVED: ::after change display inline flow list-item on none in block | DOM parent
+PRESERVED: ::after change display inline flow list-item on none in block | preceding sibling
+PRESERVED: ::after change display inline flow list-item on none in block | preceding sibling descendant
 ABSENT: ::after change display inline flow list-item on none in block | target
 ABSENT: ::after change display inline flow list-item on none in block | target descendant
-RECREATED: ::after change display inline flow list-item on none in block | following sibling
-RECREATED: ::after change display inline flow list-item on none in block | following sibling descendant
-STATS: ::after change display inline flow list-item on none in block | rebuilt subtree roots=1, escaped=false
+PRESERVED: ::after change display inline flow list-item on none in block | following sibling
+PRESERVED: ::after change display inline flow list-item on none in block | following sibling descendant
+STATS: ::after change display inline flow list-item on none in block | rebuilt subtree roots=0, escaped=false
 PASS: ::after change display inline flow list-item on none in block | incremental tree matches full rebuild
 RECREATED: ::before create grid on contents in table | fixture ancestor
 RECREATED: ::before create grid on contents in table | distant sibling
@@ -526,16 +526,16 @@ RECREATED: ::after change display table-caption on run-in in inline grid | follo
 RECREATED: ::after change display table-caption on run-in in inline grid | following sibling descendant
 STATS: ::after change display table-caption on run-in in inline grid | rebuilt subtree roots=1, escaped=false
 PASS: ::after change display table-caption on run-in in inline grid | incremental tree matches full rebuild
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | fixture ancestor
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | distant sibling
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | distant sibling descendant
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | DOM parent
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | preceding sibling
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | preceding sibling descendant
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | fixture ancestor
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | distant sibling
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | distant sibling descendant
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | DOM parent
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | preceding sibling
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | preceding sibling descendant
 RECREATED: ::after change display inline flow list-item on run-in in inline list-item | target
 RECREATED: ::after change display inline flow list-item on run-in in inline list-item | target descendant
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | following sibling
-RECREATED: ::after change display inline flow list-item on run-in in inline list-item | following sibling descendant
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | following sibling
+PRESERVED: ::after change display inline flow list-item on run-in in inline list-item | following sibling descendant
 STATS: ::after change display inline flow list-item on run-in in inline list-item | rebuilt subtree roots=1, escaped=false
 PASS: ::after change display inline flow list-item on run-in in inline list-item | incremental tree matches full rebuild
 RECREATED: ::before create grid on list-item in table-header-group | fixture ancestor
@@ -2353,13 +2353,13 @@ PASS: ::after change display table-caption on block flex in table-footer-group |
 PRESERVED: ::after change display inline flow list-item on block flex in block grid | fixture ancestor
 PRESERVED: ::after change display inline flow list-item on block flex in block grid | distant sibling
 PRESERVED: ::after change display inline flow list-item on block flex in block grid | distant sibling descendant
-RECREATED: ::after change display inline flow list-item on block flex in block grid | DOM parent
-RECREATED: ::after change display inline flow list-item on block flex in block grid | preceding sibling
-RECREATED: ::after change display inline flow list-item on block flex in block grid | preceding sibling descendant
+PRESERVED: ::after change display inline flow list-item on block flex in block grid | DOM parent
+PRESERVED: ::after change display inline flow list-item on block flex in block grid | preceding sibling
+PRESERVED: ::after change display inline flow list-item on block flex in block grid | preceding sibling descendant
 RECREATED: ::after change display inline flow list-item on block flex in block grid | target
 RECREATED: ::after change display inline flow list-item on block flex in block grid | target descendant
-RECREATED: ::after change display inline flow list-item on block flex in block grid | following sibling
-RECREATED: ::after change display inline flow list-item on block flex in block grid | following sibling descendant
+PRESERVED: ::after change display inline flow list-item on block flex in block grid | following sibling
+PRESERVED: ::after change display inline flow list-item on block flex in block grid | following sibling descendant
 STATS: ::after change display inline flow list-item on block flex in block grid | rebuilt subtree roots=1, escaped=false
 PASS: ::after change display inline flow list-item on block flex in block grid | incremental tree matches full rebuild
 PRESERVED: ::before create grid on inline flex in run-in | fixture ancestor
@@ -2806,16 +2806,16 @@ RECREATED: ::after change display table-caption on block flow list-item in block
 RECREATED: ::after change display table-caption on block flow list-item in block flow | following sibling descendant
 STATS: ::after change display table-caption on block flow list-item in block flow | rebuilt subtree roots=1, escaped=false
 PASS: ::after change display table-caption on block flow list-item in block flow | incremental tree matches full rebuild
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | fixture ancestor
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | distant sibling
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | distant sibling descendant
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | fixture ancestor
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | distant sibling
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | distant sibling descendant
 ABSENT: ::after change display inline flow list-item on block flow list-item in contents | DOM parent
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | preceding sibling
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | preceding sibling descendant
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | preceding sibling
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | preceding sibling descendant
 RECREATED: ::after change display inline flow list-item on block flow list-item in contents | target
 RECREATED: ::after change display inline flow list-item on block flow list-item in contents | target descendant
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | following sibling
-RECREATED: ::after change display inline flow list-item on block flow list-item in contents | following sibling descendant
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | following sibling
+PRESERVED: ::after change display inline flow list-item on block flow list-item in contents | following sibling descendant
 STATS: ::after change display inline flow list-item on block flow list-item in contents | rebuilt subtree roots=1, escaped=false
 PASS: ::after change display inline flow list-item on block flow list-item in contents | incremental tree matches full rebuild
 PRESERVED: ::before create grid on inline flow list-item in inline-grid | fixture ancestor

--- a/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-pseudo-elements-6.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/style-invalidation-scope-pseudo-elements-6.txt
@@ -562,16 +562,16 @@ RECREATED: ::before change display table-caption on list-item in inline grid | f
 RECREATED: ::before change display table-caption on list-item in inline grid | following sibling descendant
 STATS: ::before change display table-caption on list-item in inline grid | rebuilt subtree roots=1, escaped=false
 PASS: ::before change display table-caption on list-item in inline grid | incremental tree matches full rebuild
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | fixture ancestor
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | distant sibling
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | distant sibling descendant
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | DOM parent
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | preceding sibling
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | preceding sibling descendant
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | fixture ancestor
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | distant sibling
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | distant sibling descendant
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | DOM parent
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | preceding sibling
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | preceding sibling descendant
 RECREATED: ::before change display inline flow list-item on list-item in inline list-item | target
 RECREATED: ::before change display inline flow list-item on list-item in inline list-item | target descendant
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | following sibling
-RECREATED: ::before change display inline flow list-item on list-item in inline list-item | following sibling descendant
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | following sibling
+PRESERVED: ::before change display inline flow list-item on list-item in inline list-item | following sibling descendant
 STATS: ::before change display inline flow list-item on list-item in inline list-item | rebuilt subtree roots=1, escaped=false
 PASS: ::before change display inline flow list-item on list-item in inline list-item | incremental tree matches full rebuild
 RECREATED: ::after remove grid on list-item in table-footer-group | fixture ancestor
@@ -2389,13 +2389,13 @@ PASS: ::before change display table-caption on inline flex in table-footer-group
 PRESERVED: ::before change display inline flow list-item on inline flex in block grid | fixture ancestor
 PRESERVED: ::before change display inline flow list-item on inline flex in block grid | distant sibling
 PRESERVED: ::before change display inline flow list-item on inline flex in block grid | distant sibling descendant
-RECREATED: ::before change display inline flow list-item on inline flex in block grid | DOM parent
-RECREATED: ::before change display inline flow list-item on inline flex in block grid | preceding sibling
-RECREATED: ::before change display inline flow list-item on inline flex in block grid | preceding sibling descendant
+PRESERVED: ::before change display inline flow list-item on inline flex in block grid | DOM parent
+PRESERVED: ::before change display inline flow list-item on inline flex in block grid | preceding sibling
+PRESERVED: ::before change display inline flow list-item on inline flex in block grid | preceding sibling descendant
 RECREATED: ::before change display inline flow list-item on inline flex in block grid | target
 RECREATED: ::before change display inline flow list-item on inline flex in block grid | target descendant
-RECREATED: ::before change display inline flow list-item on inline flex in block grid | following sibling
-RECREATED: ::before change display inline flow list-item on inline flex in block grid | following sibling descendant
+PRESERVED: ::before change display inline flow list-item on inline flex in block grid | following sibling
+PRESERVED: ::before change display inline flow list-item on inline flex in block grid | following sibling descendant
 STATS: ::before change display inline flow list-item on inline flex in block grid | rebuilt subtree roots=1, escaped=false
 PASS: ::before change display inline flow list-item on inline flex in block grid | incremental tree matches full rebuild
 PRESERVED: ::after remove grid on inline flex in list-item | fixture ancestor

--- a/Tests/LibWeb/Text/input/layout-tree-update/style-invalidation-scope-list-item.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/style-invalidation-scope-list-item.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script src="resources/full-rebuild-comparison.js"></script>
+<div id="fixture"></div>
+<script>
+    // A list item that stops or starts generating a box keeps the surrounding layout tree unless
+    // some later content displays the renumbered list-item counter.
+    function listItemCase(name, { listTag, listStyle, extraCss, hide, hideLast }) {
+        return {
+            name,
+            setup(fixture) {
+                const style = document.createElement("style");
+                style.textContent = `#scope-list { list-style: ${listStyle}; } ${extraCss || ""}`;
+                const list = document.createElement(listTag);
+                list.id = "scope-list";
+                const items = [];
+                for (let i = 0; i < 4; ++i) {
+                    const item = document.createElement("li");
+                    const child = document.createElement("span");
+                    child.textContent = "child " + i;
+                    item.append("item " + i, child);
+                    list.append(item);
+                    items.push({ item, child });
+                }
+                const target = items[hideLast ? 3 : 1].item;
+                if (!hide) target.style.display = "none";
+                fixture.append(style, list);
+                return {
+                    mutate: () => {
+                        target.style.display = hide ? "none" : "";
+                    },
+                    trackedNodes: [
+                        { label: "list", node: list },
+                        { label: "preceding item", node: items[0].item },
+                        { label: "preceding item descendant", node: items[0].child },
+                        { label: "target", node: target },
+                        { label: "following item", node: items[2].item },
+                        { label: "following item descendant", node: items[2].child },
+                    ],
+                };
+            },
+        };
+    }
+
+    test(() => {
+        runLayoutTreeInvalidationScopeCases([
+            listItemCase("hide li in ul list-style none", { listTag: "ul", listStyle: "none", hide: true }),
+            listItemCase("show li in ul list-style none", { listTag: "ul", listStyle: "none", hide: false }),
+            listItemCase("hide li in ul disc", { listTag: "ul", listStyle: "disc", hide: true }),
+            listItemCase("show li in ul disc", { listTag: "ul", listStyle: "disc", hide: false }),
+            listItemCase("hide li in ol decimal", { listTag: "ol", listStyle: "decimal", hide: true }),
+            listItemCase("show li in ol decimal", { listTag: "ol", listStyle: "decimal", hide: false }),
+            listItemCase("hide last li in ol decimal", { listTag: "ol", listStyle: "decimal", hide: true, hideLast: true }),
+            listItemCase("hide li in ul none with counter in ::before", {
+                listTag: "ul",
+                listStyle: "none",
+                extraCss: "#scope-list li::before { content: counter(list-item); }",
+                hide: true,
+            }),
+            listItemCase("hide li in ul none with counter in descendant ::after", {
+                listTag: "ul",
+                listStyle: "none",
+                extraCss: "#scope-list span::after { content: counters(list-item, '.'); }",
+                hide: true,
+            }),
+            listItemCase("hide li in ul none with counter in list ::after", {
+                listTag: "ul",
+                listStyle: "none",
+                extraCss: "#scope-list::after { content: counter(list-item); }",
+                hide: true,
+            }),
+        ]);
+    });
+</script>


### PR DESCRIPTION
Switching an element between display: none and a box display rebuilt the layout tree from its parent, so hiding one <li> in a 500-item list recreated every layout node in the <ul> and the following layout could reuse nothing (no run cache hits, all text reshaped, all intrinsic sizes measured again). A display toggle only removes or adds one box in the parent's child list, which the DOM removal and insertion paths already handle without touching the other children. A new rebuild root, BoxPresenceChange, now routes such changes through those paths: hiding schedules only the element for a rebuild that drops its box, showing marks the parent for a DOM-order insertion of the new box. We still rebuild from the parent when the surrounding structure could change (anonymous wrappers, ::first-letter, out-of-flow or inline boxes, slots, top layer, SVG, counters in the subtree) and for list items whose renumbering would be visible. Pseudo-element boxes that live inside the element (::marker, non-escaping ::before/::after) now rebuild from the element instead of the parent, and the DOM removal fast path no longer leaves a lone anonymous wrapper behind.

MicroWeb (median of 3 iterations): render/layout-thrash 2429 -> 329 ms, render/display-toggle-one 1296 -> 193 ms, render/display-toggle-one-large 1377 -> 359 ms; other render tests unchanged. The style-invalidation-scope expectations change from RECREATED to PRESERVED for the siblings in every none <-> box case, and every case still matches a full rebuild.