### PR TITLE
LibWeb: Restore layout performance after Rust modularization

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -992,6 +992,7 @@ impl FfiLayoutFcCallbacks {
         shell
     }
 
+    #[inline]
     pub(crate) fn slot_index(&self, node: Node) -> u32 {
         node.slot_index()
     }
@@ -1015,6 +1016,7 @@ impl FfiLayoutFcCallbacks {
         self.arena().set_committed_fragment_link(self.arena().data(node), link);
     }
 
+    #[inline]
     pub(crate) fn has_committed_fragment_link(&self, node: Node) -> bool {
         self.node_data(node).flags & NodeFlag::HasCommittedFragmentLink as u32 != 0
     }
@@ -1029,22 +1031,27 @@ impl FfiLayoutFcCallbacks {
         self.arena().set_saved_abspos_layout_inputs(data, inputs);
     }
 
+    #[inline]
     pub(crate) fn parent(&self, node: Node) -> Node {
         self.node_data(node).parent
     }
 
+    #[inline]
     pub(crate) fn first_child(&self, node: Node) -> Node {
         self.node_data(node).first_child
     }
 
+    #[inline]
     pub(crate) fn next_sibling(&self, node: Node) -> Node {
         self.node_data(node).next_sibling
     }
 
+    #[inline]
     pub(crate) fn containing_block(&self, node: Node) -> Node {
         self.node_data(node).containing_block
     }
 
+    #[inline]
     pub(crate) fn inline_containing_block(&self, node: Node) -> Node {
         self.node_data(node).inline_containing_block
     }

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -207,16 +207,28 @@ pub(crate) fn kind_is_svg_box(kind: NodeKind) -> bool {
 pub(crate) struct NodeFacts<'pass> {
     callbacks: &'pass FfiLayoutFcCallbacks,
     node: Node,
+    data: &'pass NodeData,
+    style_payloads: Option<&'pass FfiStylePayloads>,
 }
 
 impl<'pass> NodeFacts<'pass> {
     #[inline]
     pub(crate) fn new(callbacks: &'pass FfiLayoutFcCallbacks, node: Node) -> Self {
-        Self { callbacks, node }
+        let data = callbacks.node_data(node);
+        // SAFETY: A non-null style pointer addresses the container's group
+        // pointer array, which FfiStylePayloads mirrors exactly. The node's
+        // ComputedValues keep the container alive for the layout pass.
+        let style_payloads = (!data.style.is_null()).then(|| unsafe { &*data.style.cast::<FfiStylePayloads>() });
+        Self {
+            callbacks,
+            node,
+            data,
+            style_payloads,
+        }
     }
 
     pub(super) fn data(&self) -> &'pass NodeData {
-        self.callbacks.node_data(self.node)
+        self.data
     }
 
     fn parent_data(&self) -> Option<&'pass NodeData> {
@@ -225,11 +237,15 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(super) fn style(&self) -> StyleValues<'pass> {
-        StyleValues::for_node(self.callbacks, self.node)
+        StyleValues::new(
+            self.style_payloads
+                .expect("styled node must publish its style container before layout"),
+        )
     }
 
     pub(super) fn computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
-        self.callbacks.computed_values_view_if_styled(self.node)
+        self.style_payloads
+            .map(|payloads| ComputedValuesView::new(&payloads.groups))
     }
 
     pub(super) fn parent_computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {


### PR DESCRIPTION
Commit 70d062f replaced the layout engine's `include!` composition with ordinary Rust modules, making every source file visible to rustfmt. That also separated hot accessors from their callers across Rust code generation units, so repeated node and style fact queries stopped being optimized together.

Keep pass-stable node data and style payload references in `NodeFacts`, and expose the tiny topology accessors for cross-module inlining. This preserves the ordinary module structure while restoring the lost performance.

Matched StyleBench runs across the exact regression boundary:

- Before `70d062f`: **80.54 ± 2.40**
- At `70d062f`: **73.96 ± 2.22**
- With this fix: **79.60 ± 2.43**

The full `test-web` suite passes with 9,554 tests passed, 116 skipped, and no failures, timeouts, or crashes.