### PR TITLE
LibWeb/CSS: Rename `<an+b>` to `<a-n-plus-b>`

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -131,16 +131,16 @@
     "argument": "<selector-list>"
   },
   "nth-child": {
-    "argument": "<an+b-of>"
+    "argument": "<a-n-plus-b-of>"
   },
   "nth-last-child": {
-    "argument": "<an+b-of>"
+    "argument": "<a-n-plus-b-of>"
   },
   "nth-last-of-type": {
-    "argument": "<an+b>"
+    "argument": "<a-n-plus-b>"
   },
   "nth-of-type": {
-    "argument": "<an+b>"
+    "argument": "<a-n-plus-b>"
   },
   "only-child": {
     "argument": ""

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -983,8 +983,8 @@ fn generate_selector_pseudo_types(manifest_dir: &Path, out_dir: &Path) -> Result
         }
         let parameter_type = match argument {
             "" => "None",
-            "<an+b>" => "AnPlusB",
-            "<an+b-of>" => "AnPlusBOf",
+            "<a-n-plus-b>" => "AnPlusB",
+            "<a-n-plus-b-of>" => "AnPlusBOf",
             "<compound-selector>" => "CompoundSelector",
             "<forgiving-selector-list>" => "ForgivingSelectorList",
             "<forgiving-relative-selector-list>" => "ForgivingRelativeSelectorList",


### PR DESCRIPTION
Corresponds to https://github.com/w3c/csswg-drafts/commit/a9805fbdbe95110f3b19c5111d547fc6ff742430

No behaviour change.