### PR TITLE
LibWeb: Clear hidden descendant styles instead of republishing them

### DIFF
--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -324,7 +324,13 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
         transaction_invalidation |= invalidation;
 
         auto current_style_state = document.style_computer().style_engine().style_record_state(element->style_record_identity());
-        VERIFY(current_style_state.present);
+        // A descendant whose style was cleared on entry to display:none can receive a reaction which only
+        // updates style-engine bookkeeping, such as a synthetic pseudo-element reaction. Keep the DOM style
+        // unmaterialized until a CSSOM read or the ancestor becomes visible.
+        if (!current_style_state.present) {
+            VERIFY(was_unstyled);
+            continue;
+        }
         if (current_style_state.display_none) {
             if (was_unstyled) {
                 record_direct_child_style_engine_reactions(*element, reaction_batch, StyleEngine::RecomputeStyle);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2081,6 +2081,20 @@ void Element::finish_recording_style_custom_property_references()
     }
 }
 
+static bool unregister_current_anchor_names(Element& element, Node& tree_root)
+{
+    auto const* anchor_values = element.style_group<CSS::ComputedValues::AnchorValues>();
+    if (!anchor_values || anchor_values->anchor_names_span().is_empty())
+        return false;
+
+    auto& anchor_names = is<ShadowRoot>(tree_root)
+        ? as<ShadowRoot>(tree_root).anchor_name_map()
+        : element.document().anchor_name_map();
+    for (auto const& name : anchor_values->anchor_names_span())
+        anchor_names.unregister_name(name, element);
+    return true;
+}
+
 CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason recompute_reason, u8 inherited_style_groups)
 {
     VERIFY(parent());
@@ -2155,7 +2169,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
     // already holds. Nothing derived from the originating style needs to be compared or published
     // again in that case. Pseudo-element declarations are a separate cascade projected from the
     // originating element's matches, so they still have to consume that shared match result.
-    if (style_record_is_unchanged(style_record_delta) && !did_change_custom_properties && !root_font_metrics_changed) {
+    if (old_computed_values && style_record_is_unchanged(style_record_delta) && !did_change_custom_properties && !root_font_metrics_changed) {
         if (recompute_reason == StyleEngineRecomputeReason::PseudoInputsUnchanged
             && !backdrop_style_needs_materialization()
             && style_engine_matches.node != 0
@@ -2285,14 +2299,14 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
         });
     }
 
-    // NB: Elements inside a display:none subtree keep their last computed style without being recomputed, so
-    //     entering the subtree must mark those retained styles as hidden. The caller's typed reactions propagate a
-    //     display reveal to descendants.
+    // NB: Elements inside a display:none subtree are not recomputed, so discard their materialized styles. This
+    //     makes a CSSOM read rematerialize the requested inheritance path, and the caller's typed reactions
+    //     rematerialize all descendants when the subtree becomes visible again.
     auto current_computed_values = computed_style();
     VERIFY(current_computed_values);
     if (old_computed_values && old_computed_values->display().is_none() != current_computed_values->display().is_none()) {
         if (current_computed_values->display().is_none())
-            set_in_display_none_subtree_on_descendant_styles();
+            clear_computed_styles_from_display_none_descendants();
     }
 
     auto const element_style_changed = !invalidation.is_none();
@@ -2326,29 +2340,27 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
     return invalidation;
 }
 
-void Element::set_in_display_none_subtree_on_descendant_styles()
+void Element::clear_computed_styles_from_display_none_descendants()
 {
     for_each_shadow_including_descendant([](auto& node) {
         auto* element = as_if<Element>(node);
         if (!element)
             return TraversalDecision::Continue;
-        auto computed_values = element->computed_style();
-        if (!computed_values)
+        if (!element->has_style())
             return TraversalDecision::SkipChildrenAndContinue;
-        if (computed_values->in_display_none_subtree())
-            return TraversalDecision::SkipChildrenAndContinue;
-        CSS::ComputedValues::Builder builder(*computed_values);
-        builder->set_in_display_none_subtree(true);
-        if (computed_values->has_animated_values()) {
-            CSS::ComputedValues::Builder base_values_builder(computed_values->base_values());
-            base_values_builder->set_in_display_none_subtree(true);
-            builder->set_base_values(move(base_values_builder).build());
-        }
-        auto updated_values = move(builder).build();
-        auto publication = element->document().style_computer().publish_computed_style_inputs({ *element }, *updated_values);
-        element->refresh_computed_style({}, publication.new_style_record);
-        element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element_type, SyntheticPseudoElement& pseudo_element) {
-            pseudo_element.set_computed_values_in_display_none_subtree({ *element, pseudo_element_type });
+
+        // Anchor names are registered outside the style record, so unregister them before discarding the only record
+        // that identifies them. Rematerializing the element's style will register its current names again.
+        if (element->is_connected() && unregister_current_anchor_names(*element, element->root()))
+            element->document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByStyleChange);
+
+        // The layout tree is torn down after the style transaction. Keep its style alive until then without
+        // retaining the record as the descendant's current computed style.
+        if (auto* layout_node = element->unsafe_layout_node())
+            layout_node->pin_style_record_for_detachment();
+        element->m_style_record_identity = 0;
+        element->for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+            pseudo_element.clear_computed_style();
         });
         return TraversalDecision::Continue;
     });
@@ -3074,7 +3086,6 @@ void Element::inserted()
 void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
     Base::removed_from(is_subtree_root, old_ancestor, old_root);
-    auto const* anchor_values = style_group<CSS::ComputedValues::AnchorValues>();
 
     // https://html.spec.whatwg.org/multipage/dom.html#render-blocking-mechanism
     // Whenever a render-blocking element el becomes browsing-context disconnected, unblock rendering on el.
@@ -3089,19 +3100,10 @@ void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, No
             document().element_with_id_was_removed({}, *this);
         if (m_has_name)
             document().element_with_name_was_removed({}, *this);
-        if (anchor_values) {
-            auto& anchor_names = is<ShadowRoot>(old_root)
-                ? as<ShadowRoot>(old_root).anchor_name_map()
-                : document().anchor_name_map();
-            bool element_had_registered_anchor_names = false;
-            for (auto const& name : anchor_values->anchor_names_span()) {
-                element_had_registered_anchor_names = true;
-                anchor_names.unregister_name(name, *this);
-            }
+        if (unregister_current_anchor_names(*this, old_root)) {
             // Positioned boxes anywhere may hold geometry resolved against these names, which
             // the dispatch-time check of the live anchor-name maps can no longer see.
-            if (element_had_registered_anchor_names)
-                document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByElementRemoval);
+            document().partial_relayout_invalidation().record_escape(PartialRelayoutEscapeReason::AnchorNamesUnregisteredByElementRemoval);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -875,7 +875,7 @@ private:
     void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void replace_style_record(CSS::StyleRecordID);
-    void set_in_display_none_subtree_on_descendant_styles();
+    void clear_computed_styles_from_display_none_descendants();
 
     WebIDL::ExceptionOr<GC::Ptr<Node>> insert_adjacent(Utf16View where, GC::Ref<Node> node);
 

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -92,22 +92,6 @@ void SyntheticPseudoElement::refresh_computed_style(CSS::StyleRecordID style_rec
     VERIFY(m_style_record_identity);
 }
 
-void SyntheticPseudoElement::set_computed_values_in_display_none_subtree(DOM::AbstractElement abstract_element)
-{
-    if (auto computed_values = abstract_element.computed_style()) {
-        CSS::ComputedValues::Builder builder(*computed_values);
-        builder->set_in_display_none_subtree(true);
-        if (computed_values->has_animated_values()) {
-            CSS::ComputedValues::Builder base_values_builder(computed_values->base_values());
-            base_values_builder->set_in_display_none_subtree(true);
-            builder->set_base_values(move(base_values_builder).build());
-        }
-        auto updated_values = move(builder).build();
-        auto publication = abstract_element.document().style_computer().publish_computed_style_inputs(abstract_element, *updated_values);
-        replace_style_record(publication.new_style_record);
-    }
-}
-
 RefPtr<CSS::CustomPropertyData const> SyntheticPseudoElement::custom_property_data() const
 {
     if (!m_custom_property_data)

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -58,7 +58,6 @@ public:
     void set_computed_style(CSS::StyleRecordID);
     void clear_computed_style(RefPtr<CSS::ComputedValues const> style_to_preserve_for_detachment = nullptr);
     void refresh_computed_style(CSS::StyleRecordID);
-    void set_computed_values_in_display_none_subtree(DOM::AbstractElement);
 
     RefPtr<CSS::CustomPropertyData const> custom_property_data() const override;
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const> value) override;

--- a/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-anchor-name.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-anchor-name.txt
@@ -1,0 +1,2 @@
+initial anchor left: 101
+changed anchor left: 11

--- a/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-style-rematerialization.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-style-rematerialization.txt
@@ -1,0 +1,10 @@
+hidden inherited style: rgb(40, 50, 60)
+hidden non-inherited style: 73px x 31px
+hidden pseudo style: "changed"
+hidden inserted style: 61px x 62px
+shown inherited style: rgb(70, 80, 90)
+shown target size: 91 x 47
+shown pseudo style: "final"
+shown inserted size: 61 x 62
+shown nested size: 35 x 36
+shown text: final text

--- a/Tests/LibWeb/Text/expected/css/style-engine/dom-clears-hidden-style-record-identity.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/dom-clears-hidden-style-record-identity.txt
@@ -1,3 +1,3 @@
 initial assignment is retained: true
-display-none propagation republishes the assignment: true
+display-none propagation clears the assignment: true
 returning to the shared style restores its identity: true

--- a/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-anchor-name.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-anchor-name.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<script src="../../include.js"></script>
+<style>
+    #fallback-anchor, #hidden-anchor {
+        position: absolute;
+        top: 0;
+        width: 10px;
+        height: 10px;
+        anchor-name: --old;
+    }
+    #fallback-anchor { left: 11px; }
+    #hidden-anchor { left: 101px; }
+    #hidden-anchor.changed { anchor-name: --new; }
+    #anchor-target {
+        position: absolute;
+        top: 20px;
+        position-anchor: --old;
+        left: anchor(left);
+        width: 10px;
+        height: 10px;
+    }
+    .hidden { display: none; }
+</style>
+<div id="fallback-anchor"></div>
+<div id="anchor-host"><div id="hidden-anchor"></div></div>
+<div id="anchor-target"></div>
+<script>
+    test(() => {
+        const anchorHost = document.getElementById("anchor-host");
+        const hiddenAnchor = document.getElementById("hidden-anchor");
+        const anchorTarget = document.getElementById("anchor-target");
+
+        println(`initial anchor left: ${anchorTarget.offsetLeft}`);
+
+        anchorHost.classList.add("hidden");
+        document.body.offsetWidth;
+        hiddenAnchor.classList.add("changed");
+        anchorHost.classList.remove("hidden");
+        document.body.offsetWidth;
+
+        println(`changed anchor left: ${anchorTarget.offsetLeft}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-style-rematerialization.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-style-rematerialization.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #host { color: rgb(10, 20, 30); }
+    #host.hidden { display: none; }
+    #host.changed { color: rgb(40, 50, 60); }
+    #host.final { color: rgb(70, 80, 90); }
+    #target { width: 20px; height: 10px; }
+    #target.changed { width: 73px; height: 31px; }
+    #target.final { width: 91px; height: 47px; }
+    #target::before { content: "initial"; }
+    #target.changed::before { content: "changed"; }
+    #target.final::before { content: "final"; }
+    #nested.hidden-nested { display: none; }
+    #nested-child { width: 15px; height: 16px; }
+    #nested-child.final { width: 35px; height: 36px; }
+    #inserted { width: 61px; height: 62px; }
+</style>
+<div id="host">
+    <div id="target">initial text</div>
+    <div id="nested" class="hidden-nested"><div id="nested-child"></div></div>
+</div>
+<script>
+    test(() => {
+        const host = document.getElementById("host");
+        const target = document.getElementById("target");
+        const nested = document.getElementById("nested");
+        const nestedChild = document.getElementById("nested-child");
+        host.offsetWidth;
+
+        host.classList.add("hidden");
+        document.body.offsetWidth;
+
+        host.classList.add("changed");
+        target.classList.add("changed");
+        target.textContent = "text changed while hidden";
+        nested.classList.remove("hidden-nested");
+        nestedChild.classList.add("final");
+        const inserted = document.createElement("div");
+        inserted.id = "inserted";
+        host.prepend(inserted);
+
+        println(`hidden inherited style: ${getComputedStyle(target).color}`);
+        println(`hidden non-inherited style: ${getComputedStyle(target).width} x ${getComputedStyle(target).height}`);
+        println(`hidden pseudo style: ${getComputedStyle(target, "::before").content}`);
+        println(`hidden inserted style: ${getComputedStyle(inserted).width} x ${getComputedStyle(inserted).height}`);
+
+        host.classList.remove("changed");
+        host.classList.add("final");
+        target.classList.remove("changed");
+        target.classList.add("final");
+        target.textContent = "final text";
+        host.classList.remove("hidden");
+        document.body.offsetWidth;
+
+        println(`shown inherited style: ${getComputedStyle(target).color}`);
+        println(`shown target size: ${target.offsetWidth} x ${target.offsetHeight}`);
+        println(`shown pseudo style: ${getComputedStyle(target, "::before").content}`);
+        println(`shown inserted size: ${inserted.offsetWidth} x ${inserted.offsetHeight}`);
+        println(`shown nested size: ${nestedChild.offsetWidth} x ${nestedChild.offsetHeight}`);
+        println(`shown text: ${target.textContent}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/dom-clears-hidden-style-record-identity.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/dom-clears-hidden-style-record-identity.html
@@ -14,7 +14,7 @@
         ancestor.classList.add("hidden");
         getComputedStyle(ancestor).display;
         const hiddenIdentity = internals.styleRecordIdentity(target);
-        println(`display-none propagation republishes the assignment: ${hiddenIdentity !== 0 && hiddenIdentity !== visibleIdentity}`);
+        println(`display-none propagation clears the assignment: ${hiddenIdentity === 0}`);
 
         ancestor.classList.remove("hidden");
         getComputedStyle(target).color;


### PR DESCRIPTION
Entering `display: none` currently clones and republishes every descendant computed style solely to mark it hidden. Clear DOM-held descendant style records instead, pin records still consumed by pending layout-tree teardown, and rematerialize styles only for CSSOM reads or when the subtree becomes visible. This preserves transition and animation semantics while avoiding unnecessary style publication.

Unregister anchor names before dropping the style record that identifies them so hidden `anchor-name` mutations cannot leave stale registry entries. Regression coverage includes hidden mutations, CSSOM rematerialization, pseudo-elements, nested hidden content, final geometry, and anchor-name changes.

| Benchmark | Speedup | Old total time (s) | New total time (s) |
| --- | ---: | ---: | ---: |
| MicroWeb | 0.994x, noise | 1.567 +/- 0.741 | 1.577 +/- 0.751 |
| Speedometer 2 | 1.014x | 15.245 +/- 0.109 | 15.032 +/- 0.034 |
| Speedometer 3 | 1.022x | 13.304 +/- 0.361 | 13.022 +/- 0.655 |
| StyleBench | 1.000x, flat | 4.802 +/- 0.110 | 4.800 +/- 0.143 |