### PR TITLE
LibWeb: Move layout tree structural mutation into Rust

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3333,8 +3333,7 @@ void Element::clear_synthetic_pseudo_element_layout_nodes()
                 return TraversalDecision::Continue;
             });
             layout_node->prepare_subtree_for_detach_from_layout_tree();
-            if (layout_node->parent())
-                layout_node->remove();
+            Layout::detach_layout_node_for_destruction(*layout_node);
         }
         pseudo_element.set_layout_node(nullptr);
     });

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1345,7 +1345,7 @@ void Node::remove(bool suppress_observers)
                     return TraversalDecision::Continue;
                 });
                 layout_node->prepare_subtree_for_detach_from_layout_tree();
-                layout_node->remove();
+                VERIFY(Layout::detach_layout_node_for_destruction(*layout_node));
                 if (auto* parent_layout_node = parent->unsafe_layout_node(); !parent_layout_node->has_children())
                     parent_layout_node->set_children_are_inline(false);
                 parent->set_needs_layout_update(SetNeedsLayoutReason::LayoutTreeUpdate);
@@ -2397,7 +2397,7 @@ void Node::removed_from(IsSubtreeRoot, Node* old_parent, Node&)
     if (m_layout_node) {
         if (auto* top_layer_placement = m_layout_node->topmost_layout_node_of_top_layer_placement()) {
             top_layer_placement->prepare_subtree_for_detach_from_layout_tree();
-            top_layer_placement->remove();
+            VERIFY(Layout::detach_layout_node_for_destruction(*top_layer_placement));
         }
     }
     m_layout_node = nullptr;

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -720,3 +720,8 @@ extern "C" WEB_API size_t ladybird_layout_text_node_rendered_text_offset_for_dom
         : Web::Layout::TextNode::RenderedTextBoundary::Start;
     return text_node.rendered_text_offset_for_dom_offset(offset, boundary);
 }
+
+extern "C" WEB_API void ladybird_layout_node_shell_release(void* shell)
+{
+    static_cast<Web::Layout::Node*>(shell)->unref();
+}

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -74,3 +74,5 @@ extern "C" WEB_API bool ladybird_layout_code_point_has_combining_mark_line_break
 extern "C" WEB_API bool ladybird_layout_code_point_has_emoji_property(u32);
 extern "C" WEB_API size_t ladybird_layout_text_node_dom_offset_for_rendered_text_offset(void*, size_t, bool use_end_boundary);
 extern "C" WEB_API size_t ladybird_layout_text_node_rendered_text_offset_for_dom_offset(void*, size_t, bool use_end_boundary);
+
+extern "C" WEB_API void ladybird_layout_node_shell_release(void*);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1292,6 +1292,7 @@ GC::Ptr<DOM::Element> Node::pseudo_element_generator()
 
 void Node::set_generated_for(CSS::PseudoElement type, DOM::Element& element)
 {
+    static_assert(encode_generated_for(CSS::PseudoElement::After) == RustFFI::GENERATED_FOR_AFTER);
     static_assert(encode_generated_for(CSS::PseudoElement::Marker) == RustFFI::GENERATED_FOR_MARKER);
     m_data->generated_for = encode_generated_for(type);
     m_pseudo_element_generator = element;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -202,39 +202,6 @@ void* Node::arena_handle() const
     return m_arena->handle();
 }
 
-void Node::insert_before(NonnullRefPtr<Node> node, Node* before)
-{
-    auto& adopted_node = node.leak_ref();
-    RustFFI::layout_arena_attach_child(m_arena->handle(), slot_id(this), slot_id(&adopted_node), slot_id(before));
-}
-
-void Node::append_child(NonnullRefPtr<Node> node)
-{
-    insert_before(move(node), nullptr);
-}
-
-void Node::prepend_child(NonnullRefPtr<Node> node)
-{
-    insert_before(move(node), first_child_ptr());
-}
-
-void Node::remove_child(Node& node)
-{
-    RustFFI::layout_arena_detach_child(m_arena->handle(), slot_id(this), slot_id(&node));
-}
-
-void Node::replace_child(NonnullRefPtr<Node> new_child, Node& old_child)
-{
-    VERIFY(&old_child != new_child.ptr());
-    auto& adopted_child = new_child.leak_ref();
-    RustFFI::layout_arena_replace_child(m_arena->handle(), slot_id(this), slot_id(&old_child), slot_id(&adopted_child));
-}
-
-void Node::remove()
-{
-    VERIFY(detach_layout_node_for_destruction(*this));
-}
-
 Box const* Node::containing_block() const
 {
     return static_cast<Box const*>(tree_node_from_slot_if_live(m_data->containing_block));

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -80,10 +80,6 @@ Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, AttachToDOMNode att
 Node::~Node()
 {
     VERIFY(!parent_ptr());
-    while (auto* child = first_child_ptr()) {
-        RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(child));
-        child->unref();
-    }
 }
 
 RustFFI::NodeSlotId Node::slot_id(Node const* node)
@@ -172,19 +168,9 @@ void Node::bump_fragment_cache_epoch()
     ++node_data().fragment_cache_epoch;
 }
 
-// NB: Bumps can legitimately run while another document's layout pass is on the stack (a
-// parent pass sizing a child navigable's viewport invalidates the child document), so the
-// helpers must not assert against the process-global pass flag. A bump landing between a
-// run's probe and its store is handled by storing the probe-time validity, which turns it
-// into a fail-safe miss.
 void Node::bump_fragment_cache_epoch_of_self_and_ancestors()
 {
-    for (auto* node = this; node; node = node->parent_ptr()) {
-        if (fragment_cache_epochs_enabled())
-            ++node->node_data().fragment_cache_epoch;
-        if (auto* box = as_if<Box>(*node))
-            Painting::clear_cached_overflow_data(*box);
-    }
+    RustFFI::layout_arena_bump_fragment_cache_epoch_of_self_and_ancestors(arena_handle(), slot_id(this));
 }
 
 // Reset intrinsic size caches for ancestors up to abspos or SVG root boundary.
@@ -218,9 +204,8 @@ void* Node::arena_handle() const
 
 void Node::insert_before(NonnullRefPtr<Node> node, Node* before)
 {
-    RustFFI::layout_arena_insert_child(m_arena->handle(), slot_id(this), slot_id(node.ptr()), slot_id(before));
-    bump_fragment_cache_epoch_of_self_and_ancestors();
-    (void)node.leak_ref();
+    auto& adopted_node = node.leak_ref();
+    RustFFI::layout_arena_attach_child(m_arena->handle(), slot_id(this), slot_id(&adopted_node), slot_id(before));
 }
 
 void Node::append_child(NonnullRefPtr<Node> node)
@@ -235,27 +220,19 @@ void Node::prepend_child(NonnullRefPtr<Node> node)
 
 void Node::remove_child(Node& node)
 {
-    RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(&node));
-    bump_fragment_cache_epoch_of_self_and_ancestors();
-    node.unref();
+    RustFFI::layout_arena_detach_child(m_arena->handle(), slot_id(this), slot_id(&node));
 }
 
 void Node::replace_child(NonnullRefPtr<Node> new_child, Node& old_child)
 {
     VERIFY(&old_child != new_child.ptr());
-    auto successor_slot = old_child.m_data->next_sibling;
-    RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(&old_child));
-    RustFFI::layout_arena_insert_child(m_arena->handle(), slot_id(this), slot_id(new_child.ptr()), successor_slot);
-    bump_fragment_cache_epoch_of_self_and_ancestors();
-    old_child.unref();
-    (void)new_child.leak_ref();
+    auto& adopted_child = new_child.leak_ref();
+    RustFFI::layout_arena_replace_child(m_arena->handle(), slot_id(this), slot_id(&old_child), slot_id(&adopted_child));
 }
 
 void Node::remove()
 {
-    auto* parent = parent_ptr();
-    VERIFY(parent);
-    parent->remove_child(*this);
+    VERIFY(detach_layout_node_for_destruction(*this));
 }
 
 Box const* Node::containing_block() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -233,12 +233,11 @@ public:
 
     void bump_fragment_cache_epoch();
 
-    // Any invalidation or restructuring below a node must reach every ancestor's epoch: cached
-    // runs capture subtree structure, and unlike intrinsic-size invalidation there is no
-    // absolutely-positioned or SVG boundary — those descendants' fragments live in ancestor
-    // run trees. Layout tree restructuring in particular never funnels through
-    // set_needs_layout_update (a full pass lays out everything), so the tree mutation
-    // primitives call this on the parent of every structural change.
+    // Any invalidation below a node must reach every ancestor's epoch: cached runs capture
+    // subtree structure, and unlike intrinsic-size invalidation there is no absolutely-positioned
+    // or SVG boundary — those descendants' fragments live in ancestor run trees. The arena runs
+    // the same walk for every structural change; this serves content changes that never
+    // restructure the tree.
     void bump_fragment_cache_epoch_of_self_and_ancestors();
 
     // Set when a style change altered geometry-determining properties of this node itself, so

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -209,14 +209,6 @@ public:
         return false;
     }
 
-    void append_child(NonnullRefPtr<Node>);
-    void prepend_child(NonnullRefPtr<Node>);
-    void insert_before(NonnullRefPtr<Node>, Node* before);
-    void insert_before(NonnullRefPtr<Node> node, Node& before) { insert_before(move(node), &before); }
-    void remove_child(Node&);
-    void replace_child(NonnullRefPtr<Node> new_child, Node& old_child);
-    void remove();
-
     bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }
     bool insets_use_anchor_functions() const { return has_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions); }
     DOM::Node const* dom_node() const;

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -55,6 +55,11 @@ void NodeArena::drop_intrinsic_size_cache(RustFFI::NodeData const& node_data) co
     RustFFI::layout_arena_drop_intrinsic_size_cache(m_handle, &node_data);
 }
 
+bool detach_layout_node_for_destruction(Node& node)
+{
+    return RustFFI::layout_arena_detach_node_for_destruction(node.arena_handle(), Node::slot_id(&node));
+}
+
 void NodeArena::enroll_text_node_for_content_sync(TextNode const& text_node)
 {
     m_text_nodes_enrolled_for_content_sync.append(text_node.make_weak_ptr<TextNode>());

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -54,4 +54,6 @@ private:
     Vector<WeakPtr<Node>> m_nodes_enrolled_for_replaced_content_facts_sync;
 };
 
+WEB_API bool detach_layout_node_for_destruction(Node&);
+
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -877,7 +877,7 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node
         // The parent may keep its subtree (a child lost its box in place); an emptied container
         // reads as having block-level children, like a freshly built one.
         auto* parent = layout_node->parent();
-        layout_node->remove();
+        detach_layout_node_for_destruction(*layout_node);
         if (!parent->has_children())
             parent->set_children_are_inline(false);
     }
@@ -898,9 +898,6 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
         .prepare_subtree_for_detach = [](void* layout_node_pointer) {
             VERIFY(layout_node_pointer);
             static_cast<Layout::Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
-        .remove_layout_node = [](void* layout_node_pointer) {
-            VERIFY(layout_node_pointer);
-            static_cast<Layout::Node*>(layout_node_pointer)->remove(); },
         .clear_stale_subtree = [](void* root_pointer) {
             VERIFY(root_pointer);
             auto& root = *static_cast<DOM::Node*>(root_pointer);
@@ -1172,14 +1169,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(element_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
-            bool removed_old_backdrop_layout_node = false;
             if (should_create_layout_node) {
-                // ::backdrop is a sibling of the element, not a child, so unlike other pseudo-elements, it is not
-                // automatically discarded when the element's layout is recomputed.
-                if (auto old_backdrop_node = element.pseudo_element_unsafe_layout_node(CSS::PseudoElement::Backdrop)) {
-                    removed_old_backdrop_layout_node = true;
-                    old_backdrop_node->remove();
-                }
                 LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(element);
                 update_style_if_needed_for_layout_tree_bypass_path(element);
             }
@@ -1191,7 +1181,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(computed_values);
             return {
                 .display = ffi_principal_display_facts(computed_values->display()),
-                .removed_old_backdrop_layout_node = removed_old_backdrop_layout_node,
             }; },
         .principal_element_layout_facts = [](void* frame_pointer, void* element_pointer) -> RustFFI::FfiElementLayoutFacts {
             VERIFY(frame_pointer);
@@ -1290,13 +1279,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
             builder.m_layout_root = frame.layout_node; },
-        .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(node_pointer);
-            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
-            static_cast<DOM::Node*>(node_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
-                return builder.clear_stale_layout_node(node);
-            }); },
         .document_layout_node = [](void* document_pointer) -> RustFFI::NodeSlotId {
             VERIFY(document_pointer);
             // NB: Called during layout tree construction.

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -70,8 +70,7 @@ private:
     RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks();
 
     static NonnullRefPtr<BlockContainer> create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style);
-    static NonnullRefPtr<BlockContainer> create_and_attach_list_item_marker(BlockContainer& list_box, DOM::Element&, CSS::PseudoElement originating_pseudo, CSS::LayoutStyle marker_style);
-    static void create_first_letter_wrapper(DOM::Element&, RustFFI::FfiFirstLetterTarget);
+    static RustFFI::FfiFirstLetterNodes create_first_letter_nodes(DOM::Element&, RustFFI::FfiFirstLetterTarget);
 
     RefPtr<Layout::Node> m_layout_root;
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
@@ -104,7 +103,8 @@ void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& el
 
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
-static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&, bool needs_style_wrapper);
+struct PrincipalNodeFrame;
+static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(PrincipalNodeFrame&, DOM::Text&, bool needs_style_wrapper);
 
 static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node)
 {
@@ -426,6 +426,11 @@ static NonnullRefPtr<Box> create_content_image_box(DOM::Document& document, GC::
     return image_box;
 }
 
+static RustFFI::NodeSlotId release_to_rust(NonnullRefPtr<Node> node)
+{
+    return Node::slot_id(&node.leak_ref());
+}
+
 template<typename T>
 static RustFFI::NodeSlotId retain_for_rust(RefPtr<T> const& node)
 {
@@ -472,7 +477,7 @@ static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& docu
     };
 }
 
-void LayoutTreeBuildBridge::create_first_letter_wrapper(DOM::Element& element, RustFFI::FfiFirstLetterTarget target)
+RustFFI::FfiFirstLetterNodes LayoutTreeBuildBridge::create_first_letter_nodes(DOM::Element& element, RustFFI::FfiFirstLetterTarget target)
 {
     VERIFY(target.found);
     auto& text_node = as<TextNode>(*static_cast<Node*>(target.text_node));
@@ -484,19 +489,16 @@ void LayoutTreeBuildBridge::create_first_letter_wrapper(DOM::Element& element, R
     VERIFY(first_letter_values);
     auto display = first_letter_values->display();
     auto first_letter_wrapper = DOM::Element::create_layout_node_for_display_type(document, display, CSS::LayoutStyle { element.style_record_identity(CSS::PseudoElement::FirstLetter) }, nullptr);
-    if (!first_letter_wrapper)
-        return;
-    first_letter_wrapper->attach_style_resources();
-    first_letter_wrapper->set_generated_for(CSS::PseudoElement::FirstLetter, element);
-    first_letter_wrapper->set_children_are_inline(true);
-    first_letter_wrapper->append_child(*first_letter_slice);
-    LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::FirstLetter, first_letter_wrapper);
-
-    auto* parent = text_node.parent();
-    VERIFY(parent);
-    parent->insert_before(*first_letter_wrapper, text_node);
-    parent->insert_before(*remainder_slice, text_node);
-    parent->remove_child(text_node);
+    if (first_letter_wrapper) {
+        first_letter_wrapper->attach_style_resources();
+        first_letter_wrapper->set_generated_for(CSS::PseudoElement::FirstLetter, element);
+        LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::FirstLetter, first_letter_wrapper);
+    }
+    return {
+        .wrapper = retain_for_rust(first_letter_wrapper),
+        .first_letter_slice = release_to_rust(move(first_letter_slice)),
+        .remainder_slice = release_to_rust(move(remainder_slice)),
+    };
 }
 
 NonnullRefPtr<BlockContainer> LayoutTreeBuildBridge::create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style)
@@ -550,33 +552,6 @@ static CSS::ContentData resolve_normal_marker_content(DOM::AbstractElement& elem
         });
     content.data.append(move(marker_string));
     return content;
-}
-
-NonnullRefPtr<BlockContainer> LayoutTreeBuildBridge::create_and_attach_list_item_marker(BlockContainer& list_box, DOM::Element& element, CSS::PseudoElement originating_pseudo, CSS::LayoutStyle marker_style)
-{
-    auto list_item_marker = create_list_item_marker(list_box, move(marker_style));
-    list_item_marker->attach_style_resources();
-    list_item_marker->set_generated_for(CSS::PseudoElement::Marker, element);
-    LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::Marker, list_item_marker);
-    list_box.prepend_child(*list_item_marker);
-
-    DOM::AbstractElement element_reference { element, originating_pseudo };
-    auto content = resolve_normal_marker_content(element_reference, list_box, *list_item_marker);
-    if (auto const* text = content.data.first().get_pointer<Utf16String>()) {
-        auto text_node = make_ref_counted<GeneratedTextNode>(list_box.document(), *text);
-        text_node->set_generated_for(CSS::PseudoElement::Marker, element);
-        list_item_marker->append_child(*text_node);
-    } else {
-        auto& image = *content.data.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
-        auto image_box = create_content_image_box(list_box.document(), nullptr, list_item_marker->copy_computed_values(), image);
-        image_box->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-        image_box->attach_style_resources();
-        image_box->set_generated_for(CSS::PseudoElement::Marker, element);
-        list_item_marker->append_child(*image_box);
-    }
-    list_item_marker->set_content(content);
-    list_item_marker->set_children_are_inline(true);
-    return list_item_marker;
 }
 
 static CSS::PseudoElement css_pseudo_element(RustFFI::FfiPseudoElement pseudo_element)
@@ -762,16 +737,43 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 frame.layout_node->set_display(CSS::Display::from_short(CSS::Display::Short::Inline));
             else
                 VERIFY_NOT_REACHED(); },
-        .create_nested_list_marker = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement originating_pseudo) {
-            VERIFY(builder_pointer);
+        .create_nested_list_marker = [](void* frame_pointer, void* element_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             VERIFY(frame.layout_node);
             auto marker_style = element.document().style_computer().materialize_style_record({ element, CSS::PseudoElement::Marker });
-            (void)builder.create_and_attach_list_item_marker(as<BlockContainer>(*frame.layout_node), element, css_pseudo_element(originating_pseudo), move(marker_style)); },
+            auto list_item_marker = create_list_item_marker(as<BlockContainer>(*frame.layout_node), move(marker_style));
+            list_item_marker->attach_style_resources();
+            list_item_marker->set_generated_for(CSS::PseudoElement::Marker, element);
+            LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::Marker, list_item_marker);
+            return release_to_rust(move(list_item_marker)); },
+        .create_nested_list_marker_content = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement originating_pseudo, void* marker_pointer) -> RustFFI::NodeSlotId {
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            VERIFY(marker_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            auto& list_box = as<BlockContainer>(*frame.layout_node);
+            auto& list_item_marker = as<BlockContainer>(*static_cast<Node*>(marker_pointer));
+            DOM::AbstractElement element_reference { element, css_pseudo_element(originating_pseudo) };
+            auto content = resolve_normal_marker_content(element_reference, list_box, list_item_marker);
+            auto content_node = [&]() -> NonnullRefPtr<Node> {
+                if (auto const* text = content.data.first().get_pointer<Utf16String>()) {
+                    auto text_node = make_ref_counted<GeneratedTextNode>(list_box.document(), *text);
+                    text_node->set_generated_for(CSS::PseudoElement::Marker, element);
+                    return text_node;
+                }
+                auto& image = *content.data.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
+                auto image_box = create_content_image_box(list_box.document(), nullptr, list_item_marker.copy_computed_values(), image);
+                image_box->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+                image_box->attach_style_resources();
+                image_box->set_generated_for(CSS::PseudoElement::Marker, element);
+                return image_box;
+            }();
+            list_item_marker.set_content(content);
+            return release_to_rust(move(content_node)); },
         .configure_layout_node = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -1048,9 +1050,9 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(layout_node_pointer);
             auto* element = as_if<DOM::Element>(static_cast<Node*>(layout_node_pointer)->dom_node());
             return element && element->has_style(CSS::PseudoElement::FirstLetter); },
-        .create_first_letter_wrapper = [](void*, void* element_pointer, RustFFI::FfiFirstLetterTarget target) {
+        .create_first_letter_nodes = [](void*, void* element_pointer, RustFFI::FfiFirstLetterTarget target) -> RustFFI::FfiFirstLetterNodes {
             VERIFY(element_pointer);
-            create_first_letter_wrapper(*static_cast<DOM::Element*>(element_pointer), target); },
+            return create_first_letter_nodes(*static_cast<DOM::Element*>(element_pointer), target); },
         .top_layer_element_count = [](void* document_pointer) {
             VERIFY(document_pointer);
             return static_cast<DOM::Document*>(document_pointer)->top_layer_elements().size(); },
@@ -1254,12 +1256,10 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .text_is_ascii_whitespace = text.data().is_ascii_whitespace(),
                 .parent_collapses_whitespace = style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse),
             }; },
-        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) -> RustFFI::NodeSlotId {
+        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) -> RustFFI::FfiPrincipalTextLayoutNodes {
             VERIFY(frame_pointer);
             VERIFY(text_pointer);
-            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer), needs_style_wrapper);
-            return retain_for_rust(frame.layout_node); },
+            return create_layout_node_for_text(*static_cast<PrincipalNodeFrame*>(frame_pointer), *static_cast<DOM::Text*>(text_pointer), needs_style_wrapper); },
         .reuse_principal_layout = [](void* frame_pointer, void* node_pointer) {
             VERIFY(frame_pointer);
             VERIFY(node_pointer);
@@ -1324,23 +1324,29 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
         element.document().update_style_for_element({ element });
 }
 
-static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node, bool needs_style_wrapper)
+static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(PrincipalNodeFrame& frame, DOM::Text& text_node, bool needs_style_wrapper)
 {
     auto& document = text_node.document();
-    RefPtr<Layout::Node> layout_node = make_ref_counted<Layout::TextNode>(document, text_node);
-    if (needs_style_wrapper) {
-        auto& style_parent = as<DOM::Element>(*text_node.flat_tree_parent());
-        auto style_parent_values = style_parent.computed_style();
-        VERIFY(style_parent_values);
-        auto wrapper_values = CSS::ComputedValues::Builder { *style_parent_values }.build();
-        auto wrapper = make_ref_counted<Layout::NodeWithStyle>(document, nullptr, move(wrapper_values), RustFFI::NodeKind::InlineNode);
-        wrapper->attach_style_resources();
-        wrapper->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-        wrapper->set_children_are_inline(true);
-        wrapper->append_child(*layout_node);
-        return wrapper;
+    auto layout_node = make_ref_counted<Layout::TextNode>(document, text_node);
+    if (!needs_style_wrapper) {
+        frame.layout_node = layout_node;
+        return {
+            .layout_node = retain_for_rust(frame.layout_node),
+            .wrapped_text = RustFFI::NodeSlotId_INVALID,
+        };
     }
-    return layout_node;
+    auto& style_parent = as<DOM::Element>(*text_node.flat_tree_parent());
+    auto style_parent_values = style_parent.computed_style();
+    VERIFY(style_parent_values);
+    auto wrapper_values = CSS::ComputedValues::Builder { *style_parent_values }.build();
+    auto wrapper = make_ref_counted<Layout::NodeWithStyle>(document, nullptr, move(wrapper_values), RustFFI::NodeKind::InlineNode);
+    wrapper->attach_style_resources();
+    wrapper->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+    frame.layout_node = wrapper;
+    return {
+        .layout_node = retain_for_rust(frame.layout_node),
+        .wrapped_text = release_to_rust(move(layout_node)),
+    };
 }
 
 // A full-height flex column that centers the button contents vertically.
@@ -1424,11 +1430,6 @@ static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(v
         .is_open_punctuation = Unicode::code_point_has_general_category(code_point, ps),
         .is_dash_punctuation = Unicode::code_point_has_general_category(code_point, pd),
     };
-}
-
-static RustFFI::NodeSlotId release_to_rust(NonnullRefPtr<Node> node)
-{
-    return Node::slot_id(&node.leak_ref());
 }
 
 static RustFFI::NodeSlotId ffi_create_anonymous_table_box(void*, void* parent_pointer, RustFFI::FfiAnonymousTableBoxKind kind)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -426,6 +426,15 @@ static NonnullRefPtr<Box> create_content_image_box(DOM::Document& document, GC::
     return image_box;
 }
 
+template<typename T>
+static RustFFI::NodeSlotId retain_for_rust(RefPtr<T> const& node)
+{
+    if (!node)
+        return RustFFI::NodeSlotId_INVALID;
+    node->ref();
+    return Node::slot_id(node.ptr());
+}
+
 static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::ComputedContentData const& content)
 {
     if (content.type != CSS::ComputedContentData::Type::List
@@ -709,7 +718,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 .marker_position_is_inside = frame.originating_list_box
                     && frame.originating_list_box->list_style_position() == CSS::ListStylePosition::Inside,
             }; },
-        .create_layout_node = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement, RustFFI::FfiPseudoElementDecision decision) {
+        .create_layout_node = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement, RustFFI::FfiPseudoElementDecision decision) -> RustFFI::NodeSlotId {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -731,18 +740,13 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 break;
             case RustFFI::FfiPseudoElementDecision::Box:
                 if (frame.originating_list_box) {
-                    auto marker = create_list_item_marker(*frame.originating_list_box, style);
-                    if (frame.originating_list_box->list_style_position() == CSS::ListStylePosition::Outside)
-                        frame.originating_list_box->prepend_child(*marker);
-                    frame.layout_node = move(marker);
+                    frame.layout_node = create_list_item_marker(*frame.originating_list_box, style);
                     break;
                 }
                 frame.layout_node = DOM::Element::create_layout_node_for_display_type(document, frame.display, style, nullptr);
                 break;
-            } },
-        .layout_node = [](void* frame_pointer) -> RustFFI::NodeSlotId {
-            VERIFY(frame_pointer);
-            return Node::slot_id(static_cast<PseudoElementFrame*>(frame_pointer)->layout_node.ptr()); },
+            }
+            return retain_for_rust(frame.layout_node); },
         .attach_style_resources = [](void* frame_pointer) {
             VERIFY(frame_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
@@ -829,23 +833,13 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 frame.content_item = move(image_box);
             }
             frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
-            return Node::slot_id(frame.content_item.ptr()); },
+            return retain_for_rust(frame.content_item); },
     };
 }
 
 static bool is_svg_resource_box(Node const& layout_node)
 {
     return layout_node.is_svg_pattern_box() || layout_node.is_svg_mask_box() || layout_node.is_svg_clip_box();
-}
-
-// The replacement box represents the same element in the same tree position, so the flat
-// fragment and inline-box-piece lists held by the containing block of a node that participated
-// in inline layout carry over to it; a subtree relayout that skips the containing block never
-// rebuilds them.
-static void transfer_saved_layout_state_to_replacement_box(Layout::Node& old_layout_node, Layout::Node& new_layout_node)
-{
-    if (auto* containing_block = old_layout_node.containing_block())
-        Painting::transfer_fragments_to_replacement_node(*containing_block, old_layout_node, new_layout_node);
 }
 
 TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)
@@ -1057,16 +1051,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .create_first_letter_wrapper = [](void*, void* element_pointer, RustFFI::FfiFirstLetterTarget target) {
             VERIFY(element_pointer);
             create_first_letter_wrapper(*static_cast<DOM::Element*>(element_pointer), target); },
-        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer, void* parent_pointer) -> RustFFI::NodeSlotId {
-            VERIFY(builder_pointer);
-            VERIFY(layout_node_pointer);
-            VERIFY(parent_pointer);
-            auto& layout_node = *static_cast<Layout::Node*>(layout_node_pointer);
-            if (!layout_node.first_child() || !layout_node.first_child()->is_anonymous()) {
-                auto wrapper = as<NodeWithStyle>(layout_node).create_anonymous_wrapper();
-                static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(wrapper);
-            }
-            return Node::slot_id(layout_node.first_child().ptr()); },
         .top_layer_element_count = [](void* document_pointer) {
             VERIFY(document_pointer);
             return static_cast<DOM::Document*>(document_pointer)->top_layer_elements().size(); },
@@ -1106,6 +1090,16 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(element_pointer);
             // NB: Called during layout tree construction.
             return Node::slot_id(static_cast<DOM::Element*>(element_pointer)->unsafe_layout_node()); },
+        .dom_node_layout_node = [](void* node_pointer) -> RustFFI::NodeSlotId {
+            VERIFY(node_pointer);
+            return Node::slot_id(static_cast<DOM::Node*>(node_pointer)->unsafe_layout_node()); },
+        .layout_node_dom_element = [](void* layout_node_pointer) -> void* {
+            VERIFY(layout_node_pointer);
+            auto* dom_node = static_cast<Layout::Node*>(layout_node_pointer)->dom_node();
+            return dom_node ? as_if<DOM::Element>(*dom_node) : nullptr; },
+        .element_pseudo_layout_node = [](void* element_pointer, RustFFI::FfiPseudoElement pseudo_element) -> RustFFI::NodeSlotId {
+            VERIFY(element_pointer);
+            return Node::slot_id(static_cast<DOM::Element*>(element_pointer)->pseudo_element_unsafe_layout_node(css_pseudo_element(pseudo_element))); },
         .principal_node_entry_facts = [](void*, void* node_pointer, bool must_create_subtree) -> RustFFI::FfiPrincipalNodeEntryFacts {
             VERIFY(node_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
@@ -1209,7 +1203,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .is_svg_clip_path_element = is<SVG::SVGClipPathElement>(element),
                 .is_svg_pattern_element = is<SVG::SVGPatternElement>(element),
             }; },
-        .create_principal_element_layout = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiElementLayoutKind kind) {
+        .create_principal_element_layout = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiElementLayoutKind kind) -> RustFFI::NodeSlotId {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -1239,14 +1233,16 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             case RustFFI::FfiElementLayoutKind::Normal:
                 frame.layout_node = element.create_layout_node(style);
                 break;
-            } },
-        .create_principal_document_layout = [](void* frame_pointer, void* document_pointer) {
+            }
+            return retain_for_rust(frame.layout_node); },
+        .create_principal_document_layout = [](void* frame_pointer, void* document_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(document_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& document = *static_cast<DOM::Document*>(document_pointer);
             frame.anonymous_computed_values = document.style_computer().create_document_style();
-            frame.layout_node = make_ref_counted<Layout::Viewport>(document, frame.anonymous_computed_values.release_nonnull()); },
+            frame.layout_node = make_ref_counted<Layout::Viewport>(document, frame.anonymous_computed_values.release_nonnull());
+            return retain_for_rust(frame.layout_node); },
         .principal_text_layout_facts = [](void* text_pointer) -> RustFFI::FfiTextLayoutFacts {
             VERIFY(text_pointer);
             auto& text = *static_cast<DOM::Text*>(text_pointer);
@@ -1258,11 +1254,12 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .text_is_ascii_whitespace = text.data().is_ascii_whitespace(),
                 .parent_collapses_whitespace = style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse),
             }; },
-        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) {
+        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(text_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer), needs_style_wrapper); },
+            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer), needs_style_wrapper);
+            return retain_for_rust(frame.layout_node); },
         .reuse_principal_layout = [](void* frame_pointer, void* node_pointer) {
             VERIFY(frame_pointer);
             VERIFY(node_pointer);
@@ -1286,40 +1283,13 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 as<NodeWithStyle>(*frame.layout_node).set_display(CSS::Display::from_short(CSS::Display::Short::Inline));
             else
                 VERIFY_NOT_REACHED(); },
-        .insert_principal_backdrop_before_old = [](void* builder_pointer, void* frame_pointer, void* backdrop_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(frame_pointer);
-            VERIFY(backdrop_pointer);
-            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            VERIFY(frame.old_layout_node);
-            VERIFY(frame.old_layout_node->parent());
-            auto& backdrop = *static_cast<Layout::Node*>(backdrop_pointer);
-            frame.old_layout_node->parent()->insert_before(backdrop, frame.old_layout_node); },
-        .place_principal_layout = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
+        .set_layout_root = [](void* builder_pointer, void* frame_pointer) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
-            switch (placement) {
-            case RustFFI::FfiPrincipalBoxPlacement::None:
-                break;
-            case RustFFI::FfiPrincipalBoxPlacement::DocumentRoot:
-                builder.m_layout_root = frame.layout_node;
-                break;
-            case RustFFI::FfiPrincipalBoxPlacement::ReplaceExisting:
-                VERIFY(frame.old_layout_node);
-                transfer_saved_layout_state_to_replacement_box(*frame.old_layout_node, *frame.layout_node);
-                frame.old_layout_node->prepare_subtree_for_detach_from_layout_tree();
-                frame.old_layout_node->parent()->replace_child(*frame.layout_node, *frame.old_layout_node);
-                break;
-            case RustFFI::FfiPrincipalBoxPlacement::AppendSvg:
-                VERIFY(parent_pointer);
-                static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(*frame.layout_node);
-                break;
-            case RustFFI::FfiPrincipalBoxPlacement::NormalInsertion:
-                VERIFY_NOT_REACHED();
-            } },
+            builder.m_layout_root = frame.layout_node; },
         .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
@@ -1521,72 +1491,6 @@ static RustFFI::NodeSlotId ffi_create_anonymous_wrapper(void*, void* parent_poin
     return release_to_rust(parent.create_anonymous_wrapper());
 }
 
-static void ffi_insert_child(void*, void* parent_pointer, void* child_pointer, RustFFI::FfiInsertionMode mode)
-{
-    VERIFY(parent_pointer);
-    VERIFY(child_pointer);
-    auto& parent = *static_cast<Node*>(parent_pointer);
-    NonnullRefPtr child = *static_cast<Node*>(child_pointer);
-    if (mode == RustFFI::FfiInsertionMode::Prepend) {
-        parent.prepend_child(*child);
-        return;
-    }
-    if (mode == RustFFI::FfiInsertionMode::Append) {
-        parent.append_child(*child);
-        return;
-    }
-
-    VERIFY(mode == RustFFI::FfiInsertionMode::InDomOrder);
-    auto* dom_node = child->dom_node();
-    VERIFY(dom_node);
-
-    // An inline child of a block container with block children is placed in a newly appended
-    // anonymous wrapper. Move that empty wrapper to the child's DOM position before filling it.
-    if (parent.is_anonymous() && !parent.has_children()) {
-        if (auto* wrapper_parent = parent.parent()) {
-            for (auto* sibling = dom_node->next_sibling(); sibling; sibling = sibling->next_sibling()) {
-                auto* sibling_layout_node = sibling->unsafe_layout_node();
-                while (sibling_layout_node && sibling_layout_node->parent() != wrapper_parent)
-                    sibling_layout_node = sibling_layout_node->parent();
-                if (!sibling_layout_node || sibling_layout_node == &parent)
-                    continue;
-                NonnullRefPtr wrapper = parent;
-                wrapper_parent->remove_child(parent);
-                wrapper_parent->insert_before(move(wrapper), sibling_layout_node);
-                break;
-            }
-        }
-    }
-
-    for (auto* sibling = dom_node->next_sibling(); sibling; sibling = sibling->next_sibling()) {
-        auto* sibling_layout_node = sibling->unsafe_layout_node();
-        if (sibling_layout_node && sibling_layout_node->parent() == &parent) {
-            parent.insert_before(*child, sibling_layout_node);
-            return;
-        }
-    }
-
-    if (auto const* parent_element = as_if<DOM::Element>(parent.dom_node())) {
-        if (auto* after_layout_node = parent_element->pseudo_element_unsafe_layout_node(CSS::PseudoElement::After)) {
-            auto* after_layout_child = after_layout_node;
-            while (after_layout_child->parent() && after_layout_child->parent() != &parent)
-                after_layout_child = after_layout_child->parent();
-            if (after_layout_child->parent() == &parent) {
-                parent.insert_before(*child, after_layout_child);
-                return;
-            }
-        }
-    }
-
-    for (auto layout_child = parent.first_child(); layout_child; layout_child = layout_child->next_sibling()) {
-        if (layout_child->is_generated_for_after_pseudo_element()) {
-            parent.insert_before(*child, layout_child);
-            return;
-        }
-    }
-    parent.append_child(*child);
-}
-
 static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
@@ -1629,7 +1533,9 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
         .create_anonymous_table_box = ffi_create_anonymous_table_box,
         .create_table_wrapper = ffi_create_table_wrapper,
         .create_missing_table_cell = ffi_create_missing_table_cell,
-        .insert_child = ffi_insert_child,
+        .prepare_subtree_for_detach = [](void*, void* layout_node_pointer) {
+            VERIFY(layout_node_pointer);
+            static_cast<Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
         .text_is_ascii_whitespace = [](void*, void* node_pointer) {
             VERIFY(node_pointer);
             return as<TextNode>(*static_cast<Node*>(node_pointer)).text_for_rendering().is_ascii_whitespace(); },

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1456,31 +1456,15 @@ static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(v
     };
 }
 
-static Vector<NonnullRefPtr<Node>> retain_ffi_layout_nodes(void* const* node_pointers, size_t node_count)
+static RustFFI::NodeSlotId release_to_rust(NonnullRefPtr<Node> node)
 {
-    Vector<NonnullRefPtr<Node>> nodes;
-    nodes.ensure_capacity(node_count);
-    for (size_t index = 0; index < node_count; ++index) {
-        VERIFY(node_pointers[index]);
-        nodes.unchecked_append(*static_cast<Node*>(node_pointers[index]));
-    }
-    return nodes;
+    return Node::slot_id(&node.leak_ref());
 }
 
-static void ffi_remove_layout_nodes(void*, void* const* node_pointers, size_t node_count)
+static RustFFI::NodeSlotId ffi_create_anonymous_table_box(void*, void* parent_pointer, RustFFI::FfiAnonymousTableBoxKind kind)
 {
-    auto nodes = retain_ffi_layout_nodes(node_pointers, node_count);
-    for (auto& node : nodes) {
-        VERIFY(node->parent());
-        node->parent()->remove_child(*node);
-    }
-}
-
-static void ffi_wrap_in_anonymous_table_box(void*, void* const* node_pointers, size_t node_count, void* nearest_sibling_pointer, RustFFI::FfiAnonymousTableBoxKind kind)
-{
-    VERIFY(node_count > 0);
-    auto sequence = retain_ffi_layout_nodes(node_pointers, node_count);
-    auto& parent = *sequence.first()->parent();
+    VERIFY(parent_pointer);
+    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
     auto parent_values = parent.copy_computed_values();
     auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*parent_values);
     switch (kind) {
@@ -1498,20 +1482,9 @@ static void ffi_wrap_in_anonymous_table_box(void*, void* const* node_pointers, s
         break;
     }
 
-    auto wrapper = [&]() -> NonnullRefPtr<NodeWithStyle> {
-        if (kind == RustFFI::FfiAnonymousTableBoxKind::TableCell)
-            return make_ref_counted<BlockContainer>(parent.document(), nullptr, move(builder).build());
-        return make_ref_counted<Box>(parent.document(), nullptr, move(builder).build());
-    }();
-    for (auto& child : sequence) {
-        parent.remove_child(*child);
-        wrapper->append_child(*child);
-    }
-    wrapper->set_children_are_inline(parent.children_are_inline());
-    if (nearest_sibling_pointer)
-        parent.insert_before(*wrapper, *static_cast<Node*>(nearest_sibling_pointer));
-    else
-        parent.append_child(*wrapper);
+    if (kind == RustFFI::FfiAnonymousTableBoxKind::TableCell)
+        return release_to_rust(make_ref_counted<BlockContainer>(parent.document(), nullptr, move(builder).build()));
+    return release_to_rust(make_ref_counted<Box>(parent.document(), nullptr, move(builder).build()));
 }
 
 static NonnullRefPtr<CSS::ComputedValues const> table_wrapper_computed_values(Box& table_box)
@@ -1522,23 +1495,14 @@ static NonnullRefPtr<CSS::ComputedValues const> table_wrapper_computed_values(Bo
     return move(builder).build();
 }
 
-static void ffi_wrap_table_root(void*, void* table_root_pointer, void* nearest_sibling_pointer)
+static RustFFI::NodeSlotId ffi_create_table_wrapper(void*, void* table_root_pointer)
 {
     VERIFY(table_root_pointer);
-    NonnullRefPtr table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
-    auto parent = table_box->parent();
-    VERIFY(parent);
-    auto wrapper = make_ref_counted<BlockContainer>(parent->document(), nullptr, table_wrapper_computed_values(*table_box), RustFFI::NodeKind::TableWrapper);
-    parent->remove_child(*table_box);
-    wrapper->append_child(*table_box);
-    if (nearest_sibling_pointer)
-        parent->insert_before(*wrapper, *static_cast<Node*>(nearest_sibling_pointer));
-    else
-        parent->append_child(*wrapper);
-    table_box->set_has_been_wrapped_in_table_wrapper(true);
+    auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
+    return release_to_rust(make_ref_counted<BlockContainer>(table_box.document(), nullptr, table_wrapper_computed_values(table_box), RustFFI::NodeKind::TableWrapper));
 }
 
-static void ffi_append_missing_table_cell(void*, void* row_pointer)
+static RustFFI::NodeSlotId ffi_create_missing_table_cell(void*, void* row_pointer)
 {
     VERIFY(row_pointer);
     auto& row_box = as<Box>(*static_cast<Node*>(row_pointer));
@@ -1547,31 +1511,14 @@ static void ffi_append_missing_table_cell(void*, void* row_pointer)
     builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
     // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
     builder->set_vertical_align(CSS::VerticalAlign::Middle);
-    row_box.append_child(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
+    return release_to_rust(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
 }
 
-static RustFFI::NodeSlotId ffi_create_and_append_anonymous_wrapper(void*, void* parent_pointer)
+static RustFFI::NodeSlotId ffi_create_anonymous_wrapper(void*, void* parent_pointer)
 {
     VERIFY(parent_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    auto wrapper = parent.create_anonymous_wrapper();
-    parent.append_child(*wrapper);
-    return Node::slot_id(wrapper.ptr());
-}
-
-static void ffi_wrap_children_in_anonymous(void*, void* parent_pointer, void* const* child_pointers, size_t child_count)
-{
-    VERIFY(parent_pointer);
-    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    auto children = retain_ffi_layout_nodes(child_pointers, child_count);
-    auto wrapper = parent.create_anonymous_wrapper();
-    wrapper->set_children_are_inline(true);
-    for (auto& child : children) {
-        parent.remove_child(*child);
-        wrapper->append_child(*child);
-    }
-    parent.set_children_are_inline(false);
-    parent.append_child(*wrapper);
+    return release_to_rust(parent.create_anonymous_wrapper());
 }
 
 static void ffi_insert_child(void*, void* parent_pointer, void* child_pointer, RustFFI::FfiInsertionMode mode)
@@ -1640,7 +1587,7 @@ static void ffi_insert_child(void*, void* parent_pointer, void* child_pointer, R
     parent.append_child(*child);
 }
 
-static RustFFI::NodeSlotId ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
+static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(layout_node_pointer));
@@ -1648,11 +1595,11 @@ static RustFFI::NodeSlotId ffi_create_button_content_wrapper(void*, void* layout
     // If the box does not overflow in the vertical axis, then it is centered vertically.
     // FIXME: Only apply alignment when box overflows
     auto flex_wrapper = create_button_flex_wrapper(parent);
-
     auto content_box_wrapper = create_button_content_box_wrapper(parent);
-    flex_wrapper->append_child(*content_box_wrapper);
-    parent.append_child(*flex_wrapper);
-    return Node::slot_id(content_box_wrapper.ptr());
+    return {
+        .flex_wrapper = release_to_rust(move(flex_wrapper)),
+        .content_box = release_to_rust(move(content_box_wrapper)),
+    };
 }
 
 static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointer)
@@ -1671,33 +1618,17 @@ static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layo
     // FIXME: Transfer all of these properties, not just overflow.
     wrapper->set_overflow(fieldset_box.overflow_x(), fieldset_box.overflow_y());
     fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
-
-    fieldset_box.append_child(*wrapper);
-    return Node::slot_id(wrapper.ptr());
-}
-
-static void ffi_move_nodes_to_parent(void*, void* parent_pointer, void* const* node_pointers, size_t node_count)
-{
-    VERIFY(parent_pointer);
-    auto& parent = *static_cast<Node*>(parent_pointer);
-    auto nodes = retain_ffi_layout_nodes(node_pointers, node_count);
-    for (auto& node : nodes) {
-        VERIFY(node->parent());
-        node->parent()->remove_child(*node);
-        parent.append_child(*node);
-    }
+    return release_to_rust(move(wrapper));
 }
 
 RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_callbacks()
 {
     return {
         .context = this,
-        .remove_nodes = ffi_remove_layout_nodes,
-        .wrap_in_anonymous = ffi_wrap_in_anonymous_table_box,
-        .wrap_table_root = ffi_wrap_table_root,
-        .append_missing_table_cell = ffi_append_missing_table_cell,
-        .create_and_append_anonymous_wrapper = ffi_create_and_append_anonymous_wrapper,
-        .wrap_children_in_anonymous = ffi_wrap_children_in_anonymous,
+        .create_anonymous_wrapper = ffi_create_anonymous_wrapper,
+        .create_anonymous_table_box = ffi_create_anonymous_table_box,
+        .create_table_wrapper = ffi_create_table_wrapper,
+        .create_missing_table_cell = ffi_create_missing_table_cell,
         .insert_child = ffi_insert_child,
         .text_is_ascii_whitespace = [](void*, void* node_pointer) {
             VERIFY(node_pointer);
@@ -1723,9 +1654,8 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
             auto const white_space_collapse = text_node.parent()->white_space_collapse();
             return first_is_one_of(white_space_collapse,
                 CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces); },
-        .create_button_content_wrapper = ffi_create_button_content_wrapper,
+        .create_button_content_wrappers = ffi_create_button_content_wrappers,
         .create_fieldset_content_wrapper = ffi_create_fieldset_content_wrapper,
-        .move_nodes_to_parent = ffi_move_nodes_to_parent,
     };
 }
 

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -1054,14 +1054,6 @@ void set_sticky_insets(Layout::Node const& node, OwnPtr<StickyInsets> sticky_ins
     Layout::RustFFI::layout_arena_paintable_set_sticky_insets(node.arena_handle(), committed_row_slot(node), ffi_insets, !!sticky_insets);
 }
 
-void transfer_fragments_to_replacement_node(Layout::Node const& containing_block, Layout::Node const& old_node, Layout::Node const& new_node)
-{
-    if (!is_paintable_with_lines(containing_block))
-        return;
-    Layout::RustFFI::layout_arena_paintable_transfer_fragments_to_replacement_node(
-        containing_block.arena_handle(), committed_row_slot(containing_block), Layout::Node::slot_id(&old_node), Layout::Node::slot_id(&new_node));
-}
-
 void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect>& rects)
 {
     Layout::RustFFI::layout_arena_inline_paintable_piece_border_box_rects(

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -117,7 +117,6 @@ WEB_API void clear_cached_overflow_data(Layout::Node const&);
 WEB_API void set_sticky_insets(Layout::Node const&, OwnPtr<StickyInsets>);
 WEB_API StickyInsets sticky_insets(Layout::Node const&);
 WEB_API bool has_sticky_insets(Layout::Node const&);
-WEB_API void transfer_fragments_to_replacement_node(Layout::Node const& containing_block, Layout::Node const& old_node, Layout::Node const& new_node);
 
 WEB_API void inline_piece_border_box_rects(Layout::Node const&, Vector<CSSPixelRect>&);
 WEB_API CSSPixelPoint cumulative_scroll_compensation(Layout::Node const&);

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -2662,6 +2662,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "NodeSlotId".to_string(),
     ];
     tree_builder_config.export.exclude = vec![
+        "ladybird_layout_node_shell_release".to_string(),
         "ladybird_layout_text_node_dom_offset_for_rendered_text_offset".to_string(),
         "ladybird_layout_text_node_rendered_text_offset_for_dom_offset".to_string(),
         "rust_calc_node_create_numeric_dimension".to_string(),

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -15,6 +15,7 @@ use crate::layout::LayoutMode;
 use crate::layout::SizeConstraint;
 use crate::layout::UsedValues;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::tree_mutation::{DetachedShell, DetachedShells, OwnedLayoutNode};
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -411,6 +412,18 @@ struct ChunkAddress {
     chunk_index: usize,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AncestorInvalidation {
+    StructuralChange,
+    ContentChange,
+}
+
+#[must_use]
+pub(crate) struct FreedSlot {
+    pub(crate) paintable_row_reset: Option<crate::painting::paintable_rows::PaintableRowReset>,
+    pub(crate) detached_children: DetachedShells,
+}
+
 pub(crate) struct LayoutNodeArena {
     chunks: Vec<Box<Chunk>>,
     chunks_by_address: Vec<ChunkAddress>,
@@ -509,7 +522,7 @@ impl LayoutNodeArena {
         });
     }
 
-    fn assert_owner_thread(&self) {
+    pub(crate) fn assert_owner_thread(&self) {
         debug_assert_eq!(self.owner_thread, thread::current().id());
     }
 
@@ -568,11 +581,7 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn free(
-        &mut self,
-        id: NodeSlotId,
-        generation: u32,
-    ) -> Option<crate::painting::paintable_rows::PaintableRowReset> {
+    pub(crate) fn free(&mut self, id: NodeSlotId, generation: u32) -> FreedSlot {
         self.assert_owner_thread();
 
         assert!(!id.is_invalid(), "invalid layout node arena slot ID");
@@ -584,6 +593,7 @@ impl LayoutNodeArena {
             "layout node arena slot ID and allocation generation disagree"
         );
         self.mark_descendant_subtree_caches_dirty_from_layout_node(id);
+        let detached_children = self.unlink_children_for_free(id);
         let should_reuse = {
             let metadata = self.metadata_mut(index);
             assert!(metadata.occupied, "layout node arena freed an unused slot");
@@ -645,7 +655,38 @@ impl LayoutNodeArena {
         if should_reuse {
             self.free_list.push(index);
         }
-        paintable_row_reset
+        FreedSlot {
+            paintable_row_reset,
+            detached_children,
+        }
+    }
+
+    fn unlink_children_for_free(&self, id: NodeSlotId) -> DetachedShells {
+        let data = self.data(id);
+        // SAFETY: data() validated that id names a live slot, and the links are plain values.
+        let (parent, previous_sibling, next_sibling) = unsafe {
+            (
+                (&raw const (*data).parent).read(),
+                (&raw const (*data).previous_sibling).read(),
+                (&raw const (*data).next_sibling).read(),
+            )
+        };
+        assert!(
+            parent.is_invalid() && previous_sibling.is_invalid() && next_sibling.is_invalid(),
+            "layout node arena freed a slot that is still linked under a parent"
+        );
+        let mut detached_children = DetachedShells::default();
+        loop {
+            // SAFETY: As above; unlink_child only rewrites link fields of live slots.
+            let child = unsafe { (&raw const (*data).first_child).read() };
+            if child.is_invalid() {
+                break;
+            }
+            let shell = self.node_shell(child);
+            self.unlink_child(id, child);
+            detached_children.push(DetachedShell::from_tree_reference(shell));
+        }
+        detached_children
     }
 
     pub(crate) fn data(&self, id: NodeSlotId) -> *mut NodeData {
@@ -1539,14 +1580,42 @@ impl LayoutNodeArena {
     // OPTIMIZATION: The edit invalidates line data at its direct parent and every formatting
     // ancestor. Preserve the structural proof along the same unbounded path as the fragment
     // epoch bumps so each affected inline context can reuse its unchanged line prefix.
-    pub(crate) fn note_inline_layout_damage_at_and_above(&self, mut box_: NodeSlotId) {
-        while !box_.is_invalid() {
-            let data = self.data(box_);
-            self.fc_run_cache_store.note_inline_layout_damage(box_);
-            // SAFETY: data() validated that box_ names a live slot, and the layout tree is stable
-            // for the duration of this synchronous topology update.
-            box_ = unsafe { (&raw const (*data).parent).read() };
+    // NB: Bumps can legitimately run while another document's layout pass is on the stack (a
+    // parent pass sizing a child navigable's viewport invalidates the child document), so the
+    // helpers must not assert against the process-global pass flag. A bump landing between a
+    // run's probe and its store is handled by storing the probe-time validity, which turns it
+    // into a fail-safe miss.
+    fn invalidate_at_and_above(&self, mut node: NodeSlotId, invalidation: AncestorInvalidation) {
+        let epochs_enabled =
+            crate::layout::fc_run_cache_mode_from_environment() != crate::layout::FcRunCacheMode::Disabled;
+        let paintable_rows = self.paintable_rows();
+        while !node.is_invalid() {
+            let data = self.data(node);
+            if invalidation == AncestorInvalidation::StructuralChange {
+                self.fc_run_cache_store.note_inline_layout_damage(node);
+            }
+            // SAFETY: data() validated that node names a live slot, mutation is serialized on
+            // the owner thread, and no reference into the slot is held across this write.
+            let (kind, parent) = unsafe {
+                if epochs_enabled {
+                    let epoch = &raw mut (*data).fragment_cache_epoch;
+                    epoch.write(epoch.read().wrapping_add(1));
+                }
+                ((&raw const (*data).kind).read(), (&raw const (*data).parent).read())
+            };
+            if crate::layout::kind_is_box(kind) {
+                paintable_rows.clear_cached_overflow_data(node);
+            }
+            node = parent;
         }
+    }
+
+    pub(crate) fn note_structural_change_at_and_above(&self, node: NodeSlotId) {
+        self.invalidate_at_and_above(node, AncestorInvalidation::StructuralChange);
+    }
+
+    pub(crate) fn bump_fragment_cache_epoch_of_self_and_ancestors(&self, node: NodeSlotId) {
+        self.invalidate_at_and_above(node, AncestorInvalidation::ContentChange);
     }
 
     pub(crate) fn insert_child(&self, parent: NodeSlotId, child: NodeSlotId, before: NodeSlotId) {
@@ -1630,10 +1699,15 @@ impl LayoutNodeArena {
             }
         }
 
-        self.note_inline_layout_damage_at_and_above(parent);
+        self.note_structural_change_at_and_above(parent);
     }
 
     pub(crate) fn remove_child(&self, parent: NodeSlotId, child: NodeSlotId) {
+        self.unlink_child(parent, child);
+        self.note_structural_change_at_and_above(parent);
+    }
+
+    fn unlink_child(&self, parent: NodeSlotId, child: NodeSlotId) {
         self.assert_owner_thread();
         let parent_data = self.data(parent);
         let child_data = self.data(child);
@@ -1679,8 +1753,6 @@ impl LayoutNodeArena {
             (&raw mut (*child_data).previous_sibling).write(NodeSlotId::INVALID);
             (&raw mut (*child_data).next_sibling).write(NodeSlotId::INVALID);
         }
-
-        self.note_inline_layout_damage_at_and_above(parent);
     }
 
     pub(crate) fn paint_state(&self) -> &RefCell<crate::painting::paint_state::PaintState> {
@@ -1786,6 +1858,11 @@ impl LayoutNodeArena {
         }
         // SAFETY: The metadata check established a live slot of this generation.
         unsafe { (*self.data(id)).shell }
+    }
+
+    pub(crate) fn node_shell(&self, id: NodeSlotId) -> *mut c_void {
+        // SAFETY: data() validated that id names a live slot.
+        unsafe { (&raw const (*self.data(id)).shell).read() }
     }
 
     pub(crate) fn dom_offset_for_rendered_text_offset(
@@ -1905,11 +1982,12 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, g
         assert!(!arena.is_null(), "layout node arena handle is null");
         // SAFETY: The C++ wrapper keeps the arena alive for this call and
         // serializes all access on the document thread.
-        let paintable_row_reset = {
+        let freed = {
             let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
             arena.free(id, generation)
         };
-        if let Some(reset) = paintable_row_reset {
+        freed.detached_children.release_all();
+        if let Some(reset) = freed.paintable_row_reset {
             reset.invoke_callback();
         }
     });
@@ -2023,32 +2101,92 @@ pub unsafe extern "C" fn layout_arena_node_shell_if_live(arena: *mut c_void, id:
 
 /// # Safety
 ///
-/// The arena must remain valid for the duration of the call, and `parent`,
-/// `child`, and a valid `before` must name live nodes in this arena.
+/// The arena must remain valid for the duration of the call, and `node` must name a live node
+/// in this arena. Every C++-side detach preparation that walks the tree must already have run.
+/// Unless the caller holds its own reference, the node may be destroyed before this returns.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_insert_child(
+pub unsafe extern "C" fn layout_arena_detach_node_for_destruction(arena: *mut c_void, node: NodeSlotId) -> bool {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call; the borrow
+        // ends before the release below re-enters the arena.
+        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_from_parent(node);
+        match detached {
+            Some(detached) => {
+                detached.release();
+                true
+            }
+            None => false,
+        }
+    })
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `node` must name a live node
+/// in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_bump_fragment_cache_epoch_of_self_and_ancestors(
+    arena: *mut c_void,
+    node: NodeSlotId,
+) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+        unsafe { LayoutNodeArena::from_handle(arena) }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
+    });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `parent`, `child`, and a
+/// valid `before` must name live nodes in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_attach_child(
     arena: *mut c_void,
     parent: NodeSlotId,
     child: NodeSlotId,
     before: NodeSlotId,
 ) {
     abort_on_panic(|| {
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { LayoutNodeArena::from_handle(arena) }.insert_child(parent, child, before);
+        // SAFETY: The C++ caller leaked one reference on the child before this call.
+        let child = unsafe { OwnedLayoutNode::adopt_created(child) };
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all
+        // access on the document thread.
+        unsafe { LayoutNodeArena::from_handle(arena) }.attach_child(parent, child, before);
     });
 }
 
 /// # Safety
 ///
-/// The arena must remain valid for the duration of the call, and `parent` and
-/// `child` must name live nodes in this arena.
+/// The arena must remain valid for the duration of the call, and `parent` and `child` must
+/// name live nodes in this arena.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_remove_child(arena: *mut c_void, parent: NodeSlotId, child: NodeSlotId) {
+pub unsafe extern "C" fn layout_arena_detach_child(arena: *mut c_void, parent: NodeSlotId, child: NodeSlotId) {
     abort_on_panic(|| {
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { LayoutNodeArena::from_handle(arena) }.remove_child(parent, child);
+        // SAFETY: The C++ wrapper keeps the arena alive for this call; the borrow ends before
+        // the release below re-enters the arena.
+        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_child(parent, child);
+        detached.release();
+    });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `parent`, `old_child`, and
+/// `new_child` must name live nodes in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_replace_child(
+    arena: *mut c_void,
+    parent: NodeSlotId,
+    old_child: NodeSlotId,
+    new_child: NodeSlotId,
+) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller leaked one reference on the new child before this call.
+        let new_child = unsafe { OwnedLayoutNode::adopt_created(new_child) };
+        // SAFETY: The C++ wrapper keeps the arena alive for this call; the borrow ends before
+        // the release below re-enters the arena.
+        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.replace_child(parent, old_child, new_child);
+        detached.release();
     });
 }
 
@@ -2193,9 +2331,12 @@ mod tests {
             (*first_data).table_column_span = 42;
             assert_eq!((*arena.data(first.slot)).table_column_span, 42);
         }
-        arena.free(first.slot, first.generation);
+        arena.free(first.slot, first.generation).detached_children.release_all();
         for allocation in allocations {
-            arena.free(allocation.slot, allocation.generation);
+            arena
+                .free(allocation.slot, allocation.generation)
+                .detached_children
+                .release_all();
         }
     }
 
@@ -2205,20 +2346,26 @@ mod tests {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate();
         assert_eq!(allocation.data as usize % 64, 0);
-        arena.free(allocation.slot, allocation.generation);
+        arena
+            .free(allocation.slot, allocation.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
     fn freed_slots_are_reused_with_a_new_generation() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate();
-        arena.free(first.slot, first.generation);
+        arena.free(first.slot, first.generation).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
         assert_ne!(second.generation, first.generation);
-        arena.free(second.slot, second.generation);
+        arena
+            .free(second.slot, second.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
@@ -2245,21 +2392,27 @@ mod tests {
             assert_eq!((*detached.data).flags & update_flags, update_flags);
         }
         arena.remove_child(root.slot, child.slot);
-        arena.free(root.slot, root.generation);
-        arena.free(child.slot, child.generation);
-        arena.free(detached.slot, detached.generation);
+        arena.free(root.slot, root.generation).detached_children.release_all();
+        arena.free(child.slot, child.generation).detached_children.release_all();
+        arena
+            .free(detached.slot, detached.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
     fn stale_slot_ids_do_not_resolve_to_a_new_occupant() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate();
-        arena.free(first.slot, first.generation);
+        arena.free(first.slot, first.generation).detached_children.release_all();
         let second = arena.allocate();
 
         let stale_read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| arena.data(first.slot)));
         assert!(stale_read.is_err());
-        arena.free(second.slot, second.generation);
+        arena
+            .free(second.slot, second.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
@@ -2279,7 +2432,10 @@ mod tests {
         }
 
         assert!(arena.committed_fragment_link(allocation.data).is_none());
-        arena.free(allocation.slot, allocation.generation);
+        arena
+            .free(allocation.slot, allocation.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
@@ -2302,8 +2458,8 @@ mod tests {
             .committed_fragment_link(new.data)
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
-        arena.free(old.slot, old.generation);
-        arena.free(new.slot, new.generation);
+        arena.free(old.slot, old.generation).detached_children.release_all();
+        arena.free(new.slot, new.generation).detached_children.release_all();
     }
 
     #[test]
@@ -2382,7 +2538,7 @@ mod tests {
             false
         }));
         assert_eq!(dependency_computations.get(), 2);
-        arena.free(first.slot, first.generation);
+        arena.free(first.slot, first.generation).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
@@ -2401,7 +2557,10 @@ mod tests {
             ),
             None
         );
-        arena.free(second.slot, second.generation);
+        arena
+            .free(second.slot, second.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
@@ -2501,7 +2660,10 @@ mod tests {
             arena.intrinsic_block_size_cache_get(data, max_content, key_at_another_inline_size_with_inline_basis(400)),
             None
         );
-        arena.free(allocation.slot, allocation.generation);
+        arena
+            .free(allocation.slot, allocation.generation)
+            .detached_children
+            .release_all();
     }
 
     #[test]
@@ -2549,13 +2711,16 @@ mod tests {
 
         first_data.intrinsic_cache_epoch += 1;
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
-        arena.free(first.slot, first.generation);
+        arena.free(first.slot, first.generation).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         // SAFETY: The second allocation is live and reuses the first allocation's slot.
         let second_data = unsafe { &*second.data };
         assert_eq!(arena.table_cell_measurement_cache_get(second_data, key), None);
-        arena.free(second.slot, second.generation);
+        arena
+            .free(second.slot, second.generation)
+            .detached_children
+            .release_all();
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -15,7 +15,7 @@ use crate::layout::LayoutMode;
 use crate::layout::SizeConstraint;
 use crate::layout::UsedValues;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
-use crate::layout::tree_mutation::{DetachedShell, DetachedShells, OwnedLayoutNode};
+use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -2132,61 +2132,6 @@ pub unsafe extern "C" fn layout_arena_bump_fragment_cache_epoch_of_self_and_ance
     abort_on_panic(|| {
         // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
         unsafe { LayoutNodeArena::from_handle(arena) }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
-    });
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `parent`, `child`, and a
-/// valid `before` must name live nodes in this arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_attach_child(
-    arena: *mut c_void,
-    parent: NodeSlotId,
-    child: NodeSlotId,
-    before: NodeSlotId,
-) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller leaked one reference on the child before this call.
-        let child = unsafe { OwnedLayoutNode::adopt_created(child) };
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all
-        // access on the document thread.
-        unsafe { LayoutNodeArena::from_handle(arena) }.attach_child(parent, child, before);
-    });
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `parent` and `child` must
-/// name live nodes in this arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_detach_child(arena: *mut c_void, parent: NodeSlotId, child: NodeSlotId) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ wrapper keeps the arena alive for this call; the borrow ends before
-        // the release below re-enters the arena.
-        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_child(parent, child);
-        detached.release();
-    });
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `parent`, `old_child`, and
-/// `new_child` must name live nodes in this arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_replace_child(
-    arena: *mut c_void,
-    parent: NodeSlotId,
-    old_child: NodeSlotId,
-    new_child: NodeSlotId,
-) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller leaked one reference on the new child before this call.
-        let new_child = unsafe { OwnedLayoutNode::adopt_created(new_child) };
-        // SAFETY: The C++ wrapper keeps the arena alive for this call; the borrow ends before
-        // the release below re-enters the arena.
-        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.replace_child(parent, old_child, new_child);
-        detached.release();
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -39,6 +39,7 @@ include!("geometry.rs");
 include!("fc_run_cache.rs");
 mod layout_node_arena;
 pub mod node_data;
+mod tree_mutation;
 include!("run_records.rs");
 include!("style_values.rs");
 

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -8,6 +8,7 @@ use crate::layout::CssPixels;
 use std::ffi::c_void;
 
 pub const INVALID_NODE_SLOT_INDEX: u32 = u32::MAX;
+pub const GENERATED_FOR_AFTER: u8 = 1;
 pub const GENERATED_FOR_MARKER: u8 = 6;
 
 // The full C++ StyleGroupIndex space; LayoutRustBridge.cpp static-asserts the

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -83,7 +83,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
     pub layout_node_has_first_letter_style: unsafe extern "C" fn(*mut c_void) -> bool,
-    pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget),
+    pub create_first_letter_nodes:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget) -> FfiFirstLetterNodes,
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
     pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
@@ -106,7 +107,8 @@ pub struct FfiDomTreeBuilderCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind) -> NodeSlotId,
     pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub principal_text_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiTextLayoutFacts,
-    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> NodeSlotId,
+    pub create_principal_text_layout:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> FfiPrincipalTextLayoutNodes,
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
@@ -126,6 +128,13 @@ pub struct FfiDomTreeBuilderCallbacks {
 pub struct FfiPrincipalNodeFrame {
     pub frame: *mut c_void,
     pub old_layout_node: NodeSlotId,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalTextLayoutNodes {
+    pub layout_node: NodeSlotId,
+    pub wrapped_text: NodeSlotId,
 }
 
 #[derive(Clone, Copy)]
@@ -1276,10 +1285,7 @@ unsafe fn update_principal_node_descendants(
                 {
                     let target = find_first_letter_in_block(host, layout_node);
                     if target.found {
-                        // SAFETY: `dom_node` is an Element and `target` identifies a live descendant text node.
-                        unsafe {
-                            (host.callbacks.create_first_letter_wrapper)(host.callbacks.builder, dom_node, target);
-                        }
+                        create_first_letter_boxes(host, dom_node, target);
                     }
                 }
             }
@@ -1424,7 +1430,16 @@ fn construct_principal_layout_node(
             // SAFETY: The frame and DOM text node remain live throughout construction.
             let created =
                 unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node, needs_style_wrapper) };
-            created_box = Some(host.layout().created(created));
+            let layout_host = host.layout();
+            if !created.wrapped_text.is_invalid() {
+                layout_host.set_children_are_inline(created.layout_node, true);
+                layout_host.attach_child(
+                    created.layout_node,
+                    layout_host.created(created.wrapped_text),
+                    NodeSlotId::INVALID,
+                );
+            }
+            created_box = Some(layout_host.created(created.layout_node));
         }
     } else {
         // SAFETY: The frame and DOM node remain live throughout the call.
@@ -1854,7 +1869,9 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     ) -> NodeSlotId,
     pub attach_style_resources: unsafe extern "C" fn(*mut c_void),
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
-    pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement),
+    pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_nested_list_marker_content:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, *mut c_void) -> NodeSlotId,
     pub configure_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement),
     pub resolve_content:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32) -> FfiResolvedPseudoContentFacts,
@@ -2022,8 +2039,24 @@ fn create_pseudo_element_with_frame(
 
     // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker.
     if layout_node_kind == NodeKind::ListItemBox {
-        // SAFETY: The builder, frame, and element remain live throughout marker creation.
-        unsafe { (callbacks.create_nested_list_marker)(callbacks.builder, frame, element, pseudo_element) };
+        // SAFETY: The frame and element remain live throughout marker creation.
+        let marker = layout_host.created(unsafe { (callbacks.create_nested_list_marker)(frame, element) });
+        let marker_slot = marker.slot();
+        let first_child = layout_host.first_child(layout_node);
+        layout_host.attach_child(layout_node, marker, first_child);
+        // SAFETY: The frame, element, and marker remain live throughout content creation.
+        let content = unsafe {
+            (callbacks.create_nested_list_marker_content)(
+                frame,
+                element,
+                pseudo_element,
+                layout_host.shell(marker_slot),
+            )
+        };
+        if !content.is_invalid() {
+            layout_host.attach_child(marker_slot, layout_host.created(content), NodeSlotId::INVALID);
+        }
+        layout_host.set_children_are_inline(marker_slot, true);
     }
 
     // Resolve content after insertion because counter() and counters() items read the counters established by this
@@ -2107,6 +2140,7 @@ pub(crate) fn adjusted_table_display_for_replaced_element(
 #[repr(C)]
 pub struct FfiFirstLetterTarget {
     pub text_node: *mut c_void,
+    pub text_layout_node: NodeSlotId,
     pub letter_start: usize,
     pub letter_end: usize,
     pub found: bool,
@@ -2116,11 +2150,20 @@ impl FfiFirstLetterTarget {
     fn not_found() -> Self {
         Self {
             text_node: std::ptr::null_mut(),
+            text_layout_node: NodeSlotId::INVALID,
             letter_start: 0,
             letter_end: 0,
             found: false,
         }
     }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiFirstLetterNodes {
+    pub wrapper: NodeSlotId,
+    pub first_letter_slice: NodeSlotId,
+    pub remainder_slice: NodeSlotId,
 }
 
 #[derive(Clone, Copy)]
@@ -2930,6 +2973,7 @@ pub(crate) fn find_first_letter_in_text(
         if cursor >= code_units {
             return FfiFirstLetterTarget {
                 text_node: std::ptr::null_mut(),
+                text_layout_node: NodeSlotId::INVALID,
                 letter_start: match_start,
                 letter_end: cursor,
                 found: true,
@@ -2966,6 +3010,7 @@ pub(crate) fn find_first_letter_in_text(
 
         return FfiFirstLetterTarget {
             text_node: std::ptr::null_mut(),
+            text_layout_node: NodeSlotId::INVALID,
             letter_start: match_start,
             letter_end,
             found: true,
@@ -2987,8 +3032,32 @@ fn find_first_letter_in_layout_text(host: &TreeBuilderHost<'_>, node: LayoutNode
     let mut target = find_first_letter_in_text(&text_host, preserves_segment_breaks);
     if target.found {
         target.text_node = host.shell(node);
+        target.text_layout_node = node;
     }
     target
+}
+
+fn create_first_letter_boxes(host: &DomTreeBuilderHost<'_>, element: *mut c_void, target: FfiFirstLetterTarget) {
+    let layout_host = host.layout();
+    // SAFETY: `element` is a live Element and `target` identifies a live descendant text node.
+    let nodes = unsafe { (host.callbacks.create_first_letter_nodes)(host.callbacks.builder, element, target) };
+    let first_letter_slice = layout_host.created(nodes.first_letter_slice);
+    let remainder_slice = layout_host.created(nodes.remainder_slice);
+    if nodes.wrapper.is_invalid() {
+        layout_host.release_owned(first_letter_slice);
+        layout_host.release_owned(remainder_slice);
+        return;
+    }
+    let wrapper = layout_host.created(nodes.wrapper);
+    let wrapper_slot = wrapper.slot();
+    let text_node = target.text_layout_node;
+    let parent = layout_host.parent(text_node);
+    assert!(!parent.is_invalid());
+    layout_host.set_children_are_inline(wrapper_slot, true);
+    layout_host.attach_child(wrapper_slot, first_letter_slice, NodeSlotId::INVALID);
+    layout_host.attach_child(parent, wrapper, text_node);
+    layout_host.attach_child(parent, remainder_slice, text_node);
+    layout_host.arena().detach_child(parent, text_node).release();
 }
 
 fn is_marker_content(data: &NodeData) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -114,7 +114,6 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
     pub set_layout_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub report_rebuild_outcome: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, bool),
     pub layout: FfiTreeBuilderCallbacks,
@@ -141,9 +140,6 @@ pub struct FfiPrincipalTextLayoutNodes {
 #[repr(C)]
 pub struct FfiPreparedPrincipalElementFacts {
     pub display: FfiPrincipalDisplayFacts,
-    // A stale ::backdrop box is a viewport child, so removing it restructures the tree outside
-    // every rebuild root.
-    pub removed_old_backdrop_layout_node: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -375,7 +371,6 @@ pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
 pub struct FfiTopLayerDetachCallbacks {
     pub element_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void),
-    pub remove_layout_node: unsafe extern "C" fn(*mut c_void),
     pub clear_stale_subtree: unsafe extern "C" fn(*mut c_void),
     pub slot_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
@@ -435,11 +430,12 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
             };
             // SAFETY: The chosen layout subtree and its shell remain live throughout detachment.
             let shell = unsafe { (*(*arena).data(layout_node_to_detach)).shell };
-            unsafe {
-                (callbacks.prepare_subtree_for_detach)(shell);
-                if !(*(*arena).data(layout_node_to_detach)).parent.is_invalid() {
-                    (callbacks.remove_layout_node)(shell);
-                }
+            // SAFETY: The C++ detach preparation walks the still-linked subtree; the arena borrow
+            // ends before the release below re-enters it.
+            unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
+            let detached = unsafe { &*arena }.detach_from_parent(layout_node_to_detach);
+            if let Some(detached) = detached {
+                detached.release();
             }
         }
 
@@ -1347,6 +1343,25 @@ fn construct_principal_layout_node(
     let must_create_subtree = update.must_create_subtree;
     let context = &mut *update.context;
     if entry_facts.is_element {
+        if should_create_layout_node {
+            // ::backdrop is a sibling of the element, not a child, so unlike other pseudo-elements, it is not
+            // automatically discarded when the element's layout is recomputed.
+            // A stale ::backdrop box is a viewport child, so removing it restructures the tree outside
+            // every rebuild root.
+            // SAFETY: The DOM element remains live throughout the call.
+            let old_backdrop =
+                unsafe { (host.callbacks.element_pseudo_layout_node)(dom_node, FfiPseudoElement::Backdrop) };
+            if !old_backdrop.is_invalid() {
+                update.state.layout_tree_update_escaped_rebuild_roots = true;
+                let layout_host = host.layout();
+                let backdrop_parent = layout_host.parent(old_backdrop);
+                assert!(!backdrop_parent.is_invalid());
+                layout_host
+                    .arena()
+                    .detach_child(backdrop_parent, old_backdrop)
+                    .release();
+            }
+        }
         // SAFETY: The frame, builder, and DOM element remain live throughout the call.
         let prepared = unsafe {
             (host.callbacks.prepare_principal_element)(
@@ -1356,9 +1371,6 @@ fn construct_principal_layout_node(
                 should_create_layout_node,
             )
         };
-        if prepared.removed_old_backdrop_layout_node {
-            update.state.layout_tree_update_escaped_rebuild_roots = true;
-        }
         let generation = principal_box_generation_decision(
             true,
             should_create_layout_node && prepared.display.display_is_none,

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -6,7 +6,7 @@
 
 use crate::abort_on_panic;
 use crate::layout::layout_node_arena::LayoutNodeArena;
-use crate::layout::node_data::{GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_data::{GENERATED_FOR_AFTER, GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::tree_mutation::OwnedLayoutNode;
 use crate::layout::{
     ComputedValuesView, FfiDisplay, kind_is_replaced_box, kind_is_svg_box, kind_is_svg_graphics_box,
@@ -84,7 +84,6 @@ pub struct FfiDomTreeBuilderCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
     pub layout_node_has_first_letter_style: unsafe extern "C" fn(*mut c_void) -> bool,
     pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget),
-    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> NodeSlotId,
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
     pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
@@ -93,6 +92,9 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub svg_pattern_content_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub register_svg_resource_reference: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub element_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    pub dom_node_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    pub layout_node_dom_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub element_pseudo_layout_node: unsafe extern "C" fn(*mut c_void, FfiPseudoElement) -> NodeSlotId,
     pub principal_node_entry_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> FfiPrincipalNodeEntryFacts,
     pub request_top_layer_zone_rebuild: unsafe extern "C" fn(*mut c_void),
     pub push_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiPrincipalNodeFrame,
@@ -101,16 +103,15 @@ pub struct FfiDomTreeBuilderCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPreparedPrincipalElementFacts,
     pub principal_element_layout_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiElementLayoutFacts,
     pub create_principal_element_layout:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind),
-    pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind) -> NodeSlotId,
+    pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub principal_text_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiTextLayoutFacts,
-    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
+    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> NodeSlotId,
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
-    pub insert_principal_backdrop_before_old: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
-    pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
+    pub set_layout_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub report_rebuild_outcome: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, bool),
@@ -478,8 +479,7 @@ pub(crate) struct PrincipalBoxPlacementFacts {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiPrincipalBoxPlacement {
+pub(crate) enum FfiPrincipalBoxPlacement {
     None,
     DocumentRoot,
     ReplaceExisting,
@@ -594,6 +594,11 @@ impl DomTreeBuilderHost<'_> {
     fn next_sibling(&self, node: *mut c_void) -> *mut c_void {
         // SAFETY: Callers only pass live DOM nodes.
         unsafe { (self.callbacks.next_sibling)(node) }
+    }
+
+    fn dom_node_layout_node(&self, node: *mut c_void) -> LayoutNode {
+        // SAFETY: Callers only pass live DOM nodes.
+        unsafe { (self.callbacks.dom_node_layout_node)(node) }
     }
 
     fn layout(&self) -> TreeBuilderHost<'_> {
@@ -819,13 +824,14 @@ unsafe fn update_layout_tree_for_display_contents(
         }
 
         if !facts.content_visibility_hidden && !context.has_svg_root {
-            create_pseudo_element(
+            let placed = create_pseudo_element(
                 host,
                 state,
                 element,
                 FfiPseudoElement::Before,
                 Some(FfiInsertionMode::Append),
             );
+            assert!(placed.is_none());
         }
 
         if !facts.content_visibility_hidden && (should_create_layout_node || facts.child_needs_layout_tree_update) {
@@ -886,13 +892,14 @@ unsafe fn update_layout_tree_for_display_contents(
         }
 
         if !facts.content_visibility_hidden && !context.has_svg_root {
-            create_pseudo_element(
+            let placed = create_pseudo_element(
                 host,
                 state,
                 element,
                 FfiPseudoElement::After,
                 Some(FfiInsertionMode::Append),
             );
+            assert!(placed.is_none());
         }
 
         assert!(!facts.dom_children_parent.is_null());
@@ -1032,13 +1039,14 @@ unsafe fn update_principal_node_descendants(
                 && !context.has_svg_root
             {
                 state.ancestor_stack.push(layout_node);
-                create_pseudo_element(
+                let placed = create_pseudo_element(
                     host,
                     state,
                     dom_node,
                     FfiPseudoElement::Before,
                     Some(FfiInsertionMode::Prepend),
                 );
+                assert!(placed.is_none());
                 assert!(state.ancestor_stack.pop().is_some());
             }
         }
@@ -1065,14 +1073,18 @@ unsafe fn update_principal_node_descendants(
                 if layout_node_is_replaced_box_with_children {
                     // For replaced elements with shadow DOM children, wrap the children in an
                     // anonymous BlockContainer so that a BFC handles their layout.
-                    // SAFETY: The callback returns the live first-child wrapper.
-                    let wrapper = unsafe {
-                        (host.callbacks.ensure_replaced_children_wrapper)(
-                            host.callbacks.builder,
-                            layout_host.shell(layout_node),
-                            layout_host.shell(state.current_parent()),
-                        )
-                    };
+                    let first_child = layout_host.first_child(layout_node);
+                    if first_child.is_invalid() || !node_has_flag(layout_host.data(first_child), NodeFlag::Anonymous) {
+                        // SAFETY: `layout_node` is a live NodeWithStyle.
+                        let wrapper = layout_host.created(unsafe {
+                            (layout_host.callbacks.create_anonymous_wrapper)(
+                                layout_host.callbacks.context,
+                                layout_host.shell(layout_node),
+                            )
+                        });
+                        layout_host.attach_child(state.current_parent(), wrapper, NodeSlotId::INVALID);
+                    }
+                    let wrapper = layout_host.first_child(layout_node);
                     assert!(!wrapper.is_invalid());
                     state.ancestor_stack.push(wrapper);
                 }
@@ -1239,21 +1251,23 @@ unsafe fn update_principal_node_descendants(
             {
                 state.ancestor_stack.push(layout_node);
                 if layout_host.data(layout_node).kind == NodeKind::ListItemBox {
-                    create_pseudo_element(
+                    let placed = create_pseudo_element(
                         host,
                         state,
                         dom_node,
                         FfiPseudoElement::Marker,
                         Some(FfiInsertionMode::Prepend),
                     );
+                    assert!(placed.is_none());
                 }
-                create_pseudo_element(
+                let placed = create_pseudo_element(
                     host,
                     state,
                     dom_node,
                     FfiPseudoElement::After,
                     Some(FfiInsertionMode::Append),
                 );
+                assert!(placed.is_none());
                 assert!(state.ancestor_stack.pop().is_some());
 
                 // SAFETY: The layout node's shell and its associated DOM node remain live throughout the call.
@@ -1299,12 +1313,29 @@ struct PrincipalNodeUpdate<'host, 'callbacks, 'state, 'context> {
     insertion_mode: FfiInsertionMode,
 }
 
+struct PrincipalBoxConstruction {
+    layout_node: LayoutNode,
+    created_box: Option<OwnedLayoutNode>,
+    handled_display_contents: bool,
+}
+
+impl PrincipalBoxConstruction {
+    fn none() -> Self {
+        Self {
+            layout_node: NodeSlotId::INVALID,
+            created_box: None,
+            handled_display_contents: false,
+        }
+    }
+}
+
 fn construct_principal_layout_node(
     update: &mut PrincipalNodeUpdate<'_, '_, '_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
     should_create_layout_node: bool,
-) -> (bool, bool) {
+) -> PrincipalBoxConstruction {
     let host = update.host;
+    let mut created_box = None;
     let frame = update.frame;
     let dom_node = update.dom_node;
     let must_create_subtree = update.must_create_subtree;
@@ -1328,7 +1359,7 @@ fn construct_principal_layout_node(
             prepared.display.display_is_contents,
         );
         if generation == PrincipalBoxGenerationDecision::Suppress {
-            return (false, false);
+            return PrincipalBoxConstruction::none();
         }
         if generation == PrincipalBoxGenerationDecision::DisplayContents {
             // SAFETY: The callback table, DOM element, and context remain valid throughout the recursive walk.
@@ -1342,7 +1373,10 @@ fn construct_principal_layout_node(
                     should_create_layout_node,
                 );
             }
-            return (false, true);
+            return PrincipalBoxConstruction {
+                handled_display_contents: true,
+                ..PrincipalBoxConstruction::none()
+            };
         }
         if should_create_layout_node {
             // SAFETY: The frame and element remain live throughout construction.
@@ -1353,8 +1387,11 @@ fn construct_principal_layout_node(
                 context.layout_svg_pattern,
             );
             // SAFETY: The builder, frame, and element remain live throughout construction.
-            unsafe {
-                (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, layout_kind);
+            let created = unsafe {
+                (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, layout_kind)
+            };
+            if !created.is_invalid() {
+                created_box = Some(host.layout().created(created));
             }
             if matches!(
                 layout_kind,
@@ -1373,7 +1410,8 @@ fn construct_principal_layout_node(
     } else if should_create_layout_node {
         if entry_facts.is_document {
             // SAFETY: The frame and DOM document remain live throughout construction.
-            unsafe { (host.callbacks.create_principal_document_layout)(frame, dom_node) };
+            let created = unsafe { (host.callbacks.create_principal_document_layout)(frame, dom_node) };
+            created_box = Some(host.layout().created(created));
         } else if entry_facts.is_text {
             // SAFETY: The DOM text node remains live throughout the fact query.
             let facts = unsafe { (host.callbacks.principal_text_layout_facts)(dom_node) };
@@ -1384,7 +1422,9 @@ fn construct_principal_layout_node(
                 facts.parent_collapses_whitespace,
             );
             // SAFETY: The frame and DOM text node remain live throughout construction.
-            unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node, needs_style_wrapper) };
+            let created =
+                unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node, needs_style_wrapper) };
+            created_box = Some(host.layout().created(created));
         }
     } else {
         // SAFETY: The frame and DOM node remain live throughout the call.
@@ -1392,10 +1432,35 @@ fn construct_principal_layout_node(
     }
 
     // SAFETY: The frame remains live throughout the call.
-    (
-        !unsafe { (host.callbacks.principal_layout_node)(frame) }.is_invalid(),
-        false,
-    )
+    let layout_node = unsafe { (host.callbacks.principal_layout_node)(frame) };
+    PrincipalBoxConstruction {
+        layout_node,
+        created_box,
+        handled_display_contents: false,
+    }
+}
+
+// The replacement box represents the same element in the same tree position, so the flat fragment
+// and inline-box-piece lists held by the containing block of a node that participated in inline
+// layout carry over to it; a subtree relayout that skips the containing block never rebuilds them.
+fn transfer_fragments_to_replacement_box(
+    arena: &LayoutNodeArena,
+    old_layout_node: LayoutNode,
+    new_layout_node: LayoutNode,
+) {
+    let Some(containing_block) = arena.node_containing_block_if_live(old_layout_node) else {
+        return;
+    };
+    if arena.shell_if_live(containing_block).is_null() {
+        return;
+    }
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(containing_block)
+        || !paintable_rows.paintable_data(containing_block).kind.has_lines()
+    {
+        return;
+    }
+    arena.transfer_fragments_to_replacement_node(containing_block, old_layout_node, new_layout_node);
 }
 
 fn update_principal_node_after_entry(
@@ -1414,14 +1479,15 @@ fn update_principal_node_after_entry(
         SvgEntryDecision::Continue | SvgEntryDecision::Skip => {}
     }
 
-    let (has_layout_node, handled_display_contents) = if entry_decision.svg == SvgEntryDecision::Skip {
-        (false, false)
+    let construction = if entry_decision.svg == SvgEntryDecision::Skip {
+        PrincipalBoxConstruction::none()
     } else {
         construct_principal_layout_node(update, entry_facts, entry_decision.should_create_layout_node)
     };
+    let mut created_box = construction.created_box;
     let context = &mut *update.context;
 
-    if has_layout_node {
+    if !construction.layout_node.is_invalid() {
         if entry_facts.is_element || entry_facts.is_document {
             // SAFETY: The frame owns a live NodeWithStyle for elements and documents.
             unsafe { (host.callbacks.attach_principal_style_resources)(frame) };
@@ -1476,20 +1542,17 @@ fn update_principal_node_after_entry(
             } else {
                 Some(FfiInsertionMode::Append)
             };
-            let backdrop =
+            let unplaced_backdrop =
                 create_pseudo_element(host, update.state, dom_node, FfiPseudoElement::Backdrop, insertion_mode);
-            if placement.may_replace_existing_layout_node && !backdrop.is_invalid() {
+            if let Some(backdrop) = unplaced_backdrop {
+                assert!(placement.may_replace_existing_layout_node);
+                let layout_host = host.layout();
+                let old_parent = layout_host.parent(old_layout_node);
+                assert!(!old_parent.is_invalid());
                 // The backdrop lands next to the still-attached old box, so this restructures the
                 // old box's parent.
-                note_layout_tree_restructuring_at(&host.layout(), update.state, host.layout().parent(old_layout_node));
-                // SAFETY: The frame retains the attached old layout node and `backdrop` is owned by the element.
-                unsafe {
-                    (host.callbacks.insert_principal_backdrop_before_old)(
-                        host.callbacks.builder,
-                        frame,
-                        host.layout().shell(backdrop),
-                    );
-                }
+                note_layout_tree_restructuring_at(&layout_host, update.state, old_parent);
+                layout_host.attach_child(old_parent, backdrop, old_layout_node);
             }
         }
 
@@ -1497,27 +1560,35 @@ fn update_principal_node_after_entry(
             context.layout_top_layer = false;
         }
 
-        // SAFETY: The builder and frame remain live, and Rust selected the placement mode.
         let current_parent = if update.state.ancestor_stack.is_empty() {
             NodeSlotId::INVALID
         } else {
             update.state.current_parent()
         };
-        if placement.placement == FfiPrincipalBoxPlacement::NormalInsertion {
-            let layout_host = host.layout();
-            let is_inline_outside = node_is_inline_outside(&layout_host, layout_node);
-            insert_node_into_inline_or_block_ancestor(
-                &layout_host,
-                update.state,
-                current_parent,
-                layout_node,
-                is_inline_outside,
-                update.insertion_mode,
-            );
-        } else {
-            if placement.placement == FfiPrincipalBoxPlacement::ReplaceExisting {
-                // SAFETY: The tree-builder entry point keeps the arena alive, and both slots name live nodes in it.
-                let arena = unsafe { &*host.arena };
+        match placement.placement {
+            FfiPrincipalBoxPlacement::NormalInsertion => {
+                let is_inline_outside = node_is_inline_outside(&host.layout(), layout_node);
+                insert_node_into_inline_or_block_ancestor(
+                    host,
+                    update.state,
+                    current_parent,
+                    created_box.take().expect("a principal box to place"),
+                    is_inline_outside,
+                    update.insertion_mode,
+                    dom_node,
+                );
+            }
+            FfiPrincipalBoxPlacement::AppendSvg => {
+                assert!(!current_parent.is_invalid());
+                host.layout().attach_child(
+                    current_parent,
+                    created_box.take().expect("a principal box to place"),
+                    NodeSlotId::INVALID,
+                );
+            }
+            FfiPrincipalBoxPlacement::ReplaceExisting => {
+                let layout_host = host.layout();
+                let arena = layout_host.arena();
                 let old_data = arena.data(old_layout_node);
                 let new_data = arena.data(layout_node);
                 // SAFETY: data() returned pointers to live slots.
@@ -1532,15 +1603,31 @@ fn update_principal_node_after_entry(
                 {
                     arena.set_committed_fragment_link(new_data, link);
                 }
-            }
-            unsafe {
-                (host.callbacks.place_principal_layout)(
-                    host.callbacks.builder,
-                    frame,
-                    host.layout().shell_or_null(current_parent),
-                    placement.placement,
+                transfer_fragments_to_replacement_box(arena, old_layout_node, layout_node);
+                // SAFETY: The frame retains the attached old layout node.
+                unsafe {
+                    (layout_host.callbacks.prepare_subtree_for_detach)(
+                        layout_host.callbacks.context,
+                        layout_host.shell(old_layout_node),
+                    );
+                }
+                let old_parent = layout_host.parent(old_layout_node);
+                assert!(!old_parent.is_invalid());
+                let detached_old_box = arena.replace_child(
+                    old_parent,
+                    old_layout_node,
+                    created_box.take().expect("a principal box to place"),
                 );
-            };
+                detached_old_box.release();
+            }
+            FfiPrincipalBoxPlacement::DocumentRoot => {
+                // SAFETY: The builder and frame remain live; the frame retains the viewport.
+                unsafe { (host.callbacks.set_layout_root)(host.callbacks.builder, frame) };
+                if let Some(viewport) = created_box.take() {
+                    host.layout().release_owned(viewport);
+                }
+            }
+            FfiPrincipalBoxPlacement::None => assert!(created_box.is_none()),
         }
         // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
         unsafe {
@@ -1568,7 +1655,7 @@ fn update_principal_node_after_entry(
         if placement.start_rebuild_root {
             update.state.current_rebuild_root = prior_rebuild_root;
         }
-    } else if !handled_display_contents {
+    } else if !construction.handled_display_contents {
         // If no layout node was created, remove every stale layout and paint node from the shadow-including subtree.
         // SAFETY: The builder and DOM node remain live throughout cleanup.
         unsafe {
@@ -1758,9 +1845,13 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     pub push_frame: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub pop_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub initialize: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement) -> FfiPseudoElementFacts,
-    pub create_layout_node:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiPseudoElementDecision),
-    pub layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    pub create_layout_node: unsafe extern "C" fn(
+        *mut c_void,
+        *mut c_void,
+        *mut c_void,
+        FfiPseudoElement,
+        FfiPseudoElementDecision,
+    ) -> NodeSlotId,
     pub attach_style_resources: unsafe extern "C" fn(*mut c_void),
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
     pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement),
@@ -1846,16 +1937,16 @@ fn create_pseudo_element(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> LayoutNode {
+) -> Option<OwnedLayoutNode> {
     assert!(!element.is_null());
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The builder owns frame storage that remains live throughout the build.
     let frame = unsafe { (callbacks.push_frame)(callbacks.builder) };
     assert!(!frame.is_null());
-    let layout_node = create_pseudo_element_with_frame(host, state, frame, element, pseudo_element, insertion_mode);
+    let unplaced_box = create_pseudo_element_with_frame(host, state, frame, element, pseudo_element, insertion_mode);
     // SAFETY: `frame` is the most recently pushed pseudo-element frame and Rust no longer uses it.
     unsafe { (callbacks.pop_frame)(callbacks.builder, frame) };
-    layout_node
+    unplaced_box
 }
 
 fn create_pseudo_element_with_frame(
@@ -1865,23 +1956,35 @@ fn create_pseudo_element_with_frame(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> LayoutNode {
+) -> Option<OwnedLayoutNode> {
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The frame and element remain live throughout initialization.
     let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
     let decision = pseudo_element_decision(facts);
     if decision == FfiPseudoElementDecision::None {
-        return NodeSlotId::INVALID;
+        return None;
     }
 
     // SAFETY: The builder, frame, and element remain live throughout construction.
-    unsafe {
-        (callbacks.create_layout_node)(callbacks.builder, frame, element, pseudo_element, decision);
-    }
-    // SAFETY: The frame remains live throughout the call.
-    let layout_node = unsafe { (callbacks.layout_node)(frame) };
+    let layout_node =
+        unsafe { (callbacks.create_layout_node)(callbacks.builder, frame, element, pseudo_element, decision) };
     if layout_node.is_invalid() {
-        return layout_node;
+        return None;
+    }
+    let layout_host = host.layout();
+    let mut unplaced_box = Some(layout_host.created(layout_node));
+
+    // https://drafts.csswg.org/css-lists-3/#list-style-position-outside
+    // "the marker box is a block container and is placed outside the principal block box"
+    if decision == FfiPseudoElementDecision::Box
+        && facts.originating_layout_node_is_list_item
+        && !facts.marker_position_is_inside
+    {
+        // SAFETY: The originating element remains live and owns a list item box.
+        let list_item_box = unsafe { (host.callbacks.element_layout_node)(element) };
+        assert_eq!(layout_host.data(list_item_box).kind, NodeKind::ListItemBox);
+        let first_child = layout_host.first_child(list_item_box);
+        layout_host.attach_child(list_item_box, unplaced_box.take().expect("the marker box"), first_child);
     }
 
     // SAFETY: The frame owns a live pseudo-element layout node.
@@ -1897,23 +2000,21 @@ fn create_pseudo_element_with_frame(
     let initial_quote_nesting_level = state.quote_nesting_level;
     // SAFETY: The frame and element remain live throughout configuration.
     unsafe { (callbacks.configure_layout_node)(frame, element, pseudo_element) };
-    let layout_node_kind = host.layout().data(layout_node).kind;
-    // https://drafts.csswg.org/css-lists-3/#list-style-position-outside
-    // "the marker box is a block container and is placed outside the principal block box"
+    let layout_node_kind = layout_host.data(layout_node).kind;
     let is_outside_marker = layout_node_kind == NodeKind::ListItemMarkerBox && !facts.marker_position_is_inside;
     if let Some(insertion_mode) = insertion_mode
         && !is_outside_marker
     {
-        let layout_host = host.layout();
         let current_parent = state.current_parent();
         let is_inline_outside = node_is_inline_outside(&layout_host, layout_node);
         insert_node_into_inline_or_block_ancestor(
-            &layout_host,
+            host,
             state,
             current_parent,
-            layout_node,
+            unplaced_box.take().expect("the pseudo-element box"),
             is_inline_outside,
             insertion_mode,
+            std::ptr::null_mut(),
         );
     }
     // SAFETY: The element remains live and its pseudo-element layout node is attached when requested.
@@ -1940,22 +2041,22 @@ fn create_pseudo_element_with_frame(
             if content_item.is_invalid() {
                 continue;
             }
-            let layout_host = host.layout();
             let current_parent = state.current_parent();
             let is_inline_outside = node_is_inline_outside(&layout_host, content_item);
             insert_node_into_inline_or_block_ancestor(
-                &layout_host,
+                host,
                 state,
                 current_parent,
-                content_item,
+                layout_host.created(content_item),
                 is_inline_outside,
                 FfiInsertionMode::Append,
+                std::ptr::null_mut(),
             );
         }
         assert!(state.ancestor_stack.pop().is_some());
     }
 
-    layout_node
+    unplaced_box
 }
 
 fn replaced_element_display_adjustment(
@@ -2053,10 +2154,7 @@ pub enum FfiAnonymousTableBoxKind {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-// NB: `Prepend` is constructed by C++ through the FFI.
-#[allow(dead_code)]
-pub enum FfiInsertionMode {
+pub(crate) enum FfiInsertionMode {
     Append,
     Prepend,
     InDomOrder,
@@ -2076,7 +2174,7 @@ pub struct FfiTreeBuilderCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiAnonymousTableBoxKind) -> NodeSlotId,
     pub create_table_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub create_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-    pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
+    pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub text_is_ascii_whitespace: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub prepare_first_letter_text:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiFirstLetterTextCallbacks) -> bool,
@@ -2284,14 +2382,6 @@ impl TreeBuilderHost<'_> {
         shell
     }
 
-    fn shell_or_null(&self, node: LayoutNode) -> *mut c_void {
-        if node.is_invalid() {
-            std::ptr::null_mut()
-        } else {
-            self.shell(node)
-        }
-    }
-
     fn set_children_are_inline(&self, node: LayoutNode, children_are_inline: bool) {
         self.arena()
             .set_node_flag(node, NodeFlag::ChildrenAreInline, children_are_inline);
@@ -2313,6 +2403,10 @@ impl TreeBuilderHost<'_> {
 
     fn move_child(&self, child: LayoutNode, new_parent: LayoutNode, before: LayoutNode) {
         self.arena().move_child(child, new_parent, before);
+    }
+
+    fn release_owned(&self, node: OwnedLayoutNode) {
+        node.into_detached_shell(self.arena()).release();
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
@@ -2636,21 +2730,95 @@ fn insertion_parent_for_block_node(
     new_parent
 }
 
+fn insert_child_in_dom_order(
+    host: &DomTreeBuilderHost<'_>,
+    parent: LayoutNode,
+    child: OwnedLayoutNode,
+    dom_node: *mut c_void,
+) {
+    assert!(!dom_node.is_null());
+    let layout = host.layout();
+
+    // An inline child of a block container with block children is placed in a newly appended
+    // anonymous wrapper. Move that empty wrapper to the child's DOM position before filling it.
+    let (parent_is_empty_anonymous_wrapper, wrapper_parent) = {
+        let data = layout.data(parent);
+        (
+            node_has_flag(data, NodeFlag::Anonymous) && data.first_child.is_invalid(),
+            data.parent,
+        )
+    };
+    if parent_is_empty_anonymous_wrapper && !wrapper_parent.is_invalid() {
+        let mut sibling = host.next_sibling(dom_node);
+        while !sibling.is_null() {
+            let mut sibling_layout_node = host.dom_node_layout_node(sibling);
+            while !sibling_layout_node.is_invalid() && layout.parent(sibling_layout_node) != wrapper_parent {
+                sibling_layout_node = layout.parent(sibling_layout_node);
+            }
+            if !sibling_layout_node.is_invalid() && sibling_layout_node != parent {
+                layout.move_child(parent, wrapper_parent, sibling_layout_node);
+                break;
+            }
+            sibling = host.next_sibling(sibling);
+        }
+    }
+
+    let mut sibling = host.next_sibling(dom_node);
+    while !sibling.is_null() {
+        let sibling_layout_node = host.dom_node_layout_node(sibling);
+        if !sibling_layout_node.is_invalid() && layout.parent(sibling_layout_node) == parent {
+            layout.attach_child(parent, child, sibling_layout_node);
+            return;
+        }
+        sibling = host.next_sibling(sibling);
+    }
+
+    // SAFETY: `parent` is a live layout node.
+    let parent_element = unsafe { (host.callbacks.layout_node_dom_element)(layout.shell(parent)) };
+    if !parent_element.is_null() {
+        // SAFETY: `parent_element` is a live element.
+        let after_layout_node =
+            unsafe { (host.callbacks.element_pseudo_layout_node)(parent_element, FfiPseudoElement::After) };
+        if !after_layout_node.is_invalid() {
+            let mut after_layout_child = after_layout_node;
+            while !layout.parent(after_layout_child).is_invalid() && layout.parent(after_layout_child) != parent {
+                after_layout_child = layout.parent(after_layout_child);
+            }
+            if layout.parent(after_layout_child) == parent {
+                layout.attach_child(parent, child, after_layout_child);
+                return;
+            }
+        }
+    }
+
+    let mut layout_child = layout.first_child(parent);
+    while !layout_child.is_invalid() {
+        if layout.data(layout_child).generated_for == GENERATED_FOR_AFTER {
+            layout.attach_child(parent, child, layout_child);
+            return;
+        }
+        layout_child = layout.next_sibling(layout_child);
+    }
+    layout.attach_child(parent, child, NodeSlotId::INVALID);
+}
+
 fn insert_node_into_inline_or_block_ancestor(
-    host: &TreeBuilderHost<'_>,
+    host: &DomTreeBuilderHost<'_>,
     state: &mut TreeBuilderState,
     nearest_insertion_ancestor: LayoutNode,
-    node: LayoutNode,
+    node: OwnedLayoutNode,
     is_inline_outside: bool,
     mode: FfiInsertionMode,
+    dom_node: *mut c_void,
 ) {
     assert!(!nearest_insertion_ancestor.is_invalid());
-    assert!(!node.is_invalid());
+    let layout = host.layout();
+    let node_slot = node.slot();
 
     let insertion_point = if is_inline_outside {
-        insertion_parent_for_inline_node(host, nearest_insertion_ancestor)
+        insertion_parent_for_inline_node(&layout, nearest_insertion_ancestor)
     } else {
-        insertion_parent_for_block_node(host, state, nearest_insertion_ancestor, node, mode)
+        insertion_parent_for_block_node(&layout, state, nearest_insertion_ancestor, node_slot, mode)
     };
 
     // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
@@ -2658,29 +2826,28 @@ fn insert_node_into_inline_or_block_ancestor(
     // selected after proving that an inline box can be added directly to a retained parent, so
     // that parent insertion is the planned update rather than an escape from its new subtree.
     if mode != FfiInsertionMode::InDomOrder {
-        note_layout_tree_restructuring_at(host, state, insertion_point);
+        note_layout_tree_restructuring_at(&layout, state, insertion_point);
     }
-    // SAFETY: The callback retains `node` while inserting it into the live insertion point.
-    unsafe {
-        (host.callbacks.insert_child)(
-            host.callbacks.context,
-            host.shell(insertion_point),
-            host.shell(node),
-            mode,
-        );
-    };
+    match mode {
+        FfiInsertionMode::Append => layout.attach_child(insertion_point, node, NodeSlotId::INVALID),
+        FfiInsertionMode::Prepend => {
+            let first_child = layout.first_child(insertion_point);
+            layout.attach_child(insertion_point, node, first_child);
+        }
+        FfiInsertionMode::InDomOrder => insert_child_in_dom_order(host, insertion_point, node, dom_node),
+    }
 
     if is_inline_outside {
         // After inserting an inline-level box into a parent, mark the parent as having inline children.
-        host.set_children_are_inline(insertion_point, true);
-    } else if !node_is_out_of_flow(host, node) {
+        layout.set_children_are_inline(insertion_point, true);
+    } else if !node_is_out_of_flow(&layout, node_slot) {
         // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
-        if !node_is_inline_outside(host, insertion_point)
-            || !host
+        if !node_is_inline_outside(&layout, insertion_point)
+            || !layout
                 .style(insertion_point)
                 .is_some_and(|style| style.display().is_flow_inside())
         {
-            host.set_children_are_inline(insertion_point, false);
+            layout.set_children_are_inline(insertion_point, false);
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -7,6 +7,7 @@
 use crate::abort_on_panic;
 use crate::layout::layout_node_arena::LayoutNodeArena;
 use crate::layout::node_data::{GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::tree_mutation::OwnedLayoutNode;
 use crate::layout::{
     ComputedValuesView, FfiDisplay, kind_is_replaced_box, kind_is_svg_box, kind_is_svg_graphics_box,
     node_can_have_children,
@@ -2062,22 +2063,25 @@ pub enum FfiInsertionMode {
 }
 
 #[repr(C)]
+pub struct FfiButtonContentWrappers {
+    pub flex_wrapper: NodeSlotId,
+    pub content_box: NodeSlotId,
+}
+
+#[repr(C)]
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
-    pub remove_nodes: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize),
-    pub wrap_in_anonymous:
-        unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, *mut c_void, FfiAnonymousTableBoxKind),
-    pub wrap_table_root: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
-    pub append_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub create_and_append_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-    pub wrap_children_in_anonymous: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
+    pub create_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_anonymous_table_box:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiAnonymousTableBoxKind) -> NodeSlotId,
+    pub create_table_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub text_is_ascii_whitespace: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub prepare_first_letter_text:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiFirstLetterTextCallbacks) -> bool,
-    pub create_button_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_button_content_wrappers: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiButtonContentWrappers,
     pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-    pub move_nodes_to_parent: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2289,12 +2293,26 @@ impl TreeBuilderHost<'_> {
     }
 
     fn set_children_are_inline(&self, node: LayoutNode, children_are_inline: bool) {
-        // SAFETY: Entry points guarantee that the arena remains live.
-        unsafe { (*self.arena).set_node_flag(node, NodeFlag::ChildrenAreInline, children_are_inline) };
+        self.arena()
+            .set_node_flag(node, NodeFlag::ChildrenAreInline, children_are_inline);
     }
 
-    fn shells(&self, nodes: &[LayoutNode]) -> Vec<*mut c_void> {
-        nodes.iter().map(|&node| self.shell(node)).collect()
+    fn arena(&self) -> &LayoutNodeArena {
+        // SAFETY: Entry points guarantee that the arena remains live.
+        unsafe { &*self.arena }
+    }
+
+    fn created(&self, slot: NodeSlotId) -> OwnedLayoutNode {
+        // SAFETY: Create callbacks return a live node carrying one reference for the caller.
+        unsafe { OwnedLayoutNode::adopt_created(slot) }
+    }
+
+    fn attach_child(&self, parent: LayoutNode, child: OwnedLayoutNode, before: LayoutNode) {
+        self.arena().attach_child(parent, child, before);
+    }
+
+    fn move_child(&self, child: LayoutNode, new_parent: LayoutNode, before: LayoutNode) {
+        self.arena().move_child(child, new_parent, before);
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
@@ -2358,24 +2376,32 @@ impl TreeBuilderHost<'_> {
     }
 
     fn remove_nodes(&self, nodes: &[LayoutNode]) {
-        let shells = self.shells(nodes);
-        // SAFETY: All nodes remain tree-owned until the callback first retains the complete slice.
-        unsafe { (self.callbacks.remove_nodes)(self.callbacks.context, shells.as_ptr(), shells.len()) };
+        let mut detached_shells = Vec::with_capacity(nodes.len());
+        for &node in nodes {
+            let parent = self.parent(node);
+            assert!(!parent.is_invalid());
+            detached_shells.push(self.arena().detach_child(parent, node));
+        }
+        for detached_shell in detached_shells {
+            detached_shell.release();
+        }
     }
 
     fn wrap_in_anonymous(&self, nodes: &[LayoutNode], nearest_sibling: LayoutNode, kind: FfiAnonymousTableBoxKind) {
         assert!(!nodes.is_empty());
-        let shells = self.shells(nodes);
-        // SAFETY: The nodes are live siblings and `nearest_sibling` is either null or their live next sibling.
-        unsafe {
-            (self.callbacks.wrap_in_anonymous)(
-                self.callbacks.context,
-                shells.as_ptr(),
-                shells.len(),
-                self.shell_or_null(nearest_sibling),
-                kind,
-            );
-        };
+        let parent = self.parent(nodes[0]);
+        assert!(!parent.is_invalid());
+        // SAFETY: `parent` is a live NodeWithStyle.
+        let wrapper = self.created(unsafe {
+            (self.callbacks.create_anonymous_table_box)(self.callbacks.context, self.shell(parent), kind)
+        });
+        let wrapper_slot = wrapper.slot();
+        for &node in nodes {
+            self.move_child(node, wrapper_slot, NodeSlotId::INVALID);
+        }
+        let parent_children_are_inline = node_has_flag(self.data(parent), NodeFlag::ChildrenAreInline);
+        self.set_children_are_inline(wrapper_slot, parent_children_are_inline);
+        self.attach_child(parent, wrapper, nearest_sibling);
     }
 }
 
@@ -2459,11 +2485,12 @@ fn is_out_of_flow_table_internal_child_of_table_root(
 }
 
 fn create_anonymous_wrapper(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
-    // SAFETY: `parent` is a live NodeWithStyle. The callback appends and returns a live anonymous wrapper.
+    // SAFETY: `parent` is a live NodeWithStyle.
     let wrapper =
-        unsafe { (host.callbacks.create_and_append_anonymous_wrapper)(host.callbacks.context, host.shell(parent)) };
-    assert!(!wrapper.is_invalid());
-    wrapper
+        host.created(unsafe { (host.callbacks.create_anonymous_wrapper)(host.callbacks.context, host.shell(parent)) });
+    let wrapper_slot = wrapper.slot();
+    host.attach_child(parent, wrapper, NodeSlotId::INVALID);
+    wrapper_slot
 }
 
 fn last_child_creating_anonymous_wrapper_if_needed(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
@@ -2586,23 +2613,24 @@ fn insertion_parent_for_block_node(
 
     // Parent block has inline-level children (our siblings); wrap these siblings into an anonymous wrapper block.
     note_layout_tree_restructuring_at(host, state, new_parent);
-    let mut child_shells = Vec::new();
+    let mut children_to_wrap = Vec::new();
     let mut child = host.first_child(new_parent);
     while !child.is_invalid() {
         if !is_out_of_flow_table_internal_child_of_table_root(host, new_parent, child) {
-            child_shells.push(host.shell(child));
+            children_to_wrap.push(child);
         }
         child = host.next_sibling(child);
     }
-    // SAFETY: The callback retains the children before moving them and leaves `new_parent` live.
-    unsafe {
-        (host.callbacks.wrap_children_in_anonymous)(
-            host.callbacks.context,
-            host.shell(new_parent),
-            child_shells.as_ptr(),
-            child_shells.len(),
-        );
-    };
+    // SAFETY: `new_parent` is a live NodeWithStyle.
+    let wrapper = host
+        .created(unsafe { (host.callbacks.create_anonymous_wrapper)(host.callbacks.context, host.shell(new_parent)) });
+    let wrapper_slot = wrapper.slot();
+    host.set_children_are_inline(wrapper_slot, true);
+    for child in children_to_wrap {
+        host.move_child(child, wrapper_slot, NodeSlotId::INVALID);
+    }
+    host.set_children_are_inline(new_parent, false);
+    host.attach_child(new_parent, wrapper, NodeSlotId::INVALID);
 
     // Then it's safe to insert this block into parent.
     new_parent
@@ -2877,26 +2905,25 @@ fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Layou
     let display = host.style(layout_node).map(|style| style.display());
     if !display.is_some_and(|display| display.is_grid_inside() || display.is_flex_inside()) {
         let children_are_inline = node_has_flag(host.data(layout_node), NodeFlag::ChildrenAreInline);
-        let mut child_shells = Vec::new();
+        let mut children = Vec::new();
         let mut child = host.first_child(layout_node);
         while !child.is_invalid() {
-            child_shells.push(host.shell(child));
+            children.push(child);
             child = host.next_sibling(child);
         }
 
-        // SAFETY: `layout_node` remains live and owns the returned content wrapper through its flex wrapper.
-        let content_wrapper =
-            unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, host.shell(layout_node)) };
-        assert!(!content_wrapper.is_invalid());
-        host.set_children_are_inline(content_wrapper, children_are_inline);
-        // SAFETY: The parent and content wrapper remain live, and the callback retains all nodes while moving them.
-        unsafe {
-            (host.callbacks.move_nodes_to_parent)(
-                host.callbacks.context,
-                host.shell(content_wrapper),
-                child_shells.as_ptr(),
-                child_shells.len(),
-            );
+        // SAFETY: `layout_node` is a live NodeWithStyle.
+        let wrappers =
+            unsafe { (host.callbacks.create_button_content_wrappers)(host.callbacks.context, host.shell(layout_node)) };
+        let flex_wrapper = host.created(wrappers.flex_wrapper);
+        let content_box = host.created(wrappers.content_box);
+        let flex_wrapper_slot = flex_wrapper.slot();
+        let content_box_slot = content_box.slot();
+        host.attach_child(flex_wrapper_slot, content_box, NodeSlotId::INVALID);
+        host.attach_child(layout_node, flex_wrapper, NodeSlotId::INVALID);
+        host.set_children_are_inline(content_box_slot, children_are_inline);
+        for child in children {
+            host.move_child(child, content_box_slot, NodeSlotId::INVALID);
         }
         host.set_children_are_inline(layout_node, false);
     }
@@ -2929,28 +2956,23 @@ fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Lay
             return;
         }
 
-        let mut child_shells = Vec::new();
+        let mut children = Vec::new();
         let mut child = host.first_child(layout_node);
         while !child.is_invalid() {
             if child != legend {
-                child_shells.push(host.shell(child));
+                children.push(child);
             }
             child = host.next_sibling(child);
         }
 
-        // SAFETY: The fieldset remains live and owns the returned wrapper.
-        let wrapper = unsafe {
+        // SAFETY: `layout_node` is a live fieldset box.
+        let wrapper = host.created(unsafe {
             (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, host.shell(layout_node))
-        };
-        assert!(!wrapper.is_invalid());
-        // SAFETY: The wrapper remains attached and the callback retains all nodes while moving them.
-        unsafe {
-            (host.callbacks.move_nodes_to_parent)(
-                host.callbacks.context,
-                host.shell(wrapper),
-                child_shells.as_ptr(),
-                child_shells.len(),
-            );
+        });
+        let wrapper_slot = wrapper.slot();
+        host.attach_child(layout_node, wrapper, NodeSlotId::INVALID);
+        for child in children {
+            host.move_child(child, wrapper_slot, NodeSlotId::INVALID);
         }
     }
 }
@@ -3296,14 +3318,15 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         let parent = host.parent(table_root);
         assert!(!parent.is_invalid());
         if host.data(parent).kind != NodeKind::TableWrapper {
-            // SAFETY: `table_root` is attached and `nearest_sibling` is either null or its live next sibling.
-            unsafe {
-                (host.callbacks.wrap_table_root)(
-                    host.callbacks.context,
-                    host.shell(table_root),
-                    host.shell_or_null(nearest_sibling),
-                );
-            };
+            // SAFETY: `table_root` is a live table box.
+            let wrapper = host.created(unsafe {
+                (host.callbacks.create_table_wrapper)(host.callbacks.context, host.shell(table_root))
+            });
+            let wrapper_slot = wrapper.slot();
+            host.move_child(table_root, wrapper_slot, NodeSlotId::INVALID);
+            host.attach_child(parent, wrapper, nearest_sibling);
+            host.arena()
+                .set_node_flag(table_root, NodeFlag::HasBeenWrappedInTableWrapper, true);
         }
     }
     table_roots_to_wrap
@@ -3315,7 +3338,9 @@ fn fixup_row(host: &TreeBuilderHost<'_>, row: LayoutNode, table_grid: &crate::la
             continue;
         }
         // SAFETY: `row` is a live table-row box.
-        unsafe { (host.callbacks.append_missing_table_cell)(host.callbacks.context, host.shell(row)) };
+        let cell = host
+            .created(unsafe { (host.callbacks.create_missing_table_cell)(host.callbacks.context, host.shell(row)) });
+        host.attach_child(row, cell, NodeSlotId::INVALID);
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -93,6 +93,10 @@ impl OwnedLayoutNode {
         Self(slot)
     }
 
+    pub(crate) fn slot(&self) -> NodeSlotId {
+        self.0
+    }
+
     fn into_slot(self) -> NodeSlotId {
         let slot = self.0;
         std::mem::forget(self);
@@ -136,6 +140,14 @@ impl LayoutNodeArena {
     pub(crate) fn detach_from_parent(&self, node: NodeSlotId) -> Option<DetachedShell> {
         let parent = parent_of(self, node);
         (!parent.is_invalid()).then(|| self.detach_child(parent, node))
+    }
+
+    pub(crate) fn move_child(&self, child: NodeSlotId, new_parent: NodeSlotId, before: NodeSlotId) {
+        self.assert_owner_thread();
+        let old_parent = parent_of(self, child);
+        assert!(!old_parent.is_invalid(), "moved layout node has no parent");
+        self.remove_child(old_parent, child);
+        self.insert_child(new_parent, child, before);
     }
 
     pub(crate) fn replace_child(
@@ -260,6 +272,33 @@ mod tests {
         free(&mut arena, b);
         free(&mut arena, parent);
         for orphan in [a, d, c] {
+            free(&mut arena, orphan);
+        }
+    }
+
+    #[test]
+    fn moving_a_child_relinks_it_under_the_new_parent() {
+        let mut arena = LayoutNodeArena::new();
+        let first_parent = arena.allocate();
+        let second_parent = arena.allocate();
+        let a = arena.allocate();
+        let b = arena.allocate();
+        let c = arena.allocate();
+        arena.attach_child(first_parent.slot, owned(a.slot), NodeSlotId::INVALID);
+        arena.attach_child(first_parent.slot, owned(b.slot), NodeSlotId::INVALID);
+        arena.attach_child(second_parent.slot, owned(c.slot), NodeSlotId::INVALID);
+
+        arena.move_child(b.slot, second_parent.slot, c.slot);
+
+        assert_eq!(links(&arena, first_parent.slot).first_child, a.slot);
+        assert_eq!(links(&arena, first_parent.slot).last_child, a.slot);
+        assert_eq!(links(&arena, second_parent.slot).first_child, b.slot);
+        assert_eq!(links(&arena, b.slot).next_sibling, c.slot);
+        assert_eq!(links(&arena, b.slot).parent, second_parent.slot);
+
+        free(&mut arena, first_parent);
+        free(&mut arena, second_parent);
+        for orphan in [a, b, c] {
             free(&mut arena, orphan);
         }
     }

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -102,6 +102,10 @@ impl OwnedLayoutNode {
         std::mem::forget(self);
         slot
     }
+
+    pub(crate) fn into_detached_shell(self, arena: &LayoutNodeArena) -> DetachedShell {
+        DetachedShell(arena.node_shell(self.into_slot()))
+    }
 }
 
 impl Drop for OwnedLayoutNode {

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeSlotId;
+use std::ffi::c_void;
+
+unsafe extern "C" {
+    fn ladybird_layout_node_shell_release(shell: *mut c_void);
+}
+
+fn release_shell(shell: *mut c_void) {
+    if shell.is_null() {
+        debug_assert!(cfg!(test), "layout node has no C++ shell");
+        return;
+    }
+    // SAFETY: Node::unref() may destroy the shell and re-enter layout_arena_free; every caller
+    // releases with no arena borrow live.
+    unsafe { ladybird_layout_node_shell_release(shell) };
+}
+
+#[must_use = "the tree's reference to the detached layout node must be released"]
+pub(crate) struct DetachedShell(*mut c_void);
+
+impl DetachedShell {
+    pub(crate) fn from_tree_reference(shell: *mut c_void) -> Self {
+        Self(shell)
+    }
+
+    pub(crate) fn release(self) {
+        let shell = self.0;
+        std::mem::forget(self);
+        release_shell(shell);
+    }
+}
+
+impl Drop for DetachedShell {
+    fn drop(&mut self) {
+        debug_assert!(
+            std::thread::panicking(),
+            "detached layout node shell dropped without being released"
+        );
+    }
+}
+
+#[must_use = "the tree's references to the detached layout nodes must be released"]
+#[derive(Default)]
+pub(crate) struct DetachedShells(Vec<*mut c_void>);
+
+impl DetachedShells {
+    pub(crate) fn push(&mut self, detached: DetachedShell) {
+        let shell = detached.0;
+        std::mem::forget(detached);
+        self.0.push(shell);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn release_all(mut self) {
+        let shells = std::mem::take(&mut self.0);
+        std::mem::forget(self);
+        for shell in shells {
+            release_shell(shell);
+        }
+    }
+}
+
+impl Drop for DetachedShells {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.0.is_empty() || std::thread::panicking(),
+            "detached layout node shells dropped without being released"
+        );
+    }
+}
+
+#[must_use = "an owned layout node must be attached or released"]
+pub(crate) struct OwnedLayoutNode(NodeSlotId);
+
+impl OwnedLayoutNode {
+    /// # Safety
+    ///
+    /// `slot` must name a live node whose shell carries exactly one reference that was handed
+    /// to the caller.
+    pub(crate) unsafe fn adopt_created(slot: NodeSlotId) -> Self {
+        assert!(!slot.is_invalid(), "adopted an invalid layout node slot");
+        Self(slot)
+    }
+
+    fn into_slot(self) -> NodeSlotId {
+        let slot = self.0;
+        std::mem::forget(self);
+        slot
+    }
+}
+
+impl Drop for OwnedLayoutNode {
+    fn drop(&mut self) {
+        debug_assert!(
+            std::thread::panicking(),
+            "owned layout node {:?} leaked without being attached or released",
+            self.0
+        );
+    }
+}
+
+fn parent_of(arena: &LayoutNodeArena, node: NodeSlotId) -> NodeSlotId {
+    // SAFETY: data() validated that node names a live slot; the link is a plain value.
+    unsafe { (&raw const (*arena.data(node)).parent).read() }
+}
+
+fn next_sibling_of(arena: &LayoutNodeArena, node: NodeSlotId) -> NodeSlotId {
+    // SAFETY: data() validated that node names a live slot; the link is a plain value.
+    unsafe { (&raw const (*arena.data(node)).next_sibling).read() }
+}
+
+impl LayoutNodeArena {
+    pub(crate) fn attach_child(&self, parent: NodeSlotId, child: OwnedLayoutNode, before: NodeSlotId) {
+        self.assert_owner_thread();
+        self.insert_child(parent, child.into_slot(), before);
+    }
+
+    pub(crate) fn detach_child(&self, parent: NodeSlotId, child: NodeSlotId) -> DetachedShell {
+        self.assert_owner_thread();
+        let shell = self.node_shell(child);
+        self.remove_child(parent, child);
+        DetachedShell(shell)
+    }
+
+    pub(crate) fn detach_from_parent(&self, node: NodeSlotId) -> Option<DetachedShell> {
+        let parent = parent_of(self, node);
+        (!parent.is_invalid()).then(|| self.detach_child(parent, node))
+    }
+
+    pub(crate) fn replace_child(
+        &self,
+        parent: NodeSlotId,
+        old_child: NodeSlotId,
+        new_child: OwnedLayoutNode,
+    ) -> DetachedShell {
+        let successor = next_sibling_of(self, old_child);
+        let detached = self.detach_child(parent, old_child);
+        self.attach_child(parent, new_child, successor);
+        detached
+    }
+}
+
+#[cfg(test)]
+mod ffi_test_stubs {
+    #[unsafe(no_mangle)]
+    extern "C" fn ladybird_layout_node_shell_release(_shell: *mut std::ffi::c_void) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OwnedLayoutNode;
+    use crate::layout::LayoutNodeArena;
+    use crate::layout::layout_node_arena::NodeAllocation;
+    use crate::layout::node_data::{NodeKind, NodeSlotId};
+
+    struct Links {
+        parent: NodeSlotId,
+        first_child: NodeSlotId,
+        last_child: NodeSlotId,
+        previous_sibling: NodeSlotId,
+        next_sibling: NodeSlotId,
+    }
+
+    fn links(arena: &LayoutNodeArena, node: NodeSlotId) -> Links {
+        // SAFETY: Every test keeps its allocations live while reading them.
+        let data = unsafe { &*arena.data(node) };
+        Links {
+            parent: data.parent,
+            first_child: data.first_child,
+            last_child: data.last_child,
+            previous_sibling: data.previous_sibling,
+            next_sibling: data.next_sibling,
+        }
+    }
+
+    fn fragment_cache_epoch(arena: &LayoutNodeArena, node: NodeSlotId) -> u32 {
+        // SAFETY: Every test keeps its allocations live while reading them.
+        unsafe { (*arena.data(node)).fragment_cache_epoch }
+    }
+
+    fn owned(slot: NodeSlotId) -> OwnedLayoutNode {
+        // SAFETY: Test nodes have no shell, and the release hook skips null shells.
+        unsafe { OwnedLayoutNode::adopt_created(slot) }
+    }
+
+    fn free(arena: &mut LayoutNodeArena, allocation: NodeAllocation) {
+        arena
+            .free(allocation.slot, allocation.generation)
+            .detached_children
+            .release_all();
+    }
+
+    #[test]
+    fn attaching_an_owned_child_and_detaching_it_round_trips_the_links() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate();
+        let child = arena.allocate();
+
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+        assert_eq!(links(&arena, parent.slot).first_child, child.slot);
+        assert_eq!(links(&arena, parent.slot).last_child, child.slot);
+        assert_eq!(links(&arena, child.slot).parent, parent.slot);
+
+        arena.detach_child(parent.slot, child.slot).release();
+        assert!(links(&arena, parent.slot).first_child.is_invalid());
+        assert!(links(&arena, child.slot).parent.is_invalid());
+
+        free(&mut arena, parent);
+        free(&mut arena, child);
+    }
+
+    #[test]
+    fn detaching_from_the_parent_unlinks_an_attached_child_and_skips_a_root() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate();
+        let child = arena.allocate();
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+
+        arena.detach_from_parent(child.slot).expect("attached child").release();
+        assert!(links(&arena, parent.slot).first_child.is_invalid());
+        assert!(arena.detach_from_parent(parent.slot).is_none());
+
+        free(&mut arena, parent);
+        free(&mut arena, child);
+    }
+
+    #[test]
+    fn replacing_a_child_keeps_the_sibling_position() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate();
+        let a = arena.allocate();
+        let b = arena.allocate();
+        let c = arena.allocate();
+        let d = arena.allocate();
+        for child in [a.slot, b.slot, c.slot] {
+            arena.attach_child(parent.slot, owned(child), NodeSlotId::INVALID);
+        }
+
+        arena.replace_child(parent.slot, b.slot, owned(d.slot)).release();
+
+        assert_eq!(links(&arena, parent.slot).first_child, a.slot);
+        assert_eq!(links(&arena, a.slot).next_sibling, d.slot);
+        assert_eq!(links(&arena, d.slot).previous_sibling, a.slot);
+        assert_eq!(links(&arena, d.slot).next_sibling, c.slot);
+        assert_eq!(links(&arena, c.slot).previous_sibling, d.slot);
+        assert_eq!(links(&arena, parent.slot).last_child, c.slot);
+        assert!(links(&arena, b.slot).parent.is_invalid());
+
+        free(&mut arena, b);
+        free(&mut arena, parent);
+        for orphan in [a, d, c] {
+            free(&mut arena, orphan);
+        }
+    }
+
+    #[test]
+    fn freeing_a_node_unlinks_its_children_and_hands_back_their_references() {
+        let mut arena = LayoutNodeArena::new();
+        let root = arena.allocate();
+        let a = arena.allocate();
+        let b = arena.allocate();
+        arena.attach_child(root.slot, owned(a.slot), NodeSlotId::INVALID);
+        arena.attach_child(root.slot, owned(b.slot), NodeSlotId::INVALID);
+
+        let freed = arena.free(root.slot, root.generation);
+        assert_eq!(freed.detached_children.len(), 2);
+        assert!(links(&arena, a.slot).parent.is_invalid());
+        assert!(links(&arena, b.slot).parent.is_invalid());
+        assert!(links(&arena, a.slot).next_sibling.is_invalid());
+        freed.detached_children.release_all();
+
+        free(&mut arena, a);
+        free(&mut arena, b);
+    }
+
+    #[test]
+    #[should_panic(expected = "still linked under a parent")]
+    fn freeing_a_node_still_linked_under_a_parent_panics() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate();
+        let child = arena.allocate();
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+        let _ = arena.free(child.slot, child.generation);
+    }
+
+    #[test]
+    fn a_structural_change_bumps_the_fragment_cache_epoch_of_every_ancestor() {
+        if crate::layout::fc_run_cache_mode_from_environment() == crate::layout::FcRunCacheMode::Disabled {
+            return;
+        }
+        let mut arena = LayoutNodeArena::new();
+        let grandparent = arena.allocate();
+        let parent = arena.allocate();
+        let sibling = arena.allocate();
+        let child = arena.allocate();
+        arena.attach_child(grandparent.slot, owned(parent.slot), NodeSlotId::INVALID);
+        arena.attach_child(grandparent.slot, owned(sibling.slot), NodeSlotId::INVALID);
+        let grandparent_epoch = fragment_cache_epoch(&arena, grandparent.slot);
+        let parent_epoch = fragment_cache_epoch(&arena, parent.slot);
+        let sibling_epoch = fragment_cache_epoch(&arena, sibling.slot);
+
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+
+        assert_eq!(fragment_cache_epoch(&arena, grandparent.slot), grandparent_epoch + 1);
+        assert_eq!(fragment_cache_epoch(&arena, parent.slot), parent_epoch + 1);
+        assert_eq!(fragment_cache_epoch(&arena, sibling.slot), sibling_epoch);
+        assert_eq!(fragment_cache_epoch(&arena, child.slot), 0);
+
+        free(&mut arena, grandparent);
+        for orphan in [parent, sibling, child] {
+            free(&mut arena, orphan);
+        }
+    }
+
+    #[test]
+    fn a_structural_change_clears_the_overflow_validity_of_box_ancestors_only() {
+        let mut arena = LayoutNodeArena::new();
+        let grandparent = arena.allocate();
+        let parent = arena.allocate();
+        let child = arena.allocate();
+        // SAFETY: The allocations stay live for the whole test.
+        unsafe {
+            (*grandparent.data).kind = NodeKind::BlockContainer;
+            (*parent.data).kind = NodeKind::InlineNode;
+        }
+        arena.attach_child(grandparent.slot, owned(parent.slot), NodeSlotId::INVALID);
+        for node in [grandparent.slot, parent.slot] {
+            arena.populate_paintable_row(node);
+            arena
+                .paintable_rows_mut()
+                .paintable_data_mut(node)
+                .overflow_valid_across_recommits = true;
+        }
+
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+
+        assert!(
+            !arena
+                .paintable_rows()
+                .paintable_data(grandparent.slot)
+                .overflow_valid_across_recommits
+        );
+        assert!(
+            arena
+                .paintable_rows()
+                .paintable_data(parent.slot)
+                .overflow_valid_across_recommits
+        );
+
+        free(&mut arena, grandparent);
+        free(&mut arena, parent);
+        free(&mut arena, child);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "without being released")]
+    fn dropping_a_detached_shell_without_releasing_it_panics() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate();
+        let child = arena.allocate();
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+        let _ = arena.detach_child(parent.slot, child.slot);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "leaked without being attached or released")]
+    fn dropping_an_owned_layout_node_without_placing_it_panics() {
+        let mut arena = LayoutNodeArena::new();
+        let node = arena.allocate();
+        // SAFETY: Test nodes have no shell, and the hooks skip null shells.
+        let _ = unsafe { OwnedLayoutNode::adopt_created(node.slot) };
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -481,11 +481,8 @@ pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_cached_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let mut paintable_rows = arena.paintable_rows_mut();
-        if paintable_rows.paintable_row_is_populated(slot) {
-            paintable_rows.paintable_data_mut(slot).overflow_valid_across_recommits = false;
-        }
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.paintable_rows().clear_cached_overflow_data(slot);
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -313,35 +313,6 @@ pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_transfer_fragments_to_replacement_node(
-    arena: *mut c_void,
-    containing_block: NodeSlotId,
-    old_node: NodeSlotId,
-    new_node: NodeSlotId,
-) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(containing_block) {
-            return;
-        }
-        let mut side = arena.paintable_side_data_mut(containing_block);
-        for fragment in &mut side.fragments {
-            if fragment.layout_node == old_node {
-                fragment.layout_node = new_node;
-            }
-        }
-        for piece in &mut side.inline_box_pieces {
-            if piece.node == old_node {
-                piece.node = new_node;
-            }
-        }
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
     arena: *mut c_void,
     slot: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -686,6 +686,28 @@ impl LayoutNodeArena {
         self.paintable_rows().invalidate_paint_cache(id);
     }
 
+    pub(crate) fn transfer_fragments_to_replacement_node(
+        &self,
+        containing_block: NodeSlotId,
+        old_node: NodeSlotId,
+        new_node: NodeSlotId,
+    ) {
+        if !self.paintable_row_is_populated(containing_block) {
+            return;
+        }
+        let mut side = self.paintable_side_data_mut(containing_block);
+        for fragment in &mut side.fragments {
+            if fragment.layout_node == old_node {
+                fragment.layout_node = new_node;
+            }
+        }
+        for piece in &mut side.inline_box_pieces {
+            if piece.node == old_node {
+                piece.node = new_node;
+            }
+        }
+    }
+
     pub(crate) fn mark_descendant_subtree_caches_dirty_from_layout_node(&self, node: NodeSlotId) {
         self.paintable_rows()
             .mark_descendant_subtree_caches_dirty_from_layout_node(node);

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -155,6 +155,17 @@ where
         generation != 0 && generation == id.generation()
     }
 
+    pub(crate) fn clear_cached_overflow_data(&self, id: NodeSlotId) {
+        if !self.paintable_row_is_populated(id) {
+            return;
+        }
+        let index = id.slot_index() as usize;
+        let chunk = &self.arena.paintable_rows.chunks[index / PAINTABLE_SLOTS_PER_CHUNK];
+        let data = (&raw const chunk.slots[index % PAINTABLE_SLOTS_PER_CHUNK]).cast_mut();
+        // SAFETY: paintable_row_is_populated established that the chunk and slot exist.
+        unsafe { (&raw mut (*data).overflow_valid_across_recommits).write(false) };
+    }
+
     pub(crate) fn inline_pieces_root(&self, inline_paintable: NodeSlotId) -> Option<NodeSlotId> {
         if !self.paintable_row_is_populated(inline_paintable) {
             return None;


### PR DESCRIPTION
The layout tree's links already live in the Rust node arena and the Rust tree builder already decides every structural change, but it executed them through C++ callbacks using `Layout::Node::append_child/insert_before/remove_child`.

Now Rust owns every insert, move, replace and wrap. C++ only creates node shells and destroys them; the few callers that drop a subtree use `Layout::detach_layout_node_for_destruction()`. `Layout::Node` has no structural methods and the arena's link entry points are no longer exported, so a new C++ mutation fails to compile.

Create callbacks hand Rust one reference per box (`OwnedLayoutNode`, must be attached or released); unlinking returns a `DetachedShell` token released only once no arena borrow is live. Each structural change now does one ancestor walk with no per-ancestor FFI.