### PR TITLE
LibJS: Speed up array and object spread operations

### DIFF
--- a/Libraries/LibJS/Bytecode/PropertyAccess.h
+++ b/Libraries/LibJS/Bytecode/PropertyAccess.h
@@ -46,6 +46,38 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_cached_property_value(VM& vm, Value v
     return TRY(call(vm, *getter, this_value));
 }
 
+// Non-standard
+ALWAYS_INLINE Value get_own_property_without_side_effects(Object& object, PropertyKey const& property_key, StaticPropertyLookupCache& cache)
+{
+    auto& shape = object.shape();
+
+    if (auto const* cache_entry = cache.first_entry(); cache_entry
+        && (cache_entry->type == PropertyLookupCache::Entry::Type::GetOwnProperty
+            || cache_entry->type == PropertyLookupCache::Entry::Type::GetMissingProperty)
+        && &shape == cache_entry->shape.ptr()
+        && (!shape.is_dictionary() || shape.dictionary_generation() == cache_entry->shape_dictionary_generation)) {
+        if (cache_entry->type == PropertyLookupCache::Entry::Type::GetMissingProperty)
+            return {};
+        return object.get_direct(cache_entry->property_offset);
+    }
+
+    auto metadata = shape.lookup(property_key);
+    auto cache_type = metadata.has_value()
+        ? PropertyLookupCache::Entry::Type::GetOwnProperty
+        : PropertyLookupCache::Entry::Type::GetMissingProperty;
+    cache.update(cache_type, [&](auto& entry) {
+        entry.shape = shape;
+        if (metadata.has_value())
+            entry.property_offset = metadata->offset;
+        if (shape.is_dictionary())
+            entry.shape_dictionary_generation = shape.dictionary_generation();
+    });
+
+    if (!metadata.has_value())
+        return {};
+    return object.get_direct(metadata->offset);
+}
+
 ALWAYS_INLINE GC::Ptr<Object> base_object_for_get_impl(VM& vm, Value base_value)
 {
     if (base_value.is_object()) [[likely]]

--- a/Libraries/LibJS/Interpreter/SlowPaths.cpp
+++ b/Libraries/LibJS/Interpreter/SlowPaths.cpp
@@ -2561,7 +2561,53 @@ i64 asm_slow_path_array_append(VM* vm, u32 pc, Op::ArrayAppend const* instructio
     auto lhs_size = lhs_array.indexed_array_like_size();
 
     if (instruction->is_spread()) {
+        auto* rhs_array = rhs.is_object() ? as_if<JS::Array>(rhs.as_object()) : nullptr;
+        Optional<IteratorRecordImpl> iterator_record;
+
+        if (rhs_array && lhs_array.indexed_storage_kind() <= IndexedStorageKind::Packed) {
+            static auto& iterator_method_cache = *new StaticPropertyLookupCache;
+            auto iterator_method = ASM_TRY(*vm, pc, rhs.get_method(*vm, vm->well_known_symbol_iterator(), iterator_method_cache));
+            if (!iterator_method) {
+                auto completion = vm->throw_completion<TypeError>(ErrorType::NotIterable, rhs);
+                return handle_asm_exception(*vm, pc, completion.value());
+            }
+
+            // OPTIMIZATION: The original array iterator has no observable side effects, so a packed
+            //               array can be appended in bulk if its next method is also unchanged.
+            auto original_iterator_method = vm->current_realm()->intrinsics().array_prototype_values_function();
+            if (iterator_method == original_iterator_method && rhs_array->is_simple_packed_array()) {
+                auto iterator_prototype = vm->current_realm()->intrinsics().array_iterator_prototype();
+
+                // NB: Inspect the intrinsic prototype's own property without invoking it. Using get()
+                //     here would call an accessor with the prototype as its receiver, whereas the
+                //     iterator protocol calls it with the newly created iterator as its receiver.
+                //     Accessors and replacement methods therefore take the generic path below.
+                static auto& next_method_cache = *new StaticPropertyLookupCache;
+                auto next_method = get_own_property_without_side_effects(*iterator_prototype, vm->names.next, next_method_cache);
+                if (next_method.is_function() && next_method.as_function().is_native_function()
+                    && static_cast<NativeFunction const&>(next_method.as_function()).is_array_prototype_next_builtin()) {
+                    auto elements = rhs_array->indexed_packed_elements_span();
+                    if (elements.size() <= NumericLimits<u32>::max() - lhs_size) {
+                        lhs_array.indexed_append(elements);
+                        return static_cast<i64>(pc + sizeof(Op::ArrayAppend));
+                    }
+                }
+            }
+
+            iterator_record = ASM_TRY(*vm, pc, get_iterator_from_method_impl(*vm, rhs, *iterator_method));
+        }
+
         size_t i = lhs_size;
+        if (iterator_record.has_value()) {
+            while (true) {
+                auto iterator_value = ASM_TRY(*vm, pc, iterator_step_value(*vm, *iterator_record));
+                if (!iterator_value.has_value())
+                    break;
+                lhs_array.indexed_put(i++, iterator_value.release_value());
+            }
+            return static_cast<i64>(pc + sizeof(Op::ArrayAppend));
+        }
+
         auto result = get_iterator_values(*vm, rhs, [&i, &lhs_array](Value iterator_value) -> Optional<Completion> {
             lhs_array.indexed_put(i, iterator_value);
             ++i;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -2154,6 +2154,26 @@ void Object::indexed_append(Value value, PropertyAttributes attributes)
     indexed_put(m_indexed_array_like_size, value, attributes);
 }
 
+void Object::indexed_append(ReadonlySpan<Value> values)
+{
+    VERIFY(m_indexed_storage_kind <= IndexedStorageKind::Packed);
+    VERIFY(values.size() <= NumericLimits<u32>::max() - m_indexed_array_like_size);
+
+    if (values.is_empty())
+        return;
+
+    auto old_size = m_indexed_array_like_size;
+    auto values_size = static_cast<u32>(values.size());
+    auto new_size = old_size + values_size;
+    ensure_indexed_elements(new_size);
+
+    for (u32 i = 0; i < values_size; ++i)
+        m_indexed_elements[old_size + i] = values[i];
+
+    m_indexed_storage_kind = IndexedStorageKind::Packed;
+    m_indexed_array_like_size = new_size;
+}
+
 ValueAndAttributes Object::indexed_take_first()
 {
     if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -575,6 +575,46 @@ ThrowCompletionOr<void> Object::copy_data_properties(VM& vm, Value source, HashT
     // 2. Let from be ! ToObject(source).
     auto from = MUST(source.to_object(vm));
 
+    // OPTIMIZATION: An empty ordinary object can reuse the shape of a compatible ordinary source
+    //               and copy its property storage directly. This is equivalent to defining each
+    //               property because all source properties already have the default attributes.
+    if (from.ptr() != this
+        && excluded_keys.is_empty()
+        && excluded_values.is_empty()
+        && &shape() == vm.current_realm()->intrinsics().new_object_shape().ptr()
+        && indexed_storage_kind() == IndexedStorageKind::None
+        && extensible()
+        && eligible_for_own_property_enumeration_fast_path()
+        && !has_intrinsic_accessors()
+        && !may_interfere_with_indexed_property_access()
+        && !requires_slow_add_own_property()
+        && from->indexed_storage_kind() == IndexedStorageKind::None
+        && from->eligible_for_own_property_enumeration_fast_path()
+        && !from->has_intrinsic_accessors()
+        && !from->may_interfere_with_indexed_property_access()
+        && !from->requires_slow_add_own_property()
+        && !from->shape().is_dictionary()
+        && !from->shape().is_prototype_shape()
+        && &from->shape().realm() == vm.current_realm()
+        && from->shape().prototype() == shape().prototype()) {
+        bool has_only_default_data_properties = true;
+        from->shape().for_each_property_in_insertion_order([&](auto const&, auto const& metadata) {
+            if (metadata.attributes != default_attributes || from->get_direct(metadata.offset).is_accessor()) {
+                has_only_default_data_properties = false;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+
+        if (has_only_default_data_properties) {
+            unsafe_set_shape(from->shape());
+            from->shape().for_each_property_in_insertion_order([&](auto const&, auto const& metadata) {
+                put_direct(metadata.offset, from->get_direct(metadata.offset));
+            });
+            return {};
+        }
+    }
+
     // OPTIMIZATION: For ordinary objects we can iterate the shape directly and read values by storage
     //               offset, avoiding repeated property lookups through DescriptorArray::find.
     if (from->eligible_for_own_property_enumeration_fast_path()

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -334,6 +334,7 @@ public:
     u32 indexed_array_like_size() const { return m_indexed_array_like_size; }
     bool set_indexed_array_like_size(size_t new_size);
     void indexed_append(Value value, PropertyAttributes attributes = default_attributes);
+    void indexed_append(ReadonlySpan<Value> values);
     ValueAndAttributes indexed_take_first();
     ValueAndAttributes indexed_take_last();
     size_t indexed_real_size() const;

--- a/Tests/LibJS/Runtime/builtins/Array/array-spread.js
+++ b/Tests/LibJS/Runtime/builtins/Array/array-spread.js
@@ -24,6 +24,62 @@ test("basic functionality", () => {
     expect([...[], ...[...[1, 2, 3]], 4]).toEqual([1, 2, 3, 4]);
 });
 
+test("observes custom array iterator accessors", () => {
+    const array = [1, 2];
+    const originalIterator = Array.prototype[Symbol.iterator];
+    let getterCalls = 0;
+    Object.defineProperty(array, Symbol.iterator, {
+        configurable: true,
+        get() {
+            ++getterCalls;
+            this.push(3);
+            return originalIterator;
+        },
+    });
+
+    expect([...array]).toEqual([1, 2, 3]);
+    expect(getterCalls).toBe(1);
+});
+
+test("exhausts iterators when ArrayIteratorPrototype.next is an accessor", () => {
+    const iteratorPrototype = Object.getPrototypeOf([][Symbol.iterator]());
+    const originalDescriptor = Object.getOwnPropertyDescriptor(iteratorPrototype, "next");
+    let iterator;
+
+    Object.defineProperty(iteratorPrototype, "next", {
+        configurable: true,
+        get() {
+            iterator = this;
+            return originalDescriptor.value;
+        },
+    });
+
+    try {
+        expect([...[1, 2, 3]]).toEqual([1, 2, 3]);
+        expect(iterator.next()).toEqual({ value: undefined, done: true });
+    } finally {
+        Object.defineProperty(iteratorPrototype, "next", originalDescriptor);
+    }
+});
+
+test("observes replacement ArrayIteratorPrototype.next methods", () => {
+    const iteratorPrototype = Object.getPrototypeOf([][Symbol.iterator]());
+    const originalNext = iteratorPrototype.next;
+    let calls = 0;
+
+    iteratorPrototype.next = function () {
+        ++calls;
+        return originalNext.call(this);
+    };
+
+    try {
+        expect([...[1, 2, 3]]).toEqual([1, 2, 3]);
+        expect(calls).toBe(4);
+    } finally {
+        iteratorPrototype.next = originalNext;
+    }
+});
+
 test("elisions after spread remain holes", () => {
     let array = [...[], ,];
     expect(array).toHaveLength(1);

--- a/Tests/LibJS/Runtime/object-spread.js
+++ b/Tests/LibJS/Runtime/object-spread.js
@@ -85,6 +85,34 @@ test("spread object with symbol keys", () => {
     expect(obj[s]).toBe("qux");
 });
 
+test("spread creates independent property storage", () => {
+    const source = { a: 1, b: 2, c: 3, d: 4 };
+    const result = { ...source };
+
+    source.a = 10;
+    result.b = 20;
+    result.e = 5;
+
+    expect(source).toEqual({ a: 10, b: 2, c: 3, d: 4 });
+    expect(result).toEqual({ a: 1, b: 20, c: 3, d: 4, e: 5 });
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+});
+
+test("spread normalizes property attributes", () => {
+    const source = Object.freeze({ a: 1, b: 2, c: 3 });
+    const result = { ...source };
+
+    expect(Object.getOwnPropertyDescriptor(result, "a")).toEqual({
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    });
+
+    result.a = 10;
+    expect(result.a).toBe(10);
+});
+
 test("spreading non-spreadable values", () => {
     let empty = {
         ...undefined,


### PR DESCRIPTION
Speed up common array and object spread operations while preserving the observable iterator and property-copying semantics.

- Bulk-copy packed arrays when the built-in array iterator behavior is intact, with cached side-effect-free checks for the iterator methods.
- Reuse compatible source shapes and copy property storage directly when spreading into an empty ordinary object.
- Keep custom iterators, accessors, exotic objects, indexed properties, cross-realm objects, and non-default descriptors on the existing generic paths.

MicroWeb results with Chromium running jitless, using five iterations:

| Benchmark | Ladybird before | Ladybird after | Chromium | Gap before | Gap after |
| --- | ---: | ---: | ---: | ---: | ---: |
| Array spread | 37.10 ms | 11.90 ms | 4.20 ms | 9.0x | 2.8x |
| Object spread | 28.30 ms | 8.60 ms | 3.00 ms | 10.9x | 2.9x |