### PR TITLE
LibWeb: Preserve restored attribute value postings

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/index.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/index.rs
@@ -4579,21 +4579,21 @@ impl ElementFactStore {
         // names are postings rather than facts, so they say only that at least one attribute of the
         // element answers to them.
         let keys = self.attribute_name_keys(name);
-        let old_value = self
-            .staging
-            .get(node)
-            .and_then(|facts| {
-                facts
-                    .attributes
-                    .binary_search_by_key(&name, |entry| entry.0)
-                    .ok()
-                    .map(|index| facts.attributes[index].1)
-            })
-            .or_else(|| {
-                let attributes = self.rows.attributes_of(self.rows.row_of(node)?);
-                let index = attributes.binary_search_by_key(&name, |entry| entry.name).ok()?;
-                Some(attributes[index].value)
-            });
+        let old_value = if let Some(facts) = self.staging.get(node) {
+            facts
+                .attributes
+                .binary_search_by_key(&name, |entry| entry.0)
+                .ok()
+                .map(|index| facts.attributes[index].1)
+        } else if let Some(row) = self.rows.row_of(node) {
+            let attributes = self.rows.attributes_of(row);
+            attributes
+                .binary_search_by_key(&name, |entry| entry.name)
+                .ok()
+                .map(|index| attributes[index].value)
+        } else {
+            None
+        };
         let changed = self.edit_staged_row(node, |facts| {
             let found = facts.attributes.binary_search_by_key(&name, |entry| entry.0);
             match (present, found) {
@@ -4626,7 +4626,7 @@ impl ElementFactStore {
                 }
             }
         }
-        if old_value != Some(value) {
+        if !present || old_value != Some(value) {
             if let Some(old_value) = old_value {
                 let old_value_is_still_present = self
                     .staging

--- a/Tests/LibWeb/Text/expected/css/style-engine/query-selector-all-attribute-value-index.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/query-selector-all-attribute-value-index.txt
@@ -21,5 +21,6 @@ moved results use tree order: true
 old value removed from index: true
 new value added to index: true
 old value posting is removed: true
+value restored before commit stays indexed: true
 shared value remains indexed: true
 shadow-root query stays scoped: true

--- a/Tests/LibWeb/Text/input/css/style-engine/query-selector-all-attribute-value-index.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/query-selector-all-attribute-value-index.html
@@ -88,6 +88,14 @@
         const staleAfter = internals.styleEngineCounters().selectorQueryEvaluations;
         println(`old value posting is removed: ${staleResults.length === 0 && staleAfter === staleBefore}`);
 
+        const restored = document.createElement("span");
+        restored.setAttribute("data-restored-value", "same");
+        root.appendChild(restored);
+        internals.updateStyle();
+        restored.removeAttribute("data-restored-value");
+        restored.setAttribute("data-restored-value", "same");
+        println(`value restored before commit stays indexed: ${root.querySelectorAll('[data-restored-value="same"]')[0] === restored}`);
+
         const shared = document.createElement("span");
         shared.setAttribute("data-first", "shared");
         shared.setAttribute("data-second", "shared");


### PR DESCRIPTION
Treat staged attribute facts as authoritative when updating the attribute-value selector index. This keeps a remove-and-restore sequence from consulting an older committed row and skipping reinsertion of the value posting.

Always perform value-posting cleanup when removing an attribute, and cover restoring the same value before staged facts are committed.

Work towards #11355