### PR TITLE
LibJS: Optimize intrinsic Promise combinators

### DIFF
--- a/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Libraries/LibJS/Runtime/Promise.cpp
@@ -14,6 +14,7 @@
 #include <LibJS/Runtime/JobCallback.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/PromiseCapability.h>
+#include <LibJS/Runtime/PromiseConstructor.h>
 #include <LibJS/Runtime/PromiseJobs.h>
 #include <LibJS/Runtime/PromiseReaction.h>
 #include <LibJS/Runtime/PromiseResolvingFunction.h>
@@ -25,6 +26,8 @@ GC_DEFINE_ALLOCATOR(Promise);
 // 27.2.4.7.1 PromiseResolve ( C, x ), https://tc39.es/ecma262/#sec-promise-resolve
 ThrowCompletionOr<Object*> promise_resolve(VM& vm, Object& constructor, Value value)
 {
+    auto& realm = *vm.current_realm();
+
     // 1. If IsPromise(x) is true, then
     if (auto promise = value.as_if<Promise>()) {
         // a. Let xConstructor be ? Get(x, "constructor").
@@ -33,6 +36,14 @@ ThrowCompletionOr<Object*> promise_resolve(VM& vm, Object& constructor, Value va
         // b. If SameValue(xConstructor, C) is true, return x.
         if (same_value(value_constructor, &constructor))
             return promise.ptr();
+    }
+
+    // OPTIMIZATION: Resolving an intrinsic Promise with a primitive cannot invoke user code, and the capability's resolving
+    //               functions do not escape. Create and fulfill the Promise directly instead of allocating those functions.
+    if (&constructor == realm.intrinsics().promise_constructor().ptr() && !value.is_object()) {
+        auto promise = Promise::create(realm);
+        promise->fulfill(value);
+        return promise.ptr();
     }
 
     // 2. Let promiseCapability be ? NewPromiseCapability(C).
@@ -76,7 +87,6 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 
     // 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
     auto resolve_function = PromiseResolvingFunction::create_resolve(realm, *this);
-    resolve_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
     // 7. Let stepsReject be the algorithm steps defined in Promise Reject Functions.
     // 8. Let lengthReject be the number of non-optional parameters of the function definition in Promise Reject Functions.
@@ -86,7 +96,6 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 
     // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
     auto reject_function = PromiseResolvingFunction::create_reject(realm, *this, resolve_function);
-    reject_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
     // 12. Return the Record { [[Resolve]]: resolve, [[Reject]]: reject }.
     return { *resolve_function, *reject_function };
@@ -306,33 +315,39 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GC::Ptr<Promi
     // 2. If resultCapability is not present, then
     //     a. Set resultCapability to undefined.
 
-    // 3. If IsCallable(onFulfilled) is false, then
-    //     a. Let onFulfilledJobCallback be empty.
-    GC::Ptr<JobCallback> on_fulfilled_job_callback;
+    // OPTIMIZATION: A settled promise only uses one of these reactions. Create both reactions for a pending promise, but
+    //               defer their creation until the promise state determines which ones are needed.
+    auto create_fulfill_reaction = [&] {
+        // 3. If IsCallable(onFulfilled) is false, then
+        //     a. Let onFulfilledJobCallback be empty.
+        GC::Ptr<JobCallback> on_fulfilled_job_callback;
 
-    // 4. Else,
-    if (on_fulfilled.is_function()) {
-        // a. Let onFulfilledJobCallback be HostMakeJobCallback(onFulfilled).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_fulfilled function @ {}", this, &on_fulfilled.as_function());
-        on_fulfilled_job_callback = vm.host_make_job_callback(on_fulfilled.as_function());
-    }
+        // 4. Else,
+        if (on_fulfilled.is_function()) {
+            // a. Let onFulfilledJobCallback be HostMakeJobCallback(onFulfilled).
+            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_fulfilled function @ {}", this, &on_fulfilled.as_function());
+            on_fulfilled_job_callback = vm.host_make_job_callback(on_fulfilled.as_function());
+        }
 
-    // 5. If IsCallable(onRejected) is false, then
-    //     a. Let onRejectedJobCallback be empty.
-    GC::Ptr<JobCallback> on_rejected_job_callback;
+        // 7. Let fulfillReaction be the PromiseReaction Record { [[Capability]]: resultCapability, [[Type]]: fulfill, [[Handler]]: onFulfilledJobCallback }.
+        return PromiseReaction::create(vm, PromiseReaction::Type::Fulfill, result_capability, move(on_fulfilled_job_callback));
+    };
 
-    // 6. Else,
-    if (on_rejected.is_function()) {
-        // a. Let onRejectedJobCallback be HostMakeJobCallback(onRejected).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_rejected function @ {}", this, &on_rejected.as_function());
-        on_rejected_job_callback = vm.host_make_job_callback(on_rejected.as_function());
-    }
+    auto create_reject_reaction = [&] {
+        // 5. If IsCallable(onRejected) is false, then
+        //     a. Let onRejectedJobCallback be empty.
+        GC::Ptr<JobCallback> on_rejected_job_callback;
 
-    // 7. Let fulfillReaction be the PromiseReaction { [[Capability]]: resultCapability, [[Type]]: Fulfill, [[Handler]]: onFulfilledJobCallback }.
-    auto fulfill_reaction = PromiseReaction::create(vm, PromiseReaction::Type::Fulfill, result_capability, move(on_fulfilled_job_callback));
+        // 6. Else,
+        if (on_rejected.is_function()) {
+            // a. Let onRejectedJobCallback be HostMakeJobCallback(onRejected).
+            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_rejected function @ {}", this, &on_rejected.as_function());
+            on_rejected_job_callback = vm.host_make_job_callback(on_rejected.as_function());
+        }
 
-    // 8. Let rejectReaction be the PromiseReaction { [[Capability]]: resultCapability, [[Type]]: Reject, [[Handler]]: onRejectedJobCallback }.
-    auto reject_reaction = PromiseReaction::create(vm, PromiseReaction::Type::Reject, result_capability, move(on_rejected_job_callback));
+        // 8. Let rejectReaction be the PromiseReaction Record { [[Capability]]: resultCapability, [[Type]]: reject, [[Handler]]: onRejectedJobCallback }.
+        return PromiseReaction::create(vm, PromiseReaction::Type::Reject, result_capability, move(on_rejected_job_callback));
+    };
 
     switch (m_state) {
     // 9. If promise.[[PromiseState]] is pending, then
@@ -340,10 +355,10 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GC::Ptr<Promi
         dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: state is State::Pending, adding fulfill/reject reactions", this);
 
         // a. Append fulfillReaction as the last element of the List that is promise.[[PromiseFulfillReactions]].
-        m_fulfill_reactions.append(fulfill_reaction);
+        m_fulfill_reactions.append(create_fulfill_reaction());
 
         // b. Append rejectReaction as the last element of the List that is promise.[[PromiseRejectReactions]].
-        m_reject_reactions.append(reject_reaction);
+        m_reject_reactions.append(create_reject_reaction());
         break;
     // 10. Else if promise.[[PromiseState]] is fulfilled, then
     case Promise::State::Fulfilled: {
@@ -351,6 +366,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GC::Ptr<Promi
         auto value = m_result;
 
         // b. Let fulfillJob be NewPromiseReactionJob(fulfillReaction, value).
+        auto fulfill_reaction = create_fulfill_reaction();
         dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: State is State::Fulfilled, creating PromiseJob for PromiseReaction @ {} with argument {}", this, fulfill_reaction.ptr(), value);
         auto [fulfill_job, realm] = create_promise_reaction_job(vm, fulfill_reaction, value);
 
@@ -371,6 +387,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, GC::Ptr<Promi
             vm.host_promise_rejection_tracker(*this, RejectionOperation::Handle);
 
         // d. Let rejectJob be NewPromiseReactionJob(rejectReaction, reason).
+        auto reject_reaction = create_reject_reaction();
         dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: State is State::Rejected, creating PromiseJob for PromiseReaction @ {} with argument {}", this, reject_reaction.ptr(), reason);
         auto [reject_job, realm] = create_promise_reaction_job(vm, *reject_reaction, reason);
 

--- a/Libraries/LibJS/Runtime/PromiseCapability.cpp
+++ b/Libraries/LibJS/Runtime/PromiseCapability.cpp
@@ -7,7 +7,9 @@
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/PromiseCapability.h>
+#include <LibJS/Runtime/PromiseConstructor.h>
 
 namespace JS {
 
@@ -63,6 +65,14 @@ ThrowCompletionOr<GC::Ref<PromiseCapability>> new_promise_capability(VM& vm, Val
         return vm.throw_completion<TypeError>(ErrorType::NotAConstructor, constructor);
 
     // 2. NOTE: C is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see 27.2.3.1).
+
+    // OPTIMIZATION: Constructing the intrinsic Promise only creates a Promise and its resolving functions before invoking
+    //               the executor below. Create the resulting capability directly to avoid the temporary executor closure.
+    if (&constructor.as_function() == realm.intrinsics().promise_constructor().ptr()) {
+        auto promise = TRY(ordinary_create_from_constructor<Promise>(vm, constructor.as_function(), &Intrinsics::promise_prototype));
+        auto [resolve, reject] = promise->create_resolving_functions();
+        return PromiseCapability::create(vm, promise, resolve, reject);
+    }
 
     // 3. Let resolvingFunctions be the Record { [[Resolve]]: undefined, [[Reject]]: undefined }.
     auto resolving_functions = realm.create<ResolvingFunctions>();

--- a/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
+#include <LibJS/Runtime/PromisePrototype.h>
 #include <LibJS/Runtime/PromiseResolvingElementFunctions.h>
 #include <LibJS/Runtime/ValueInlines.h>
 
@@ -40,6 +41,30 @@ static ThrowCompletionOr<Value> get_promise_resolve(VM& vm, Value constructor)
 
 using EndOfElementsCallback = Function<ThrowCompletionOr<Value>(PromiseValueList&)>;
 using InvokeElementFunctionCallback = Function<ThrowCompletionOr<Value>(PromiseValueList&, RemainingElements&, Value, size_t)>;
+
+enum class ResultVisibility {
+    Observable,
+    Unobservable,
+};
+
+static ThrowCompletionOr<Value> invoke_then(VM& vm, Realm& realm, Value promise_value, Value on_fulfilled, Value on_rejected, ResultVisibility result_visibility)
+{
+    auto then = TRY(promise_value.get(vm, vm.names.then));
+
+    // OPTIMIZATION: Promise combinators do not use the result of invoking the intrinsic Promise.prototype.then. If its
+    //               species is also the intrinsic Promise, omit the otherwise unused promise and resolving functions.
+    auto promise = promise_value.as_if<Promise>();
+    if (result_visibility == ResultVisibility::Unobservable && promise && PromisePrototype::is_original_then_function(then) && then.as_function().realm() == &realm) {
+        auto* constructor = TRY(species_constructor(vm, *promise, realm.intrinsics().promise_constructor()));
+        if (constructor == realm.intrinsics().promise_constructor().ptr())
+            return promise->perform_then(on_fulfilled, on_rejected, nullptr);
+
+        auto result_capability = TRY(new_promise_capability(vm, constructor));
+        return promise->perform_then(on_fulfilled, on_rejected, result_capability);
+    }
+
+    return call(vm, then, promise_value, on_fulfilled, on_rejected);
+}
 
 static ThrowCompletionOr<Value> perform_promise_common(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve, EndOfElementsCallback end_of_list, InvokeElementFunctionCallback invoke_element_function)
 {
@@ -96,6 +121,7 @@ static ThrowCompletionOr<Value> perform_promise_common(VM& vm, IteratorRecord& i
 static ThrowCompletionOr<Value> perform_promise_all(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve)
 {
     auto& realm = *vm.current_realm();
+    auto result_visibility = &constructor.as_function() == realm.intrinsics().promise_constructor().ptr() ? ResultVisibility::Unobservable : ResultVisibility::Observable;
 
     return perform_promise_common(
         vm, iterator_record, constructor, result_capability, promise_resolve,
@@ -119,10 +145,9 @@ static ThrowCompletionOr<Value> perform_promise_all(VM& vm, IteratorRecord& iter
             // p. Set onFulfilled.[[Capability]] to resultCapability.
             // q. Set onFulfilled.[[RemainingElements]] to remainingElementsCount.
             auto on_fulfilled = PromiseAllResolveElementFunction::create(realm, index, values, result_capability, remaining_elements_count);
-            on_fulfilled->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
             // s. Perform ? Invoke(nextPromise, "then", « onFulfilled, resultCapability.[[Reject]] »).
-            return next_promise.invoke(vm, vm.names.then, on_fulfilled, result_capability.reject());
+            return invoke_then(vm, realm, next_promise, on_fulfilled, result_capability.reject(), result_visibility);
         });
 }
 
@@ -130,6 +155,7 @@ static ThrowCompletionOr<Value> perform_promise_all(VM& vm, IteratorRecord& iter
 static ThrowCompletionOr<Value> perform_promise_all_settled(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve)
 {
     auto& realm = *vm.current_realm();
+    auto result_visibility = &constructor.as_function() == realm.intrinsics().promise_constructor().ptr() ? ResultVisibility::Unobservable : ResultVisibility::Observable;
 
     return perform_promise_common(
         vm, iterator_record, constructor, result_capability, promise_resolve,
@@ -151,7 +177,6 @@ static ThrowCompletionOr<Value> perform_promise_all_settled(VM& vm, IteratorReco
             // q. Set onFulfilled.[[Capability]] to resultCapability.
             // r. Set onFulfilled.[[RemainingElements]] to remainingElementsCount.
             auto on_fulfilled = PromiseAllSettledResolveElementFunction::create(realm, index, values, result_capability, remaining_elements_count);
-            on_fulfilled->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
             // s. Let stepsRejected be the algorithm steps defined in Promise.allSettled Reject Element Functions.
             // t. Let lengthRejected be the number of non-optional parameters of the function definition in Promise.allSettled Reject Element Functions.
@@ -162,10 +187,9 @@ static ThrowCompletionOr<Value> perform_promise_all_settled(VM& vm, IteratorReco
             // y. Set onRejected.[[Capability]] to resultCapability.
             // z. Set onRejected.[[RemainingElements]] to remainingElementsCount.
             auto on_rejected = PromiseAllSettledRejectElementFunction::create(realm, index, values, result_capability, remaining_elements_count);
-            on_rejected->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
             // ab. Perform ? Invoke(nextPromise, "then", « onFulfilled, onRejected »).
-            return next_promise.invoke(vm, vm.names.then, on_fulfilled, on_rejected);
+            return invoke_then(vm, realm, next_promise, on_fulfilled, on_rejected, result_visibility);
         });
 }
 
@@ -173,6 +197,7 @@ static ThrowCompletionOr<Value> perform_promise_all_settled(VM& vm, IteratorReco
 static ThrowCompletionOr<Value> perform_promise_any(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability& result_capability, Value promise_resolve)
 {
     auto& realm = *vm.current_realm();
+    auto result_visibility = &constructor.as_function() == realm.intrinsics().promise_constructor().ptr() ? ResultVisibility::Unobservable : ResultVisibility::Observable;
 
     return perform_promise_common(
         vm, iterator_record, constructor, result_capability, promise_resolve,
@@ -198,16 +223,18 @@ static ThrowCompletionOr<Value> perform_promise_any(VM& vm, IteratorRecord& iter
             // p. Set onRejected.[[Capability]] to resultCapability.
             // q. Set onRejected.[[RemainingElements]] to remainingElementsCount.
             auto on_rejected = PromiseAnyRejectElementFunction::create(realm, index, errors, result_capability, remaining_elements_count);
-            on_rejected->define_direct_property(vm.names.name, PrimitiveString::create(vm, Utf16String {}), Attribute::Configurable);
 
             // s. Perform ? Invoke(nextPromise, "then", « resultCapability.[[Resolve]], onRejected »).
-            return next_promise.invoke(vm, vm.names.then, result_capability.resolve(), on_rejected);
+            return invoke_then(vm, realm, next_promise, result_capability.resolve(), on_rejected, result_visibility);
         });
 }
 
 // 27.2.4.5.1 PerformPromiseRace ( iteratorRecord, constructor, resultCapability, promiseResolve ), https://tc39.es/ecma262/#sec-performpromiserace
 static ThrowCompletionOr<Value> perform_promise_race(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve)
 {
+    auto& realm = *vm.current_realm();
+    auto result_visibility = &constructor.as_function() == realm.intrinsics().promise_constructor().ptr() ? ResultVisibility::Unobservable : ResultVisibility::Observable;
+
     return perform_promise_common(
         vm, iterator_record, constructor, result_capability, promise_resolve,
         [&](PromiseValueList&) -> ThrowCompletionOr<Value> {
@@ -216,7 +243,7 @@ static ThrowCompletionOr<Value> perform_promise_race(VM& vm, IteratorRecord& ite
         },
         [&](PromiseValueList&, RemainingElements&, Value next_promise, size_t) {
             // i. Perform ? Invoke(nextPromise, "then", « resultCapability.[[Resolve]], resultCapability.[[Reject]] »).
-            return next_promise.invoke(vm, vm.names.then, result_capability.resolve(), result_capability.reject());
+            return invoke_then(vm, realm, next_promise, result_capability.resolve(), result_capability.reject(), result_visibility);
         });
 }
 

--- a/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -66,6 +66,80 @@ static ThrowCompletionOr<Value> invoke_then(VM& vm, Realm& realm, Value promise_
     return call(vm, then, promise_value, on_fulfilled, on_rejected);
 }
 
+static ThrowCompletionOr<Value> run_promise_all_resolve_element_job(VM& vm, PromiseValueList& values, JobCallback& resolve_values_array, RemainingElements& remaining_elements_count, size_t index, Value value)
+{
+    // 5. Set values[thisIndex] to value.
+    values.values()[index] = value;
+
+    // 6. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
+    // 7. If remainingElementsCount.[[Value]] = 0, then
+    if (--remaining_elements_count.value == 0) {
+        // a. Let valuesArray be CreateArrayFromList(values).
+        auto values_array = Array::create_from(*vm.current_realm(), values.values());
+
+        // b. Return ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+        Value argument = values_array;
+        return vm.host_call_job_callback(resolve_values_array, js_undefined(), ReadonlySpan<Value> { &argument, 1 });
+    }
+
+    // 8. Return undefined.
+    return js_undefined();
+}
+
+static ThrowCompletionOr<Value> invoke_promise_all_then(VM& vm, Realm& realm, Value promise_value, PromiseValueList& values, PromiseCapability const& result_capability, RemainingElements& remaining_elements_count, size_t index, ResultVisibility result_visibility, GC::Ptr<JobCallback>& resolve_values_array)
+{
+    // OPTIMIZATION: Share the host callback used to resolve the final values array across all internal reaction jobs.
+    if (result_visibility == ResultVisibility::Unobservable && !resolve_values_array) {
+        auto resolve_values_array_function = NativeFunction::create(realm, [result_capability = GC::Ref { result_capability }](VM& vm) { return call(vm, *result_capability->resolve(), js_undefined(), vm.argument(0)); }, 1);
+        resolve_values_array = vm.host_make_job_callback(resolve_values_array_function);
+    }
+
+    auto then = TRY(promise_value.get(vm, vm.names.then));
+
+    auto create_on_fulfilled = [&] {
+        return PromiseAllResolveElementFunction::create(realm, index, values, result_capability, remaining_elements_count);
+    };
+
+    // OPTIMIZATION: Queue the intrinsic Promise.all reaction directly for an already-settled promise, avoiding the
+    //               otherwise unobservable per-element resolve function, JobCallback, and PromiseReaction allocations.
+    auto promise = promise_value.as_if<Promise>();
+    if (result_visibility == ResultVisibility::Unobservable && promise && PromisePrototype::is_original_then_function(then) && then.as_function().realm() == &realm) {
+        auto* constructor = TRY(species_constructor(vm, *promise, realm.intrinsics().promise_constructor()));
+        if (constructor == realm.intrinsics().promise_constructor().ptr()) {
+            if (promise->state() == Promise::State::Fulfilled) {
+                auto value = promise->result();
+                auto job = GC::create_function(vm.heap(), [&vm, values = GC::Ref { values }, resolve_values_array = GC::Ref { *resolve_values_array }, remaining_elements_count = GC::Ref { remaining_elements_count }, index, value] {
+                    return run_promise_all_resolve_element_job(vm, values, resolve_values_array, remaining_elements_count, index, value);
+                });
+                vm.host_enqueue_promise_job(job, &realm);
+                promise->set_is_handled();
+                return js_undefined();
+            }
+
+            if (promise->state() == Promise::State::Rejected) {
+                auto reason = promise->result();
+                if (!promise->is_handled())
+                    vm.host_promise_rejection_tracker(*promise, Promise::RejectionOperation::Handle);
+
+                auto reject = result_capability.reject();
+                auto job = GC::create_function(vm.heap(), [&vm, reject, reason] {
+                    return call(vm, *reject, js_undefined(), reason);
+                });
+                vm.host_enqueue_promise_job(job, &realm);
+                promise->set_is_handled();
+                return js_undefined();
+            }
+
+            return promise->perform_then(create_on_fulfilled(), result_capability.reject(), nullptr);
+        }
+
+        auto dependent_capability = TRY(new_promise_capability(vm, constructor));
+        return promise->perform_then(create_on_fulfilled(), result_capability.reject(), dependent_capability);
+    }
+
+    return call(vm, then, promise_value, create_on_fulfilled(), result_capability.reject());
+}
+
 static ThrowCompletionOr<Value> perform_promise_common(VM& vm, IteratorRecord& iterator_record, Value constructor, PromiseCapability const& result_capability, Value promise_resolve, EndOfElementsCallback end_of_list, InvokeElementFunctionCallback invoke_element_function)
 {
     VERIFY(constructor.is_constructor());
@@ -122,6 +196,7 @@ static ThrowCompletionOr<Value> perform_promise_all(VM& vm, IteratorRecord& iter
 {
     auto& realm = *vm.current_realm();
     auto result_visibility = &constructor.as_function() == realm.intrinsics().promise_constructor().ptr() ? ResultVisibility::Unobservable : ResultVisibility::Observable;
+    GC::Ptr<JobCallback> resolve_values_array;
 
     return perform_promise_common(
         vm, iterator_record, constructor, result_capability, promise_resolve,
@@ -136,18 +211,7 @@ static ThrowCompletionOr<Value> perform_promise_all(VM& vm, IteratorRecord& iter
             return result_capability.promise();
         },
         [&](PromiseValueList& values, RemainingElements& remaining_elements_count, Value next_promise, size_t index) {
-            // j. Let steps be the algorithm steps defined in Promise.all Resolve Element Functions.
-            // k. Let length be the number of non-optional parameters of the function definition in Promise.all Resolve Element Functions.
-            // l. Let onFulfilled be CreateBuiltinFunction(steps, length, "", « [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] »).
-            // m. Set onFulfilled.[[AlreadyCalled]] to false.
-            // n. Set onFulfilled.[[Index]] to index.
-            // o. Set onFulfilled.[[Values]] to values.
-            // p. Set onFulfilled.[[Capability]] to resultCapability.
-            // q. Set onFulfilled.[[RemainingElements]] to remainingElementsCount.
-            auto on_fulfilled = PromiseAllResolveElementFunction::create(realm, index, values, result_capability, remaining_elements_count);
-
-            // s. Perform ? Invoke(nextPromise, "then", « onFulfilled, resultCapability.[[Reject]] »).
-            return invoke_then(vm, realm, next_promise, on_fulfilled, result_capability.reject(), result_visibility);
+            return invoke_promise_all_then(vm, realm, next_promise, values, result_capability, remaining_elements_count, index, result_visibility, resolve_values_array);
         });
 }
 

--- a/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -17,6 +17,12 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(PromisePrototype);
 
+bool PromisePrototype::is_original_then_function(Value value)
+{
+    auto function = value.as_if<RawNativeFunction>();
+    return function && function->native_function() == then;
+}
+
 PromisePrototype::PromisePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Libraries/LibJS/Runtime/PromisePrototype.h
+++ b/Libraries/LibJS/Runtime/PromisePrototype.h
@@ -15,6 +15,8 @@ class PromisePrototype final : public PrototypeObject<PromisePrototype, Promise>
     GC_DECLARE_ALLOCATOR(PromisePrototype);
 
 public:
+    static bool is_original_then_function(Value);
+
     virtual void initialize(Realm&) override;
     virtual ~PromisePrototype() override = default;
 

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -45,7 +45,11 @@ PromiseResolvingElementFunction::PromiseResolvingElementFunction(size_t index, P
 void PromiseResolvingElementFunction::initialize(Realm& realm)
 {
     Base::initialize(realm);
-    define_direct_property(vm().names.length, Value(1), Attribute::Configurable);
+
+    auto& intrinsics = realm.intrinsics();
+    unsafe_set_shape(intrinsics.native_function_shape());
+    put_direct(intrinsics.native_function_length_offset(), Value(1));
+    put_direct(intrinsics.native_function_name_offset(), PrimitiveString::create(vm(), Utf16String {}));
 }
 
 ThrowCompletionOr<Value> PromiseResolvingElementFunction::call()

--- a/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -34,7 +34,11 @@ PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, Kind kind, 
 void PromiseResolvingFunction::initialize(Realm& realm)
 {
     Base::initialize(realm);
-    define_direct_property(vm().names.length, Value(1), Attribute::Configurable);
+
+    auto& intrinsics = realm.intrinsics();
+    unsafe_set_shape(intrinsics.native_function_shape());
+    put_direct(intrinsics.native_function_length_offset(), Value(1));
+    put_direct(intrinsics.native_function_name_offset(), PrimitiveString::create(vm(), Utf16String {}));
 }
 
 ThrowCompletionOr<Value> PromiseResolvingFunction::call()

--- a/Tests/LibJS/Runtime/builtins/Promise/Promise.all.js
+++ b/Tests/LibJS/Runtime/builtins/Promise/Promise.all.js
@@ -76,6 +76,76 @@ describe("normal behavior", () => {
         expect(resolvedValues).toEqual([42]);
     });
 
+    test("invokes a then getter that returns the original method", () => {
+        const promise = Promise.resolve(42);
+        const originalThen = promise.then;
+        let callCount = 0;
+        let resolvedValues = null;
+
+        Object.defineProperty(promise, "then", {
+            configurable: true,
+            get() {
+                ++callCount;
+                return originalThen;
+            },
+        });
+
+        Promise.all([promise]).then(values => {
+            resolvedValues = values;
+        });
+
+        runQueuedPromiseJobs();
+        expect(callCount).toBe(1);
+        expect(resolvedValues).toEqual([42]);
+    });
+
+    test("observes the promise constructor when invoking then", () => {
+        const promise = Promise.resolve(42);
+        let constructorCallCount = 0;
+
+        Object.defineProperty(promise, "constructor", {
+            configurable: true,
+            get() {
+                ++constructorCallCount;
+                return Promise;
+            },
+        });
+
+        Promise.all([promise]);
+        expect(constructorCallCount).toBe(2);
+        runQueuedPromiseJobs();
+        expect(constructorCallCount).toBe(2);
+    });
+
+    test("resolves the result array through an inherited then getter", () => {
+        const originalThen = Object.getOwnPropertyDescriptor(Array.prototype, "then");
+        const marker = {};
+        let thenCallCount = 0;
+        let resolvedValues = null;
+
+        Object.defineProperty(Array.prototype, "then", {
+            configurable: true,
+            get() {
+                if (this.length === 1 && this[0] === marker) ++thenCallCount;
+                return undefined;
+            },
+        });
+
+        try {
+            Promise.all([Promise.resolve(marker)]).then(values => {
+                resolvedValues = values;
+            });
+
+            runQueuedPromiseJobs();
+        } finally {
+            if (originalThen) Object.defineProperty(Array.prototype, "then", originalThen);
+            else delete Array.prototype.then;
+        }
+
+        expect(thenCallCount).toBe(1);
+        expect(resolvedValues).toEqual([marker]);
+    });
+
     test("observes Symbol.species when invoking then", () => {
         const originalSpecies = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
         let speciesCallCount = 0;

--- a/Tests/LibJS/Runtime/builtins/Promise/Promise.all.js
+++ b/Tests/LibJS/Runtime/builtins/Promise/Promise.all.js
@@ -55,6 +55,74 @@ describe("normal behavior", () => {
         expect(rejectionReason).toBe("foo");
         expect(wasResolved).toBeFalse();
     });
+
+    test("invokes an overridden then method", () => {
+        const promise = Promise.resolve(42);
+        const originalThen = promise.then;
+        let callCount = 0;
+        let resolvedValues = null;
+
+        promise.then = function (...args) {
+            ++callCount;
+            return originalThen.apply(this, args);
+        };
+
+        Promise.all([promise]).then(values => {
+            resolvedValues = values;
+        });
+
+        runQueuedPromiseJobs();
+        expect(callCount).toBe(1);
+        expect(resolvedValues).toEqual([42]);
+    });
+
+    test("observes Symbol.species when invoking then", () => {
+        const originalSpecies = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+        let speciesCallCount = 0;
+
+        Object.defineProperty(Promise, Symbol.species, {
+            configurable: true,
+            get() {
+                ++speciesCallCount;
+                return Promise;
+            },
+        });
+
+        try {
+            Promise.all([Promise.resolve(42)]);
+            expect(speciesCallCount).toBe(1);
+            runQueuedPromiseJobs();
+            expect(speciesCallCount).toBe(1);
+        } finally {
+            Object.defineProperty(Promise, Symbol.species, originalSpecies);
+        }
+    });
+
+    test("constructs a custom Symbol.species promise when invoking then", () => {
+        const originalSpecies = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+        let constructionCount = 0;
+
+        class SpeciesPromise extends Promise {
+            constructor(executor) {
+                super(executor);
+                ++constructionCount;
+            }
+        }
+
+        Object.defineProperty(Promise, Symbol.species, {
+            configurable: true,
+            value: SpeciesPromise,
+        });
+
+        try {
+            Promise.all([Promise.resolve(42)]);
+            expect(constructionCount).toBe(1);
+            runQueuedPromiseJobs();
+            expect(constructionCount).toBe(1);
+        } finally {
+            Object.defineProperty(Promise, Symbol.species, originalSpecies);
+        }
+    });
 });
 
 describe("exceptional behavior", () => {


### PR DESCRIPTION
Avoid unnecessary allocations when operating on the intrinsic `Promise` constructor. Construct intrinsic capabilities directly, fulfill primitive values without temporary resolving functions, create only the reaction used by an already-settled promise, and omit unobservable dependent promises from combinators.

Queue dedicated internal `Promise.all` jobs for already-settled intrinsic promises instead of allocating a resolve-element function, `JobCallback`, and `PromiseReaction` per element. Preserve the generic path for pending promises, overridden `then`, custom constructors and species, and retain host callback state for final array resolution.

This reduces MicroWeb/timers/promise-all-fanout.html from 3.10 ms to 0.80 ms, approximately a 3.9x speedup.