### PR TITLE
LibWeb: Ensure all rust files are formatted

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -4,26 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-fn axis_modes(style: StyleValues) -> (AbsposAxisMode, AbsposAxisMode) {
+use super::*;
+
+pub(super) fn axis_modes(style: StyleValues) -> (abspos_inputs::AbsposAxisMode, abspos_inputs::AbsposAxisMode) {
     (
         if style.inset_left().is_auto() && style.inset_right().is_auto() {
-            AbsposAxisMode::StaticPosition
+            abspos_inputs::AbsposAxisMode::StaticPosition
         } else {
-            AbsposAxisMode::InsetFromRect
+            abspos_inputs::AbsposAxisMode::InsetFromRect
         },
         if style.inset_top().is_auto() && style.inset_bottom().is_auto() {
-            AbsposAxisMode::StaticPosition
+            abspos_inputs::AbsposAxisMode::StaticPosition
         } else {
-            AbsposAxisMode::InsetFromRect
+            abspos_inputs::AbsposAxisMode::InsetFromRect
         },
     )
 }
 
 pub(crate) fn aligned_static_offset(
-    static_position_rect: StaticPositionRect,
+    static_position_rect: abspos_inputs::StaticPositionRect,
     margin_box_inline_size: CssPixels,
     margin_box_block_size: CssPixels,
-) -> LogicalOffset {
+) -> geometry::LogicalOffset {
     let mut offset = static_position_rect.rect.offset;
     match static_position_rect.inline_alignment {
         StaticPositionAlignment::Start => {}
@@ -46,8 +48,8 @@ pub(crate) fn aligned_static_offset(
     offset
 }
 
-fn out_of_flow_root_space(inputs: AbsposLayoutInputs) -> (AvailableSpace, ContainingBlockConstraints) {
-    let containing_block_size = LogicalSize {
+fn out_of_flow_root_space(inputs: abspos_inputs::AbsposLayoutInputs) -> (AvailableSpace, ContainingBlockConstraints) {
+    let containing_block_size = geometry::LogicalSize {
         inline_size: clamp_to_max_dimension_value(inputs.containing_block_info.rect.size.inline_size),
         block_size: clamp_to_max_dimension_value(inputs.containing_block_info.rect.size.block_size),
     };
@@ -98,14 +100,14 @@ impl ContainingBlockGeometry {
 }
 
 pub(crate) struct AbsposEngine {
-    purpose: LayoutPurpose,
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
-    fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
 }
 
 impl AbsposEngine {
-    pub(crate) fn for_run(run: &crate::layout::FormattingContextRun) -> Self {
+    pub(crate) fn for_run(run: &FormattingContextRun) -> Self {
         Self {
             purpose: run.purpose,
             records: run.records.clone(),
@@ -114,7 +116,10 @@ impl AbsposEngine {
         }
     }
 
-    fn containing_block_geometry_for_pending_child(&self, entry: &PendingAbsposChild) -> ContainingBlockGeometry {
+    fn containing_block_geometry_for_pending_child(
+        &self,
+        entry: &abspos_inputs::PendingAbsposChild,
+    ) -> ContainingBlockGeometry {
         let containing_block = self.callbacks.containing_block(entry.child_box);
         let Some(containing_block_used) = self.records.used_values_if_owned(containing_block) else {
             panic!(
@@ -144,7 +149,7 @@ impl AbsposEngine {
             else {
                 break;
             };
-            origin = point_add(origin, used.content_offset.get());
+            origin = formatting_context::point_add(origin, used.content_offset.get());
             chain_box = self.callbacks.containing_block(chain_box);
             if chain_box.is_invalid() {
                 break;
@@ -153,8 +158,11 @@ impl AbsposEngine {
         let mut space_box = entry_space;
         let mut space_origin = FfiCssPixelPoint::default();
         loop {
-            if let Some((_, origin)) = origins_by_chain_box.iter().find(|(chain_box, _)| *chain_box == space_box) {
-                return point_sub(*origin, space_origin);
+            if let Some((_, origin)) = origins_by_chain_box
+                .iter()
+                .find(|(chain_box, _)| *chain_box == space_box)
+            {
+                return formatting_context::point_sub(*origin, space_origin);
             }
             let used = self
                 .records
@@ -166,7 +174,7 @@ impl AbsposEngine {
                         space_box.slot_index()
                     )
                 });
-            space_origin = point_add(space_origin, used.content_offset.get());
+            space_origin = formatting_context::point_add(space_origin, used.content_offset.get());
             space_box = self.callbacks.containing_block(space_box);
             assert!(
                 !space_box.is_invalid(),
@@ -194,20 +202,20 @@ impl AbsposEngine {
                         current.slot_index()
                     )
                 });
-                offset = point_add(offset, used.content_offset.get());
+                offset = formatting_context::point_add(offset, used.content_offset.get());
                 current = self.callbacks.containing_block(current);
                 assert!(!current.is_invalid());
             }
             offset
         };
-        point_sub(
+        formatting_context::point_sub(
             offset_relative_to_merge_point(from_space),
             offset_relative_to_merge_point(to_space),
         )
     }
 
-    fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
     fn style(&self, node: Node) -> StyleValues<'static> {
@@ -226,22 +234,22 @@ impl AbsposEngine {
     fn base_containing_block_info(
         &self,
         node: Node,
-        inline_containing_block_rect: Option<PhysicalRect>,
+        inline_containing_block_rect: Option<formatting_context::PhysicalRect>,
         entry_containing_block_geometry: &ContainingBlockGeometry,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
-    ) -> AbsposContainingBlockInfo {
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
+    ) -> abspos_inputs::AbsposContainingBlockInfo {
         let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let (inline_axis_mode, block_axis_mode) = axis_modes(style);
         let containing_block = self.callbacks.containing_block(node);
         assert!(!containing_block.is_invalid());
         if let Some(rect) = inline_containing_block_rect {
-            return AbsposContainingBlockInfo {
-                rect: LogicalRect {
-                    offset: LogicalOffset {
+            return abspos_inputs::AbsposContainingBlockInfo {
+                rect: geometry::LogicalRect {
+                    offset: geometry::LogicalOffset {
                         inline_offset: rect.x,
                         block_offset: rect.y,
                     },
-                    size: LogicalSize {
+                    size: geometry::LogicalSize {
                         inline_size: rect.width,
                         block_size: rect.height,
                     },
@@ -254,13 +262,13 @@ impl AbsposEngine {
             };
         }
 
-        AbsposContainingBlockInfo {
-            rect: LogicalRect {
-                offset: LogicalOffset {
+        abspos_inputs::AbsposContainingBlockInfo {
+            rect: geometry::LogicalRect {
+                offset: geometry::LogicalOffset {
                     inline_offset: -entry_containing_block_geometry.padding_left,
                     block_offset: -entry_containing_block_geometry.padding_top,
                 },
-                size: LogicalSize {
+                size: geometry::LogicalSize {
                     inline_size: entry_containing_block_geometry.padding_box_inline_size(),
                     block_size: entry_containing_block_geometry.padding_box_block_size(),
                 },
@@ -272,12 +280,11 @@ impl AbsposEngine {
             derives_from_own_computed_values: false,
         }
     }
-
 }
 
 fn calc_node_create_px_dimension(value: f64) -> *const c_void {
     crate::css::calc::rust_calc_node_create_numeric_dimension(
-        CALC_NUMERIC_KIND_LENGTH,
+        formatting_context::CALC_NUMERIC_KIND_LENGTH,
         value,
         crate::css::style_compute::px_length_unit(),
     )
@@ -388,7 +395,7 @@ impl AbsposEngine {
         containing_block: Node,
         entry_containing_block_geometry: Option<&ContainingBlockGeometry>,
         entry_coordinate_space_box: Node,
-    ) -> PhysicalRect {
+    ) -> formatting_context::PhysicalRect {
         let (rect, coordinate_space_box) = self
             .fragments
             .as_deref()
@@ -398,7 +405,7 @@ impl AbsposEngine {
             Some(geometry) => {
                 let fold_into_entry_space =
                     self.translation_between_payload_resting_spaces(coordinate_space_box, entry_coordinate_space_box);
-                PhysicalRect {
+                formatting_context::PhysicalRect {
                     x: rect.x + fold_into_entry_space.x - geometry.content_origin_in_entry_space.x
                         + geometry.padding_left,
                     y: rect.y + fold_into_entry_space.y - geometry.content_origin_in_entry_space.y
@@ -409,7 +416,7 @@ impl AbsposEngine {
             }
             None => {
                 let containing_block_used = self.used(containing_block);
-                PhysicalRect {
+                formatting_context::PhysicalRect {
                     x: rect.x + containing_block_used.padding_left.get(),
                     y: rect.y + containing_block_used.padding_top.get(),
                     width: rect.width,
@@ -422,7 +429,7 @@ impl AbsposEngine {
     fn anchor_side(
         &self,
         side: AnchorSide,
-        rect: PhysicalRect,
+        rect: formatting_context::PhysicalRect,
         positioned_box: Node,
         containing_block: Node,
         is_from_end: bool,
@@ -515,7 +522,7 @@ impl AbsposEngine {
     #[allow(clippy::too_many_arguments)]
     fn resolve_anchor_value(
         &self,
-        value: InsetValue,
+        value: style_values::InsetValue,
         positioned_box: Node,
         containing_block: Node,
         containing_block_geometry: Option<ContainingBlockGeometry>,
@@ -539,7 +546,7 @@ impl AbsposEngine {
         // SAFETY: The calculated handle is retained by the style cache and
         // all callback state remains live for this synchronous resolution.
         let result = unsafe {
-            resolve_calc_with_external_resolutions(
+            style_values::resolve_calc_with_external_resolutions(
                 calculated,
                 axis.containing_block_extent,
                 (&raw mut callback_context).cast(),
@@ -554,7 +561,7 @@ impl AbsposEngine {
         node: Node,
         entry_containing_block_geometry: Option<&ContainingBlockGeometry>,
         entry_coordinate_space_box: Node,
-    ) -> Option<ResolvedAnchorInsets> {
+    ) -> Option<formatting_context::ResolvedAnchorInsets> {
         // Clear a stale default scroll shift before any early return.
         // SAFETY: The node is live and a null anchor clears the weak target.
         unsafe {
@@ -597,7 +604,7 @@ impl AbsposEngine {
             compensates_for_horizontal_scroll: false,
             compensates_for_vertical_scroll: false,
         };
-        let mut resolved = ResolvedAnchorInsets::default();
+        let mut resolved = formatting_context::ResolvedAnchorInsets::default();
 
         if top_contains_anchor {
             let value = self.resolve_anchor_value(
@@ -767,7 +774,7 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
             // SAFETY: The anchor() shell retains the fallback calculation for
             // this synchronous resolution.
             let resolved = unsafe {
-                resolve_calc_with_external_resolutions(
+                style_values::resolve_calc_with_external_resolutions(
                     fallback_value.pointer().cast(),
                     context.containing_block_extent,
                     (&raw mut nested_context).cast(),
@@ -783,7 +790,9 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
             let mut nested_context = *context;
             // SAFETY: The outer anchor() shell retains the nested anchor()
             // for this synchronous resolution.
-            unsafe { resolve_anchor_non_math_function((&raw mut nested_context).cast(), fallback_value.pointer().cast()) }
+            unsafe {
+                resolve_anchor_non_math_function((&raw mut nested_context).cast(), fallback_value.pointer().cast())
+            }
         }
         Some(_) => unreachable!("anchor() fallback must be a length, percentage, calculation or nested anchor()"),
     }
@@ -791,7 +800,7 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
 
 type AutoPx = Option<CssPixels>;
 
-fn resolve_or_auto(value: InsetValue, basis: CssPixels) -> AutoPx {
+fn resolve_or_auto(value: style_values::InsetValue, basis: CssPixels) -> AutoPx {
     (!value.is_auto()).then(|| value.to_px(basis))
 }
 
@@ -927,7 +936,7 @@ pub(crate) fn solve_replaced_axis(
 }
 
 impl AbsposEngine {
-    fn static_offset(&self, node: Node, rect: StaticPositionRect) -> LogicalOffset {
+    fn static_offset(&self, node: Node, rect: abspos_inputs::StaticPositionRect) -> geometry::LogicalOffset {
         let used = self.used(node);
         let collapsed = used.uses_collapsing_borders_model.get();
         aligned_static_offset(
@@ -944,9 +953,9 @@ impl AbsposEngine {
         containing_block_inline_size: CssPixels,
         _available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
+        static_position_rect: abspos_inputs::StaticPositionRect,
         input_inline_size: AutoPx,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) -> (AutoPx, CssPixels, CssPixels, AutoPx, AutoPx) {
         let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let used = self.used(node);
@@ -1080,8 +1089,8 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        static_position_rect: abspos_inputs::StaticPositionRect,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
         let style = self.style(node);
@@ -1092,7 +1101,7 @@ impl AbsposEngine {
                 available_space,
                 constraints,
                 None,
-                crate::layout::TableWrapperInlineSizeMode::ClampToAvailableInlineSize,
+                formatting_context::TableWrapperInlineSizeMode::ClampToAvailableInlineSize,
             ))
         } else if style.width().is_auto() {
             None
@@ -1154,8 +1163,8 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        static_position_rect: abspos_inputs::StaticPositionRect,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         let sizing = self.sizing();
         let inline_size = sizing.compute_inline_size_for_replaced_element(node, available_space, constraints);
@@ -1194,8 +1203,8 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        static_position_rect: abspos_inputs::StaticPositionRect,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         if self
             .sizing()
@@ -1285,10 +1294,10 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
+        static_position_rect: abspos_inputs::StaticPositionRect,
         pass: BlockSizePass,
         block_size: AutoPx,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) -> BlockAxisSolution {
         let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
@@ -1381,9 +1390,9 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
+        static_position_rect: abspos_inputs::StaticPositionRect,
         pass: BlockSizePass,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         let style = self.style(node);
         let mut intrinsic_available_space = available_space;
@@ -1478,9 +1487,9 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
+        static_position_rect: abspos_inputs::StaticPositionRect,
         pass: BlockSizePass,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         let block_size = self
             .sizing()
@@ -1528,9 +1537,9 @@ impl AbsposEngine {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
-        static_position_rect: StaticPositionRect,
+        static_position_rect: abspos_inputs::StaticPositionRect,
         pass: BlockSizePass,
-        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
+        resolved_anchor_insets: Option<&formatting_context::ResolvedAnchorInsets>,
     ) {
         if self
             .sizing()
@@ -1561,7 +1570,7 @@ impl AbsposEngine {
     // Run-prelude sizing for an absolutely positioned root: box-model
     // metrics, the inset-aware inline solve, the pre-inside-layout block
     // pass, and the definiteness overrides insets and aspect ratios provide.
-    pub(crate) fn dimension_out_of_flow_root(&self, node: Node, inputs: AbsposLayoutInputs) {
+    pub(crate) fn dimension_out_of_flow_root(&self, node: Node, inputs: abspos_inputs::AbsposLayoutInputs) {
         let (available_space, constraints) = out_of_flow_root_space(inputs);
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
         let resolved = inputs.resolved_anchor_insets.as_ref();
@@ -1590,7 +1599,13 @@ impl AbsposEngine {
                 .set(style.padding_bottom().to_px(containing_block_inline_size));
         }
 
-        self.compute_inline_size(node, available_space, constraints, inputs.static_position_rect, resolved);
+        self.compute_inline_size(
+            node,
+            available_space,
+            constraints,
+            inputs.static_position_rect,
+            resolved,
+        );
         self.compute_block_size(
             node,
             available_space,
@@ -1632,11 +1647,11 @@ impl AbsposEngine {
     pub(crate) fn finalize_out_of_flow_root_after_inside_layout(
         &self,
         node: Node,
-        inputs: AbsposLayoutInputs,
+        inputs: abspos_inputs::AbsposLayoutInputs,
         automatic_content_block_size_of_inside_layout: Option<CssPixels>,
     ) {
         let (available_space, constraints) = out_of_flow_root_space(inputs);
-        let containing_block_size = LogicalSize {
+        let containing_block_size = geometry::LogicalSize {
             inline_size: available_space.inline_size.to_px_or_zero(),
             block_size: available_space.block_size.to_px_or_zero(),
         };
@@ -1699,21 +1714,25 @@ impl AbsposEngine {
         }
     }
 
-    fn layout_element(&self, run: &crate::layout::FormattingContextRun, node: Node, inputs: AbsposLayoutInputs) {
+    fn layout_element(&self, run: &FormattingContextRun, node: Node, inputs: abspos_inputs::AbsposLayoutInputs) {
         assert!(!self.facts(node).is_svg_box());
         let (available_space, constraints) = out_of_flow_root_space(inputs);
 
-        match crate::layout::layout_inside_child(
+        match formatting_context::layout_inside_child(
             run,
             None,
             None,
             node,
             LayoutMode::Normal,
-            LayoutInput::new(available_space, constraints, ParticipationInParentFormattingContext::AbsolutelyPositioned(inputs)),
+            LayoutInput::new(
+                available_space,
+                constraints,
+                ParticipationInParentFormattingContext::AbsolutelyPositioned(inputs),
+            ),
             false,
         ) {
-            crate::layout::ChildLayoutOutcome::Created(_) | crate::layout::ChildLayoutOutcome::Skipped => {}
-            crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+            ChildLayoutOutcome::Created(_) | ChildLayoutOutcome::Skipped => {}
+            ChildLayoutOutcome::ReenterCurrent => {
                 unreachable!("abspos child with contents did not establish a formatting context")
             }
         }
@@ -1721,13 +1740,17 @@ impl AbsposEngine {
         let static_offset = self.static_offset(node, inputs.static_position_rect);
         let used = self.used(node);
         let collapsed = used.uses_collapsing_borders_model.get();
-        let mut used_offset = LogicalOffset {
-            inline_offset: if inputs.containing_block_info.inline_axis_mode == AbsposAxisMode::StaticPosition {
+        let mut used_offset = geometry::LogicalOffset {
+            inline_offset: if inputs.containing_block_info.inline_axis_mode
+                == abspos_inputs::AbsposAxisMode::StaticPosition
+            {
                 static_offset.inline_offset
             } else {
                 inputs.containing_block_info.rect.offset.inline_offset + used.inset_left.get()
             },
-            block_offset: if inputs.containing_block_info.block_axis_mode == AbsposAxisMode::StaticPosition {
+            block_offset: if inputs.containing_block_info.block_axis_mode
+                == abspos_inputs::AbsposAxisMode::StaticPosition
+            {
                 static_offset.block_offset
             } else {
                 inputs.containing_block_info.rect.offset.block_offset + used.inset_top.get()
@@ -1737,11 +1760,9 @@ impl AbsposEngine {
         used_offset.block_offset += used.margin_top.get() + used.border_box_top(collapsed);
         let is_measurement = self.purpose.is_measurement();
         if !is_measurement {
-            self.used(node)
-                .rare_data_mut()
-                .abspos_layout_inputs = Some(inputs);
+            self.used(node).rare_data_mut().abspos_layout_inputs = Some(inputs);
         }
-        crate::layout::place_child(
+        formatting_context::place_child(
             run,
             node,
             FfiCssPixelPoint {
@@ -1752,7 +1773,11 @@ impl AbsposEngine {
         );
     }
 
-    pub(crate) fn layout_pending_child(&self, run: &crate::layout::FormattingContextRun, mut child: PendingAbsposChild) {
+    pub(crate) fn layout_pending_child(
+        &self,
+        run: &FormattingContextRun,
+        mut child: abspos_inputs::PendingAbsposChild,
+    ) {
         debug_assert!(!self.purpose.is_measurement());
         let child_box = child.child_box;
         self.records
@@ -1762,11 +1787,15 @@ impl AbsposEngine {
             self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
         let inline_containing_block_rect =
             self.inline_containing_block_rect_for_pending_child(&child, &containing_block_geometry);
-        let translation_into_containing_block_space =
-            point_sub(FfiCssPixelPoint::default(), containing_block_geometry.content_origin_in_entry_space);
-        child.static_position_rect =
-            crate::layout::translate_static_position_rect(child.static_position_rect, translation_into_containing_block_space);
-        let inputs = AbsposLayoutInputs {
+        let translation_into_containing_block_space = formatting_context::point_sub(
+            FfiCssPixelPoint::default(),
+            containing_block_geometry.content_origin_in_entry_space,
+        );
+        child.static_position_rect = formatting_context::translate_static_position_rect(
+            child.static_position_rect,
+            translation_into_containing_block_space,
+        );
+        let inputs = abspos_inputs::AbsposLayoutInputs {
             static_position_rect: child.static_position_rect,
             containing_block_info: child
                 .containing_block_info_override
@@ -1793,9 +1822,9 @@ impl AbsposEngine {
     /// block's content-box space (no padding term, unlike anchor rects).
     fn inline_containing_block_rect_for_pending_child(
         &self,
-        child: &PendingAbsposChild,
+        child: &abspos_inputs::PendingAbsposChild,
         containing_block_geometry: &ContainingBlockGeometry,
-    ) -> Option<PhysicalRect> {
+    ) -> Option<formatting_context::PhysicalRect> {
         if child.inline_containing_block.is_invalid() {
             return None;
         }
@@ -1803,7 +1832,7 @@ impl AbsposEngine {
         let (rect, payload_space) = fragments.find_inline_containing_block_rect(child.inline_containing_block)?;
         let fold_into_entry_space =
             self.translation_between_payload_resting_spaces(payload_space, child.coordinate_space_box);
-        Some(PhysicalRect {
+        Some(formatting_context::PhysicalRect {
             x: rect.x + fold_into_entry_space.x - containing_block_geometry.content_origin_in_entry_space.x,
             y: rect.y + fold_into_entry_space.y - containing_block_geometry.content_origin_in_entry_space.y,
             width: rect.width,
@@ -1811,14 +1840,16 @@ impl AbsposEngine {
         })
     }
 
-    fn replay(&self, run: &crate::layout::FormattingContextRun, node: Node) {
+    pub(super) fn replay(&self, run: &FormattingContextRun, node: Node) {
         let saved_inputs = self.callbacks.saved_abspos_layout_inputs(node);
         let found = saved_inputs.is_some();
         assert!(found);
         let mut inputs = saved_inputs.unwrap();
         if !inputs.containing_block_info.derives_from_own_computed_values {
-            let (inline, block) =
-                axis_modes(self.style(node).with_resolved_insets(inputs.resolved_anchor_insets.as_ref()));
+            let (inline, block) = axis_modes(
+                self.style(node)
+                    .with_resolved_insets(inputs.resolved_anchor_insets.as_ref()),
+            );
             inputs.containing_block_info.inline_axis_mode = inline;
             inputs.containing_block_info.block_axis_mode = block;
         }
@@ -1832,7 +1863,7 @@ impl AbsposEngine {
     fn compute_inset(
         &self,
         node: Node,
-        containing_block_size: LogicalSize,
+        containing_block_size: geometry::LogicalSize,
         formatting_context_root: Node,
         treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     ) {
@@ -1859,7 +1890,7 @@ impl AbsposEngine {
             return;
         }
 
-        let resolve_opposing = |first: InsetValue, second: InsetValue, basis: CssPixels| {
+        let resolve_opposing = |first: style_values::InsetValue, second: style_values::InsetValue, basis: CssPixels| {
             let resolved_first = first.to_px(basis);
             let resolved_second = second.to_px(basis);
             if first.is_auto() && second.is_auto() {
@@ -1878,16 +1909,19 @@ impl AbsposEngine {
 
         let treat_block_axis_percentage_insets_as_auto = (style.inset_top().contains_percentage()
             || style.inset_bottom().contains_percentage())
-            && !crate::layout::resolve_block_axis_percentage_inset_basis_is_definite(
+            && !formatting_context::resolve_block_axis_percentage_inset_basis_is_definite(
                 &self.records,
                 &self.callbacks,
                 self.callbacks.containing_block(node),
                 formatting_context_root,
                 treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
-        fn block_axis_inset_value(value: InsetValue<'_>, treat_percentage_as_auto: bool) -> InsetValue<'_> {
+        fn block_axis_inset_value(
+            value: style_values::InsetValue<'_>,
+            treat_percentage_as_auto: bool,
+        ) -> style_values::InsetValue<'_> {
             if treat_percentage_as_auto && value.contains_percentage() {
-                InsetValue::auto_value()
+                style_values::InsetValue::auto_value()
             } else {
                 value
             }
@@ -1909,11 +1943,11 @@ pub(crate) fn drain_abspos_with_placed_containing_blocks(
     records: &std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
-    entry_fragments: &std::rc::Rc<crate::layout::RunFragmentBuilder>,
+    entry_fragments: &std::rc::Rc<fragment_tree::RunFragmentBuilder>,
 ) {
     let accumulator_root = entry_fragments.root_node();
-    let run = crate::layout::FormattingContextRun {
-        purpose: LayoutPurpose::Commit,
+    let run = FormattingContextRun {
+        purpose: formatting_context::LayoutPurpose::Commit,
         records: records.clone(),
         box_: accumulator_root,
         layout_mode: LayoutMode::Normal,
@@ -1936,14 +1970,14 @@ pub(crate) fn drain_abspos_with_placed_containing_blocks(
 }
 
 pub(crate) fn compute_inset_native(
-    run: &crate::layout::FormattingContextRun,
+    run: &FormattingContextRun,
     node: Node,
     inline_size: CssPixels,
     block_size: CssPixels,
 ) {
     AbsposEngine::for_run(run).compute_inset(
         node,
-        LogicalSize {
+        geometry::LogicalSize {
             inline_size,
             block_size,
         },

--- a/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum StaticPositionAlignment {
     Start,
@@ -13,7 +15,7 @@ pub(crate) enum StaticPositionAlignment {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct StaticPositionRect {
-    pub(crate) rect: LogicalRect,
+    pub(crate) rect: geometry::LogicalRect,
     pub(crate) inline_alignment: StaticPositionAlignment,
     pub(crate) block_alignment: StaticPositionAlignment,
     pub(crate) alignment_derives_from_own_computed_values: bool,
@@ -44,7 +46,7 @@ pub(crate) enum AbsposAlignment {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AbsposContainingBlockInfo {
-    pub(crate) rect: LogicalRect,
+    pub(crate) rect: geometry::LogicalRect,
     pub(crate) inline_axis_mode: AbsposAxisMode,
     pub(crate) block_axis_mode: AbsposAxisMode,
     pub(crate) inline_alignment: Option<AbsposAlignment>,
@@ -56,14 +58,14 @@ pub(crate) struct AbsposContainingBlockInfo {
 pub(crate) struct AbsposLayoutInputs {
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info: AbsposContainingBlockInfo,
-    pub(crate) resolved_anchor_insets: Option<ResolvedAnchorInsets>,
+    pub(crate) resolved_anchor_insets: Option<super::formatting_context::ResolvedAnchorInsets>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PendingAbsposChild {
-    pub(crate) child_box: Node,
-    pub(crate) coordinate_space_box: Node,
+    pub(crate) child_box: super::formatting_context::Node,
+    pub(crate) coordinate_space_box: super::formatting_context::Node,
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info_override: Option<AbsposContainingBlockInfo>,
-    pub(crate) inline_containing_block: Node,
+    pub(crate) inline_containing_block: super::formatting_context::Node,
 }

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 struct FloatAvoidanceProbe {
     opportunity: Option<CssPixels>,
     content_inline_size: Option<CssPixels>,
@@ -181,13 +183,13 @@ struct FloatPlacement {
 
 // https://www.w3.org/TR/css-display/#block-formatting-context
 pub(crate) struct BlockFormattingContext {
-    purpose: LayoutPurpose,
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     root: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
     block_offset_of_current_block_container: Cell<Option<CssPixels>>,
-    pending_legend_flow_position: Cell<Option<LogicalOffset>>,
+    pending_legend_flow_position: Cell<Option<geometry::LogicalOffset>>,
     margin_state: RefCell<BlockMarginState>,
     floats: RefCell<Vec<FloatingBox>>,
     bands: RefCell<Vec<FloatBand>>,
@@ -198,10 +200,10 @@ pub(crate) struct BlockFormattingContext {
     trailing_collapsed_margin: Cell<Option<(Node, CssPixels)>>,
     table_box_in_wrapper_border_box_block_size: Cell<Option<CssPixels>>,
     min_content_inline_size_from_max_content_layout: Cell<Option<CssPixels>>,
-    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
-    previous_line_data: Option<std::rc::Rc<LineData>>,
+    previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
 }
 
 impl BlockFormattingContext {
@@ -226,7 +228,8 @@ impl BlockFormattingContext {
             table_box_in_wrapper_border_box_block_size: Cell::new(None),
             min_content_inline_size_from_max_content_layout: Cell::new(None),
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             previous_line_data: run.previous_line_data.clone(),
         }
     }
@@ -239,7 +242,8 @@ impl BlockFormattingContext {
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
             should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: self.fragments.clone(),
             previous_line_data: self.previous_line_data.clone(),
         }
@@ -298,8 +302,8 @@ impl BlockFormattingContext {
         ancestor == node || self.is_ancestor_of(ancestor, node)
     }
 
-    pub(crate) fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    pub(crate) fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
     fn place_child(&self, node: Node, offset: FfiCssPixelPoint) {
@@ -310,25 +314,30 @@ impl BlockFormattingContext {
         &self,
         node: Node,
         offset: FfiCssPixelPoint,
-        containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
+        containing_line_box_fragment: Option<used_values::LineBoxFragmentCoordinate>,
     ) {
-        crate::layout::place_child(&self.formatting_context_run(), node, offset, containing_line_box_fragment);
+        formatting_context::place_child(
+            &self.formatting_context_run(),
+            node,
+            offset,
+            containing_line_box_fragment,
+        );
     }
 
     fn register_contained_abspos_child(&self, node: Node, block_offset: CssPixels, coordinate_space_box: Node) {
-        let static_position = StaticPositionRect {
-            rect: LogicalRect {
-                offset: LogicalOffset {
+        let static_position = abspos_inputs::StaticPositionRect {
+            rect: geometry::LogicalRect {
+                offset: geometry::LogicalOffset {
                     inline_offset: CssPixels::default(),
                     block_offset,
                 },
-                size: LogicalSize::default(),
+                size: geometry::LogicalSize::default(),
             },
             inline_alignment: StaticPositionAlignment::Start,
             block_alignment: StaticPositionAlignment::Start,
             alignment_derives_from_own_computed_values: false,
         };
-        crate::layout::register_contained_abspos_child(
+        formatting_context::register_contained_abspos_child(
             &self.callbacks,
             self.fragments.as_deref(),
             coordinate_space_box,
@@ -339,11 +348,11 @@ impl BlockFormattingContext {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        let baselines = crate::layout::derive_baselines(&self.records, &self.callbacks, node, false);
+        let baselines = formatting_context::derive_baselines(&self.records, &self.callbacks, node, false);
         if node == self.root {
             self.record_derived_baselines_of_root_box(baselines);
         } else {
-            crate::layout::store_derived_baselines(&self.used(node), baselines);
+            formatting_context::store_derived_baselines(&self.used(node), baselines);
         }
     }
 
@@ -359,8 +368,13 @@ impl BlockFormattingContext {
         self.derived_baselines_of_root_box.get()
     }
 
-    fn compute_inset(&self, run: &FormattingContextRun, node: Node, containing_block_size: LogicalSize) {
-        crate::layout::compute_inset_native(run, node, containing_block_size.inline_size, containing_block_size.block_size);
+    fn compute_inset(&self, run: &FormattingContextRun, node: Node, containing_block_size: geometry::LogicalSize) {
+        abspos_engine::compute_inset_native(
+            run,
+            node,
+            containing_block_size.inline_size,
+            containing_block_size.block_size,
+        );
     }
 
     fn containing_block_rect(&self, node: Node, position: FfiCssPixelPoint) -> BlockCssPixelRect {
@@ -423,8 +437,12 @@ impl BlockFormattingContext {
         // instead of block layout: floats do not intrude into the grid container, and the grid container’s margins do
         // not collapse with the margins of its contents.
         matches!(
-            formatting_context_type_created_by_box(self.facts(node)),
-            Some(FfiFormattingContextType::Block | FfiFormattingContextType::Flex | FfiFormattingContextType::Grid)
+            formatting_context::formatting_context_type_created_by_box(self.facts(node)),
+            Some(
+                formatting_context::FfiFormattingContextType::Block
+                    | formatting_context::FfiFormattingContextType::Flex
+                    | formatting_context::FfiFormattingContextType::Grid
+            )
         )
     }
 
@@ -475,8 +493,12 @@ impl BlockFormattingContext {
     ) {
         let float_avoidance_inline_size =
             self.float_reduced_inline_opportunity(node, available_space, content_position_in_root);
-        let content_inline_size =
-            self.resolve_root_inline_metrics_and_content_size(node, available_space, constraints, float_avoidance_inline_size);
+        let content_inline_size = self.resolve_root_inline_metrics_and_content_size(
+            node,
+            available_space,
+            constraints,
+            float_avoidance_inline_size,
+        );
         if let Some(content_inline_size) = content_inline_size {
             self.used(node).set_content_inline_size(content_inline_size);
         }
@@ -512,7 +534,8 @@ impl BlockFormattingContext {
                 used.border_left.set(style.border_left_width());
                 used.border_right.set(style.border_right_width());
                 used.padding_left.set(style.padding_left().to_px(available_inline_size));
-                used.padding_right.set(style.padding_right().to_px(available_inline_size));
+                used.padding_right
+                    .set(style.padding_right().to_px(available_inline_size));
             }
             sizing.compute_inline_size_for_replaced_element(node, available_space, constraints)
         });
@@ -631,11 +654,11 @@ impl BlockFormattingContext {
                     if matches!(available_space.inline_size, AvailableSize::Definite(_)) {
                         inline_size = Some(underflow.max(CssPixels::default()));
                     } else if available_space.inline_size == AvailableSize::MinContent {
-                        if formatting_context_type_created_by_box(facts).is_some() {
+                        if formatting_context::formatting_context_type_created_by_box(facts).is_some() {
                             inline_size = Some(sizing.calculate_min_content_inline_size(node, constraints));
                         }
                     } else if available_space.inline_size == AvailableSize::MaxContent {
-                        if formatting_context_type_created_by_box(facts).is_some() {
+                        if formatting_context::formatting_context_type_created_by_box(facts).is_some() {
                             inline_size = Some(sizing.calculate_max_content_inline_size(node, constraints));
                         }
                     } else {
@@ -674,12 +697,12 @@ impl BlockFormattingContext {
                 remaining_available_space,
                 constraints,
                 None,
-                crate::layout::TableWrapperInlineSizeMode::ClampToAvailableInlineSize,
+                formatting_context::TableWrapperInlineSizeMode::ClampToAvailableInlineSize,
             ))
         } else if facts.uses_button_layout() && style.width().is_auto() {
             // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
             // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
-            Some(sizing.calculate_fit_content_size(node, crate::layout::SizingAxis::Inline, available_space, constraints))
+            Some(sizing.calculate_fit_content_size(node, SizingAxis::Inline, available_space, constraints))
         } else if sizing.should_treat_inline_size_as_auto(node, available_space) {
             None
         } else {
@@ -735,7 +758,11 @@ impl BlockFormattingContext {
             used.margin_left.set(margin_left);
             used.margin_right.set(margin_right);
         }
-        if sized_as_replaced { replaced_inline_size } else { used_inline_size }
+        if sized_as_replaced {
+            replaced_inline_size
+        } else {
+            used_inline_size
+        }
     }
 
     fn compute_floating_root_inline_sizes(
@@ -893,10 +920,10 @@ impl BlockFormattingContext {
         &self,
         block_start_in_root: CssPixels,
         block_end_in_root: CssPixels,
-    ) -> SpaceUsedByFloats {
+    ) -> inline_formatting_context::SpaceUsedByFloats {
         let bands = self.bands.borrow();
         assert!(!bands.is_empty());
-        let mut intrusions = SpaceUsedByFloats::default();
+        let mut intrusions = inline_formatting_context::SpaceUsedByFloats::default();
         if block_end_in_root <= block_start_in_root {
             let band = bands[self.band_index_at(block_start_in_root)];
             intrusions.left = band.left_intrusion;
@@ -913,11 +940,15 @@ impl BlockFormattingContext {
         intrusions
     }
 
-    fn intrusions_for_band_into_rect(&self, band: FloatBand, rect_in_root: BlockCssPixelRect) -> SpaceUsedByFloats {
+    fn intrusions_for_band_into_rect(
+        &self,
+        band: FloatBand,
+        rect_in_root: BlockCssPixelRect,
+    ) -> inline_formatting_context::SpaceUsedByFloats {
         // Deliberately read the root inline size at query time. It can be stale while
         // intrinsic sizing of this context's own root is in progress.
         let root_content_inline_size = self.used(self.root).content_inline_size.get();
-        SpaceUsedByFloats {
+        inline_formatting_context::SpaceUsedByFloats {
             left: if band.left_intrusion == CssPixels::default() {
                 CssPixels::default()
             } else {
@@ -936,7 +967,7 @@ impl BlockFormattingContext {
         box_in_root_rect: FfiCssPixelRect,
         block_start_in_box: CssPixels,
         block_end_in_box: CssPixels,
-    ) -> SpaceUsedByFloats {
+    ) -> inline_formatting_context::SpaceUsedByFloats {
         let rect = BlockCssPixelRect {
             x: box_in_root_rect.x,
             y: box_in_root_rect.y,
@@ -946,7 +977,7 @@ impl BlockFormattingContext {
         let intrusions = self.available_inline_space(rect.y + block_start_in_box, rect.y + block_end_in_box);
         // Deliberately read the root inline size at query time.
         let root_content_inline_size = self.used(self.root).content_inline_size.get();
-        SpaceUsedByFloats {
+        inline_formatting_context::SpaceUsedByFloats {
             left: if intrusions.left == CssPixels::default() {
                 CssPixels::default()
             } else {
@@ -982,9 +1013,7 @@ impl BlockFormattingContext {
                 AvailableSize::MaxContent | AvailableSize::Indefinite
             ) || margin_box_inline_size <= available_inline_size
                 || !has_floats_present;
-            if !fits
-                && let Some(next) = self.next_float_band_block_start_after(candidate_block_start)
-            {
+            if !fits && let Some(next) = self.next_float_band_block_start_after(candidate_block_start) {
                 candidate_block_start = next;
                 continue;
             }
@@ -1145,7 +1174,7 @@ impl BlockFormattingContext {
         &self,
         node: Node,
         used: &UsedValues,
-        space_used_by_floats: SpaceUsedByFloats,
+        space_used_by_floats: inline_formatting_context::SpaceUsedByFloats,
     ) -> CssPixels {
         if self.style(node).margin_left().is_auto() {
             return space_used_by_floats.left + used.margin_left.get();
@@ -1168,7 +1197,9 @@ impl BlockFormattingContext {
         containing_block_rect_in_root: BlockCssPixelRect,
         probe: &mut FloatAvoidanceProbe,
     ) -> CssPixels {
-        if !matches!(available_space.inline_size, AvailableSize::Definite(_)) || !self.box_should_avoid_floats_because_it_establishes_fc(node) {
+        if !matches!(available_space.inline_size, AvailableSize::Definite(_))
+            || !self.box_should_avoid_floats_because_it_establishes_fc(node)
+        {
             return content_block_offset;
         }
         // https://drafts.csswg.org/css2/#floats
@@ -1272,7 +1303,7 @@ impl BlockFormattingContext {
         }
         // https://drafts.csswg.org/css-display-3/#independent-formatting-context
         // NOTE: [..] margins do not collapse across formatting context boundaries.
-        if formatting_context_type_created_by_box(facts).is_some() {
+        if formatting_context::formatting_context_type_created_by_box(facts).is_some() {
             return false;
         }
         // NB: This should take care of the height and min-height constraints.
@@ -1313,7 +1344,7 @@ impl BlockFormattingContext {
     pub(crate) fn clear_floating_boxes(
         &self,
         node: Node,
-        inline_context: Option<&InlineFormattingContext>,
+        inline_context: Option<&inline_formatting_context::InlineFormattingContext>,
         containing_block_position_in_root: FfiCssPixelPoint,
     ) -> bool {
         let style = self.style(node);
@@ -1421,7 +1452,7 @@ impl BlockFormattingContext {
         &self,
         run: &FormattingContextRun,
         list_item: Node,
-        inline_space_used_before_list_item_elements_formatted: SpaceUsedByFloats,
+        inline_space_used_before_list_item_elements_formatted: inline_formatting_context::SpaceUsedByFloats,
         list_item_first_baseline: Option<CssPixels>,
     ) {
         let marker = self.facts(list_item).list_item_marker();
@@ -1453,11 +1484,11 @@ impl BlockFormattingContext {
         let marker_used = self.used(marker);
         marker_used.set_content_inline_size(max_content_inline_size);
         marker_used.has_definite_inline_size.set(true);
-        let inner_available_space = crate::layout::AvailableSpace {
-            inline_size: crate::layout::AvailableSize::definite(max_content_inline_size),
-            block_size: crate::layout::AvailableSize::Indefinite,
+        let inner_available_space = AvailableSpace {
+            inline_size: AvailableSize::definite(max_content_inline_size),
+            block_size: AvailableSize::Indefinite,
         };
-        match crate::layout::layout_inside_child(
+        match formatting_context::layout_inside_child(
             run,
             None,
             None,
@@ -1475,8 +1506,8 @@ impl BlockFormattingContext {
             },
             true,
         ) {
-            crate::layout::ChildLayoutOutcome::Created(_) | crate::layout::ChildLayoutOutcome::Skipped => {}
-            crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+            ChildLayoutOutcome::Created(_) | ChildLayoutOutcome::Skipped => {}
+            ChildLayoutOutcome::ReenterCurrent => {
                 unreachable!("marker inside layout did not establish a formatting context")
             }
         }
@@ -1496,7 +1527,10 @@ impl BlockFormattingContext {
         {
             list_item_first_baseline - marker_used.first_baseline.get()
         } else {
-            round_css_pixels(Self::marker_centered_block_offset(marker_style.line_height(), marker_block_size))
+            round_css_pixels(Self::marker_centered_block_offset(
+                marker_style.line_height(),
+                marker_block_size,
+            ))
         };
 
         self.place_child(
@@ -1514,8 +1548,8 @@ impl BlockFormattingContext {
         node: Node,
         input: LayoutInput,
         force_independent_context_run: bool,
-    ) -> Option<ChildLayoutResult> {
-        match crate::layout::layout_inside_child(
+    ) -> Option<formatting_context::ChildLayoutResult> {
+        match formatting_context::layout_inside_child(
             run,
             Some(self),
             None,
@@ -1524,9 +1558,9 @@ impl BlockFormattingContext {
             input,
             force_independent_context_run,
         ) {
-            crate::layout::ChildLayoutOutcome::Skipped => None,
-            crate::layout::ChildLayoutOutcome::Created(child_layout) => Some(child_layout),
-            crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+            ChildLayoutOutcome::Skipped => None,
+            ChildLayoutOutcome::Created(child_layout) => Some(child_layout),
+            ChildLayoutOutcome::ReenterCurrent => {
                 self.run(run, input);
                 None
             }
@@ -1557,7 +1591,7 @@ impl BlockFormattingContext {
         block_container: Node,
         bottom_of_lowest_margin_box: &mut CssPixels,
         input: LayoutInput,
-        containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
+        containing_line_box_fragment: Option<used_values::LineBoxFragmentCoordinate>,
     ) {
         let available_space = input.available_space;
         let facts = self.facts(node);
@@ -1647,14 +1681,14 @@ impl BlockFormattingContext {
             );
         }
 
-        let independent_type = formatting_context_type_created_by_box(facts);
+        let independent_type = formatting_context::formatting_context_type_created_by_box(facts);
         let has_independent_formatting_context = independent_type.is_some();
 
         if !has_independent_formatting_context && !facts.is_block_container() {
             // Keep the C++ behavior: diagnose and skip this unsupported box after its
             // vertical metrics have been resolved.
             eprintln!("FIXME: Block-level box is not BlockContainer but does not create formatting context");
-            crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+            formatting_context::propagate_percentage_block_size_dependency_to_containing_block(
                 &run.records,
                 &self.callbacks,
                 node,
@@ -1716,9 +1750,7 @@ impl BlockFormattingContext {
             &mut probe,
         );
         let float_avoidance_inline_size = probe.opportunity;
-        if !has_independent_formatting_context
-            && let Some(content_inline_size) = probe.content_inline_size
-        {
+        if !has_independent_formatting_context && let Some(content_inline_size) = probe.content_inline_size {
             self.used(node).set_content_inline_size(content_inline_size);
         }
         let content_inline_size_now = probe
@@ -1734,10 +1766,10 @@ impl BlockFormattingContext {
         let is_list_item_box = facts.is_list_item_box();
         let marker = facts.list_item_marker();
 
-        let is_table_formatting_context = independent_type == Some(FfiFormattingContextType::Table);
+        let is_table_formatting_context = independent_type == Some(formatting_context::FfiFormattingContextType::Table);
         let mut pending_position = None;
         if box_is_positioned_by_fieldset_layout {
-            self.pending_legend_flow_position.set(Some(LogicalOffset {
+            self.pending_legend_flow_position.set(Some(geometry::LogicalOffset {
                 inline_offset: content_inline_offset,
                 block_offset: content_block_offset,
             }));
@@ -1778,12 +1810,12 @@ impl BlockFormattingContext {
         // Before we insert the children of a list item we need to know the location of the marker.
         // If we do not do this then left-floating elements inside the list item will push the marker to the right,
         // in some cases even causing it to overlap with the non-floating content of the list.
-        let mut inline_space_used_before_children_formatted = SpaceUsedByFloats::default();
+        let mut inline_space_used_before_children_formatted = inline_formatting_context::SpaceUsedByFloats::default();
         if is_list_item_box && !marker.is_invalid() {
             let marker_facts = self.facts(marker);
             if !marker_facts.list_marker_is_inside() {
                 let marker_style = self.style(marker);
-                let estimated_block_size = normal_line_height(marker_style);
+                let estimated_block_size = line_builder::normal_line_height(marker_style);
                 let marker_block_offset =
                     Self::marker_centered_block_offset(marker_style.line_height(), estimated_block_size);
                 let list_item_used = self.used(node);
@@ -1830,8 +1862,9 @@ impl BlockFormattingContext {
             let child_layout = self.layout_inside(run, node, inside_layout_input, true);
             if container_facts.is_table_wrapper() && style.display().is_table_inside() && child_layout.is_some() {
                 let used = self.used(node);
-                self.table_box_in_wrapper_border_box_block_size
-                    .set(Some(used.border_box_block_size(used.uses_collapsing_borders_model.get())));
+                self.table_box_in_wrapper_border_box_block_size.set(Some(
+                    used.border_box_block_size(used.uses_collapsing_borders_model.get()),
+                ));
                 if used.uses_collapsing_borders_model.get()
                     && let Some(position) = pending_position.as_mut()
                     && let Some((pre_run_border_box_left, pre_run_border_box_top)) = pre_run_table_border_box
@@ -1879,7 +1912,7 @@ impl BlockFormattingContext {
                     block_offset + resolved_margin_top + self.used(node).border_box_top(false)
                 };
                 if box_is_positioned_by_fieldset_layout {
-                    self.pending_legend_flow_position.set(Some(LogicalOffset {
+                    self.pending_legend_flow_position.set(Some(geometry::LogicalOffset {
                         inline_offset: content_inline_offset,
                         block_offset: final_content_block_offset,
                     }));
@@ -1930,7 +1963,7 @@ impl BlockFormattingContext {
 
         let dependency_was_not_reported_by_a_child_run = !has_independent_formatting_context;
         if dependency_was_not_reported_by_a_child_run {
-            crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+            formatting_context::propagate_percentage_block_size_dependency_to_containing_block(
                 &run.records,
                 &self.callbacks,
                 node,
@@ -1942,7 +1975,7 @@ impl BlockFormattingContext {
         self.compute_inset(
             run,
             node,
-            LogicalSize {
+            geometry::LogicalSize {
                 inline_size: block_container_used.content_inline_size.get(),
                 block_size: block_container_used.content_block_size.get(),
             },
@@ -2046,7 +2079,12 @@ impl BlockFormattingContext {
             self.layout_block_level_box(run, child, wrapper, &mut bottom_of_lowest_margin_box, child_input, None);
         }
         self.block_offset_of_current_block_container.set(saved);
-        self.finish_block_level_children_layout(wrapper, input, available_space_for_children, bottom_of_lowest_margin_box);
+        self.finish_block_level_children_layout(
+            wrapper,
+            input,
+            available_space_for_children,
+            bottom_of_lowest_margin_box,
+        );
     }
 
     fn finish_block_level_children_layout(
@@ -2128,7 +2166,14 @@ impl BlockFormattingContext {
             let saved = self.block_offset_of_current_block_container.replace(Some(extra_top));
             for child in self.children(fieldset) {
                 if child != legend {
-                    self.layout_block_level_box(run, child, fieldset, &mut bottom_of_lowest_margin_box, child_input, None);
+                    self.layout_block_level_box(
+                        run,
+                        child,
+                        fieldset,
+                        &mut bottom_of_lowest_margin_box,
+                        child_input,
+                        None,
+                    );
                 }
             }
             self.block_offset_of_current_block_container.set(saved);
@@ -2306,7 +2351,7 @@ impl BlockFormattingContext {
         node: Node,
         containing_block: Node,
         input: LayoutInput,
-        line_builder: &mut LineBuilder<'_, '_>,
+        line_builder: &mut line_builder::LineBuilder<'_, '_>,
     ) {
         let line_index = line_builder.line_index_for_block_level_box();
         let current_block_offset = line_builder.current_block_offset();
@@ -2320,7 +2365,7 @@ impl BlockFormattingContext {
             containing_block,
             &mut dummy_bottom,
             input,
-            Some(LineBoxFragmentCoordinate {
+            Some(used_values::LineBoxFragmentCoordinate {
                 line_box_index: line_index,
                 fragment_index: 0,
             }),
@@ -2432,7 +2477,7 @@ impl BlockFormattingContext {
         node: Node,
         input: LayoutInput,
         block_offset: CssPixels,
-        mut line_builder: Option<&mut LineBuilder<'_, '_>>,
+        mut line_builder: Option<&mut line_builder::LineBuilder<'_, '_>>,
     ) {
         let available_space = input.available_space;
         assert!(self.facts(node).is_floating());
@@ -2541,7 +2586,7 @@ impl BlockFormattingContext {
         self.compute_inset(
             run,
             node,
-            LogicalSize {
+            geometry::LogicalSize {
                 inline_size: block_container_used.content_inline_size.get(),
                 block_size: block_container_used.content_block_size.get(),
             },
@@ -2576,7 +2621,7 @@ impl BlockFormattingContext {
     ) {
         assert!(self.facts(block_container).children_are_inline());
         let inline_input = self.child_layout_input(block_container, input, available_space_for_children);
-        let mut context = InlineFormattingContext::new_with_rust_parent(
+        let mut context = inline_formatting_context::InlineFormattingContext::new_with_rust_parent(
             run,
             block_container,
             self.layout_mode,
@@ -2624,8 +2669,10 @@ impl BlockFormattingContext {
                 let min_is_auto = style.min_width().is_auto()
                     || (style.min_width().is_fit_content()
                         && input.available_space.inline_size.is_intrinsic_sizing_constraint())
-                    || (style.min_width().is_max_content() && input.available_space.inline_size == AvailableSize::MaxContent)
-                    || (style.min_width().is_min_content() && input.available_space.inline_size == AvailableSize::MinContent);
+                    || (style.min_width().is_max_content()
+                        && input.available_space.inline_size == AvailableSize::MaxContent)
+                    || (style.min_width().is_min_content()
+                        && input.available_space.inline_size == AvailableSize::MinContent);
                 if !min_is_auto {
                     let minimum = sizing.calculate_inner_inline_size(
                         block_container,
@@ -2655,11 +2702,7 @@ impl BlockFormattingContext {
             constraints,
             automatic_content_block_size_of_completed_run,
         );
-        floor_list_item_automatic_block_size_by_marker_line_height(
-            self.callbacks,
-            node,
-            automatic_content_block_size,
-        )
+        floor_list_item_automatic_block_size_by_marker_line_height(self.callbacks, node, automatic_content_block_size)
     }
 
     fn automatic_block_size_for_block_level_element_disregarding_marker(
@@ -2676,7 +2719,7 @@ impl BlockFormattingContext {
             || style.display().is_grid_inside()
             || style.display().is_table_inside()
         {
-            return independent_root_automatic_block_size(
+            return formatting_context::independent_root_automatic_block_size(
                 self.purpose,
                 &self.records,
                 &self.callbacks,
@@ -2793,7 +2836,7 @@ impl BlockFormattingContext {
             .iter()
             .filter(|floating_box| self.containing_block(floating_box.box_) == node)
         {
-            let mut inline_space = SpaceUsedByFloats::default();
+            let mut inline_space = inline_formatting_context::SpaceUsedByFloats::default();
             for direct_float in floats
                 .iter()
                 .filter(|floating_box| self.containing_block(floating_box.box_) == node)
@@ -2814,7 +2857,7 @@ impl BlockFormattingContext {
         if facts.children_are_inline() {
             if let Some(data) = self.used(node).line_data_ref() {
                 for line in &data.line_boxes {
-                    let mut inline_size_here = crate::layout::line_physical_horizontal_extent(line);
+                    let mut inline_size_here = inline_formatting_context::line_physical_horizontal_extent(line);
                     let line_block_start = line.physical_vertical_end() - line.physical_vertical_extent();
                     let line_block_end = line.physical_vertical_end();
                     let mut extra_left = CssPixels::default();

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiCommitSink {
     pub context: *mut c_void,
-    pub content_size_changed: unsafe extern "C" fn(
-        *mut c_void,
-        *mut c_void,
-        crate::layout::FfiCssPixelSize,
-        crate::layout::FfiCssPixelSize,
-    ),
+    pub content_size_changed: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCssPixelSize, FfiCssPixelSize),
     pub finish_commit: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize),
 }
 
@@ -22,8 +19,8 @@ fn commit_subtree(
     callbacks: &FfiLayoutFcCallbacks,
     sink: &FfiCommitSink,
     paintables: &mut crate::painting::paintable_build::PaintableCommit<'_>,
-    links_by_slot: &std::collections::HashMap<u32, &crate::layout::FragmentLink>,
-    pass_fragments: &crate::layout::CompletedPassFragments,
+    links_by_slot: &std::collections::HashMap<u32, &FragmentLink>,
+    pass_fragments: &fragment_tree::CompletedPassFragments,
     enclosing_line_root_content_changed: bool,
 ) {
     let slot_index = callbacks.slot_index(node);
@@ -111,7 +108,7 @@ pub(crate) fn commit_replacing(
     root: Node,
     callbacks: &FfiLayoutFcCallbacks,
     sink: &FfiCommitSink,
-    pass_fragments: &crate::layout::CompletedPassFragments,
+    pass_fragments: &fragment_tree::CompletedPassFragments,
 ) {
     let links_by_slot = pass_fragments.links_by_slot();
     let mut paintables = crate::painting::paintable_build::PaintableCommit::new(callbacks);

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum FcRunCacheMode {
+pub(super) enum FcRunCacheMode {
     Disabled,
     Enabled,
     /// Hits do not replay: the real layout runs and the entry is verified
@@ -13,14 +15,16 @@ enum FcRunCacheMode {
     Shadow,
 }
 
-fn fc_run_cache_mode_from_environment() -> FcRunCacheMode {
+pub(super) fn fc_run_cache_mode_from_environment() -> FcRunCacheMode {
     static MODE: std::sync::OnceLock<FcRunCacheMode> = std::sync::OnceLock::new();
     *MODE.get_or_init(|| match std::env::var("LADYBIRD_FC_RUN_CACHE").as_deref() {
         Ok("0") => FcRunCacheMode::Disabled,
         Ok("1") => FcRunCacheMode::Enabled,
         Ok("shadow") => FcRunCacheMode::Shadow,
         Ok(unknown) => {
-            eprintln!("Unknown LADYBIRD_FC_RUN_CACHE value {unknown:?} (expected 0, 1, or shadow); disabling the run cache");
+            eprintln!(
+                "Unknown LADYBIRD_FC_RUN_CACHE value {unknown:?} (expected 0, 1, or shadow); disabling the run cache"
+            );
             FcRunCacheMode::Disabled
         }
         Err(_) => FcRunCacheMode::Enabled,
@@ -33,10 +37,10 @@ fn fc_run_cache_mode_from_environment() -> FcRunCacheMode {
 /// reach a run through that input or through the normal style/layout epoch
 /// invalidation for viewport-dependent computed values.
 #[derive(Clone, Copy, PartialEq)]
-struct FcRunCacheKey {
-    fc_type: FfiFormattingContextType,
+pub(super) struct FcRunCacheKey {
+    fc_type: formatting_context::FfiFormattingContextType,
     input: LayoutInput,
-    root_cells: UsedValuesCellState,
+    root_cells: used_values::UsedValuesCellState,
 }
 
 impl FcRunCacheKey {
@@ -54,7 +58,8 @@ impl FcRunCacheKey {
 }
 
 fn available_block_sizes_are_interchangeable(a: AvailableSize, b: AvailableSize) -> bool {
-    let is_definite_or_indefinite = |size: AvailableSize| matches!(size, AvailableSize::Definite(_) | AvailableSize::Indefinite);
+    let is_definite_or_indefinite =
+        |size: AvailableSize| matches!(size, AvailableSize::Definite(_) | AvailableSize::Indefinite);
     a == b || (is_definite_or_indefinite(a) && is_definite_or_indefinite(b))
 }
 
@@ -100,8 +105,12 @@ fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectiv
         && adopt_automatic_content_block_size == b.adopt_automatic_content_block_size
         && float_avoidance_inline_size == b.float_avoidance_inline_size
         && outer_float_intrusion_before_list_item_children == b.outer_float_intrusion_before_list_item_children
-        && treat_block_axis_percentage_insets_as_auto_beyond_root == b.treat_block_axis_percentage_insets_as_auto_beyond_root
-        && match (flex_self_block_size_resolution_space, b.flex_self_block_size_resolution_space) {
+        && treat_block_axis_percentage_insets_as_auto_beyond_root
+            == b.treat_block_axis_percentage_insets_as_auto_beyond_root
+        && match (
+            flex_self_block_size_resolution_space,
+            b.flex_self_block_size_resolution_space,
+        ) {
             (None, None) => true,
             (Some(a_space), Some(b_space)) => {
                 a_space.inline_size == b_space.inline_size
@@ -120,10 +129,10 @@ pub(crate) struct FcRunCacheValidity {
     pub(crate) fragment_cache_epoch: u32,
 }
 
-struct FcRunCacheEntry {
+pub(super) struct FcRunCacheEntry {
     key: FcRunCacheKey,
     validity: FcRunCacheValidity,
-    outputs: RunOutputs,
+    pub(super) outputs: formatting_context::RunOutputs,
     /// Keeps every font referenced by cached line data alive: glyph runs
     /// borrow raw font pointers, and a paint-only style change can drop
     /// the owning computed values without touching any layout epoch.
@@ -138,27 +147,31 @@ struct FcRunCacheEntry {
 }
 
 impl FcRunCacheEntry {
-    fn can_reuse_committed_subtree(&self) -> bool {
+    pub(super) fn can_reuse_committed_subtree(&self) -> bool {
         self.outputs
             .root
             .as_ref()
             .is_none_or(|root| root.propagated_pending_abspos.is_empty())
     }
 
-    fn outputs_for_reused_subtree(&self) -> RunOutputs {
+    pub(super) fn outputs_for_reused_subtree(&self) -> formatting_context::RunOutputs {
         debug_assert!(self.can_reuse_committed_subtree());
-        let root = self.outputs.root.as_ref().map(|root| UnplacedRootFragment {
-            node: root.node,
-            // Commit stops at the reused root, so descendant fragments and nested reuse markers never
-            // enter its scopes. Only payloads that escape the run still have to reach the parent.
-            scoped_descendants: Vec::new(),
-            reused_subtree_roots: std::collections::HashSet::new(),
-            propagated_pending_abspos: root.propagated_pending_abspos.clone(),
-            propagated_anchor_candidates: root.propagated_anchor_candidates.clone(),
-            propagated_inline_containing_block_rects: root.propagated_inline_containing_block_rects.clone(),
-            propagated_abspos_containing_block_info: root.propagated_abspos_containing_block_info.clone(),
-        });
-        RunOutputs {
+        let root = self
+            .outputs
+            .root
+            .as_ref()
+            .map(|root| fragment_tree::UnplacedRootFragment {
+                node: root.node,
+                // Commit stops at the reused root, so descendant fragments and nested reuse markers never
+                // enter its scopes. Only payloads that escape the run still have to reach the parent.
+                scoped_descendants: Vec::new(),
+                reused_subtree_roots: std::collections::HashSet::new(),
+                propagated_pending_abspos: root.propagated_pending_abspos.clone(),
+                propagated_anchor_candidates: root.propagated_anchor_candidates.clone(),
+                propagated_inline_containing_block_rects: root.propagated_inline_containing_block_rects.clone(),
+                propagated_abspos_containing_block_info: root.propagated_abspos_containing_block_info.clone(),
+            });
+        formatting_context::RunOutputs {
             result: self.outputs.result,
             root,
             root_outcome: self.outputs.root_outcome.clone(),
@@ -251,7 +264,10 @@ impl FcRunCacheArenaStore {
         if entry.validity != validity {
             return None;
         }
-        if !entry.key.matches(key, entry.outputs.result.depends_on_percentage_block_size) {
+        if !entry
+            .key
+            .matches(key, entry.outputs.result.depends_on_percentage_block_size)
+        {
             return None;
         }
         Some(entry.clone())
@@ -309,7 +325,7 @@ impl FcRunCacheArenaStore {
     }
 }
 
-fn collect_line_data_fonts(line_data: &LineData, fonts: &mut Vec<*const c_void>) {
+fn collect_line_data_fonts(line_data: &used_values::LineData, fonts: &mut Vec<*const c_void>) {
     for line in &line_data.line_boxes {
         for fragment in &line.fragments {
             if let Some(glyphs) = &fragment.glyphs
@@ -346,7 +362,7 @@ fn run_root_validity(callbacks: &FfiLayoutFcCallbacks, box_: Node) -> FcRunCache
 /// side effects are audited; pass entries and internal runs are not
 /// spawned child runs; devtools collection emits per-run callbacks a
 /// replay would skip.
-enum FcRunCacheAttempt {
+pub(super) enum FcRunCacheAttempt {
     Bypass,
     Store {
         key: Box<FcRunCacheKey>,
@@ -363,16 +379,16 @@ enum FcRunCacheAttempt {
 impl FcRunCacheAttempt {
     /// Err carries the entry the caller must replay instead of running.
     #[expect(clippy::too_many_arguments)]
-    fn probe(
-        purpose: LayoutPurpose,
+    pub(super) fn probe(
+        purpose: formatting_context::LayoutPurpose,
         box_: Node,
         parent_grid_is_present: bool,
-        fc_type: FfiFormattingContextType,
+        fc_type: formatting_context::FfiFormattingContextType,
         layout_mode: LayoutMode,
         should_collect_devtools_layout_data: bool,
         callbacks: &FfiLayoutFcCallbacks,
         input: &LayoutInput,
-        root_cells: &UsedValuesCellState,
+        root_cells: &used_values::UsedValuesCellState,
     ) -> Result<Self, std::rc::Rc<FcRunCacheEntry>> {
         let mode = fc_run_cache_mode_from_environment();
         // A run this cache cannot describe still commits its subtree, so a stored entry would go on
@@ -390,20 +406,20 @@ impl FcRunCacheAttempt {
             || input.participation == ParticipationInParentFormattingContext::Root
             || matches!(
                 fc_type,
-                FfiFormattingContextType::InternalReplaced | FfiFormattingContextType::InternalDummy
+                formatting_context::FfiFormattingContextType::InternalReplaced | formatting_context::FfiFormattingContextType::InternalDummy
             )
             // The direct normal-layout path for an empty atomic block only sizes and snapshots its root.
             // Replaying a stored output costs more than rebuilding it and retains an entry needlessly.
-            || (fc_type == FfiFormattingContextType::Block
+            || (fc_type == formatting_context::FfiFormattingContextType::Block
                 && input.participation == ParticipationInParentFormattingContext::AtomicInline
                 && callbacks.first_child(box_).is_invalid())
         {
             drop_superseded_entry();
             return Ok(Self::Bypass);
         }
-        if fc_type == FfiFormattingContextType::Grid
+        if fc_type == formatting_context::FfiFormattingContextType::Grid
             && parent_grid_is_present
-            && grid_template_declares_a_subgrid_axis(callbacks, box_)
+            && grid_formatting_context::grid_template_declares_a_subgrid_axis(callbacks, box_)
         {
             drop_superseded_entry();
             return Ok(Self::Bypass);
@@ -417,7 +433,10 @@ impl FcRunCacheAttempt {
         // registers scroll-shift side effects a replay would skip; and anchor-size()
         // resolves to None today, so inset properties are the only anchor dependency a
         // run can have.
-        if has_flag(NodeFacts::new(callbacks, box_).data(), NodeFlag::InsetsUseAnchorFunctions) {
+        if node_facts::has_flag(
+            NodeFacts::new(callbacks, box_).data(),
+            NodeFlag::InsetsUseAnchorFunctions,
+        ) {
             drop_superseded_entry();
             return Ok(Self::Bypass);
         }
@@ -459,7 +478,7 @@ impl FcRunCacheAttempt {
         }
     }
 
-    fn previous_line_data(&self) -> Option<std::rc::Rc<LineData>> {
+    pub(super) fn previous_line_data(&self) -> Option<std::rc::Rc<used_values::LineData>> {
         let Self::Store {
             structurally_damaged_entry: Some(entry),
             ..
@@ -470,7 +489,12 @@ impl FcRunCacheAttempt {
         entry.outputs.root_outcome.line_data.clone()
     }
 
-    fn conclude(self, callbacks: &FfiLayoutFcCallbacks, box_: Node, outputs: &RunOutputs) {
+    pub(super) fn conclude(
+        self,
+        callbacks: &FfiLayoutFcCallbacks,
+        box_: Node,
+        outputs: &formatting_context::RunOutputs,
+    ) {
         let Self::Store {
             key,
             validity,
@@ -578,18 +602,26 @@ macro_rules! shadow_comparable_rare_payloads {
     };
 }
 
-fn line_data_matches(cached: Option<&LineData>, fresh: Option<&LineData>) -> bool {
+fn line_data_matches(cached: Option<&used_values::LineData>, fresh: Option<&used_values::LineData>) -> bool {
     cached == fresh
 }
 
-fn assert_line_data_matches(root_slot: u32, cached: Option<&LineData>, fresh: Option<&LineData>) {
+fn assert_line_data_matches(
+    root_slot: u32,
+    cached: Option<&used_values::LineData>,
+    fresh: Option<&used_values::LineData>,
+) {
     assert!(
         line_data_matches(cached, fresh),
         "run cache shadow: root line data diverged for slot {root_slot}"
     );
 }
 
-fn assert_rare_data_matches(root_slot: u32, cached: Option<&UsedValuesRareData>, fresh: Option<&UsedValuesRareData>) {
+fn assert_rare_data_matches(
+    root_slot: u32,
+    cached: Option<&used_values::UsedValuesRareData>,
+    fresh: Option<&used_values::UsedValuesRareData>,
+) {
     assert!(
         cached.is_some() == fresh.is_some(),
         "run cache shadow: root rare data presence diverged for slot {root_slot}"
@@ -610,7 +642,11 @@ fn sorted_by_key<T: Clone, K: Ord>(items: &[T], key: impl Fn(&T) -> K) -> Vec<T>
     sorted
 }
 
-fn assert_unplaced_roots_match(root_slot: u32, cached: Option<&UnplacedRootFragment>, fresh: Option<&UnplacedRootFragment>) {
+fn assert_unplaced_roots_match(
+    root_slot: u32,
+    cached: Option<&fragment_tree::UnplacedRootFragment>,
+    fresh: Option<&fragment_tree::UnplacedRootFragment>,
+) {
     assert!(
         cached.is_some() == fresh.is_some(),
         "run cache shadow: unplaced root presence diverged for slot {root_slot}"
@@ -626,31 +662,35 @@ fn assert_unplaced_roots_match(root_slot: u32, cached: Option<&UnplacedRootFragm
     // Escape lists are collected partly from hash-map sweeps, whose order
     // is not deterministic between runs; consumption sorts registrations
     // into tree order, so the oracle compares them order-insensitively.
-    let pending_order =
-        |child: &PendingAbsposChild| (child.child_box.slot_index(), child.coordinate_space_box.slot_index());
+    let pending_order = |child: &abspos_inputs::PendingAbsposChild| {
+        (child.child_box.slot_index(), child.coordinate_space_box.slot_index())
+    };
     let cached_pending = sorted_by_key(&cached.propagated_pending_abspos, pending_order);
     let fresh_pending = sorted_by_key(&fresh.propagated_pending_abspos, pending_order);
     assert!(
         cached_pending == fresh_pending,
         "run cache shadow: propagated abspos children diverged for slot {root_slot}\ncached: {cached_pending:#?}\nfresh: {fresh_pending:#?}"
     );
-    let candidate_order =
-        |candidate: &AnchorCandidate| (candidate.node.slot_index(), candidate.coordinate_space_box.slot_index());
+    let candidate_order = |candidate: &fragment_tree::AnchorCandidate| {
+        (candidate.node.slot_index(), candidate.coordinate_space_box.slot_index())
+    };
     let cached_candidates = sorted_by_key(&cached.propagated_anchor_candidates, candidate_order);
     let fresh_candidates = sorted_by_key(&fresh.propagated_anchor_candidates, candidate_order);
     assert!(
         cached_candidates == fresh_candidates,
         "run cache shadow: propagated anchor candidates diverged for slot {root_slot}"
     );
-    let inline_rect_order =
-        |rect: &InlineContainingBlockRect| (rect.inline_box.slot_index(), rect.coordinate_space_box.slot_index());
+    let inline_rect_order = |rect: &fragment_tree::InlineContainingBlockRect| {
+        (rect.inline_box.slot_index(), rect.coordinate_space_box.slot_index())
+    };
     let cached_inline_rects = sorted_by_key(&cached.propagated_inline_containing_block_rects, inline_rect_order);
     let fresh_inline_rects = sorted_by_key(&fresh.propagated_inline_containing_block_rects, inline_rect_order);
     assert!(
         cached_inline_rects == fresh_inline_rects,
         "run cache shadow: propagated inline containing block rects diverged for slot {root_slot}"
     );
-    let contribution_order = |contribution: &AbsposContainingBlockInfoContribution| contribution.child_box.slot_index();
+    let contribution_order =
+        |contribution: &fragment_tree::AbsposContainingBlockInfoContribution| contribution.child_box.slot_index();
     let cached_contributions = sorted_by_key(&cached.propagated_abspos_containing_block_info, contribution_order);
     let fresh_contributions = sorted_by_key(&fresh.propagated_abspos_containing_block_info, contribution_order);
     assert!(
@@ -676,8 +716,12 @@ fn assert_links_match(root_slot: u32, cached: &FragmentLink, fresh: &FragmentLin
     if cached.committed_offset != fresh.committed_offset {
         diverged.push("committed_offset");
     }
-    if (cached.inset_left, cached.inset_right, cached.inset_top, cached.inset_bottom)
-        != (fresh.inset_left, fresh.inset_right, fresh.inset_top, fresh.inset_bottom)
+    if (
+        cached.inset_left,
+        cached.inset_right,
+        cached.inset_top,
+        cached.inset_bottom,
+    ) != (fresh.inset_left, fresh.inset_right, fresh.inset_top, fresh.inset_bottom)
     {
         diverged.push("insets");
     }
@@ -697,26 +741,55 @@ fn assert_links_match(root_slot: u32, cached: &FragmentLink, fresh: &FragmentLin
     assert_link_lists_match(root_slot, &cached.fragment.children, &fresh.fragment.children);
 }
 
-fn collect_diverged_fragment_fields(cached: &Fragment, fresh: &Fragment, diverged: &mut Vec<&'static str>) {
+fn collect_diverged_fragment_fields(
+    cached: &fragment_tree::Fragment,
+    fresh: &fragment_tree::Fragment,
+    diverged: &mut Vec<&'static str>,
+) {
     if cached.node != fresh.node {
         diverged.push("node");
     }
-    if (cached.content_inline_size, cached.content_block_size) != (fresh.content_inline_size, fresh.content_block_size) {
+    if (cached.content_inline_size, cached.content_block_size) != (fresh.content_inline_size, fresh.content_block_size)
+    {
         diverged.push("content_size");
     }
-    if (cached.margin_left, cached.margin_right, cached.margin_top, cached.margin_bottom)
-        != (fresh.margin_left, fresh.margin_right, fresh.margin_top, fresh.margin_bottom)
-    {
+    if (
+        cached.margin_left,
+        cached.margin_right,
+        cached.margin_top,
+        cached.margin_bottom,
+    ) != (
+        fresh.margin_left,
+        fresh.margin_right,
+        fresh.margin_top,
+        fresh.margin_bottom,
+    ) {
         diverged.push("margins");
     }
-    if (cached.border_left, cached.border_right, cached.border_top, cached.border_bottom)
-        != (fresh.border_left, fresh.border_right, fresh.border_top, fresh.border_bottom)
-    {
+    if (
+        cached.border_left,
+        cached.border_right,
+        cached.border_top,
+        cached.border_bottom,
+    ) != (
+        fresh.border_left,
+        fresh.border_right,
+        fresh.border_top,
+        fresh.border_bottom,
+    ) {
         diverged.push("borders");
     }
-    if (cached.padding_left, cached.padding_right, cached.padding_top, cached.padding_bottom)
-        != (fresh.padding_left, fresh.padding_right, fresh.padding_top, fresh.padding_bottom)
-    {
+    if (
+        cached.padding_left,
+        cached.padding_right,
+        cached.padding_top,
+        cached.padding_bottom,
+    ) != (
+        fresh.padding_left,
+        fresh.padding_right,
+        fresh.padding_top,
+        fresh.padding_bottom,
+    ) {
         diverged.push("paddings");
     }
     if shadow_comparable_rare_payloads!(cached) != shadow_comparable_rare_payloads!(fresh) {

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FlexFactor {
     Grow,
@@ -146,7 +148,7 @@ struct FlexLine {
     has_baseline_aligned_items: bool,
     remaining_free_space: Option<CssPixels>,
     chosen_flex_fraction: f64,
-    growth_state: FlexLayoutGrowthState,
+    growth_state: formatting_context::FlexLayoutGrowthState,
 }
 
 impl Default for FlexLine {
@@ -157,7 +159,7 @@ impl Default for FlexLine {
             has_baseline_aligned_items: false,
             remaining_free_space: None,
             chosen_flex_fraction: 0.0,
-            growth_state: FlexLayoutGrowthState::Growing,
+            growth_state: formatting_context::FlexLayoutGrowthState::Growing,
         }
     }
 }
@@ -169,13 +171,13 @@ struct AxisAgnosticAvailableSpace {
     space: AvailableSpace,
 }
 
-struct FlexFormattingContext<'pass> {
-    purpose: LayoutPurpose,
+pub(super) struct FlexFormattingContext<'pass> {
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     flex_container: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
-    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     flex_lines: Vec<FlexLine>,
@@ -189,7 +191,7 @@ struct FlexFormattingContext<'pass> {
 }
 
 impl<'pass> FlexFormattingContext<'pass> {
-    fn new(run: &FormattingContextRun) -> Self {
+    pub(super) fn new(run: &FormattingContextRun) -> Self {
         let flex_direction = StyleValues::for_node(&run.callbacks, run.box_).flex_direction();
         Self {
             purpose: run.purpose,
@@ -199,7 +201,8 @@ impl<'pass> FlexFormattingContext<'pass> {
             callbacks: run.callbacks,
             fragments: run.fragments.clone(),
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             flex_lines: Vec::new(),
             flex_items: Vec::new(),
             derived_baselines_of_root_box: DerivedBaselines::default(),
@@ -219,7 +222,8 @@ impl<'pass> FlexFormattingContext<'pass> {
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
             should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: self.fragments.clone(),
             previous_line_data: None,
         }
@@ -240,8 +244,8 @@ impl<'pass> FlexFormattingContext<'pass> {
         NodeFacts::new(&self.callbacks, node)
     }
 
-    fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
     fn create_used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
@@ -312,7 +316,11 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     // Picks whichever of the two values describes the main (resp. cross) axis of this flex container.
     fn select_main<T>(&self, horizontal: T, vertical: T) -> T {
-        if self.main_axis_is_horizontal() { horizontal } else { vertical }
+        if self.main_axis_is_horizontal() {
+            horizontal
+        } else {
+            vertical
+        }
     }
 
     fn select_cross<T>(&self, horizontal: T, vertical: T) -> T {
@@ -369,7 +377,7 @@ impl<'pass> FlexFormattingContext<'pass> {
     fn main_size_from_cross_size_and_aspect_ratio(
         &self,
         cross_size: CssPixels,
-        aspect_ratio: PixelFraction,
+        aspect_ratio: formatting_context::PixelFraction,
     ) -> CssPixels {
         if self.main_axis_is_horizontal() {
             aspect_ratio.multiply(cross_size)
@@ -381,7 +389,7 @@ impl<'pass> FlexFormattingContext<'pass> {
     fn cross_size_from_main_size_and_aspect_ratio(
         &self,
         main_size: CssPixels,
-        aspect_ratio: PixelFraction,
+        aspect_ratio: formatting_context::PixelFraction,
     ) -> CssPixels {
         if self.main_axis_is_horizontal() {
             aspect_ratio.divide(main_size)
@@ -468,22 +476,34 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     fn computed_main_size(&self, node: Node) -> (&'pass ComputedSize, SizingProperty) {
         let style = self.style(node);
-        self.select_main((style.width(), SizingProperty::Width), (style.height(), SizingProperty::Height))
+        self.select_main(
+            (style.width(), SizingProperty::Width),
+            (style.height(), SizingProperty::Height),
+        )
     }
 
     fn computed_main_min_size(&self, node: Node) -> (&'pass ComputedSize, SizingProperty) {
         let style = self.style(node);
-        self.select_main((style.min_width(), SizingProperty::MinWidth), (style.min_height(), SizingProperty::MinHeight))
+        self.select_main(
+            (style.min_width(), SizingProperty::MinWidth),
+            (style.min_height(), SizingProperty::MinHeight),
+        )
     }
 
     fn computed_main_max_size(&self, node: Node) -> (&'pass ComputedSize, SizingProperty) {
         let style = self.style(node);
-        self.select_main((style.max_width(), SizingProperty::MaxWidth), (style.max_height(), SizingProperty::MaxHeight))
+        self.select_main(
+            (style.max_width(), SizingProperty::MaxWidth),
+            (style.max_height(), SizingProperty::MaxHeight),
+        )
     }
 
     fn computed_cross_size(&self, node: Node) -> (&'pass ComputedSize, SizingProperty) {
         let style = self.style(node);
-        self.select_cross((style.width(), SizingProperty::Width), (style.height(), SizingProperty::Height))
+        self.select_cross(
+            (style.width(), SizingProperty::Width),
+            (style.height(), SizingProperty::Height),
+        )
     }
 
     fn computed_cross_min_size(&self, node: Node) -> (&'pass ComputedSize, SizingProperty) {
@@ -597,10 +617,7 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn should_treat_main_size_as_auto(&self, node: Node) -> bool {
-        self.should_treat_size_as_auto(
-            node,
-            self.main_sizing_axis(),
-        )
+        self.should_treat_size_as_auto(node, self.main_sizing_axis())
     }
 
     fn should_treat_cross_size_as_auto(&self, node: Node) -> bool {
@@ -905,7 +922,10 @@ impl<'pass> FlexFormattingContext<'pass> {
         let node = self.flex_items[index].box_;
         let style = self.style(node);
         // We can resolve percentage min/max-width if the available inline size is definite.
-        let can_resolve_percentages = matches!(self.available_space_for_items.unwrap().space.inline_size, AvailableSize::Definite(_));
+        let can_resolve_percentages = matches!(
+            self.available_space_for_items.unwrap().space.inline_size,
+            AvailableSize::Definite(_)
+        );
         let min_inline_size =
             if !style.min_width().is_auto() && (!style.min_width().contains_percentage() || can_resolve_percentages) {
                 self.resolve_inner_inline_size(index, SizingProperty::MinWidth)
@@ -925,11 +945,7 @@ impl<'pass> FlexFormattingContext<'pass> {
 
         let inline_size = if self.should_treat_size_as_auto(node, SizingAxis::Inline) || style.width().is_fit_content()
         {
-            self.calculate_fit_content_size(
-                index,
-                SizingAxis::Inline,
-                self.available_space_for_items.unwrap().space,
-            )
+            self.calculate_fit_content_size(index, SizingAxis::Inline, self.available_space_for_items.unwrap().space)
         } else if style.width().is_min_content() {
             self.calculate_min_content_inline_size(index)
         } else if style.width().is_max_content() {
@@ -1222,13 +1238,21 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     fn main_gap(&self) -> CssPixels {
         let style = self.style(self.flex_container);
-        let gap = if self.is_row_layout() { style.column_gap() } else { style.row_gap() };
+        let gap = if self.is_row_layout() {
+            style.column_gap()
+        } else {
+            style.row_gap()
+        };
         gap.to_px(self.inner_main_size_used(&self.container_used()))
     }
 
     fn cross_gap(&self) -> CssPixels {
         let style = self.style(self.flex_container);
-        let gap = if self.is_row_layout() { style.row_gap() } else { style.column_gap() };
+        let gap = if self.is_row_layout() {
+            style.row_gap()
+        } else {
+            style.column_gap()
+        };
         gap.to_px(self.inner_cross_size_used(&self.container_used()))
     }
 
@@ -1370,9 +1394,9 @@ impl<'pass> FlexFormattingContext<'pass> {
             FlexFactor::Shrink
         };
         self.flex_lines[line_index].growth_state = if factor == FlexFactor::Grow {
-            FlexLayoutGrowthState::Growing
+            formatting_context::FlexLayoutGrowthState::Growing
         } else {
-            FlexLayoutGrowthState::Shrinking
+            formatting_context::FlexLayoutGrowthState::Shrinking
         };
 
         // 2. Each item in the flex line has a target main size, initially set to its flex base size.
@@ -1692,11 +1716,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 },
             )
         } else {
-            self.calculate_fit_content_size(
-                index,
-                SizingAxis::Inline,
-                self.available_space_for_items.unwrap().space,
-            )
+            self.calculate_fit_content_size(index, SizingAxis::Inline, self.available_space_for_items.unwrap().space)
         };
         self.flex_items[index].hypothetical_cross_size = css_clamp(fit_content, clamp_min, clamp_max);
     }
@@ -2270,11 +2290,11 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     fn item_box_baseline(&self, index: usize) -> CssPixels {
         let item = &self.flex_items[index];
-        crate::layout::box_baseline_with_content_baselines(
+        formatting_context::box_baseline_with_content_baselines(
             &self.callbacks,
             item.box_,
             &self.item_used(index),
-            crate::layout::BaselineSet::First,
+            formatting_context::BaselineSet::First,
             item.content_baselines,
         )
     }
@@ -2354,7 +2374,8 @@ impl<'pass> FlexFormattingContext<'pass> {
         // the table wrapper box's edges and the table box's content edges
         // were all part of the table box's border+padding area,
         // and the table box were the flex item.
-        if self.facts(node).is_table_wrapper() && !self.cross_axis_is_horizontal() && self.flex_item_is_stretched(index) {
+        if self.facts(node).is_table_wrapper() && !self.cross_axis_is_horizontal() && self.flex_item_is_stretched(index)
+        {
             let mut intrinsic_space = input.available_space;
             intrinsic_space.block_size = AvailableSize::Indefinite;
             let intrinsic_size = self.sizing().compute_table_box_block_size_inside_wrapper(
@@ -2368,22 +2389,22 @@ impl<'pass> FlexFormattingContext<'pass> {
         }
 
         self.flex_items[index].content_baselines =
-            match crate::layout::layout_inside_child(run, None, None, node, LayoutMode::Normal, input, false) {
-                crate::layout::ChildLayoutOutcome::Created(result) => result.baselines,
-                crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+            match formatting_context::layout_inside_child(run, None, None, node, LayoutMode::Normal, input, false) {
+                ChildLayoutOutcome::Created(result) => result.baselines,
+                ChildLayoutOutcome::ReenterCurrent => {
                     self.run(run, input);
                     self.item_used(index).content_baselines_from_cells()
                 }
-                crate::layout::ChildLayoutOutcome::Skipped => self.item_used(index).content_baselines_from_cells(),
+                ChildLayoutOutcome::Skipped => self.item_used(index).content_baselines_from_cells(),
             };
 
         let container_inline_size = self.container_used().content_inline_size.get();
         let container_block_size = self.container_used().content_block_size.get();
-        crate::layout::compute_inset_native(run, node, container_inline_size, container_block_size);
+        abspos_engine::compute_inset_native(run, node, container_inline_size, container_block_size);
     }
 
     // https://drafts.csswg.org/css-flexbox-1/#abspos-items
-    fn calculate_static_position_rect(&self, node: Node) -> StaticPositionRect {
+    fn calculate_static_position_rect(&self, node: Node) -> abspos_inputs::StaticPositionRect {
         // The cross-axis edges of the static-position rectangle of an absolutely-positioned child
         // of a flex container are the content edges of the flex container.
 
@@ -2446,7 +2467,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         } else {
             (cross_size, main_size)
         };
-        let (inline_size, block_size) = to_physical(
+        let (inline_size, block_size) = geometry::to_physical(
             self.style(self.flex_container).writing_mode(),
             logical_inline_size,
             logical_block_size,
@@ -2456,15 +2477,15 @@ impl<'pass> FlexFormattingContext<'pass> {
         } else {
             (cross_alignment, main_alignment)
         };
-        let (inline_alignment, block_alignment) = to_physical(
+        let (inline_alignment, block_alignment) = geometry::to_physical(
             self.style(self.flex_container).writing_mode(),
             logical_inline_alignment,
             logical_block_alignment,
         );
-        StaticPositionRect {
-            rect: crate::layout::LogicalRect {
+        abspos_inputs::StaticPositionRect {
+            rect: geometry::LogicalRect {
                 offset: Default::default(),
-                size: crate::layout::LogicalSize {
+                size: geometry::LogicalSize {
                     inline_size,
                     block_size,
                 },
@@ -2500,16 +2521,16 @@ impl<'pass> FlexFormattingContext<'pass> {
                         (item.cross_offset, item.main_offset, cross_size, main_size)
                     };
                 let writing_mode = self.style(self.flex_container).writing_mode();
-                let (x, y) = to_physical(writing_mode, logical_inline_offset, logical_block_offset);
-                let (width, height) = to_physical(writing_mode, logical_inline_size, logical_block_size);
-                let rect = FlexLayoutItemRect { x, y, width, height };
+                let (x, y) = geometry::to_physical(writing_mode, logical_inline_offset, logical_block_offset);
+                let (width, height) = geometry::to_physical(writing_mode, logical_inline_size, logical_block_size);
+                let rect = formatting_context::FlexLayoutItemRect { x, y, width, height };
                 let node = item.box_;
                 let style = self.style(node);
                 let main_size_property = self.select_main(style.width(), style.height());
                 let main_min_size_property = self.select_main(style.min_width(), style.min_height());
                 let main_max_size_property = self.select_main(style.max_width(), style.max_height());
                 let node_id = unsafe { (self.callbacks.node_unique_id)(self.callbacks.shell(node)) };
-                items.push(FlexLayoutItem {
+                items.push(formatting_context::FlexLayoutItem {
                     node_id: (node_id >= 0).then_some(node_id),
                     rect,
                     main_base_size: item.flex_base_size,
@@ -2535,11 +2556,11 @@ impl<'pass> FlexFormattingContext<'pass> {
                         item.cross_size.unwrap_or(item.hypothetical_cross_size)
                     },
                     clamp_state: if item.is_min_violation {
-                        FlexLayoutClampState::ClampedToMin
+                        formatting_context::FlexLayoutClampState::ClampedToMin
                     } else if item.is_max_violation {
-                        FlexLayoutClampState::ClampedToMax
+                        formatting_context::FlexLayoutClampState::ClampedToMax
                     } else {
-                        FlexLayoutClampState::Unclamped
+                        formatting_context::FlexLayoutClampState::Unclamped
                     },
                     flex_basis: if style.flex_basis_is_content() {
                         "content".to_string()
@@ -2560,7 +2581,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 .map(|index| self.flex_items[index].cross_offset)
                 .min()
                 .unwrap_or_default();
-            lines.push(FlexLayoutLine {
+            lines.push(formatting_context::FlexLayoutLine {
                 growth_state: line.growth_state,
                 cross_start,
                 cross_size: line.cross_size,
@@ -2568,7 +2589,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             });
         }
         let style = self.style(self.flex_container);
-        let data = FlexLayoutData {
+        let data = formatting_context::FlexLayoutData {
             align_content: style.align_content(),
             align_items: style.align_items(),
             flex_direction: style.flex_direction(),
@@ -2775,7 +2796,11 @@ impl<'pass> FlexFormattingContext<'pass> {
         // https://drafts.csswg.org/css-align-3/#gap-percent
         // In Flex Layout: Cyclic percentage sizes resolve against zero in all cases.
         let style = self.style(self.flex_container);
-        let gap = if self.is_row_layout() { style.row_gap() } else { style.column_gap() };
+        let gap = if self.is_row_layout() {
+            style.row_gap()
+        } else {
+            style.column_gap()
+        };
         let cross_gap_resolved_against_zero = gap.to_px(CssPixels::default());
         let mut line_cross_size_sum = self
             .flex_lines
@@ -2965,7 +2990,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         sum
     }
 
-    fn run(&mut self, run: &FormattingContextRun, layout_input: LayoutInput) {
+    pub(super) fn run(&mut self, run: &FormattingContextRun, layout_input: LayoutInput) {
         let available_space = layout_input.available_space;
         // This implements https://www.w3.org/TR/css-flexbox-1/#layout-algorithm
 
@@ -3164,10 +3189,10 @@ impl<'pass> FlexFormattingContext<'pass> {
                         y: item.main_offset,
                     }
                 };
-                crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
+                formatting_context::place_child(&self.formatting_context_run(), item.box_, offset, None);
             }
             self.derived_baselines_of_root_box =
-                crate::layout::derive_baselines(&self.records, &self.callbacks, self.flex_container, true);
+                formatting_context::derive_baselines(&self.records, &self.callbacks, self.flex_container, true);
         }
 
         if self.should_collect_devtools_layout_data {
@@ -3175,7 +3200,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         }
     }
 
-    fn parent_did_dimension(&self) {
+    pub(super) fn parent_did_dimension(&self) {
         if self.layout_mode != LayoutMode::Normal {
             return;
         }
@@ -3184,7 +3209,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             let next = self.callbacks.next_sibling(child);
             let facts = self.facts(child);
             if facts.is_box() && facts.is_absolutely_positioned() {
-                crate::layout::register_contained_abspos_child(
+                formatting_context::register_contained_abspos_child(
                     &self.callbacks,
                     self.fragments.as_deref(),
                     self.flex_container,
@@ -3197,15 +3222,15 @@ impl<'pass> FlexFormattingContext<'pass> {
         }
     }
 
-    fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+    pub(super) fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
         self.derived_baselines_of_root_box
     }
 
-    fn automatic_content_inline_size(&self) -> CssPixels {
+    pub(super) fn automatic_content_inline_size(&self) -> CssPixels {
         self.container_used().content_inline_size.get()
     }
 
-    fn automatic_content_block_size(&self) -> CssPixels {
+    pub(super) fn automatic_content_block_size(&self) -> CssPixels {
         self.container_used().content_block_size.get()
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/font.rs
+++ b/Libraries/LibWeb/Rust/src/layout/font.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[inline]
 pub(crate) fn font_glyph_width(font: *const c_void, code_point: u32) -> f32 {
     // SAFETY: Font pointers in layout snapshots are borrowed from the host for
@@ -19,7 +21,7 @@ pub(crate) fn font_glyph_id(font: *const c_void, code_point: u32) -> u32 {
 }
 
 pub(crate) struct ShapedRun {
-    pub(crate) glyphs: Vec<FfiDrawGlyph>,
+    pub(crate) glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
     pub(crate) width: f32,
     pub(crate) trailing_whitespace_length_in_code_units: usize,
     pub(crate) trailing_whitespace_advance: f32,
@@ -36,14 +38,13 @@ pub(crate) fn shape_text_with_font(
     // SAFETY: Font pointers in layout snapshots are borrowed from the host for
     // the synchronous layout pass.
     let font = unsafe { libgfx_rust::font::FontRef::from_raw(font) };
-    let text_type =
-        libgfx_rust::text_layout::TextType::try_from(text_type).expect("invalid Gfx::GlyphRun::TextType");
+    let text_type = libgfx_rust::text_layout::TextType::try_from(text_type).expect("invalid Gfx::GlyphRun::TextType");
     let shaped =
         libgfx_rust::text_layout::shape_text(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
     let glyphs = shaped
         .glyphs()
         .iter()
-        .map(|glyph| FfiDrawGlyph {
+        .map(|glyph| inline_level_iterator::FfiDrawGlyph {
             x: glyph.x,
             y: glyph.y,
             length_in_code_units: glyph.length_in_code_units,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-const CALC_NUMERIC_KIND_LENGTH: u8 = 4;
+use super::*;
+
+pub(super) const CALC_NUMERIC_KIND_LENGTH: u8 = 4;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum LayoutMode {
@@ -38,17 +40,16 @@ pub(crate) struct ResolvedAnchorInsets {
 }
 
 impl ResolvedAnchorInsets {
-    pub(crate) fn override_for(&self, field: InsetField) -> Option<ResolvedInsetOverride> {
+    pub(crate) fn override_for(&self, field: style_values::InsetField) -> Option<style_values::ResolvedInsetOverride> {
         let (resolves, is_auto, px) = match field {
-            InsetField::Top => (self.resolves_top, self.top_is_auto, self.top),
-            InsetField::Right => (self.resolves_right, self.right_is_auto, self.right),
-            InsetField::Bottom => (self.resolves_bottom, self.bottom_is_auto, self.bottom),
-            InsetField::Left => (self.resolves_left, self.left_is_auto, self.left),
+            style_values::InsetField::Top => (self.resolves_top, self.top_is_auto, self.top),
+            style_values::InsetField::Right => (self.resolves_right, self.right_is_auto, self.right),
+            style_values::InsetField::Bottom => (self.resolves_bottom, self.bottom_is_auto, self.bottom),
+            style_values::InsetField::Left => (self.resolves_left, self.left_is_auto, self.left),
         };
-        resolves.then_some(ResolvedInsetOverride { is_auto, px })
+        resolves.then_some(style_values::ResolvedInsetOverride { is_auto, px })
     }
 }
-
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct PhysicalRect {
@@ -59,39 +60,41 @@ pub(crate) struct PhysicalRect {
 }
 
 impl PhysicalRect {
-    fn left(self) -> CssPixels {
+    pub(super) fn left(self) -> CssPixels {
         self.x
     }
 
-    fn top(self) -> CssPixels {
+    pub(super) fn top(self) -> CssPixels {
         self.y
     }
 
-    fn right(self) -> CssPixels {
+    pub(super) fn right(self) -> CssPixels {
         self.x + self.width
     }
 
-    fn bottom(self) -> CssPixels {
+    pub(super) fn bottom(self) -> CssPixels {
         self.y + self.height
     }
-
 }
 
-fn point_add(left: FfiCssPixelPoint, right: FfiCssPixelPoint) -> FfiCssPixelPoint {
+pub(super) fn point_add(left: FfiCssPixelPoint, right: FfiCssPixelPoint) -> FfiCssPixelPoint {
     FfiCssPixelPoint {
         x: left.x + right.x,
         y: left.y + right.y,
     }
 }
 
-fn point_sub(left: FfiCssPixelPoint, right: FfiCssPixelPoint) -> FfiCssPixelPoint {
+pub(super) fn point_sub(left: FfiCssPixelPoint, right: FfiCssPixelPoint) -> FfiCssPixelPoint {
     FfiCssPixelPoint {
         x: left.x - right.x,
         y: left.y - right.y,
     }
 }
 
-pub(crate) fn translate_static_position_rect(mut rect: StaticPositionRect, offset: FfiCssPixelPoint) -> StaticPositionRect {
+pub(crate) fn translate_static_position_rect(
+    mut rect: abspos_inputs::StaticPositionRect,
+    offset: FfiCssPixelPoint,
+) -> abspos_inputs::StaticPositionRect {
     rect.rect.offset.inline_offset += offset.x;
     rect.rect.offset.block_offset += offset.y;
     rect
@@ -119,21 +122,21 @@ pub(crate) struct PixelFraction {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-struct ReplacedIntrinsicSize {
-    width: Option<CssPixels>,
-    height: Option<CssPixels>,
-    aspect_ratio: Option<PixelFraction>,
+pub(super) struct ReplacedIntrinsicSize {
+    pub(super) width: Option<CssPixels>,
+    pub(super) height: Option<CssPixels>,
+    pub(super) aspect_ratio: Option<PixelFraction>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-struct ReplacedMaxContentSizeConstraints {
-    definite_size_in_ratio_determining_axis: Option<CssPixels>,
-    minimum_inline_size: Option<CssPixels>,
-    minimum_block_size: Option<CssPixels>,
+pub(super) struct ReplacedMaxContentSizeConstraints {
+    pub(super) definite_size_in_ratio_determining_axis: Option<CssPixels>,
+    pub(super) minimum_inline_size: Option<CssPixels>,
+    pub(super) minimum_block_size: Option<CssPixels>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SizeDimension {
+pub(super) enum SizeDimension {
     Inline,
     Block,
 }
@@ -165,7 +168,7 @@ impl MeasurementState {
         Self { callbacks }
     }
 
-    fn run(&self, node: Node, node_used: &UsedValues, input: LayoutInput) -> ChildLayoutResult {
+    pub(super) fn run(&self, node: Node, node_used: &UsedValues, input: LayoutInput) -> ChildLayoutResult {
         self.run_with_layout_mode(node, node_used, LayoutMode::IntrinsicSizing, input)
     }
 
@@ -176,8 +179,8 @@ impl MeasurementState {
         layout_mode: LayoutMode,
         input: LayoutInput,
     ) -> ChildLayoutResult {
-        let fc_type = crate::layout::independent_formatting_context_type(node, &self.callbacks);
-        crate::layout::run_formatting_context(
+        let fc_type = independent_formatting_context_type(node, &self.callbacks);
+        run_formatting_context(
             LayoutPurpose::Measurement,
             None,
             node_used,
@@ -196,12 +199,16 @@ impl MeasurementState {
         &self.callbacks
     }
 
-    pub(crate) fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> std::rc::Rc<UsedValues> {
-        create_used_values(&self.callbacks, node, constraints)
+    pub(crate) fn create_used_values(
+        &self,
+        node: Node,
+        constraints: ContainingBlockConstraints,
+    ) -> std::rc::Rc<UsedValues> {
+        used_values::create_used_values(&self.callbacks, node, constraints)
     }
 }
 
-fn cache_key(
+pub(super) fn cache_key(
     measured_at_inline_size: Option<CssPixels>,
     measured_at_block_size: Option<CssPixels>,
     constraints: ContainingBlockConstraints,
@@ -345,7 +352,7 @@ pub(crate) fn place_child(
     run: &FormattingContextRun,
     node: Node,
     offset: FfiCssPixelPoint,
-    containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
+    containing_line_box_fragment: Option<used_values::LineBoxFragmentCoordinate>,
 ) {
     let purpose = run.purpose;
     let records = &*run.records;
@@ -363,7 +370,7 @@ pub(crate) fn place_child(
             if batch.is_empty() {
                 break;
             }
-            let engine = crate::layout::AbsposEngine::for_run(run);
+            let engine = abspos_engine::AbsposEngine::for_run(run);
             for entry in batch {
                 engine.layout_pending_child(run, entry);
             }
@@ -374,23 +381,29 @@ pub(crate) fn place_child(
                 .used_values_if_owned(containing_block)
                 .is_none_or(|containing_block_used| containing_block_used.has_content_offset.get());
         let node_facts = NodeFacts::new(callbacks, node);
-        let own_anchor_candidate_border_box_rect = (node_facts.is_box() && node_facts.has_anchor_names())
-            .then(|| {
-                let collapsed = used.uses_collapsing_borders_model.get();
-                PhysicalRect {
-                    x: used.content_offset.get().x - used.border_box_left(collapsed),
-                    y: used.content_offset.get().y - used.border_box_top(collapsed),
-                    width: used.border_box_inline_size(collapsed),
-                    height: used.border_box_block_size(collapsed),
-                }
-            });
+        let own_anchor_candidate_border_box_rect = (node_facts.is_box() && node_facts.has_anchor_names()).then(|| {
+            let collapsed = used.uses_collapsing_borders_model.get();
+            PhysicalRect {
+                x: used.content_offset.get().x - used.border_box_left(collapsed),
+                y: used.content_offset.get().y - used.border_box_top(collapsed),
+                width: used.border_box_inline_size(collapsed),
+                height: used.border_box_block_size(collapsed),
+            }
+        });
         fragments.build_fragment_for_placed_box(
             callbacks,
             node,
             (!containing_block.is_invalid()).then_some(containing_block),
             &used,
             containing_block_is_sealed,
-            resolve_containing_line_box_index(records, callbacks, node, containing_block, containing_line_box_fragment, offset),
+            resolve_containing_line_box_index(
+                records,
+                callbacks,
+                node,
+                containing_block,
+                containing_line_box_fragment,
+                offset,
+            ),
             point_add(
                 offset,
                 committed_offset_delta_at_placement(purpose, records, callbacks, node, containing_block, &used),
@@ -407,7 +420,7 @@ fn resolve_containing_line_box_index(
     callbacks: &FfiLayoutFcCallbacks,
     node: Node,
     containing_block: Node,
-    coordinate: Option<LineBoxFragmentCoordinate>,
+    coordinate: Option<used_values::LineBoxFragmentCoordinate>,
     placed_offset: FfiCssPixelPoint,
 ) -> Option<usize> {
     let coordinate = coordinate?;
@@ -422,7 +435,7 @@ fn resolve_containing_line_box_index(
     if let Some(fragment) = line.fragments.get(coordinate.fragment_index) {
         let (x, y) = fragment.offset();
         debug_assert_eq!(
-            crate::layout::FfiCssPixelPoint { x, y },
+            FfiCssPixelPoint { x, y },
             placed_offset,
             "stored line fragment offset diverged from the placed offset (is_block_outside={})",
             facts.display().is_block_outside()
@@ -452,7 +465,7 @@ fn committed_offset_delta_at_placement(
         delta.y += used.inset_top.get();
     }
     if facts.is_in_flow() && facts.display().is_block_outside() {
-        let chain = accumulated_relative_insets_from_inline_ancestor_chain(
+        let chain = inline_formatting_context::accumulated_relative_insets_from_inline_ancestor_chain(
             records,
             callbacks,
             callbacks.parent(node),
@@ -468,11 +481,11 @@ fn committed_offset_delta_at_placement(
 
 pub(crate) fn register_contained_abspos_child(
     callbacks: &FfiLayoutFcCallbacks,
-    fragments: Option<&RunFragmentBuilder>,
+    fragments: Option<&fragment_tree::RunFragmentBuilder>,
     coordinate_space_box: Node,
     child: Node,
-    static_position_rect: StaticPositionRect,
-    containing_block_info_override: Option<AbsposContainingBlockInfo>,
+    static_position_rect: abspos_inputs::StaticPositionRect,
+    containing_block_info_override: Option<abspos_inputs::AbsposContainingBlockInfo>,
 ) {
     let Some(fragments) = fragments else {
         return;
@@ -483,7 +496,7 @@ pub(crate) fn register_contained_abspos_child(
     let inline_containing_block = callbacks.inline_containing_block(child);
     fragments.register_pending_abspos(
         coordinate_space_box,
-        PendingAbsposChild {
+        abspos_inputs::PendingAbsposChild {
             child_box: child,
             coordinate_space_box,
             static_position_rect,
@@ -713,7 +726,7 @@ pub(crate) fn derive_baselines(
             if !child_facts.is_flow_layout_participant() || (!inhibits_floating && child_facts.is_floating()) {
                 continue;
             }
-            if !child_participates_in_table_run(container_display, &child_facts) {
+            if !table_formatting_context::child_participates_in_table_run(container_display, &child_facts) {
                 continue;
             }
             if container_skips_anonymous_whitespace_runs && callbacks.can_skip_is_anonymous_text_run(child) {
@@ -774,10 +787,10 @@ pub(crate) struct ChildLayoutResult {
 
 #[derive(Clone)]
 pub(crate) struct RunRootOutcome {
-    cells: UsedValuesCellState,
-    own_metrics_sealed: bool,
-    line_data: Option<std::rc::Rc<LineData>>,
-    rare: Option<UsedValuesRareData>,
+    pub(super) cells: used_values::UsedValuesCellState,
+    pub(super) own_metrics_sealed: bool,
+    pub(super) line_data: Option<std::rc::Rc<used_values::LineData>>,
+    pub(super) rare: Option<used_values::UsedValuesRareData>,
 }
 
 impl RunRootOutcome {
@@ -798,7 +811,7 @@ impl RunRootOutcome {
 #[derive(Clone)]
 pub(crate) struct RunOutputs {
     pub(crate) result: ChildLayoutResult,
-    pub(crate) root: Option<UnplacedRootFragment>,
+    pub(crate) root: Option<fragment_tree::UnplacedRootFragment>,
     pub(crate) root_outcome: RunRootOutcome,
 }
 
@@ -893,9 +906,14 @@ pub struct FfiLayoutFcCallbacks {
     pub initial_containing_block_inline_size: CssPixels,
     pub document_in_quirks_mode: bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgElementFacts,
-    pub compute_svg_path: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiSvgPathRequest) -> FfiSvgPathResult,
-    pub svg_image_bounding_box: unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> FfiFloatRect,
+    pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> svg_formatting_context::FfiSvgElementFacts,
+    pub compute_svg_path: unsafe extern "C" fn(
+        *mut c_void,
+        *mut c_void,
+        svg_formatting_context::FfiSvgPathRequest,
+    ) -> svg_formatting_context::FfiSvgPathResult,
+    pub svg_image_bounding_box:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> svg_formatting_context::FfiFloatRect,
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub node_unique_id: unsafe extern "C" fn(*mut c_void) -> i64,
     pub set_default_scroll_shift: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool, bool),
@@ -952,15 +970,14 @@ impl FfiLayoutFcCallbacks {
 
     pub(crate) fn can_skip_is_anonymous_text_run(&self, node: Node) -> bool {
         let data = self.node_data(node);
-        if !crate::layout::has_flag(data, NodeFlag::Anonymous) || data.generated_for != 0 {
+        if !node_facts::has_flag(data, NodeFlag::Anonymous) || data.generated_for != 0 {
             return false;
         }
 
         let mut child = data.first_child;
         while !child.is_invalid() {
             let data = self.node_data(child);
-            if !crate::layout::kind_is_text(data.kind)
-                || !self.text_content(child).untransformed_text_is_ascii_whitespace
+            if !node_facts::kind_is_text(data.kind) || !self.text_content(child).untransformed_text_is_ascii_whitespace
             {
                 return false;
             }
@@ -983,18 +1000,18 @@ impl FfiLayoutFcCallbacks {
         self.arena().is_before(self.node_data(node), self.node_data(other))
     }
 
-    pub(crate) fn saved_abspos_layout_inputs(&self, node: Node) -> Option<crate::layout::AbsposLayoutInputs> {
+    pub(crate) fn saved_abspos_layout_inputs(&self, node: Node) -> Option<abspos_inputs::AbsposLayoutInputs> {
         let data = self.arena().data(node);
         // SAFETY: node_data_pointer() returns a live arena slot.
-        assert!(unsafe { crate::layout::kind_is_box((*data).kind) });
+        assert!(unsafe { node_facts::kind_is_box((*data).kind) });
         self.arena().saved_abspos_layout_inputs(data)
     }
 
-    pub(crate) fn committed_fragment_link(&self, node: Node) -> Option<crate::layout::FragmentLink> {
+    pub(crate) fn committed_fragment_link(&self, node: Node) -> Option<FragmentLink> {
         self.arena().committed_fragment_link(self.arena().data(node))
     }
 
-    pub(crate) fn set_committed_fragment_link(&self, node: Node, link: crate::layout::FragmentLink) {
+    pub(crate) fn set_committed_fragment_link(&self, node: Node, link: FragmentLink) {
         self.arena().set_committed_fragment_link(self.arena().data(node), link);
     }
 
@@ -1002,11 +1019,11 @@ impl FfiLayoutFcCallbacks {
         self.node_data(node).flags & NodeFlag::HasCommittedFragmentLink as u32 != 0
     }
 
-    pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<crate::layout::AbsposLayoutInputs>) {
+    pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<abspos_inputs::AbsposLayoutInputs>) {
         let data = self.arena().data(node);
         // Match prepare_node's former as_if<Box>() guard.
         // SAFETY: node_data_pointer() returns a live arena slot.
-        if !unsafe { crate::layout::kind_is_box((*data).kind) } {
+        if !unsafe { node_facts::kind_is_box((*data).kind) } {
             return;
         }
         self.arena().set_saved_abspos_layout_inputs(data, inputs);
@@ -1061,19 +1078,23 @@ pub(crate) struct FormattingContextRun {
     pub(crate) callbacks: FfiLayoutFcCallbacks,
     pub(crate) should_collect_devtools_layout_data: bool,
     pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
-    pub(crate) fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
-    pub(crate) previous_line_data: Option<std::rc::Rc<LineData>>,
+    pub(crate) fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
+    pub(crate) previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
 }
 
 impl FormattingContextRun {
-    pub(crate) fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    pub(crate) fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
-    pub(crate) fn outputs(&self, result: ChildLayoutResult, root: Option<UnplacedRootFragment>) -> RunOutputs {
+    pub(crate) fn outputs(
+        &self,
+        result: ChildLayoutResult,
+        root: Option<fragment_tree::UnplacedRootFragment>,
+    ) -> RunOutputs {
         let record = self.records.used_values(self.box_);
         let root_outcome = RunRootOutcome {
-            cells: UsedValuesCellState::capture(&record),
+            cells: used_values::UsedValuesCellState::capture(&record),
             own_metrics_sealed: record.own_metrics_are_sealed(),
             line_data: record.line_data.get().map(std::cell::RefCell::take),
             rare: record.rare_data.get().map(std::cell::RefCell::take),
@@ -1087,11 +1108,11 @@ impl FormattingContextRun {
 }
 
 enum FormattingContextImplementation<'pass> {
-    Block(Box<BlockFormattingContext>),
-    Flex(Box<FlexFormattingContext<'pass>>),
-    Grid(Box<GridFormattingContext>),
-    Table(Box<TableFormattingContext>),
-    Svg(Box<SvgFormattingContext>),
+    Block(Box<block_formatting_context::BlockFormattingContext>),
+    Flex(Box<flex_formatting_context::FlexFormattingContext<'pass>>),
+    Grid(Box<grid_formatting_context::GridFormattingContext>),
+    Table(Box<table_formatting_context::TableFormattingContext>),
+    Svg(Box<svg_formatting_context::SvgFormattingContext>),
     ReplacedWithChildren,
     InternalReplaced,
     InternalDummy,
@@ -1105,8 +1126,8 @@ pub(crate) fn formatting_context_type_created_by_node_data(
     if data.kind == crate::layout::node_data::NodeKind::SVGSVGBox {
         return Some(FfiFormattingContextType::Svg);
     }
-    let is_replaced_box = crate::layout::kind_is_replaced_box(data.kind);
-    let can_have_children = crate::layout::node_can_have_children(data);
+    let is_replaced_box = node_facts::kind_is_replaced_box(data.kind);
+    let can_have_children = node_facts::node_can_have_children(data);
     if is_replaced_box && can_have_children {
         return Some(FfiFormattingContextType::ReplacedWithChildren);
     }
@@ -1116,13 +1137,13 @@ pub(crate) fn formatting_context_type_created_by_node_data(
     if !can_have_children {
         return None;
     }
-    if crate::layout::has_flag(data, NodeFlag::IsReplacedElement)
+    if node_facts::has_flag(data, NodeFlag::IsReplacedElement)
         && style.is_some_and(|style| {
             let display = style.display_before_box_type_transformation();
             display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
         })
     {
-        return Some(if crate::layout::kind_is_block_container(data.kind) {
+        return Some(if node_facts::kind_is_block_container(data.kind) {
             FfiFormattingContextType::Block
         } else {
             FfiFormattingContextType::InternalReplaced
@@ -1139,11 +1160,11 @@ pub(crate) fn formatting_context_type_created_by_node_data(
         return Some(FfiFormattingContextType::Grid);
     }
     if display.is_some_and(|display| display.is_math_inside())
-        || crate::layout::node_creates_block_formatting_context(data, style, parent_style)
+        || node_facts::node_creates_block_formatting_context(data, style, parent_style)
     {
         return Some(FfiFormattingContextType::Block);
     }
-    if crate::layout::has_flag(data, NodeFlag::ChildrenAreInline)
+    if node_facts::has_flag(data, NodeFlag::ChildrenAreInline)
         || display.is_some_and(|display| {
             display.is_table_column()
                 || display.is_table_column_group()
@@ -1184,7 +1205,9 @@ pub extern "C" fn rust_layout_formatting_context_type_for_box(facts: FfiFormatti
         let arena = unsafe { LayoutNodeArena::from_handle(facts.arena) };
         // SAFETY: The caller supplies the live box's arena slot.
         let data = unsafe { &*arena.data(facts.node) };
-        let style = arena.style_payloads(facts.node).map(|payloads| ComputedValuesView::new(&payloads.groups));
+        let style = arena
+            .style_payloads(facts.node)
+            .map(|payloads| ComputedValuesView::new(&payloads.groups));
         let parent_style = (!data.parent.is_invalid())
             .then(|| arena.style_payloads(data.parent))
             .flatten()
@@ -1197,19 +1220,25 @@ pub extern "C" fn rust_layout_formatting_context_type_for_box(facts: FfiFormatti
 
 fn create_formatting_context_implementation<'pass>(
     run: &FormattingContextRun,
-    parent_grid: Option<&GridFormattingContext>,
+    parent_grid: Option<&grid_formatting_context::GridFormattingContext>,
     fc_type: FfiFormattingContextType,
 ) -> FormattingContextImplementation<'pass> {
     match fc_type {
         FfiFormattingContextType::Block => {
-            FormattingContextImplementation::Block(Box::new(BlockFormattingContext::new(run)))
+            FormattingContextImplementation::Block(Box::new(block_formatting_context::BlockFormattingContext::new(run)))
         }
-        FfiFormattingContextType::Flex => FormattingContextImplementation::Flex(Box::new(FlexFormattingContext::new(run))),
-        FfiFormattingContextType::Grid => {
-            FormattingContextImplementation::Grid(Box::new(GridFormattingContext::new(run, parent_grid)))
+        FfiFormattingContextType::Flex => {
+            FormattingContextImplementation::Flex(Box::new(flex_formatting_context::FlexFormattingContext::new(run)))
         }
-        FfiFormattingContextType::Table => FormattingContextImplementation::Table(Box::new(TableFormattingContext::new(run))),
-        FfiFormattingContextType::Svg => FormattingContextImplementation::Svg(Box::new(SvgFormattingContext::new(run))),
+        FfiFormattingContextType::Grid => FormattingContextImplementation::Grid(Box::new(
+            grid_formatting_context::GridFormattingContext::new(run, parent_grid),
+        )),
+        FfiFormattingContextType::Table => {
+            FormattingContextImplementation::Table(Box::new(table_formatting_context::TableFormattingContext::new(run)))
+        }
+        FfiFormattingContextType::Svg => {
+            FormattingContextImplementation::Svg(Box::new(svg_formatting_context::SvgFormattingContext::new(run)))
+        }
         FfiFormattingContextType::ReplacedWithChildren => FormattingContextImplementation::ReplacedWithChildren,
         FfiFormattingContextType::InternalReplaced => FormattingContextImplementation::InternalReplaced,
         FfiFormattingContextType::InternalDummy => FormattingContextImplementation::InternalDummy,
@@ -1229,7 +1258,7 @@ fn register_table_abspos_descendants(run: &FormattingContextRun, parent: Node) {
                     run.fragments.as_deref(),
                     run.box_,
                     child,
-                    StaticPositionRect {
+                    abspos_inputs::StaticPositionRect {
                         rect: Default::default(),
                         inline_alignment: StaticPositionAlignment::Start,
                         block_alignment: StaticPositionAlignment::Start,
@@ -1273,11 +1302,8 @@ pub(crate) fn independent_root_automatic_block_size(
         // max-content size.
         // https://drafts.csswg.org/css-flexbox-1/#algo-main-container
         // https://www.w3.org/TR/css-grid-2/#intrinsic-sizes
-        return SizingContext::new(purpose, records.clone(), *callbacks).calculate_max_content_block_size(
-            node,
-            available_inner_space.inline_size.to_px_or_zero(),
-            constraints,
-        );
+        return sizing_context::SizingContext::new(purpose, records.clone(), *callbacks)
+            .calculate_max_content_block_size(node, available_inner_space.inline_size.to_px_or_zero(), constraints);
     }
     debug_assert!(false, "independent formatting context root of unexpected kind");
     CssPixels::default()
@@ -1285,7 +1311,7 @@ pub(crate) fn independent_root_automatic_block_size(
 
 fn flex_self_block_size_resolution_space(
     child_run_builds_fragments: bool,
-    sizing: &SizingContext,
+    sizing: &sizing_context::SizingContext,
     node: Node,
     resolution_space: AvailableSpace,
     constraints: ContainingBlockConstraints,
@@ -1372,7 +1398,7 @@ fn apply_root_sizing_directives(run: &FormattingContextRun, input: &LayoutInput)
             body_input
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::for_run(run).dimension_out_of_flow_root(run.box_, abspos_inputs);
+            abspos_engine::AbsposEngine::for_run(run).dimension_out_of_flow_root(run.box_, abspos_inputs);
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::Item => {
@@ -1471,7 +1497,7 @@ fn finalize_float_root(run: &FormattingContextRun, input: &LayoutInput, body_res
 }
 
 fn dimension_root_in_parent_scope(
-    parent_block: Option<&BlockFormattingContext>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
     child: Node,
     input: &LayoutInput,
     child_run_builds_fragments: bool,
@@ -1508,7 +1534,7 @@ fn dimension_root_in_parent_scope(
 
 fn size_skipped_independent_root(
     run: &FormattingContextRun,
-    parent_block: Option<&BlockFormattingContext>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
     child: Node,
     input: &LayoutInput,
 ) {
@@ -1524,7 +1550,7 @@ fn size_skipped_independent_root(
             );
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            let engine = AbsposEngine::for_run(run);
+            let engine = abspos_engine::AbsposEngine::for_run(run);
             engine.dimension_out_of_flow_root(child, abspos_inputs);
             engine.finalize_out_of_flow_root_after_inside_layout(child, abspos_inputs, None);
         }
@@ -1546,21 +1572,21 @@ fn body_input_with_inner_available_space(run: &FormattingContextRun, input: &Lay
 }
 
 #[expect(clippy::too_many_arguments)]
-fn run_formatting_context(
+pub(super) fn run_formatting_context(
     purpose: LayoutPurpose,
-    parent_fragments: Option<&RunFragmentBuilder>,
+    parent_fragments: Option<&fragment_tree::RunFragmentBuilder>,
     parent_used: &UsedValues,
     box_: Node,
-    parent_grid: Option<&GridFormattingContext>,
+    parent_grid: Option<&grid_formatting_context::GridFormattingContext>,
     fc_type: FfiFormattingContextType,
     layout_mode: LayoutMode,
     should_collect_devtools_layout_data: bool,
     callbacks: FfiLayoutFcCallbacks,
     input: LayoutInput,
-    parent_block: Option<&BlockFormattingContext>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
 ) -> ChildLayoutResult {
-    let root_cells = UsedValuesCellState::capture(parent_used);
-    let cache_attempt = match FcRunCacheAttempt::probe(
+    let root_cells = used_values::UsedValuesCellState::capture(parent_used);
+    let cache_attempt = match fc_run_cache::FcRunCacheAttempt::probe(
         purpose,
         box_,
         parent_grid.is_some(),
@@ -1607,16 +1633,16 @@ fn run_formatting_context(
 #[expect(clippy::too_many_arguments)]
 fn execute_formatting_context_run(
     purpose: LayoutPurpose,
-    root_cells: UsedValuesCellState,
+    root_cells: used_values::UsedValuesCellState,
     box_: Node,
-    parent_grid: Option<&GridFormattingContext>,
+    parent_grid: Option<&grid_formatting_context::GridFormattingContext>,
     fc_type: FfiFormattingContextType,
     layout_mode: LayoutMode,
     should_collect_devtools_layout_data: bool,
     callbacks: FfiLayoutFcCallbacks,
     input: LayoutInput,
-    parent_block: Option<&BlockFormattingContext>,
-    previous_line_data: Option<std::rc::Rc<LineData>>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
+    previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
 ) -> RunOutputs {
     assert!(!box_.is_invalid());
     let root_used = std::rc::Rc::new(root_cells.materialize_record());
@@ -1627,10 +1653,12 @@ fn execute_formatting_context_run(
         layout_mode,
         callbacks,
         should_collect_devtools_layout_data,
-        treat_block_axis_percentage_insets_as_auto_beyond_root: input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: input
+            .sizing
+            .treat_block_axis_percentage_insets_as_auto_beyond_root,
         fragments: (layout_mode == LayoutMode::Normal && !purpose.is_measurement()).then(|| {
             let root_containing_block = callbacks.containing_block(box_);
-            std::rc::Rc::new(RunFragmentBuilder::new(
+            std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new(
                 box_,
                 (!root_containing_block.is_invalid()).then_some(root_containing_block),
             ))
@@ -1640,7 +1668,10 @@ fn execute_formatting_context_run(
     let run = &run;
     let body_input = apply_root_sizing_directives(run, &input);
 
-    let cached_atomic_block_size = if matches!(input.participation, ParticipationInParentFormattingContext::AtomicInline) {
+    let cached_atomic_block_size = if matches!(
+        input.participation,
+        ParticipationInParentFormattingContext::AtomicInline
+    ) {
         run.sizing().apply_cached_intrinsic_inline_measurement(
             run.box_,
             input.available_space.inline_size,
@@ -1659,7 +1690,10 @@ fn execute_formatting_context_run(
         }
     } else if layout_mode == LayoutMode::Normal
         && !purpose.is_measurement()
-        && matches!(input.participation, ParticipationInParentFormattingContext::AtomicInline)
+        && matches!(
+            input.participation,
+            ParticipationInParentFormattingContext::AtomicInline
+        )
         && fc_type == FfiFormattingContextType::Block
         && callbacks.first_child(box_).is_invalid()
     {
@@ -1720,8 +1754,12 @@ fn execute_formatting_context_run(
                 context.run(run, body_input);
                 ChildLayoutResult::default()
             }
-            FormattingContextImplementation::ReplacedWithChildren => layout_replaced_with_children(run, body_input),
-            FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => ChildLayoutResult::default(),
+            FormattingContextImplementation::ReplacedWithChildren => {
+                replaced_with_children_formatting_context::layout_replaced_with_children(run, body_input)
+            }
+            FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => {
+                ChildLayoutResult::default()
+            }
         };
         implementation = Some(context_implementation);
         result
@@ -1747,7 +1785,7 @@ fn execute_formatting_context_run(
             );
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::for_run(run).finalize_out_of_flow_root_after_inside_layout(
+            abspos_engine::AbsposEngine::for_run(run).finalize_out_of_flow_root_after_inside_layout(
                 run.box_,
                 abspos_inputs,
                 Some(result.automatic_content_block_size),
@@ -1801,7 +1839,7 @@ fn finalize_atomic_root_block_size(
     input: &LayoutInput,
     cached_intrinsic_measurement_block_size: Option<CssPixels>,
     automatic_content_block_size_of_completed_body_run: Option<CssPixels>,
-    parent_block: Option<&BlockFormattingContext>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
 ) {
     let node = run.box_;
     let available_space = input.available_space;
@@ -1879,8 +1917,8 @@ pub(crate) fn propagate_percentage_block_size_dependency_to_containing_block(
 
 pub(crate) fn layout_inside_child(
     run: &FormattingContextRun,
-    parent_block: Option<&BlockFormattingContext>,
-    parent_grid: Option<&GridFormattingContext>,
+    parent_block: Option<&block_formatting_context::BlockFormattingContext>,
+    parent_grid: Option<&grid_formatting_context::GridFormattingContext>,
     child: Node,
     layout_mode: LayoutMode,
     mut input: LayoutInput,
@@ -1890,7 +1928,10 @@ pub(crate) fn layout_inside_child(
     let used = run.records.used_values(child);
     if let Some((padding_top, padding_bottom)) = input.sizing.table_cell_intrinsic_block_padding {
         debug_assert!(facts.is_table_cell());
-        debug_assert!(matches!(input.participation, ParticipationInParentFormattingContext::Item));
+        debug_assert!(matches!(
+            input.participation,
+            ParticipationInParentFormattingContext::Item
+        ));
         used.padding_top.set(used.padding_top.get() + padding_top);
         used.padding_bottom.set(used.padding_bottom.get() + padding_bottom);
     }
@@ -1904,7 +1945,10 @@ pub(crate) fn layout_inside_child(
     };
     if !force_independent_context_run
         && layout_mode == LayoutMode::IntrinsicSizing
-        && matches!(input.participation, ParticipationInParentFormattingContext::AtomicInline)
+        && matches!(
+            input.participation,
+            ParticipationInParentFormattingContext::AtomicInline
+        )
         && formatting_context_type_created_by_box(facts) == Some(FfiFormattingContextType::Block)
         && run.callbacks.first_child(child).is_invalid()
     {
@@ -1949,9 +1993,8 @@ pub(crate) fn layout_inside_child(
         return ChildLayoutOutcome::Skipped;
     }
 
-    let fc_type = formatting_context_type_created_by_box(facts).or_else(|| {
-        force_independent_context_run.then(|| independent_formatting_context_type(child, &run.callbacks))
-    });
+    let fc_type = formatting_context_type_created_by_box(facts)
+        .or_else(|| force_independent_context_run.then(|| independent_formatting_context_type(child, &run.callbacks)));
     let Some(fc_type) = fc_type else {
         if force_independent_context_run {
             note_skipped_child_dependency();
@@ -1996,7 +2039,7 @@ pub(crate) fn layout_inside_child(
 }
 
 fn absorb_run_outputs(
-    parent_fragments: Option<&RunFragmentBuilder>,
+    parent_fragments: Option<&fragment_tree::RunFragmentBuilder>,
     parent_used: &UsedValues,
     child: Node,
     outputs: RunOutputs,
@@ -2018,7 +2061,7 @@ fn absorb_run_outputs(
     result
 }
 
-fn independent_formatting_context_type(
+pub(super) fn independent_formatting_context_type(
     box_: Node,
     callbacks: &FfiLayoutFcCallbacks,
 ) -> FfiFormattingContextType {
@@ -2088,7 +2131,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
     viewport_block_size_raw: i32,
     should_collect_devtools_layout_data: bool,
     callbacks: *const FfiLayoutFcCallbacks,
-    sink: *const FfiCommitSink,
+    sink: *const commit::FfiCommitSink,
 ) {
     abort_on_panic(|| {
         assert!(!root.is_invalid());
@@ -2101,14 +2144,14 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
         let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
 
-        let root_constraints = crate::layout::ContainingBlockConstraints {
+        let root_constraints = ContainingBlockConstraints {
             percentage_basis_inline_size: Some(viewport_inline_size),
             percentage_basis_block_size: Some(viewport_block_size),
-            ..crate::layout::ContainingBlockConstraints::default()
+            ..ContainingBlockConstraints::default()
         };
         let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
         let viewport_used = entry_records.create_used_values(&callbacks, root, root_constraints);
-        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
+        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
         let entry_run = FormattingContextRun {
             purpose: LayoutPurpose::Commit,
             records: entry_records.clone(),
@@ -2136,7 +2179,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
                 inline_size: AvailableSize::definite(viewport_inline_size),
                 block_size: AvailableSize::definite(viewport_block_size),
             },
-            crate::layout::ContainingBlockConstraints::default(),
+            ContainingBlockConstraints::default(),
             ParticipationInParentFormattingContext::Root,
         )
         .with_forced_sizes(viewport_inline_size, viewport_block_size);
@@ -2169,21 +2212,24 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
 
 fn drain_and_commit_entry_pass(
     entry_records: &std::rc::Rc<RunRecords>,
-    entry_fragments: &std::rc::Rc<RunFragmentBuilder>,
+    entry_fragments: &std::rc::Rc<fragment_tree::RunFragmentBuilder>,
     callbacks: &FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
     commit_root: Node,
-    sink: &FfiCommitSink,
+    sink: &commit::FfiCommitSink,
 ) {
-    drain_abspos_with_placed_containing_blocks(
+    abspos_engine::drain_abspos_with_placed_containing_blocks(
         entry_records,
         *callbacks,
         should_collect_devtools_layout_data,
         entry_fragments,
     );
     let pass_fragments = entry_fragments.take_completed_pass(entry_records, callbacks);
-    debug_assert!(!pass_fragments.roots.is_empty(), "an entry pass always produces the entry root's fragment");
-    commit_replacing(commit_root, callbacks, sink, &pass_fragments);
+    debug_assert!(
+        !pass_fragments.roots.is_empty(),
+        "an entry pass always produces the entry root's fragment"
+    );
+    commit::commit_replacing(commit_root, callbacks, sink, &pass_fragments);
 }
 
 /// # Safety
@@ -2196,7 +2242,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
     viewport_inline_size_raw: i32,
     viewport_block_size_raw: i32,
     callbacks: *const FfiLayoutFcCallbacks,
-    sink: *const FfiCommitSink,
+    sink: *const commit::FfiCommitSink,
 ) {
     abort_on_panic(|| {
         assert!(!root.is_invalid());
@@ -2208,10 +2254,10 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let sink = unsafe { &*sink };
 
         let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
-        let root_used = used_values_from_committed_fragment_link(&callbacks, root)
+        let root_used = used_values::used_values_from_committed_fragment_link(&callbacks, root)
             .expect("partial relayout root must have committed geometry");
         entry_records.register(root, root_used.clone());
-        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
+        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
         let entry_run = FormattingContextRun {
             purpose: LayoutPurpose::Commit,
             records: entry_records.clone(),
@@ -2226,10 +2272,10 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         if !viewport.is_invalid() && viewport != root {
             let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
             let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
-            let viewport_constraints = crate::layout::ContainingBlockConstraints {
+            let viewport_constraints = ContainingBlockConstraints {
                 percentage_basis_inline_size: Some(viewport_inline_size),
                 percentage_basis_block_size: Some(viewport_block_size),
-                ..crate::layout::ContainingBlockConstraints::default()
+                ..ContainingBlockConstraints::default()
             };
             let viewport_used = entry_records.create_used_values(&callbacks, viewport, viewport_constraints);
             viewport_used.set_content_inline_size(viewport_inline_size);
@@ -2243,7 +2289,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             },
             // The subtree root has definite sizes in both axes, so boxes
             // below it do not need inherited percentage constraints.
-            crate::layout::ContainingBlockConstraints::default(),
+            ContainingBlockConstraints::default(),
             ParticipationInParentFormattingContext::Root,
         );
 
@@ -2274,14 +2320,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             root_used.content_offset.get(),
             None,
         );
-        drain_and_commit_entry_pass(
-            &entry_records,
-            &entry_fragments,
-            &callbacks,
-            false,
-            root,
-            sink,
-        );
+        drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, root, sink);
         callbacks.arena().sweep_stale_fc_run_cache_entries();
     });
 }
@@ -2293,7 +2332,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
 pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
     box_: NodeSlotId,
     callbacks: *const FfiLayoutFcCallbacks,
-    sink: *const FfiCommitSink,
+    sink: *const commit::FfiCommitSink,
 ) {
     abort_on_panic(|| {
         assert!(!box_.is_invalid());
@@ -2305,9 +2344,11 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         let sink = unsafe { &*sink };
         let containing_block = callbacks.containing_block(box_);
         assert!(!containing_block.is_invalid());
-        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(containing_block));
+        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(
+            containing_block,
+        ));
         let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, containing_block));
-        let run = crate::layout::FormattingContextRun {
+        let run = FormattingContextRun {
             purpose: LayoutPurpose::Commit,
             records: entry_records.clone(),
             box_: containing_block,
@@ -2318,15 +2359,8 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
             fragments: Some(entry_fragments.clone()),
             previous_line_data: None,
         };
-        AbsposEngine::for_run(&run).replay(&run, box_);
-        drain_and_commit_entry_pass(
-            &entry_records,
-            &entry_fragments,
-            &callbacks,
-            false,
-            box_,
-            sink,
-        );
+        abspos_engine::AbsposEngine::for_run(&run).replay(&run, box_);
+        drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, box_, sink);
         callbacks.arena().sweep_stale_fc_run_cache_entries();
     });
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) struct Fragment {
     pub(crate) identity: u64,
     pub(crate) node: crate::layout::node_data::NodeSlotId,
@@ -22,14 +24,14 @@ pub(crate) struct Fragment {
     pub(crate) padding_top: CssPixels,
     pub(crate) padding_bottom: CssPixels,
     pub(crate) uses_collapsing_borders_model: bool,
-    pub(crate) collapsed_table_borders: Option<std::rc::Rc<OwnedCollapsedTableBorders>>,
-    pub(crate) line_data: Option<std::rc::Rc<LineData>>,
-    pub(crate) grid_layout_data: Option<std::rc::Rc<GridLayoutData>>,
-    pub(crate) flex_layout_data: Option<std::rc::Rc<FlexLayoutData>>,
-    pub(crate) used_grid_tracks: Option<std::rc::Rc<OwnedUsedGridTracks>>,
-    pub(crate) svg_viewport_transform: Option<crate::layout::FfiAffineTransform>,
-    pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
-    pub(crate) svg_view_box: Option<crate::layout::FfiSvgViewBox>,
+    pub(crate) collapsed_table_borders: Option<std::rc::Rc<table_formatting_context::OwnedCollapsedTableBorders>>,
+    pub(crate) line_data: Option<std::rc::Rc<used_values::LineData>>,
+    pub(crate) grid_layout_data: Option<std::rc::Rc<grid_formatting_context::GridLayoutData>>,
+    pub(crate) flex_layout_data: Option<std::rc::Rc<formatting_context::FlexLayoutData>>,
+    pub(crate) used_grid_tracks: Option<std::rc::Rc<grid_formatting_context::OwnedUsedGridTracks>>,
+    pub(crate) svg_viewport_transform: Option<svg_formatting_context::FfiAffineTransform>,
+    pub(crate) svg_viewport_size: Option<FfiCssPixelSize>,
+    pub(crate) svg_view_box: Option<svg_formatting_context::FfiSvgViewBox>,
     pub(crate) svg_viewport_percentage_basis: CssPixels,
     pub(crate) computed_svg_path: Option<std::rc::Rc<libgfx_rust::path::OwnedPath>>,
     pub(crate) children: Vec<FragmentLink>,
@@ -44,7 +46,7 @@ pub(crate) struct FragmentLink {
     pub(crate) inset_top: CssPixels,
     pub(crate) inset_bottom: CssPixels,
     pub(crate) containing_line_box_index: Option<usize>,
-    pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
+    pub(crate) abspos_layout_inputs: Option<abspos_inputs::AbsposLayoutInputs>,
 }
 
 fn same_allocation<T>(left: Option<&std::rc::Rc<T>>, right: Option<&std::rc::Rc<T>>) -> bool {
@@ -73,7 +75,10 @@ impl Fragment {
             && self.padding_top == previous.padding_top
             && self.padding_bottom == previous.padding_bottom
             && self.uses_collapsing_borders_model == previous.uses_collapsing_borders_model
-            && same_allocation(self.collapsed_table_borders.as_ref(), previous.collapsed_table_borders.as_ref())
+            && same_allocation(
+                self.collapsed_table_borders.as_ref(),
+                previous.collapsed_table_borders.as_ref(),
+            )
             && same_allocation(self.line_data.as_ref(), previous.line_data.as_ref())
             && same_allocation(self.grid_layout_data.as_ref(), previous.grid_layout_data.as_ref())
             && same_allocation(self.flex_layout_data.as_ref(), previous.flex_layout_data.as_ref())
@@ -108,7 +113,7 @@ impl FragmentLink {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AnchorCandidate {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
-    pub(crate) border_box_rect: PhysicalRect,
+    pub(crate) border_box_rect: formatting_context::PhysicalRect,
     pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
 }
 
@@ -117,7 +122,7 @@ pub(crate) struct AnchorCandidate {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct InlineContainingBlockRect {
     pub(crate) inline_box: crate::layout::node_data::NodeSlotId,
-    pub(crate) rect: PhysicalRect,
+    pub(crate) rect: formatting_context::PhysicalRect,
     pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
 }
 
@@ -129,7 +134,7 @@ pub(crate) struct InlineContainingBlockRect {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AbsposContainingBlockInfoContribution {
     pub(crate) child_box: crate::layout::node_data::NodeSlotId,
-    pub(crate) info: AbsposContainingBlockInfo,
+    pub(crate) info: abspos_inputs::AbsposContainingBlockInfo,
 }
 
 trait PropagatedPayload {
@@ -138,7 +143,7 @@ trait PropagatedPayload {
     fn translate_by(&mut self, offset: FfiCssPixelPoint);
 }
 
-impl PropagatedPayload for PendingAbsposChild {
+impl PropagatedPayload for abspos_inputs::PendingAbsposChild {
     fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
         self.coordinate_space_box
     }
@@ -146,7 +151,8 @@ impl PropagatedPayload for PendingAbsposChild {
         self.coordinate_space_box = node;
     }
     fn translate_by(&mut self, offset: FfiCssPixelPoint) {
-        self.static_position_rect = crate::layout::translate_static_position_rect(self.static_position_rect, offset);
+        self.static_position_rect =
+            formatting_context::translate_static_position_rect(self.static_position_rect, offset);
     }
 }
 
@@ -305,7 +311,7 @@ pub(crate) struct PlacementData {
     pub(crate) inset_top: CssPixels,
     pub(crate) inset_bottom: CssPixels,
     pub(crate) containing_line_box_index: Option<usize>,
-    pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
+    pub(crate) abspos_layout_inputs: Option<abspos_inputs::AbsposLayoutInputs>,
 }
 
 impl PlacementData {
@@ -321,10 +327,7 @@ impl PlacementData {
             inset_top: used.inset_top.get(),
             inset_bottom: used.inset_bottom.get(),
             containing_line_box_index,
-            abspos_layout_inputs: used
-                .rare_data
-                .get()
-                .and_then(|cell| cell.borrow().abspos_layout_inputs),
+            abspos_layout_inputs: used.rare_data.get().and_then(|cell| cell.borrow().abspos_layout_inputs),
         }
     }
 }
@@ -347,7 +350,7 @@ pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) scoped_descendants: Vec<FragmentLink>,
     pub(crate) reused_subtree_roots: std::collections::HashSet<u32>,
-    pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
+    pub(crate) propagated_pending_abspos: Vec<abspos_inputs::PendingAbsposChild>,
     pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
     pub(crate) propagated_inline_containing_block_rects: Vec<InlineContainingBlockRect>,
     pub(crate) propagated_abspos_containing_block_info: Vec<AbsposContainingBlockInfoContribution>,
@@ -387,7 +390,7 @@ impl CompletedPassFragments {
 struct PendingFragment {
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
-    pending_abspos: Vec<PendingAbsposChild>,
+    pending_abspos: Vec<abspos_inputs::PendingAbsposChild>,
     anchor_candidates: Vec<AnchorCandidate>,
     inline_containing_block_rects: Vec<InlineContainingBlockRect>,
 }
@@ -417,7 +420,7 @@ struct RunFragmentBuilderInner {
     #[cfg(debug_assertions)]
     placed_slots: std::collections::HashSet<u32>,
     child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
-    pending_abspos_at_root: Vec<PendingAbsposChild>,
+    pending_abspos_at_root: Vec<abspos_inputs::PendingAbsposChild>,
     anchor_candidates_at_root: Vec<AnchorCandidate>,
     inline_containing_block_rects_at_root: Vec<InlineContainingBlockRect>,
     abspos_containing_block_info_contributions: Vec<AbsposContainingBlockInfoContribution>,
@@ -426,7 +429,7 @@ struct RunFragmentBuilderInner {
 }
 
 impl RunFragmentBuilderInner {
-    fn iter_pending_abspos(&self) -> impl Iterator<Item = &PendingAbsposChild> {
+    fn iter_pending_abspos(&self) -> impl Iterator<Item = &abspos_inputs::PendingAbsposChild> {
         self.pending_fragments
             .values()
             .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter())
@@ -477,7 +480,7 @@ impl RunFragmentBuilder {
     pub(crate) fn register_pending_abspos(
         &self,
         coordinate_space_box: crate::layout::node_data::NodeSlotId,
-        entry: PendingAbsposChild,
+        entry: abspos_inputs::PendingAbsposChild,
     ) {
         let mut inner = self.inner.borrow_mut();
         #[cfg(debug_assertions)]
@@ -497,7 +500,9 @@ impl RunFragmentBuilder {
                 } else {
                     let mut pending_fragment = PendingFragment::new(coordinate_space_box);
                     pending_fragment.pending_abspos.push(entry);
-                    inner.pending_fragments.insert(coordinate_space_box.slot_index(), pending_fragment);
+                    inner
+                        .pending_fragments
+                        .insert(coordinate_space_box.slot_index(), pending_fragment);
                 }
             }
         }
@@ -506,7 +511,7 @@ impl RunFragmentBuilder {
     pub(crate) fn register_inline_containing_block_rect(
         &self,
         inline_box: crate::layout::node_data::NodeSlotId,
-        rect: PhysicalRect,
+        rect: formatting_context::PhysicalRect,
         coordinate_space_box: crate::layout::node_data::NodeSlotId,
     ) {
         let mut inner = self.inner.borrow_mut();
@@ -538,7 +543,9 @@ impl RunFragmentBuilder {
                 } else {
                     let mut pending_fragment = PendingFragment::new(coordinate_space_box);
                     pending_fragment.inline_containing_block_rects.push(payload);
-                    inner.pending_fragments.insert(coordinate_space_box.slot_index(), pending_fragment);
+                    inner
+                        .pending_fragments
+                        .insert(coordinate_space_box.slot_index(), pending_fragment);
                 }
             }
         }
@@ -547,7 +554,7 @@ impl RunFragmentBuilder {
     pub(crate) fn find_inline_containing_block_rect(
         &self,
         inline_box: crate::layout::node_data::NodeSlotId,
-    ) -> Option<(PhysicalRect, crate::layout::node_data::NodeSlotId)> {
+    ) -> Option<(formatting_context::PhysicalRect, crate::layout::node_data::NodeSlotId)> {
         self.inner
             .borrow()
             .iter_inline_containing_block_rects()
@@ -566,7 +573,7 @@ impl RunFragmentBuilder {
         callbacks: &FfiLayoutFcCallbacks,
     ) -> Vec<crate::layout::node_data::NodeSlotId> {
         let inner = self.inner.borrow();
-        let awaits_info = |entry: &PendingAbsposChild| {
+        let awaits_info = |entry: &abspos_inputs::PendingAbsposChild| {
             entry.containing_block_info_override.is_none()
                 && callbacks.containing_block(entry.child_box) == containing_block
         };
@@ -589,7 +596,7 @@ impl RunFragmentBuilder {
     pub(crate) fn register_abspos_containing_block_info(
         &self,
         child_box: crate::layout::node_data::NodeSlotId,
-        info: AbsposContainingBlockInfo,
+        info: abspos_inputs::AbsposContainingBlockInfo,
     ) {
         let mut inner = self.inner.borrow_mut();
         debug_assert!(
@@ -607,7 +614,7 @@ impl RunFragmentBuilder {
     pub(crate) fn find_abspos_containing_block_info(
         &self,
         child_box: crate::layout::node_data::NodeSlotId,
-    ) -> Option<AbsposContainingBlockInfo> {
+    ) -> Option<abspos_inputs::AbsposContainingBlockInfo> {
         self.inner
             .borrow()
             .abspos_containing_block_info_contributions
@@ -623,7 +630,10 @@ impl RunFragmentBuilder {
             .any(|entry| !entry.inline_containing_block.is_invalid())
     }
 
-    pub(crate) fn any_pending_abspos_names_inline_containing_block(&self, inline_box: crate::layout::node_data::NodeSlotId) -> bool {
+    pub(crate) fn any_pending_abspos_names_inline_containing_block(
+        &self,
+        inline_box: crate::layout::node_data::NodeSlotId,
+    ) -> bool {
         self.inner
             .borrow()
             .iter_pending_abspos()
@@ -641,7 +651,7 @@ impl RunFragmentBuilder {
     pub(crate) fn find_anchor_candidate(
         &self,
         node: crate::layout::node_data::NodeSlotId,
-    ) -> Option<(PhysicalRect, crate::layout::node_data::NodeSlotId)> {
+    ) -> Option<(formatting_context::PhysicalRect, crate::layout::node_data::NodeSlotId)> {
         self.inner
             .borrow()
             .iter_anchor_candidates()
@@ -654,9 +664,9 @@ impl RunFragmentBuilder {
         placed: crate::layout::node_data::NodeSlotId,
         records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
-    ) -> Vec<PendingAbsposChild> {
+    ) -> Vec<abspos_inputs::PendingAbsposChild> {
         let mut inner = self.inner.borrow_mut();
-        let containing_block_is_owned_and_placed = |entry: &PendingAbsposChild| {
+        let containing_block_is_owned_and_placed = |entry: &abspos_inputs::PendingAbsposChild| {
             let containing_block = callbacks.containing_block(entry.child_box);
             !containing_block.is_invalid()
                 && (self.is_entry_accumulator || containing_block != self.root_node)
@@ -664,7 +674,7 @@ impl RunFragmentBuilder {
                     .used_values_if_owned(containing_block)
                     .is_some_and(|containing_block_used| containing_block_used.has_content_offset.get())
         };
-        let mut taken: Vec<PendingAbsposChild> = inner
+        let mut taken: Vec<abspos_inputs::PendingAbsposChild> = inner
             .pending_abspos_at_root
             .extract_if(.., |entry| containing_block_is_owned_and_placed(entry))
             .collect();
@@ -690,7 +700,9 @@ impl RunFragmentBuilder {
     pub(crate) fn hold_unplaced_root(&self, root: UnplacedRootFragment) {
         let slot = root.node.slot_index();
         let mut inner = self.inner.borrow_mut();
-        inner.reused_subtree_roots.extend(root.reused_subtree_roots.iter().copied());
+        inner
+            .reused_subtree_roots
+            .extend(root.reused_subtree_roots.iter().copied());
         let previous = inner.child_roots_awaiting_placement.insert(slot, root);
         debug_assert!(
             previous.is_none(),
@@ -710,18 +722,26 @@ impl RunFragmentBuilder {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
         let root = inner.child_roots_awaiting_placement.remove(&slot);
-        let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment::new(node));
+        let pending_fragment = inner
+            .pending_fragments
+            .entry(slot)
+            .or_insert_with(|| PendingFragment::new(node));
         let Some(root) = root else {
             return;
         };
-        debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
+        debug_assert!(
+            root.node == node,
+            "a held unplaced root was keyed under a different box"
+        );
         debug_assert!(
             pending_fragment.children.is_empty() || root.scoped_descendants.is_empty(),
             "a held unplaced root and an open pending fragment both carry children for slot {slot}"
         );
         pending_fragment.children.extend(root.scoped_descendants);
         pending_fragment.pending_abspos.extend(root.propagated_pending_abspos);
-        pending_fragment.anchor_candidates.extend(root.propagated_anchor_candidates);
+        pending_fragment
+            .anchor_candidates
+            .extend(root.propagated_anchor_candidates);
         pending_fragment
             .inline_containing_block_rects
             .extend(root.propagated_inline_containing_block_rects);
@@ -740,7 +760,7 @@ impl RunFragmentBuilder {
         containing_block_is_sealed: bool,
         containing_line_box_index: Option<usize>,
         committed_offset: FfiCssPixelPoint,
-        own_anchor_candidate_border_box_rect: Option<PhysicalRect>,
+        own_anchor_candidate_border_box_rect: Option<formatting_context::PhysicalRect>,
     ) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
@@ -756,7 +776,10 @@ impl RunFragmentBuilder {
             pending_abspos: pending_abspos_from_placed_box,
             anchor_candidates: anchor_candidates_from_placed_box,
             inline_containing_block_rects: inline_containing_block_rects_from_placed_box,
-        } = inner.pending_fragments.remove(&slot).unwrap_or_else(|| PendingFragment::new(node));
+        } = inner
+            .pending_fragments
+            .remove(&slot)
+            .unwrap_or_else(|| PendingFragment::new(node));
         let link = link_fragment(
             snapshot_fragment(callbacks, node, children, used),
             PlacementData::from_record(used, containing_line_box_index, committed_offset),
@@ -770,7 +793,10 @@ impl RunFragmentBuilder {
                 entry.child_box.slot_index()
             );
             propagate_payload_into_containing_block_space(&mut entry, node, containing_block, content_offset);
-            match inner.pending_fragments.get_mut(&entry.coordinate_space_box.slot_index()) {
+            match inner
+                .pending_fragments
+                .get_mut(&entry.coordinate_space_box.slot_index())
+            {
                 Some(pending_fragment) => pending_fragment.pending_abspos.push(entry),
                 None => inner.pending_abspos_at_root.push(entry),
             }
@@ -782,14 +808,20 @@ impl RunFragmentBuilder {
         });
         for mut candidate in anchor_candidates_from_placed_box.into_iter().chain(own_candidate) {
             propagate_payload_into_containing_block_space(&mut candidate, node, containing_block, content_offset);
-            match inner.pending_fragments.get_mut(&candidate.coordinate_space_box.slot_index()) {
+            match inner
+                .pending_fragments
+                .get_mut(&candidate.coordinate_space_box.slot_index())
+            {
                 Some(pending_fragment) => pending_fragment.anchor_candidates.push(candidate),
                 None => inner.anchor_candidates_at_root.push(candidate),
             }
         }
         for mut payload in inline_containing_block_rects_from_placed_box {
             propagate_payload_into_containing_block_space(&mut payload, node, containing_block, content_offset);
-            match inner.pending_fragments.get_mut(&payload.coordinate_space_box.slot_index()) {
+            match inner
+                .pending_fragments
+                .get_mut(&payload.coordinate_space_box.slot_index())
+            {
                 Some(pending_fragment) => pending_fragment.inline_containing_block_rects.push(payload),
                 None => inner.inline_containing_block_rects_at_root.push(payload),
             }
@@ -807,7 +839,8 @@ impl RunFragmentBuilder {
             inner.top_scope_links.push(link);
             return;
         };
-        if containing_block == self.root_node || Some(containing_block.slot_index()) == self.root_containing_block_slot {
+        if containing_block == self.root_node || Some(containing_block.slot_index()) == self.root_containing_block_slot
+        {
             inner.top_scope_links.push(link);
             return;
         }
@@ -821,7 +854,9 @@ impl RunFragmentBuilder {
         }
         let mut pending_fragment = PendingFragment::new(containing_block);
         pending_fragment.children.push(link);
-        inner.pending_fragments.insert(containing_block.slot_index(), pending_fragment);
+        inner
+            .pending_fragments
+            .insert(containing_block.slot_index(), pending_fragment);
     }
 
     pub(crate) fn take_unplaced_root(
@@ -829,7 +864,10 @@ impl RunFragmentBuilder {
         records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
     ) -> UnplacedRootFragment {
-        debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
+        debug_assert!(
+            !self.is_entry_accumulator,
+            "an entry accumulator closes as a pass, not a run"
+        );
         self.close(records, callbacks)
     }
 
@@ -838,7 +876,10 @@ impl RunFragmentBuilder {
         records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
     ) -> CompletedPassFragments {
-        debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
+        debug_assert!(
+            self.is_entry_accumulator,
+            "an ordinary run closes as a singular unplaced root"
+        );
         let root = self.close(records, callbacks);
         CompletedPassFragments {
             roots: root.scoped_descendants,
@@ -850,8 +891,10 @@ impl RunFragmentBuilder {
         let mut inner = self.inner.take();
         let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
         let mut propagated_anchor_candidates = std::mem::take(&mut inner.anchor_candidates_at_root);
-        let mut propagated_inline_containing_block_rects = std::mem::take(&mut inner.inline_containing_block_rects_at_root);
-        let propagated_abspos_containing_block_info = std::mem::take(&mut inner.abspos_containing_block_info_contributions);
+        let mut propagated_inline_containing_block_rects =
+            std::mem::take(&mut inner.inline_containing_block_rects_at_root);
+        let propagated_abspos_containing_block_info =
+            std::mem::take(&mut inner.abspos_containing_block_info_contributions);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
         for (_, pending_fragment) in pending_fragments {
             propagated_pending_abspos.extend(pending_fragment.pending_abspos);

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) fn to_physical<T>(writing_mode: u8, inline: T, block: T) -> (T, T) {
     if writing_mode == writing_mode::HORIZONTAL_TB {
         (inline, block)
@@ -128,7 +130,7 @@ pub(crate) struct RootSizingDirectives {
     pub(crate) adopt_automatic_content_block_size: bool,
     pub(crate) flex_self_block_size_resolution_space: Option<AvailableSpace>,
     pub(crate) float_avoidance_inline_size: Option<CssPixels>,
-    pub(crate) outer_float_intrusion_before_list_item_children: SpaceUsedByFloats,
+    pub(crate) outer_float_intrusion_before_list_item_children: inline_formatting_context::SpaceUsedByFloats,
     pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
@@ -137,7 +139,7 @@ pub(crate) enum ParticipationInParentFormattingContext {
     BlockLevel,
     Float,
     AtomicInline,
-    AbsolutelyPositioned(AbsposLayoutInputs),
+    AbsolutelyPositioned(abspos_inputs::AbsposLayoutInputs),
     Item,
     Root,
 }

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Alignment {
@@ -213,7 +214,6 @@ pub(crate) fn align_item(
     result
 }
 
-
 /// The pass-facing view of one stored track sizing function; sized breadths
 /// borrow the computed size from the style group payload, which outlives the
 /// pass.
@@ -348,10 +348,7 @@ pub(crate) struct OwnedUsedGridTracks {
 }
 
 impl OwnedUsedGridTracks {
-    pub(crate) fn with_ffi_views(
-        &self,
-        callback: impl FnOnce(&FfiUsedGridTrackList, &FfiUsedGridTrackList),
-    ) {
+    pub(crate) fn with_ffi_views(&self, callback: impl FnOnce(&FfiUsedGridTrackList, &FfiUsedGridTrackList)) {
         let column_lines = self.columns.ffi_lines();
         let row_lines = self.rows.ffi_lines();
         let columns = FfiUsedGridTrackList {
@@ -932,7 +929,7 @@ impl GridItem {
 }
 
 pub(crate) struct GridFormattingContext {
-    purpose: LayoutPurpose,
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     grid_container: Node,
     derived_baselines_of_root_box: DerivedBaselines,
@@ -941,7 +938,7 @@ pub(crate) struct GridFormattingContext {
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
-    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     available_space: Option<AvailableSpace>,
     layout_input: Option<LayoutInput>,
     column_lines: Vec<Vec<LineName>>,
@@ -1016,7 +1013,7 @@ impl ParentGridData {
 /// Conservative superset of is_subgridded() for callers outside a live grid run
 /// (the fc-run-cache probe): a declared subgrid axis counts regardless of the
 /// parent-grid placement check only a run in progress can make.
-fn grid_template_declares_a_subgrid_axis(callbacks: &FfiLayoutFcCallbacks, box_: Node) -> bool {
+pub(super) fn grid_template_declares_a_subgrid_axis(callbacks: &FfiLayoutFcCallbacks, box_: Node) -> bool {
     let grid_style = ComputedValuesView::new(&callbacks.style_payloads(box_).groups).grid_values();
     grid_style.template_columns.is_subgrid || grid_style.template_rows.is_subgrid
 }
@@ -1033,7 +1030,8 @@ impl GridFormattingContext {
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: run.fragments.clone(),
             available_space: None,
             layout_input: None,
@@ -1064,7 +1062,8 @@ impl GridFormattingContext {
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
             should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: self.fragments.clone(),
             previous_line_data: None,
         }
@@ -1113,8 +1112,8 @@ impl GridFormattingContext {
         ComputedValuesView::new(&self.callbacks.style_payloads(node).groups).grid_values()
     }
 
-    fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
     fn parent_grid(&self) -> Option<&ParentGridData> {
@@ -1468,7 +1467,6 @@ impl GridFormattingContext {
         }
     }
 
-
     fn clamp_area_to_subgrid(start: &mut i32, span: &mut usize, track_count: usize) {
         if track_count == 0 {
             return;
@@ -1551,7 +1549,7 @@ impl GridFormattingContext {
         }
 
         let style = self.style(self.grid_container);
-        let mut result = crate::layout::place_items_with_grid(
+        let mut result = place_items_with_grid(
             &inputs,
             self.column_lines.len().saturating_sub(1),
             self.row_lines.len().saturating_sub(1),
@@ -1743,7 +1741,12 @@ impl GridFormattingContext {
         }
     }
 
-    fn initialize_tracks(&mut self, grid_style: &'static GridValues, columns: &ExpandedTrackList, rows: &ExpandedTrackList) {
+    fn initialize_tracks(
+        &mut self,
+        grid_style: &'static GridValues,
+        columns: &ExpandedTrackList,
+        rows: &ExpandedTrackList,
+    ) {
         self.columns = self.initialize_tracks_for_axis(
             Axis::Column,
             grid_style,
@@ -1830,8 +1833,10 @@ impl GridFormattingContext {
     }
 
     fn store_interleaved_tracks(&mut self, axis: Axis, interleaved: &[Track]) {
-        let (tracks, gaps) =
-            axis.select((&mut self.columns, &mut self.column_gaps), (&mut self.rows, &mut self.row_gaps));
+        let (tracks, gaps) = axis.select(
+            (&mut self.columns, &mut self.column_gaps),
+            (&mut self.rows, &mut self.row_gaps),
+        );
         for (index, track) in tracks.iter_mut().enumerate() {
             *track = interleaved[Self::interleaved_index_of_track(index)];
         }
@@ -2331,7 +2336,10 @@ impl GridFormattingContext {
             return false;
         }
         let grid_style = self.grid_style(item.box_);
-        axis.select(grid_style.template_columns.is_subgrid, grid_style.template_rows.is_subgrid)
+        axis.select(
+            grid_style.template_columns.is_subgrid,
+            grid_style.template_rows.is_subgrid,
+        )
     }
 
     fn apply_subgrid_edge_extra_margins(&self, item: &mut GridItem, axis: Axis) {
@@ -2378,14 +2386,18 @@ impl GridFormattingContext {
     }
 
     fn subgrid_item_contributions_to_track_sizing(&self, subgrid: GridItem, axis: Axis) -> Vec<ItemContribution> {
-        let scratch = MeasurementState::create(self.callbacks);
+        let scratch = formatting_context::MeasurementState::create(self.callbacks);
         let live = self.used(subgrid);
         let scratch_root = scratch.create_used_values(subgrid.box_, ContainingBlockConstraints::default());
         live.mirror_box_metrics_and_size_constraints_into(&scratch_root);
-        scratch_root.has_definite_inline_size.set(live.has_definite_inline_size.get());
-        scratch_root.has_definite_block_size.set(live.has_definite_block_size.get());
+        scratch_root
+            .has_definite_inline_size
+            .set(live.has_definite_inline_size.get());
+        scratch_root
+            .has_definite_block_size
+            .set(live.has_definite_block_size.get());
         let scratch_run = FormattingContextRun {
-            purpose: LayoutPurpose::Measurement,
+            purpose: formatting_context::LayoutPurpose::Measurement,
             records: std::rc::Rc::new(RunRecords::new(self.callbacks.arena, subgrid.box_, scratch_root)),
             box_: subgrid.box_,
             layout_mode: LayoutMode::IntrinsicSizing,
@@ -2400,7 +2412,11 @@ impl GridFormattingContext {
         if !axis.is_column() && live.has_definite_inline_size() {
             available.inline_size = AvailableSize::definite(live.content_inline_size.get());
         }
-        let input = LayoutInput::new(available, self.track_sizing_constraints(), ParticipationInParentFormattingContext::Item);
+        let input = LayoutInput::new(
+            available,
+            self.track_sizing_constraints(),
+            ParticipationInParentFormattingContext::Item,
+        );
         context.reset_for_run(input);
         let grid_style = context.grid_style(context.grid_container);
         context.cache_subgrid_axes(grid_style);
@@ -2422,7 +2438,8 @@ impl GridFormattingContext {
         context.items = items;
 
         let mut contributions = context.item_contributions_to_track_sizing(axis);
-        let interleaved_index_offset_in_parent = Self::interleaved_index_of_track(subgrid.position(axis).max(0) as usize);
+        let interleaved_index_offset_in_parent =
+            Self::interleaved_index_of_track(subgrid.position(axis).max(0) as usize);
         for contribution in &mut contributions {
             for index in &mut contribution.spanned_tracks {
                 *index += interleaved_index_offset_in_parent;
@@ -2468,7 +2485,10 @@ impl GridFormattingContext {
         let contributions = self.item_contributions_to_track_sizing(axis);
         let style = self.style(self.grid_container);
         let distribution_stretches = axis.select(
-            matches!(style.justify_content(), justify_content::NORMAL | justify_content::STRETCH),
+            matches!(
+                style.justify_content(),
+                justify_content::NORMAL | justify_content::STRETCH
+            ),
             matches!(style.align_content(), align_content::NORMAL | align_content::STRETCH),
         );
         run_track_sizing(
@@ -2610,7 +2630,7 @@ impl GridFormattingContext {
             available,
             constraints,
             Some(containing_for_wrapper),
-            crate::layout::TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto,
+            formatting_context::TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto,
         );
         let wrapper_style = self.style(item.box_);
         let table_box = self.sizing().table_box_inside_wrapper(item.box_);
@@ -2803,12 +2823,8 @@ impl GridFormattingContext {
                 //     grid container's own definiteness.
                 containing - self.item_margin_box_start(item, axis) - self.item_margin_box_end(item, axis)
             } else if preferred.is_auto() || preferred.is_fit_content() {
-                self.sizing().calculate_fit_content_size(
-                    item.box_,
-                    axis.sizing_axis(),
-                    available,
-                    constraints,
-                )
+                self.sizing()
+                    .calculate_fit_content_size(item.box_, axis.sizing_axis(), available, constraints)
             } else {
                 self.sizing().calculate_inner_size_for_property(
                     item.box_,
@@ -2976,15 +2992,15 @@ impl GridFormattingContext {
         self.resolve_item_sizes(Axis::Row);
     }
 
-    fn grid_area(&self, item: GridItem) -> LogicalRect {
+    fn grid_area(&self, item: GridItem) -> geometry::LogicalRect {
         let (inline_offset, inline_size) = self.axis_grid_area(Axis::Column, Some((item.column, item.column_span)));
         let (block_offset, block_size) = self.axis_grid_area(Axis::Row, Some((item.row, item.row_span)));
-        LogicalRect {
-            offset: LogicalOffset {
+        geometry::LogicalRect {
+            offset: geometry::LogicalOffset {
                 inline_offset,
                 block_offset,
             },
-            size: LogicalSize {
+            size: geometry::LogicalSize {
                 inline_size,
                 block_size,
             },
@@ -3045,8 +3061,10 @@ impl GridFormattingContext {
             (!(is_auto_positioned(start) && is_auto_positioned(end))).then_some((resolved.start, resolved.span)),
         );
 
-        let start_is_augmented = is_auto_positioned(start) && end.kind == crate::layout::ComputedGridPlacementKind::Line as u8;
-        let end_is_augmented = is_auto_positioned(end) && start.kind == crate::layout::ComputedGridPlacementKind::Line as u8;
+        let start_is_augmented =
+            is_auto_positioned(start) && end.kind == crate::layout::ComputedGridPlacementKind::Line as u8;
+        let end_is_augmented =
+            is_auto_positioned(end) && start.kind == crate::layout::ComputedGridPlacementKind::Line as u8;
         if !start_is_augmented && !end_is_augmented {
             return rect;
         }
@@ -3133,7 +3151,7 @@ impl GridFormattingContext {
                 sizing: RootSizingDirectives::default(),
                 participation: ParticipationInParentFormattingContext::Item,
             };
-            match crate::layout::layout_inside_child(
+            match formatting_context::layout_inside_child(
                 run,
                 None,
                 Some(self),
@@ -3142,8 +3160,8 @@ impl GridFormattingContext {
                 input,
                 false,
             ) {
-                crate::layout::ChildLayoutOutcome::Created(_) | crate::layout::ChildLayoutOutcome::Skipped => {}
-                crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+                ChildLayoutOutcome::Created(_) | ChildLayoutOutcome::Skipped => {}
+                ChildLayoutOutcome::ReenterCurrent => {
                     self.run(run, input);
                 }
             };
@@ -3153,11 +3171,11 @@ impl GridFormattingContext {
             };
             // Resolve relative-position insets before placement seals the
             // item's committed metrics.
-            crate::layout::compute_inset_native(run, item.box_, area.size.inline_size, area.size.block_size);
-            crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
+            abspos_engine::compute_inset_native(run, item.box_, area.size.inline_size, area.size.block_size);
+            formatting_context::place_child(&self.formatting_context_run(), item.box_, offset, None);
         }
         self.derived_baselines_of_root_box =
-            crate::layout::derive_baselines(&self.records, &self.callbacks, self.grid_container, false);
+            formatting_context::derive_baselines(&self.records, &self.callbacks, self.grid_container, false);
     }
 
     fn used_track_list_data(&self, axis: Axis, subgrid: bool) -> OwnedUsedGridTrackList {
@@ -3195,9 +3213,7 @@ impl GridFormattingContext {
             columns: self.used_track_list_data(Axis::Column, self.is_subgridded(Axis::Column, grid_style)),
             rows: self.used_track_list_data(Axis::Row, self.is_subgridded(Axis::Row, grid_style)),
         };
-        self.container_used()
-            .rare_data_mut()
-            .used_grid_tracks = Some(std::rc::Rc::new(tracks));
+        self.container_used().rare_data_mut().used_grid_tracks = Some(std::rc::Rc::new(tracks));
     }
 
     fn save_devtools_data(&self, grid_style: &GridValues) {
@@ -3294,11 +3310,7 @@ impl GridFormattingContext {
                 column_end: area.column_end as u32 + 1,
             })
             .collect::<Vec<_>>();
-        let fragment = GridLayoutFragment {
-            areas,
-            columns,
-            rows,
-        };
+        let fragment = GridLayoutFragment { areas, columns, rows };
         let style = self.style(self.grid_container);
         let data = GridLayoutData {
             direction: style.direction(),
@@ -3306,9 +3318,7 @@ impl GridFormattingContext {
             is_subgrid: self.is_subgridded(Axis::Column, grid_style) || self.is_subgridded(Axis::Row, grid_style),
             fragments: vec![fragment],
         };
-        self.container_used()
-            .rare_data_mut()
-            .grid_layout_data = Some(std::rc::Rc::new(data));
+        self.container_used().rare_data_mut().grid_layout_data = Some(std::rc::Rc::new(data));
     }
 
     pub(crate) fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
@@ -3417,8 +3427,8 @@ impl GridFormattingContext {
         while !child.is_invalid() {
             let next = self.callbacks.next_sibling(child);
             if self.facts(child).is_absolutely_positioned() {
-                let rect = StaticPositionRect {
-                    rect: LogicalRect::default(),
+                let rect = abspos_inputs::StaticPositionRect {
+                    rect: geometry::LogicalRect::default(),
                     inline_alignment: StaticPositionAlignment::Start,
                     block_alignment: StaticPositionAlignment::Start,
                     alignment_derives_from_own_computed_values: false,
@@ -3427,7 +3437,7 @@ impl GridFormattingContext {
                 // static position for the grid's own abspos children.
                 let containing_block_info = (self.callbacks.containing_block(child) == self.grid_container)
                     .then(|| self.abspos_containing_block_info(child));
-                crate::layout::register_contained_abspos_child(
+                formatting_context::register_contained_abspos_child(
                     &self.callbacks,
                     self.fragments.as_deref(),
                     self.grid_container,
@@ -3450,7 +3460,7 @@ impl GridFormattingContext {
                 // Registration-time axis modes read raw style: anchor()
                 // insets resolve later in layout_pending_child, and an
                 // anchor-bearing inset is never auto either way.
-                let (inline_axis_mode, block_axis_mode) = axis_modes(self.style(child));
+                let (inline_axis_mode, block_axis_mode) = abspos_engine::axis_modes(self.style(child));
                 info.inline_axis_mode = inline_axis_mode;
                 info.block_axis_mode = block_axis_mode;
                 fragments.register_abspos_containing_block_info(child, info);
@@ -3459,26 +3469,26 @@ impl GridFormattingContext {
     }
 
     // https://www.w3.org/TR/css-grid-2/#abspos-items
-    pub(crate) fn abspos_containing_block_info(&self, node: Node) -> AbsposContainingBlockInfo {
+    pub(crate) fn abspos_containing_block_info(&self, node: Node) -> abspos_inputs::AbsposContainingBlockInfo {
         let grid_style = self.grid_style(node);
         let name_raws = grid_style.names.raws();
         let (block_offset, block_size) =
             self.absolute_axis_grid_area(Axis::Row, grid_style.row_start, grid_style.row_end, name_raws);
         let (inline_offset, inline_size) =
             self.absolute_axis_grid_area(Axis::Column, grid_style.column_start, grid_style.column_end, name_raws);
-        AbsposContainingBlockInfo {
-            rect: LogicalRect {
-                offset: LogicalOffset {
+        abspos_inputs::AbsposContainingBlockInfo {
+            rect: geometry::LogicalRect {
+                offset: geometry::LogicalOffset {
                     inline_offset,
                     block_offset,
                 },
-                size: LogicalSize {
+                size: geometry::LogicalSize {
                     inline_size,
                     block_size,
                 },
             },
-            inline_axis_mode: AbsposAxisMode::InsetFromRect,
-            block_axis_mode: AbsposAxisMode::InsetFromRect,
+            inline_axis_mode: abspos_inputs::AbsposAxisMode::InsetFromRect,
+            block_axis_mode: abspos_inputs::AbsposAxisMode::InsetFromRect,
             inline_alignment: Some(abspos_alignment(self.item_alignment_for_node(node, Axis::Column))),
             block_alignment: Some(abspos_alignment(self.item_alignment_for_node(node, Axis::Row))),
             derives_from_own_computed_values: true,
@@ -3503,7 +3513,6 @@ fn abspos_alignment(alignment: Alignment) -> AbsposAlignment {
         Alignment::Unsafe => AbsposAlignment::Unsafe,
     }
 }
-
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SpaceDistributionPhase {
@@ -3980,13 +3989,13 @@ pub(crate) fn expand_flexible_tracks_indefinite(tracks: &mut [Track], items: &[I
     // First, find the grid’s used flex fraction:
     // Otherwise, if the free space is an indefinite length:
     // The used flex fraction is the maximum of:
-    let mut flex_fraction = PixelFraction::zero();
+    let mut flex_fraction = formatting_context::PixelFraction::zero();
     // For each flexible track, if the flexible track’s flex factor is greater than one, the result of dividing
     // the track’s base size by its flex factor; otherwise, the track’s base size.
     for track in tracks.iter() {
         if let Some(factor) = track.flex_factor {
             let divisor = CssPixels::nearest_value_for(factor.max(1.0));
-            flex_fraction = flex_fraction.max(PixelFraction::new(track.base_size, divisor));
+            flex_fraction = flex_fraction.max(formatting_context::PixelFraction::new(track.base_size, divisor));
         }
     }
     // For each grid item that crosses a flexible track, the result of finding the size of an fr using all the
@@ -4101,7 +4110,7 @@ pub(crate) fn run_track_sizing<MaximumSize>(
             // Otherwise, if the free space is a definite length:
             // The used flex fraction is the result of finding the size of an fr using all of the grid tracks and a space
             // to fill of the available grid space.
-            crate::layout::expand_flexible_tracks(tracks, available_size - gap_size);
+            expand_flexible_tracks(tracks, available_size - gap_size);
         // If the free space is zero or if sizing the grid container under a min-content constraint:
         // The used flex fraction is zero.
         } else if available != AvailableSize::MinContent {
@@ -4116,7 +4125,6 @@ pub(crate) fn run_track_sizing<MaximumSize>(
     // tracks have definite sizes, also apply align-content to find the final effective size of any gaps
     // spanned by such items; otherwise ignore the effects of track alignment in this estimation.
 }
-
 
 pub(crate) const REPEAT_AUTO_FIT: u8 = 0;
 const REPEAT_AUTO_FILL: u8 = 1;
@@ -4265,7 +4273,9 @@ fn expand_standalone_list(
         kind if kind == ComputedGridTrackEntryKind::LineNames as u8 => {
             pending_names.extend(source.names(entry));
         }
-        kind if kind == ComputedGridTrackEntryKind::TrackSize as u8 || kind == ComputedGridTrackEntryKind::MinMax as u8 => {
+        kind if kind == ComputedGridTrackEntryKind::TrackSize as u8
+            || kind == ComputedGridTrackEntryKind::MinMax as u8 =>
+        {
             lines.push(std::mem::take(pending_names));
             tracks.push(definition_for(entry, inherited_auto_fit, inherited_auto_repeat));
         }
@@ -4517,7 +4527,6 @@ pub(crate) fn nth_named_line(lines: &[Vec<LineName>], name_raw: usize, nth_line:
     None
 }
 
-
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum TrackSizingFunction {
     Auto,
@@ -4746,7 +4755,7 @@ pub(crate) fn initialize_track_sizes(tracks: &mut [Track], available: AvailableS
     has_flexible_tracks
 }
 
-pub(crate) fn find_fr_size(tracks: &[Track], space_to_fill: CssPixels) -> PixelFraction {
+pub(crate) fn find_fr_size(tracks: &[Track], space_to_fill: CssPixels) -> formatting_context::PixelFraction {
     // https://www.w3.org/TR/css-grid-2/#algo-find-fr-size
     let mut inflexible = vec![false; tracks.len()];
     loop {
@@ -4773,7 +4782,7 @@ pub(crate) fn find_fr_size(tracks: &[Track], space_to_fill: CssPixels) -> PixelF
             flex_factor_sum = CssPixels::from_integer(1);
         }
         // 3. Let the hypothetical fr size be the leftover space divided by the flex factor sum.
-        let hypothetical_fr_size = PixelFraction::new(leftover_space, flex_factor_sum);
+        let hypothetical_fr_size = formatting_context::PixelFraction::new(leftover_space, flex_factor_sum);
 
         // 4. If the product of the hypothetical fr size and a flexible track’s flex factor is less than the track’s
         //    base size, restart this algorithm treating all such tracks as inflexible.

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 const ELLIPSIS_CODE_POINT: u32 = 0x2026;
 
 pub(crate) trait EllipsisFontProvider {
@@ -11,7 +13,7 @@ pub(crate) trait EllipsisFontProvider {
     fn font_glyph_id(&self, font: *const c_void, code_point: u32) -> u32;
 }
 
-pub(crate) fn apply(line_boxes: &mut [LineBoxData], provider: &impl EllipsisFontProvider) {
+pub(crate) fn apply(line_boxes: &mut [line_box::LineBoxData], provider: &impl EllipsisFontProvider) {
     for line in line_boxes {
         if !matches!(line.original_available_inline_size, AvailableSize::Definite(_)) {
             continue;
@@ -53,7 +55,7 @@ pub(crate) fn apply(line_boxes: &mut [LineBoxData], provider: &impl EllipsisFont
 
             let glyph_data = line.fragments[index].glyphs.as_mut().unwrap();
             glyph_data.glyphs.truncate(keep_count);
-            glyph_data.glyphs.push(FfiDrawGlyph {
+            glyph_data.glyphs.push(inline_level_iterator::FfiDrawGlyph {
                 x: last_kept_end,
                 y: glyph_block_offset,
                 length_in_code_units: 1,
@@ -73,7 +75,7 @@ pub(crate) fn apply(line_boxes: &mut [LineBoxData], provider: &impl EllipsisFont
     }
 }
 
-pub(crate) fn apply_to_fragments(text_justify: u8, line: &mut LineBoxData, is_last_line: bool) {
+pub(crate) fn apply_to_fragments(text_justify: u8, line: &mut line_box::LineBoxData, is_last_line: bool) {
     if text_justify == text_justify::NONE || is_last_line || line.has_forced_break {
         return;
     }
@@ -241,7 +243,7 @@ fn edge_bits(horizontal: bool, low: bool, high: bool) -> u8 {
 
 pub(crate) struct InlineContainingBlockRectCandidate {
     pub(crate) inline_containing_block: Node,
-    pub(crate) rect: PhysicalRect,
+    pub(crate) rect: formatting_context::PhysicalRect,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -266,9 +268,9 @@ pub(crate) fn compute(
         .run
         .fragments
         .as_deref()
-        .is_some_and(RunFragmentBuilder::any_pending_abspos_has_inline_containing_block);
-    let container_inline_axis_is_reverse = collect_inline_containing_block_rects
-        && context.facts(context.containing_block).inline_axis_is_reverse();
+        .is_some_and(fragment_tree::RunFragmentBuilder::any_pending_abspos_has_inline_containing_block);
+    let container_inline_axis_is_reverse =
+        collect_inline_containing_block_rects && context.facts(context.containing_block).inline_axis_is_reverse();
     let mut inline_containing_block_rect_candidates = Vec::<InlineContainingBlockRectCandidate>::new();
     let mut per_nodes = Vec::<PerNode>::new();
     let mut node_to_index = HashMap::<Node, usize>::new();
@@ -613,7 +615,7 @@ pub(crate) fn compute(
         {
             inline_containing_block_rect_candidates.push(InlineContainingBlockRectCandidate {
                 inline_containing_block: node,
-                rect: PhysicalRect {
+                rect: formatting_context::PhysicalRect {
                     x: placeholder_rect.x,
                     y: placeholder_rect.y,
                     width: placeholder_rect.width,
@@ -649,7 +651,7 @@ fn padding_box_rect_spanning_first_and_last_content_lines(
     horizontal: bool,
     inline_axis_is_reverse: bool,
     container_inline_axis_is_reverse: bool,
-) -> Option<PhysicalRect> {
+) -> Option<formatting_context::PhysicalRect> {
     let first = corners.first?;
     let last = corners.last?;
 
@@ -688,14 +690,14 @@ fn padding_box_rect_spanning_first_and_last_content_lines(
         (start - size, size)
     };
     Some(if horizontal {
-        PhysicalRect {
+        formatting_context::PhysicalRect {
             x: inline_low,
             y: block_start,
             width: inline_size,
             height: block_size,
         }
     } else {
-        PhysicalRect {
+        formatting_context::PhysicalRect {
             x: block_start,
             y: inline_low,
             width: block_size,
@@ -751,7 +753,7 @@ pub(crate) struct InlineFormattingContext<'context> {
     pub(crate) layout_mode: LayoutMode,
     pub(crate) input: LayoutInput,
     pub(crate) callbacks: FfiLayoutFcCallbacks,
-    parent: &'context BlockFormattingContext,
+    parent: &'context block_formatting_context::BlockFormattingContext,
     pub(crate) containing_used_values: std::rc::Rc<UsedValues>,
     pub(crate) fragmented_inlines_in_pre_order: Vec<Node>,
     pub(crate) automatic_content_inline_size: CssPixels,
@@ -767,7 +769,7 @@ impl<'context> InlineFormattingContext<'context> {
         layout_mode: LayoutMode,
         input: LayoutInput,
         callbacks: FfiLayoutFcCallbacks,
-        parent: &'context BlockFormattingContext,
+        parent: &'context block_formatting_context::BlockFormattingContext,
     ) -> Self {
         let containing_used_values = run.records.used_values(containing_block);
         containing_used_values.line_data_cell();
@@ -811,12 +813,17 @@ impl<'context> InlineFormattingContext<'context> {
         }
     }
 
-    pub(crate) fn line_data(&self) -> Ref<'_, LineData> {
-        Ref::map(self.containing_used_values.line_data_cell().borrow(), |shared| &**shared)
+    pub(crate) fn line_data(&self) -> Ref<'_, used_values::LineData> {
+        Ref::map(self.containing_used_values.line_data_cell().borrow(), |shared| {
+            &**shared
+        })
     }
 
-    pub(crate) fn line_data_mut(&self) -> RefMut<'_, LineData> {
-        RefMut::map(self.containing_used_values.line_data_cell().borrow_mut(), std::rc::Rc::make_mut)
+    pub(crate) fn line_data_mut(&self) -> RefMut<'_, used_values::LineData> {
+        RefMut::map(
+            self.containing_used_values.line_data_cell().borrow_mut(),
+            std::rc::Rc::make_mut,
+        )
     }
 
     pub(crate) fn containing_used(&self) -> std::rc::Rc<UsedValues> {
@@ -876,7 +883,12 @@ impl<'context> InlineFormattingContext<'context> {
 
     pub(crate) fn compute_inset(&self, node: Node) {
         let used = self.containing_used();
-        crate::layout::compute_inset_native(self.run, node, used.content_inline_size.get(), used.content_block_size.get());
+        abspos_engine::compute_inset_native(
+            self.run,
+            node,
+            used.content_inline_size.get(),
+            used.content_block_size.get(),
+        );
     }
 
     pub(crate) fn parent_commit_pending_margin_before_inline_content(&self) -> CssPixels {
@@ -913,12 +925,12 @@ impl<'context> InlineFormattingContext<'context> {
         &self,
         block_offset: CssPixels,
         line_block_size: CssPixels,
-    ) -> crate::layout::AvailableSize {
+    ) -> AvailableSize {
         if !matches!(self.input.available_space.inline_size, AvailableSize::Definite(_)) {
             return self.input.available_space.inline_size;
         }
         let intrusions = self.intrusion_by_floats_into_containing_block(block_offset, block_offset + line_block_size);
-        crate::layout::AvailableSize::definite(
+        AvailableSize::definite(
             self.input.available_space.inline_size.to_px_or_zero() - intrusions.left - intrusions.right,
         )
     }
@@ -958,14 +970,21 @@ impl<'context> InlineFormattingContext<'context> {
             self.input.containing_block_constraints,
             ParticipationInParentFormattingContext::AtomicInline,
         );
-        match crate::layout::layout_inside_child(self.run, Some(self.parent), None, node, self.layout_mode, input, false)
-        {
-            crate::layout::ChildLayoutOutcome::Created(result) => result.baselines,
-            crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+        match formatting_context::layout_inside_child(
+            self.run,
+            Some(self.parent),
+            None,
+            node,
+            self.layout_mode,
+            input,
+            false,
+        ) {
+            ChildLayoutOutcome::Created(result) => result.baselines,
+            ChildLayoutOutcome::ReenterCurrent => {
                 self.parent.run(self.run, input);
                 self.used(node).content_baselines_from_cells()
             }
-            crate::layout::ChildLayoutOutcome::Skipped => self.used(node).content_baselines_from_cells(),
+            ChildLayoutOutcome::Skipped => self.used(node).content_baselines_from_cells(),
         }
     }
 
@@ -1030,16 +1049,19 @@ impl<'context> InlineFormattingContext<'context> {
 
     fn reusable_atomic_line_prefix(
         &self,
-        previous: &LineData,
-        iterator: &InlineLevelIterator,
-    ) -> (Vec<LineBoxData>, usize) {
+        previous: &used_values::LineData,
+        iterator: &inline_level_iterator::InlineLevelIterator,
+    ) -> (Vec<line_box::LineBoxData>, usize) {
         if self.containing_block != self.run.box_
             || !previous.inline_box_pieces.is_empty()
             || previous
                 .line_boxes
                 .iter()
                 .any(|line| line.writing_mode != writing_mode::HORIZONTAL_TB)
-            || iterator.items().iter().any(|item| item.type_ != ItemType::Element)
+            || iterator
+                .items()
+                .iter()
+                .any(|item| item.type_ != inline_level_iterator::ItemType::Element)
         {
             return (Vec::new(), 0);
         }
@@ -1102,7 +1124,10 @@ impl<'context> InlineFormattingContext<'context> {
         (reused_lines, item_index)
     }
 
-    fn min_content_inline_size_from_max_content_items(&self, items: &[Item]) -> Option<CssPixels> {
+    fn min_content_inline_size_from_max_content_items(
+        &self,
+        items: &[inline_level_iterator::Item],
+    ) -> Option<CssPixels> {
         if self.input.available_space.inline_size != AvailableSize::MaxContent {
             return None;
         }
@@ -1123,15 +1148,14 @@ impl<'context> InlineFormattingContext<'context> {
         let mut maximum = CssPixels::default();
         let mut current = CssPixels::default();
         let mut line_has_content = false;
-        let finish_line =
-            |maximum: &mut CssPixels, current: &mut CssPixels, line_has_content: &mut bool| {
-                *maximum = (*maximum).max(*current);
-                *current = CssPixels::default();
-                *line_has_content = false;
-            };
+        let finish_line = |maximum: &mut CssPixels, current: &mut CssPixels, line_has_content: &mut bool| {
+            *maximum = (*maximum).max(*current);
+            *current = CssPixels::default();
+            *line_has_content = false;
+        };
         for item in items {
             match item.type_ {
-                ItemType::Element => {
+                inline_level_iterator::ItemType::Element => {
                     if item.has_box_model_metrics() {
                         return None;
                     }
@@ -1141,7 +1165,7 @@ impl<'context> InlineFormattingContext<'context> {
                     current += item.min_content_inline_size?;
                     line_has_content = true;
                 }
-                ItemType::Text => {
+                inline_level_iterator::ItemType::Text => {
                     if item.has_box_model_metrics() || item.contains_tab(self) {
                         return None;
                     }
@@ -1172,10 +1196,12 @@ impl<'context> InlineFormattingContext<'context> {
                     current += item.inline_size;
                     line_has_content = true;
                 }
-                ItemType::ForcedBreak => {
+                inline_level_iterator::ItemType::ForcedBreak => {
                     finish_line(&mut maximum, &mut current, &mut line_has_content);
                 }
-                ItemType::BlockLevelBox | ItemType::AbsolutelyPositionedElement | ItemType::FloatingElement => {
+                inline_level_iterator::ItemType::BlockLevelBox
+                | inline_level_iterator::ItemType::AbsolutelyPositionedElement
+                | inline_level_iterator::ItemType::FloatingElement => {
                     return None;
                 }
             }
@@ -1185,7 +1211,7 @@ impl<'context> InlineFormattingContext<'context> {
     }
 
     pub(crate) fn generate_line_boxes(&mut self) {
-        let mut iterator = InlineLevelIterator::new(self);
+        let mut iterator = inline_level_iterator::InlineLevelIterator::new(self);
         self.min_content_inline_size_from_max_content_layout =
             self.min_content_inline_size_from_max_content_items(iterator.items());
         self.fragmented_inlines_in_pre_order = iterator.take_visited_fragmented_inlines();
@@ -1203,9 +1229,9 @@ impl<'context> InlineFormattingContext<'context> {
         iterator.skip_items(reused_item_count);
         let reused_line_count = self.line_data().line_boxes.len();
         let mut line_builder = if reused_line_count == 0 {
-            LineBuilder::new(self)
+            line_builder::LineBuilder::new(self)
         } else {
-            LineBuilder::new_after_reused_lines(self)
+            line_builder::LineBuilder::new_after_reused_lines(self)
         };
 
         let mut leading_margin = CssPixels::default();
@@ -1241,14 +1267,14 @@ impl<'context> InlineFormattingContext<'context> {
             leading_padding = CssPixels::default();
 
             match item.type_ {
-                ItemType::ForcedBreak => {
-                    line_builder.break_line(ForcedBreak::Yes, None);
+                inline_level_iterator::ItemType::ForcedBreak => {
+                    line_builder.break_line(line_builder::ForcedBreak::Yes, None);
                     if !item.node.is_invalid() && self.clear_floating_boxes(item.node) {
                         line_builder.did_introduce_clearance(self.block_axis_float_clearance.get());
                         self.reset_parent_margin_state();
                     }
                 }
-                ItemType::Element => {
+                inline_level_iterator::ItemType::Element => {
                     line_builder.prepare_to_append_inline_content();
                     self.compute_inset(item.node);
                     if self.style(self.containing_block).text_wrap_mode() == text_wrap_mode::WRAP {
@@ -1270,7 +1296,7 @@ impl<'context> InlineFormattingContext<'context> {
                         item.content_baselines,
                     );
                 }
-                ItemType::BlockLevelBox => {
+                inline_level_iterator::ItemType::BlockLevelBox => {
                     leading_margin += item.margin_start;
                     leading_border += item.border_start;
                     leading_padding += item.padding_start;
@@ -1283,7 +1309,7 @@ impl<'context> InlineFormattingContext<'context> {
                         &mut line_builder,
                     );
                 }
-                ItemType::AbsolutelyPositionedElement => {
+                inline_level_iterator::ItemType::AbsolutelyPositionedElement => {
                     if !self.facts(item.node).is_box() {
                         continue;
                     }
@@ -1294,7 +1320,7 @@ impl<'context> InlineFormattingContext<'context> {
                     line_builder.append_static_position_marker(item.node, preceded);
                     absolute_boxes.push(item.node);
                 }
-                ItemType::FloatingElement => {
+                inline_level_iterator::ItemType::FloatingElement => {
                     line_builder.commit_pending_margin_before_float();
                     self.create_used_values(item.node, self.input.containing_block_constraints);
                     self.clear_floating_boxes(item.node);
@@ -1309,7 +1335,7 @@ impl<'context> InlineFormattingContext<'context> {
                         Some(&mut line_builder),
                     );
                 }
-                ItemType::Text => {
+                inline_level_iterator::ItemType::Text => {
                     line_builder.prepare_to_append_inline_content();
                     if self.style(self.parent_node(item.node)).text_wrap_mode() == text_wrap_mode::WRAP {
                         let is_whitespace = item.is_collapsible_whitespace || item.is_ascii_whitespace(self);
@@ -1325,7 +1351,11 @@ impl<'context> InlineFormattingContext<'context> {
                             line_builder.set_trailing_whitespace_on_previous_line();
                             continue;
                         }
-                        let line_is_empty = self.line_data().line_boxes.last().is_some_and(LineBoxData::is_empty);
+                        let line_is_empty = self
+                            .line_data()
+                            .line_boxes
+                            .last()
+                            .is_some_and(line_box::LineBoxData::is_empty);
                         if !is_whitespace && (item.can_break_before || line_is_empty) {
                             line_builder.break_if_needed(item.border_box_inline_size());
                         }
@@ -1379,11 +1409,11 @@ impl<'context> InlineFormattingContext<'context> {
                     continue;
                 }
                 let (x, y) = fragment.offset();
-                crate::layout::place_child(
+                formatting_context::place_child(
                     self.run,
                     fragment.layout_node,
                     FfiCssPixelPoint { x, y },
-                    Some(LineBoxFragmentCoordinate {
+                    Some(used_values::LineBoxFragmentCoordinate {
                         line_box_index: line_index,
                         fragment_index,
                     }),
@@ -1393,7 +1423,7 @@ impl<'context> InlineFormattingContext<'context> {
 
         if self.layout_mode == LayoutMode::Normal {
             for box_ in absolute_boxes {
-                let mut static_position = StaticPositionRect {
+                let mut static_position = abspos_inputs::StaticPositionRect {
                     rect: Default::default(),
                     inline_alignment: StaticPositionAlignment::Start,
                     block_alignment: StaticPositionAlignment::Start,
@@ -1404,7 +1434,10 @@ impl<'context> InlineFormattingContext<'context> {
                         if marker.box_ != box_ {
                             continue;
                         }
-                        if self.facts(box_).display_before_box_type_transformation_is_block_outside() {
+                        if self
+                            .facts(box_)
+                            .display_before_box_type_transformation_is_block_outside()
+                        {
                             let block_position = if marker.preceded_by_in_flow_content {
                                 line.physical_vertical_end()
                             } else {
@@ -1425,7 +1458,7 @@ impl<'context> InlineFormattingContext<'context> {
                         break 'lines;
                     }
                 }
-                crate::layout::register_contained_abspos_child(
+                formatting_context::register_contained_abspos_child(
                     &self.callbacks,
                     self.run.fragments.as_deref(),
                     self.containing_block,
@@ -1451,7 +1484,7 @@ impl<'context> InlineFormattingContext<'context> {
             if lines.iter().any(|line| line.has_block_level_box) {
                 lines
                     .last()
-                    .map_or(CssPixels::default(), LineBoxData::physical_vertical_end)
+                    .map_or(CssPixels::default(), line_box::LineBoxData::physical_vertical_end)
             } else {
                 lines
                     .iter()
@@ -1461,14 +1494,12 @@ impl<'context> InlineFormattingContext<'context> {
         self.automatic_content_inline_size = self
             .parent
             .greatest_child_inline_size_including_floats(self.containing_block);
-        let baselines = crate::layout::derive_baselines(&self.run.records, &self.callbacks, self.containing_block, false);
+        let baselines =
+            formatting_context::derive_baselines(&self.run.records, &self.callbacks, self.containing_block, false);
         if self.containing_block == self.parent.root_box() {
             self.parent.record_derived_baselines_of_root_box(baselines);
         } else {
-            crate::layout::store_derived_baselines(
-                &self.used(self.containing_block),
-                baselines,
-            );
+            formatting_context::store_derived_baselines(&self.used(self.containing_block), baselines);
         }
     }
 
@@ -1486,7 +1517,11 @@ impl<'context> InlineFormattingContext<'context> {
             rect.x += relative_inset_chain.offset_x;
             rect.y += relative_inset_chain.offset_y;
             if let Some(fragments) = self.run.fragments.as_deref() {
-                fragments.register_inline_containing_block_rect(candidate.inline_containing_block, rect, self.containing_block);
+                fragments.register_inline_containing_block_rect(
+                    candidate.inline_containing_block,
+                    rect,
+                    self.containing_block,
+                );
             }
         }
     }
@@ -1533,11 +1568,11 @@ impl<'context> InlineFormattingContext<'context> {
 
 impl EllipsisFontProvider for InlineFormattingContext<'_> {
     fn font_glyph_width(&self, font: *const c_void, code_point: u32) -> f32 {
-        font_glyph_width(font, code_point)
+        font::font_glyph_width(font, code_point)
     }
 
     fn font_glyph_id(&self, font: *const c_void, code_point: u32) -> u32 {
-        font_glyph_id(font, code_point)
+        font::font_glyph_id(font, code_point)
     }
 }
 
@@ -1547,7 +1582,7 @@ pub(crate) struct SpaceUsedByFloats {
     pub right: CssPixels,
 }
 
-pub(crate) fn line_physical_horizontal_extent(line: &LineBoxData) -> CssPixels {
+pub(crate) fn line_physical_horizontal_extent(line: &line_box::LineBoxData) -> CssPixels {
     if line.has_block_level_box || line.writing_mode == writing_mode::HORIZONTAL_TB {
         return line.inline_length;
     }
@@ -1564,7 +1599,7 @@ pub(crate) fn line_physical_horizontal_extent(line: &LineBoxData) -> CssPixels {
     right - left
 }
 
-pub(crate) fn line_rect(line: &LineBoxData, content_inline_size: CssPixels) -> FfiCssPixelRect {
+pub(crate) fn line_rect(line: &line_box::LineBoxData, content_inline_size: CssPixels) -> FfiCssPixelRect {
     let Some(first) = line.fragments.first() else {
         return FfiCssPixelRect {
             x: CssPixels::default(),

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ItemType {
     Text,
@@ -18,7 +20,7 @@ pub(crate) enum ItemType {
 pub(crate) struct Item {
     pub(crate) type_: ItemType,
     pub(crate) node: Node,
-    pub(crate) glyphs: Option<GlyphData>,
+    pub(crate) glyphs: Option<line_box_fragment::GlyphData>,
     pub(crate) offset_in_node: usize,
     pub(crate) length_in_node: usize,
     pub(crate) inline_size: CssPixels,
@@ -33,7 +35,7 @@ pub(crate) struct Item {
     pub(crate) can_break_before: bool,
     pub(crate) preceded_by_unattached_inline_start_edges: bool,
     pub(crate) content_baselines: DerivedBaselines,
-    pub(crate) trailing_whitespace: TrailingWhitespace,
+    pub(crate) trailing_whitespace: line_box_fragment::TrailingWhitespace,
 }
 
 impl Item {
@@ -56,7 +58,7 @@ impl Item {
             can_break_before: false,
             preceded_by_unattached_inline_start_edges: false,
             content_baselines: DerivedBaselines::default(),
-            trailing_whitespace: TrailingWhitespace::default(),
+            trailing_whitespace: line_box_fragment::TrailingWhitespace::default(),
         }
     }
 
@@ -73,7 +75,7 @@ impl Item {
             || self.margin_end != CssPixels::default()
     }
 
-    pub(crate) fn is_ascii_whitespace(&self, context: &InlineFormattingContext<'_>) -> bool {
+    pub(crate) fn is_ascii_whitespace(&self, context: &inline_formatting_context::InlineFormattingContext<'_>) -> bool {
         assert_eq!(self.type_, ItemType::Text);
         let text = &context.callbacks.text_content(self.node).text;
         text[self.offset_in_node..self.offset_in_node + self.length_in_node]
@@ -81,7 +83,7 @@ impl Item {
             .all(|unit| *unit <= 0x7f && (*unit as u8).is_ascii_whitespace())
     }
 
-    pub(crate) fn contains_tab(&self, context: &InlineFormattingContext<'_>) -> bool {
+    pub(crate) fn contains_tab(&self, context: &inline_formatting_context::InlineFormattingContext<'_>) -> bool {
         assert_eq!(self.type_, ItemType::Text);
         let text = &context.callbacks.text_content(self.node).text;
         text[self.offset_in_node..self.offset_in_node + self.length_in_node].contains(&(b'\t' as u16))
@@ -97,7 +99,7 @@ struct ExtraBoxMetrics {
 
 #[derive(Clone, Copy)]
 struct TextNodeContext {
-    chunks: &'static [TextChunk],
+    chunks: &'static [text_chunker::TextChunk],
     text: &'static [u16],
     next_chunk_index: usize,
     should_collapse_whitespace: bool,
@@ -106,7 +108,7 @@ struct TextNodeContext {
 }
 
 struct InlineLevelIteratorGenerator<'iterator, 'context> {
-    context: &'iterator mut InlineFormattingContext<'context>,
+    context: &'iterator mut inline_formatting_context::InlineFormattingContext<'context>,
     current_node: Node,
     next_node: Node,
     text_node_context: Option<TextNodeContext>,
@@ -122,7 +124,9 @@ struct InlineLevelIteratorGenerator<'iterator, 'context> {
 }
 
 impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
-    fn generate(context: &'iterator mut InlineFormattingContext<'context>) -> InlineLevelIterator {
+    fn generate(
+        context: &'iterator mut inline_formatting_context::InlineFormattingContext<'context>,
+    ) -> InlineLevelIterator {
         let containing_block = context.containing_block;
         let next_node = context.first_child(containing_block);
         let mut iterator = Self {
@@ -150,11 +154,11 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         }
     }
 
-    fn context(&self) -> &InlineFormattingContext<'context> {
+    fn context(&self) -> &inline_formatting_context::InlineFormattingContext<'context> {
         self.context
     }
 
-    fn context_mut(&mut self) -> &mut InlineFormattingContext<'context> {
+    fn context_mut(&mut self) -> &mut inline_formatting_context::InlineFormattingContext<'context> {
         self.context
     }
 
@@ -235,7 +239,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         leading.padding += used.padding_left.get();
         self.context().compute_inset(node);
         if self.context().run.fragments.is_some() {
-            crate::layout::place_child(self.context().run, node, FfiCssPixelPoint::default(), None);
+            formatting_context::place_child(self.context().run, node, FfiCssPixelPoint::default(), None);
         }
         self.box_model_node_stack.push(node);
     }
@@ -337,7 +341,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
             white_space_collapse::COLLAPSE | white_space_collapse::PRESERVE_BREAKS
         );
         let callbacks = self.context().callbacks;
-        let chunks = text_chunks(
+        let chunks = text_chunker::text_chunks(
             &callbacks,
             text_node,
             should_wrap_lines,
@@ -356,24 +360,26 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
 
     fn resolve_text_direction_from_context(&self) -> u8 {
         let context = self.text_node_context.unwrap();
-        let next_known_direction = context.chunks[context.next_chunk_index..]
-            .iter()
-            .find_map(|chunk| {
-                matches!(chunk.text_type, GLYPH_TEXT_TYPE_LTR | GLYPH_TEXT_TYPE_RTL).then_some(chunk.text_type)
-            });
+        let next_known_direction = context.chunks[context.next_chunk_index..].iter().find_map(|chunk| {
+            matches!(
+                chunk.text_type,
+                line_box_fragment::GLYPH_TEXT_TYPE_LTR | line_box_fragment::GLYPH_TEXT_TYPE_RTL
+            )
+            .then_some(chunk.text_type)
+        });
         if let (Some(last), Some(next)) = (context.last_known_direction, next_known_direction)
             && last != next
         {
             return match self.context().style(self.context().containing_block).direction() {
-                direction::LTR => GLYPH_TEXT_TYPE_LTR,
-                direction::RTL => GLYPH_TEXT_TYPE_RTL,
+                direction::LTR => line_box_fragment::GLYPH_TEXT_TYPE_LTR,
+                direction::RTL => line_box_fragment::GLYPH_TEXT_TYPE_RTL,
                 _ => unreachable!(),
             };
         }
         context
             .last_known_direction
             .or(next_known_direction)
-            .unwrap_or(GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT)
+            .unwrap_or(line_box_fragment::GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT)
     }
 
     fn shape_text(
@@ -384,15 +390,15 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         baseline_start_x: f32,
         letter_spacing: f32,
         word_spacing: f32,
-    ) -> (GlyphData, TrailingWhitespace) {
-        let shaped = shape_text_with_font(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
-        let glyph_data = GlyphData {
+    ) -> (line_box_fragment::GlyphData, line_box_fragment::TrailingWhitespace) {
+        let shaped = font::shape_text_with_font(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
+        let glyph_data = line_box_fragment::GlyphData {
             glyphs: shaped.glyphs,
             font,
             text_type,
             width: shaped.width,
         };
-        let trailing_whitespace = TrailingWhitespace {
+        let trailing_whitespace = line_box_fragment::TrailingWhitespace {
             length_in_code_units: shaped.trailing_whitespace_length_in_code_units,
             inline_size: CssPixels::nearest_value_for_f32(shaped.trailing_whitespace_advance),
         };
@@ -439,7 +445,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         } else if synthesize_zero_length_chunk {
             text_context.next_chunk_index = 1;
             let parent_style = self.context().style(self.context().parent_node(text_node));
-            TextChunk {
+            text_chunker::TextChunk {
                 start: 0,
                 length: 0,
                 font: parent_style.first_available_font(),
@@ -447,7 +453,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
                 has_breaking_tab: false,
                 is_all_whitespace: true,
                 can_break_after: false,
-                text_type: GLYPH_TEXT_TYPE_COMMON,
+                text_type: line_box_fragment::GLYPH_TEXT_TYPE_COMMON,
             }
         } else {
             self.text_node_context = None;
@@ -457,17 +463,20 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         };
 
         let mut text_type = chunk.text_type;
-        if matches!(text_type, GLYPH_TEXT_TYPE_LTR | GLYPH_TEXT_TYPE_RTL) {
+        if matches!(
+            text_type,
+            line_box_fragment::GLYPH_TEXT_TYPE_LTR | line_box_fragment::GLYPH_TEXT_TYPE_RTL
+        ) {
             text_context.last_known_direction = Some(text_type);
         }
         if text_context.should_respect_linebreaks && chunk.has_breaking_newline {
             is_last_chunk = true;
             if chunk.is_all_whitespace {
-                text_type = GLYPH_TEXT_TYPE_END_PADDING;
+                text_type = line_box_fragment::GLYPH_TEXT_TYPE_END_PADDING;
             }
         }
         self.text_node_context = Some(text_context);
-        if text_type == GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT {
+        if text_type == line_box_fragment::GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT {
             text_type = self.resolve_text_direction_from_context();
         }
         if text_context.should_respect_linebreaks && chunk.has_breaking_newline {
@@ -482,7 +491,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         let word_spacing = style.word_spacing();
         if chunk.has_breaking_tab {
             let tab_inline_size = if style.tab_size_is_number() {
-                let space = font_glyph_width(chunk.font, b' ' as u32);
+                let space = font::font_glyph_width(chunk.font, b' ' as u32);
                 CssPixels::nearest_value_for(
                     style.tab_size_number()
                         * (space + word_spacing.to_double() as f32 + style.letter_spacing().to_double() as f32) as f64,
@@ -496,7 +505,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
             } else {
                 tab_inline_size
             };
-            let zero_width = font_glyph_width(chunk.font, b'0' as u32);
+            let zero_width = font::font_glyph_width(chunk.font, b'0' as u32);
             if tab_stop_distance.to_double() < f64::from(zero_width) * 0.5 {
                 tab_stop_distance += tab_inline_size;
             }
@@ -527,7 +536,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
         item.length_in_node = chunk.length;
         item.inline_size = chunk_inline_size;
         item.trailing_whitespace = if chunk.is_all_whitespace {
-            TrailingWhitespace {
+            line_box_fragment::TrailingWhitespace {
                 length_in_code_units: chunk.length,
                 inline_size: chunk_inline_size,
             }
@@ -624,7 +633,7 @@ pub(crate) struct InlineLevelIterator {
 }
 
 impl InlineLevelIterator {
-    pub(crate) fn new(context: &mut InlineFormattingContext<'_>) -> Self {
+    pub(crate) fn new(context: &mut inline_formatting_context::InlineFormattingContext<'_>) -> Self {
         InlineLevelIteratorGenerator::generate(context)
     }
 
@@ -651,7 +660,7 @@ impl InlineLevelIterator {
 
     pub(crate) fn next_non_whitespace_sequence_inline_size(
         &self,
-        context: &InlineFormattingContext<'_>,
+        context: &inline_formatting_context::InlineFormattingContext<'_>,
     ) -> CssPixels {
         let mut size = CssPixels::default();
         for item in &self.items[self.next_item_index..] {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::abspos_inputs::AbsposLayoutInputs;
+use super::formatting_context::DerivedBaselines;
+use super::formatting_context::LayoutMode;
+use super::geometry::AvailableSize;
+use super::geometry::AvailableSpace;
+use super::used_values::SizeConstraint;
+use super::used_values::UsedValues;
 use crate::abort_on_panic;
-use crate::layout::AbsposLayoutInputs;
-use crate::layout::AvailableSize;
-use crate::layout::AvailableSpace;
 use crate::layout::CssPixels;
-use crate::layout::DerivedBaselines;
 use crate::layout::FfiReplacedContentFacts;
-use crate::layout::LayoutMode;
-use crate::layout::SizeConstraint;
-use crate::layout::UsedValues;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
@@ -329,13 +329,13 @@ pub(crate) struct TextContent {
     pub(crate) untransformed_text_is_ascii_whitespace: bool,
     pub(crate) may_require_bidi_processing: bool,
     pub(crate) dom_start_offset: usize,
-    grapheme_segmenter: std::cell::OnceCell<crate::layout::GraphemeSegmenter>,
+    grapheme_segmenter: std::cell::OnceCell<super::text_chunker::GraphemeSegmenter>,
 }
 
 impl TextContent {
-    pub(crate) fn grapheme_segmenter(&self) -> &crate::layout::GraphemeSegmenter {
+    pub(crate) fn grapheme_segmenter(&self) -> &super::text_chunker::GraphemeSegmenter {
         self.grapheme_segmenter
-            .get_or_init(|| crate::layout::GraphemeSegmenter::new(&self.text))
+            .get_or_init(|| super::text_chunker::GraphemeSegmenter::new(&self.text))
     }
 }
 
@@ -365,7 +365,7 @@ pub(crate) struct TextChunkCacheKey {
 struct TextChunkCacheEntry {
     key: TextChunkCacheKey,
     _retained_font_cascade_list: libgfx_rust::font::RetainedFontCascadeList,
-    chunks: Vec<crate::layout::TextChunk>,
+    chunks: Vec<super::text_chunker::TextChunk>,
 }
 
 #[derive(Default)]
@@ -441,7 +441,7 @@ pub(crate) struct LayoutNodeArena {
     raw_table_column_spans: HashMap<NodeSlotId, u32>,
     run_used_records: RefCell<Vec<RunRecordSlot>>,
     next_run_nonce: Cell<u64>,
-    fc_run_cache_store: crate::layout::FcRunCacheArenaStore,
+    fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore,
     pub(crate) paintable_rows: crate::painting::paintable_rows::PaintableRowStore,
     paint_state: RefCell<crate::painting::paint_state::PaintState>,
     svg_pattern_referencing_nodes: RefCell<Vec<NodeSlotId>>,
@@ -467,7 +467,7 @@ impl LayoutNodeArena {
             raw_table_column_spans: HashMap::new(),
             run_used_records: RefCell::new(Vec::new()),
             next_run_nonce: Cell::new(1),
-            fc_run_cache_store: crate::layout::FcRunCacheArenaStore::default(),
+            fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore::default(),
             paintable_rows: crate::painting::paintable_rows::PaintableRowStore::default(),
             paint_state: RefCell::new(crate::painting::paint_state::PaintState::default()),
             svg_pattern_referencing_nodes: RefCell::new(Vec::new()),
@@ -500,7 +500,7 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn fc_run_cache_store(&self) -> &crate::layout::FcRunCacheArenaStore {
+    pub(crate) fn fc_run_cache_store(&self) -> &super::fc_run_cache::FcRunCacheArenaStore {
         &self.fc_run_cache_store
     }
 
@@ -776,7 +776,7 @@ impl LayoutNodeArena {
     fn node_is_capable_of_forming_a_containing_block(&self, id: NodeSlotId) -> bool {
         // SAFETY: data() validated that id names a live slot.
         let data = unsafe { &*self.data(id) };
-        if crate::layout::kind_is_block_container(data.kind)
+        if super::node_facts::kind_is_block_container(data.kind)
             && !crate::painting::fragment_ownership::node_is_fragmented_inline(self, id)
         {
             return true;
@@ -787,7 +787,7 @@ impl LayoutNodeArena {
                 return true;
             }
         }
-        crate::layout::kind_is_replaced_box(data.kind) && crate::layout::node_can_have_children(data)
+        super::node_facts::kind_is_replaced_box(data.kind) && super::node_facts::node_can_have_children(data)
     }
 
     fn nearest_ancestor_capable_of_forming_a_containing_block(&self, node: NodeSlotId) -> NodeSlotId {
@@ -820,7 +820,7 @@ impl LayoutNodeArena {
 
         // SAFETY: As above.
         let kind = unsafe { (&raw const (*data).kind).read() };
-        if crate::layout::kind_is_text(kind) {
+        if super::node_facts::kind_is_text(kind) {
             let containing_block = self.nearest_ancestor_capable_of_forming_a_containing_block(node);
             // SAFETY: As above.
             unsafe { (&raw mut (*data).containing_block).write(containing_block) };
@@ -890,7 +890,7 @@ impl LayoutNodeArena {
         let data = self.data(node);
         // SAFETY: data() validated that node names a live slot.
         let kind = unsafe { (&raw const (*data).kind).read() };
-        if !crate::layout::kind_is_box(kind) {
+        if !super::node_facts::kind_is_box(kind) {
             return;
         }
         self.set_node_flag(node, NodeFlag::AbsposDescendantEscapes, false);
@@ -906,7 +906,7 @@ impl LayoutNodeArena {
         while !ancestor.is_invalid() && ancestor != containing_block {
             // SAFETY: As above.
             let ancestor_kind = unsafe { (&raw const (*self.data(ancestor)).kind).read() };
-            if crate::layout::kind_is_box(ancestor_kind) {
+            if super::node_facts::kind_is_box(ancestor_kind) {
                 self.set_node_flag(ancestor, NodeFlag::AbsposDescendantEscapes, true);
             }
             // SAFETY: As above.
@@ -1313,7 +1313,7 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<crate::layout::FragmentLink> {
+    pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<super::fragment_tree::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
         let link = self
             .paintable_rows
@@ -1330,7 +1330,7 @@ impl LayoutNodeArena {
         link
     }
 
-    pub(crate) fn set_committed_fragment_link(&self, data: *mut NodeData, link: crate::layout::FragmentLink) {
+    pub(crate) fn set_committed_fragment_link(&self, data: *mut NodeData, link: super::fragment_tree::FragmentLink) {
         let (index, metadata) = self.slot_for_data(data);
         self.paintable_rows
             .set_committed_fragment_link(index, metadata.generation, link);
@@ -1344,7 +1344,10 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn take_committed_fragment_link(&self, data: *mut NodeData) -> Option<crate::layout::FragmentLink> {
+    pub(crate) fn take_committed_fragment_link(
+        &self,
+        data: *mut NodeData,
+    ) -> Option<super::fragment_tree::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
         let link = self
             .paintable_rows
@@ -1480,8 +1483,8 @@ impl LayoutNodeArena {
         &self,
         id: NodeSlotId,
         key: TextChunkCacheKey,
-        compute: impl FnOnce() -> Vec<crate::layout::TextChunk>,
-    ) -> &'static [crate::layout::TextChunk] {
+        compute: impl FnOnce() -> Vec<super::text_chunker::TextChunk>,
+    ) -> &'static [super::text_chunker::TextChunk] {
         // data() validates that id names a live slot with a matching generation.
         self.data(id);
         let index = id.slot_index() as usize;
@@ -1587,7 +1590,7 @@ impl LayoutNodeArena {
     // into a fail-safe miss.
     fn invalidate_at_and_above(&self, mut node: NodeSlotId, invalidation: AncestorInvalidation) {
         let epochs_enabled =
-            crate::layout::fc_run_cache_mode_from_environment() != crate::layout::FcRunCacheMode::Disabled;
+            super::fc_run_cache::fc_run_cache_mode_from_environment() != super::fc_run_cache::FcRunCacheMode::Disabled;
         let paintable_rows = self.paintable_rows();
         while !node.is_invalid() {
             let data = self.data(node);
@@ -1603,7 +1606,7 @@ impl LayoutNodeArena {
                 }
                 ((&raw const (*data).kind).read(), (&raw const (*data).parent).read())
             };
-            if crate::layout::kind_is_box(kind) {
+            if super::node_facts::kind_is_box(kind) {
                 paintable_rows.clear_cached_overflow_data(node);
             }
             node = parent;
@@ -1820,7 +1823,7 @@ impl LayoutNodeArena {
 
     pub(crate) fn node_is_out_of_flow_if_live(&self, id: NodeSlotId) -> bool {
         self.node_data_if_live(id)
-            .is_some_and(|data| crate::layout::node_is_out_of_flow(data, self.node_style_if_live(id)))
+            .is_some_and(|data| super::node_facts::node_is_out_of_flow(data, self.node_style_if_live(id)))
     }
 
     pub(crate) fn node_containing_block_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
@@ -1872,7 +1875,7 @@ impl LayoutNodeArena {
         boundary: RenderedTextBoundary,
     ) -> usize {
         let shell = self.shell_if_live(id);
-        if shell.is_null() || !self.node_kind_if_live(id).is_some_and(crate::layout::kind_is_text) {
+        if shell.is_null() || !self.node_kind_if_live(id).is_some_and(super::node_facts::kind_is_text) {
             return offset;
         }
         // SAFETY: shell_if_live() returned the live C++ TextNode corresponding to this text layout node.
@@ -1892,7 +1895,7 @@ impl LayoutNodeArena {
         boundary: RenderedTextBoundary,
     ) -> usize {
         let shell = self.shell_if_live(id);
-        if shell.is_null() || !self.node_kind_if_live(id).is_some_and(crate::layout::kind_is_text) {
+        if shell.is_null() || !self.node_kind_if_live(id).is_some_and(super::node_facts::kind_is_text) {
             return offset;
         }
         // SAFETY: shell_if_live() returned the live C++ TextNode corresponding to this text layout node.
@@ -1995,7 +1998,7 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, g
 
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_fc_run_cache_epochs_enabled() -> bool {
-    crate::layout::fc_run_cache_mode_from_environment() != crate::layout::FcRunCacheMode::Disabled
+    super::fc_run_cache::fc_run_cache_mode_from_environment() != super::fc_run_cache::FcRunCacheMode::Disabled
 }
 
 #[unsafe(no_mangle)]
@@ -2212,13 +2215,11 @@ mod tests {
         IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
     };
     use crate::layout::node_data::{NodeFlag, NodeSlotId};
-    use crate::layout::{
-        AvailableSize, AvailableSpace, CssPixels, DerivedBaselines, Fragment, FragmentLink, LayoutMode, SizeConstraint,
-    };
+    use crate::layout::{CssPixels, fragment_tree, used_values};
 
-    fn test_fragment_link(node: NodeSlotId) -> FragmentLink {
-        FragmentLink {
-            fragment: std::rc::Rc::new(Fragment {
+    fn test_fragment_link(node: NodeSlotId) -> fragment_tree::FragmentLink {
+        fragment_tree::FragmentLink {
+            fragment: std::rc::Rc::new(fragment_tree::Fragment {
                 identity: 1,
                 node,
                 content_inline_size: CssPixels::default(),
@@ -2423,7 +2424,7 @@ mod tests {
         let inline_measurement = IntrinsicInlineSizeMeasurement {
             automatic_content_inline_size: CssPixels::from_raw(192),
             min_content_inline_size_from_max_content_layout: Some(CssPixels::from_raw(96)),
-            available_block_size: AvailableSize::MaxContent,
+            available_block_size: crate::layout::layout_node_arena::AvailableSize::MaxContent,
             content_inline_size: CssPixels::from_raw(192),
             content_block_size: CssPixels::from_raw(256),
             automatic_content_block_size: CssPixels::from_raw(320),
@@ -2616,23 +2617,23 @@ mod tests {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate();
         let key = TableCellMeasurementKey {
-            layout_mode: LayoutMode::Normal,
-            available_space: AvailableSpace {
-                inline_size: AvailableSize::definite(CssPixels::from_raw(640)),
-                block_size: AvailableSize::Indefinite,
+            layout_mode: crate::layout::layout_node_arena::LayoutMode::Normal,
+            available_space: crate::layout::layout_node_arena::AvailableSpace {
+                inline_size: crate::layout::layout_node_arena::AvailableSize::definite(CssPixels::from_raw(640)),
+                block_size: crate::layout::layout_node_arena::AvailableSize::Indefinite,
             },
             content_inline_size: CssPixels::from_raw(640),
             content_block_size: CssPixels::default(),
             has_definite_inline_size: true,
             has_definite_block_size: false,
-            inline_size_constraint: SizeConstraint::None,
-            block_size_constraint: SizeConstraint::None,
+            inline_size_constraint: used_values::SizeConstraint::None,
+            block_size_constraint: used_values::SizeConstraint::None,
             uses_collapsing_borders_model: true,
             adopt_automatic_content_block_size: true,
         };
         let value = TableCellMeasurement {
             automatic_content_block_size: CssPixels::from_raw(320),
-            baselines: DerivedBaselines {
+            baselines: crate::layout::layout_node_arena::DerivedBaselines {
                 first: Some(CssPixels::from_raw(64)),
                 last: None,
             },

--- a/Libraries/LibWeb/Rust/src/layout/line_box.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_box.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct StaticPositionMarker {
     pub(crate) box_: Node,
@@ -15,7 +17,7 @@ pub(crate) struct StaticPositionMarker {
 
 impl StaticPositionMarker {
     pub(crate) fn offset(self) -> (CssPixels, CssPixels) {
-        to_physical(self.writing_mode, self.inline_offset, self.block_offset)
+        geometry::to_physical(self.writing_mode, self.inline_offset, self.block_offset)
     }
 }
 
@@ -28,7 +30,7 @@ pub(crate) struct InlineBoxBaseline {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct LineBoxData {
-    pub(crate) fragments: Vec<LineBoxFragmentData>,
+    pub(crate) fragments: Vec<line_box_fragment::LineBoxFragmentData>,
     pub(crate) static_position_markers: Vec<StaticPositionMarker>,
     pub(crate) inline_box_baselines: Vec<InlineBoxBaseline>,
     pub(crate) inline_length: CssPixels,
@@ -67,15 +69,15 @@ impl LineBoxData {
     }
 
     pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
-        to_physical(self.writing_mode, self.inline_length, self.block_length).0
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
     }
 
     pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
-        to_physical(self.writing_mode, self.inline_length, self.block_length).1
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
     }
 
     pub(crate) fn physical_vertical_end(&self) -> CssPixels {
-        to_physical(self.writing_mode, self.inline_length, self.block_end).1
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_end).1
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -92,10 +94,10 @@ impl LineBoxData {
         content_block_size: CssPixels,
         border_box_block_start: CssPixels,
         border_box_block_end: CssPixels,
-        glyphs: Option<GlyphData>,
-        facts: FragmentBuildFacts,
+        glyphs: Option<line_box_fragment::GlyphData>,
+        facts: line_box_fragment::FragmentBuildFacts,
         text_align_is_justify: bool,
-        trailing_whitespace: TrailingWhitespace,
+        trailing_whitespace: line_box_fragment::TrailingWhitespace,
     ) {
         let can_merge = glyphs.as_ref().is_some_and(|glyphs| {
             !text_align_is_justify
@@ -120,7 +122,7 @@ impl LineBoxData {
             }
         } else {
             let inline_offset = leading_margin + leading_size + self.inline_length;
-            let mut fragment = LineBoxFragmentData::new(
+            let mut fragment = line_box_fragment::LineBoxFragmentData::new(
                 layout_node,
                 start,
                 length,
@@ -153,7 +155,12 @@ impl LineBoxData {
         });
     }
 
-    pub(crate) fn set_inline_box_baseline(&mut self, box_: Node, baseline: CssPixels, accumulated_vertical_shift: CssPixels) -> bool {
+    pub(crate) fn set_inline_box_baseline(
+        &mut self,
+        box_: Node,
+        baseline: CssPixels,
+        accumulated_vertical_shift: CssPixels,
+    ) -> bool {
         if self.inline_box_baselines.iter().any(|entry| entry.box_ == box_) {
             return false;
         }
@@ -166,7 +173,10 @@ impl LineBoxData {
     }
 
     pub(crate) fn inline_box_baseline(&self, box_: Node) -> Option<InlineBoxBaseline> {
-        self.inline_box_baselines.iter().find(|entry| entry.box_ == box_).copied()
+        self.inline_box_baselines
+            .iter()
+            .find(|entry| entry.box_ == box_)
+            .copied()
     }
 
     pub(crate) fn clamp_static_position_markers_to_inline_length(&mut self) {
@@ -223,7 +233,7 @@ impl LineBoxData {
             let fragment = &mut self.fragments[last_fragment_index];
             fragment.length_in_code_units -= fragment_trailing_whitespace.length_in_code_units;
             fragment.inline_length -= fragment_trailing_whitespace.inline_size;
-            fragment.trailing_whitespace = TrailingWhitespace::default();
+            fragment.trailing_whitespace = line_box_fragment::TrailingWhitespace::default();
             self.inline_length -= fragment_trailing_whitespace.inline_size;
             self.clamp_static_position_markers_to_inline_length();
         }
@@ -249,7 +259,7 @@ impl LineBoxData {
     pub(crate) fn is_empty_or_ends_in_whitespace(&self) -> bool {
         self.fragments
             .last()
-            .is_none_or(LineBoxFragmentData::ends_in_whitespace)
+            .is_none_or(line_box_fragment::LineBoxFragmentData::ends_in_whitespace)
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) const GLYPH_TEXT_TYPE_COMMON: u8 = 0;
 pub(crate) const GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT: u8 = 1;
 pub(crate) const GLYPH_TEXT_TYPE_END_PADDING: u8 = 2;
@@ -16,7 +18,7 @@ pub(crate) fn is_ascii_space(code_unit: u16) -> bool {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct GlyphData {
-    pub(crate) glyphs: Vec<FfiDrawGlyph>,
+    pub(crate) glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
     pub(crate) font: *const c_void,
     pub(crate) text_type: u8,
     // GlyphRun::width is not updated by the C++ fragment merge machine.
@@ -122,19 +124,19 @@ impl LineBoxFragmentData {
     }
 
     pub(crate) fn offset(&self) -> (CssPixels, CssPixels) {
-        to_physical(self.writing_mode, self.inline_offset, self.block_offset)
+        geometry::to_physical(self.writing_mode, self.inline_offset, self.block_offset)
     }
 
     pub(crate) fn size(&self) -> (CssPixels, CssPixels) {
-        to_physical(self.writing_mode, self.inline_length, self.block_length)
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length)
     }
 
     pub(crate) fn physical_horizontal_extent(&self) -> CssPixels {
-        to_physical(self.writing_mode, self.inline_length, self.block_length).0
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).0
     }
 
     pub(crate) fn physical_vertical_extent(&self) -> CssPixels {
-        to_physical(self.writing_mode, self.inline_length, self.block_length).1
+        geometry::to_physical(self.writing_mode, self.inline_length, self.block_length).1
     }
 
     pub(crate) fn text(&self) -> &[u16] {

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ForcedBreak {
     No,
@@ -48,7 +50,7 @@ struct LineRelativeAlignedSubtree {
 }
 
 pub(crate) struct LineBuilder<'builder, 'context> {
-    context: &'builder InlineFormattingContext<'context>,
+    context: &'builder inline_formatting_context::InlineFormattingContext<'context>,
     available_inline_size_for_current_line: AvailableSize,
     current_block_offset: CssPixels,
     max_block_size_on_current_line: CssPixels,
@@ -65,13 +67,13 @@ pub(crate) struct LineBuilder<'builder, 'context> {
 }
 
 impl<'builder, 'context> LineBuilder<'builder, 'context> {
-    pub(crate) fn new(context: &'builder InlineFormattingContext<'context>) -> Self {
+    pub(crate) fn new(context: &'builder inline_formatting_context::InlineFormattingContext<'context>) -> Self {
         let mut builder = Self::initialized(context);
         builder.begin_new_line(false, true, ForcedBreak::No);
         builder
     }
 
-    fn initialized(context: &'builder InlineFormattingContext<'context>) -> Self {
+    fn initialized(context: &'builder inline_formatting_context::InlineFormattingContext<'context>) -> Self {
         let style = context.style(context.containing_block);
         let containing_inline_size = context.input.containing_block_constraints.inline_basis();
         Self {
@@ -92,7 +94,9 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         }
     }
 
-    pub(crate) fn new_after_reused_lines(context: &'builder InlineFormattingContext<'context>) -> Self {
+    pub(crate) fn new_after_reused_lines(
+        context: &'builder inline_formatting_context::InlineFormattingContext<'context>,
+    ) -> Self {
         assert!(!context.line_data().line_boxes.is_empty());
         let current_block_offset = context.line_data().line_boxes.last().unwrap().physical_vertical_end();
         let mut builder = Self::initialized(context);
@@ -100,13 +104,13 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         context
             .line_data_mut()
             .line_boxes
-            .push(LineBoxData::new(builder.direction, builder.writing_mode));
+            .push(line_box::LineBoxData::new(builder.direction, builder.writing_mode));
         builder.begin_new_line(false, true, ForcedBreak::No);
         builder.current_line_committed_pending_margin = true;
         builder
     }
 
-    fn context(&self) -> &InlineFormattingContext<'context> {
+    fn context(&self) -> &inline_formatting_context::InlineFormattingContext<'context> {
         self.context
     }
 
@@ -121,16 +125,16 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             self.context()
                 .line_data_mut()
                 .line_boxes
-                .push(LineBoxData::new(direction, writing_mode));
+                .push(line_box::LineBoxData::new(direction, writing_mode));
         }
         self.line_count() - 1
     }
 
-    fn line(&self, index: usize) -> Ref<'_, LineBoxData> {
+    fn line(&self, index: usize) -> Ref<'_, line_box::LineBoxData> {
         Ref::map(self.context().line_data(), |data| &data.line_boxes[index])
     }
 
-    fn line_mut(&self, index: usize) -> RefMut<'_, LineBoxData> {
+    fn line_mut(&self, index: usize) -> RefMut<'_, line_box::LineBoxData> {
         RefMut::map(self.context().line_data_mut(), |data| &mut data.line_boxes[index])
     }
 
@@ -138,7 +142,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         self.context().style(self.context().containing_block)
     }
 
-    fn fragment_facts(&self, node: Node) -> FragmentBuildFacts {
+    fn fragment_facts(&self, node: Node) -> line_box_fragment::FragmentBuildFacts {
         let style_source = self.context().style_source(node);
         let style = self.context().style(style_source);
         let facts = self.context().facts(node);
@@ -148,7 +152,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         } else {
             (std::ptr::null(), 0)
         };
-        FragmentBuildFacts {
+        line_box_fragment::FragmentBuildFacts {
             style_source,
             is_atomic_inline: facts.is_atomic_inline(),
             white_space_collapse: style.white_space_collapse(),
@@ -210,7 +214,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             self.context()
                 .line_data_mut()
                 .line_boxes
-                .push(LineBoxData::new(self.direction, self.writing_mode));
+                .push(line_box::LineBoxData::new(self.direction, self.writing_mode));
             self.begin_new_line(true, break_count == 0, forced);
             break_count += 1;
             let line_height = self.containing_style().line_height();
@@ -260,7 +264,8 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         let line_index = self.ensure_last_line_index();
         let fragment_index = self.line(line_index).fragments.len();
         let fragment_facts = self.fragment_facts(node);
-        let text_align_is_justify = self.context().style(fragment_facts.style_source).text_align() == text_align::JUSTIFY;
+        let text_align_is_justify =
+            self.context().style(fragment_facts.style_source).text_align() == text_align::JUSTIFY;
         self.line_mut(line_index).add_fragment(
             node,
             0,
@@ -276,7 +281,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             None,
             fragment_facts,
             text_align_is_justify,
-            TrailingWhitespace::default(),
+            line_box_fragment::TrailingWhitespace::default(),
         );
         self.line_mut(line_index).fragments[fragment_index].content_baselines = Some(content_baselines);
         self.max_block_size_on_current_line = self.max_block_size_on_current_line.max(margin_block_size);
@@ -294,8 +299,8 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         trailing_margin: CssPixels,
         content_inline_size: CssPixels,
         content_block_size: CssPixels,
-        glyphs: GlyphData,
-        trailing_whitespace: TrailingWhitespace,
+        glyphs: line_box_fragment::GlyphData,
+        trailing_whitespace: line_box_fragment::TrailingWhitespace,
     ) {
         self.prepare_to_append_inline_content();
         let line_index = self.ensure_last_line_index();
@@ -363,7 +368,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         self.context()
             .line_data_mut()
             .line_boxes
-            .push(LineBoxData::new(self.direction, self.writing_mode));
+            .push(line_box::LineBoxData::new(self.direction, self.writing_mode));
         self.begin_new_line(true, true, ForcedBreak::No);
     }
 
@@ -382,18 +387,18 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
     ) {
         let used = self.context().used(node);
         assert!(used.has_content_offset.get());
-        let (inline_offset, block_offset) = to_logical(
+        let (inline_offset, block_offset) = geometry::to_logical(
             self.writing_mode,
             used.content_offset.get().x,
             used.content_offset.get().y,
         );
-        let (inline_length, block_length) = to_logical(
+        let (inline_length, block_length) = geometry::to_logical(
             self.writing_mode,
             used.content_inline_size.get(),
             used.content_block_size.get(),
         );
         let border_start = used.border_box_top(false);
-        let line_inline_length = to_logical(
+        let line_inline_length = geometry::to_logical(
             self.writing_mode,
             used.margin_box_inline_size(false),
             used.margin_box_block_size(false),
@@ -402,7 +407,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         let ensured_line_index = self.ensure_last_line_index();
         assert_eq!(line_index, ensured_line_index);
         assert!(self.line(line_index).fragments.is_empty());
-        let fragment = LineBoxFragmentData::new(
+        let fragment = line_box_fragment::LineBoxFragmentData::new(
             node,
             0,
             0,
@@ -441,7 +446,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         self.context()
             .line_data_mut()
             .line_boxes
-            .push(LineBoxData::new(self.direction, self.writing_mode));
+            .push(line_box::LineBoxData::new(self.direction, self.writing_mode));
         self.begin_new_line(false, true, ForcedBreak::No);
     }
 
@@ -679,19 +684,19 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             let fragment_baseline = if self.context().facts(node).is_text_node() {
                 Self::baseline_for_style(style, style.line_height())
             } else if let Some(content_baselines) = content_baselines {
-                crate::layout::box_baseline_with_content_baselines(
+                formatting_context::box_baseline_with_content_baselines(
                     &self.context().callbacks,
                     node,
                     &self.context().used(node),
-                    crate::layout::BaselineSet::Last,
+                    formatting_context::BaselineSet::Last,
                     content_baselines,
                 )
             } else {
-                crate::layout::box_baseline(
+                formatting_context::box_baseline(
                     &self.context().callbacks,
                     node,
                     &self.context().used(node),
-                    crate::layout::BaselineSet::Last,
+                    formatting_context::BaselineSet::Last,
                 )
             };
             self.line_mut(line_index).fragments[fragment_index].baseline = fragment_baseline;
@@ -822,14 +827,17 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                 let ancestor_metrics = self.inline_box_alignment_metrics(ancestor);
                 let ancestor_parent_style = self.parent_style(ancestor);
                 let baseline_style = ancestor_style.with_vertical_align_keyword(vertical_align::BASELINE);
-                let ancestor_vertical_shift =
-                    self.block_offset_for_alignment(ancestor_style, ancestor_parent_style, ancestor_metrics, line_box_baseline)
-                        - self.block_offset_for_alignment(
-                            baseline_style,
-                            ancestor_parent_style,
-                            ancestor_metrics,
-                            line_box_baseline,
-                        );
+                let ancestor_vertical_shift = self.block_offset_for_alignment(
+                    ancestor_style,
+                    ancestor_parent_style,
+                    ancestor_metrics,
+                    line_box_baseline,
+                ) - self.block_offset_for_alignment(
+                    baseline_style,
+                    ancestor_parent_style,
+                    ancestor_metrics,
+                    line_box_baseline,
+                );
                 new_block_offset += ancestor_vertical_shift;
                 inline_box_alignments.push(InlineBoxAlignment {
                     box_: ancestor,
@@ -991,8 +999,11 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             // Static position markers are resolved against the inline box that contains them, so they move with that
             // box's aligned subtree.
             let box_ = self.line(line_index).static_position_markers[marker_index].box_;
-            let shift =
-                self.subtree_shift_for_box(self.context().parent_node(box_), &aligned_subtrees, normal_subtree_shift);
+            let shift = self.subtree_shift_for_box(
+                self.context().parent_node(box_),
+                &aligned_subtrees,
+                normal_subtree_shift,
+            );
             let mut line = self.line_mut(line_index);
             let marker = &mut line.static_position_markers[marker_index];
             marker.inline_offset += inline_offset;
@@ -1065,7 +1076,9 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
 
 // https://drafts.csswg.org/css2/#propdef-vertical-align
 fn line_relative_alignment(style: StyleValues) -> Option<u8> {
-    let keyword = style.vertical_align_is_keyword().then(|| style.vertical_align_keyword())?;
+    let keyword = style
+        .vertical_align_is_keyword()
+        .then(|| style.vertical_align_keyword())?;
     matches!(keyword, vertical_align::TOP | vertical_align::BOTTOM).then_some(keyword)
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-// The layout engine sources compose into one flat namespace: the files below
-// are include!d rather than declared as submodules, and the re-exports here
-// make the css-module types they use resolve without per-file imports.
 pub(crate) use crate::abort_on_panic;
 pub(crate) use crate::css::computed_value_types::*;
 pub(crate) use crate::css::computed_value_views::*;
@@ -14,38 +11,35 @@ pub(crate) use crate::css::css_enums::*;
 pub(crate) use crate::css::css_pixels::*;
 pub(crate) use crate::css::display::*;
 
-include!("node_facts.rs");
-include!("fragment_tree.rs");
-
-include!("formatting_context.rs");
-include!("commit.rs");
-include!("sizing_context.rs");
-include!("abspos_inputs.rs");
-include!("abspos_engine.rs");
-include!("block_formatting_context.rs");
-include!("flex_formatting_context.rs");
-include!("grid_formatting_context.rs");
-include!("svg_formatting_context.rs");
-include!("inline_level_iterator.rs");
-include!("line_box.rs");
-include!("line_box_fragment.rs");
-include!("line_builder.rs");
-include!("inline_formatting_context.rs");
-include!("font.rs");
-include!("text_chunker.rs");
-include!("replaced_with_children_formatting_context.rs");
-include!("table_formatting_context.rs");
-include!("geometry.rs");
-include!("fc_run_cache.rs");
+pub(crate) mod abspos_engine;
+pub(crate) mod abspos_inputs;
+pub(crate) mod block_formatting_context;
+pub mod commit;
+pub(crate) mod fc_run_cache;
+pub(crate) mod flex_formatting_context;
+pub(crate) mod font;
+pub mod formatting_context;
+pub(crate) mod fragment_tree;
+pub mod geometry;
+pub mod grid_formatting_context;
+pub(crate) mod inline_formatting_context;
+pub mod inline_level_iterator;
 mod layout_node_arena;
+pub(crate) mod line_box;
+pub(crate) mod line_box_fragment;
+pub(crate) mod line_builder;
 pub mod node_data;
-mod tree_mutation;
-include!("run_records.rs");
-include!("style_values.rs");
-
+pub(crate) mod node_facts;
+mod replaced_with_children_formatting_context;
+pub(crate) mod run_records;
+pub(crate) mod sizing_context;
+pub(crate) mod style_values;
+pub mod svg_formatting_context;
+pub mod table_formatting_context;
+pub(crate) mod text_chunker;
 mod tree_builder;
-
-include!("used_values.rs");
+mod tree_mutation;
+pub mod used_values;
 
 use crate::layout::layout_node_arena::IntrinsicBlockSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
@@ -60,6 +54,18 @@ use crate::layout::node_data::NodeFlag;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
 pub use crate::layout::node_data::STYLE_GROUP_COUNT;
+pub(crate) use abspos_inputs::{AbsposAlignment, StaticPositionAlignment};
+pub(crate) use formatting_context::{
+    ChildLayoutOutcome, DerivedBaselines, FfiLayoutFcCallbacks, FormattingContextRun, LayoutMode, Node, SizingAxis,
+    SizingProperty,
+};
+pub(crate) use fragment_tree::FragmentLink;
+pub(crate) use geometry::{
+    AvailableSize, AvailableSpace, ContainingBlockConstraints, LayoutInput, ParticipationInParentFormattingContext,
+    RootSizingDirectives,
+};
+pub(crate) use node_facts::NodeFacts;
+pub(crate) use run_records::RunRecords;
 use std::cell::Cell;
 use std::cell::OnceCell;
 use std::cell::Ref;
@@ -68,3 +74,5 @@ use std::cell::RefMut;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::c_void;
+pub(crate) use style_values::StyleValues;
+pub(crate) use used_values::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, SizeConstraint, UsedValues};

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) fn node_may_have_replaced_content_facts(data: &NodeData) -> bool {
     kind_is_replaced_box(data.kind)
         || matches!(
@@ -45,11 +47,14 @@ pub(crate) fn node_is_positioned(data: &NodeData, style: Option<ComputedValuesVi
     };
     let box_values = style.box_values();
     let is_flex_or_grid_item = has_flag(data, NodeFlag::IsFlexItem) || has_flag(data, NodeFlag::IsGridItem);
-    box_values.position != crate::css::css_enums::positioning::STATIC || (is_flex_or_grid_item && box_values.has_z_index)
+    box_values.position != crate::css::css_enums::positioning::STATIC
+        || (is_flex_or_grid_item && box_values.has_z_index)
 }
 
 pub(crate) fn node_position(style: Option<ComputedValuesView<'_>>) -> u8 {
-    style.map_or(crate::css::css_enums::positioning::STATIC, |style| style.box_values().position)
+    style.map_or(crate::css::css_enums::positioning::STATIC, |style| {
+        style.box_values().position
+    })
 }
 
 /// Flex items never float, whatever their computed float value says.
@@ -194,7 +199,6 @@ pub(crate) fn kind_is_svg_box(kind: NodeKind) -> bool {
     )
 }
 
-
 /// A pass-scoped lens over one node's facts. Pure classification reads the
 /// arena NodeData directly; style-derived answers read the per-slot style
 /// snapshot; content-derived answers read the kind-gated lazy fact stores.
@@ -211,7 +215,7 @@ impl<'pass> NodeFacts<'pass> {
         Self { callbacks, node }
     }
 
-    fn data(&self) -> &'pass NodeData {
+    pub(super) fn data(&self) -> &'pass NodeData {
         self.callbacks.node_data(self.node)
     }
 
@@ -220,15 +224,15 @@ impl<'pass> NodeFacts<'pass> {
         (!parent.is_invalid()).then(|| self.callbacks.node_data(parent))
     }
 
-    fn style(&self) -> StyleValues<'pass> {
+    pub(super) fn style(&self) -> StyleValues<'pass> {
         StyleValues::for_node(self.callbacks, self.node)
     }
 
-    fn computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
+    pub(super) fn computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
         self.callbacks.computed_values_view_if_styled(self.node)
     }
 
-    fn parent_computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
+    pub(super) fn parent_computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
         let parent = self.data().parent;
         if parent.is_invalid() {
             return None;
@@ -242,11 +246,11 @@ impl<'pass> NodeFacts<'pass> {
             // half of the enrollment predicate is debug-only because this
             // miss path is the steady state for ordinary boxes.
             assert!(
-                !crate::layout::node_may_have_replaced_content_facts(self.data()),
+                !node_may_have_replaced_content_facts(self.data()),
                 "replaced content facts were not synced to the arena before layout"
             );
             debug_assert!(
-                !crate::layout::node_may_have_replaced_content_facts_including_size_containment(self.data()),
+                !node_may_have_replaced_content_facts_including_size_containment(self.data()),
                 "replaced content facts were not synced to the arena before layout"
             );
             return crate::layout::FfiReplacedContentFacts::default();
@@ -255,7 +259,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_text_node(&self) -> bool {
-        crate::layout::kind_is_text(self.data().kind)
+        kind_is_text(self.data().kind)
     }
 
     pub(crate) fn is_break_node(&self) -> bool {
@@ -263,24 +267,25 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_box(&self) -> bool {
-        crate::layout::kind_is_box(self.data().kind)
+        kind_is_box(self.data().kind)
     }
 
     pub(crate) fn is_block_container(&self) -> bool {
-        crate::layout::kind_is_block_container(self.data().kind)
+        kind_is_block_container(self.data().kind)
     }
 
     pub(crate) fn is_replaced_box(&self) -> bool {
-        crate::layout::kind_is_replaced_box(self.data().kind)
+        kind_is_replaced_box(self.data().kind)
     }
 
     pub(crate) fn is_replaced_box_with_children(&self) -> bool {
         let data = self.data();
-        crate::layout::kind_is_replaced_box(data.kind) && crate::layout::node_can_have_children(data)
+        kind_is_replaced_box(data.kind) && node_can_have_children(data)
     }
 
     pub(crate) fn is_floating(&self) -> bool {
-        self.computed_values_view_if_styled().is_some_and(|style| style.is_floating())
+        self.computed_values_view_if_styled()
+            .is_some_and(|style| style.is_floating())
     }
 
     pub(crate) fn is_absolutely_positioned(&self) -> bool {
@@ -294,7 +299,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_in_flow(&self) -> bool {
-        !crate::layout::node_is_out_of_flow(self.data(), self.computed_values_view_if_styled())
+        !node_is_out_of_flow(self.data(), self.computed_values_view_if_styled())
     }
 
     pub(crate) fn is_floating_or_absolutely_positioned(&self) -> bool {
@@ -303,7 +308,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_inline(&self) -> bool {
-        crate::layout::kind_is_text(self.data().kind)
+        kind_is_text(self.data().kind)
             || self
                 .computed_values_view_if_styled()
                 .is_some_and(|style| style.display().is_inline_outside())
@@ -311,7 +316,7 @@ impl<'pass> NodeFacts<'pass> {
 
     pub(crate) fn is_atomic_inline(&self) -> bool {
         let data = self.data();
-        crate::layout::has_flag(data, NodeFlag::IsReplacedElement)
+        has_flag(data, NodeFlag::IsReplacedElement)
             || data.kind == NodeKind::ListItemMarkerBox
             || self.computed_values_view_if_styled().is_some_and(|style| {
                 let display = style.display();
@@ -363,9 +368,7 @@ impl<'pass> NodeFacts<'pass> {
             return false;
         }
         let style = self.computed_values_view_if_styled();
-        if style.is_some_and(|style| style.display().is_inline_outside())
-            || crate::layout::node_is_out_of_flow(data, style)
-        {
+        if style.is_some_and(|style| style.display().is_inline_outside()) || node_is_out_of_flow(data, style) {
             return false;
         }
         let display = self.display();
@@ -378,15 +381,13 @@ impl<'pass> NodeFacts<'pass> {
         if parent.kind == NodeKind::SVGForeignObjectBox {
             return false;
         }
-        if crate::layout::kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGForeignObjectBox {
+        if kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGForeignObjectBox {
             return false;
         }
-        if data.kind == NodeKind::SVGSVGBox
-            && (crate::layout::kind_is_svg_box(parent.kind) || parent.kind == NodeKind::SVGSVGBox)
-        {
+        if data.kind == NodeKind::SVGSVGBox && (kind_is_svg_box(parent.kind) || parent.kind == NodeKind::SVGSVGBox) {
             return false;
         }
-        if crate::layout::kind_is_replaced_box(parent.kind) && crate::layout::node_can_have_children(parent) {
+        if kind_is_replaced_box(parent.kind) && node_can_have_children(parent) {
             return false;
         }
         true
@@ -426,7 +427,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn has_dom_node(&self) -> bool {
-        !crate::layout::has_flag(self.data(), NodeFlag::Anonymous)
+        !has_flag(self.data(), NodeFlag::Anonymous)
     }
 
     pub(crate) fn is_generated_for_pseudo_element(&self) -> bool {
@@ -434,33 +435,31 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn children_are_inline(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::ChildrenAreInline)
+        has_flag(self.data(), NodeFlag::ChildrenAreInline)
     }
 
     pub(crate) fn is_anonymous(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::Anonymous)
+        has_flag(self.data(), NodeFlag::Anonymous)
     }
 
     pub(crate) fn has_anchor_names(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::HasAnchorNames)
+        has_flag(self.data(), NodeFlag::HasAnchorNames)
     }
 
     pub(crate) fn can_have_children(&self) -> bool {
-        crate::layout::node_can_have_children(self.data())
+        node_can_have_children(self.data())
     }
 
     pub(crate) fn has_replaced_element_table_display_adjustment(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsReplacedElement)
-            && self
-                .computed_values_view_if_styled()
-                .is_some_and(|style| {
-                    let display = style.display_before_box_type_transformation();
-                    display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
-                })
+        has_flag(self.data(), NodeFlag::IsReplacedElement)
+            && self.computed_values_view_if_styled().is_some_and(|style| {
+                let display = style.display_before_box_type_transformation();
+                display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
+            })
     }
 
     pub(crate) fn creates_block_formatting_context(&self) -> bool {
-        crate::layout::node_creates_block_formatting_context(
+        node_creates_block_formatting_context(
             self.data(),
             self.computed_values_view_if_styled(),
             self.parent_computed_values_view_if_styled(),
@@ -468,26 +467,24 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_editing_host(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsEditingHost)
+        has_flag(self.data(), NodeFlag::IsEditingHost)
     }
 
     pub(crate) fn produces_line_box_fragment_when_empty(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::ProducesLineBoxFragmentWhenEmpty)
+        has_flag(self.data(), NodeFlag::ProducesLineBoxFragmentWhenEmpty)
     }
 
     pub(crate) fn uses_button_layout(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::UsesButtonLayout)
+        has_flag(self.data(), NodeFlag::UsesButtonLayout)
     }
 
     pub(crate) fn vertical_align_applies(&self) -> bool {
         let data = self.data();
-        crate::layout::kind_is_box(data.kind)
-            && !crate::layout::has_flag(data, NodeFlag::IsFlexItem)
-            && !crate::layout::has_flag(data, NodeFlag::IsGridItem)
+        kind_is_box(data.kind) && !has_flag(data, NodeFlag::IsFlexItem) && !has_flag(data, NodeFlag::IsGridItem)
     }
 
     pub(crate) fn is_html_input_element(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsHtmlInputElement)
+        has_flag(self.data(), NodeFlag::IsHtmlInputElement)
     }
 
     pub(crate) fn is_fieldset_box(&self) -> bool {
@@ -503,7 +500,7 @@ impl<'pass> NodeFacts<'pass> {
         while !child.is_invalid() {
             let child_data = self.callbacks.node_data(child);
             if child_data.kind == NodeKind::LegendBox
-                && !crate::layout::node_is_out_of_flow(child_data, self.callbacks.computed_values_view_if_styled(child))
+                && !node_is_out_of_flow(child_data, self.callbacks.computed_values_view_if_styled(child))
             {
                 return child;
             }
@@ -526,7 +523,7 @@ impl<'pass> NodeFacts<'pass> {
                 return candidate;
             }
             if data.kind == NodeKind::BlockContainer
-                && crate::layout::has_flag(data, NodeFlag::Anonymous)
+                && has_flag(data, NodeFlag::Anonymous)
                 && data.generated_for == 0
                 && !data.first_child.is_invalid()
             {
@@ -549,7 +546,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn list_marker_is_inside(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::ListMarkerIsInside)
+        has_flag(self.data(), NodeFlag::ListMarkerIsInside)
     }
 
     pub(crate) fn has_auto_content_width(&self) -> bool {
@@ -581,7 +578,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn has_auto_content_box_size(&self) -> bool {
-        crate::layout::node_has_auto_content_box_size(self.data())
+        node_has_auto_content_box_size(self.data())
     }
 
     pub(crate) fn node_has_size_containment(&self) -> bool {
@@ -597,19 +594,20 @@ impl<'pass> NodeFacts<'pass> {
         self.preferred_aspect_ratio().is_some()
     }
 
-    pub(crate) fn preferred_aspect_ratio(&self) -> Option<PixelFraction> {
+    pub(crate) fn preferred_aspect_ratio(&self) -> Option<formatting_context::PixelFraction> {
         let style = self.style();
         if !self.node_has_size_containment() && style.aspect_ratio_uses_natural_when_available() {
             let replaced = self.replaced_content();
             if replaced.auto_content_aspect_ratio_denominator != crate::layout::CssPixels::default() {
-                return Some(PixelFraction {
+                return Some(formatting_context::PixelFraction {
                     numerator: replaced.auto_content_aspect_ratio_numerator,
                     denominator: replaced.auto_content_aspect_ratio_denominator,
                 });
             }
         }
         let (numerator, denominator) = style.css_preferred_aspect_ratio();
-        (denominator != crate::layout::CssPixels::default()).then_some(PixelFraction { numerator, denominator })
+        (denominator != crate::layout::CssPixels::default())
+            .then_some(formatting_context::PixelFraction { numerator, denominator })
     }
 
     pub(crate) fn has_default_preferred_width(&self) -> bool {
@@ -651,7 +649,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_svg_box(&self) -> bool {
-        crate::layout::kind_is_svg_box(self.data().kind)
+        kind_is_svg_box(self.data().kind)
     }
 
     pub(crate) fn is_svg_svg_box(&self) -> bool {
@@ -711,23 +709,21 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_in_user_agent_shadow_tree(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsInUserAgentShadowTree)
+        has_flag(self.data(), NodeFlag::IsInUserAgentShadowTree)
     }
 
     pub(crate) fn is_html_html_element(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsHtmlHtmlElement)
+        has_flag(self.data(), NodeFlag::IsHtmlHtmlElement)
     }
 
     pub(crate) fn is_html_body_element(&self) -> bool {
-        crate::layout::has_flag(self.data(), NodeFlag::IsBody)
+        has_flag(self.data(), NodeFlag::IsBody)
     }
 }
-
 
 #[cfg(test)]
 mod node_facts_tests {
     use crate::layout::node_data::{NodeData, NodeFlag, NodeKind};
-    use crate::layout::node_can_have_children;
 
     fn data_with_kind(kind: NodeKind) -> NodeData {
         NodeData {
@@ -738,21 +734,25 @@ mod node_facts_tests {
 
     #[test]
     fn child_policy_follows_kind_and_replaced_shadow_root_flag() {
-        assert!(!node_can_have_children(&data_with_kind(NodeKind::BreakNode)));
-        assert!(node_can_have_children(&data_with_kind(NodeKind::ListItemMarkerBox)));
-        assert!(!node_can_have_children(&data_with_kind(NodeKind::ImageBox)));
-        assert!(!node_can_have_children(&data_with_kind(NodeKind::ReplacedBox)));
-        assert!(!node_can_have_children(&data_with_kind(NodeKind::NavigableContainerViewport)));
-        assert!(node_can_have_children(&data_with_kind(NodeKind::SVGSVGBox)));
-        assert!(node_can_have_children(&data_with_kind(NodeKind::BlockContainer)));
-        assert!(node_can_have_children(&data_with_kind(NodeKind::InlineNode)));
-        assert!(node_can_have_children(&data_with_kind(NodeKind::TextNode)));
+        assert!(!super::node_can_have_children(&data_with_kind(NodeKind::BreakNode)));
+        assert!(super::node_can_have_children(&data_with_kind(
+            NodeKind::ListItemMarkerBox
+        )));
+        assert!(!super::node_can_have_children(&data_with_kind(NodeKind::ImageBox)));
+        assert!(!super::node_can_have_children(&data_with_kind(NodeKind::ReplacedBox)));
+        assert!(!super::node_can_have_children(&data_with_kind(
+            NodeKind::NavigableContainerViewport
+        )));
+        assert!(super::node_can_have_children(&data_with_kind(NodeKind::SVGSVGBox)));
+        assert!(super::node_can_have_children(&data_with_kind(NodeKind::BlockContainer)));
+        assert!(super::node_can_have_children(&data_with_kind(NodeKind::InlineNode)));
+        assert!(super::node_can_have_children(&data_with_kind(NodeKind::TextNode)));
 
         let mut media = data_with_kind(NodeKind::AudioBox);
-        assert!(!node_can_have_children(&media));
+        assert!(!super::node_can_have_children(&media));
         media.flags = NodeFlag::ReplacedBoxCanHaveChildren as u32;
-        assert!(node_can_have_children(&media));
+        assert!(super::node_can_have_children(&media));
         media.kind = NodeKind::VideoBox;
-        assert!(node_can_have_children(&media));
+        assert!(super::node_can_have_children(&media));
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: LayoutInput) -> ChildLayoutResult {
+use super::*;
+
+pub(super) fn layout_replaced_with_children(
+    run: &formatting_context::FormattingContextRun,
+    layout_input: geometry::LayoutInput,
+) -> formatting_context::ChildLayoutResult {
     // The parent FC has already resolved this replaced box's used size (natural size, explicit size, or the default
     // object size), so both dimensions are definite for its children — shadow content sized to fill
     // (e.g. width/height: 100%) resolves against them.
@@ -18,22 +23,22 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         )
     };
 
-    let child_available_space = AvailableSpace {
-        inline_size: AvailableSize::definite(content_inline_size),
-        block_size: AvailableSize::definite(root_content_block_size),
+    let child_available_space = geometry::AvailableSpace {
+        inline_size: geometry::AvailableSize::definite(content_inline_size),
+        block_size: geometry::AvailableSize::definite(root_content_block_size),
     };
 
     // The TreeBuilder wraps shadow DOM children in an anonymous BlockContainer.
     // Delegate layout to a BFC for that wrapper.
     let mut wrapper = run.callbacks.first_child(run.box_);
     while !wrapper.is_invalid() {
-        if NodeFacts::new(&run.callbacks, wrapper).is_block_container() {
+        if node_facts::NodeFacts::new(&run.callbacks, wrapper).is_block_container() {
             break;
         }
         wrapper = run.callbacks.next_sibling(wrapper);
     }
     if wrapper.is_invalid() {
-        return ChildLayoutResult::default();
+        return formatting_context::ChildLayoutResult::default();
     }
 
     let wrapper_constraints = run
@@ -44,40 +49,40 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         .create_used_values(&run.callbacks, wrapper, wrapper_constraints);
     wrapper_state.set_content_inline_size(content_inline_size);
 
-    let wrapper_result = crate::layout::run_formatting_context(
+    let wrapper_result = formatting_context::run_formatting_context(
         run.purpose,
         run.fragments.as_deref(),
         &wrapper_state,
         wrapper,
         None,
-        FfiFormattingContextType::Block,
+        formatting_context::FfiFormattingContextType::Block,
         run.layout_mode,
         run.should_collect_devtools_layout_data,
         run.callbacks,
-        LayoutInput {
+        geometry::LayoutInput {
             available_space: child_available_space,
             containing_block_constraints: wrapper_constraints,
             content_box_position_in_bfc_root: None,
-            sizing: RootSizingDirectives {
+            sizing: geometry::RootSizingDirectives {
                 adopt_automatic_content_block_size: true,
-                ..RootSizingDirectives::default()
+                ..geometry::RootSizingDirectives::default()
             },
-            participation: ParticipationInParentFormattingContext::Item,
+            participation: geometry::ParticipationInParentFormattingContext::Item,
         },
         None,
     );
-    crate::layout::propagate_percentage_block_size_dependency_to_containing_block(
+    formatting_context::propagate_percentage_block_size_dependency_to_containing_block(
         &run.records,
         &run.callbacks,
         wrapper,
         wrapper_result.depends_on_percentage_block_size,
     );
-    crate::layout::place_child(run, wrapper, FfiCssPixelPoint::default(), None);
+    formatting_context::place_child(run, wrapper, used_values::FfiCssPixelPoint::default(), None);
 
-    ChildLayoutResult {
+    formatting_context::ChildLayoutResult {
         automatic_content_inline_size: content_inline_size,
         automatic_content_block_size: wrapper_result.automatic_content_block_size,
-        baselines: DerivedBaselines::default(),
-        ..ChildLayoutResult::default()
+        baselines: formatting_context::DerivedBaselines::default(),
+        ..formatting_context::ChildLayoutResult::default()
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/run_records.rs
+++ b/Libraries/LibWeb/Rust/src/layout/run_records.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 /// The per-run registry of UsedValues records, backed by the slot-indexed side
 /// table in the layout node arena. Registering a slot that a surrounding run
 /// owns displaces that run's entry, and dropping the RunRecords restores it.
@@ -63,7 +65,7 @@ impl RunRecords {
         node: Node,
         constraints: ContainingBlockConstraints,
     ) -> std::rc::Rc<UsedValues> {
-        let used = crate::layout::create_used_values(callbacks, node, constraints);
+        let used = used_values::create_used_values(callbacks, node, constraints);
         self.register(node, used.clone());
         used
     }

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -4,15 +4,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) struct SizingContext {
-    purpose: LayoutPurpose,
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
 }
 
 impl SizingContext {
     pub(crate) fn new(
-        purpose: LayoutPurpose,
+        purpose: formatting_context::LayoutPurpose,
         records: std::rc::Rc<RunRecords>,
         callbacks: FfiLayoutFcCallbacks,
     ) -> Self {
@@ -23,11 +25,11 @@ impl SizingContext {
         }
     }
 
-    fn facts(&self, node: Node) -> NodeFacts<'_> {
+    pub(super) fn facts(&self, node: Node) -> NodeFacts<'_> {
         NodeFacts::new(&self.callbacks, node)
     }
 
-    fn style(&self, node: Node) -> StyleValues<'static> {
+    pub(super) fn style(&self, node: Node) -> StyleValues<'static> {
         StyleValues::for_node(&self.callbacks, node)
     }
 
@@ -87,8 +89,8 @@ impl SizingContext {
                                     || style.min_height().contains_percentage()
                                     || style.max_height().contains_percentage()
                                     || (style.height().is_auto()
-                                        && (has_flag(facts.data(), NodeFlag::IsFlexItem)
-                                            || has_flag(facts.data(), NodeFlag::IsGridItem))))
+                                        && (node_facts::has_flag(facts.data(), NodeFlag::IsFlexItem)
+                                            || node_facts::has_flag(facts.data(), NodeFlag::IsGridItem))))
                             {
                                 return true;
                             }
@@ -107,7 +109,7 @@ impl SizingContext {
     fn content_block_size_from_aspect_ratio(&self, node: Node, content_inline_size: CssPixels) -> CssPixels {
         let style = self.style(node);
         let used = self.used(node);
-        content_block_size_from_aspect_ratio_values(
+        formatting_context::content_block_size_from_aspect_ratio_values(
             content_inline_size,
             self.facts(node).preferred_aspect_ratio().unwrap(),
             style.box_sizing_for_aspect_ratio() == box_sizing::BORDER_BOX,
@@ -121,7 +123,7 @@ impl SizingContext {
     fn content_inline_size_from_aspect_ratio(&self, node: Node, content_block_size: CssPixels) -> CssPixels {
         let style = self.style(node);
         let used = self.used(node);
-        content_inline_size_from_aspect_ratio_values(
+        formatting_context::content_inline_size_from_aspect_ratio_values(
             content_block_size,
             self.facts(node).preferred_aspect_ratio().unwrap(),
             style.box_sizing_for_aspect_ratio() == box_sizing::BORDER_BOX,
@@ -132,19 +134,21 @@ impl SizingContext {
         )
     }
 
-    fn auto_content_size(&self, node: Node) -> ReplacedIntrinsicSize {
+    fn auto_content_size(&self, node: Node) -> formatting_context::ReplacedIntrinsicSize {
         let facts = self.facts(node);
-        ReplacedIntrinsicSize {
+        formatting_context::ReplacedIntrinsicSize {
             width: facts.has_auto_content_width().then_some(facts.auto_content_width()),
             height: facts.has_auto_content_height().then_some(facts.auto_content_height()),
-            aspect_ratio: facts.has_auto_content_aspect_ratio().then_some(PixelFraction {
-                numerator: facts.auto_content_aspect_ratio_numerator(),
-                denominator: facts.auto_content_aspect_ratio_denominator(),
-            }),
+            aspect_ratio: facts
+                .has_auto_content_aspect_ratio()
+                .then_some(formatting_context::PixelFraction {
+                    numerator: facts.auto_content_aspect_ratio_numerator(),
+                    denominator: facts.auto_content_aspect_ratio_denominator(),
+                }),
         }
     }
 
-    fn intrinsic_size_for_replaced_sizing(&self, node: Node) -> ReplacedIntrinsicSize {
+    fn intrinsic_size_for_replaced_sizing(&self, node: Node) -> formatting_context::ReplacedIntrinsicSize {
         let auto_size = self.auto_content_size(node);
         if auto_size.width.is_some() || auto_size.height.is_some() || auto_size.aspect_ratio.is_some() {
             return auto_size;
@@ -158,7 +162,7 @@ impl SizingContext {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget
         // An input element whose type attribute is in one of the above states is an element with default preferred size,
         // and user agents are expected to apply the 'field-sizing' CSS property to the element.
-        ReplacedIntrinsicSize {
+        formatting_context::ReplacedIntrinsicSize {
             width: facts
                 .has_default_preferred_width()
                 .then_some(facts.default_preferred_width()),
@@ -172,14 +176,14 @@ impl SizingContext {
     fn max_content_size_for_replaced_element_without_natural_size(
         &self,
         node: Node,
-        natural_size: ReplacedIntrinsicSize,
-        dimension: SizeDimension,
-        constraints: ReplacedMaxContentSizeConstraints,
+        natural_size: formatting_context::ReplacedIntrinsicSize,
+        dimension: formatting_context::SizeDimension,
+        constraints: formatting_context::ReplacedMaxContentSizeConstraints,
     ) -> Option<CssPixels> {
         // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
         // the intrinsic sizes of replaced elements without natural sizes are defined below:
         let facts = self.facts(node);
-        let is_inline_axis = dimension == SizeDimension::Inline;
+        let is_inline_axis = dimension == formatting_context::SizeDimension::Inline;
         if !facts.is_replaced_box()
             || if is_inline_axis {
                 natural_size.width.is_some()
@@ -366,17 +370,17 @@ impl SizingContext {
             if !available_space.inline_size.is_intrinsic_sizing_constraint() {
                 return self.calculate_stretch_fit_inline_size(node, available_space.inline_size);
             }
-            match cyclic_percentage_intrinsic_contribution(
+            match formatting_context::cyclic_percentage_intrinsic_contribution(
                 self.facts(node).is_replaced_box(),
                 style.width().contains_percentage(),
                 available_space.inline_size,
-                CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
             ) {
-                CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
                     return CssPixels::default();
                 }
-                CyclicPercentageIntrinsicContribution::TreatAsInitialValue => {}
-                CyclicPercentageIntrinsicContribution::NotCyclic => {
+                formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => {}
+                formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => {
                     return self.calculate_stretch_fit_inline_size(node, available_space.inline_size);
                 }
             }
@@ -861,7 +865,8 @@ impl SizingContext {
             || self.own_style_depends_on_percentage_block_size(node)
             || (used.has_descendant_that_depends_on_percentage_block_size.get()
                 && self.passes_percentage_block_size_through_to_children(node));
-        used.depends_on_percentage_block_size.set(depends_on_percentage_block_size);
+        used.depends_on_percentage_block_size
+            .set(depends_on_percentage_block_size);
         depends_on_percentage_block_size
     }
 
@@ -904,7 +909,12 @@ impl SizingContext {
         if let Some(record) = self.records.used_values_if_owned(node) {
             record.depends_on_percentage_block_size.set(true);
         }
-        propagate_percentage_block_size_dependency_to_containing_block(&self.records, &self.callbacks, node, true);
+        formatting_context::propagate_percentage_block_size_dependency_to_containing_block(
+            &self.records,
+            &self.callbacks,
+            node,
+            true,
+        );
     }
 
     pub(crate) fn should_treat_inline_size_as_auto(&self, node: Node, available_space: AvailableSpace) -> bool {
@@ -915,15 +925,19 @@ impl SizingContext {
         }
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         if size.contains_percentage() {
-            match cyclic_percentage_intrinsic_contribution(
+            match formatting_context::cyclic_percentage_intrinsic_contribution(
                 self.facts(node).is_replaced_box(),
                 true,
                 available_space.inline_size,
-                CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
             ) {
-                CyclicPercentageIntrinsicContribution::ResolveAsZero => return false,
-                CyclicPercentageIntrinsicContribution::TreatAsInitialValue => return true,
-                CyclicPercentageIntrinsicContribution::NotCyclic => {}
+                formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                    return false;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => {
+                    return true;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => {}
             }
             if available_space.inline_size == AvailableSize::Indefinite {
                 return true;
@@ -961,15 +975,19 @@ impl SizingContext {
         }
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         if size.contains_percentage() {
-            match cyclic_percentage_intrinsic_contribution(
+            match formatting_context::cyclic_percentage_intrinsic_contribution(
                 facts.is_replaced_box(),
                 true,
                 available_space.block_size,
-                CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
             ) {
-                CyclicPercentageIntrinsicContribution::ResolveAsZero => return false,
-                CyclicPercentageIntrinsicContribution::TreatAsInitialValue => return true,
-                CyclicPercentageIntrinsicContribution::NotCyclic => {}
+                formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                    return false;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => {
+                    return true;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => {}
             }
             // https://www.w3.org/TR/CSS22/visudet.html#the-height-property
             // If the height of the containing block is not specified explicitly (i.e., it depends on
@@ -1025,15 +1043,19 @@ impl SizingContext {
         }
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         if size.contains_percentage() {
-            match cyclic_percentage_intrinsic_contribution(
+            match formatting_context::cyclic_percentage_intrinsic_contribution(
                 self.facts(node).is_replaced_box(),
                 true,
                 available,
-                CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
             ) {
-                CyclicPercentageIntrinsicContribution::ResolveAsZero => return false,
-                CyclicPercentageIntrinsicContribution::TreatAsInitialValue => return true,
-                CyclicPercentageIntrinsicContribution::NotCyclic => {}
+                formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                    return false;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => {
+                    return true;
+                }
+                formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => {}
             }
             if constraints.percentage_basis_inline_size.is_none() {
                 return true;
@@ -1252,7 +1274,9 @@ impl SizingContext {
             self.used(node).set_content_block_size(block_size);
             let block_size_is_automatic =
                 style.height().is_auto() || self.should_treat_block_size_as_auto(node, available_space, constraints);
-            if self.used(node).has_definite_inline_size() && facts.has_preferred_aspect_ratio() && block_size_is_automatic
+            if self.used(node).has_definite_inline_size()
+                && facts.has_preferred_aspect_ratio()
+                && block_size_is_automatic
             {
                 self.used(node).has_definite_block_size.set(true);
             }
@@ -1303,7 +1327,9 @@ impl SizingContext {
                 intrinsic_content_inline_size
                     .unwrap_or_else(|| self.calculate_max_content_inline_size(node, constraints))
             }
-        } else if style.width().contains_percentage() && !matches!(available_space.inline_size, AvailableSize::Definite(_)) {
+        } else if style.width().contains_percentage()
+            && !matches!(available_space.inline_size, AvailableSize::Definite(_))
+        {
             CssPixels::default()
         } else {
             self.calculate_inner_inline_size(node, available_space.inline_size, style.width(), constraints)
@@ -1344,7 +1370,7 @@ impl SizingContext {
             self.intrinsic_inline_measurement_cache_get(
                 node,
                 IntrinsicSizeCacheKind::MaxContentInline,
-                cache_key(None, None, constraints),
+                formatting_context::cache_key(None, None, constraints),
             )?
             .min_content_inline_size_from_max_content_layout?
         } else {
@@ -1401,10 +1427,10 @@ impl SizingContext {
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
     ) -> Option<IntrinsicBlockSizeMeasurement> {
-        let measurement = self
-            .callbacks
-            .arena()
-            .intrinsic_block_size_cache_get(self.callbacks.node_data(node), kind, key)?;
+        let measurement =
+            self.callbacks
+                .arena()
+                .intrinsic_block_size_cache_get(self.callbacks.node_data(node), kind, key)?;
         self.charge_measurement_dependency_to_measured_box_and_containing_block(
             node,
             measurement.depends_on_percentage_block_size,
@@ -1464,7 +1490,7 @@ impl SizingContext {
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
         measurement_root_used: &UsedValues,
-        result: ChildLayoutResult,
+        result: formatting_context::ChildLayoutResult,
         available_block_size: AvailableSize,
     ) {
         let used = measurement_root_used;
@@ -1474,8 +1500,7 @@ impl SizingContext {
             key,
             IntrinsicInlineSizeMeasurement {
                 automatic_content_inline_size: result.automatic_content_inline_size,
-                min_content_inline_size_from_max_content_layout: result
-                    .min_content_inline_size_from_max_content_layout,
+                min_content_inline_size_from_max_content_layout: result.min_content_inline_size_from_max_content_layout,
                 available_block_size,
                 content_inline_size: used.content_inline_size.get(),
                 content_block_size: used.content_block_size.get(),
@@ -1513,7 +1538,7 @@ impl SizingContext {
         let measurement = self.intrinsic_inline_measurement_cache_get(
             node,
             kind,
-            cache_key(None, None, constraints),
+            formatting_context::cache_key(None, None, constraints),
         )?;
         if measurement.available_block_size != available_block_size {
             return None;
@@ -1530,7 +1555,7 @@ impl SizingContext {
             first: measurement.has_first_baseline.then_some(measurement.first_baseline),
             last: measurement.has_last_baseline.then_some(measurement.last_baseline),
         };
-        crate::layout::store_derived_baselines(&used, baselines);
+        formatting_context::store_derived_baselines(&used, baselines);
         Some((measurement.automatic_content_block_size, baselines))
     }
 
@@ -1629,8 +1654,8 @@ impl SizingContext {
             && let Some(fallback) = self.max_content_size_for_replaced_element_without_natural_size(
                 node,
                 auto_size,
-                SizeDimension::Inline,
-                ReplacedMaxContentSizeConstraints::default(),
+                formatting_context::SizeDimension::Inline,
+                formatting_context::ReplacedMaxContentSizeConstraints::default(),
             )
         {
             return fallback;
@@ -1642,7 +1667,7 @@ impl SizingContext {
         if let Some(cached) = self.intrinsic_inline_measurement_cache_get(
             node,
             IntrinsicSizeCacheKind::MinContentInline,
-            cache_key(
+            formatting_context::cache_key(
                 None,
                 self.block_size_for_intrinsic_inline_measurement_cache_key(node, block_size),
                 constraints,
@@ -1665,7 +1690,7 @@ impl SizingContext {
         self.intrinsic_inline_measurement_cache_get(
             node,
             IntrinsicSizeCacheKind::MaxContentInline,
-            cache_key(
+            formatting_context::cache_key(
                 None,
                 self.block_size_for_intrinsic_inline_measurement_cache_key(node, block_size),
                 constraints,
@@ -1714,7 +1739,7 @@ impl SizingContext {
             // size to max-content sizing. Do not use this for min-content sizing: CSS Sizing's "Compressible Replaced
             // Elements" section considers non-button-like <input> controls replaced for the percentage-sized replaced
             // element rule, so their cyclic-percentage min-content contribution can still compress toward zero.
-            auto_size = ReplacedIntrinsicSize {
+            auto_size = formatting_context::ReplacedIntrinsicSize {
                 width: facts
                     .has_default_preferred_width()
                     .then_some(facts.default_preferred_width()),
@@ -1739,23 +1764,23 @@ impl SizingContext {
             block_size: AvailableSize::Indefinite,
         };
         let resolve_destination_inline_size =
-            |size: &ComputedSize, property: CyclicPercentageSizeProperty| -> Option<CssPixels> {
+            |size: &ComputedSize, property: formatting_context::CyclicPercentageSizeProperty| -> Option<CssPixels> {
                 if !size.is_length_percentage() {
                     return None;
                 }
-                match cyclic_percentage_intrinsic_contribution(
+                match formatting_context::cyclic_percentage_intrinsic_contribution(
                     facts.is_replaced_box(),
                     size.contains_percentage(),
                     max_content_available,
                     property,
                 ) {
-                    CyclicPercentageIntrinsicContribution::TreatAsInitialValue => None,
-                    CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                    formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => None,
+                    formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
                         let mut zero_constraints = constraints;
                         zero_constraints.percentage_basis_inline_size = Some(CssPixels::default());
                         Some(self.calculate_inner_inline_size(node, max_content_available, size, zero_constraints))
                     }
-                    CyclicPercentageIntrinsicContribution::NotCyclic => {
+                    formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => {
                         if size.contains_percentage() && constraints.percentage_basis_inline_size.is_none() {
                             None
                         } else {
@@ -1764,33 +1789,39 @@ impl SizingContext {
                     }
                 }
             };
-        let resolve_block_size = |size: &ComputedSize, property: CyclicPercentageSizeProperty| -> Option<CssPixels> {
-            if !size.is_length_percentage() {
-                return None;
-            }
-            if !size.contains_percentage() || constraints.percentage_basis_block_size.is_some() {
-                return Some(self.calculate_inner_block_size(node, intrinsic_available_space, size, constraints));
-            }
-            match cyclic_percentage_intrinsic_contribution(
-                facts.is_replaced_box(),
-                size.contains_percentage(),
-                max_content_available,
-                property,
-            ) {
-                CyclicPercentageIntrinsicContribution::TreatAsInitialValue => None,
-                CyclicPercentageIntrinsicContribution::ResolveAsZero => {
-                    let mut zero_constraints = constraints;
-                    zero_constraints.percentage_basis_block_size = Some(CssPixels::default());
-                    Some(self.calculate_inner_block_size(node, intrinsic_available_space, size, zero_constraints))
+        let resolve_block_size =
+            |size: &ComputedSize, property: formatting_context::CyclicPercentageSizeProperty| -> Option<CssPixels> {
+                if !size.is_length_percentage() {
+                    return None;
                 }
-                CyclicPercentageIntrinsicContribution::NotCyclic => None,
-            }
-        };
+                if !size.contains_percentage() || constraints.percentage_basis_block_size.is_some() {
+                    return Some(self.calculate_inner_block_size(node, intrinsic_available_space, size, constraints));
+                }
+                match formatting_context::cyclic_percentage_intrinsic_contribution(
+                    facts.is_replaced_box(),
+                    size.contains_percentage(),
+                    max_content_available,
+                    property,
+                ) {
+                    formatting_context::CyclicPercentageIntrinsicContribution::TreatAsInitialValue => None,
+                    formatting_context::CyclicPercentageIntrinsicContribution::ResolveAsZero => {
+                        let mut zero_constraints = constraints;
+                        zero_constraints.percentage_basis_block_size = Some(CssPixels::default());
+                        Some(self.calculate_inner_block_size(node, intrinsic_available_space, size, zero_constraints))
+                    }
+                    formatting_context::CyclicPercentageIntrinsicContribution::NotCyclic => None,
+                }
+            };
 
-        let definite_minimum_inline_size =
-            resolve_destination_inline_size(style.min_width(), CyclicPercentageSizeProperty::MinSize);
-        let definite_minimum_block_size = resolve_block_size(style.min_height(), CyclicPercentageSizeProperty::MinSize);
-        let replaced_constraints = ReplacedMaxContentSizeConstraints {
+        let definite_minimum_inline_size = resolve_destination_inline_size(
+            style.min_width(),
+            formatting_context::CyclicPercentageSizeProperty::MinSize,
+        );
+        let definite_minimum_block_size = resolve_block_size(
+            style.min_height(),
+            formatting_context::CyclicPercentageSizeProperty::MinSize,
+        );
+        let replaced_constraints = formatting_context::ReplacedMaxContentSizeConstraints {
             definite_size_in_ratio_determining_axis: definite_block_size,
             minimum_inline_size: definite_minimum_inline_size,
             minimum_block_size: definite_minimum_block_size,
@@ -1798,13 +1829,15 @@ impl SizingContext {
         if let Some(max_content_inline_size) = self.max_content_size_for_replaced_element_without_natural_size(
             node,
             auto_size,
-            SizeDimension::Inline,
+            formatting_context::SizeDimension::Inline,
             replaced_constraints,
         ) {
             if definite_block_size.is_none()
                 && facts.has_preferred_aspect_ratio()
-                && let Some(definite_maximum_block_size) =
-                    resolve_block_size(style.max_height(), CyclicPercentageSizeProperty::PreferredOrMaxSize)
+                && let Some(definite_maximum_block_size) = resolve_block_size(
+                    style.max_height(),
+                    formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                )
             {
                 // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers
                 // First, any definite minimum size is converted and transferred from the origin to destination axis.
@@ -1814,13 +1847,13 @@ impl SizingContext {
                 if let Some(value) = transferred_minimum {
                     transferred_minimum = resolve_destination_inline_size(
                         style.width(),
-                        CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                        formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
                     )
                     .map_or(Some(value), |resolved| Some(value.min(resolved)));
                     let value = transferred_minimum.unwrap();
                     transferred_minimum = resolve_destination_inline_size(
                         style.max_width(),
-                        CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                        formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
                     )
                     .map_or(Some(value), |resolved| Some(value.min(resolved)));
                 }
@@ -1830,14 +1863,16 @@ impl SizingContext {
                 // as well as by the transferred minimum, if any.
                 let mut transferred_maximum =
                     self.content_inline_size_from_aspect_ratio(node, definite_maximum_block_size);
-                if let Some(resolved) =
-                    resolve_destination_inline_size(style.width(), CyclicPercentageSizeProperty::PreferredOrMaxSize)
-                {
+                if let Some(resolved) = resolve_destination_inline_size(
+                    style.width(),
+                    formatting_context::CyclicPercentageSizeProperty::PreferredOrMaxSize,
+                ) {
                     transferred_maximum = transferred_maximum.max(resolved);
                 }
-                if let Some(resolved) =
-                    resolve_destination_inline_size(style.min_width(), CyclicPercentageSizeProperty::MinSize)
-                {
+                if let Some(resolved) = resolve_destination_inline_size(
+                    style.min_width(),
+                    formatting_context::CyclicPercentageSizeProperty::MinSize,
+                ) {
                     transferred_maximum = transferred_maximum.max(resolved);
                 }
                 if let Some(transferred_minimum) = transferred_minimum {
@@ -1867,7 +1902,7 @@ impl SizingContext {
             IntrinsicSizeCacheKind::MaxContentInline => (SizeConstraint::MaxContent, AvailableSize::MaxContent),
             _ => unreachable!("inline measurement cache kind must use the inline axis"),
         };
-        let key = cache_key(
+        let key = formatting_context::cache_key(
             None,
             self.block_size_for_intrinsic_inline_measurement_cache_key(node, block_size),
             constraints,
@@ -1877,7 +1912,7 @@ impl SizingContext {
         }
 
         self.callbacks.arena().note_intrinsic_measurement();
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
         let root = measurement.create_used_values(node, constraints);
         // NB: A parent layout can assign a definite block size that is not present in computed style,
         //     such as the stretched cross size of a flex item. Preserve it so descendant percentages
@@ -1931,13 +1966,13 @@ impl SizingContext {
             IntrinsicSizeCacheKind::MaxContentBlock => (SizeConstraint::MaxContent, AvailableSize::MaxContent),
             _ => unreachable!("block size cache kind must use the block axis"),
         };
-        let key = cache_key(Some(inline_size), None, constraints);
+        let key = formatting_context::cache_key(Some(inline_size), None, constraints);
         if let Some(cached) = self.intrinsic_block_cache_get(node, kind, key) {
             return cached.size;
         }
 
         self.callbacks.arena().note_intrinsic_measurement();
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
         let root = measurement.create_used_values(node, constraints);
         root.block_size_constraint.set(size_constraint);
         root.has_definite_block_size.set(false);
@@ -2011,8 +2046,8 @@ impl SizingContext {
         if let Some(fallback) = self.max_content_size_for_replaced_element_without_natural_size(
             node,
             auto_size,
-            SizeDimension::Block,
-            ReplacedMaxContentSizeConstraints::default(),
+            formatting_context::SizeDimension::Block,
+            formatting_context::ReplacedMaxContentSizeConstraints::default(),
         ) {
             return fallback;
         }
@@ -2030,14 +2065,18 @@ impl SizingContext {
         inner_available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
     ) -> CssPixels {
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
         let node_used = measurement.create_used_values(node, constraints);
         measurement
             .run_with_layout_mode(
                 node,
                 &node_used,
                 layout_mode,
-                LayoutInput::new(inner_available_space, constraints, ParticipationInParentFormattingContext::Root),
+                LayoutInput::new(
+                    inner_available_space,
+                    constraints,
+                    ParticipationInParentFormattingContext::Root,
+                ),
             )
             .automatic_content_block_size
     }
@@ -2138,7 +2177,7 @@ impl SizingContext {
         available_space: AvailableSpace,
         table_wrapper_constraints: ContainingBlockConstraints,
         table_wrapper_containing_block_inline_size: Option<CssPixels>,
-        table_wrapper_inline_size_mode: TableWrapperInlineSizeMode,
+        table_wrapper_inline_size_mode: formatting_context::TableWrapperInlineSizeMode,
     ) -> CssPixels {
         // CSS 2 says the table wrapper inline size is the border-edge inline size of the table grid box inside it.
 
@@ -2154,7 +2193,7 @@ impl SizingContext {
         let available_inline_size = containing_block_inline_size - margin_left - margin_right;
         let table_box = self.table_box_inside_wrapper(wrapper);
 
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
 
         // The table wrapper is invisible to percentage resolution, so the table box gets the
         // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
@@ -2171,9 +2210,13 @@ impl SizingContext {
             .padding_right
             .set(table_style.padding_right().to_px(containing_block_inline_size));
 
-        let table_run = crate::layout::FormattingContextRun {
-            purpose: LayoutPurpose::Measurement,
-            records: std::rc::Rc::new(RunRecords::new(measurement.callbacks().arena, table_box, table_used.clone())),
+        let table_run = FormattingContextRun {
+            purpose: formatting_context::LayoutPurpose::Measurement,
+            records: std::rc::Rc::new(RunRecords::new(
+                measurement.callbacks().arena,
+                table_box,
+                table_used.clone(),
+            )),
             box_: table_box,
             layout_mode: LayoutMode::IntrinsicSizing,
             callbacks: *measurement.callbacks(),
@@ -2182,15 +2225,20 @@ impl SizingContext {
             fragments: None,
             previous_line_data: None,
         };
-        let mut table = TableFormattingContext::new(&table_run);
+        let mut table = table_formatting_context::TableFormattingContext::new(&table_run);
         let table_available = table_used.available_inner_space_or_constraints_from(available_space);
         table.run_until_inline_size_calculation(
-            LayoutInput::new(table_available, table_constraints, ParticipationInParentFormattingContext::Root),
+            LayoutInput::new(
+                table_available,
+                table_constraints,
+                ParticipationInParentFormattingContext::Root,
+            ),
             true,
         );
 
         let table_used_inline_size = table_used.border_box_inline_size(table_used.uses_collapsing_borders_model.get());
-        if table_wrapper_inline_size_mode == TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto
+        if table_wrapper_inline_size_mode
+            == formatting_context::TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto
             && !table_style.width().is_auto()
         {
             return table_used_inline_size;
@@ -2223,7 +2271,7 @@ impl SizingContext {
         // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
         let available_block_size = containing_block_block_size - margin_top - margin_bottom;
 
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
         let wrapper_used = measurement.create_used_values(wrapper, table_wrapper_constraints);
         let wrapper_outputs = measurement.run_with_layout_mode(
             wrapper,
@@ -2341,7 +2389,7 @@ impl SizingContext {
         let style = self.style(node);
         if style.box_sizing() == box_sizing::BORDER_BOX {
             let used = self.used(node);
-            return subtract_border_box_adjustment(
+            return formatting_context::subtract_border_box_adjustment(
                 value,
                 style.border_left_width(),
                 used.padding_left.get(),
@@ -2414,7 +2462,7 @@ impl SizingContext {
         let style = self.style(node);
         if style.box_sizing() == box_sizing::BORDER_BOX {
             let used = self.used(node);
-            return subtract_border_box_adjustment(
+            return formatting_context::subtract_border_box_adjustment(
                 value,
                 style.border_top_width(),
                 used.padding_top.get(),

--- a/Libraries/LibWeb/Rust/src/layout/style_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_values.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 /// The four inset properties.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InsetField {
@@ -93,7 +95,7 @@ impl InsetValue<'_> {
 #[derive(Clone, Copy)]
 pub(crate) struct StyleValues<'a> {
     style: ComputedValuesView<'a>,
-    resolved_anchor_insets: Option<&'a ResolvedAnchorInsets>,
+    resolved_anchor_insets: Option<&'a formatting_context::ResolvedAnchorInsets>,
     vertical_align_override: u16,
 }
 
@@ -120,7 +122,10 @@ impl<'a> StyleValues<'a> {
         StyleValues::new(callbacks.style_payloads(node))
     }
 
-    pub(crate) fn with_resolved_insets(mut self, resolved: Option<&'a ResolvedAnchorInsets>) -> Self {
+    pub(crate) fn with_resolved_insets(
+        mut self,
+        resolved: Option<&'a formatting_context::ResolvedAnchorInsets>,
+    ) -> Self {
         self.resolved_anchor_insets = resolved;
         self
     }
@@ -135,11 +140,19 @@ impl<'a> StyleValues<'a> {
         };
         // SAFETY: The node's style group payload retains the wrapper for the
         // view's lifetime.
-        unsafe { handle.pointer.cast::<crate::css::style_value::StyleValueData>().as_ref() }
+        unsafe {
+            handle
+                .pointer
+                .cast::<crate::css::style_value::StyleValueData>()
+                .as_ref()
+        }
     }
 
     fn inset_value(self, field: InsetField) -> InsetValue<'a> {
-        if let Some(resolved) = self.resolved_anchor_insets.and_then(|insets| insets.override_for(field)) {
+        if let Some(resolved) = self
+            .resolved_anchor_insets
+            .and_then(|insets| insets.override_for(field))
+        {
             return InsetValue::Resolved(resolved);
         }
         if let Some(wrapper) = self.bare_anchor_wrapper(field) {

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]
 pub struct FfiFloatPoint {
@@ -354,8 +356,8 @@ pub(crate) fn scale_and_align_viewbox_content(
     result
 }
 
-struct SvgFormattingContext {
-    purpose: LayoutPurpose,
+pub(super) struct SvgFormattingContext {
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     box_: Node,
     layout_mode: LayoutMode,
@@ -365,13 +367,13 @@ struct SvgFormattingContext {
     viewport_width: CssPixels,
     viewport_height: CssPixels,
     current_text_position: FfiFloatPoint,
-    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
 impl SvgFormattingContext {
-    fn new(run: &FormattingContextRun) -> Self {
+    pub(super) fn new(run: &FormattingContextRun) -> Self {
         Self::new_nested(run, run.box_)
     }
 
@@ -389,7 +391,8 @@ impl SvgFormattingContext {
             viewport_height: CssPixels::default(),
             current_text_position: FfiFloatPoint::default(),
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
         }
     }
 
@@ -401,7 +404,8 @@ impl SvgFormattingContext {
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
             should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: self.fragments.clone(),
             previous_line_data: None,
         }
@@ -456,7 +460,7 @@ impl SvgFormattingContext {
         // SVG layout resolves percentages against the SVG viewport, not a CSS containing
         // block, so boxes inside the SVG subtree carry no percentage basis.
         self.records
-            .create_used_values(&self.callbacks, node, crate::layout::ContainingBlockConstraints::default())
+            .create_used_values(&self.callbacks, node, ContainingBlockConstraints::default())
     }
 
     fn set_svg_viewport_transform(&self, node: Node, transform: FfiAffineTransform) {
@@ -475,7 +479,7 @@ impl SvgFormattingContext {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
+        formatting_context::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
     }
 
     fn for_each_child(&self, node: Node, mut callback: impl FnMut(Node)) {
@@ -497,7 +501,7 @@ impl SvgFormattingContext {
         result
     }
 
-    fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
+    pub(super) fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
         // NOTE: SVG doesn't have a "formatting context" in the spec, but this is the most
         //       obvious way to drive SVG layout in our engine at the moment.
         let kind = self.node_kind(self.box_);
@@ -661,9 +665,9 @@ impl SvgFormattingContext {
                 sizing: RootSizingDirectives::default(),
                 participation: ParticipationInParentFormattingContext::Item,
             };
-            match crate::layout::layout_inside_child(run, None, None, child, self.layout_mode, child_input, true) {
-                crate::layout::ChildLayoutOutcome::Created(_) => {}
-                crate::layout::ChildLayoutOutcome::Skipped | crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+            match formatting_context::layout_inside_child(run, None, None, child, self.layout_mode, child_input, true) {
+                ChildLayoutOutcome::Created(_) => {}
+                ChildLayoutOutcome::Skipped | ChildLayoutOutcome::ReenterCurrent => {
                     panic!("SVG foreign object did not create an independent formatting context")
                 }
             };
@@ -895,9 +899,7 @@ impl SvgFormattingContext {
         while !child.is_invalid() {
             let next = self.next_sibling(child);
             // Masks/clips/patterns do not change the bounding box of their parents.
-            if NodeFacts::new(&self.callbacks, child).is_box()
-                && !kind_is_svg_resource_box(self.node_kind(child))
-            {
+            if NodeFacts::new(&self.callbacks, child).is_box() && !kind_is_svg_resource_box(self.node_kind(child)) {
                 self.layout_svg_element(run, child, input);
                 let child_used_pointer = self.used_values(child);
                 let child_used = child_used_pointer;

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 pub(crate) const LINE_STYLE_NONE: u8 = 0;
 pub(crate) const LINE_STYLE_HIDDEN: u8 = 1;
 pub(crate) const LINE_STYLE_DOTTED: u8 = 2;
@@ -42,7 +44,10 @@ pub(crate) fn child_participates_in_table_run(container_display: FfiDisplay, chi
     }
 }
 
-pub(crate) fn border_is_less_specific(incumbent: BorderData, candidate: BorderData) -> bool {
+pub(crate) fn border_is_less_specific(
+    incumbent: formatting_context::BorderData,
+    candidate: formatting_context::BorderData,
+) -> bool {
     // Implements criteria for steps 1, 2 and 3 of border conflict resolution algorithm, as described in
     // https://www.w3.org/TR/CSS22/tables.html#border-conflict-resolution.
 
@@ -71,16 +76,16 @@ pub(crate) fn border_is_less_specific(incumbent: BorderData, candidate: BorderDa
     line_style_score(incumbent.line_style) < line_style_score(candidate.line_style)
 }
 
-fn candidate_wins(candidate: BorderData, incumbent: BorderData) -> bool {
+fn candidate_wins(candidate: formatting_context::BorderData, incumbent: formatting_context::BorderData) -> bool {
     candidate.line_style != LINE_STYLE_NONE && border_is_less_specific(incumbent, candidate)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ElementBorders {
-    pub(crate) top: BorderData,
-    pub(crate) right: BorderData,
-    pub(crate) bottom: BorderData,
-    pub(crate) left: BorderData,
+    pub(crate) top: formatting_context::BorderData,
+    pub(crate) right: formatting_context::BorderData,
+    pub(crate) bottom: formatting_context::BorderData,
+    pub(crate) left: formatting_context::BorderData,
 }
 
 // Each segment stores the border that currently wins at one slot boundary of the table grid,
@@ -112,7 +117,7 @@ pub(crate) struct BorderWidths {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CollapsedBorderEdge {
-    pub border_data: BorderData,
+    pub border_data: formatting_context::BorderData,
     pub source_order: u32,
 }
 
@@ -198,7 +203,7 @@ impl CollapsedBorderGrid {
         // Segments strictly inside a spanning cell are not borders of any element; mark them as hidden
         // so that borders of rows and columns crossing the span cannot win there.
         let hidden = CollapsedBorderEdge {
-            border_data: BorderData {
+            border_data: formatting_context::BorderData {
                 color: 0,
                 line_style: LINE_STYLE_HIDDEN,
                 width: CssPixels::default(),
@@ -225,14 +230,28 @@ impl CollapsedBorderGrid {
         column_end: usize,
     ) -> BorderWidths {
         BorderWidths {
-            top: Self::most_specific(&self.horizontal_lines[row_start], column_start, column_end).border_data.width,
-            right: Self::most_specific(&self.vertical_lines[column_end], row_start, row_end).border_data.width,
-            bottom: Self::most_specific(&self.horizontal_lines[row_end], column_start, column_end).border_data.width,
-            left: Self::most_specific(&self.vertical_lines[column_start], row_start, row_end).border_data.width,
+            top: Self::most_specific(&self.horizontal_lines[row_start], column_start, column_end)
+                .border_data
+                .width,
+            right: Self::most_specific(&self.vertical_lines[column_end], row_start, row_end)
+                .border_data
+                .width,
+            bottom: Self::most_specific(&self.horizontal_lines[row_end], column_start, column_end)
+                .border_data
+                .width,
+            left: Self::most_specific(&self.vertical_lines[column_start], row_start, row_end)
+                .border_data
+                .width,
         }
     }
 
-    fn apply_to_segments(line: &mut [CollapsedBorderEdge], start: usize, end: usize, data: BorderData, source_order: u32) {
+    fn apply_to_segments(
+        line: &mut [CollapsedBorderEdge],
+        start: usize,
+        end: usize,
+        data: formatting_context::BorderData,
+        source_order: u32,
+    ) {
         if data.line_style == LINE_STYLE_NONE {
             return;
         }
@@ -627,15 +646,11 @@ pub(crate) struct TableGrid {
     pub(crate) occupancy: HashSet<(usize, usize)>,
 }
 
-fn matching_children<T: TableTree>(
-    tree: &T,
-    parent: Node,
-    predicate: impl Fn(FfiDisplay) -> bool,
-) -> Vec<Node> {
+fn matching_children<T: TableTree>(tree: &T, parent: Node, predicate: impl Fn(FfiDisplay) -> bool) -> Vec<Node> {
     let mut result = Vec::new();
     let mut child = tree.first_child(parent);
     while !child.is_invalid() {
-        if kind_is_box(tree.node_data(child).kind) && predicate(tree.display(child)) {
+        if node_facts::kind_is_box(tree.node_data(child).kind) && predicate(tree.display(child)) {
             result.push(child);
         }
         child = tree.next_sibling(child);
@@ -654,7 +669,7 @@ fn count_columns_in_subtree<T: TableTree>(tree: &T, root: Node) -> usize {
             child = tree.next_sibling(child);
         }
         for child in children.into_iter().rev() {
-            if kind_is_box(tree.node_data(child).kind) && tree.display(child).is_table_column() {
+            if node_facts::kind_is_box(tree.node_data(child).kind) && tree.display(child).is_table_column() {
                 count = count.saturating_add(tree.table_column_span(child));
             }
             stack.push(child);
@@ -730,7 +745,7 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
 
     let mut child = tree.first_child(table);
     while !child.is_invalid() {
-        let child_is_box = kind_is_box(tree.node_data(child).kind);
+        let child_is_box = node_facts::kind_is_box(tree.node_data(child).kind);
         let child_display = tree.display(child);
         if child_is_box
             && (child_display.is_table_row_group()
@@ -807,20 +822,20 @@ enum TrackAxis {
     Column,
 }
 
-struct TableFormattingContext {
-    purpose: LayoutPurpose,
+pub(super) struct TableFormattingContext {
+    purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
     table_box: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
-    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    fragments: Option<std::rc::Rc<fragment_tree::RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     table_constraints: ContainingBlockConstraints,
     participant_constraints: ContainingBlockConstraints,
     available_space: AvailableSpace,
     table_block_size: CssPixels,
-    automatic_content_block_size: CssPixels,
+    pub(super) automatic_content_block_size: CssPixels,
     table_box_content_block_offset_in_wrapper: CssPixels,
     min_border_box_block_size_from_flex_item: Option<CssPixels>,
     needs_fixed_mode_row_measurement: bool,
@@ -873,7 +888,7 @@ impl TableFormattingContext {
         self.callbacks.arena().raw_table_column_span(column) as usize
     }
 
-    fn new(run: &FormattingContextRun) -> Self {
+    pub(super) fn new(run: &FormattingContextRun) -> Self {
         Self {
             purpose: run.purpose,
             records: run.records.clone(),
@@ -882,7 +897,8 @@ impl TableFormattingContext {
             callbacks: run.callbacks,
             fragments: run.fragments.clone(),
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             table_constraints: ContainingBlockConstraints::default(),
             participant_constraints: ContainingBlockConstraints::default(),
             available_space: AvailableSpace::default(),
@@ -902,8 +918,8 @@ impl TableFormattingContext {
         }
     }
 
-    fn sizing(&self) -> SizingContext {
-        SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
+    fn sizing(&self) -> sizing_context::SizingContext {
+        sizing_context::SizingContext::new(self.purpose, self.records.clone(), self.callbacks)
     }
 
     fn formatting_context_run(&self) -> FormattingContextRun {
@@ -914,7 +930,8 @@ impl TableFormattingContext {
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
             should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self
+                .treat_block_axis_percentage_insets_as_auto_beyond_root,
             fragments: self.fragments.clone(),
             previous_line_data: None,
         }
@@ -947,7 +964,7 @@ impl TableFormattingContext {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
+        formatting_context::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
     }
 
     fn border_spacing_inline(&mut self) -> CssPixels {
@@ -975,22 +992,22 @@ impl TableFormattingContext {
     fn element_borders(&mut self, node: Node) -> ElementBorders {
         let style = self.style(node);
         ElementBorders {
-            top: BorderData {
+            top: formatting_context::BorderData {
                 color: style.border_top_color(),
                 line_style: style.border_top_style(),
                 width: style.border_top_width(),
             },
-            right: BorderData {
+            right: formatting_context::BorderData {
                 color: style.border_right_color(),
                 line_style: style.border_right_style(),
                 width: style.border_right_width(),
             },
-            bottom: BorderData {
+            bottom: formatting_context::BorderData {
                 color: style.border_bottom_color(),
                 line_style: style.border_bottom_style(),
                 width: style.border_bottom_width(),
             },
-            left: BorderData {
+            left: formatting_context::BorderData {
                 color: style.border_left_color(),
                 line_style: style.border_left_style(),
                 width: style.border_left_width(),
@@ -1131,11 +1148,13 @@ impl TableFormattingContext {
             return;
         }
         let column_offsets = grid_line_offsets(self.columns.iter().map(|column| column.used_inline_size));
-        let row_offsets = grid_line_offsets(
-            self.rows
-                .iter()
-                .map(|row| if row.is_collapsed { CssPixels::default() } else { row.final_block_size }),
-        );
+        let row_offsets = grid_line_offsets(self.rows.iter().map(|row| {
+            if row.is_collapsed {
+                CssPixels::default()
+            } else {
+                row.final_block_size
+            }
+        }));
         let (horizontal_edges, vertical_edges) = grid.take_edges();
         self.used_values(self.table_box).rare_data_mut().collapsed_table_borders =
             Some(std::rc::Rc::new(OwnedCollapsedTableBorders {
@@ -1789,7 +1808,7 @@ impl TableFormattingContext {
             if width.is_length_percentage() && !width.contains_percentage() {
                 let mut preferred = width.to_px(basis);
                 if style.box_sizing() == box_sizing::BORDER_BOX {
-                    preferred = subtract_border_box_adjustment(
+                    preferred = formatting_context::subtract_border_box_adjustment(
                         preferred,
                         style.border_left_width(),
                         style.padding_left().to_px(basis),
@@ -1889,10 +1908,7 @@ impl TableFormattingContext {
                 AvailableSize::Definite(available) => grid_max.min(available).max(used_min),
                 AvailableSize::Indefinite => grid_max.max(used_min),
             };
-            if !matches!(
-                available_inline,
-                AvailableSize::MinContent | AvailableSize::MaxContent
-            ) {
+            if !matches!(available_inline, AvailableSize::MinContent | AvailableSize::MaxContent) {
                 // https://www.w3.org/TR/CSS22/tables.html#auto-table-layout
                 // A percentage value for a column inline size is relative to the table inline size. If the table has
                 // 'width: auto', a percentage represents a constraint on the column's inline size, which a UA should try to satisfy.
@@ -1960,7 +1976,7 @@ impl TableFormattingContext {
         true
     }
 
-    fn run_until_inline_size_calculation(&mut self, input: LayoutInput, skip_row_measurement: bool) {
+    pub(super) fn run_until_inline_size_calculation(&mut self, input: LayoutInput, skip_row_measurement: bool) {
         self.available_space = input.available_space;
         // Determine the number of rows/columns the table requires.
         let table_grid = calculate_table_grid(self, self.table_box);
@@ -2046,13 +2062,14 @@ impl TableFormattingContext {
             },
             participation: ParticipationInParentFormattingContext::Item,
         };
-        match crate::layout::layout_inside_child(run, None, None, cell.box_, self.layout_mode, layout_input, false) {
-            crate::layout::ChildLayoutOutcome::Created(result) => result.baselines,
-            crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+        match formatting_context::layout_inside_child(run, None, None, cell.box_, self.layout_mode, layout_input, false)
+        {
+            ChildLayoutOutcome::Created(result) => result.baselines,
+            ChildLayoutOutcome::ReenterCurrent => {
                 self.run(run, layout_input);
                 self.used_values(cell.box_).content_baselines_from_cells()
             }
-            crate::layout::ChildLayoutOutcome::Skipped => self.used_values(cell.box_).content_baselines_from_cells(),
+            ChildLayoutOutcome::Skipped => self.used_values(cell.box_).content_baselines_from_cells(),
         }
     }
 
@@ -2060,21 +2077,21 @@ impl TableFormattingContext {
         let Some(content_baselines) = committing_run_baselines else {
             return self.box_baseline(cell_box);
         };
-        crate::layout::box_baseline_with_content_baselines(
+        formatting_context::box_baseline_with_content_baselines(
             &self.callbacks,
             cell_box,
             &self.used_values(cell_box),
-            crate::layout::BaselineSet::First,
+            formatting_context::BaselineSet::First,
             content_baselines,
         )
     }
 
     fn box_baseline(&self, node: Node) -> CssPixels {
-        crate::layout::box_baseline(
+        formatting_context::box_baseline(
             &self.callbacks,
             node,
             &self.used_values(node),
-            crate::layout::BaselineSet::First,
+            formatting_context::BaselineSet::First,
         )
     }
 
@@ -2132,7 +2149,7 @@ impl TableFormattingContext {
     ) -> TableCellMeasurement {
         // The table formatting context owns the cell's outer geometry. Seed the inputs
         // needed to lay out its contents without copying placement or layout outputs.
-        let measurement = MeasurementState::create(self.callbacks);
+        let measurement = formatting_context::MeasurementState::create(self.callbacks);
         let measured_root = measurement.create_used_values(cell.box_, ContainingBlockConstraints::default());
         used.mirror_box_metrics_and_size_constraints_into(&measured_root);
         measured_root
@@ -2379,9 +2396,7 @@ impl TableFormattingContext {
             return;
         }
         let auto_rows = (0..self.rows.len())
-            .filter(|index| {
-                !self.rows[*index].is_collapsed && self.style(self.rows[*index].box_).height().is_auto()
-            })
+            .filter(|index| !self.rows[*index].is_collapsed && self.style(self.rows[*index].box_).height().is_auto())
             .collect::<Vec<_>>();
         if self.table_block_size <= sum {
             // If the table block size is no larger than the sum of reference sizes, each final row block size is the
@@ -2428,8 +2443,7 @@ impl TableFormattingContext {
         let table_used = self.used_values(self.table_box);
         let block_spacing = self.border_spacing_block();
         let inline_spacing = self.border_spacing_inline();
-        let inline_offset =
-            table_used.border_box_left(table_used.uses_collapsing_borders_model.get()) + inline_spacing;
+        let inline_offset = table_used.border_box_left(table_used.uses_collapsing_borders_model.get()) + inline_spacing;
         let mut row_block_offset = self.table_box_content_block_offset_in_wrapper + block_spacing;
         for row_index in 0..self.rows.len() {
             let row = &self.rows[row_index];
@@ -2499,7 +2513,13 @@ impl TableFormattingContext {
             // the same basis the measurement saw.
             used.set_content_block_size(self.cell_pre_layout_content_block_sizes[cell_index]);
             let inner = self.cell_inside_layout_inputs[cell_index];
-            self.layout_inside_cell(run, cell, inner, adopt_automatic_content_block_size, intrinsic_block_padding);
+            self.layout_inside_cell(
+                run,
+                cell,
+                inner,
+                adopt_automatic_content_block_size,
+                intrinsic_block_padding,
+            );
             if adopt_automatic_content_block_size {
                 debug_assert_eq!(
                     used.content_block_size.get(),
@@ -2550,7 +2570,10 @@ impl TableFormattingContext {
 
                 // The baseline of the cell is put at the same height as the baseline of the first of the rows it spans.
                 let padding_top = self.rows[cell.row_index].baseline - cell.baseline;
-                Some((padding_top, row_size - (used.border_box_block_size(collapsed) + padding_top)))
+                Some((
+                    padding_top,
+                    row_size - (used.border_box_block_size(collapsed) + padding_top),
+                ))
             }
             _ => panic!("invalid vertical-align keyword"),
         }
@@ -2625,19 +2648,21 @@ impl TableFormattingContext {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        let baselines = crate::layout::derive_baselines(&self.records, &self.callbacks, node, false);
+        let baselines = formatting_context::derive_baselines(&self.records, &self.callbacks, node, false);
         if node == self.table_box {
             self.derived_baselines_of_root_box.set(baselines);
         } else {
-            crate::layout::store_derived_baselines(&self.used_values(node), baselines);
+            formatting_context::store_derived_baselines(&self.used_values(node), baselines);
         }
     }
 
-    fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
+    pub(super) fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
         self.available_space = input.available_space;
         self.min_border_box_block_size_from_flex_item = input.sizing.forced_min_border_box_block_size;
-        self.table_box_content_block_offset_in_wrapper =
-            input.sizing.table_box_content_block_offset_in_wrapper.unwrap_or_default();
+        self.table_box_content_block_offset_in_wrapper = input
+            .sizing
+            .table_box_content_block_offset_in_wrapper
+            .unwrap_or_default();
         self.run_until_inline_size_calculation(input, false);
         if matches!(
             self.available_space.inline_size,
@@ -2683,11 +2708,11 @@ impl TableFormattingContext {
         self.automatic_content_block_size = self.table_block_size;
     }
 
-    fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+    pub(super) fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
         self.derived_baselines_of_root_box.get()
     }
 
-    fn automatic_content_inline_size(&self) -> CssPixels {
+    pub(super) fn automatic_content_inline_size(&self) -> CssPixels {
         let used = self.used_values(self.table_box);
         used.content_inline_size.get()
     }

--- a/Libraries/LibWeb/Rust/src/layout/text_chunker.rs
+++ b/Libraries/LibWeb/Rust/src/layout/text_chunker.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 use libgfx_rust::font::{EmojiPresentation, FontCascadeListRef, FontRef, emoji_presentation_for_code_point};
 
 unsafe extern "C" {
@@ -237,7 +239,7 @@ impl<'text> TextChunker<'text> {
 
     fn current_text_type(&self) -> u8 {
         if self.unidirectional_ltr {
-            return GLYPH_TEXT_TYPE_LTR;
+            return line_box_fragment::GLYPH_TEXT_TYPE_LTR;
         }
         // SAFETY: Pure Unicode table lookup.
         unsafe { ladybird_layout_text_type_for_code_point(self.current_code_point()) }
@@ -351,16 +353,19 @@ impl<'text> TextChunker<'text> {
         while i < self.text.len() {
             let code_point = code_point_at(self.text, i);
             if !is_interword_space(code_point) && code_point != '\t' as u32 && code_point != '\n' as u32 {
-                let font =
-                    self.font_cascade_list
-                        .font_for_code_point(code_point, self.emoji_presentation_at(i, code_point));
+                let font = self
+                    .font_cascade_list
+                    .font_for_code_point(code_point, self.emoji_presentation_at(i, code_point));
                 if !font.is_emoji_font() && has_glyph(font) {
                     return font;
                 }
                 // Text is coming from an emoji face; we'll fall back to (3).
                 break;
             }
-            i = self.grapheme_segmenter.next_boundary(i, false).unwrap_or(self.text.len());
+            i = self
+                .grapheme_segmenter
+                .next_boundary(i, false)
+                .unwrap_or(self.text.len());
         }
 
         // 3. No text around (leading/trailing/all spaces) — pick a font with the glyph from the cascade.
@@ -377,10 +382,8 @@ impl<'text> TextChunker<'text> {
         if is_interword_space(code_point) {
             self.font_for_space(self.current_index, code_point)
         } else {
-            self.font_cascade_list.font_for_code_point(
-                code_point,
-                self.emoji_presentation_at(self.current_index, code_point),
-            )
+            self.font_cascade_list
+                .font_for_code_point(code_point, self.emoji_presentation_at(self.current_index, code_point))
         }
     }
 
@@ -530,8 +533,7 @@ impl<'text> TextChunker<'text> {
                         continue;
                     }
 
-                    if can_break_at_current_position
-                        && let Some(chunk) = self.try_commit_chunk_at_cursor(pending, true)
+                    if can_break_at_current_position && let Some(chunk) = self.try_commit_chunk_at_cursor(pending, true)
                     {
                         return Some(chunk);
                     }

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 use crate::abort_on_panic;
 use crate::layout::layout_node_arena::LayoutNodeArena;
 use crate::layout::node_data::{GENERATED_FOR_AFTER, GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::tree_mutation::OwnedLayoutNode;
-use crate::layout::{
-    ComputedValuesView, FfiDisplay, kind_is_replaced_box, kind_is_svg_box, kind_is_svg_graphics_box,
-    node_can_have_children,
-};
+use crate::layout::{ComputedValuesView, FfiDisplay};
 use std::ffi::c_void;
 
 type LayoutNode = NodeSlotId;
@@ -1022,10 +1021,10 @@ unsafe fn update_principal_node_descendants(
         };
         let (layout_node_can_have_children, layout_node_is_replaced_box_with_children) = {
             let layout_node_data = layout_host.data(layout_node);
-            let can_have_children = node_can_have_children(layout_node_data);
+            let can_have_children = node_facts::node_can_have_children(layout_node_data);
             (
                 can_have_children,
-                kind_is_replaced_box(layout_node_data.kind) && can_have_children,
+                node_facts::kind_is_replaced_box(layout_node_data.kind) && can_have_children,
             )
         };
         let prior_quote_nesting_level = state.quote_nesting_level;
@@ -2348,29 +2347,29 @@ fn node_kind_is_svg_box(kind: NodeKind) -> bool {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_node_kind_is_replaced_box(kind: NodeKind) -> bool {
-    kind_is_replaced_box(kind)
+    node_facts::kind_is_replaced_box(kind)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_node_kind_is_svg_box(kind: NodeKind) -> bool {
-    kind_is_svg_box(kind)
+    node_facts::kind_is_svg_box(kind)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_node_kind_is_svg_graphics_box(kind: NodeKind) -> bool {
-    kind_is_svg_graphics_box(kind)
+    svg_formatting_context::kind_is_svg_graphics_box(kind)
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_node_data_can_have_children(data: *const NodeData) -> bool {
     // SAFETY: The C++ caller passes the node's live arena slot.
-    node_can_have_children(unsafe { &*data })
+    node_facts::node_can_have_children(unsafe { &*data })
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_node_data_may_have_replaced_content_facts(data: *const NodeData) -> bool {
     // SAFETY: The C++ caller passes the node's live arena slot.
-    crate::layout::node_may_have_replaced_content_facts_including_size_containment(unsafe { &*data })
+    node_facts::node_may_have_replaced_content_facts_including_size_containment(unsafe { &*data })
 }
 
 fn node_is_generated_for_pseudo_element(data: &NodeData) -> bool {
@@ -2385,7 +2384,7 @@ fn node_is_inline_outside(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool 
 }
 
 fn node_is_out_of_flow(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
-    crate::layout::node_is_out_of_flow(host.data(node), host.style(node))
+    node_facts::node_is_out_of_flow(host.data(node), host.style(node))
 }
 
 fn node_has_replaced_element_table_display_adjustment(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
@@ -2554,7 +2553,7 @@ impl TreeBuilderHost<'_> {
     }
 }
 
-impl crate::layout::TableTree for TreeBuilderHost<'_> {
+impl table_formatting_context::TableTree for TreeBuilderHost<'_> {
     fn first_child(&self, node: LayoutNode) -> LayoutNode {
         TreeBuilderHost::first_child(self, node)
     }
@@ -3580,7 +3579,12 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
     table_roots_to_wrap
 }
 
-fn fixup_row(host: &TreeBuilderHost<'_>, row: LayoutNode, table_grid: &crate::layout::TableGrid, row_index: usize) {
+fn fixup_row(
+    host: &TreeBuilderHost<'_>,
+    row: LayoutNode,
+    table_grid: &table_formatting_context::TableGrid,
+    row_index: usize,
+) {
     for column_index in 0..table_grid.column_count {
         if table_grid.occupancy.contains(&(column_index, row_index)) {
             continue;
@@ -3598,7 +3602,7 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     // cells to fill all the columns of the table, when taking spans into account. New table-cell anonymous boxes must
     // be appended to its rows content until this condition is met.
     for &table_root in table_roots {
-        let grid = crate::layout::calculate_table_grid(host, table_root);
+        let grid = table_formatting_context::calculate_table_grid(host, table_root);
         for (row_index, row) in grid.rows.iter().enumerate() {
             fixup_row(host, row.box_, &grid, row_index);
         }

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -339,7 +339,9 @@ mod tests {
 
     #[test]
     fn a_structural_change_bumps_the_fragment_cache_epoch_of_every_ancestor() {
-        if crate::layout::fc_run_cache_mode_from_environment() == crate::layout::FcRunCacheMode::Disabled {
+        if super::super::fc_run_cache::fc_run_cache_mode_from_environment()
+            == super::super::fc_run_cache::FcRunCacheMode::Disabled
+        {
             return;
         }
         let mut arena = LayoutNodeArena::new();

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use super::*;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum SizeConstraint {
@@ -237,9 +239,7 @@ impl<T> LazyRefCell<T> {
     }
 
     pub(crate) fn get_or_init(&self, initialize: impl FnOnce() -> T) -> &RefCell<T> {
-        self.value
-            .get_or_init(|| Box::new(RefCell::new(initialize())))
-            .as_ref()
+        self.value.get_or_init(|| Box::new(RefCell::new(initialize()))).as_ref()
     }
 }
 
@@ -289,22 +289,22 @@ impl<T: Copy> SealableCell<T> {
 
 #[derive(Clone, Default, PartialEq)]
 pub(crate) struct LineData {
-    pub(crate) line_boxes: Vec<LineBoxData>,
-    pub(crate) inline_box_pieces: Vec<InlineBoxPieceData>,
+    pub(crate) line_boxes: Vec<line_box::LineBoxData>,
+    pub(crate) inline_box_pieces: Vec<inline_formatting_context::InlineBoxPieceData>,
 }
 
 #[derive(Clone, Default)]
 pub(crate) struct UsedValuesRareData {
     pub(crate) computed_svg_path: Option<std::rc::Rc<libgfx_rust::path::OwnedPath>>,
-    pub(crate) svg_viewport_transform: Option<crate::layout::FfiAffineTransform>,
-    pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
-    pub(crate) svg_view_box: Option<crate::layout::FfiSvgViewBox>,
+    pub(crate) svg_viewport_transform: Option<svg_formatting_context::FfiAffineTransform>,
+    pub(crate) svg_viewport_size: Option<FfiCssPixelSize>,
+    pub(crate) svg_view_box: Option<svg_formatting_context::FfiSvgViewBox>,
     pub(crate) svg_viewport_percentage_basis: CssPixels,
-    pub(crate) grid_layout_data: Option<std::rc::Rc<GridLayoutData>>,
-    pub(crate) flex_layout_data: Option<std::rc::Rc<FlexLayoutData>>,
-    pub(crate) used_grid_tracks: Option<std::rc::Rc<OwnedUsedGridTracks>>,
-    pub(crate) collapsed_table_borders: Option<std::rc::Rc<OwnedCollapsedTableBorders>>,
-    pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
+    pub(crate) grid_layout_data: Option<std::rc::Rc<grid_formatting_context::GridLayoutData>>,
+    pub(crate) flex_layout_data: Option<std::rc::Rc<formatting_context::FlexLayoutData>>,
+    pub(crate) used_grid_tracks: Option<std::rc::Rc<grid_formatting_context::OwnedUsedGridTracks>>,
+    pub(crate) collapsed_table_borders: Option<std::rc::Rc<table_formatting_context::OwnedCollapsedTableBorders>>,
+    pub(crate) abspos_layout_inputs: Option<abspos_inputs::AbsposLayoutInputs>,
 }
 
 impl UsedValuesRareData {
@@ -466,15 +466,17 @@ impl UsedValues {
     }
 
     pub(crate) fn line_data_ref(&self) -> Option<Ref<'_, LineData>> {
-        self.line_data.get().map(|cell| Ref::map(cell.borrow(), |shared| &**shared))
+        self.line_data
+            .get()
+            .map(|cell| Ref::map(cell.borrow(), |shared| &**shared))
     }
 
     pub(crate) fn line_data_cell(&self) -> &RefCell<std::rc::Rc<LineData>> {
         self.line_data.get_or_init(std::rc::Rc::default)
     }
 
-    pub(crate) fn content_baselines_from_cells(&self) -> crate::layout::DerivedBaselines {
-        crate::layout::DerivedBaselines {
+    pub(crate) fn content_baselines_from_cells(&self) -> DerivedBaselines {
+        DerivedBaselines {
             first: self.has_first_baseline.get().then(|| self.first_baseline.get()),
             last: self.has_last_baseline.get().then(|| self.last_baseline.get()),
         }
@@ -733,11 +735,8 @@ impl UsedValues {
             + self.margin_box_bottom(collapsed)
     }
 
-    pub(crate) fn available_inner_space_or_constraints_from(
-        &self,
-        outer: crate::layout::AvailableSpace,
-    ) -> crate::layout::AvailableSpace {
-        use crate::layout::AvailableSize;
+    pub(crate) fn available_inner_space_or_constraints_from(&self, outer: AvailableSpace) -> AvailableSpace {
+        use AvailableSize;
 
         let mut inline_size = match self.inline_size_constraint.get() {
             SizeConstraint::MinContent => AvailableSize::MinContent,
@@ -756,22 +755,16 @@ impl UsedValues {
             SizeConstraint::None => AvailableSize::Indefinite,
         };
         if inline_size == AvailableSize::Indefinite
-            && matches!(
-                outer.inline_size,
-                AvailableSize::MinContent | AvailableSize::MaxContent
-            )
+            && matches!(outer.inline_size, AvailableSize::MinContent | AvailableSize::MaxContent)
         {
             inline_size = outer.inline_size;
         }
         if block_size == AvailableSize::Indefinite
-            && matches!(
-                outer.block_size,
-                AvailableSize::MinContent | AvailableSize::MaxContent
-            )
+            && matches!(outer.block_size, AvailableSize::MinContent | AvailableSize::MaxContent)
         {
             block_size = outer.block_size;
         }
-        crate::layout::AvailableSpace {
+        AvailableSpace {
             inline_size,
             block_size,
         }

--- a/Libraries/LibWeb/Rust/src/painting/devtools_layout.rs
+++ b/Libraries/LibWeb/Rust/src/painting/devtools_layout.rs
@@ -4,28 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::{
-    FlexLayoutClampState, FlexLayoutData, FlexLayoutGrowthState, GridLayoutArea, GridLayoutData, GridLayoutDimension,
-    GridLayoutFragment, GridLayoutLine, GridLayoutTrack, GridTrackState, GridTrackType,
-};
+use crate::layout::{formatting_context, grid_formatting_context};
+
 use serde_json::{Value, json};
 
-fn grid_track_type_name(type_: GridTrackType) -> &'static str {
+fn grid_track_type_name(type_: grid_formatting_context::GridTrackType) -> &'static str {
     match type_ {
-        GridTrackType::Explicit => "explicit",
-        GridTrackType::Implicit => "implicit",
+        grid_formatting_context::GridTrackType::Explicit => "explicit",
+        grid_formatting_context::GridTrackType::Implicit => "implicit",
     }
 }
 
-fn grid_track_state_name(state: GridTrackState) -> &'static str {
+fn grid_track_state_name(state: grid_formatting_context::GridTrackState) -> &'static str {
     match state {
-        GridTrackState::Static => "static",
-        GridTrackState::Repeat => "repeat",
-        GridTrackState::Removed => "removed",
+        grid_formatting_context::GridTrackState::Static => "static",
+        grid_formatting_context::GridTrackState::Repeat => "repeat",
+        grid_formatting_context::GridTrackState::Removed => "removed",
     }
 }
 
-fn serialize_grid_line(line: &GridLayoutLine) -> Value {
+fn serialize_grid_line(line: &grid_formatting_context::GridLayoutLine) -> Value {
     json!({
         "breadth": line.breadth.to_double(),
         "names": line.names,
@@ -36,7 +34,7 @@ fn serialize_grid_line(line: &GridLayoutLine) -> Value {
     })
 }
 
-fn serialize_grid_track(track: &GridLayoutTrack) -> Value {
+fn serialize_grid_track(track: &grid_formatting_context::GridLayoutTrack) -> Value {
     json!({
         "breadth": track.breadth.to_double(),
         "start": track.start.to_double(),
@@ -45,7 +43,7 @@ fn serialize_grid_track(track: &GridLayoutTrack) -> Value {
     })
 }
 
-fn serialize_grid_area(area: &GridLayoutArea) -> Value {
+fn serialize_grid_area(area: &grid_formatting_context::GridLayoutArea) -> Value {
     json!({
         "columnEnd": area.column_end,
         "columnStart": area.column_start,
@@ -56,14 +54,14 @@ fn serialize_grid_area(area: &GridLayoutArea) -> Value {
     })
 }
 
-fn serialize_grid_dimension(dimension: &GridLayoutDimension) -> Value {
+fn serialize_grid_dimension(dimension: &grid_formatting_context::GridLayoutDimension) -> Value {
     json!({
         "lines": dimension.lines.iter().map(serialize_grid_line).collect::<Vec<_>>(),
         "tracks": dimension.tracks.iter().map(serialize_grid_track).collect::<Vec<_>>(),
     })
 }
 
-fn serialize_grid_fragment(fragment: &GridLayoutFragment) -> Value {
+fn serialize_grid_fragment(fragment: &grid_formatting_context::GridLayoutFragment) -> Value {
     json!({
         "areas": fragment.areas.iter().map(serialize_grid_area).collect::<Vec<_>>(),
         "cols": serialize_grid_dimension(&fragment.columns),
@@ -71,7 +69,7 @@ fn serialize_grid_fragment(fragment: &GridLayoutFragment) -> Value {
     })
 }
 
-pub(crate) fn serialize_grid_layout(data: &GridLayoutData, container_node_id: i64) -> Vec<u8> {
+pub(crate) fn serialize_grid_layout(data: &grid_formatting_context::GridLayoutData, container_node_id: i64) -> Vec<u8> {
     serde_json::to_vec(&json!({
         "containerNodeId": container_node_id,
         "direction": crate::css::css_enums::direction::NAMES[data.direction as usize],
@@ -82,18 +80,18 @@ pub(crate) fn serialize_grid_layout(data: &GridLayoutData, container_node_id: i6
     .expect("grid layout data serializes to JSON")
 }
 
-fn flex_layout_growth_state_name(state: FlexLayoutGrowthState) -> &'static str {
+fn flex_layout_growth_state_name(state: formatting_context::FlexLayoutGrowthState) -> &'static str {
     match state {
-        FlexLayoutGrowthState::Growing => "growing",
-        FlexLayoutGrowthState::Shrinking => "shrinking",
+        formatting_context::FlexLayoutGrowthState::Growing => "growing",
+        formatting_context::FlexLayoutGrowthState::Shrinking => "shrinking",
     }
 }
 
-fn flex_layout_clamp_state_name(state: FlexLayoutClampState) -> &'static str {
+fn flex_layout_clamp_state_name(state: formatting_context::FlexLayoutClampState) -> &'static str {
     match state {
-        FlexLayoutClampState::Unclamped => "unclamped",
-        FlexLayoutClampState::ClampedToMin => "clamped_to_min",
-        FlexLayoutClampState::ClampedToMax => "clamped_to_max",
+        formatting_context::FlexLayoutClampState::Unclamped => "unclamped",
+        formatting_context::FlexLayoutClampState::ClampedToMin => "clamped_to_min",
+        formatting_context::FlexLayoutClampState::ClampedToMax => "clamped_to_max",
     }
 }
 
@@ -107,7 +105,7 @@ fn axis_direction_name(direction: u8) -> &'static str {
     }
 }
 
-pub(crate) fn serialize_flex_layout(data: &FlexLayoutData, container_node_id: i64) -> Vec<u8> {
+pub(crate) fn serialize_flex_layout(data: &formatting_context::FlexLayoutData, container_node_id: i64) -> Vec<u8> {
     let main_axis_direction = axis_direction_name(data.main_axis_direction);
     let cross_axis_direction = axis_direction_name(data.cross_axis_direction);
     let main_size_property_name = if data.main_axis_direction <= 1 {

--- a/Libraries/LibWeb/Rust/src/painting/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/dump.rs
@@ -7,6 +7,7 @@
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::fragment_ownership;
 use crate::painting::paintable_data::FragmentRecord;
 use crate::painting::paintable_rows::PaintableRowsRead;
@@ -111,7 +112,7 @@ fn dump_fragment(
     if fragment.length_in_code_units > 0 {
         push_indent(out, indent);
         out.extend_from_slice(b"      \"");
-        if crate::layout::kind_is_text(kind)
+        if node_facts::kind_is_text(kind)
             && let Some(content) = layout_arena.text_content(fragment.layout_node)
         {
             let end = fragment

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -6,11 +6,12 @@
 
 use crate::abort_on_panic;
 use crate::css::css_pixels::CssPixels;
-use crate::layout::FfiCssPixelPoint;
-use crate::layout::FfiCssPixelRect;
-use crate::layout::FfiCssPixelSize;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::used_values::FfiCssPixelPoint;
+use crate::layout::used_values::FfiCssPixelRect;
+use crate::layout::used_values::FfiCssPixelSize;
+use crate::layout::{grid_formatting_context, svg_formatting_context, used_values};
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_rows::PaintableRowsRead;
 use std::ffi::c_void;
@@ -557,7 +558,7 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_size(
 #[repr(C)]
 pub struct FfiOptionalAffineTransform {
     pub has_value: bool,
-    pub transform: crate::layout::FfiAffineTransform,
+    pub transform: svg_formatting_context::FfiAffineTransform,
 }
 
 /// # Safety
@@ -610,7 +611,7 @@ pub unsafe extern "C" fn layout_arena_paintable_transform_reference_box(
 pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_user_rect(
     arena: *mut c_void,
     slot: NodeSlotId,
-) -> crate::layout::OptionalCssPixelRect {
+) -> used_values::OptionalCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         if !arena.paintable_row_is_populated(slot) {
@@ -618,7 +619,7 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_user_rect(
         }
         let paintable_rows = arena.paintable_rows();
         crate::painting::svg_viewport::nearest_svg_viewport_user_rect(&paintable_rows, slot)
-            .map(|rect| crate::layout::FfiCssPixelRect {
+            .map(|rect| used_values::FfiCssPixelRect {
                 x: crate::css::css_pixels::CssPixels::nearest_value_for(rect.x as f64),
                 y: crate::css::css_pixels::CssPixels::nearest_value_for(rect.y as f64),
                 width: crate::css::css_pixels::CssPixels::nearest_value_for(rect.width as f64),
@@ -1178,9 +1179,9 @@ pub struct FfiImagePaintRecordInputs {
     pub first_stop_position: f32,
     pub repeat_length: f32,
     pub interpolation_method: libgfx_rust::GradientInterpolationMethod,
-    pub center: crate::layout::FfiCssPixelPoint,
-    pub size: crate::layout::FfiCssPixelSize,
-    pub position: crate::layout::FfiCssPixelPoint,
+    pub center: used_values::FfiCssPixelPoint,
+    pub size: used_values::FfiCssPixelSize,
+    pub position: used_values::FfiCssPixelPoint,
     pub color_stop_colors: *const libgfx_rust::Color,
     pub color_stop_positions: *const f32,
     pub color_stop_count: usize,
@@ -2224,8 +2225,8 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
     context: *mut c_void,
     consume: unsafe extern "C" fn(
         *mut c_void,
-        *const crate::layout::FfiUsedGridTrackList,
-        *const crate::layout::FfiUsedGridTrackList,
+        *const grid_formatting_context::FfiUsedGridTrackList,
+        *const grid_formatting_context::FfiUsedGridTrackList,
     ),
 ) {
     abort_on_panic(|| {
@@ -2403,7 +2404,7 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
         // SAFETY: The caller provides writable storage for exactly `output_length` exports.
         let output = unsafe { std::slice::from_raw_parts_mut(output, output_length) };
         for (output, item) in output.iter_mut().zip(items.iter()) {
-            let rect = |rect: crate::css::css_pixels::CssPixelRect| crate::layout::FfiCssPixelRect::from(rect);
+            let rect = |rect: crate::css::css_pixels::CssPixelRect| used_values::FfiCssPixelRect::from(rect);
             assert!(
                 arena.paintable_row_is_populated(item.paintable),
                 "exporting a hit-test item for a non-live paintable"
@@ -2882,7 +2883,7 @@ pub struct FfiResolvedGradientPaint {
     pub color_stops_repeating: bool,
     pub interpolation_method: libgfx_rust::GradientInterpolationMethod,
     pub center: FfiCssPixelPoint,
-    pub size: crate::layout::FfiCssPixelSize,
+    pub size: used_values::FfiCssPixelSize,
 }
 
 /// # Safety
@@ -2940,7 +2941,7 @@ pub unsafe extern "C" fn layout_arena_resolve_gradient_paint_for_size(
                     x: center.x,
                     y: center.y,
                 };
-                out.size = crate::layout::FfiCssPixelSize {
+                out.size = used_values::FfiCssPixelSize {
                     width: size.width,
                     height: size.height,
                 };

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::layout::OptionalCssPixelRect;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::used_values;
+use crate::layout::used_values::OptionalCssPixelRect;
 use crate::painting::display_list::commands::OptionalU32;
 use std::ffi::c_void;
 
@@ -30,7 +31,7 @@ pub struct FfiHitTestTextNodeFacts {
 #[repr(C)]
 pub struct FfiLineBreakCaretTarget {
     pub caret_offset: usize,
-    pub rect: crate::layout::FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
 }
 
 #[derive(Clone, Copy)]
@@ -70,20 +71,20 @@ pub struct FfiHitTestQueryCallbacks {
     pub local_point_for_visual_context: unsafe extern "C" fn(
         *mut c_void,
         usize,
-        crate::layout::FfiCssPixelPoint,
+        used_values::FfiCssPixelPoint,
         bool,
         *mut libgfx_rust::FloatPoint,
     ) -> bool,
     pub line_in_scope: unsafe extern "C" fn(*mut c_void, usize) -> bool,
     pub sorting_context_group: unsafe extern "C" fn(*mut c_void, usize, *mut usize) -> bool,
-    pub plane_depth_key: unsafe extern "C" fn(*mut c_void, usize, crate::layout::FfiCssPixelPoint, *mut i64) -> bool,
+    pub plane_depth_key: unsafe extern "C" fn(*mut c_void, usize, used_values::FfiCssPixelPoint, *mut i64) -> bool,
 }
 
 impl FfiHitTestQueryCallbacks {
     pub(crate) fn local_point_for_visual_context(
         &self,
         index: usize,
-        point: crate::layout::FfiCssPixelPoint,
+        point: used_values::FfiCssPixelPoint,
         respect_clip: bool,
     ) -> Option<(f32, f32)> {
         let mut local = libgfx_rust::FloatPoint::default();
@@ -122,7 +123,7 @@ impl FfiHitTestQueryCallbacks {
 pub struct FfiTopmostItem {
     pub has_item: bool,
     pub index: usize,
-    pub local: crate::layout::FfiCssPixelPoint,
+    pub local: used_values::FfiCssPixelPoint,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -173,15 +174,15 @@ pub struct FfiHitTestItemExport {
     pub text_fragment_index: OptionalU32,
     pub caret_node_shell: *mut c_void,
     pub caret_offset: usize,
-    pub rect: crate::layout::FfiCssPixelRect,
-    pub caret_rect: crate::layout::FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
+    pub caret_rect: used_values::FfiCssPixelRect,
     pub visual_context_index: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
 pub struct FfiCaretLineExport {
-    pub rect: crate::layout::FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
     pub visual_context_index: usize,
     pub first_caret_item_index: usize,
     pub last_caret_item_index: usize,

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -5,7 +5,8 @@
  */
 
 use super::*;
-use crate::layout::{OptionalCssPixelRect, OptionalCssPixels, OptionalFloatSize, OptionalIntRect};
+
+use crate::layout::used_values;
 use crate::painting::display_list::commands::{OptionalAffineTransform, OptionalColor};
 use libgfx_rust::{
     AffineTransform, Color, FloatMatrix4x4, FloatRect, FloatSize, IntPoint, IntRect, InterpolationColorSpace,
@@ -17,7 +18,7 @@ use std::ffi::c_void;
 pub struct FfiRecordingInputs {
     pub device_pixels_per_css_pixel: f64,
     pub device_viewport_rect: IntRect,
-    pub css_viewport_rect: crate::layout::FfiCssPixelRect,
+    pub css_viewport_rect: used_values::FfiCssPixelRect,
     pub should_show_line_box_borders: bool,
     pub should_paint_overlay: bool,
     pub is_recording_async_scrolling_metadata: bool,
@@ -29,9 +30,9 @@ pub struct FfiRecordingInputs {
     pub paint_viewport_scrollbars: bool,
     pub async_scrolling_enabled: bool,
     pub middle_button_scroll_active: bool,
-    pub middle_button_scroll_origin: crate::layout::FfiCssPixelPoint,
+    pub middle_button_scroll_origin: used_values::FfiCssPixelPoint,
     pub root_background_source: FfiRootBackgroundSource,
-    pub canvas_fill_rect: OptionalIntRect,
+    pub canvas_fill_rect: used_values::OptionalIntRect,
     pub canvas_color: Color,
     pub opaque_canvas: bool,
     pub bitmap_rect: IntRect,
@@ -49,7 +50,7 @@ pub struct FfiRecordingInputs {
     pub grid_overlay_count: usize,
     pub flex_overlays: *const FfiFlexOverlayInput,
     pub flex_overlay_count: usize,
-    pub caret_debug_rect: OptionalCssPixelRect,
+    pub caret_debug_rect: used_values::OptionalCssPixelRect,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -88,8 +89,8 @@ pub struct FfiOverlayLabelFacts {
 #[repr(C)]
 pub struct FfiImageIntrinsicFacts {
     pub is_paintable: bool,
-    pub natural_width: OptionalCssPixels,
-    pub natural_height: OptionalCssPixels,
+    pub natural_width: used_values::OptionalCssPixels,
+    pub natural_height: used_values::OptionalCssPixels,
     pub has_natural_aspect_ratio: bool,
     pub natural_aspect_ratio_numerator: crate::css::css_pixels::CssPixels,
     pub natural_aspect_ratio_denominator: crate::css::css_pixels::CssPixels,
@@ -125,8 +126,8 @@ pub enum FfiVideoRepresentation {
 #[repr(C)]
 pub struct FfiReplacedPaintFacts {
     pub has_decoded_image_data: bool,
-    pub natural_width: OptionalCssPixels,
-    pub natural_height: OptionalCssPixels,
+    pub natural_width: used_values::OptionalCssPixels,
+    pub natural_height: used_values::OptionalCssPixels,
     pub has_natural_aspect_ratio: bool,
     pub natural_aspect_ratio_numerator: crate::css::css_pixels::CssPixels,
     pub natural_aspect_ratio_denominator: crate::css::css_pixels::CssPixels,
@@ -160,7 +161,7 @@ pub struct FfiReplacedPaintFacts {
 #[repr(C)]
 pub struct FfiSvgImageFacts {
     pub has_decoded_image_data: bool,
-    pub natural_size: OptionalFloatSize,
+    pub natural_size: used_values::OptionalFloatSize,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -264,7 +265,7 @@ pub struct FfiSelectionStyleFacts {
 #[repr(C)]
 pub struct FfiCursorFacts {
     pub paints: bool,
-    pub rect: crate::layout::FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
     pub color: Color,
 }
 
@@ -366,7 +367,7 @@ pub struct FfiPaintHostCallbacks {
         FfiLayerImageList,
         u32,
         FloatRect,
-        crate::layout::FfiCssPixelSize,
+        used_values::FfiCssPixelSize,
         u8,
         FloatSize,
     ) -> FfiImagePaintFacts,
@@ -514,7 +515,7 @@ impl FfiPaintHostCallbacks {
         list: FfiLayerImageList,
         computed_index: u32,
         dest: FloatRect,
-        css_tile_size: crate::layout::FfiCssPixelSize,
+        css_tile_size: used_values::FfiCssPixelSize,
         image_rendering: u8,
         accumulated_scale: libgfx_rust::FloatSize,
     ) -> FfiImagePaintFacts {

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -5,7 +5,9 @@
  */
 
 use super::*;
-use crate::layout::OptionalCssPixelRect;
+
+use crate::layout::used_values;
+use crate::layout::used_values::OptionalCssPixelRect;
 use crate::painting::visual_context::{MaskLayerOrigin, TransformDataRole};
 use libgfx_rust::{
     CompositingAndBlendingOperator, CornerRadii, FloatMatrix4x4, FloatPoint, IntRect, MaskKind, WindingRule,
@@ -42,7 +44,7 @@ pub struct FfiResolvedEffectsFilter {
 pub struct FfiVisualContextHostCallbacks {
     pub context: *mut c_void,
     pub tree_inputs: unsafe extern "C" fn(*mut c_void) -> FfiVisualContextTreeInputs,
-    pub scroll_offset: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiCssPixelPoint,
+    pub scroll_offset: unsafe extern "C" fn(*mut c_void, *mut c_void) -> used_values::FfiCssPixelPoint,
     pub svg_additional_element_transform:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut libgfx_rust::AffineTransform) -> bool,
     pub root_background_source: unsafe extern "C" fn(*mut c_void) -> FfiRootBackgroundSource,
@@ -57,7 +59,7 @@ impl FfiVisualContextHostCallbacks {
         // SAFETY: The C++ host answers synchronously.
         unsafe { (self.tree_inputs)(self.context) }
     }
-    pub(crate) fn scroll_offset(&self, layout_node_shell: *mut c_void) -> crate::layout::FfiCssPixelPoint {
+    pub(crate) fn scroll_offset(&self, layout_node_shell: *mut c_void) -> used_values::FfiCssPixelPoint {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.scroll_offset)(self.context, layout_node_shell) }
     }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -6,10 +6,10 @@
 
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
+use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
 use crate::layout::{
-    FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiLayoutFcCallbacks, FragmentLink, LayoutNodeArena, LineData,
-    Node, NodeFacts,
+    formatting_context, fragment_tree, inline_formatting_context, inline_level_iterator, node_facts, used_values,
 };
 use crate::painting::paintable_data::*;
 
@@ -20,11 +20,11 @@ pub(crate) struct PreparedPaintable {
 }
 
 pub(crate) struct ReplacedCommittedFragmentLink {
-    pub(crate) content_size_change: Option<(FfiCssPixelSize, FfiCssPixelSize)>,
+    pub(crate) content_size_change: Option<(used_values::FfiCssPixelSize, used_values::FfiCssPixelSize)>,
     pub(crate) committed_fragment_identity_changed: bool,
 }
 
-pub(crate) fn paintable_kind_for_node(facts: &NodeFacts<'_>, kind: NodeKind) -> PaintableKind {
+pub(crate) fn paintable_kind_for_node(facts: &node_facts::NodeFacts<'_>, kind: NodeKind) -> PaintableKind {
     match kind {
         NodeKind::Viewport => PaintableKind::ViewportPaintable,
         NodeKind::BlockContainer
@@ -69,13 +69,13 @@ pub(crate) fn paintable_kind_for_node(facts: &NodeFacts<'_>, kind: NodeKind) -> 
 }
 
 pub(crate) struct PaintableCommit<'a> {
-    callbacks: &'a FfiLayoutFcCallbacks,
-    committed_offsets_before_recommit_reset: std::collections::HashMap<NodeSlotId, FfiCssPixelPoint>,
+    callbacks: &'a formatting_context::FfiLayoutFcCallbacks,
+    committed_offsets_before_recommit_reset: std::collections::HashMap<NodeSlotId, used_values::FfiCssPixelPoint>,
     committed_navigable_container_viewports: Vec<NodeSlotId>,
 }
 
 impl<'a> PaintableCommit<'a> {
-    pub(crate) fn new(callbacks: &'a FfiLayoutFcCallbacks) -> Self {
+    pub(crate) fn new(callbacks: &'a formatting_context::FfiLayoutFcCallbacks) -> Self {
         Self {
             callbacks,
             committed_offsets_before_recommit_reset: std::collections::HashMap::new(),
@@ -104,13 +104,13 @@ impl<'a> PaintableCommit<'a> {
 
     pub(crate) fn prepare_node(
         &mut self,
-        node: Node,
+        node: formatting_context::Node,
         has_used_values: bool,
         reuses_committed_subtree: bool,
         enclosing_line_root_content_changed: bool,
     ) -> PreparedPaintable {
         let (expected_kind, wants_paintable, node_kind) = {
-            let facts = NodeFacts::new(self.callbacks, node);
+            let facts = node_facts::NodeFacts::new(self.callbacks, node);
             let data = self.callbacks.node_data(node);
             let expected_kind = paintable_kind_for_node(&facts, data.kind);
             (
@@ -198,22 +198,22 @@ impl<'a> PaintableCommit<'a> {
 
     pub(crate) fn replace_committed_fragment_link(
         &mut self,
-        node: Node,
-        link: &FragmentLink,
+        node: formatting_context::Node,
+        link: &fragment_tree::FragmentLink,
         reuses_committed_subtree: bool,
         enclosing_line_root_content_changed: bool,
     ) -> ReplacedCommittedFragmentLink {
         let fragment = &link.fragment;
-        let new_content_size = FfiCssPixelSize {
+        let new_content_size = used_values::FfiCssPixelSize {
             width: fragment.content_inline_size,
             height: fragment.content_block_size,
         };
         let mut content_size_change = None;
         let (old_identity, old_content_size) = self.arena().with_committed_fragment_link(node, |old_link| {
-            old_link.map_or((0, FfiCssPixelSize::default()), |old_link| {
+            old_link.map_or((0, used_values::FfiCssPixelSize::default()), |old_link| {
                 (
                     old_link.fragment.identity,
-                    FfiCssPixelSize {
+                    used_values::FfiCssPixelSize {
                         width: old_link.fragment.content_inline_size,
                         height: old_link.fragment.content_block_size,
                     },
@@ -223,7 +223,7 @@ impl<'a> PaintableCommit<'a> {
         let previous_content_size_for_diff = if reuses_committed_subtree {
             old_content_size
         } else {
-            FfiCssPixelSize::default()
+            used_values::FfiCssPixelSize::default()
         };
         if previous_content_size_for_diff != new_content_size {
             assert!(
@@ -234,7 +234,7 @@ impl<'a> PaintableCommit<'a> {
         }
         let committed_fragment_identity_changed = old_identity != fragment.identity;
         let painted_geometry_lives_in_enclosing_line_root =
-            || NodeFacts::new(self.callbacks, node).is_fragmented_inline();
+            || node_facts::NodeFacts::new(self.callbacks, node).is_fragmented_inline();
         let painted_content_changed = committed_fragment_identity_changed
             || (enclosing_line_root_content_changed && painted_geometry_lives_in_enclosing_line_root());
         // A reused committed subtree's root counts as unchanged even though its run-root
@@ -265,7 +265,12 @@ impl<'a> PaintableCommit<'a> {
         }
     }
 
-    pub(crate) fn set_line_data(&self, slot: NodeSlotId, line_data: &LineData, content_inline_size: CssPixels) -> bool {
+    pub(crate) fn set_line_data(
+        &self,
+        slot: NodeSlotId,
+        line_data: &used_values::LineData,
+        content_inline_size: CssPixels,
+    ) -> bool {
         if !self.arena().paintable_rows().paintable_data(slot).kind.has_lines() {
             return false;
         }
@@ -286,7 +291,7 @@ impl<'a> PaintableCommit<'a> {
 
     fn build_line_records(
         &self,
-        data: &LineData,
+        data: &used_values::LineData,
         content_inline_size: CssPixels,
     ) -> (Vec<LineRecord>, Vec<FragmentRecord>, Vec<InlineBoxPieceRecord>) {
         let mut lines = Vec::with_capacity(data.line_boxes.len());
@@ -298,7 +303,7 @@ impl<'a> PaintableCommit<'a> {
                 .filter(|fragment| !fragment.is_fully_truncated)
                 .count() as u32;
             lines.push(LineRecord {
-                rect: crate::layout::line_rect(line, content_inline_size),
+                rect: inline_formatting_context::line_rect(line, content_inline_size),
                 baseline: line.block_start + line.baseline,
                 fragment_count: committed_fragment_count,
             });
@@ -314,11 +319,11 @@ impl<'a> PaintableCommit<'a> {
                     let text_type = libgfx_rust::text_layout::TextType::try_from(glyph_data.text_type)
                         .expect("committed glyph run carries a valid text type");
                     const _: () = assert!(
-                        std::mem::size_of::<crate::layout::FfiDrawGlyph>()
+                        std::mem::size_of::<inline_level_iterator::FfiDrawGlyph>()
                             == std::mem::size_of::<libgfx_rust::text_layout::DrawGlyph>()
                     );
                     const _: () = assert!(
-                        std::mem::align_of::<crate::layout::FfiDrawGlyph>()
+                        std::mem::align_of::<inline_level_iterator::FfiDrawGlyph>()
                             == std::mem::align_of::<libgfx_rust::text_layout::DrawGlyph>()
                     );
                     // SAFETY: FfiDrawGlyph mirrors libgfx's DrawGlyph layout (asserted above), and
@@ -357,8 +362,8 @@ impl<'a> PaintableCommit<'a> {
                 );
                 fragments.push(FragmentRecord {
                     layout_node: fragment.layout_node,
-                    offset: FfiCssPixelPoint { x, y },
-                    size: FfiCssPixelSize { width, height },
+                    offset: used_values::FfiCssPixelPoint { x, y },
+                    size: used_values::FfiCssPixelSize { width, height },
                     line_index,
                     start_offset: fragment.start,
                     length_in_code_units: fragment.length_in_code_units,
@@ -382,7 +387,7 @@ impl<'a> PaintableCommit<'a> {
                 first_fragment_index: piece.first_fragment_index,
                 fragment_count: piece.fragment_count,
                 line_index: piece.line_index,
-                border_box_rect: FfiCssPixelRect {
+                border_box_rect: used_values::FfiCssPixelRect {
                     x: piece.border_box_rect.x + piece.relpos_delta.x,
                     y: piece.border_box_rect.y + piece.relpos_delta.y,
                     width: piece.border_box_rect.width,
@@ -405,7 +410,7 @@ impl<'a> PaintableCommit<'a> {
         has_trailing_whitespace: bool,
     ) -> (usize, usize, usize, usize) {
         let data = self.callbacks.node_data(layout_node);
-        if !crate::layout::kind_is_text(data.kind) {
+        if !node_facts::kind_is_text(data.kind) {
             return (
                 start_offset,
                 start_offset + length_in_code_units,
@@ -456,7 +461,7 @@ impl<'a> PaintableCommit<'a> {
         )
     }
 
-    pub(crate) fn stamp_containing_block(&mut self, node: Node) {
+    pub(crate) fn stamp_containing_block(&mut self, node: formatting_context::Node) {
         let containing_block = self.callbacks.node_data(node).containing_block;
         let arena = self.arena_mut();
         let mut paintable_rows = arena.paintable_rows_mut();

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -6,7 +6,7 @@
 
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, FfiDrawGlyph};
+use crate::layout::{inline_level_iterator, used_values};
 use std::cell::Cell;
 
 pub const NO_STACKING_CONTEXT: u32 = u32::MAX;
@@ -115,7 +115,7 @@ pub struct FfiStickyInsets {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct FfiOverflowData {
-    pub rect: FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
     pub has_scrollable_overflow: bool,
 }
 
@@ -128,10 +128,10 @@ pub struct PaintableData {
     pub slot_generation: u8,
     pub flags: u32,
 
-    pub offset: FfiCssPixelPoint,
-    pub content_size: FfiCssPixelSize,
-    pub local_padding_box_union: FfiCssPixelRect,
-    pub local_border_box_union: FfiCssPixelRect,
+    pub offset: used_values::FfiCssPixelPoint,
+    pub content_size: used_values::FfiCssPixelSize,
+    pub local_padding_box_union: used_values::FfiCssPixelRect,
+    pub local_border_box_union: used_values::FfiCssPixelRect,
 
     pub overflow_relative_to_padding_box: FfiOverflowData,
     pub overflow_measured_this_commit: bool,
@@ -162,10 +162,10 @@ impl Default for PaintableData {
             selection_state: 0,
             slot_generation: 0,
             flags: 0,
-            offset: FfiCssPixelPoint::default(),
-            content_size: FfiCssPixelSize::default(),
-            local_padding_box_union: FfiCssPixelRect::default(),
-            local_border_box_union: FfiCssPixelRect::default(),
+            offset: used_values::FfiCssPixelPoint::default(),
+            content_size: used_values::FfiCssPixelSize::default(),
+            local_padding_box_union: used_values::FfiCssPixelRect::default(),
+            local_border_box_union: used_values::FfiCssPixelRect::default(),
             overflow_relative_to_padding_box: FfiOverflowData::default(),
             overflow_measured_this_commit: false,
             overflow_valid_across_recommits: false,
@@ -224,21 +224,21 @@ pub enum PaintableRowResetKind {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct LineRecord {
-    pub rect: FfiCssPixelRect,
+    pub rect: used_values::FfiCssPixelRect,
     pub baseline: CssPixels,
     pub fragment_count: u32,
 }
 
 pub struct GlyphRunRecord {
-    pub glyphs: Vec<FfiDrawGlyph>,
+    pub glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
     pub font: libgfx_rust::font::RetainedFont,
     pub retained: libgfx_rust::text_layout::RetainedGlyphRun,
 }
 
 pub struct FragmentRecord {
     pub layout_node: NodeSlotId,
-    pub offset: FfiCssPixelPoint,
-    pub size: FfiCssPixelSize,
+    pub offset: used_values::FfiCssPixelPoint,
+    pub size: used_values::FfiCssPixelSize,
     pub line_index: u32,
     pub start_offset: usize,
     pub length_in_code_units: usize,
@@ -259,7 +259,7 @@ pub struct InlineBoxPieceRecord {
     pub first_fragment_index: u32,
     pub fragment_count: u32,
     pub line_index: u32,
-    pub border_box_rect: FfiCssPixelRect,
+    pub border_box_rect: used_values::FfiCssPixelRect,
     pub baseline: CssPixels,
     pub accumulated_vertical_shift: CssPixels,
     pub present_edges: u8,
@@ -294,7 +294,7 @@ pub struct PaintableSideData {
     pub(crate) fragments: Vec<FragmentRecord>,
     pub(crate) inline_box_pieces: Vec<InlineBoxPieceRecord>,
     pub(crate) piece_indices: Vec<u32>,
-    pub(crate) svg_filter_bounds: Cell<Option<FfiCssPixelRect>>,
+    pub(crate) svg_filter_bounds: Cell<Option<used_values::FfiCssPixelRect>>,
     // Only meaningful while is_self_painting(); assigned by the containing block's
     // assign_fragment_ownership().
     pub(crate) fragment_ownership: Option<crate::painting::fragment_ownership::FragmentOwnershipFilter>,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -8,6 +8,9 @@ use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::{
+    formatting_context, grid_formatting_context, svg_formatting_context, table_formatting_context, used_values,
+};
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_rows::PaintableRowsRead;
 
@@ -23,27 +26,24 @@ pub(crate) fn is_svg_paintable(kind: PaintableKind) -> bool {
     )
 }
 
-pub(crate) fn committed_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> crate::layout::FfiCssPixelPoint {
+pub(crate) fn committed_offset(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> used_values::FfiCssPixelPoint {
     let data = arena.paintable_data(slot);
     if data.kind == PaintableKind::InlinePaintable {
         return data.offset;
     }
     arena.with_committed_fragment_link(slot, |link| {
-        link.map_or_else(crate::layout::FfiCssPixelPoint::default, |link| link.committed_offset)
+        link.map_or_else(used_values::FfiCssPixelPoint::default, |link| link.committed_offset)
     })
 }
 
-pub(crate) fn committed_content_size(
-    arena: &impl PaintableRowsRead,
-    slot: NodeSlotId,
-) -> crate::layout::FfiCssPixelSize {
+pub(crate) fn committed_content_size(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> used_values::FfiCssPixelSize {
     let data = arena.paintable_data(slot);
     if data.kind == PaintableKind::InlinePaintable {
         return data.content_size;
     }
     arena.with_committed_fragment_link(slot, |link| {
-        link.map_or_else(crate::layout::FfiCssPixelSize::default, |link| {
-            crate::layout::FfiCssPixelSize {
+        link.map_or_else(used_values::FfiCssPixelSize::default, |link| {
+            used_values::FfiCssPixelSize {
                 width: link.fragment.content_inline_size,
                 height: link.fragment.content_block_size,
             }
@@ -104,7 +104,7 @@ pub(crate) fn committed_uses_collapsing_borders_model(arena: &LayoutNodeArena, s
 pub(crate) fn committed_grid_layout_data(
     arena: &LayoutNodeArena,
     slot: NodeSlotId,
-) -> Option<std::rc::Rc<crate::layout::GridLayoutData>> {
+) -> Option<std::rc::Rc<grid_formatting_context::GridLayoutData>> {
     arena.with_committed_fragment_link(slot, |link| {
         link.and_then(|link| link.fragment.grid_layout_data.clone())
     })
@@ -113,7 +113,7 @@ pub(crate) fn committed_grid_layout_data(
 pub(crate) fn committed_flex_layout_data(
     arena: &LayoutNodeArena,
     slot: NodeSlotId,
-) -> Option<std::rc::Rc<crate::layout::FlexLayoutData>> {
+) -> Option<std::rc::Rc<formatting_context::FlexLayoutData>> {
     arena.with_committed_fragment_link(slot, |link| {
         link.and_then(|link| link.fragment.flex_layout_data.clone())
     })
@@ -122,7 +122,7 @@ pub(crate) fn committed_flex_layout_data(
 pub(crate) fn committed_used_grid_tracks(
     arena: &LayoutNodeArena,
     slot: NodeSlotId,
-) -> Option<std::rc::Rc<crate::layout::OwnedUsedGridTracks>> {
+) -> Option<std::rc::Rc<grid_formatting_context::OwnedUsedGridTracks>> {
     arena.with_committed_fragment_link(slot, |link| {
         link.and_then(|link| link.fragment.used_grid_tracks.clone())
     })
@@ -131,7 +131,7 @@ pub(crate) fn committed_used_grid_tracks(
 pub(crate) fn committed_collapsed_table_borders(
     arena: &LayoutNodeArena,
     slot: NodeSlotId,
-) -> Option<std::rc::Rc<crate::layout::OwnedCollapsedTableBorders>> {
+) -> Option<std::rc::Rc<table_formatting_context::OwnedCollapsedTableBorders>> {
     arena.with_committed_fragment_link(slot, |link| {
         link.and_then(|link| link.fragment.collapsed_table_borders.clone())
     })
@@ -156,16 +156,16 @@ pub(crate) fn committed_containing_line_box_index(arena: &LayoutNodeArena, slot:
 pub(crate) fn committed_svg_viewport_transform(
     arena: &LayoutNodeArena,
     slot: NodeSlotId,
-) -> Option<crate::layout::FfiAffineTransform> {
+) -> Option<svg_formatting_context::FfiAffineTransform> {
     arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.fragment.svg_viewport_transform))
 }
 
 pub(crate) fn committed_svg_viewport_size(
     arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
-) -> crate::layout::FfiCssPixelSize {
+) -> used_values::FfiCssPixelSize {
     if arena.paintable_data(slot).kind != PaintableKind::SVGSVGPaintable {
-        return crate::layout::FfiCssPixelSize::default();
+        return used_values::FfiCssPixelSize::default();
     }
     arena.with_committed_fragment_link(slot, |link| {
         link.and_then(|link| link.fragment.svg_viewport_size)
@@ -176,7 +176,7 @@ pub(crate) fn committed_svg_viewport_size(
 pub(crate) fn committed_svg_view_box(
     arena: &impl PaintableRowsRead,
     slot: NodeSlotId,
-) -> Option<crate::layout::FfiSvgViewBox> {
+) -> Option<svg_formatting_context::FfiSvgViewBox> {
     arena.with_committed_fragment_link(slot, |link| link.and_then(|link| link.fragment.svg_view_box))
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -6,7 +6,7 @@
 
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeSlotId};
-use crate::layout::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize};
+use crate::layout::{fragment_tree, used_values};
 use crate::painting::paintable_data::*;
 use crate::painting::record::cache::PaintCache;
 use std::cell::{Cell, Ref, RefCell, RefMut};
@@ -57,7 +57,7 @@ impl PaintableRowReset {
 #[derive(Default)]
 struct CommittedFragmentLinkSlot {
     layout_slot_generation: u8,
-    link: Option<Box<crate::layout::FragmentLink>>,
+    link: Option<Box<fragment_tree::FragmentLink>>,
 }
 
 #[derive(Default)]
@@ -339,13 +339,13 @@ where
     pub(crate) fn begin_paintable_row_recommit(&mut self, id: NodeSlotId) {
         {
             let data = self.paintable_data_mut(id);
-            data.offset = FfiCssPixelPoint::default();
-            data.content_size = FfiCssPixelSize::default();
+            data.offset = used_values::FfiCssPixelPoint::default();
+            data.content_size = used_values::FfiCssPixelSize::default();
             data.overflow_measured_this_commit = false;
             data.sticky_insets = FfiStickyInsets::default();
             data.has_sticky_insets = false;
-            data.local_padding_box_union = FfiCssPixelRect::default();
-            data.local_border_box_union = FfiCssPixelRect::default();
+            data.local_padding_box_union = used_values::FfiCssPixelRect::default();
+            data.local_border_box_union = used_values::FfiCssPixelRect::default();
             data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;
         }
         // The paint cache is deliberately kept; the commit diff marks rows whose committed
@@ -381,7 +381,7 @@ impl PaintableRowStore {
         &self,
         layout_slot_index: u32,
         layout_slot_generation: u8,
-    ) -> Option<crate::layout::FragmentLink> {
+    ) -> Option<fragment_tree::FragmentLink> {
         self.committed_fragment_links
             .borrow()
             .get(layout_slot_index as usize)
@@ -393,7 +393,7 @@ impl PaintableRowStore {
         &self,
         layout_slot_index: u32,
         layout_slot_generation: u8,
-        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+        read: impl FnOnce(Option<&fragment_tree::FragmentLink>) -> R,
     ) -> R {
         let slots = self.committed_fragment_links.borrow();
         read(
@@ -408,7 +408,7 @@ impl PaintableRowStore {
         &self,
         layout_slot_index: u32,
         layout_slot_generation: u8,
-        link: crate::layout::FragmentLink,
+        link: fragment_tree::FragmentLink,
     ) {
         let mut slots = self.committed_fragment_links.borrow_mut();
         if slots.len() <= layout_slot_index as usize {
@@ -431,7 +431,7 @@ impl PaintableRowStore {
         &self,
         layout_slot_index: u32,
         layout_slot_generation: u8,
-    ) -> Option<crate::layout::FragmentLink> {
+    ) -> Option<fragment_tree::FragmentLink> {
         self.committed_fragment_links
             .borrow_mut()
             .get_mut(layout_slot_index as usize)
@@ -475,7 +475,7 @@ impl LayoutNodeArena {
     pub(crate) fn with_committed_fragment_link<R>(
         &self,
         node: NodeSlotId,
-        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+        read: impl FnOnce(Option<&fragment_tree::FragmentLink>) -> R,
     ) -> R {
         debug_assert!(self.paintable_row_is_populated(node));
         let slots = self.paintable_rows.committed_fragment_links.borrow();
@@ -489,7 +489,7 @@ impl LayoutNodeArena {
     pub(crate) fn with_committed_fragment_link_during_layout<R>(
         &self,
         node: NodeSlotId,
-        read: impl FnOnce(Option<&crate::layout::FragmentLink>) -> R,
+        read: impl FnOnce(Option<&fragment_tree::FragmentLink>) -> R,
     ) -> R {
         self.paintable_rows
             .with_committed_fragment_link(node.slot_index(), node.generation(), read)

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -7,7 +7,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use crate::layout::FfiCssPixelPoint;
+use crate::layout::used_values::FfiCssPixelPoint;
 use crate::painting::display_list::builder::CommandRange;
 use crate::painting::hit_test::HitTestItem;
 use crate::painting::record::PaintPhase;

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -8,6 +8,7 @@ use super::{PaintPhase, PaintRecorder};
 use crate::css::css_enums;
 use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_facts;
 use crate::painting::fragment_ownership;
 use crate::painting::hit_test::*;
 use crate::painting::host::FfiHitTestTextNodeFacts;
@@ -363,7 +364,7 @@ impl<'a> PaintRecorder<'a> {
         let Some(kind) = self.layout_arena.node_kind_if_live(node) else {
             return false;
         };
-        if !crate::layout::kind_is_text(kind) {
+        if !node_facts::kind_is_text(kind) {
             return false;
         }
         let Some(parent) = self.layout_arena.node_parent_if_live(node) else {

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -14,6 +14,7 @@ pub mod traversal;
 use crate::css::css_enums;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::used_values;
 use crate::painting::border_radii::BorderRadii;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::display_list::recorder::DisplayListRecorder;
@@ -85,12 +86,12 @@ pub struct PaintRecorder<'a> {
     list: HitTestList,
     base_paint_facts_cache: Vec<Option<(NodeSlotId, BasePaintFacts)>>,
     paintable_facts_cache: Vec<Option<(NodeSlotId, hit_test_items::HitTestFacts)>>,
-    pub(crate) absolute_position_cache: Vec<std::cell::Cell<Option<(NodeSlotId, crate::layout::FfiCssPixelPoint)>>>,
+    pub(crate) absolute_position_cache: Vec<std::cell::Cell<Option<(NodeSlotId, used_values::FfiCssPixelPoint)>>>,
     // Validity checks must compare against this recording-start snapshot, not the live per-row
     // cell: the first phase that re-records a moved row updates the cell, and later phases
     // would then wrongly accept their stale captures.
     pub(crate) previously_captured_position_cache:
-        Vec<std::cell::Cell<Option<(NodeSlotId, crate::layout::FfiCssPixelPoint)>>>,
+        Vec<std::cell::Cell<Option<(NodeSlotId, used_values::FfiCssPixelPoint)>>>,
     pub(crate) completed_record_gen: u64,
     pub(crate) all_paint_caches_dirty: bool,
     pub(crate) all_descendant_subtree_caches_dirty: bool,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -8,6 +8,7 @@ use crate::css::css_enums;
 use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::border_radii::BorderRadii;
 use crate::painting::display_list::commands::{
     DisplayListResourceId, ImageFrameResourceId, OptionalAffineTransform, VisualContextIndex,
@@ -777,7 +778,7 @@ fn append_text_clip_paths(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotI
         let is_text = recorder
             .layout_arena
             .node_kind_if_live(fragment.layout_node)
-            .is_some_and(crate::layout::kind_is_text);
+            .is_some_and(node_facts::kind_is_text);
         if !is_text {
             return;
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -7,6 +7,7 @@
 use crate::css::css_enums::flex_direction;
 use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};
+use crate::layout::grid_formatting_context;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::display_list::commands::{
     DisplayListGlyph, FontResourceId, VISUAL_VIEWPORT_NODE_INDEX, VisualContextIndex,
@@ -307,10 +308,10 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
             paint_label(recorder, top_left, text, fly_string_raw);
         };
 
-    let line_start_for_number = |lines: &[crate::layout::GridLayoutLine], number: u32| -> Option<CssPixels> {
+    let line_start_for_number = |lines: &[grid_formatting_context::GridLayoutLine], number: u32| -> Option<CssPixels> {
         lines.iter().find(|line| line.number == number).map(|line| line.start)
     };
-    let line_number_label = |line: &crate::layout::GridLayoutLine| -> Vec<u16> {
+    let line_number_label = |line: &grid_formatting_context::GridLayoutLine| -> Vec<u16> {
         let text = if line.negative_number < 0 {
             format!("{} / {}", line.number, line.negative_number)
         } else {
@@ -318,7 +319,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
         };
         text.encode_utf16().collect()
     };
-    let track_size_label = |track: &crate::layout::GridLayoutTrack| -> Vec<u16> {
+    let track_size_label = |track: &grid_formatting_context::GridLayoutTrack| -> Vec<u16> {
         format!("{:.2}px", track.breadth.to_double().max(0.0))
             .encode_utf16()
             .collect()

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/table_borders.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/table_borders.rs
@@ -5,10 +5,11 @@
  */
 
 use crate::css::css_enums::line_style;
-use crate::layout::CollapsedBorderEdge;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::table_formatting_context;
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::{Color, IntPoint, IntRect, LineStyle};
+use table_formatting_context::CollapsedBorderEdge;
 
 #[derive(Clone, Copy, Default)]
 struct DeviceBorderData {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -6,6 +6,7 @@
 
 use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::display_list::commands::{DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
 use crate::painting::paintable_data::{FragmentRecord, SELECTION_STATE_NONE, SELECTION_STATE_START_AND_END};
@@ -87,7 +88,7 @@ fn compute_render_spans(
         }
         if !arena
             .node_kind_if_live(fragment.layout_node)
-            .is_some_and(crate::layout::kind_is_text)
+            .is_some_and(node_facts::kind_is_text)
         {
             continue;
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
@@ -10,6 +10,7 @@ use crate::css::css_enums::{
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::display_list::recorder::{PaintStyleOrColor, StrokePathParams};
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::path::PathBuilder;
@@ -127,10 +128,7 @@ pub(crate) fn decoration_sets_for_span(
     let arena = recorder.layout_arena;
     let fragment = &recorder.layout_arena.paintable_side_data(block).fragments[span.fragment_index as usize];
     let text_node = fragment.layout_node;
-    if !arena
-        .node_kind_if_live(text_node)
-        .is_some_and(crate::layout::kind_is_text)
-    {
+    if !arena.node_kind_if_live(text_node).is_some_and(node_facts::kind_is_text) {
         return sets;
     }
     let Some(text_parent) = arena.node_parent_if_live(text_node) else {

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -8,6 +8,7 @@ use super::{PaintPhase, PaintRecorder};
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::{node_facts, used_values};
 use crate::painting::display_list::builder::CommandRange;
 use crate::painting::display_list::commands::VisualContextIndex;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
@@ -554,7 +555,7 @@ impl PaintRecorder<'_> {
         );
     }
 
-    fn previously_captured_position(&self, paintable: NodeSlotId) -> crate::layout::FfiCssPixelPoint {
+    fn previously_captured_position(&self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
         let index = paintable.slot_index() as usize;
         if let Some(cell) = self.previously_captured_position_cache.get(index)
             && let Some((memoized_id, position)) = cell.get()
@@ -572,7 +573,7 @@ impl PaintRecorder<'_> {
         position
     }
 
-    fn current_absolute_position(&self, paintable: NodeSlotId) -> crate::layout::FfiCssPixelPoint {
+    fn current_absolute_position(&self, paintable: NodeSlotId) -> used_values::FfiCssPixelPoint {
         let index = paintable.slot_index() as usize;
         if let Some(cell) = self.absolute_position_cache.get(index)
             && let Some((memoized_id, position)) = cell.get()
@@ -580,7 +581,7 @@ impl PaintRecorder<'_> {
         {
             return position;
         }
-        let position: crate::layout::FfiCssPixelPoint =
+        let position: used_values::FfiCssPixelPoint =
             crate::painting::paintable_geometry::absolute_position(self.layout_arena, paintable).into();
         if let Some(cell) = self.absolute_position_cache.get(index) {
             cell.set(Some((paintable, position)));
@@ -633,9 +634,7 @@ impl PaintRecorder<'_> {
         let kind = self.data(svg_box).kind;
         if kind != PaintableKind::SVGSVGPaintable
             && !crate::painting::paintable_geometry::is_svg_paintable(kind)
-            && self
-                .layout_kind(svg_box)
-                .is_some_and(crate::layout::kind_is_replaced_box)
+            && self.layout_kind(svg_box).is_some_and(node_facts::kind_is_replaced_box)
         {
             crate::painting::record::paint::paint(self, svg_box, PaintPhase::Background);
         }

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -9,6 +9,7 @@ use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::css::display::FfiDisplay;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_facts;
 use crate::painting::host::{FfiScrollableOverflowHostCallbacks, FfiVisualContextHostCallbacks};
 use crate::painting::paintable_data::FfiOverflowData;
 use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
@@ -38,7 +39,7 @@ pub(crate) fn refill_contained_boxes_index(
             }
             let node_is_box_kind = layout_arena
                 .node_kind_if_live(node)
-                .is_some_and(crate::layout::kind_is_box);
+                .is_some_and(node_facts::kind_is_box);
             if !node_is_box_kind || !layout_arena.paintable_row_is_populated(node) {
                 continue;
             }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::paintable_rows::PaintableRowsWrite;
 use crate::painting::style_queries::{self, effective_z_index};
 
@@ -103,7 +104,7 @@ fn visit(
             parent.non_positioned_floating_descendants.push(paintable);
         }
         let layout_kind = layout_arena.node_kind_if_live(paintable);
-        if !establishes_stacking_context && (inline || layout_kind.is_some_and(crate::layout::kind_is_replaced_box)) {
+        if !establishes_stacking_context && (inline || layout_kind.is_some_and(node_facts::kind_is_replaced_box)) {
             parent.contains_inline_or_replaced_descendants = true;
         }
     }

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -16,6 +16,7 @@ use crate::css::serialize::{StringUnits, with_fly_string_units};
 use crate::css::style_value::StyleValueData;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_facts;
 
 const SEPARATOR_COMMA: u8 = 1;
 
@@ -137,7 +138,7 @@ fn containment_applies_to_display(arena: &LayoutNodeArena, node: NodeSlotId, sty
     }
     let is_replaced_box = arena
         .node_kind_if_live(node)
-        .is_some_and(crate::layout::kind_is_replaced_box);
+        .is_some_and(node_facts::kind_is_replaced_box);
     if display.is_inline_outside() && display.is_flow_inside() && !is_replaced_box {
         return false;
     }
@@ -274,7 +275,7 @@ pub(crate) fn establishes_positioning_containing_blocks(arena: &LayoutNodeArena,
     let Some(kind) = arena.node_kind_if_live(node) else {
         return (false, false);
     };
-    if !crate::layout::kind_is_box(kind) {
+    if !node_facts::kind_is_box(kind) {
         return (false, false);
     }
 
@@ -336,9 +337,9 @@ pub(crate) fn is_transformable(arena: &LayoutNodeArena, node: NodeSlotId) -> boo
     }
 
     let is_dom_element =
-        !has_flag(arena, node, NodeFlag::Anonymous) && !crate::layout::kind_is_text(kind) && kind != NodeKind::Viewport;
+        !has_flag(arena, node, NodeFlag::Anonymous) && !node_facts::kind_is_text(kind) && kind != NodeKind::Viewport;
     let is_element_or_pseudo_element = is_dom_element || arena.node_is_generated_for_pseudo_element(node);
-    if is_element_or_pseudo_element && crate::layout::kind_is_box(kind) {
+    if is_element_or_pseudo_element && node_facts::kind_is_box(kind) {
         let Some(style) = arena.node_style_if_live(node) else {
             return false;
         };
@@ -516,11 +517,11 @@ pub(crate) fn effective_z_index(arena: &LayoutNodeArena, paintable: NodeSlotId) 
 pub(crate) fn is_positioned(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     arena
         .node_data_if_live(node)
-        .is_some_and(|data| crate::layout::node_is_positioned(data, arena.node_style_if_live(node)))
+        .is_some_and(|data| node_facts::node_is_positioned(data, arena.node_style_if_live(node)))
 }
 
 pub(crate) fn position(arena: &LayoutNodeArena, node: NodeSlotId) -> u8 {
-    crate::layout::node_position(arena.node_style_if_live(node))
+    node_facts::node_position(arena.node_style_if_live(node))
 }
 
 pub(crate) fn is_fixed_position(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
@@ -534,15 +535,15 @@ pub(crate) fn is_sticky_position(arena: &LayoutNodeArena, node: NodeSlotId) -> b
 pub(crate) fn is_floating(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     arena
         .node_data_if_live(node)
-        .is_some_and(|data| crate::layout::node_is_floating(data, arena.node_style_if_live(node)))
+        .is_some_and(|data| node_facts::node_is_floating(data, arena.node_style_if_live(node)))
 }
 
 pub(crate) fn is_inline(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
-    crate::layout::node_is_inline_outside(arena.node_style_if_live(node))
+    node_facts::node_is_inline_outside(arena.node_style_if_live(node))
 }
 
 pub(crate) fn display(arena: &LayoutNodeArena, node: NodeSlotId) -> crate::css::display::FfiDisplay {
-    crate::layout::node_display(arena.node_style_if_live(node))
+    node_facts::node_display(arena.node_style_if_live(node))
 }
 
 pub(crate) fn is_flex_or_grid_item(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
@@ -560,7 +561,7 @@ pub(crate) fn is_replaced_element(arena: &LayoutNodeArena, node: NodeSlotId) -> 
 pub(crate) fn is_replaced_box(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     arena
         .node_kind_if_live(node)
-        .is_some_and(crate::layout::kind_is_replaced_box)
+        .is_some_and(node_facts::kind_is_replaced_box)
 }
 
 pub(crate) fn establishes_stacking_context(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {

--- a/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
@@ -7,6 +7,7 @@
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::{inline_level_iterator, node_facts};
 use crate::painting::paintable_data::FragmentRecord;
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::PaintableRowsRead;
@@ -228,7 +229,7 @@ pub(crate) fn selection_offsets_for_dom_range(
 }
 
 fn for_each_cluster_in_glyph_run(
-    glyphs: &[crate::layout::FfiDrawGlyph],
+    glyphs: &[inline_level_iterator::FfiDrawGlyph],
     fragment_length_in_code_units: usize,
     mut callback: impl FnMut(usize, usize, f32) -> bool,
 ) {
@@ -430,7 +431,7 @@ pub(crate) fn index_in_node_for_point(
 ) -> usize {
     if !layout_arena
         .node_kind_if_live(fragment.layout_node)
-        .is_some_and(crate::layout::kind_is_text)
+        .is_some_and(node_facts::kind_is_text)
     {
         return 0;
     }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -12,6 +12,7 @@ use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::css::style_value::StyleValueData;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::border_radii::BorderRadii;
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::host::{FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
@@ -458,7 +459,7 @@ fn overflow_clip_edge_rect(
         top_side.visual_box
     } else {
         let node_kind = layout_arena.node_kind_if_live(slot);
-        if node_kind.is_some_and(crate::layout::kind_is_replaced_box) {
+        if node_kind.is_some_and(node_facts::kind_is_replaced_box) {
             CONTENT_BOX
         } else {
             crate::css::css_enums::background_box::PADDING_BOX
@@ -662,7 +663,7 @@ pub(crate) fn mask_layer_presence(
             && style_queries::mask_layers_have_image(style.mask())
             && layout_arena
                 .node_kind_if_live(node)
-                .is_some_and(crate::layout::kind_is_box)
+                .is_some_and(node_facts::kind_is_box)
             && style_queries::establishes_stacking_context(layout_arena, node)
         {
             layers.push(MaskLayerPresenceEntry {


### PR DESCRIPTION
We currently include many rust files using the `include!` macro. This actually prevents `cargo fmt` from finding these files, and they have gone entirely unformatted. Let's bring them in using standard `mod` declarations.