### PR TITLE
Clean up WebContent

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -333,6 +333,9 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         auto has_received_all_reported_bytes = m_internal_stream_data->request_done && m_internal_stream_data->delivered_size >= m_internal_stream_data->total_size;
         if (!m_internal_stream_data->user_finish_called && (!m_internal_stream_data->read_stream || m_internal_stream_data->read_stream->is_eof() || has_received_all_reported_bytes)) {
             m_internal_stream_data->user_finish_called = true;
+            m_internal_stream_data->read_notifier->close();
+            m_internal_stream_data->read_notifier = nullptr;
+            m_internal_stream_data->read_stream = nullptr;
             user_on_finish(m_internal_stream_data->total_size, m_internal_stream_data->timing_info, m_internal_stream_data->network_error);
         }
     };
@@ -342,7 +345,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         static char buffer[buffer_size];
 
         // If the request was stopped while this IPC was in-flight, just bail.
-        if (!m_internal_stream_data)
+        if (!m_internal_stream_data || !m_internal_stream_data->read_stream)
             return;
 
         do {
@@ -367,7 +370,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
 
             m_internal_stream_data->delivered_size += read_bytes.size();
             m_internal_stream_data->on_data_available(ResponseData::from_bytes(read_bytes));
-            if (!m_internal_stream_data)
+            if (!m_internal_stream_data || !m_internal_stream_data->read_stream)
                 return;
 
             if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1709,7 +1709,8 @@ void LocalTraversableNavigable::finalize_same_document_navigation(GC::Ref<LocalN
 void LocalTraversableNavigable::close_top_level_traversable(PromptToUnload prompt_to_unload)
 {
     // 1. If traversable's is closing is true, then return.
-    if (is_closing())
+    // AD-HOC: A forced close must be able to supersede an in-progress prompted close.
+    if (is_closing() && prompt_to_unload == PromptToUnload::Yes)
         return;
 
     // AD-HOC: Set the is closing flag to prevent re-entrant calls from queuing duplicate session history steps.
@@ -1725,14 +1726,21 @@ void LocalTraversableNavigable::definitely_close_top_level_traversable(PromptToU
     VERIFY(is_top_level_traversable());
 
     auto append_close_steps = [this] {
+        if (m_close_steps_have_been_appended)
+            return;
+        m_close_steps_have_been_appended = true;
+
         // 3. Append the following session history traversal steps to traversable:
         request_history_operation(
             CloseTopLevelTraversableHistoryOperationParameters { .traversable_id = id() },
             {
                 .on_complete = GC::create_function(heap(), [this](HistoryStepResult result) {
                     // NB: An abandoned close never reached its queue position; do not destroy the traversable for it.
-                    if (result != HistoryStepResult::Applied)
+                    if (result != HistoryStepResult::Applied) {
+                        m_close_steps_have_been_appended = false;
+                        set_closing(false);
                         return;
+                    }
 
                     // 1. Let afterAllUnloads be an algorithm step which destroys traversable.
                     auto after_all_unloads = GC::create_function(heap(), [this] {
@@ -1757,7 +1765,8 @@ void LocalTraversableNavigable::definitely_close_top_level_traversable(PromptToU
     check_if_unloading_is_canceled(move(to_unload), GC::create_function(heap(), [this, append_close_steps = move(append_close_steps)](CheckIfUnloadingIsCanceledResult result) {
         if (result != CheckIfUnloadingIsCanceledResult::Continue) {
             // AD-HOC: Allow a later close attempt if this one was canceled.
-            set_closing(false);
+            if (!m_close_steps_have_been_appended)
+                set_closing(false);
             return;
         }
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -172,6 +172,9 @@ private:
     // https://html.spec.whatwg.org/multipage/document-sequences.html#is-created-by-web-content
     bool m_is_created_by_web_content { false };
 
+    // AD-HOC: A forced close may supersede a prompted close while its beforeunload check is still pending.
+    bool m_close_steps_have_been_appended { false };
+
     // https://storage.spec.whatwg.org/#traversable-navigable-storage-shed
     // A traversable navigable holds a storage shed, which is a storage shed. A traversable navigable’s storage shed holds all session storage data.
     GC::Ref<StorageAPI::StorageShed> m_storage_shed;

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/EventLoop.h>
 #include <LibWebView/HeadlessWebView.h>
 
 namespace WebView {
@@ -38,12 +39,21 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
             ? HeadlessWebView::create_child(*this, *page_index)
             : HeadlessWebView::create(m_theme, m_viewport_size);
 
+        auto* child_web_view = web_view.ptr();
+        auto weak_this = make_weak_ptr<HeadlessWebView>();
+        web_view->m_parent_web_view = weak_this;
+        auto discard_child_web_view = [weak_this, child_web_view]() {
+            if (weak_this)
+                weak_this->discard_child_web_view(*child_web_view);
+        };
+
         // Propagate crashes from child views to parent, so parent tests don't hang
         // waiting for a child that crashed.
-        web_view->on_web_content_crashed = [this]() {
-            if (on_web_content_crashed)
-                on_web_content_crashed();
+        web_view->on_web_content_crashed = [child_web_view, discard_child_web_view]() {
+            child_web_view->propagate_web_content_crash();
+            discard_child_web_view();
         };
+        web_view->on_close = move(discard_child_web_view);
 
         m_child_web_views.append(move(web_view));
         return m_child_web_views.last()->handle();
@@ -154,6 +164,32 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
     };
 
     m_top_level_traversable.set_system_visibility_state(Web::HTML::VisibilityState::Visible);
+}
+
+void HeadlessWebView::propagate_web_content_crash()
+{
+    if (!m_propagate_crashes_to_parent)
+        return;
+
+    if (m_parent_web_view) {
+        m_parent_web_view->propagate_web_content_crash();
+        return;
+    }
+
+    if (on_web_content_crashed)
+        on_web_content_crashed();
+}
+
+void HeadlessWebView::discard_child_web_view(HeadlessWebView& child_web_view)
+{
+    auto* child_web_view_pointer = &child_web_view;
+    Core::deferred_invoke([weak_this = make_weak_ptr<HeadlessWebView>(), child_web_view_pointer] {
+        if (!weak_this)
+            return;
+        weak_this->m_child_web_views.remove_first_matching([child_web_view_pointer](auto const& child) {
+            return child.ptr() == child_web_view_pointer;
+        });
+    });
 }
 
 void HeadlessWebView::initialize_client(CreateNewClient create_new_client, Optional<Web::HTML::CrossProcessId> initial_document_state_id)

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -10,6 +10,7 @@
 namespace WebView {
 
 static Web::DevicePixelRect const screen_rect { 0, 0, 1920, 1080 };
+static constexpr auto child_close_timeout_ms = 1000;
 
 NonnullOwnPtr<HeadlessWebView> HeadlessWebView::create(Core::AnonymousBuffer theme, Web::DevicePixelSize window_size)
 {
@@ -190,6 +191,20 @@ void HeadlessWebView::discard_child_web_view(HeadlessWebView& child_web_view)
             return child.ptr() == child_web_view_pointer;
         });
     });
+}
+
+void HeadlessWebView::schedule_forced_close()
+{
+    if (!m_forced_close_timer) {
+        m_forced_close_timer = Core::Timer::create_single_shot(child_close_timeout_ms, [weak_this = make_weak_ptr<HeadlessWebView>()] {
+            if (!weak_this || weak_this->handle().is_empty() || !weak_this->client().is_open())
+                return;
+            weak_this->force_close();
+        });
+    }
+
+    if (!m_forced_close_timer->is_active())
+        m_forced_close_timer->start();
 }
 
 void HeadlessWebView::initialize_client(CreateNewClient create_new_client, Optional<Web::HTML::CrossProcessId> initial_document_state_id)

--- a/Libraries/LibWebView/HeadlessWebView.h
+++ b/Libraries/LibWebView/HeadlessWebView.h
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16String.h>
 #include <LibCore/Forward.h>
+#include <LibCore/Timer.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
@@ -28,8 +29,10 @@ public:
         for (auto& child : m_child_web_views) {
             child->close_child_web_views();
             // Children sharing a crashed WebContent process are discarded by their pending crash callbacks.
-            if (!child->handle().is_empty() && child->client().is_open())
+            if (!child->handle().is_empty() && child->client().is_open()) {
                 child->request_close();
+                child->schedule_forced_close();
+            }
         }
     }
 
@@ -49,6 +52,7 @@ protected:
 
     void propagate_web_content_crash();
     void discard_child_web_view(HeadlessWebView&);
+    void schedule_forced_close();
     void initialize_client(CreateNewClient, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {}) override;
     void update_zoom() override;
 
@@ -65,6 +69,7 @@ protected:
     // When restoring from fullscreen, we need to know to what dimension.
     Web::DevicePixelRect m_previous_dimensions;
 
+    RefPtr<Core::Timer> m_forced_close_timer;
     WeakPtr<HeadlessWebView> m_parent_web_view;
     bool m_propagate_crashes_to_parent { true };
     Vector<NonnullOwnPtr<HeadlessWebView>> m_child_web_views;

--- a/Libraries/LibWebView/HeadlessWebView.h
+++ b/Libraries/LibWebView/HeadlessWebView.h
@@ -23,13 +23,23 @@ public:
 
     void reset_viewport_size(Web::DevicePixelSize);
 
+    void close_child_web_views()
+    {
+        for (auto& child : m_child_web_views) {
+            child->close_child_web_views();
+            // Children sharing a crashed WebContent process are discarded by their pending crash callbacks.
+            if (!child->handle().is_empty() && child->client().is_open())
+                child->request_close();
+        }
+    }
+
     void disconnect_child_crash_handlers()
     {
         // Disconnect crash handlers so child crashes don't propagate to parent.
         // We don't destroy the children because there may be pending deferred_invokes
         // that would cause use-after-free.
         for (auto& child : m_child_web_views) {
-            child->on_web_content_crashed = nullptr;
+            child->m_propagate_crashes_to_parent = false;
             child->disconnect_child_crash_handlers();
         }
     }

--- a/Libraries/LibWebView/HeadlessWebView.h
+++ b/Libraries/LibWebView/HeadlessWebView.h
@@ -37,6 +37,8 @@ public:
 protected:
     HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);
 
+    void propagate_web_content_crash();
+    void discard_child_web_view(HeadlessWebView&);
     void initialize_client(CreateNewClient, Optional<Web::HTML::CrossProcessId> initial_document_state_id = {}) override;
     void update_zoom() override;
 
@@ -53,6 +55,8 @@ protected:
     // When restoring from fullscreen, we need to know to what dimension.
     Web::DevicePixelRect m_previous_dimensions;
 
+    WeakPtr<HeadlessWebView> m_parent_web_view;
+    bool m_propagate_crashes_to_parent { true };
     Vector<NonnullOwnPtr<HeadlessWebView>> m_child_web_views;
 };
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -3607,6 +3607,11 @@ void ViewImplementation::request_close()
     client().request_close(page_id());
 }
 
+void ViewImplementation::force_close()
+{
+    client().async_force_close(page_id());
+}
+
 Function<void()> ViewImplementation::prepare_for_immediate_close()
 {
     VERIFY(!needs_beforeunload_check());

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1916,7 +1916,10 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client, Op
         m_client_state.hosts_committed_entry = !replaces_existing_client;
 
         // FIXME: Fail to open the tab, rather than crashing the whole application if this fails.
-        m_client_state.client = Application::the().launch_web_content_process(*this, root_navigable_id, initial_document_state_id).release_value_but_fixme_should_propagate_errors();
+        auto client_or_error = Application::the().launch_web_content_process(*this, root_navigable_id, initial_document_state_id);
+        if (client_or_error.is_error())
+            warnln("Failed to launch WebContent during process swap: {}", client_or_error.error());
+        m_client_state.client = client_or_error.release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }
@@ -2269,8 +2272,10 @@ void ViewImplementation::did_close_browsing_context(Badge<WebContentClient>)
     // Headless views retain their closed children. Remove the view from routing immediately so a command racing
     // with the close cannot be sent to a page that no longer exists.
     all_views().remove(m_view_id);
-    if (m_client_state.client)
+    if (m_client_state.client) {
         m_client_state.client->unregister_view(m_client_state.page_index);
+        m_client_state.client = nullptr;
+    }
 
     if (!window_handle.is_empty())
         Application::the().notify_webdriver_window_closed(window_handle);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -351,6 +351,7 @@ public:
     void set_user_style_sheet(String const& source);
 
     void request_close();
+    void force_close();
     Function<void()> prepare_for_immediate_close();
     bool needs_beforeunload_check() const { return m_needs_beforeunload_check; }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1836,10 +1836,11 @@ void WebContentClient::did_close_browsing_context(u64 page_id)
     unregister_embedded_page(page_id);
     m_detached_pages_pending_close.remove(page_id);
 
-    if (auto view = m_views.get(page_id); view.has_value()) {
-        (*view)->did_close_browsing_context({});
-        if ((*view)->on_close)
-            (*view)->on_close();
+    if (auto registered_view = m_views.get(page_id); registered_view.has_value()) {
+        auto view = *registered_view;
+        view->did_close_browsing_context({});
+        if (view->on_close)
+            view->on_close();
     }
 
     close_server_if_unused();

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2532,6 +2532,12 @@ void ConnectionFromClient::request_close(u64 page_id)
         page->page().top_level_traversable()->close_top_level_traversable();
 }
 
+void ConnectionFromClient::force_close(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().top_level_traversable()->close_top_level_traversable(Web::HTML::LocalTraversableNavigable::PromptToUnload::No);
+}
+
 void ConnectionFromClient::exit_fullscreen(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -246,6 +246,7 @@ private:
     virtual void did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) override;
 
     virtual void request_close(u64 page_id) override;
+    virtual void force_close(u64 page_id) override;
 
     virtual void exit_fullscreen(u64 page_id) override;
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -228,6 +228,7 @@ endpoint WebContentServer
     did_worker_agent_close(Web::HTML::WorkerAgentOwnerToken owner_token) =|
 
     request_close(u64 page_id) =|
+    force_close(u64 page_id) =|
 
     exit_fullscreen(u64 page_id) =|
 }

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -1186,6 +1186,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
             // Disconnect child crash handlers so old child crashes don't affect the next test
             view->disconnect_child_crash_handlers();
+            view->close_child_web_views();
 
             // Don't try to reset state if WebContent crashed - it's gone
             if (test_result != TestResult::Crashed) {


### PR DESCRIPTION
Address a few places where we could accumulate stale connections while running the test suite. Certain tests added in #11121 both create child web views, which then repeatedly `fetch()` until they succeed. Those fetches keep connections around, and so they'd live as long as the child views that spawned them... except we never cleaned up those children. With enough test iterations, we'd exhaust the system file table, crash `test-web` when it tried to create a new WebContent process, and also perform a DoS on the host.

The commits here address a few parts of this: Discarding children when they are closed, closing them when a test ends, and releasing the WebContentClient connection when it's not needed.

This primarily affects `test-web`, because in the UIs, popup windows are directly associated with a UI tab or window and their lifecycle is attached to that.