### PR TITLE
LibWeb: Preserve navigation ID during finalization

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3601,7 +3601,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
             .expected_ongoing_navigation_id = expected_ongoing_navigation_id,
             .local_target_navigable_id = navigable->id(),
             .local_target_entry = history_entry,
-            .pre_steps = GC::create_function(navigable->heap(), [navigable, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](Optional<Web::ReconstructedChildNavigation>, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) mutable {
+            .pre_steps = GC::create_function(navigable->heap(), [navigable, pending_document, expected_ongoing_navigation_id](Optional<Web::ReconstructedChildNavigation>, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) mutable {
                 auto host_state = prepare_to_finalize_a_cross_document_navigation(navigable, pending_document, expected_ongoing_navigation_id);
                 if (!host_state.has_value()) {
                     ready->function()(HistoryStepResult::Applied);


### PR DESCRIPTION
Function arguments do not have a fixed evaluation order. GCC may construct the history operation state first, moving expected_ongoing_navigation_id into the pre-steps callback before the finalization parameters copy it. This leaves the parameters with an engaged but empty navigation ID, so the UI process rejects the history operation and navigation stalls.

Capture the ID by copy so both arguments receive the original value regardless of their evaluation order.