### PR TITLE
LibWebView: Don't treat numbers as URLs for context menu purposes

### DIFF
--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -207,6 +207,17 @@ Optional<URL::URL> url_from_text(StringView text)
     if (trimmed_text.starts_with('.') || trimmed_text.starts_with('/'))
         return {};
 
+    // The URL parser accepts abbreviated IPv4 addresses, causing numeric text such as "88" to be parsed as
+    // 0.0.0.88. For selected text, only recognize an IPv4 address when all four parts are present.
+    auto hostname_end = trimmed_text.find_any_of(":/?#"sv).value_or(trimmed_text.length());
+    auto hostname = trimmed_text.substring_view(0, hostname_end);
+    auto is_numeric_hostname = all_of(hostname.bytes(), [](auto byte) { return is_ascii_digit(byte) || byte == '.'; });
+    if (is_numeric_hostname) {
+        auto parts = hostname.split_view('.', SplitBehavior::KeepEmpty);
+        if (parts.size() != 4 || any_of(parts, [](auto part) { return part.is_empty(); }))
+            return {};
+    }
+
     return sanitize_url(trimmed_text);
 }
 

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -370,10 +370,15 @@ TEST_CASE(context_menu_url_text)
     expect_context_menu_text_url("www.ladybird.org/path?x=1"sv, "https://www.ladybird.org/path?x=1"sv);
     expect_context_menu_text_url("localhost:8000"sv, "http://localhost:8000/"sv);
     expect_context_menu_text_url("https://ladybird.org"sv, "https://ladybird.org/"sv);
+    expect_context_menu_text_url("192.168.0.1"sv, "http://192.168.0.1/"sv);
 
     expect_context_menu_text_not_url("ladybird"sv);
     expect_context_menu_text_not_url("ladybird org"sv);
     expect_context_menu_text_not_url("ladybird.org hello"sv);
+    expect_context_menu_text_not_url("192"sv);
+    expect_context_menu_text_not_url("192.168"sv);
+    expect_context_menu_text_not_url("192.168.0"sv);
+    expect_context_menu_text_not_url("192.168.0.999"sv);
     expect_context_menu_text_not_url("./Meta/ladybird.py"sv);
     expect_context_menu_text_not_url("../ladybird.org"sv);
     expect_context_menu_text_not_url("/tmp/ladybird.org"sv);


### PR DESCRIPTION
"88" is technically parsable as a URL, but it feels unintuitive to get the "Open in new tab" etc menu options in the context menu for it.