### PR TITLE
Paint CSS images through their observers' decoded image data

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -6,6 +6,8 @@
 
 #include "AbstractImageStyleValue.h"
 #include <LibWeb/CSS/CSSImageValue.h>
+#include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
@@ -65,6 +67,17 @@ GC::Ref<CSSStyleValue> AbstractImageStyleValue::reify(Utf16FlyString const&) con
 void AbstractImageStyleValue::load_any_resources(Layout::NodeWithStyle const& layout_node)
 {
     load_any_resources(const_cast<DOM::Document&>(layout_node.document()));
+}
+
+ImageStyleValue const* AbstractImageStyleValue::selected_image_style_value() const
+{
+    if (is_image())
+        return &as_image();
+    if (is_image_set()) {
+        if (auto const* selected_image = as_image_set().selected_image(); selected_image && selected_image->is_image())
+            return &selected_image->as_image();
+    }
+    return nullptr;
 }
 
 Optional<Painting::ImagePaint> AbstractImageStyleValue::image_paint(Painting::ImagePaintRequest const&, ResolvedImage const& resolved) const

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/CSS/CSSImageValue.h>
 #include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
+#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
@@ -78,6 +79,15 @@ ImageStyleValue const* AbstractImageStyleValue::selected_image_style_value() con
             return &selected_image->as_image();
     }
     return nullptr;
+}
+
+SizeWithAspectRatio AbstractImageStyleValue::natural_size(HTML::DecodedImageData const& decoded_image_data) const
+{
+    return {
+        .width = decoded_image_data.intrinsic_width(),
+        .height = decoded_image_data.intrinsic_height(),
+        .aspect_ratio = decoded_image_data.intrinsic_aspect_ratio(),
+    };
 }
 
 Optional<Painting::ImagePaint> AbstractImageStyleValue::image_paint(Painting::ImagePaintRequest const&, ResolvedImage const& resolved) const

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -11,6 +11,7 @@
 
 #include <AK/Variant.h>
 #include <LibWeb/CSS/PercentageOr.h>
+#include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 #include <LibWeb/Export.h>
@@ -28,26 +29,13 @@ class WEB_API AbstractImageStyleValue : public StyleValue {
 public:
     using StyleValue::StyleValue;
 
-    virtual Optional<CSSPixels> natural_width(DOM::Document const&) const { return {}; }
-    virtual Optional<CSSPixels> natural_height(DOM::Document const&) const { return {}; }
-
-    virtual Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const& document) const
-    {
-        auto width = natural_width(document);
-        auto height = natural_height(document);
-        if (width.has_value() && height.has_value() && *height != 0)
-            return *width / *height;
-        return {};
-    }
-
     virtual void load_any_resources(DOM::Document&) { }
     virtual void load_any_resources(Layout::NodeWithStyle const&);
     virtual ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const { return Empty {}; }
 
-    virtual bool is_paintable(DOM::Document const&) const = 0;
+    virtual bool is_paintable(GC::Ptr<HTML::DecodedImageData>) const = 0;
+    virtual SizeWithAspectRatio natural_size(HTML::DecodedImageData const&) const;
     virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const;
-
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 
     ImageStyleValue const* selected_image_style_value() const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -49,6 +49,8 @@ public:
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 
+    ImageStyleValue const* selected_image_style_value() const;
+
     GC::Ref<CSSStyleValue> reify(Utf16FlyString const& associated_property) const;
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -36,7 +36,7 @@ public:
         return color_stops_from_rust_data(list.pointer, list.length);
     }
 
-    bool is_paintable(DOM::Document const&) const override { return true; }
+    bool is_paintable(GC::Ptr<HTML::DecodedImageData>) const override { return true; }
 
     ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
@@ -54,11 +55,11 @@ ValueComparingNonnullRefPtr<StyleValue const> CursorStyleValue::absolutized(Comp
     return CursorStyleValue::create(image().absolutized(computation_context)->as_abstract_image(), absolutized_x, absolutized_y);
 }
 
-Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithStyle const& layout_node) const
+Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithStyle const& layout_node, GC::Ptr<HTML::DecodedImageData> decoded_image_data) const
 {
     auto const& image = this->image();
     auto const& document = layout_node.document();
-    if (!image.is_paintable(document))
+    if (!image.is_paintable(decoded_image_data))
         return {};
 
     auto current_color = layout_node.color();
@@ -79,7 +80,8 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         // 32x32 is selected arbitrarily.
         // FIXME: Ask the OS for the default size?
         CSSPixelSize const default_cursor_size { 32, 32 };
-        auto cursor_css_size = run_default_sizing_algorithm({}, {}, { image.natural_width(document), image.natural_height(document), image.natural_aspect_ratio(document) }, default_cursor_size);
+        auto natural_size = decoded_image_data ? image.natural_size(*decoded_image_data) : SizeWithAspectRatio {};
+        auto cursor_css_size = run_default_sizing_algorithm({}, {}, natural_size, default_cursor_size);
         // FIXME: How do we determine what cursor sizes the OS allows?
         // We don't multiply by the pixel ratio, because we want to use the image's actual pixel size.
         DevicePixelSize cursor_device_size { cursor_css_size.to_type<double>().to_rounded<int>() };
@@ -117,7 +119,8 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
             .accumulated_scale = { 1, 1 },
             .resource_storage = resource_storage,
         };
-        if (auto image_paint = image.image_paint(request, resolved_image); image_paint.has_value()) {
+        auto image_paint = decoded_image_data ? decoded_image_data->image_paint(request) : image.image_paint(request, resolved_image);
+        if (image_paint.has_value()) {
             auto display_list = Painting::record_image_paint_display_list(*image_paint, request.dest_rect, ImageRendering::Auto, document.page().client().device_pixels_per_css_pixel(), visual_context_tree, resource_storage);
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
             Painting::DisplayListPlayerSkia display_list_player;

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
@@ -26,7 +26,7 @@ public:
 
     AbstractImageStyleValue const& image() const { return m_image; }
 
-    Optional<Gfx::ImageCursor> make_image_cursor(Layout::NodeWithStyle const&) const;
+    Optional<Gfx::ImageCursor> make_image_cursor(Layout::NodeWithStyle const&, GC::Ptr<HTML::DecodedImageData>) const;
 
     ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/SupportedImageTypes.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
@@ -94,31 +95,18 @@ void ImageSetStyleValue::load_any_resources(DOM::Document& document)
         const_cast<AbstractImageStyleValue&>(*m_selected_image).load_any_resources(document);
 }
 
-Optional<CSSPixels> ImageSetStyleValue::natural_width(DOM::Document const& document) const
+SizeWithAspectRatio ImageSetStyleValue::natural_size(HTML::DecodedImageData const& decoded_image_data) const
 {
-    if (!m_selected_image)
-        return {};
-    auto natural_width = m_selected_image->natural_width(document);
-    if (!natural_width.has_value())
-        return {};
-    return CSSPixels { natural_width->to_double() / m_selected_resolution };
-}
-
-Optional<CSSPixels> ImageSetStyleValue::natural_height(DOM::Document const& document) const
-{
-    if (!m_selected_image)
-        return {};
-    auto natural_height = m_selected_image->natural_height(document);
-    if (!natural_height.has_value())
-        return {};
-    return CSSPixels { natural_height->to_double() / m_selected_resolution };
-}
-
-Optional<CSSPixelFraction> ImageSetStyleValue::natural_aspect_ratio(DOM::Document const& document) const
-{
-    if (m_selected_image)
-        return m_selected_image->natural_aspect_ratio(document);
-    return {};
+    auto scaled_by_selected_resolution = [&](Optional<CSSPixels> length) -> Optional<CSSPixels> {
+        if (!length.has_value())
+            return {};
+        return CSSPixels { length->to_double() / m_selected_resolution };
+    };
+    return {
+        .width = scaled_by_selected_resolution(decoded_image_data.intrinsic_width()),
+        .height = scaled_by_selected_resolution(decoded_image_data.intrinsic_height()),
+        .aspect_ratio = decoded_image_data.intrinsic_aspect_ratio(),
+    };
 }
 
 ResolvedImage ImageSetStyleValue::resolve_for_size(Layout::NodeWithStyle const& layout_node, CSSPixelSize size) const
@@ -128,25 +116,11 @@ ResolvedImage ImageSetStyleValue::resolve_for_size(Layout::NodeWithStyle const& 
     return Empty {};
 }
 
-bool ImageSetStyleValue::is_paintable(DOM::Document const& document) const
+bool ImageSetStyleValue::is_paintable(GC::Ptr<HTML::DecodedImageData> decoded_image_data) const
 {
     if (m_selected_image)
-        return m_selected_image->is_paintable(document);
+        return m_selected_image->is_paintable(decoded_image_data);
     return false;
-}
-
-Optional<Painting::ImagePaint> ImageSetStyleValue::image_paint(Painting::ImagePaintRequest const& request, ResolvedImage const& resolved_image) const
-{
-    if (m_selected_image)
-        return m_selected_image->image_paint(request, resolved_image);
-    return {};
-}
-
-Optional<Gfx::Color> ImageSetStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const
-{
-    if (m_selected_image)
-        return m_selected_image->color_if_single_pixel_bitmap(document);
-    return {};
 }
 
 void ImageSetStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -28,14 +28,9 @@ public:
 
     virtual void load_any_resources(DOM::Document&) override;
 
-    virtual Optional<CSSPixels> natural_width(DOM::Document const&) const override;
-    virtual Optional<CSSPixels> natural_height(DOM::Document const&) const override;
-    virtual Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
-
     virtual ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
-    virtual bool is_paintable(DOM::Document const&) const override;
-    virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const override;
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
+    virtual bool is_paintable(GC::Ptr<HTML::DecodedImageData>) const override;
+    virtual SizeWithAspectRatio natural_size(HTML::DecodedImageData const&) const override;
 
     AbstractImageStyleValue const* selected_image() const { return m_selected_image; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -15,8 +15,6 @@
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOMURL/DOMURL.h>
-#include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
-#include <LibWeb/HTML/BitmapDecodedImageData.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -236,19 +234,7 @@ Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap(DOM::Document
     auto image_data = this->image_data(document);
     if (!image_data)
         return {};
-
-    if (!is<HTML::BitmapDecodedImageData>(*image_data) && !is<HTML::AnimatedBitmapDecodedImageData>(*image_data))
-        return {};
-
-    auto decoded_frame = image_data->current_frame();
-    if (!decoded_frame.has_value())
-        return {};
-
-    auto const& bitmap = decoded_frame->bitmap();
-    if (bitmap.width() == 1 && bitmap.height() == 1)
-        return bitmap.get_pixel(0, 0);
-
-    return {};
+    return image_data->color_if_single_pixel_bitmap();
 }
 
 void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <LibGC/Weak.h>
-#include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Fetch.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
@@ -159,82 +158,6 @@ GC::Ptr<HTML::SharedResourceRequest> ImageStyleValue::fetch_image(DOM::Document&
 void ImageStyleValue::load_any_resources(DOM::Document& document)
 {
     fetch_image(document);
-}
-
-Optional<CSSPixels> ImageStyleValue::natural_width(DOM::Document const& document) const
-{
-    if (auto image_data = this->image_data(document))
-        return image_data->intrinsic_width();
-    return {};
-}
-
-Optional<CSSPixels> ImageStyleValue::natural_height(DOM::Document const& document) const
-{
-    if (auto image_data = this->image_data(document))
-        return image_data->intrinsic_height();
-    return {};
-}
-
-Optional<CSSPixelFraction> ImageStyleValue::natural_aspect_ratio(DOM::Document const& document) const
-{
-    if (auto image_data = this->image_data(document))
-        return image_data->intrinsic_aspect_ratio();
-    return {};
-}
-
-bool ImageStyleValue::is_paintable(DOM::Document const& document) const
-{
-    return !!image_data(document);
-}
-
-Optional<Painting::ImagePaint> ImageStyleValue::image_paint(Painting::ImagePaintRequest const& request, ResolvedImage const&) const
-{
-    auto image_data = this->image_data(request.document);
-    if (!image_data)
-        return {};
-
-    auto integer_request = request;
-    integer_request.dest_rect = request.dest_rect.to_type<int>().to_type<float>();
-    return image_data->image_paint(integer_request);
-}
-
-Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(Painting::DisplayListResourceStorage& resource_storage, DOM::Document const& document, DevicePixelRect const& dest_rect, PreferredColorScheme color_scheme) const
-{
-    auto image_data = this->image_data(document);
-    if (!image_data)
-        return {};
-
-    return image_data->record_display_list(dest_rect.size().to_type<int>(), color_scheme, resource_storage);
-}
-
-Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DOM::Document const& document, DevicePixelRect const& dest_rect) const
-{
-    if (auto image_data = this->image_data(document))
-        return image_data->current_frame(dest_rect.size().to_type<int>());
-    return {};
-}
-
-GC::Ptr<HTML::DecodedImageData> ImageStyleValue::image_data(DOM::Document const& document) const
-{
-    auto resolved_url = this->resolved_url(document);
-    if (!resolved_url.has_value())
-        return nullptr;
-
-    auto const* resource = document.css_image_resource(*resolved_url);
-
-    // NB: We should have registered a client for this before now which ensures a resource exists if we have a valid
-    //     resolved URL.
-    VERIFY(resource);
-
-    return resource->decoded_image_data();
-}
-
-Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const
-{
-    auto image_data = this->image_data(document);
-    if (!image_data)
-        return {};
-    return image_data->color_if_single_pixel_bitmap();
 }
 
 void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/AnyOf.h>
 #include <LibGC/Weak.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
@@ -61,7 +60,7 @@ ImageStyleValueResource::ImageStyleValueResource(GC::Ref<HTML::SharedResourceReq
 
 ImageStyleValueResource::~ImageStyleValueResource()
 {
-    VERIFY(m_image_style_values.is_empty());
+    VERIFY(m_registration_counts_by_image_style_value.is_empty());
     unregister_with_decoded_image_data_if_needed();
 }
 
@@ -72,15 +71,23 @@ void ImageStyleValueResource::visit_edges(JS::Cell::Visitor& visitor)
 
 void ImageStyleValueResource::register_image_style_value(ImageStyleValue const& image_style_value)
 {
-    m_image_style_values.set(&image_style_value);
+    ++m_registration_counts_by_image_style_value.ensure(&image_style_value);
     register_with_decoded_image_data_if_needed();
 }
 
 void ImageStyleValueResource::unregister_image_style_value(ImageStyleValue const& image_style_value)
 {
-    m_image_style_values.remove(&image_style_value);
-    if (m_image_style_values.is_empty())
+    auto it = m_registration_counts_by_image_style_value.find(&image_style_value);
+    VERIFY(it != m_registration_counts_by_image_style_value.end());
+    if (--it->value == 0)
+        m_registration_counts_by_image_style_value.remove(it);
+    if (m_registration_counts_by_image_style_value.is_empty())
         unregister_with_decoded_image_data_if_needed();
+}
+
+::URL::URL const& ImageStyleValueResource::url() const
+{
+    return m_resource_request->url();
 }
 
 GC::Ptr<HTML::DecodedImageData> ImageStyleValueResource::decoded_image_data() const
@@ -91,14 +98,14 @@ GC::Ptr<HTML::DecodedImageData> ImageStyleValueResource::decoded_image_data() co
 void ImageStyleValueResource::on_decoded_image_data_loaded()
 {
     notify_image_style_values_did_update();
-    if (!m_image_style_values.is_empty())
+    if (!m_registration_counts_by_image_style_value.is_empty())
         register_with_decoded_image_data_if_needed();
 }
 
 void ImageStyleValueResource::notify_image_style_values_did_update()
 {
-    for (auto const* image_style_value : m_image_style_values)
-        image_style_value->notify_clients_did_update();
+    for (auto const& registration : m_registration_counts_by_image_style_value)
+        registration.key->notify_clients_did_update();
 }
 
 ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url)
@@ -319,49 +326,38 @@ void ImageStyleValue::register_client(Client& client) const
     if (!resolved_url.has_value())
         return;
 
-    // NB: Store the resolved URL so that we can unregister from the resource later even if the document's base URL
-    //     changes in the interim.
-    client.m_registered_url = *resolved_url;
-
-    GC::Ptr<CSS::ImageStyleValueResource> resource;
-
-    if (auto* existing_resource = document->css_image_resource(*resolved_url)) {
-        resource = existing_resource;
-    } else {
+    ImageStyleValueResource* resource = document->css_image_resource(*resolved_url);
+    if (!resource) {
         auto resource_request = fetch_image(*document);
 
         // NB: This can only fail if the URL is invalid or ResourceLoader is not initialized, neither of which should be
         //     the case here.
         VERIFY(resource_request);
 
-        resource = document->create_css_image_resource(*resource_request);
+        resource = &document->create_css_image_resource(*resource_request);
     }
 
     resource->register_image_style_value(*this);
+    client.m_resource = resource;
 }
 
 void ImageStyleValue::unregister_client(Client& client) const
 {
-    auto document = client.document();
-    auto registered_url = move(client.m_registered_url);
-    client.m_registered_url.clear();
-
     auto did_remove = m_clients.remove(&client);
     VERIFY(did_remove);
 
-    if (!document || !registered_url.has_value())
+    auto* resource = exchange(client.m_resource, nullptr);
+    if (!resource)
         return;
 
-    if (any_of(m_clients, [&](auto const* remaining_client) {
-            return remaining_client->document() == document
-                && remaining_client->m_registered_url.has_value()
-                && *remaining_client->m_registered_url == *registered_url;
-        }))
+    // The document owns the resource, so a collected document has already destroyed it.
+    auto document = client.document();
+    if (!document)
         return;
 
-    if (auto* resource = document->css_image_resource(*registered_url))
-        resource->unregister_image_style_value(*this);
-    document->remove_css_image_resource_if_unused(*registered_url);
+    auto url = resource->url();
+    resource->unregister_image_style_value(*this);
+    document->remove_css_image_resource_if_unused(url);
 }
 
 void ImageStyleValue::notify_clients_did_update() const
@@ -400,6 +396,13 @@ ImageStyleValue::Client::~Client()
 void ImageStyleValue::Client::image_style_value_finalize()
 {
     m_image_style_value.unregister_client(*this);
+}
+
+GC::Ptr<HTML::DecodedImageData> ImageStyleValue::Client::decoded_image_data() const
+{
+    if (!m_resource)
+        return nullptr;
+    return m_resource->decoded_image_data();
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
 #include <LibGC/Weak.h>
@@ -34,7 +35,9 @@ public:
 
     void register_image_style_value(ImageStyleValue const&);
     void unregister_image_style_value(ImageStyleValue const&);
-    bool can_be_removed() const { return m_image_style_values.is_empty(); }
+    bool can_be_removed() const { return m_registration_counts_by_image_style_value.is_empty(); }
+
+    ::URL::URL const& url() const;
 
     [[nodiscard]] virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override;
 
@@ -45,7 +48,7 @@ private:
     void notify_image_style_values_did_update();
 
     GC::Ref<HTML::SharedResourceRequest> m_resource_request;
-    HashTable<ImageStyleValue const*> m_image_style_values;
+    HashMap<ImageStyleValue const*, size_t> m_registration_counts_by_image_style_value;
 };
 
 class ImageStyleValue final
@@ -63,13 +66,15 @@ public:
         virtual ~Client();
         virtual void image_style_value_did_update(ImageStyleValue&) = 0;
 
+        GC::Ptr<HTML::DecodedImageData> decoded_image_data() const;
+
     protected:
         void image_style_value_finalize();
         GC::Ptr<DOM::Document> document() const { return m_document.ptr(); }
 
         ImageStyleValue const& m_image_style_value;
         GC::Weak<DOM::Document> m_document;
-        Optional<::URL::URL> m_registered_url;
+        ImageStyleValueResource* m_resource { nullptr };
     };
 
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&);

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -13,7 +13,6 @@
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
 #include <LibGC/Weak.h>
-#include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
@@ -84,18 +83,7 @@ public:
 
     virtual void load_any_resources(DOM::Document&) override;
 
-    Optional<CSSPixels> natural_width(DOM::Document const&) const override;
-    Optional<CSSPixels> natural_height(DOM::Document const&) const override;
-    Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
-
-    virtual bool is_paintable(DOM::Document const&) const override;
-    Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&, ResolvedImage const&) const override;
-    Optional<Painting::DisplayListResource> record_display_list(Painting::DisplayListResourceStorage&, DOM::Document const&, DevicePixelRect const&, PreferredColorScheme) const;
-
-    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
-    Optional<Gfx::DecodedImageFrame> current_frame(DOM::Document const&, DevicePixelRect const& dest_rect = {}) const;
-
-    GC::Ptr<HTML::DecodedImageData> image_data(DOM::Document const&) const;
+    virtual bool is_paintable(GC::Ptr<HTML::DecodedImageData> decoded_image_data) const override { return !!decoded_image_data; }
 
 private:
     friend class ImageStyleValueResource;

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -65,7 +65,7 @@ public:
 
     ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 
-    bool is_paintable(DOM::Document const&) const override { return true; }
+    bool is_paintable(GC::Ptr<HTML::DecodedImageData>) const override { return true; }
 
 private:
     friend class StyleValue;

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -38,7 +38,7 @@ public:
         return color_stops_from_rust_data(list.pointer, list.length);
     }
 
-    bool is_paintable(DOM::Document const&) const override { return true; }
+    bool is_paintable(GC::Ptr<HTML::DecodedImageData>) const override { return true; }
 
     ResolvedImage resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1547,20 +1547,6 @@ CSS::PreferredColorScheme Document::canvas_color_scheme() const
     return color_scheme;
 }
 
-Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
-{
-    auto* body_element = body();
-    if (!body_element)
-        return {};
-
-    // NB: Called during painting inside update_layout().
-    auto body_layout_node = body_element->unsafe_layout_node();
-    if (!body_layout_node)
-        return {};
-
-    return &body_layout_node->background_layers();
-}
-
 CSS::ImageRendering Document::background_image_rendering() const
 {
     auto* body_element = body();
@@ -7197,14 +7183,6 @@ HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>> const& Document::shared_
 }
 
 CSS::ImageStyleValueResource* Document::css_image_resource(URL::URL const& url)
-{
-    auto it = m_css_image_resources.find(url);
-    if (it == m_css_image_resources.end())
-        return nullptr;
-    return it->value.ptr();
-}
-
-CSS::ImageStyleValueResource const* Document::css_image_resource(URL::URL const& url) const
 {
     auto it = m_css_image_resources.find(url);
     if (it == m_css_image_resources.end())

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -450,7 +450,6 @@ public:
     Color background_color() const;
     Color canvas_background_color() const;
     CSS::PreferredColorScheme canvas_color_scheme() const;
-    Vector<CSS::BackgroundLayerData> const* background_layers() const;
     CSS::ImageRendering background_image_rendering() const;
 
     Optional<Color> normal_link_color() const;
@@ -988,7 +987,6 @@ public:
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& shared_resource_requests();
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>> const& shared_resource_requests() const;
     CSS::ImageStyleValueResource* css_image_resource(URL::URL const&);
-    CSS::ImageStyleValueResource const* css_image_resource(URL::URL const&) const;
     CSS::ImageStyleValueResource& create_css_image_resource(GC::Ref<HTML::SharedResourceRequest>);
     void remove_css_image_resource_if_unused(URL::URL const&);
     void prune_image_resource_caches();

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -227,6 +227,17 @@ Optional<Gfx::DecodedImageFrame> AnimatedBitmapDecodedImageData::current_frame(G
     return frame(m_current_frame_index, size);
 }
 
+Optional<Gfx::Color> AnimatedBitmapDecodedImageData::color_if_single_pixel_bitmap() const
+{
+    auto frame = current_frame();
+    if (!frame.has_value())
+        return {};
+    auto const& bitmap = frame->bitmap();
+    if (bitmap.width() != 1 || bitmap.height() != 1)
+        return {};
+    return bitmap.get_pixel(0, 0);
+}
+
 int AnimatedBitmapDecodedImageData::frame_duration(size_t frame_index) const
 {
     if (frame_index >= m_durations.size())

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -46,6 +46,8 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
+
     virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const override;
 
     void receive_frames(Vector<NonnullRefPtr<Gfx::Bitmap>>, u32 start_frame_index);

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
@@ -60,6 +60,14 @@ Optional<CSSPixelFraction> BitmapDecodedImageData::intrinsic_aspect_ratio() cons
     return CSSPixels(m_frame.width()) / CSSPixels(m_frame.height());
 }
 
+Optional<Gfx::Color> BitmapDecodedImageData::color_if_single_pixel_bitmap() const
+{
+    auto const& bitmap = m_frame.bitmap();
+    if (bitmap.width() != 1 || bitmap.height() != 1)
+        return {};
+    return bitmap.get_pixel(0, 0);
+}
+
 Optional<Painting::ImagePaint> BitmapDecodedImageData::image_paint(Painting::ImagePaintRequest const&) const
 {
     return Painting::ImagePaint { Painting::ImagePaint::DecodedFrame { .frame = m_frame, .natural_size = m_frame.size() } };

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
@@ -32,6 +32,8 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
+
     virtual Optional<Painting::ImagePaint> image_paint(Painting::ImagePaintRequest const&) const override;
 
 private:

--- a/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
@@ -55,6 +56,9 @@ public:
     virtual Optional<CSSPixels> intrinsic_width() const = 0;
     virtual Optional<CSSPixels> intrinsic_height() const = 0;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const = 0;
+
+    // Only bitmap-backed data answers this, so asking never rasterizes an SVG image.
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const { return {}; }
 
     bool has_clients() const { return !m_clients.is_empty(); }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -10,7 +10,6 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CursorStyleValue.h>
-#include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Document.h>
@@ -578,40 +577,55 @@ NodeWithStyle::~NodeWithStyle()
 
 void NodeWithStyle::clear_image_observers()
 {
-    m_image_observers.clear();
+    m_image_observers = {};
 }
 
 void NodeWithStyle::rebuild_image_observers()
 {
-    auto add_observer_for = [&](CSS::AbstractImageStyleValue const* abstract_image, Vector<NonnullOwnPtr<ImageObserver>>& observers) {
+    auto observer_for = [&](CSS::AbstractImageStyleValue const* abstract_image) -> OwnPtr<ImageObserver> {
         if (!abstract_image)
-            return;
-        CSS::ImageStyleValue const* image_to_observe = nullptr;
-        if (abstract_image->is_image()) {
-            image_to_observe = &abstract_image->as_image();
-        } else if (abstract_image->is_image_set()) {
-            if (auto const* selected = abstract_image->as_image_set().selected_image(); selected && selected->is_image())
-                image_to_observe = &selected->as_image();
-        }
+            return nullptr;
+        auto const* image_to_observe = abstract_image->selected_image_style_value();
         if (!image_to_observe)
-            return;
-        observers.append(make<ImageObserver>(*this, *image_to_observe));
+            return nullptr;
+        return make<ImageObserver>(*this, *image_to_observe);
     };
 
-    Vector<NonnullOwnPtr<ImageObserver>> new_observers;
+    ImageObserverSlots new_observers;
     for (auto const& layer : background_layers())
-        add_observer_for(layer.background_image.ptr(), new_observers);
-    add_observer_for(list_style_image(), new_observers);
+        new_observers.background_layers.append(observer_for(layer.background_image.ptr()));
     for (auto const& layer : mask_layers())
-        add_observer_for(layer.background_image.ptr(), new_observers);
-    for (auto const& cursor_style_value : m_cursor_style_values) {
-        if (cursor_style_value)
-            add_observer_for(&cursor_style_value->image(), new_observers);
-    }
-    add_observer_for(border_image_source(), new_observers);
+        new_observers.mask_layers.append(observer_for(layer.background_image.ptr()));
+    for (auto const& cursor_style_value : m_cursor_style_values)
+        new_observers.cursors.append(cursor_style_value ? observer_for(&cursor_style_value->image()) : nullptr);
+    new_observers.border_image_source = observer_for(border_image().source.ptr());
+    new_observers.list_style_image = observer_for(list_style_image());
     // TODO: Observe other <image> accepting properties once we support them.
 
+    // Register the new observers before the old ones unregister so a shared resource is never dropped and refetched.
     m_image_observers = move(new_observers);
+}
+
+static NodeWithStyle::ImageObserver const* image_observer_at(Vector<OwnPtr<NodeWithStyle::ImageObserver>> const& observers, size_t index)
+{
+    if (index >= observers.size())
+        return nullptr;
+    return observers[index].ptr();
+}
+
+NodeWithStyle::ImageObserver const* NodeWithStyle::background_image_observer(size_t layer_index) const
+{
+    return image_observer_at(m_image_observers.background_layers, layer_index);
+}
+
+NodeWithStyle::ImageObserver const* NodeWithStyle::mask_image_observer(size_t layer_index) const
+{
+    return image_observer_at(m_image_observers.mask_layers, layer_index);
+}
+
+NodeWithStyle::ImageObserver const* NodeWithStyle::cursor_image_observer(size_t cursor_index) const
+{
+    return image_observer_at(m_image_observers.cursors, cursor_index);
 }
 
 }
@@ -657,7 +671,7 @@ void NodeWithStyle::attach_style_resources()
         load_image(layer.background_image.ptr());
     for (auto const& layer : mask_layers())
         load_image(layer.background_image.ptr());
-    load_image(border_image_source());
+    load_image(border_image().source.ptr());
     m_cursor_style_values.clear();
     m_cursor_style_values.ensure_capacity(cursor().size());
     for (auto const& cursor_data : cursor()) {

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -9,6 +9,7 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
@@ -422,6 +423,11 @@ public:
         NonnullRefPtr<CSS::ImageStyleValue const> m_image;
     };
 
+    ImageObserver const* background_image_observer(size_t layer_index) const;
+    ImageObserver const* mask_image_observer(size_t layer_index) const;
+    ImageObserver const* cursor_image_observer(size_t cursor_index) const;
+    ImageObserver const* border_image_source_observer() const { return m_image_observers.border_image_source.ptr(); }
+
     NonnullRefPtr<CSS::ComputedValues const> copy_computed_values() const;
     CSS::ComputedStyleRecordView computed_style_record_view() const;
     CSS::StyleRecordID style_record_identity() const { return m_style_record_identity; }
@@ -741,7 +747,14 @@ private:
     // unpins their records before this root is cleared. Every document destruction path goes
     // through that teardown.
     GC::Root<DOM::Document> m_style_record_owner;
-    Vector<NonnullOwnPtr<ImageObserver>> m_image_observers;
+    struct ImageObserverSlots {
+        Vector<OwnPtr<ImageObserver>> background_layers;
+        Vector<OwnPtr<ImageObserver>> mask_layers;
+        Vector<OwnPtr<ImageObserver>> cursors;
+        OwnPtr<ImageObserver> border_image_source;
+        OwnPtr<ImageObserver> list_style_image;
+    };
+    ImageObserverSlots m_image_observers;
     Vector<RefPtr<CSS::CursorStyleValue const>> m_cursor_style_values;
     mutable Optional<Vector<CSS::BackgroundLayerData>> m_background_layers;
     mutable Optional<Vector<CSS::BackgroundLayerData>> m_mask_layers;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -334,33 +334,14 @@ public:
 
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override
     {
-        if (auto document = m_document.ptr()) {
-            if (auto const* image = m_image->selected_image_style_value())
-                return image->image_data(*document);
-        }
-        return nullptr;
+        if (!m_image_client)
+            return nullptr;
+        return m_image_client->decoded_image_data();
     }
 
-    virtual Optional<CSSPixels> intrinsic_width() const override
-    {
-        if (auto document = m_document.ptr())
-            return m_image->natural_width(*document);
-        return {};
-    }
-
-    virtual Optional<CSSPixels> intrinsic_height() const override
-    {
-        if (auto document = m_document.ptr())
-            return m_image->natural_height(*document);
-        return {};
-    }
-
-    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override
-    {
-        if (auto document = m_document.ptr())
-            return m_image->natural_aspect_ratio(*document);
-        return {};
-    }
+    virtual Optional<CSSPixels> intrinsic_width() const override { return natural_size().width; }
+    virtual Optional<CSSPixels> intrinsic_height() const override { return natural_size().height; }
+    virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override { return natural_size().aspect_ratio; }
 
 private:
     class ImageClient final : public CSS::ImageStyleValue::Client {
@@ -388,14 +369,20 @@ private:
     };
 
     GeneratedContentImageProvider(DOM::Document& document, NonnullRefPtr<CSS::AbstractImageStyleValue> image)
-        : m_document(document)
-        , m_image(move(image))
+        : m_image(move(image))
     {
         if (auto const* image = m_image->selected_image_style_value())
             m_image_client = make<ImageClient>(*this, document, *image);
     }
 
-    GC::Weak<DOM::Document> m_document;
+    CSS::SizeWithAspectRatio natural_size() const
+    {
+        auto decoded_image_data = this->decoded_image_data();
+        if (!decoded_image_data)
+            return {};
+        return m_image->natural_size(*decoded_image_data);
+    }
+
     mutable WeakPtr<Layout::Node> m_layout_node;
     NonnullRefPtr<CSS::AbstractImageStyleValue> m_image;
     mutable OwnPtr<ImageClient> m_image_client;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -25,7 +25,6 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
-#include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -336,7 +335,7 @@ public:
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override
     {
         if (auto document = m_document.ptr()) {
-            if (auto const* image = selected_image_style_value())
+            if (auto const* image = m_image->selected_image_style_value())
                 return image->image_data(*document);
         }
         return nullptr;
@@ -392,21 +391,8 @@ private:
         : m_document(document)
         , m_image(move(image))
     {
-        if (auto const* image = selected_image_style_value())
+        if (auto const* image = m_image->selected_image_style_value())
             m_image_client = make<ImageClient>(*this, document, *image);
-    }
-
-    CSS::ImageStyleValue const* selected_image_style_value() const
-    {
-        if (m_image->is_image())
-            return &m_image->as_image();
-
-        if (m_image->is_image_set()) {
-            if (auto const* selected_image = m_image->as_image_set().selected_image(); selected_image && selected_image->is_image())
-                return &selected_image->as_image();
-        }
-
-        return nullptr;
     }
 
     GC::Weak<DOM::Document> m_document;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -3525,8 +3525,11 @@ static constexpr Gfx::Cursor css_to_gfx_cursor(CSS::CursorPredefined css_cursor)
     }
 }
 
-static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, ReadonlySpan<CSS::ComputedValuesFFI::ComputedCursor> cursor_data, ReadonlySpan<RefPtr<CSS::CursorStyleValue const>> cursor_style_values, Gfx::StandardCursor auto_cursor)
+static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Layout::NodeWithStyle const* cursor_values_owner, ReadonlySpan<CSS::ComputedValuesFFI::ComputedCursor> cursor_data, Gfx::StandardCursor auto_cursor)
 {
+    ReadonlySpan<RefPtr<CSS::CursorStyleValue const>> cursor_style_values;
+    if (cursor_values_owner)
+        cursor_style_values = cursor_values_owner->cursor_style_values();
     for (size_t index = 0; index < cursor_data.size(); ++index) {
         auto const& cursor = cursor_data[index];
         if (!cursor.is_cursor_value) {
@@ -3539,7 +3542,10 @@ static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Read
         if (!cursor_style_value)
             cursor_style_value = CSS::ComputedValues::InheritedUIValues::cursor_style_value(cursor);
         VERIFY(cursor_style_value);
-        if (auto image_cursor = cursor_style_value->make_image_cursor(layout_node); image_cursor.has_value())
+        GC::Ptr<HTML::DecodedImageData> decoded_image_data;
+        if (auto const* observer = cursor_values_owner ? cursor_values_owner->cursor_image_observer(index) : nullptr)
+            decoded_image_data = observer->decoded_image_data();
+        if (auto image_cursor = cursor_style_value->make_image_cursor(layout_node, decoded_image_data); image_cursor.has_value())
             return image_cursor.release_value();
     }
 
@@ -3560,12 +3566,10 @@ void EventHandler::update_cursor(Layout::Node const* layout_node, GC::Ptr<DOM::N
         if (layout_node) {
             auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
             auto const& node_with_style = as<Layout::NodeWithStyle>(*layout_node);
-            auto cursor_data = node_with_style.cursor();
-            auto cursor_style_values = node_with_style.cursor_style_values();
+            auto const* cursor_values_owner = &node_with_style;
             if (hit_text_fragment && host_layout_node)
-                cursor_data = as<Layout::NodeWithStyle>(*host_layout_node).cursor();
-            if (hit_text_fragment && host_layout_node)
-                cursor_style_values = as<Layout::NodeWithStyle>(*host_layout_node).cursor_style_values();
+                cursor_values_owner = &as<Layout::NodeWithStyle>(*host_layout_node);
+            auto cursor_data = cursor_values_owner->cursor();
 
             auto* host_node_with_style = host_layout_node ? as_if<Layout::NodeWithStyle>(*host_layout_node) : nullptr;
             auto is_selectable_text_fragment = hit_text_fragment
@@ -3574,18 +3578,18 @@ void EventHandler::update_cursor(Layout::Node const* layout_node, GC::Ptr<DOM::N
 
             if (is_selectable_text_fragment || host_element->is_editable_or_editing_host()) {
                 if (host_node_with_style)
-                    return resolve_cursor(*host_node_with_style, cursor_data, cursor_style_values, Gfx::StandardCursor::IBeam);
-                return resolve_cursor(*node_with_style.parent(), cursor_data, cursor_style_values, Gfx::StandardCursor::IBeam);
+                    return resolve_cursor(*host_node_with_style, cursor_values_owner, cursor_data, Gfx::StandardCursor::IBeam);
+                return resolve_cursor(*node_with_style.parent(), cursor_values_owner, cursor_data, Gfx::StandardCursor::IBeam);
             }
             if (host_element && host_element->is_element() && host_node_with_style)
-                return resolve_cursor(*host_node_with_style, cursor_data, cursor_style_values, Gfx::StandardCursor::Arrow);
+                return resolve_cursor(*host_node_with_style, cursor_values_owner, cursor_data, Gfx::StandardCursor::Arrow);
 
             // AD-HOC: Area elements are never rendered, so they have no layout node of their own to resolve a cursor
             //         from. Resolve the cursor from the area's computed values instead, falling back to the layout
             //         node of the image that renders the area's image map for image cursors.
             if (auto const* area_element = as_if<HTML::HTMLAreaElement>(host_element.ptr())) {
                 if (auto area_computed_values = area_element->computed_style(); area_computed_values)
-                    return resolve_cursor(node_with_style, area_computed_values->cursor(), {}, Gfx::StandardCursor::Arrow);
+                    return resolve_cursor(node_with_style, nullptr, area_computed_values->cursor(), Gfx::StandardCursor::Arrow);
             }
         }
 

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -425,25 +425,46 @@ extern "C" void* ladybird_web_svg_path_from_path_data_utf16(char16_t const* unit
     return new Gfx::Path(path_data.to_gfx_path());
 }
 
-static CSS::AbstractImageStyleValue const* layer_image_for(Layout::NodeWithStyle const& layout_node, Layout::RustFFI::FfiLayerImageList list, u32 computed_index)
+struct LayerImage {
+    CSS::AbstractImageStyleValue const* value { nullptr };
+    GC::Ptr<HTML::DecodedImageData> decoded_image_data;
+};
+
+static GC::Ptr<HTML::DecodedImageData> decoded_image_data_of(Layout::NodeWithStyle::ImageObserver const* observer)
+{
+    if (!observer)
+        return nullptr;
+    return observer->decoded_image_data();
+}
+
+static LayerImage layer_image_for(Layout::NodeWithStyle const& layout_node, Layout::RustFFI::FfiLayerImageList list, u32 computed_index)
 {
     switch (list) {
     case Layout::RustFFI::FfiLayerImageList::Background: {
         auto const& layers = layout_node.background_layers();
-        return computed_index < layers.size() ? layers[computed_index].background_image.ptr() : nullptr;
+        if (computed_index >= layers.size())
+            return {};
+        return { layers[computed_index].background_image.ptr(), decoded_image_data_of(layout_node.background_image_observer(computed_index)) };
     }
     case Layout::RustFFI::FfiLayerImageList::Mask: {
         auto const& layers = layout_node.mask_layers();
-        return computed_index < layers.size() ? layers[computed_index].background_image.ptr() : nullptr;
+        if (computed_index >= layers.size())
+            return {};
+        return { layers[computed_index].background_image.ptr(), decoded_image_data_of(layout_node.mask_image_observer(computed_index)) };
     }
     case Layout::RustFFI::FfiLayerImageList::BorderImageSource:
-        return layout_node.border_image().source.ptr();
+        return { layout_node.border_image().source.ptr(), decoded_image_data_of(layout_node.border_image_source_observer()) };
     case Layout::RustFFI::FfiLayerImageList::DocumentBackground: {
-        auto const* layers = layout_node.document().background_layers();
-        return layers && computed_index < layers->size() ? (*layers)[computed_index].background_image.ptr() : nullptr;
+        auto* body_element = layout_node.document().body();
+        if (!body_element)
+            return {};
+        auto const* body_layout_node = body_element->unsafe_layout_node();
+        if (!body_layout_node)
+            return {};
+        return layer_image_for(*body_layout_node, Layout::RustFFI::FfiLayerImageList::Background, computed_index);
     }
     default:
-        return nullptr;
+        return {};
     }
 }
 
@@ -867,18 +888,20 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
         },
         .image_intrinsic_facts = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiImageIntrinsicFacts {
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
-            auto const& document = layout_node.document();
             Layout::RustFFI::FfiImageIntrinsicFacts facts {};
-            auto const* image = layer_image_for(layout_node, list, computed_index);
+            auto [image, decoded_image_data] = layer_image_for(layout_node, list, computed_index);
             if (!image)
                 return facts;
-            facts.is_paintable = image->is_paintable(document);
-            facts.natural_width = image->natural_width(document);
-            facts.natural_height = image->natural_height(document);
-            if (auto aspect_ratio = image->natural_aspect_ratio(document); aspect_ratio.has_value()) {
-                facts.has_natural_aspect_ratio = true;
-                facts.natural_aspect_ratio_numerator = aspect_ratio->numerator();
-                facts.natural_aspect_ratio_denominator = aspect_ratio->denominator();
+            facts.is_paintable = image->is_paintable(decoded_image_data);
+            if (decoded_image_data) {
+                auto natural_size = image->natural_size(*decoded_image_data);
+                facts.natural_width = natural_size.width;
+                facts.natural_height = natural_size.height;
+                if (natural_size.aspect_ratio.has_value()) {
+                    facts.has_natural_aspect_ratio = true;
+                    facts.natural_aspect_ratio_numerator = natural_size.aspect_ratio->numerator();
+                    facts.natural_aspect_ratio_denominator = natural_size.aspect_ratio->denominator();
+                }
             }
             if (auto const* image_set = as_if<CSS::ImageSetStyleValue>(*image)) {
                 if (auto const* selected_image = image_set->selected_image()) {
@@ -957,23 +980,22 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
         .layer_image_prepare = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiLayerImagePrepareFacts {
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiLayerImagePrepareFacts facts {};
-            auto const* image = layer_image_for(layout_node, list, computed_index);
+            auto [image, decoded_image_data] = layer_image_for(layout_node, list, computed_index);
             if (!image)
                 return facts;
             facts.is_image_style_value = is<CSS::ImageStyleValue>(*image);
-            facts.single_pixel_color = image->color_if_single_pixel_bitmap(layout_node.document());
+            if (decoded_image_data)
+                facts.single_pixel_color = decoded_image_data->color_if_single_pixel_bitmap();
             return facts;
         },
         .layer_image_nested_display_list = [](void* context_pointer, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index, Gfx::IntRect dest) -> Layout::RustFFI::FfiLayerImageNestedDisplayListFacts {
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiLayerImageNestedDisplayListFacts facts {};
-            auto const* image = layer_image_for(layout_node, list, computed_index);
-            if (!image || !is<CSS::ImageStyleValue>(*image))
+            auto [image, decoded_image_data] = layer_image_for(layout_node, list, computed_index);
+            if (!image || !is<CSS::ImageStyleValue>(*image) || !decoded_image_data)
                 return facts;
-            auto dest_rect = dest.to_type<DevicePixels>();
-            auto color_scheme = layout_node.color_scheme();
-            if (auto display_list = static_cast<CSS::ImageStyleValue const&>(*image).record_display_list(context.resource_storage, layout_node.document(), dest_rect, color_scheme); display_list.has_value()) {
+            if (auto display_list = decoded_image_data->record_display_list(dest.size(), layout_node.color_scheme(), context.resource_storage); display_list.has_value()) {
                 facts.has_nested_display_list = true;
                 facts.nested_display_list_id = context.resource_storage.add_display_list(display_list->display_list, display_list->visual_context_tree).value();
             }
@@ -983,11 +1005,10 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiLayerImageFrameFacts facts {};
-            auto const* image = layer_image_for(layout_node, list, computed_index);
-            if (!image || !is<CSS::ImageStyleValue>(*image))
+            auto [image, decoded_image_data] = layer_image_for(layout_node, list, computed_index);
+            if (!image || !is<CSS::ImageStyleValue>(*image) || !decoded_image_data)
                 return facts;
-            auto dest_rect = dest.to_type<DevicePixels>();
-            if (auto frame = static_cast<CSS::ImageStyleValue const&>(*image).current_frame(layout_node.document(), dest_rect); frame.has_value()) {
+            if (auto frame = decoded_image_data->current_frame(dest.size()); frame.has_value()) {
                 facts.has_frame = true;
                 facts.frame_id = context.resource_storage.add_image_frame(*frame).value();
                 facts.frame_width = frame->size().width();
@@ -999,19 +1020,18 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             auto& context = *static_cast<PaintHostContext*>(context_pointer);
             auto const& layout_node = *static_cast<Layout::NodeWithStyle const*>(layout_node_shell);
             Layout::RustFFI::FfiImagePaintFacts facts {};
-            auto const* image_pointer = layer_image_for(layout_node, list, computed_index);
-            if (!image_pointer)
+            auto [image, decoded_image_data] = layer_image_for(layout_node, list, computed_index);
+            if (!image)
                 return facts;
-            auto const& image = *image_pointer;
             ImagePaintRequest request {
                 .document = layout_node.document(),
-                .dest_rect = dest_rect,
+                .dest_rect = decoded_image_data ? dest_rect.to_type<int>().to_type<float>() : dest_rect,
                 .image_rendering = static_cast<CSS::ImageRendering>(image_rendering_raw),
                 .color_scheme = layout_node.color_scheme(),
                 .accumulated_scale = accumulated_scale,
                 .resource_storage = context.resource_storage,
             };
-            auto paint = image.image_paint(request, image.resolve_for_size(layout_node, css_size));
+            auto paint = decoded_image_data ? decoded_image_data->image_paint(request) : image->image_paint(request, image->resolve_for_size(layout_node, css_size));
             if (paint.has_value())
                 write_image_paint_facts(*paint, context, facts);
             return facts;


### PR DESCRIPTION
Every paint-time question about a url() image went through
ImageStyleValue::image_data(document), which rebuilt the CSS URL from
the Rust payload, ran the full URL parser against the style resource
base URL, and then looked the resource up in the document's map, whose
hash serializes the URL again. Display list recording asked about six
times per bitmap background or mask layer (intrinsic facts, the
single-pixel check, then the frame, nested display list or paint), once
per border image, and generated content boxes asked four times per
layout pass. All of that repeated work only re-derived the resource the
layout node's image observer had already registered with.

Read the decoded image data from that observer instead. The paint bridge
resolves each layer image to its value plus the observer's decoded data,
and answers intrinsic size, single-pixel color, frame, nested display
list and paint from the data directly; only gradients still go through
the style value. The document background paints from the body's layout
node, which owns the observers for those layers. Generated content
images read through their image client, and cursor images through the
cursor observer of the node whose cursor values are being resolved, so
the <area> path no longer trips over a resource nobody registered.

The AbstractImageStyleValue queries that took a document now take the
decoded image data: is_paintable() decides from it, and natural_size()
replaces the natural width, height and aspect ratio trio, with the
image-set() override still dividing by the selected resolution. The
document-keyed ImageStyleValue API and Document::background_layers() go
away, and resolved_url() is only called when a client registers.
