### PR TITLE
LibJS: Initialize CreateArrayFromList storage in bulk

### DIFF
--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -53,12 +53,11 @@ GC::Ref<Array> Array::create_from(Realm& realm, ReadonlySpan<Value> elements)
 
     // 2. Let n be 0.
     // 3. For each element e of elements, do
-    for (u32 n = 0; n < elements.size(); ++n) {
-        // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
-        MUST(array->create_data_property_or_throw(n, elements[n]));
-
-        // b. Set n to n + 1.
-    }
+    // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
+    // b. Set n to n + 1.
+    // OPTIMIZATION: These are consecutive default data properties, so initialize the packed
+    //               indexed storage in one allocation instead of defining them individually.
+    array->set_indexed_property_elements(elements);
 
     // 4. Return array.
     return array;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -2256,7 +2256,7 @@ Vector<u32> Object::indexed_indices() const
     VERIFY_NOT_REACHED();
 }
 
-void Object::set_indexed_property_elements(Vector<Value>&& values)
+void Object::set_indexed_property_elements(ReadonlySpan<Value> values)
 {
     free_indexed_elements();
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -338,7 +338,7 @@ public:
     ValueAndAttributes indexed_take_last();
     size_t indexed_real_size() const;
     Vector<u32> indexed_indices() const;
-    void set_indexed_property_elements(Vector<Value>&& values);
+    void set_indexed_property_elements(ReadonlySpan<Value> values);
     IndexedStorageKind indexed_storage_kind() const { return m_indexed_storage_kind; }
 
     template<typename Callback>

--- a/Tests/LibJS/Runtime/builtins/Object/Object.entries.js
+++ b/Tests/LibJS/Runtime/builtins/Object/Object.entries.js
@@ -37,6 +37,24 @@ describe("basic functionality", () => {
         ]);
     });
 
+    test("result arrays ignore inherited indexed setters", () => {
+        Object.defineProperty(Array.prototype, "0", {
+            configurable: true,
+            set() {
+                throw new Error("Inherited setter must not be called");
+            },
+        });
+
+        let entries;
+        try {
+            entries = Object.entries({ foo: 1 });
+        } finally {
+            delete Array.prototype[0];
+        }
+
+        expect(entries).toEqual([["foo", 1]]);
+    });
+
     test("ignores non-enumerable properties", () => {
         let obj = { foo: 1 };
         Object.defineProperty(obj, "getFoo", {


### PR DESCRIPTION
CreateArrayFromList currently defines every indexed property through the generic property path. Initialize its packed storage directly to avoid repeated capacity growth, length updates, and property checks.

Cover the requirement that inherited indexed setters remain unobserved.