### PR TITLE
LibWeb: Track live ranges per document

### DIFF
--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -142,21 +142,21 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
     auto replaced_data_end_offset = offset + count;
     auto replacement_data_length = data.length_in_code_units();
-    for (auto* range : Range::live_ranges()) {
-        if (range == selection_range_to_preserve.ptr())
+    for (auto& range : document().live_ranges()) {
+        if (&range == selection_range_to_preserve.ptr())
             continue;
 
-        if (range->start_container().ptr() == this) {
-            if (range->start_offset() > offset && range->start_offset() <= replaced_data_end_offset)
-                range->set_start_offset(offset);
-            else if (range->start_offset() > replaced_data_end_offset)
-                range->set_start_offset(range->start_offset() + replacement_data_length - count);
+        if (range.start_container().ptr() == this) {
+            if (range.start_offset() > offset && range.start_offset() <= replaced_data_end_offset)
+                range.set_start_offset(offset);
+            else if (range.start_offset() > replaced_data_end_offset)
+                range.set_start_offset(range.start_offset() + replacement_data_length - count);
         }
-        if (range->end_container().ptr() == this) {
-            if (range->end_offset() > offset && range->end_offset() <= replaced_data_end_offset)
-                range->set_end_offset(offset);
-            else if (range->end_offset() > replaced_data_end_offset)
-                range->set_end_offset(range->end_offset() + replacement_data_length - count);
+        if (range.end_container().ptr() == this) {
+            if (range.end_offset() > offset && range.end_offset() <= replaced_data_end_offset)
+                range.set_end_offset(offset);
+            else if (range.end_offset() > replaced_data_end_offset)
+                range.set_end_offset(range.end_offset() + replacement_data_length - count);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3912,6 +3912,19 @@ void Document::adopt_node_steps(Node& node)
             m_node_iterators.set(&node_iterator);
         }
 
+        // AD-HOC: Live ranges are registered with the document their boundary points belong to. The removal in step 2
+        //         only clamps ranges anchored in node's own tree, so ranges anchored in a parentless node's tree cross
+        //         into this document with their boundaries intact and must be re-registered here.
+        if (!old_document.live_ranges().is_empty()) {
+            Vector<GC::Ref<Range>> ranges_to_transfer;
+            for (auto& range : old_document.live_ranges()) {
+                if (&range.start_container()->document() == this)
+                    ranges_to_transfer.append(range);
+            }
+            for (auto range : ranges_to_transfer)
+                range->update_owner_document({});
+        }
+
         // AD-HOC: A parentless node leaves oldDocument without any mutation observable through oldDocument's
         //         dom_tree_version. Bump it so that caches keyed on that version can't serve stale results for this
         //         node if it is later adopted back after being mutated under another document.
@@ -5265,6 +5278,18 @@ void Document::unregister_node_iterator(Badge<NodeIterator>, NodeIterator& node_
 {
     bool was_removed = m_node_iterators.remove(&node_iterator);
     VERIFY(was_removed);
+}
+
+void Document::attach_range(Badge<Range>, Range& range)
+{
+    VERIFY(!m_live_ranges.contains(range));
+    m_live_ranges.append(range);
+}
+
+void Document::detach_range(Badge<Range>, Range& range)
+{
+    VERIFY(m_live_ranges.contains(range));
+    m_live_ranges.remove(range);
 }
 
 void Document::register_document_observer(Badge<DocumentObserver>, DocumentObserver& document_observer)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -40,6 +40,7 @@
 #include <LibWeb/DOM/AnchorNameMap.h>
 #include <LibWeb/DOM/HoverEventData.h>
 #include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/ViewportClient.h>
 #include <LibWeb/Export.h>
@@ -788,6 +789,11 @@ public:
 
     void register_node_iterator(Badge<NodeIterator>, NodeIterator&);
     void unregister_node_iterator(Badge<NodeIterator>, NodeIterator&);
+
+    void attach_range(Badge<Range>, Range&);
+    void detach_range(Badge<Range>, Range&);
+
+    Range::DocumentLiveRangeList& live_ranges() { return m_live_ranges; }
 
     void register_document_observer(Badge<DocumentObserver>, DocumentObserver&);
     void unregister_document_observer(Badge<DocumentObserver>, DocumentObserver&);
@@ -1692,6 +1698,9 @@ private:
     bool m_needs_animated_style_update { false };
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
+
+    // A live Range keeps its owner document alive and removes itself from this list when finalized.
+    Range::DocumentLiveRangeList m_live_ranges;
 
     // Document should not visit DocumentObserver to avoid leaks.
     // It's responsibility of object that requires DocumentObserver to keep it alive.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -512,22 +512,22 @@ WebIDL::ExceptionOr<void> Node::normalize()
             // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
             auto* current_node_parent = current_node->parent();
             auto current_node_index = current_node->index();
-            for (auto& range : Range::live_ranges()) {
-                if (range->start_container().ptr() == current_node) {
-                    range->increase_start_offset(length);
-                    range->set_start_node(node);
+            for (auto& range : document().live_ranges()) {
+                if (range.start_container().ptr() == current_node) {
+                    range.increase_start_offset(length);
+                    range.set_start_node(node);
                 }
-                if (range->end_container().ptr() == current_node) {
-                    range->increase_end_offset(length);
-                    range->set_end_node(node);
+                if (range.end_container().ptr() == current_node) {
+                    range.increase_end_offset(length);
+                    range.set_end_node(node);
                 }
-                if (range->start_container().ptr() == current_node_parent && range->start_offset() == current_node_index) {
-                    range->set_start_node(node);
-                    range->set_start_offset(length);
+                if (range.start_container().ptr() == current_node_parent && range.start_offset() == current_node_index) {
+                    range.set_start_node(node);
+                    range.set_start_offset(length);
                 }
-                if (range->end_container().ptr() == current_node_parent && range->end_offset() == current_node_index) {
-                    range->set_end_node(node);
-                    range->set_end_offset(length);
+                if (range.end_container().ptr() == current_node_parent && range.end_offset() == current_node_index) {
+                    range.set_end_node(node);
+                    range.set_end_offset(length);
                 }
             }
 
@@ -868,11 +868,11 @@ void Node::insert_nodes_before(Vector<GC::Root<Node>> nodes, GC::Ptr<Node> child
         //    increase its end offset by count.
         // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
         auto child_index = child->index();
-        for (auto& range : Range::live_ranges()) {
-            if (range->start_container().ptr() == this && range->start_offset() > child_index)
-                range->increase_start_offset(count);
-            if (range->end_container().ptr() == this && range->end_offset() > child_index)
-                range->increase_end_offset(count);
+        for (auto& range : document().live_ranges()) {
+            if (range.start_container().ptr() == this && range.start_offset() > child_index)
+                range.increase_start_offset(count);
+            if (range.end_container().ptr() == this && range.end_offset() > child_index)
+                range.increase_end_offset(count);
         }
     }
 
@@ -1104,15 +1104,15 @@ void Node::live_range_pre_remove()
     //    offset by 1.
     // 7. For each live range whose end node is parent and end offset is greater than index, decrease its end offset by 1.
     // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
-    for (auto* range : Range::live_ranges()) {
-        if (range->start_container()->is_inclusive_descendant_of(*this))
-            MUST(range->set_start(*parent, index));
-        if (range->end_container()->is_inclusive_descendant_of(*this))
-            MUST(range->set_end(*parent, index));
-        if (range->start_container().ptr() == parent && range->start_offset() > index)
-            range->decrease_start_offset(1);
-        if (range->end_container().ptr() == parent && range->end_offset() > index)
-            range->decrease_end_offset(1);
+    for (auto& range : document().live_ranges()) {
+        if (range.start_container()->is_inclusive_descendant_of(*this))
+            MUST(range.set_start(*parent, index));
+        if (range.end_container()->is_inclusive_descendant_of(*this))
+            MUST(range.set_end(*parent, index));
+        if (range.start_container().ptr() == parent && range.start_offset() > index)
+            range.decrease_start_offset(1);
+        if (range.end_container().ptr() == parent && range.end_offset() > index)
+            range.decrease_end_offset(1);
     }
 }
 
@@ -1768,11 +1768,11 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
         //    increase its end offset by 1.
         // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
         auto child_index = child->index();
-        for (auto& range : Range::live_ranges()) {
-            if (range->start_container().ptr() == &new_parent && range->start_offset() > child_index)
-                range->increase_start_offset(1);
-            if (range->end_container().ptr() == &new_parent && range->end_offset() > child_index)
-                range->increase_end_offset(1);
+        for (auto& range : new_parent.document().live_ranges()) {
+            if (range.start_container().ptr() == &new_parent && range.start_offset() > child_index)
+                range.increase_start_offset(1);
+            if (range.end_container().ptr() == &new_parent && range.end_offset() > child_index)
+                range.increase_end_offset(1);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/NeverDestroyed.h>
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>
@@ -42,12 +41,6 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(Range);
 
-HashTable<Range*>& Range::live_ranges()
-{
-    static NeverDestroyed<HashTable<Range*>> ranges;
-    return *ranges;
-}
-
 GC::Ref<Range> Range::create(Document& document)
 {
     return GC::Heap::the().allocate<Range>(document);
@@ -74,7 +67,7 @@ Range::Range(GC::Ref<Node> start_container, WebIDL::UnsignedLong start_offset, G
     VERIFY(start_offset <= start_container->length());
     VERIFY(end_offset <= end_container->length());
 
-    live_ranges().set(this);
+    update_owner_document();
 }
 
 Range::~Range() = default;
@@ -82,13 +75,26 @@ Range::~Range() = default;
 void Range::finalize()
 {
     Base::finalize();
-    live_ranges().remove(this);
+    if (m_owner_document)
+        m_owner_document->detach_range({}, *this);
 }
 
 void Range::visit_edges(GC::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_associated_selection);
+    visitor.visit(m_owner_document);
+}
+
+void Range::update_owner_document()
+{
+    auto& document = m_start_container->document();
+    if (&document == m_owner_document.ptr())
+        return;
+    if (m_owner_document)
+        m_owner_document->detach_range({}, *this);
+    m_owner_document = document;
+    document.attach_range({}, *this);
 }
 
 void Range::set_associated_selection(Badge<Selection::Selection>, GC::Ptr<Selection::Selection> selection)
@@ -242,6 +248,7 @@ WebIDL::ExceptionOr<void> Range::set_start_or_end(GC::Ref<Node> node, u32 offset
         m_end_offset = offset;
     }
 
+    update_owner_document();
     update_associated_selection();
     return {};
 }
@@ -424,6 +431,7 @@ WebIDL::ExceptionOr<void> Range::select(GC::Ref<Node> node)
     m_end_container = *parent;
     m_end_offset = index + 1;
 
+    update_owner_document();
     update_associated_selection();
     return {};
 }
@@ -467,6 +475,7 @@ WebIDL::ExceptionOr<void> Range::select_node_contents(GC::Ref<Node> node)
     m_end_container = node;
     m_end_offset = length;
 
+    update_owner_document();
     update_associated_selection();
     return {};
 }

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/IntrusiveList.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/DOM/AbstractRange.h>
 #include <LibWeb/DOM/Node.h>
@@ -91,7 +92,7 @@ public:
 
     Utf16String to_string() const;
 
-    static HashTable<Range*>& live_ranges();
+    void update_owner_document(Badge<Document>) { update_owner_document(); }
 
     GC::Ref<Geometry::DOMRectList> get_client_rects();
     GC::Ref<Geometry::DOMRect> get_bounding_client_rect();
@@ -146,9 +147,17 @@ private:
         End,
     };
 
-    void set_start_node(GC::Ref<Node> node) { m_start_container = node; }
+    void set_start_node(GC::Ref<Node> node)
+    {
+        m_start_container = node;
+        update_owner_document();
+    }
     void set_start_offset(WebIDL::UnsignedLong offset) { m_start_offset = offset; }
-    void set_end_node(GC::Ref<Node> node) { m_end_container = node; }
+    void set_end_node(GC::Ref<Node> node)
+    {
+        m_end_container = node;
+        update_owner_document();
+    }
     void set_end_offset(WebIDL::UnsignedLong offset) { m_end_offset = offset; }
 
     void increase_start_offset(WebIDL::UnsignedLong count) { m_start_offset += count; }
@@ -165,7 +174,15 @@ private:
 
     bool partially_contains_node(GC::Ref<Node>) const;
 
+    void update_owner_document();
+
     GC::Ptr<Selection::Selection> m_associated_selection;
+    GC::Ptr<Document> m_owner_document;
+
+    IntrusiveListNode<Range> m_live_range_list_node;
+
+public:
+    using DocumentLiveRangeList = IntrusiveList<&Range::m_live_range_list_node>;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Text.cpp
+++ b/Libraries/LibWeb/DOM/Text.cpp
@@ -110,19 +110,19 @@ WebIDL::ExceptionOr<GC::Ref<Text>> Text::split_text(size_t offset)
         //    its end offset by 1.
         // OPTIMIZATION: These steps are independent between ranges, so traverse the live ranges only once.
         auto node_index = index();
-        for (auto* range : Range::live_ranges()) {
-            if (range->start_container().ptr() == this && range->start_offset() > offset) {
-                range->set_start_node(*new_node);
-                range->decrease_start_offset(offset);
+        for (auto& range : document().live_ranges()) {
+            if (range.start_container().ptr() == this && range.start_offset() > offset) {
+                range.set_start_node(*new_node);
+                range.decrease_start_offset(offset);
             }
-            if (range->end_container().ptr() == this && range->end_offset() > offset) {
-                range->set_end_node(*new_node);
-                range->decrease_end_offset(offset);
+            if (range.end_container().ptr() == this && range.end_offset() > offset) {
+                range.set_end_node(*new_node);
+                range.decrease_end_offset(offset);
             }
-            if (range->start_container().ptr() == parent.ptr() && range->start_offset() == node_index + 1)
-                range->increase_start_offset(1);
-            if (range->end_container().ptr() == parent.ptr() && range->end_offset() == node_index + 1)
-                range->increase_end_offset(1);
+            if (range.start_container().ptr() == parent.ptr() && range.start_offset() == node_index + 1)
+                range.increase_start_offset(1);
+            if (range.end_container().ptr() == parent.ptr() && range.end_offset() == node_index + 1)
+                range.increase_end_offset(1);
         }
     }
 


### PR DESCRIPTION
Previously, every live range was stored in a single process-wide table, so DOM mutations that adjust range boundaries traversed every range in every document. Each document now tracks the live ranges anchored within it, and a range moves between these tables when its boundary points move into another document.

This drops the total runtime of the MicroWeb benchmark from 38.2s to 28.8s on my machine and gives a large win in tests which perform many DOM mutations. Previously, every mutation scanned all live ranges stored in the  process-wide table, so ranges left behind by earlier tests slowed down every later test.

Here's a summary of some of the most heavily impacted tests:

| Benchmark | Before | After | Speedup | vs Chromium (jitless) |
| --- | --- | --- | --- | --- |
| `edit/range-surround` | 1409ms | 6.3ms | 223.7x | 165.8x -> 0.7x |
| `edit/textarea-value-events` | 291ms | 2.1ms | 138.5x | 193.9x -> 1.4x |
| `shadow/slot-reassignment` | 137ms | 4.0ms | 34.3x | 85.8x -> 2.5x |
| `shadow/connected-callback` | 141ms | 4.8ms | 29.4x | 37.1x -> 1.3x |
| `frameworks/replace-children` | 282ms | 14.2ms | 19.8x | 56.3x -> 2.8x |
| `parse/entity-heavy` | 339ms | 17.3ms | 19.6x | 52.2x -> 2.7x |
| `frameworks/keyed-reorder` | 442ms | 22.9ms | 19.3x | 54.0x -> 2.8x |
| `shadow/define-and-upgrade` | 116ms | 10.5ms | 11.0x | 21.0x -> 1.9x |
| `shadow/attach-shadow` | 124ms | 13.8ms | 8.9x | 12.6x -> 1.4x |
| `frameworks/fragment-batch-insert` | 604ms | 73.8ms | 8.2x | 28.8x -> 3.5x |
| `parse/inner-html-fragment` | 330ms | 50.8ms | 6.5x | 47.1x -> 7.3x |
| `edit/range-extract-insert` | 22.0ms | 4.3ms | 5.1x | 3.7x -> 0.7x |