### PR TITLE
LibWeb+LibWebView: Coordinate visibility state in the browser process

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -810,7 +810,7 @@ void LocalNavigable::consume_child_navigable_history_reconstruction_id(size_t in
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#initialize-the-navigable
-void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document)
+void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state)
 {
     set_id(page().client().allocate_navigable_id());
 
@@ -844,11 +844,11 @@ void LocalNavigable::initialize_navigable(NonnullRefPtr<DocumentState> document_
     }
 
     // 6. Set the initial visibility state of documentState's document to navigable's traversable navigable's system visibility state.
-    document->set_initial_visibility_state(traversable_navigable()->system_visibility_state());
+    document->set_initial_visibility_state(system_visibility_state);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#activate-history-entry
-void LocalNavigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, GC::Ref<DOM::Document> document)
+void LocalNavigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state)
 {
     // 1. Save persisted state to the navigable's active session history entry.
     save_persisted_state_to_active_session_history_entry();
@@ -884,7 +884,7 @@ void LocalNavigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, G
     new_document->make_active();
 
     // 6. Set the initial visibility state of newDocument to navigable's traversable navigable's system visibility state.
-    new_document->set_initial_visibility_state(traversable_navigable()->system_visibility_state());
+    new_document->set_initial_visibility_state(system_visibility_state);
 
     // AD-HOC: In the async state machine, documents created during populate may have completed
     //         their loading lifecycle before being activated (when they had no navigable).
@@ -1333,8 +1333,8 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
             if (!name.equals_ignoring_ascii_case(u"_blank"sv))
                 target_name = Utf16String::from_utf16(name);
 
-            auto create_new_traversable_closure = [page = new_web_view.page, window_handle = move(new_web_view.window_handle), target_name](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalNavigable> {
-                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*page, opener, target_name);
+            auto create_new_traversable_closure = [page = new_web_view.page, system_visibility_state = new_web_view.system_visibility_state, window_handle = move(new_web_view.window_handle), target_name](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalNavigable> {
+                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*page, opener, target_name, {}, system_visibility_state);
                 page->set_top_level_traversable(traversable);
                 traversable->set_window_handle(Utf16String::from_ascii_without_validation(window_handle.bytes()));
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -40,6 +40,7 @@
 #include <LibWeb/HTML/StructuredSerializeTypes.h>
 #include <LibWeb/HTML/TargetSnapshotParams.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WindowType.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Page/EventHandler.h>
@@ -67,7 +68,7 @@ public:
     using NullOrError = NavigationParamsNullOrError;
     using NavigationParamsVariant = HTML::NavigationParamsVariant;
 
-    void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document);
+    void initialize_navigable(NonnullRefPtr<DocumentState> document_state, GC::Ptr<LocalNavigable> parent, GC::Ref<DOM::Document> document, VisibilityState system_visibility_state);
     void set_id_for_session_history_reconstruction(CrossProcessId id) { set_id(id); }
 
     void register_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);
@@ -101,7 +102,7 @@ public:
     Optional<CrossProcessId> child_navigable_history_reconstruction_id(size_t index) const;
     void consume_child_navigable_history_reconstruction_id(size_t index);
 
-    void activate_history_entry(RefPtr<SessionHistoryEntry>, GC::Ref<DOM::Document>);
+    void activate_history_entry(RefPtr<SessionHistoryEntry>, GC::Ref<DOM::Document>, VisibilityState system_visibility_state);
     void notify_navigation_observers_navigation_complete();
 
     GC::Ptr<DOM::Document> active_document() const;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -89,7 +89,7 @@ BrowsingContextAndDocument create_a_new_top_level_browsing_context_and_document(
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
-GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id)
+GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id, VisibilityState system_visibility_state)
 {
     auto& vm = Bindings::main_thread_vm();
     page->ensure_compositor_host();
@@ -130,7 +130,7 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
     auto traversable = vm.heap().allocate<LocalTraversableNavigable>(page);
 
     // 6. Initialize the navigable traversable given documentState.
-    traversable->initialize_navigable(document_state, nullptr, *document);
+    traversable->initialize_navigable(document_state, nullptr, *document, system_visibility_state);
 
     // 7. Let initialHistoryEntry be traversable's active session history entry.
     auto initial_history_entry = traversable->active_session_history_entry();
@@ -157,10 +157,10 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#create-a-fresh-top-level-traversable
-GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top_level_traversable(GC::Ref<Page> page, URL::URL const& initial_navigation_url, DocumentResource initial_navigation_post_resource, CrossProcessId initial_document_state_id)
+GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top_level_traversable(GC::Ref<Page> page, URL::URL const& initial_navigation_url, DocumentResource initial_navigation_post_resource, CrossProcessId initial_document_state_id, VisibilityState system_visibility_state)
 {
     // 1. Let traversable be the result of creating a new top-level traversable given null and the empty string.
-    auto traversable = create_a_new_top_level_traversable(page, nullptr, {}, initial_document_state_id);
+    auto traversable = create_a_new_top_level_traversable(page, nullptr, {}, initial_document_state_id, system_visibility_state);
     page->set_top_level_traversable(traversable);
 
     // AD-HOC: Deny geolocation until the UI process sends the browser-wide setting via IPC. This prevents a request
@@ -965,7 +965,7 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
     bool const update_only = continuation->update_only;
     RefPtr<SessionHistoryEntry> const target_entry = continuation->target_entry;
     auto const displayed_document_id = continuation->displayed_document_id;
-    auto after_potential_unload = GC::create_function(heap(), [this, navigable, update_only, target_entry, continuation, population_output, old_origin, displayed_document_id, script_history_length, script_history_index, entries_for_navigation_api = move(command.entries_for_navigation_api), navigation_type = continuation->navigation_type, navigation_api_abort_behavior = continuation->navigation_api_abort_behavior, on_complete] {
+    auto after_potential_unload = GC::create_function(heap(), [this, navigable, update_only, target_entry, continuation, population_output, old_origin, displayed_document_id, script_history_length, script_history_index, entries_for_navigation_api = move(command.entries_for_navigation_api), system_visibility_state = command.system_visibility_state, navigation_type = continuation->navigation_type, navigation_api_abort_behavior = continuation->navigation_api_abort_behavior, on_complete] {
         if (update_only || continuation->resolved_document.ptr() == continuation->displayed_document.ptr()) {
             auto applies_same_document_push_or_replace = is_same_document_push_or_replace(
                 navigation_type, *target_entry, displayed_document_id);
@@ -1031,7 +1031,7 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
         auto resolved_document = continuation->resolved_document;
         Optional<ReplicatedNavigableState> activated_navigable_state;
         if (!update_only) {
-            navigable->activate_history_entry(*target_entry, *resolved_document);
+            navigable->activate_history_entry(*target_entry, *resolved_document, system_visibility_state);
             activated_navigable_state = navigable->replicated_state();
         }
         if (target_entry_persisted_state.has_value())
@@ -1621,7 +1621,7 @@ static Vector<NonnullRefPtr<SessionHistoryEntry>> session_history_entries_for_na
     return entries;
 }
 
-void LocalTraversableNavigable::apply_ui_changing_navigable_continuation(CrossProcessId operation_id, CrossProcessId navigable_id, HistoryObjectLengthAndIndex history_object_length_and_index, Vector<SessionHistoryEntryDescriptor> entry_descriptors_for_navigation_api, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>> on_complete)
+void LocalTraversableNavigable::apply_ui_changing_navigable_continuation(CrossProcessId operation_id, CrossProcessId navigable_id, HistoryObjectLengthAndIndex history_object_length_and_index, Vector<SessionHistoryEntryDescriptor> entry_descriptors_for_navigation_api, VisibilityState system_visibility_state, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>> on_complete)
 {
     auto operation = m_history_operations.find(operation_id);
     if (operation == m_history_operations.end()) {
@@ -1644,6 +1644,7 @@ void LocalTraversableNavigable::apply_ui_changing_navigable_continuation(CrossPr
         {
             .history_object_length_and_index = history_object_length_and_index,
             .entries_for_navigation_api = move(entries_for_navigation_api),
+            .system_visibility_state = system_visibility_state,
         },
         on_complete);
 }
@@ -1798,33 +1799,6 @@ void LocalTraversableNavigable::destroy_top_level_traversable()
     //        However, without this, we can keep stale destroyed traversables around.
     set_has_been_destroyed();
     remove_from_all_local_navigables();
-}
-
-// https://html.spec.whatwg.org/multipage/interaction.html#system-visibility-state
-void LocalTraversableNavigable::set_system_visibility_state(VisibilityState visibility_state)
-{
-    if (m_system_visibility_state == visibility_state)
-        return;
-    m_system_visibility_state = visibility_state;
-
-    // When a user agent determines that the system visibility state for
-    // traversable navigable traversable has changed to newState, it must run the following steps:
-
-    // 1. Let navigables be the inclusive descendant navigables of traversable's active document.
-    auto navigables = active_document()->inclusive_descendant_navigables();
-
-    // 2. For each navigable of navigables:
-    for (auto& navigable : navigables) {
-        // 1. Let document be navigable's active document.
-        auto document = navigable->active_document();
-        VERIFY(document);
-
-        // 2. Queue a global task on the user interaction task source given document's relevant global object
-        //    to update the visibility state of document with newState.
-        queue_global_task(Task::Source::UserInteraction, relevant_global_object(*document), GC::create_function(heap(), [visibility_state, document] {
-            document->update_the_visibility_state(visibility_state);
-        }));
-    }
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -39,17 +39,14 @@ class WEB_API LocalTraversableNavigable final : public LocalNavigable {
     GC_DECLARE_ALLOCATOR(LocalTraversableNavigable);
 
 public:
-    static GC::Ref<LocalTraversableNavigable> create_a_new_top_level_traversable(GC::Ref<Page>, GC::Ptr<BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id = {});
-    static GC::Ref<LocalTraversableNavigable> create_a_fresh_top_level_traversable(GC::Ref<Page>, URL::URL const& initial_navigation_url, DocumentResource, CrossProcessId initial_document_state_id);
+    static GC::Ref<LocalTraversableNavigable> create_a_new_top_level_traversable(GC::Ref<Page>, GC::Ptr<BrowsingContext> opener, Utf16String target_name, Optional<CrossProcessId> initial_document_state_id = {}, VisibilityState system_visibility_state = VisibilityState::Hidden);
+    static GC::Ref<LocalTraversableNavigable> create_a_fresh_top_level_traversable(GC::Ref<Page>, URL::URL const& initial_navigation_url, DocumentResource, CrossProcessId initial_document_state_id, VisibilityState system_visibility_state);
 
     virtual ~LocalTraversableNavigable() override;
 
     virtual bool is_top_level_traversable() const override;
 
     u64 session_history_entry_count() const { return m_session_history_entry_count; }
-
-    VisibilityState system_visibility_state() const { return m_system_visibility_state; }
-    void set_system_visibility_state(VisibilityState);
 
     bool is_created_by_web_content() const { return m_is_created_by_web_content; }
     void set_is_created_by_web_content(bool value) { m_is_created_by_web_content = value; }
@@ -78,7 +75,7 @@ public:
     void handle_ui_history_operation_started(CrossProcessId operation_id, Optional<Web::ReconstructedChildNavigation>, GC::Ref<OnHistoryOperationReady>);
     void run_ui_history_step_unload_cancelation_job(CrossProcessId operation_id, SessionHistoryEntryDescriptor target_entry, Vector<CrossProcessId> navigables_crossing_documents, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>>);
     void run_ui_changing_navigable_history_job(CrossProcessId operation_id, CrossProcessId navigable_id, SessionHistoryEntryDescriptor target_entry, UserNavigationInvolvement, Optional<Bindings::NavigationType>, LocalNavigable::NavigationAPIAbortBehavior, bool superseded_by_newer_navigation, GC::Ref<OnChangingNavigableHistoryStepJobComplete>);
-    void apply_ui_changing_navigable_continuation(CrossProcessId operation_id, CrossProcessId navigable_id, HistoryObjectLengthAndIndex, Vector<SessionHistoryEntryDescriptor> entries_for_navigation_api, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>>);
+    void apply_ui_changing_navigable_continuation(CrossProcessId operation_id, CrossProcessId navigable_id, HistoryObjectLengthAndIndex, Vector<SessionHistoryEntryDescriptor> entries_for_navigation_api, VisibilityState, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>>);
     void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
     void complete_ui_history_operation(CrossProcessId operation_id, HistoryStepResult, Optional<i32> committed_step, u64 session_history_entry_count);
 
@@ -151,6 +148,7 @@ private:
     struct LocalApplyChangingNavigableHistoryStepContinuation {
         HistoryObjectLengthAndIndex history_object_length_and_index;
         Vector<NonnullRefPtr<SessionHistoryEntry>> entries_for_navigation_api;
+        VisibilityState system_visibility_state { VisibilityState::Hidden };
     };
     bool run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob, GC::Ptr<SourceSnapshotParams>, GC::Ptr<DOM::Document> pending_document, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete>);
     void apply_changing_navigable_history_step_continuation_impl(GC::Ref<ChangingNavigableContinuationState>, LocalApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>> on_complete);
@@ -165,9 +163,6 @@ private:
     // complete_history_operation; records for operations initiated elsewhere are created by the first UI job
     // that references them.
     HashMap<CrossProcessId, HistoryOperationState> m_history_operations;
-
-    // https://html.spec.whatwg.org/multipage/document-sequences.html#system-visibility-state
-    VisibilityState m_system_visibility_state { VisibilityState::Hidden };
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#is-created-by-web-content
     bool m_is_created_by_web_content { false };

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -101,7 +101,7 @@ void NavigableContainer::create_new_child_navigable()
     GC::Ref<LocalNavigable> navigable = *GC::Heap::the().allocate<LocalNavigable>(page, false);
 
     // 8. Initialize the navigable navigable given documentState and parentNavigable.
-    navigable->initialize_navigable(document_state, parent_navigable, *document);
+    navigable->initialize_navigable(document_state, parent_navigable, *document, parent_navigable->active_document()->visibility_state_value());
 
     // 9. Set element's content navigable to navigable.
     m_content_navigable = navigable;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1122,7 +1122,7 @@ void Internals::perform_per_test_cleanup()
     page().top_level_traversable()->event_handler().clear_per_test_input_state({});
 
     // Restore the page to the visible state.
-    page().top_level_traversable()->set_system_visibility_state(HTML::VisibilityState::Visible);
+    page().client().page_did_request_set_system_visibility_state(HTML::VisibilityState::Visible);
 }
 
 void Internals::set_highlighted_node(GC::Ptr<DOM::Node> node)
@@ -1522,7 +1522,7 @@ void Internals::set_page_focus(bool has_focus)
 void Internals::set_system_visibility_state(Utf16String const& state)
 {
     auto visibility_state = state == "hidden"sv ? HTML::VisibilityState::Hidden : HTML::VisibilityState::Visible;
-    page().top_level_traversable()->set_system_visibility_state(visibility_state);
+    page().client().page_did_request_set_system_visibility_state(visibility_state);
 }
 
 Utf16String Internals::canvas_color_scheme()

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -63,6 +63,7 @@
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/HTML/UserNavigationInvolvement.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentForward.h>
 #include <LibWeb/IndexedDB/TransactionChanges.h>
@@ -588,6 +589,7 @@ public:
     virtual void page_did_update_resource_count(i32) { }
     struct NewWebViewResult {
         GC::Ptr<Page> page;
+        HTML::VisibilityState system_visibility_state { HTML::VisibilityState::Hidden };
         String window_handle;
     };
     virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, HTML::TokenizedFeature::NoOpener) { return {}; }
@@ -598,6 +600,7 @@ public:
     virtual void page_did_update_session_history_entry_scroll_restoration_mode([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] HTML::ScrollRestorationMode scroll_restoration_mode) { }
     virtual void page_did_update_session_history_entry_document_state_navigable_target_name([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] Utf16String const& navigable_target_name) { }
     virtual void page_did_set_session_history_entry_document_state_reload_pending([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] bool reload_pending) { }
+    virtual void page_did_request_set_system_visibility_state([[maybe_unused]] HTML::VisibilityState visibility_state) { }
     virtual String page_did_request_ui_process_session_history_for_testing() { return "{}"_string; }
     virtual bool page_did_request_capture_session_history_snapshot_for_testing() { return false; }
     virtual bool page_did_request_restore_session_history_snapshot_for_testing() { return false; }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -824,7 +824,8 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::create_web_content_client(
         initial_document_state_id = cross_process_id_allocator.allocate();
 
     auto client = TRY(WebView::launch_web_content_process(is_private, initial_page_id, *root_navigable_id));
-    client->async_initialize(initial_page_id, *root_navigable_id, cross_process_id_allocator, *initial_document_state_id);
+    auto system_visibility_state = view.has_value() ? view->traversable().system_visibility_state() : Web::HTML::VisibilityState::Hidden;
+    client->async_initialize(initial_page_id, *root_navigable_id, cross_process_id_allocator, *initial_document_state_id, system_visibility_state);
     if (view.has_value())
         client->assign_view({}, *view);
 

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -35,6 +35,31 @@ void CanonicalTraversable::clone_session_storage_from(CanonicalTraversable const
     m_session_storage->clone_from(*other.m_session_storage);
 }
 
+// https://html.spec.whatwg.org/multipage/interaction.html#system-visibility-state
+void CanonicalTraversable::set_system_visibility_state(Web::HTML::VisibilityState visibility_state)
+{
+    if (m_system_visibility_state == visibility_state)
+        return;
+    m_system_visibility_state = visibility_state;
+
+    // When a user agent determines that the system visibility state for
+    // traversable navigable traversable has changed to newState, it must run the following steps:
+
+    // 1. Let navigables be the inclusive descendant navigables of traversable's active document.
+    // 2. For each navigable of navigables:
+    for_each_in_inclusive_subtree([&](CanonicalNavigable& navigable) {
+        // 1. Let document be navigable's active document.
+        auto endpoint = history_job_endpoint_for(navigable);
+        if (!endpoint.client)
+            return IterationDecision::Continue;
+
+        // 2. Queue a global task on the user interaction task source given document's relevant global object
+        //    to update the visibility state of document with newState.
+        endpoint.client->async_update_visibility_state(endpoint.page_id, navigable.id(), visibility_state);
+        return IterationDecision::Continue;
+    });
+}
+
 CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state, CanonicalNavigable& fallback_parent)
 {
     Optional<Web::HTML::SessionHistoryEntryIdentity> current_session_history_entry;
@@ -911,8 +936,8 @@ CanonicalTraversable::HistoryJobEndpoint CanonicalTraversable::history_job_endpo
     // NB: The traversable is the view's root navigable; the process hosting its documents is the view's client
     //     rather than a reporting client recorded in the tree.
     if (&navigable == this) {
-        if (auto view = ViewImplementation::find_view_for_traversable(*this); view.has_value())
-            return { &view->client(), view->page_id() };
+        if (auto view = ViewImplementation::find_view_for_traversable(*this); view.has_value() && view->m_client_state.client)
+            return { view->m_client_state.client, view->m_client_state.page_index };
     }
     return {};
 }
@@ -1050,7 +1075,8 @@ void CanonicalTraversable::dispatch_changing_navigable_history_step_continuation
         endpoint->page_id, operation.operation_id, navigable_id,
         continuation.history_object_length_and_index.script_history_length,
         continuation.history_object_length_and_index.script_history_index,
-        move(continuation.entries_for_navigation_api));
+        move(continuation.entries_for_navigation_api),
+        system_visibility_state());
 }
 
 void CanonicalTraversable::dispatch_crash_recovery_changing_job(HistoryOperation& operation, HistoryJobEndpoint endpoint, Web::HTML::HistoryObjectLengthAndIndex history_object_length_and_index, Function<void()> on_complete)

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -96,7 +96,7 @@ public:
     Function<void()> on_session_history_changed;
 
     Web::HTML::VisibilityState system_visibility_state() const { return m_system_visibility_state; }
-    void set_system_visibility_state(Web::HTML::VisibilityState visibility_state) { m_system_visibility_state = visibility_state; }
+    void set_system_visibility_state(Web::HTML::VisibilityState);
 
     Optional<BrowserHistoryTraversalDiagnostic> browser_history_traversal_for_testing() const;
     Web::HTML::SessionHistoryEntryDescriptor const* ongoing_browser_history_traversal_target_entry() const;
@@ -195,6 +195,8 @@ private:
     u64 m_next_pending_browser_history_traversal_generation { 1 };
     HashMap<Web::HTML::CrossProcessId, NonnullOwnPtr<HistoryOperation>> m_history_operations;
     Optional<PendingBrowserHistoryTraversal> m_pending_browser_history_traversal;
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#system-visibility-state
     Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
 };
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -355,12 +355,6 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
         return;
 
     m_top_level_traversable.set_system_visibility_state(visibility_state);
-    client().async_set_system_visibility_state(m_client_state.page_index, visibility_state);
-    m_top_level_traversable.for_each_in_subtree([&](CanonicalNavigable& navigable) {
-        if (navigable.has_remote_host())
-            navigable.remote_host_client().async_set_system_visibility_state(navigable.remote_host_page_id(), visibility_state);
-        return IterationDecision::Continue;
-    });
     Application::the().update_compositor_context_visibility(client().compositor_context_id_for_page(m_client_state.page_index), visibility_state);
 }
 
@@ -1929,7 +1923,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
-    client().async_set_system_visibility_state(m_client_state.page_index, m_top_level_traversable.system_visibility_state());
+    client().async_update_visibility_state(m_client_state.page_index, m_top_level_traversable.id(), m_top_level_traversable.system_visibility_state());
     auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
     Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
     Application::the().update_compositor_context_visibility(compositor_context_id, m_top_level_traversable.system_visibility_state());

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -836,7 +836,7 @@ bool WebContentClient::continue_navigation_population_in_selected_process(u64 pa
             navigable->device_pixel_ratio(),
             Web::ViewportIsFullscreen::No);
     }
-    remote_client->async_set_system_visibility_state(remote_page_id, navigable->top_level_traversable().system_visibility_state());
+    remote_client->async_update_visibility_state(remote_page_id, navigable->id(), navigable->top_level_traversable().system_visibility_state());
     remote_client->async_populate_navigation(remote_page_id, ongoing_navigation->loader->request(), ongoing_navigation->loader->take_result());
 
     SiteIsolationManager::the().transition_child_frame_to_remote(navigable->reporting_client(), navigable->reporting_page_id(), navigable_id, move(remote_client), remote_page_id);
@@ -1809,7 +1809,7 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
 
     auto view = view_for_page_id(new_page_id);
     if (!view.has_value())
-        return { {}, {}, move(handle) };
+        return { {}, {}, Web::HTML::VisibilityState::Hidden, move(handle) };
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
     // 10. If opener is non-null, then legacy-clone a traversable storage shed given opener's top-level traversable and traversable. [STORAGE]
@@ -1819,7 +1819,7 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
     auto root_navigable_id = Application::the().allocate_ui_process_cross_process_id();
     view->traversable().set_id(root_navigable_id);
 
-    return { new_page_id, root_navigable_id, move(handle) };
+    return { new_page_id, root_navigable_id, view->traversable().system_visibility_state(), move(handle) };
 }
 
 void WebContentClient::did_request_activate_tab(u64 page_id)
@@ -2121,6 +2121,12 @@ void WebContentClient::did_set_session_history_entry_document_state_reload_pendi
     if (!navigable.has_value())
         return;
     navigable->top_level_traversable().set_session_history_entry_document_state_reload_pending(*navigable, navigation_api_key, reload_pending);
+}
+
+void WebContentClient::did_request_set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state)
+{
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->set_system_visibility_state(visibility_state);
 }
 
 Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse WebContentClient::did_request_ui_process_session_history_for_testing(u64 page_id)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -270,6 +270,7 @@ private:
     virtual void did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual void did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) override;
     virtual void did_set_session_history_entry_document_state_reload_pending(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, bool reload_pending) override;
+    virtual void did_request_set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;
     virtual void request_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -127,9 +127,9 @@ Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_tra
     VERIFY_NOT_REACHED();
 }
 
-void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id)
+void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
 {
-    m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, initial_document_state_id);
+    m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, initial_document_state_id, system_visibility_state);
 }
 
 void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)
@@ -412,7 +412,7 @@ void ConnectionFromClient::run_changing_navigable_history_job(u64 page_id, Web::
         }));
 }
 
-void ConnectionFromClient::apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api)
+void ConnectionFromClient::apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api, Web::HTML::VisibilityState system_visibility_state)
 {
     auto page = this->page(page_id);
     if (!page.has_value()) {
@@ -420,7 +420,7 @@ void ConnectionFromClient::apply_changing_navigable_continuation(u64 page_id, We
         return;
     }
 
-    page->page().top_level_traversable()->apply_ui_changing_navigable_continuation(operation_id, navigable_id, { script_history_length, script_history_index }, move(entries_for_navigation_api),
+    page->page().top_level_traversable()->apply_ui_changing_navigable_continuation(operation_id, navigable_id, { script_history_length, script_history_index }, move(entries_for_navigation_api), system_visibility_state,
         GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Optional<Web::HTML::ReplicatedNavigableState> activated_navigable_state, Optional<Web::HTML::SessionHistoryEntryPersistedState> previous_entry_persisted_state) {
             async_changing_navigable_continuation_applied(page_id, operation_id, navigable_id, move(activated_navigable_state), move(previous_entry_persisted_state));
         }));
@@ -2347,10 +2347,26 @@ void ConnectionFromClient::request_file(u64 page_id, Web::FileRequest file_reque
     async_did_request_file(page_id, path, id);
 }
 
-void ConnectionFromClient::set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state)
+void ConnectionFromClient::update_visibility_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::VisibilityState visibility_state)
 {
-    if (auto page = this->page(page_id); page.has_value())
-        page->page().top_level_traversable()->set_system_visibility_state(visibility_state);
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    auto navigable = Web::HTML::local_navigable_with_id(navigable_id);
+    if (!navigable || &navigable->page() != &page->page())
+        return;
+
+    // 1. Let document be navigable's active document.
+    auto document = navigable->active_document();
+    if (!document)
+        return;
+
+    // 2. Queue a global task on the user interaction task source given document's relevant global object
+    //    to update the visibility state of document with newState.
+    Web::HTML::queue_global_task(Web::HTML::Task::Source::UserInteraction, Web::HTML::relevant_global_object(*document), GC::create_function(GC::Heap::the(), [visibility_state, document] {
+        document->update_the_visibility_state(visibility_state);
+    }));
 }
 
 void ConnectionFromClient::reset_zoom(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -76,7 +76,7 @@ private:
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
-    virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id) override;
+    virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;
@@ -108,7 +108,7 @@ private:
     virtual void history_operation_started(u64 page_id, Web::HTML::CrossProcessId operation_id, Optional<Web::ReconstructedChildNavigation> reconstructed_child_navigation) override;
     virtual void run_history_step_unload_cancelation_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Vector<Web::HTML::CrossProcessId> navigables_crossing_documents, Web::HTML::UserNavigationInvolvement user_involvement) override;
     virtual void run_changing_navigable_history_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Web::HTML::UserNavigationInvolvement user_involvement, Optional<Web::Bindings::NavigationType> navigation_type, Web::HTML::LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior, bool superseded_by_newer_navigation) override;
-    virtual void apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api) override;
+    virtual void apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api, Web::HTML::VisibilityState system_visibility_state) override;
     virtual void update_nonchanging_navigable_history_state(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index) override;
     virtual void complete_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult result, Optional<i32> committed_step, u64 session_history_entry_count) override;
     virtual void reset_session_history_for_testing(u64 page_id) override;
@@ -185,7 +185,7 @@ private:
     virtual void did_complete_window_rect_request(u64 page_id, u64 completion_id) override;
     virtual void handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) override;
     virtual void did_delete_all_cookies(u64 page_id, u64 request_id) override;
-    virtual void set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState) override;
+    virtual void update_visibility_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::VisibilityState) override;
     virtual void reset_zoom(u64 page_id) override;
 
     virtual void js_console_input(u64 page_id, String) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1174,7 +1174,7 @@ PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML
     VERIFY(response->root_navigable_id().has_value());
 
     auto& new_client = m_owner.create_page(*response->new_page_id(), *response->root_navigable_id());
-    return { &new_client.page(), response->take_handle() };
+    return { &new_client.page(), response->system_visibility_state(), response->take_handle() };
 }
 
 void PageClient::page_did_request_activate_tab()
@@ -1227,6 +1227,11 @@ void PageClient::page_did_update_session_history_entry_document_state_navigable_
 void PageClient::page_did_set_session_history_entry_document_state_reload_pending(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, bool reload_pending)
 {
     client().async_did_set_session_history_entry_document_state_reload_pending(m_id, navigable_id, navigation_api_key, reload_pending);
+}
+
+void PageClient::page_did_request_set_system_visibility_state(Web::HTML::VisibilityState visibility_state)
+{
+    client().async_did_request_set_system_visibility_state(m_id, visibility_state);
 }
 
 void PageClient::page_did_request_history_operation(Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters parameters)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -249,6 +249,7 @@ private:
     virtual void page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual void page_did_update_session_history_entry_document_state_navigable_target_name(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Utf16String const& navigable_target_name) override;
     virtual void page_did_set_session_history_entry_document_state_reload_pending(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, bool reload_pending) override;
+    virtual void page_did_request_set_system_visibility_state(Web::HTML::VisibilityState) override;
     virtual void page_did_request_history_operation(Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters) override;
     virtual String page_did_request_ui_process_session_history_for_testing() override;
     virtual bool page_did_request_capture_session_history_snapshot_for_testing() override;

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -22,12 +22,12 @@ PageHost::PageHost(ConnectionFromClient& client)
 {
 }
 
-void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id)
+void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
 {
     VERIFY(m_pages.is_empty());
     m_cross_process_id_allocator = cross_process_id_allocator;
     auto& first_page = create_page(initial_page_id, root_navigable_id);
-    auto traversable = Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, initial_document_state_id);
+    auto traversable = Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
     auto initial_history_entry = traversable->active_session_history_entry();
     VERIFY(initial_history_entry);
     first_page.page().client().page_did_create_top_level_traversable(traversable->id(), Web::HTML::create_session_history_entry_descriptor(*initial_history_entry));

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -14,6 +14,7 @@
 #include <AK/OwnPtr.h>
 #include <LibGC/Root.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <WebContent/Forward.h>
 
 namespace Web {
@@ -36,7 +37,7 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator, Web::HTML::CrossProcessId initial_document_state_id);
+    void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state);
     Optional<PageClient&> page(u64 page_id);
     PageClient& create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -36,6 +36,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
@@ -157,7 +158,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, bool clone_session_storage) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, bool clone_session_storage) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Web::HTML::VisibilityState system_visibility_state, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|
@@ -193,6 +194,7 @@ endpoint WebContentClient
     did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) =|
     did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) =|
     did_set_session_history_entry_document_state_reload_pending(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, bool reload_pending) =|
+    did_request_set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)
     did_request_site_isolation_process_tree_for_testing(u64 page_id) => (String process_tree)
     request_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters parameters) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -48,7 +48,7 @@
 endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
-    initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id) =|
+    initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)
@@ -84,7 +84,7 @@ endpoint WebContentServer
     history_operation_started(u64 page_id, Web::HTML::CrossProcessId operation_id, Optional<Web::ReconstructedChildNavigation> reconstructed_child_navigation) =|
     run_history_step_unload_cancelation_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Vector<Web::HTML::CrossProcessId> navigables_crossing_documents, Web::HTML::UserNavigationInvolvement user_involvement) =|
     run_changing_navigable_history_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Web::HTML::UserNavigationInvolvement user_involvement, Optional<Web::Bindings::NavigationType> navigation_type, Web::HTML::LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior, bool superseded_by_newer_navigation) =|
-    apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api) =|
+    apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api, Web::HTML::VisibilityState system_visibility_state) =|
     update_nonchanging_navigable_history_state(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index) =|
     complete_history_operation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult result, Optional<i32> committed_step, u64 session_history_entry_count) =|
     reset_session_history_for_testing(u64 page_id) =|
@@ -193,7 +193,7 @@ endpoint WebContentServer
     handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) =|
     did_delete_all_cookies(u64 page_id, u64 request_id) =|
 
-    set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|
+    update_visibility_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::VisibilityState visibility_state) =|
 
     alert_closed(u64 page_id) =|
     confirm_closed(u64 page_id, bool accepted) =|

--- a/Tests/LibWeb/Text/expected/HTML/window-open-initial-visibility-state.txt
+++ b/Tests/LibWeb/Text/expected/HTML/window-open-initial-visibility-state.txt
@@ -1,0 +1,2 @@
+opener visibility state: visible
+popup visibility state: visible

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-timeline-in-hidden-document.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-timeline-in-hidden-document.html
@@ -9,11 +9,7 @@
         const video = document.getElementById("video");
         video.src = "../../../Assets/test-webm.webm";
 
-        const becameHidden = new Promise(resolve => {
-            document.addEventListener("visibilitychange", resolve, { once: true });
-        });
-        internals.setSystemVisibilityState("hidden");
-        await becameHidden;
+        await setSystemVisibilityState("hidden");
         println(`document.hidden: ${document.hidden}`);
 
         await video.play();

--- a/Tests/LibWeb/Text/input/HTML/video-ends-while-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-ends-while-page-hidden.html
@@ -12,8 +12,9 @@
         await new Promise(resolve => video.addEventListener("seeked", resolve, { once: true }));
 
         await video.play();
-        internals.setSystemVisibilityState("hidden");
-        await new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
+        const ended = new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
+        await setSystemVisibilityState("hidden");
+        await ended;
 
         println(`ended while hidden, currentTime === duration: ${video.currentTime === video.duration}`);
     });

--- a/Tests/LibWeb/Text/input/HTML/video-only-ends-while-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-only-ends-while-page-hidden.html
@@ -11,7 +11,7 @@
         video.src = "../../../Assets/resize-320x240-640x480.webm";
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
 
-        internals.setSystemVisibilityState("hidden");
+        await setSystemVisibilityState("hidden");
         await video.play();
         await new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
 

--- a/Tests/LibWeb/Text/input/HTML/video-sink-stops-ticking-when-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-sink-stops-ticking-when-page-hidden.html
@@ -4,10 +4,6 @@
 <script>
     const video = document.getElementById("video");
 
-    function nextVisibilityChange() {
-        return new Promise(resolve => document.addEventListener("visibilitychange", resolve, { once: true }));
-    }
-
     asyncTest(async done => {
         video.src = "../../../Assets/test-webm.webm";
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
@@ -15,9 +11,7 @@
         await animationFrame();
         println(`ticking while visible: ${internals.mediaElementVideoSinkIsTicking(video)}`);
 
-        let visibilityChanged = nextVisibilityChange();
-        internals.setSystemVisibilityState("hidden");
-        await visibilityChanged;
+        await setSystemVisibilityState("hidden");
         println(`document.hidden: ${document.hidden}`);
         println(`ticking while hidden: ${internals.mediaElementVideoSinkIsTicking(video)}`);
 
@@ -28,9 +22,7 @@
         println(`ticking for a sink created while hidden: ${internals.mediaElementVideoSinkIsTicking(videoCreatedWhileHidden)}`);
 
         video.getBoundingClientRect();
-        visibilityChanged = nextVisibilityChange();
-        internals.setSystemVisibilityState("visible");
-        await visibilityChanged;
+        await setSystemVisibilityState("visible");
         println(`ticking after becoming visible: ${internals.mediaElementVideoSinkIsTicking(video)}`);
         document.body.appendChild(videoCreatedWhileHidden);
         await animationFrame();

--- a/Tests/LibWeb/Text/input/HTML/window-open-initial-visibility-state.html
+++ b/Tests/LibWeb/Text/input/HTML/window-open-initial-visibility-state.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const popup = window.open();
+
+        println(`opener visibility state: ${document.visibilityState}`);
+        println(`popup visibility state: ${popup.document.visibilityState}`);
+
+        popup.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -52,6 +52,20 @@ function timeout(ms) {
     return promise;
 }
 
+async function setSystemVisibilityState(state) {
+    // Tests assume that the document reflects the UI process's system visibility state and that
+    // no previous visibility state change is still pending.
+    if (document.visibilityState === state) {
+        return;
+    }
+
+    const visibilityChanged = new Promise(resolve =>
+        document.addEventListener("visibilitychange", resolve, { once: true })
+    );
+    internals.setSystemVisibilityState(state);
+    await visibilityChanged;
+}
+
 function withCollectedWrapper(makeAndMark, reacquire, verify) {
     let wasPreserved = false;
     (() => {


### PR DESCRIPTION
Keep the system visibility state on CanonicalTraversable so there is a single authoritative value for the entire cross-process traversable.

Implement the specification's navigable iteration in the UI process and ask each document's WebContent process to queue its visibility update task. Pass the current state through document initialization and activation requests instead of maintaining a WebContent copy.

This will allow visibility changes reach documents in site-isolated child processes