### PR TITLE
LibWeb: Improve performance of adding and removing list items

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -812,7 +812,7 @@ ListStyleType ComputedStyleWorkingSet::list_style_type(StyleScope const& style_s
         return counter_style;
 
     VERIFY(value.as_counter_style().value().has<Utf16FlyString>());
-    return value.as_counter_style().value().get<Utf16FlyString>();
+    return UnresolvedCounterStyleName { value.as_counter_style().value().get<Utf16FlyString>() };
 }
 
 FontKerning ComputedStyleWorkingSet::font_kerning() const

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -1168,7 +1168,7 @@ ListStyleType ComputedValues::InheritedListValues::list_style_type_value(StyleSc
     auto counter_style = counter_style_value.resolve_counter_style(style_scope);
     if (!counter_style) {
         VERIFY(counter_style_descriptor.has<Utf16FlyString>());
-        return counter_style_descriptor.get<Utf16FlyString>();
+        return UnresolvedCounterStyleName { counter_style_descriptor.get<Utf16FlyString>() };
     }
     if (!counter_style_descriptor.has<CounterStyleStyleValue::SymbolsFunction>())
         return counter_style;

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/CSSCounterStyleRule.h>
 #include <LibWeb/CSS/ComputedStyleWorkingSet.h>
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/GridTrackPlacement.h>
 #include <LibWeb/CSS/GridTrackSize.h>
 #include <LibWeb/CSS/StyleComputer.h>
@@ -1196,6 +1197,28 @@ bool ComputedValues::InheritedListValues::list_style_type_uses_non_overridable_c
             value->as_counter_style().value().get<Utf16FlyString>());
 }
 
+bool marker_text_depends_on_list_item_counter_value(ListStyleType const& list_style_type)
+{
+    return list_style_type.visit(
+        [](Empty const&) {
+            return false;
+        },
+        [](RefPtr<CounterStyle const> const& counter_style) {
+            return !counter_style || !counter_style->representation_is_constant();
+        },
+        [](Utf16String const&) {
+            // A string literal marker is the same for every item, regardless of the counter value.
+            return false;
+        },
+        [](UnresolvedCounterStyleName const&) {
+            // The name of a counter style that could not be resolved renders the counter value as `decimal`.
+            return true;
+        },
+        [](ListStyleSymbols const& symbols) {
+            return !symbols.counter_style->representation_is_constant();
+        });
+}
+
 RefPtr<AbstractImageStyleValue const> ComputedValues::InheritedListValues::list_style_image_value() const
 {
     auto value = animation_style_value(list_style_image);
@@ -1268,6 +1291,26 @@ ComputedContentData ComputedValues::ContentValues::computed_content_value() cons
             append_item(item, result.alt_text);
     }
     return result;
+}
+
+bool ComputedValues::ContentValues::content_is_normal() const
+{
+    auto value = animation_style_value(content);
+    return value->is_keyword() && value->to_keyword() == Keyword::Normal;
+}
+
+bool ComputedValues::ContentValues::content_uses_list_item_counter() const
+{
+    auto value = animation_style_value(content);
+    if (!value->is_content())
+        return false;
+    auto item_uses_list_item_counter = [](auto const& item) {
+        return item->is_counter() && item->as_counter().counter_name() == list_item_counter_name();
+    };
+    auto const& content_value = value->as_content();
+    if (any_of(content_value.content().values(), item_uses_list_item_counter))
+        return true;
+    return content_value.alt_text() && any_of(content_value.alt_text()->values(), item_uses_list_item_counter);
 }
 
 static Vector<CounterData, 0> counter_data_from_handle(ComputedValuesFFI::ComputedStyleValueHandle const& handle)
@@ -2176,7 +2219,7 @@ RefPtr<StyleValue const> ComputedValues::computed_style_value_for_inheritance(Pr
     return computed_style_value(property_id, with_animations_applied);
 }
 
-static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, QuotesData const& quotes_data, DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level)
+static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, QuotesData const& quotes_data, DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level, NotifyListItemCounterRendered notify_list_item_counter_rendered)
 {
     auto quote_nesting_level = initial_quote_nesting_level;
 
@@ -2248,6 +2291,8 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
                 }
             } else if (item->is_counter()) {
                 flush_pending_text();
+                if (notify_list_item_counter_rendered == NotifyListItemCounterRendered::Yes && item->as_counter().counter_name() == list_item_counter_name())
+                    element_reference.element().document().did_render_list_item_counter_value(element_reference.element());
                 content_data.counter_style_dependencies.append(item->as_counter().counter_style()->as_counter_style().resolve_counter_style(element_reference.style_scope()));
                 content_data.data.append(item->as_counter().resolve(element_reference));
             } else if (item->is_image() || item->is_image_set()) {
@@ -2270,6 +2315,8 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
                 if (item->is_string()) {
                     alt_text_builder.append(item->as_string().string_value().view());
                 } else if (item->is_counter()) {
+                    if (notify_list_item_counter_rendered == NotifyListItemCounterRendered::Yes && item->as_counter().counter_name() == list_item_counter_name())
+                        element_reference.element().document().did_render_list_item_counter_value(element_reference.element());
                     content_data.counter_style_dependencies.append(item->as_counter().counter_style()->as_counter_style().resolve_counter_style(element_reference.style_scope()));
                     alt_text_builder.append(item->as_counter().resolve(element_reference));
                 } else {
@@ -2312,7 +2359,7 @@ static NonnullRefPtr<StyleValue const> computed_content_item_style_value(Compute
         [](NonnullRefPtr<AbstractImageStyleValue const> const& image) -> NonnullRefPtr<StyleValue const> { return image; });
 }
 
-ContentDataAndQuoteNestingLevel ComputedValues::resolved_content(DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level) const
+ContentDataAndQuoteNestingLevel ComputedValues::resolved_content(DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level, NotifyListItemCounterRendered notify_list_item_counter_rendered) const
 {
     // The content value resolve_content() consumes is rebuilt from the content group's data
     // rather than minted from the longhand table: the group holds the live image style values
@@ -2341,7 +2388,7 @@ ContentDataAndQuoteNestingLevel ComputedValues::resolved_content(DOM::AbstractEl
         }
         VERIFY_NOT_REACHED();
     }();
-    return resolve_content(content_style_value, quotes(), element_reference, initial_quote_nesting_level);
+    return resolve_content(content_style_value, quotes(), element_reference, initial_quote_nesting_level, notify_list_item_counter_rendered);
 }
 
 }

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -423,6 +423,8 @@ struct UnresolvedCounterStyleName {
 
 using ListStyleType = Variant<Empty, RefPtr<CounterStyle const>, Utf16String, UnresolvedCounterStyleName, ListStyleSymbols>;
 
+bool marker_text_depends_on_list_item_counter_value(ListStyleType const&);
+
 struct ComputedFontStyle {
     FontStyleKeyword keyword { FontStyleKeyword::Normal };
     Optional<Variant<Angle, NonnullRefPtr<CalculatedStyleValue const>>> angle;
@@ -843,6 +845,11 @@ struct ContentData {
 struct ContentDataAndQuoteNestingLevel {
     ContentData content_data;
     u32 final_quote_nesting_level { 0 };
+};
+
+enum class NotifyListItemCounterRendered : u8 {
+    No,
+    Yes,
 };
 
 struct ComputedContentCounter {
@@ -1275,7 +1282,9 @@ public:
     ContentVisibility content_visibility() const { return static_cast<ContentVisibility>(m_inherited.box->content_visibility); }
     ReadonlySpan<ComputedValuesFFI::ComputedCursor> cursor() const { return m_inherited.ui->cursor_span(); }
     ComputedContentData computed_content() const { return m_noninherited.content_data->computed_content_value(); }
-    ContentDataAndQuoteNestingLevel resolved_content(DOM::AbstractElement&, u32 initial_quote_nesting_level) const;
+    bool content_is_normal() const { return m_noninherited.content_data->content_is_normal(); }
+    bool content_uses_list_item_counter() const { return m_noninherited.content_data->content_uses_list_item_counter(); }
+    ContentDataAndQuoteNestingLevel resolved_content(DOM::AbstractElement&, u32 initial_quote_nesting_level, NotifyListItemCounterRendered) const;
     Vector<CounterData, 0> counter_increment() const { return m_noninherited.content_data->counter_increment_value(); }
     Vector<CounterData, 0> counter_reset() const { return m_noninherited.content_data->counter_reset_value(); }
     Vector<CounterData, 0> counter_set() const { return m_noninherited.content_data->counter_set_value(); }
@@ -1382,6 +1391,7 @@ public:
     Color webkit_text_fill_color() const { return m_inherited.text->webkit_text_fill_color_value(); }
 
     ListStyleType list_style_type(StyleScope const& style_scope) const { return m_inherited.list->list_style_type_value(style_scope); }
+    RefPtr<AbstractImageStyleValue const> list_style_image() const { return m_inherited.list->list_style_image_value(); }
     bool list_style_type_depends_on_counter_style_environment() const { return m_inherited.list->list_style_type_depends_on_counter_style_environment(); }
     bool list_style_type_uses_non_overridable_counter_style() const { return m_inherited.list->list_style_type_uses_non_overridable_counter_style(); }
 
@@ -1847,6 +1857,8 @@ public:
         static constexpr auto style_group_lifecycle = ComputedValuesFFI::StyleGroupLifecycle::Content;
 
         ComputedContentData computed_content_value() const;
+        bool content_is_normal() const;
+        bool content_uses_list_item_counter() const;
         Vector<CounterData, 0> counter_increment_value() const;
         Vector<CounterData, 0> counter_reset_value() const;
         Vector<CounterData, 0> counter_set_value() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -415,7 +415,13 @@ struct ListStyleSymbols {
     bool operator==(ListStyleSymbols const&) const = default;
 };
 
-using ListStyleType = Variant<Empty, RefPtr<CounterStyle const>, Utf16String, Utf16FlyString, ListStyleSymbols>;
+struct UnresolvedCounterStyleName {
+    Utf16FlyString name;
+
+    bool operator==(UnresolvedCounterStyleName const&) const = default;
+};
+
+using ListStyleType = Variant<Empty, RefPtr<CounterStyle const>, Utf16String, UnresolvedCounterStyleName, ListStyleSymbols>;
 
 struct ComputedFontStyle {
     FontStyleKeyword keyword { FontStyleKeyword::Normal };

--- a/Libraries/LibWeb/CSS/CounterStyle.cpp
+++ b/Libraries/LibWeb/CSS/CounterStyle.cpp
@@ -626,6 +626,16 @@ bool CounterStyle::uses_a_negative_sign() const
         });
 }
 
+bool CounterStyle::representation_is_constant() const
+{
+    auto const* generic_algorithm = m_algorithm.get_pointer<GenericCounterStyleAlgorithm>();
+    if (!generic_algorithm || generic_algorithm->type != CounterStyleSystem::Cyclic || generic_algorithm->symbol_list.size() != 1)
+        return false;
+    return m_range.size() == 1
+        && m_range.first().start == NumericLimits<i32>::min()
+        && m_range.first().end == NumericLimits<i32>::max();
+}
+
 // https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter
 static Utf16String generate_a_counter_representation_impl(RefPtr<CounterStyle const> const& counter_style, StyleScope const& style_scope, i32 value, HashTable<Utf16FlyString>& fallback_history)
 {

--- a/Libraries/LibWeb/CSS/CounterStyle.h
+++ b/Libraries/LibWeb/CSS/CounterStyle.h
@@ -39,6 +39,7 @@ public:
 
     Optional<Utf16String> generate_an_initial_representation_for_the_counter_value(i64 value) const;
     bool uses_a_negative_sign() const;
+    bool representation_is_constant() const;
     bool equals(CounterStyle const&) const;
 
     virtual ~CounterStyle() = default;

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -355,6 +355,11 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     if (AK::first_is_one_of(property_id, CSS::PropertyID::Content, CSS::PropertyID::ContentVisibility, CSS::PropertyID::TextTransform))
         return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::Self);
 
+    // Marker boxes and their text are generated during layout tree construction and belong to the item's own subtree.
+    if (AK::first_is_one_of(property_id, CSS::PropertyID::ListStyleType, CSS::PropertyID::ListStyleImage, CSS::PropertyID::ListStylePosition)
+        && (old_computed_values.display().is_list_item() || new_computed_values.display().is_list_item()))
+        return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::Self);
+
     // A box that appears or disappears leaves every sibling box intact, so the parent can treat the
     // change like a child-list mutation instead of rebuilding its whole subtree.
     if (property_id == CSS::PropertyID::Display) {
@@ -512,6 +517,8 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     if (AK::first_is_one_of(property_id, PropertyID::Display, PropertyID::Float, PropertyID::Position))
         return RequiredInvalidationAfterStyleChange::full();
     if (AK::first_is_one_of(property_id, PropertyID::Content, PropertyID::ContentVisibility, PropertyID::TextTransform))
+        return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::Self);
+    if (AK::first_is_one_of(property_id, PropertyID::ListStyleType, PropertyID::ListStyleImage, PropertyID::ListStylePosition))
         return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::Self);
     if (property_id == PropertyID::OverflowX || property_id == PropertyID::OverflowY)
         return RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(LayoutTreeRebuildRoot::SelfUnlessDocumentElementOrBody);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -804,6 +804,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     for (auto& pending_scroll_event : m_pending_scroll_events)
         visitor.visit(pending_scroll_event.event_target);
     visitor.visit(m_query_containers_needing_container_query_evaluation_after_layout);
+    visitor.visit(m_list_owners_pending_item_renumber);
+    visitor.visit(m_list_owners_with_stale_item_counters);
 
     visitor.visit(m_shared_resource_requests);
     for (auto& resource : m_css_image_resources)
@@ -2136,6 +2138,77 @@ void Document::flush_deferred_style_change_event()
     update_style();
 }
 
+void Document::schedule_list_item_renumber(Element& list_owner)
+{
+    m_list_owners_pending_item_renumber.set(list_owner);
+}
+
+void Document::process_pending_list_item_renumbers()
+{
+    if (m_list_owners_pending_item_renumber.is_empty())
+        return;
+    auto pending = move(m_list_owners_pending_item_renumber);
+    for (auto const& list_owner : pending) {
+        if (!list_owner->is_connected()) {
+            m_list_owners_with_stale_item_counters.remove(list_owner);
+            continue;
+        }
+        if (list_owner->list_item_renumber_affects_rendered_content()) {
+            list_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::ListItemCounters);
+            m_list_owners_with_stale_item_counters.remove(list_owner);
+        } else {
+            m_list_owners_with_stale_item_counters.set(list_owner);
+        }
+    }
+}
+
+void Document::did_render_list_item_counter_value(Element& element)
+{
+    if (m_stale_list_item_counter_rendered || m_list_owners_with_stale_item_counters.is_empty())
+        return;
+    for (GC::Ptr<Element> ancestor = element; ancestor; ancestor = ancestor->parent_element()) {
+        if (m_list_owners_with_stale_item_counters.contains(*ancestor)) {
+            m_stale_list_item_counter_rendered = true;
+            return;
+        }
+    }
+}
+
+bool Document::reconcile_stale_list_item_counters_after_tree_build(Vector<Layout::Node*> const& rebuilt_subtree_roots)
+{
+    if (m_list_owners_with_stale_item_counters.is_empty()) {
+        m_stale_list_item_counter_rendered = false;
+        return false;
+    }
+
+    // A rebuilt subtree has re-resolved the counters sets of any stale owner inside it, and an owner that has left
+    // the document renders nothing.
+    HashTable<Node const*> rebuilt_dom_roots;
+    for (auto const* rebuilt_root : rebuilt_subtree_roots) {
+        if (auto const* dom_node = rebuilt_root->dom_node())
+            rebuilt_dom_roots.set(dom_node);
+    }
+    m_list_owners_with_stale_item_counters.remove_all_matching([&](GC::Ref<Element> const& list_owner) {
+        if (!list_owner->is_connected())
+            return true;
+        for (Node const* node = list_owner.ptr(); node; node = node->parent()) {
+            if (rebuilt_dom_roots.contains(node))
+                return true;
+        }
+        return false;
+    });
+
+    if (!m_stale_list_item_counter_rendered)
+        return false;
+    m_stale_list_item_counter_rendered = false;
+    if (m_list_owners_with_stale_item_counters.is_empty())
+        return false;
+    for (auto const& list_owner : m_list_owners_with_stale_item_counters)
+        list_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::ListItemCounters);
+    m_list_owners_with_stale_item_counters.clear();
+    return true;
+}
+
 bool Document::needs_style_update_after_layout()
 {
     return !m_query_containers_needing_container_query_evaluation_after_layout.is_empty()
@@ -2168,6 +2241,8 @@ Document::PartialRelayoutResult Document::try_partial_relayout(HashTable<WeakPtr
         set_layout_root(as<Layout::Viewport>(*tree_build_result.root));
         record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
         needs_layout_tree_rebuild = false;
+        if (reconcile_stale_list_item_counters_after_tree_build(tree_build_result.rebuilt_subtree_roots))
+            return PartialRelayoutResult::NeedsAnotherLayoutPass;
         layout_tree_was_built_in_partial_branch = true;
         pending_updates_escaped_during_partial_build = m_partial_relayout_invalidation.escapes()
             || tree_build_result.layout_tree_update_escaped_rebuild_roots;
@@ -2302,6 +2377,7 @@ void Document::update_layout(UpdateLayoutReason reason)
     // freshly parsed document after update_layout() has already started.
     for (u64 layout_pass = 0; layout_pass < ordinary_stabilization_round_limit + static_cast<u64>(style_computer().style_engine().connected_element_count()) + 1; ++layout_pass) {
         update_style();
+        process_pending_list_item_renumbers();
         process_pending_top_layer_layout_changes();
 
         auto const should_collect_devtools_layout_data = page().client().has_active_devtools_client();
@@ -2349,6 +2425,9 @@ void Document::update_layout(UpdateLayoutReason reason)
             if constexpr (UPDATE_LAYOUT_DEBUG) {
                 dbgln("TREEBUILD {} µs", timer.elapsed_time().to_microseconds());
             }
+
+            if (reconcile_stale_list_item_counters_after_tree_build(tree_build_result.rebuilt_subtree_roots))
+                continue;
         }
 
         if (document_element && document_element->unsafe_layout_node()) {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1150,6 +1150,9 @@ public:
     void set_snapped_areas_of_scroll_container(Compositor::AsyncScrollNodeStableID const&, Painting::SnappedAreas);
     void forget_snapped_areas_of_scroll_container(Layout::Node const&);
 
+    void schedule_list_item_renumber(Element& list_owner);
+    void did_render_list_item_counter_value(Element&);
+
     void schedule_scroll_container_resnap() { m_needs_scroll_container_resnap = true; }
     void cancel_scheduled_scroll_container_resnap() { m_needs_scroll_container_resnap = false; }
     [[nodiscard]] bool needs_scroll_container_resnap() const { return m_needs_scroll_container_resnap; }
@@ -1459,6 +1462,9 @@ private:
     bool needs_style_update_after_layout();
     bool any_anchor_names_are_registered() const;
     PartialRelayoutResult try_partial_relayout(HashTable<WeakPtr<Layout::Box>> registered_partial_relayout_roots, bool& needs_layout_tree_rebuild, bool should_collect_devtools_layout_data);
+
+    void process_pending_list_item_renumbers();
+    bool reconcile_stale_list_item_counters_after_tree_build(Vector<Layout::Node*> const& rebuilt_subtree_roots);
     enum class LayoutTreeChanged : u8 {
         No,
         Yes,
@@ -1852,6 +1858,10 @@ private:
     Vector<WeakPtr<Layout::Node const>> m_scroll_snap_containers;
     bool m_needs_scroll_container_resnap { false };
     bool m_may_have_scroll_snap_areas { false };
+
+    HashTable<GC::Ref<Element>> m_list_owners_pending_item_renumber;
+    HashTable<GC::Ref<Element>> m_list_owners_with_stale_item_counters;
+    bool m_stale_list_item_counter_rendered { false };
     CSS::SheetSetStyleCacheRegistry m_sheet_set_style_cache_registry;
     RefPtr<Painting::HitTestDisplayList> m_hit_test_display_list;
     // The previous recording's list, retained so cached per-paintable item ranges can be spliced into

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1874,7 +1874,7 @@ static bool element_displays_a_list_item_counter_value(Element const& element)
         [](Utf16String const&) {
             return false;
         },
-        [](Utf16FlyString const&) {
+        [](CSS::UnresolvedCounterStyleName const&) {
             return true;
         },
         [](CSS::ListStyleSymbols const& symbols) {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1554,7 +1554,7 @@ static void add_element_dependent_invalidation(CSS::RequiredInvalidationAfterSty
     // 'content' change, they rebuild from the element rather than its parent.
     auto compare = [&](Optional<Vector<ValueComparingRefPtr<CSS::CounterStyle const>>> const& old_content_dependencies, Optional<ValueComparingRefPtr<CSS::CounterStyle const>> const& old_list_counter_style) {
         if (old_content_dependencies.has_value()
-            && *old_content_dependencies != new_computed_values.resolved_content(abstract_element, 0).content_data.counter_style_dependencies)
+            && *old_content_dependencies != new_computed_values.resolved_content(abstract_element, 0, CSS::NotifyListItemCounterRendered::No).content_data.counter_style_dependencies)
             invalidation |= CSS::RequiredInvalidationAfterStyleChange::rebuild_layout_tree_from(CSS::LayoutTreeRebuildRoot::Self);
 
         if (old_list_counter_style.has_value()) {
@@ -5510,15 +5510,72 @@ bool Element::skips_its_contents()
     return false;
 }
 
-void Element::invalidate_list_item_counters_for_list_owner()
+void Element::schedule_list_item_renumber_for_list_owner()
 {
-    for_each_ancestor([](GC::Ref<Node> node) {
+    for_each_ancestor([&](GC::Ref<Node> node) {
         if (node->is_html_ol_ul_menu_element()) {
-            static_cast<Element&>(*node).set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::ListItemCounters);
+            document().schedule_list_item_renumber(static_cast<Element&>(*node));
             return IterationDecision::Break;
         }
         return IterationDecision::Continue;
     });
+}
+
+bool Element::after_pseudo_element_style_depends_on_list_item_counter() const
+{
+    auto style_depends_on_list_item_counter = [](CSS::ComputedValues const& style) {
+        auto definitions_contain_list_item_counter = [](auto const& definitions) {
+            return any_of(definitions, [](auto const& definition) {
+                return definition.name == CSS::list_item_counter_name();
+            });
+        };
+        return style.display().is_list_item()
+            || style.content_uses_list_item_counter()
+            || definitions_contain_list_item_counter(style.counter_increment())
+            || definitions_contain_list_item_counter(style.counter_reset())
+            || definitions_contain_list_item_counter(style.counter_set());
+    };
+
+    auto style = computed_style(CSS::PseudoElement::After);
+    return style && style_depends_on_list_item_counter(*style);
+}
+
+static bool subtree_renders_list_item_counters(Element const& ancestor, bool items_renumber_with_walked_owner)
+{
+    for (auto* child = ancestor.first_child(); child; child = child->next_sibling()) {
+        auto* element = as_if<Element>(*child);
+        if (!element)
+            continue;
+        auto style = element->computed_style();
+        if (!style || style->display().is_none())
+            continue;
+        if (style->content_uses_list_item_counter())
+            return true;
+        for (auto pseudo_element : { CSS::PseudoElement::Before, CSS::PseudoElement::After }) {
+            auto pseudo_style = element->computed_style(pseudo_element);
+            if (pseudo_style && pseudo_style->content_uses_list_item_counter())
+                return true;
+        }
+        auto marker_style = element->computed_style(CSS::PseudoElement::Marker);
+        if (marker_style && marker_style->content_uses_list_item_counter())
+            return true;
+        if (items_renumber_with_walked_owner
+            && style->display().is_list_item()
+            && (!marker_style || marker_style->content_is_normal())
+            && !style->list_style_image()
+            && CSS::marker_text_depends_on_list_item_counter_value(style->list_style_type(element->style_scope())))
+            return true;
+        if (subtree_renders_list_item_counters(*element, items_renumber_with_walked_owner && !element->is_html_ol_ul_menu_element()))
+            return true;
+    }
+    return false;
+}
+
+bool Element::list_item_renumber_affects_rendered_content() const
+{
+    if (after_pseudo_element_style_depends_on_list_item_counter())
+        return true;
+    return subtree_renders_list_item_counters(*this, true);
 }
 
 bool Element::id_reference_exists(Utf16View id_reference) const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -751,7 +751,9 @@ public:
     bool matches_local_link_pseudo_class() const;
     bool matches_focus_within_pseudo_class() const;
 
-    void invalidate_list_item_counters_for_list_owner();
+    void schedule_list_item_renumber_for_list_owner();
+    bool list_item_renumber_affects_rendered_content() const;
+    bool after_pseudo_element_style_depends_on_list_item_counter() const;
 
     bool captured_in_a_view_transition() const;
     void set_captured_in_a_view_transition(bool);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -95,41 +95,12 @@
 
 namespace Web::DOM {
 
-static bool content_uses_list_item_counter(CSS::ComputedContentData const& content)
-{
-    auto item_uses_list_item_counter = [](CSS::ComputedContentItem const& item) {
-        auto const* counter = item.get_pointer<CSS::ComputedContentCounter>();
-        return counter && counter->name == CSS::list_item_counter_name();
-    };
-    return any_of(content.items, item_uses_list_item_counter)
-        || any_of(content.alt_text, item_uses_list_item_counter);
-}
-
-static bool style_after_list_items_depends_on_list_item_counter(Element const& list_owner)
-{
-    auto style_depends_on_list_item_counter = [](CSS::ComputedValues const& style) {
-        auto definitions_contain_list_item_counter = [](auto const& definitions) {
-            return any_of(definitions, [](auto const& definition) {
-                return definition.name == CSS::list_item_counter_name();
-            });
-        };
-        return style.display().is_list_item()
-            || content_uses_list_item_counter(style.computed_content())
-            || definitions_contain_list_item_counter(style.counter_increment())
-            || definitions_contain_list_item_counter(style.counter_reset())
-            || definitions_contain_list_item_counter(style.counter_set());
-    };
-
-    auto style = list_owner.computed_style(CSS::PseudoElement::After);
-    return style && style_depends_on_list_item_counter(*style);
-}
-
 static bool final_direct_list_item_does_not_renumber_existing_content(Element const& list_item)
 {
     auto list_owner = list_item.parent_element();
     if (!list_owner || !list_owner->is_html_ol_ul_menu_element() || list_item.next_element_sibling())
         return false;
-    if (style_after_list_items_depends_on_list_item_counter(*list_owner))
+    if (list_owner->after_pseudo_element_style_depends_on_list_item_counter())
         return false;
 
     auto counters_set = list_owner->counters_set();
@@ -1030,7 +1001,7 @@ void Node::insert_nodes_before(Vector<GC::Root<Node>> nodes, GC::Ptr<Node> child
         if (inserted_node->is_html_li_element()) {
             auto& list_item = static_cast<Element&>(*inserted_node);
             if (!final_direct_list_item_does_not_renumber_existing_content(list_item))
-                list_item.invalidate_list_item_counters_for_list_owner();
+                list_item.schedule_list_item_renumber_for_list_owner();
             break;
         }
     }
@@ -1308,7 +1279,7 @@ void Node::remove(bool suppress_observers)
         auto style = this_element->computed_style();
         if ((is_html_li_element() || (style && style->display().is_list_item()))
             && !final_direct_list_item_does_not_renumber_existing_content(*this_element)) {
-            this_element->invalidate_list_item_counters_for_list_owner();
+            this_element->schedule_list_item_renumber_for_list_owner();
         }
     }
 

--- a/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -30,7 +30,7 @@ void HTMLLIElement::attribute_changed(Utf16FlyString const& local_name, Optional
     Base::attribute_changed(local_name, old_value, value, namespace_);
 
     if (local_name == HTML::AttributeNames::value)
-        invalidate_list_item_counters_for_list_owner();
+        schedule_list_item_renumber_for_list_owner();
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#dom-li-value

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -498,6 +498,9 @@ static CSS::ContentData resolve_normal_marker_content(DOM::AbstractElement& elem
         return content;
     }
 
+    if (CSS::marker_text_depends_on_list_item_counter_value(list_box.list_style_type()))
+        element_reference.element().document().did_render_list_item_counter_value(element_reference.element());
+
     auto counter_value = element_reference.ensure_counters_set().counter_value_for_use(CSS::list_item_counter_name(), element_reference);
 
     auto generate_from_counter_style = [&](RefPtr<CSS::CounterStyle const> const& counter_style) -> Utf16String {
@@ -775,7 +778,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                     .content_item_count = frame.resolved_content.data.size(),
                 };
             }
-            auto [content, final_quote_nesting_level] = computed_values->resolved_content(element_reference, initial_quote_nesting_level);
+            auto [content, final_quote_nesting_level] = computed_values->resolved_content(element_reference, initial_quote_nesting_level, CSS::NotifyListItemCounterRendered::Yes);
             frame.resolved_content = move(content);
             frame.layout_node->set_content(frame.resolved_content);
             return {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -517,7 +517,7 @@ static CSS::ContentData resolve_normal_marker_content(DOM::AbstractElement& elem
         [](Utf16String const& string) -> Utf16String {
             return string;
         },
-        [&](Utf16FlyString const&) -> Utf16String {
+        [&](CSS::UnresolvedCounterStyleName const&) -> Utf16String {
             return generate_from_counter_style(nullptr);
         },
         [&](CSS::ListStyleSymbols const& symbols) -> Utf16String {

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -19,7 +19,7 @@ fn commit_subtree(
     callbacks: &FfiLayoutFcCallbacks,
     sink: &FfiCommitSink,
     paintables: &mut crate::painting::paintable_build::PaintableCommit<'_>,
-    links_by_slot: &std::collections::HashMap<u32, &FragmentLink>,
+    links_by_slot: &HashMap<u32, &FragmentLink>,
     pass_fragments: &fragment_tree::CompletedPassFragments,
     enclosing_line_root_content_changed: bool,
 ) {

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -165,7 +165,7 @@ impl FcRunCacheEntry {
                 // Commit stops at the reused root, so descendant fragments and nested reuse markers never
                 // enter its scopes. Only payloads that escape the run still have to reach the parent.
                 scoped_descendants: Vec::new(),
-                reused_subtree_roots: std::collections::HashSet::new(),
+                reused_subtree_roots: HashSet::default(),
                 propagated_pending_abspos: root.propagated_pending_abspos.clone(),
                 propagated_anchor_candidates: root.propagated_anchor_candidates.clone(),
                 propagated_inline_containing_block_rects: root.propagated_inline_containing_block_rects.clone(),

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -771,7 +771,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         // calculations that could change that.
         // This is particularly important since we take references to the items stored in flex_items
         // later, whose addresses won't be stable if we added or removed any items.
-        let mut buckets: HashMap<i32, Vec<FlexItem>> = HashMap::new();
+        let mut buckets: HashMap<i32, Vec<FlexItem>> = HashMap::default();
         let mut child = self.callbacks.first_child(self.flex_container);
         while !child.is_invalid() {
             let next = self.callbacks.next_sibling(child);

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -349,7 +349,7 @@ fn link_fragment(fragment: std::rc::Rc<Fragment>, placement: PlacementData) -> F
 pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) scoped_descendants: Vec<FragmentLink>,
-    pub(crate) reused_subtree_roots: std::collections::HashSet<u32>,
+    pub(crate) reused_subtree_roots: HashSet<u32>,
     pub(crate) propagated_pending_abspos: Vec<abspos_inputs::PendingAbsposChild>,
     pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
     pub(crate) propagated_inline_containing_block_rects: Vec<InlineContainingBlockRect>,
@@ -358,15 +358,12 @@ pub(crate) struct UnplacedRootFragment {
 
 pub(crate) struct CompletedPassFragments {
     pub(crate) roots: Vec<FragmentLink>,
-    pub(crate) reused_subtree_roots: std::collections::HashSet<u32>,
+    pub(crate) reused_subtree_roots: HashSet<u32>,
 }
 
 impl CompletedPassFragments {
-    pub(crate) fn links_by_slot(&self) -> std::collections::HashMap<u32, &FragmentLink> {
-        fn insert_links<'tree>(
-            links: &'tree [FragmentLink],
-            links_by_slot: &mut std::collections::HashMap<u32, &'tree FragmentLink>,
-        ) {
+    pub(crate) fn links_by_slot(&self) -> HashMap<u32, &FragmentLink> {
+        fn insert_links<'tree>(links: &'tree [FragmentLink], links_by_slot: &mut HashMap<u32, &'tree FragmentLink>) {
             for link in links {
                 let previous = links_by_slot.insert(link.fragment.node.slot_index(), link);
                 assert!(
@@ -377,7 +374,7 @@ impl CompletedPassFragments {
                 insert_links(&link.fragment.children, links_by_slot);
             }
         }
-        let mut links_by_slot = std::collections::HashMap::new();
+        let mut links_by_slot = HashMap::default();
         insert_links(&self.roots, &mut links_by_slot);
         links_by_slot
     }
@@ -416,16 +413,16 @@ pub(crate) struct RunFragmentBuilder {
 
 #[derive(Default)]
 struct RunFragmentBuilderInner {
-    pending_fragments: std::collections::HashMap<u32, PendingFragment>,
+    pending_fragments: HashMap<u32, PendingFragment>,
     #[cfg(debug_assertions)]
-    placed_slots: std::collections::HashSet<u32>,
-    child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
+    placed_slots: HashSet<u32>,
+    child_roots_awaiting_placement: HashMap<u32, UnplacedRootFragment>,
     pending_abspos_at_root: Vec<abspos_inputs::PendingAbsposChild>,
     anchor_candidates_at_root: Vec<AnchorCandidate>,
     inline_containing_block_rects_at_root: Vec<InlineContainingBlockRect>,
     abspos_containing_block_info_contributions: Vec<AbsposContainingBlockInfoContribution>,
     top_scope_links: Vec<FragmentLink>,
-    reused_subtree_roots: std::collections::HashSet<u32>,
+    reused_subtree_roots: HashSet<u32>,
 }
 
 impl RunFragmentBuilderInner {

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -582,7 +582,7 @@ pub(crate) struct OccupationGrid {
 impl OccupationGrid {
     pub(crate) fn new(column_count: usize, row_count: usize) -> Self {
         Self {
-            occupied: HashSet::new(),
+            occupied: HashSet::default(),
             min_column_index: 0,
             max_column_index: column_count.saturating_sub(1) as i32,
             min_row_index: 0,

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -273,7 +273,7 @@ pub(crate) fn compute(
         collect_inline_containing_block_rects && context.facts(context.containing_block).inline_axis_is_reverse();
     let mut inline_containing_block_rect_candidates = Vec::<InlineContainingBlockRectCandidate>::new();
     let mut per_nodes = Vec::<PerNode>::new();
-    let mut node_to_index = HashMap::<Node, usize>::new();
+    let mut node_to_index = HashMap::<Node, usize>::default();
 
     let mut committed_fragment_index = 0u32;
     for (line_index, line) in context.line_data().line_boxes.iter().enumerate() {
@@ -1535,7 +1535,7 @@ impl<'context> InlineFormattingContext<'context> {
         if data.inline_box_pieces.is_empty() {
             return;
         }
-        let mut accumulated_relative_offset_by_chain_start = HashMap::<Node, FfiCssPixelPoint>::new();
+        let mut accumulated_relative_offset_by_chain_start = HashMap::<Node, FfiCssPixelPoint>::default();
         let mut accumulated_relative_offset_from = |first_ancestor: Node| -> FfiCssPixelPoint {
             *accumulated_relative_offset_by_chain_start
                 .entry(first_ancestor)

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -12,13 +12,13 @@ use super::geometry::AvailableSpace;
 use super::used_values::SizeConstraint;
 use super::used_values::UsedValues;
 use crate::abort_on_panic;
+use crate::css::style::fast_hash::FastMap as HashMap;
 use crate::layout::CssPixels;
 use crate::layout::FfiReplacedContentFacts;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ffi::c_void;
 
 unsafe extern "C" {
@@ -464,7 +464,7 @@ impl LayoutNodeArena {
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
             replaced_content_facts: Vec::new(),
-            raw_table_column_spans: HashMap::new(),
+            raw_table_column_spans: HashMap::default(),
             run_used_records: RefCell::new(Vec::new()),
             next_run_nonce: Cell::new(1),
             fc_run_cache_store: super::fc_run_cache::FcRunCacheArenaStore::default(),

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -41,6 +41,8 @@ mod tree_builder;
 mod tree_mutation;
 pub mod used_values;
 
+use crate::css::style::fast_hash::FastMap as HashMap;
+use crate::css::style::fast_hash::FastSet as HashSet;
 use crate::layout::layout_node_arena::IntrinsicBlockSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
@@ -71,8 +73,6 @@ use std::cell::OnceCell;
 use std::cell::Ref;
 use std::cell::RefCell;
 use std::cell::RefMut;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::ffi::c_void;
 pub(crate) use style_values::StyleValues;
 pub(crate) use used_values::{FfiCssPixelPoint, FfiCssPixelRect, FfiCssPixelSize, SizeConstraint, UsedValues};

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -681,7 +681,7 @@ fn count_columns_in_subtree<T: TableTree>(tree: &T, root: Node) -> usize {
 pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> TableGrid {
     let mut cells = Vec::new();
     let mut rows = Vec::new();
-    let mut occupancy = HashSet::new();
+    let mut occupancy = HashSet::default();
     let mut column_count = 0usize;
     let mut row_count = 0usize;
     let mut current_row = 0usize;

--- a/Tests/LibWeb/Ref/expected/list-renumbers-when-counter-content-appears-after-mutation-ref.html
+++ b/Tests/LibWeb/Ref/expected/list-renumbers-when-counter-content-appears-after-mutation-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    ul {
+        list-style-type: none;
+    }
+    ul li::before {
+        content: counter(list-item) ") ";
+    }
+</style>
+<ul><li>b</li><li>c</li><li>d</li></ul>

--- a/Tests/LibWeb/Ref/expected/list-renumbers-when-markers-appear-after-mutation-ref.html
+++ b/Tests/LibWeb/Ref/expected/list-renumbers-when-markers-appear-after-mutation-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<ol><li>b</li><li>c</li><li>d</li></ol>

--- a/Tests/LibWeb/Ref/expected/ol-renumbers-after-inserting-list-item-ref.html
+++ b/Tests/LibWeb/Ref/expected/ol-renumbers-after-inserting-list-item-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<ol><li>a</li><li>b</li><li>c</li><li>d</li></ol>

--- a/Tests/LibWeb/Ref/expected/ol-renumbers-after-removing-list-item-ref.html
+++ b/Tests/LibWeb/Ref/expected/ol-renumbers-after-removing-list-item-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<ol><li>b</li><li>c</li><li>d</li></ol>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+
+<p>The test passes if you see the list marker followed by the text "inline" and "axxx" in a line below.</p>
+
+<ul>
+  <li style="list-style-position:inside;">
+    <span>inline</span>
+    <div style="overflow:hidden;">
+      <span>a</span>xxx
+    </div>
+  </li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-002-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+<style>
+div {
+  display: list-item;
+  margin-left: 40px;
+  border: 5px solid;
+}
+div > div { list-style-type: decimal }
+div > div > div { list-style-type: lower-roman }
+.inside { list-style-position: inside }
+</style>
+<div><div><div class="inside">text</div></div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-position-003-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+<style>
+div {
+  border: 5px solid orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 40px;
+}
+div > div {
+  list-style-type: decimal;
+}
+</style>
+<div><div>text</div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-type-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-type-001-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-type</title>
+<link rel=help href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=966750">
+<style type="text/css">
+.inside {
+  list-style-position: inside;
+}
+
+.none2symbol {
+  list-style-type: square;
+}
+
+.symbol2none {
+  list-style-type: none;
+}
+
+.symbol2symbol {
+  list-style-type: square;
+}
+
+.symbol2ordinal {
+  list-style-type: upper-roman;
+}
+
+.ordinal2ordinal {
+  list-style-type: decimal;
+}
+</style>
+
+<ul class="inside"><li class="none2symbol">inside: none to square</li></ul>
+<ul><li class="none2symbol">outside: none to square</li></ul>
+
+<ul class="inside"><li class="symbol2none">inside: square to none</li></ul>
+<ul><li class="symbol2none">outside: square to none</li></ul>
+
+<ul class="inside"><li class="symbol2symbol">inside: disc to square</li></ul>
+<ul><li class="symbol2symbol">outside: disc to square</li></ul>
+
+<ul class="inside"><li class="symbol2ordinal">inside: disc to upper-roman</li></ul>
+<ul><li class="symbol2ordinal">outside: disc to upper-roman</li></ul>
+
+<ul class="inside"><li class="ordinal2ordinal">inside: upper-roman to decimal</li></ul>
+<ul><li class="ordinal2ordinal">outside: upper-roman to decimal</li></ul>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-type-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/change-list-style-type-002-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-type</title>
+<ol>
+  <li>text</li>
+  <li><p>text</p></li>
+  <li>
+    <p>text</p>
+  </li>
+  <li>
+    <p></p>
+    <p>text</p>
+  </li>
+  <li>
+    <div>
+      <p>text</p>
+    </div>
+  </li>
+</ol>

--- a/Tests/LibWeb/Ref/input/list-renumbers-when-counter-content-appears-after-mutation.html
+++ b/Tests/LibWeb/Ref/input/list-renumbers-when-counter-content-appears-after-mutation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/list-renumbers-when-counter-content-appears-after-mutation-ref.html">
+<style>
+    ul {
+        list-style-type: none;
+    }
+    ul.numbered li::before {
+        content: counter(list-item) ") ";
+    }
+</style>
+<ul id="list"><li>a</li><li>b</li><li>c</li><li>d</li></ul>
+<script>
+    const list = document.getElementById("list");
+    document.body.offsetHeight;
+    list.children[0].remove();
+    document.body.offsetHeight;
+    list.classList.add("numbered");
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Ref/input/list-renumbers-when-markers-appear-after-mutation.html
+++ b/Tests/LibWeb/Ref/input/list-renumbers-when-markers-appear-after-mutation.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/list-renumbers-when-markers-appear-after-mutation-ref.html">
+<style>
+    ol.plain {
+        list-style-type: none;
+    }
+</style>
+<ol id="list" class="plain"><li>a</li><li>b</li><li>c</li><li>d</li></ol>
+<script>
+    const list = document.getElementById("list");
+    document.body.offsetHeight;
+    list.children[0].remove();
+    document.body.offsetHeight;
+    list.classList.remove("plain");
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Ref/input/ol-renumbers-after-inserting-list-item.html
+++ b/Tests/LibWeb/Ref/input/ol-renumbers-after-inserting-list-item.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/ol-renumbers-after-inserting-list-item-ref.html">
+<ol id="list"><li>a</li><li>c</li><li>d</li></ol>
+<script>
+    const list = document.getElementById("list");
+    document.body.offsetHeight;
+    const item = document.createElement("li");
+    item.textContent = "b";
+    list.insertBefore(item, list.children[1]);
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Ref/input/ol-renumbers-after-removing-list-item.html
+++ b/Tests/LibWeb/Ref/input/ol-renumbers-after-removing-list-item.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/ol-renumbers-after-removing-list-item-ref.html">
+<ol id="list"><li>a</li><li>b</li><li>c</li><li>d</li></ol>
+<script>
+    const list = document.getElementById("list");
+    document.body.offsetHeight;
+    list.children[0].remove();
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-001.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+<link rel=help href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<link rel=match href="../../../../expected/wpt-import/css/css-lists/change-list-style-position-001-ref.html">
+
+<p>The test passes if you see the list marker followed by the text "inline" and "axxx" in a line below.</p>
+
+<ul>
+  <li>
+    <span>inline</span>
+    <div style="overflow:hidden;">
+      <span>a</span>xxx
+    </div>
+  </li>
+</ul>
+<script>
+  document.body.offsetHeight;
+  document.querySelector("li").style.listStylePosition = "inside";
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../../../expected/wpt-import/css/css-lists/change-list-style-position-002-ref.html">
+<link rel="help" href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<style>
+div {
+  display: list-item;
+  margin-left: 40px;
+  border: 5px solid;
+}
+div > div { list-style-type: decimal }
+div > div > div { list-style-type: lower-roman }
+.inside { list-style-position: inside }
+</style>
+<div><div id="bar"><div id="baz">text</div></div></div>
+<script>
+document.getElementById("bar").className = "inside";
+document.body.offsetHeight;
+document.getElementById("bar").className = "";
+document.body.offsetHeight;
+document.getElementById("baz").className = "inside";
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-position-003.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-position</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../../../expected/wpt-import/css/css-lists/change-list-style-position-003-ref.html">
+<link rel="help" href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<style>
+div {
+  border: 5px solid orange;
+  display: list-item;
+  margin-left: 40px;
+}
+div > div {
+  list-style-type: decimal;
+}
+</style>
+<div><div>text</div></div>
+<script>
+document.body.offsetHeight;
+document.body.style.listStylePosition = "inside";
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-type-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-type-001.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-type</title>
+<link rel="match" href="../../../../expected/wpt-import/css/css-lists/change-list-style-type-001-ref.html">
+<link rel=help href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=966750">
+<style type="text/css">
+.inside {
+  list-style-position: inside;
+}
+
+.none2symbol {
+  list-style-type: none;
+}
+
+.symbol2none {
+  list-style-type: square;
+}
+
+.symbol2symbol {
+  list-style-type: disc;
+}
+
+.symbol2ordinal {
+  list-style-type: disc;
+}
+
+.ordinal2ordinal {
+  list-style-type: upper-roman;
+}
+</style>
+
+<ul class="inside"><li class="none2symbol">inside: none to square</li></ul>
+<ul><li class="none2symbol">outside: none to square</li></ul>
+
+<ul class="inside"><li class="symbol2none">inside: square to none</li></ul>
+<ul><li class="symbol2none">outside: square to none</li></ul>
+
+<ul class="inside"><li class="symbol2symbol">inside: disc to square</li></ul>
+<ul><li class="symbol2symbol">outside: disc to square</li></ul>
+
+<ul class="inside"><li class="symbol2ordinal">inside: disc to upper-roman</li></ul>
+<ul><li class="symbol2ordinal">outside: disc to upper-roman</li></ul>
+
+<ul class="inside"><li class="ordinal2ordinal">inside: upper-roman to decimal</li></ul>
+<ul><li class="ordinal2ordinal">outside: upper-roman to decimal</li></ul>
+
+<script>
+document.body.offsetLeft;
+</script>
+
+<style type="text/css">
+.none2symbol {
+  list-style-type: square;
+}
+
+.symbol2none {
+  list-style-type: none;
+}
+
+.symbol2symbol {
+  list-style-type: square;
+}
+
+.symbol2ordinal {
+  list-style-type: upper-roman;
+}
+
+.ordinal2ordinal {
+  list-style-type: decimal;
+}
+</style>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-type-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/change-list-style-type-002.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: test the change of list-style-type</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="match" href="../../../../expected/wpt-import/css/css-lists/change-list-style-type-002-ref.html">
+<link rel="help" href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<style>
+.no-marker li {
+  list-style-type: none;
+}
+</style>
+<ol>
+  <li>text</li>
+  <li><p>text</p></li>
+  <li>
+    <p>text</p>
+  </li>
+  <li>
+    <p></p>
+    <p>text</p>
+  </li>
+  <li>
+    <div>
+      <p>text</p>
+    </div>
+  </li>
+</ol>
+<script>
+// Force layout
+document.body.offsetHeight;
+
+// Remove list markers
+document.body.className = "no-marker";
+
+// Force layout
+document.body.offsetHeight;
+
+// Recover list markers
+document.body.className = "";
+</script>


### PR DESCRIPTION
See individual commits for details.

These changes improve the following MicroWeb benchmarks:

| Benchmark | Before | After  | Speedup | vs Chromium (jitless)
 | --- | ---- |--- | --- | --- |
| `render/remove-one-item` | 2057ms | 281ms | 7.3x | 127x -> 17.5x slower
| `render/insert-middle-item` | 1909ms | 307ms | 6.2x | 112x -> 18.3x slower
