### PR TITLE
LibWeb: Crash and layout fixes for ChatGPT

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -890,6 +890,7 @@ static GC::Ref<CSS::CSSStyleProperties> placeholder_style_when_visible()
     if (!style) {
         style = CSS::CSSStyleProperties::create({}, {});
         style->set_declarations_from_text(R"~~~(
+                display: block;
                 width: 100%;
                 height: 1lh;
                 overflow: hidden;

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -54,6 +54,7 @@ namespace Web::Layout {
 
 static_assert(to_underlying(CSS::StyleGroupIndex::Count) == RustFFI::STYLE_GROUP_COUNT);
 static_assert(to_underlying(CSS::StyleGroupIndex::GridValues) == RustFFI::STYLE_GROUP_INDEX_GRID);
+static_assert(to_underlying(CSS::StyleGroupIndex::AnchorValues) == RustFFI::STYLE_GROUP_INDEX_ANCHOR);
 static_assert(to_underlying(CSS::StyleGroupIndex::InheritedTableValues) == RustFFI::STYLE_GROUP_INDEX_INHERITED_TABLE);
 static_assert(to_underlying(CSS::StyleGroupIndex::InheritedTextValues) == RustFFI::STYLE_GROUP_INDEX_INHERITED_TEXT);
 static_assert(to_underlying(CSS::StyleGroupIndex::InheritedBoxValues) == RustFFI::STYLE_GROUP_INDEX_INHERITED_BOX);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -785,19 +785,12 @@ bool Node::is_replaced_element() const
 
 bool Node::is_atomic_inline() const
 {
-    if (is_replaced_element() || is_list_item_marker_box())
-        return true;
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto display = node_with_style->display();
-    return display.is_inline_outside() && !display.is_flow_inside();
+    return RustFFI::layout_node_data_is_atomic_inline(m_data);
 }
 
 bool Node::is_fragmented_inline() const
 {
-    return is_inline_node()
-        || (is_list_item_box() && as<NodeWithStyle>(*this).display().is_inline_outside() && as<NodeWithStyle>(*this).display().is_flow_inside());
+    return RustFFI::layout_node_data_is_fragmented_inline(m_data);
 }
 
 NodeWithStyle const* Node::nearest_fragmented_inline_ancestor() const

--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -916,6 +916,7 @@ pub const STYLE_GROUP_INDEX_INHERITED_BOX: usize = 5;
 pub const STYLE_GROUP_INDEX_FONT: usize = 6;
 pub const STYLE_GROUP_INDEX_SVG_RESET: usize = 8;
 pub const STYLE_GROUP_INDEX_GRID: usize = 9;
+pub const STYLE_GROUP_INDEX_ANCHOR: usize = 10;
 pub const STYLE_GROUP_INDEX_EFFECTS: usize = 11;
 pub const STYLE_GROUP_INDEX_MASK: usize = 12;
 pub const STYLE_GROUP_INDEX_TEXT_RESET: usize = 13;

--- a/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
@@ -11,16 +11,17 @@
 
 use crate::css::calc;
 use crate::css::computed_value_types::{
-    AlignmentValues, BackgroundValues, BorderLayoutFacts, BorderValues, BoxValues, ComputedAspectRatio, ComputedGap,
-    ComputedLengthPercentageOrAuto, ComputedSize, ComputedSizeKind, ComputedStyleValueHandle, EffectsValues,
-    FontLayoutFacts, FontValues, GridValues, InheritedListValues, InheritedSVGValues, InheritedTextLayoutFacts,
-    InheritedTextValues, InheritedUIValues, MaskValues, MiscResetValues, STYLE_GROUP_INDEX_ALIGNMENT,
-    STYLE_GROUP_INDEX_BACKGROUND, STYLE_GROUP_INDEX_BORDER, STYLE_GROUP_INDEX_BOX, STYLE_GROUP_INDEX_EFFECTS,
-    STYLE_GROUP_INDEX_FONT, STYLE_GROUP_INDEX_GRID, STYLE_GROUP_INDEX_INHERITED_BOX, STYLE_GROUP_INDEX_INHERITED_LIST,
-    STYLE_GROUP_INDEX_INHERITED_SVG, STYLE_GROUP_INDEX_INHERITED_TABLE, STYLE_GROUP_INDEX_INHERITED_TEXT,
-    STYLE_GROUP_INDEX_INHERITED_UI, STYLE_GROUP_INDEX_MASK, STYLE_GROUP_INDEX_MISC_RESET, STYLE_GROUP_INDEX_SIZING,
-    STYLE_GROUP_INDEX_SURROUND, STYLE_GROUP_INDEX_SVG_RESET, STYLE_GROUP_INDEX_TEXT_RESET, STYLE_GROUP_INDEX_TRANSFORM,
-    SVGResetValues, SizingValues, SurroundValues, TextResetValues, TransformValues,
+    AlignmentValues, AnchorValues, BackgroundValues, BorderLayoutFacts, BorderValues, BoxValues, ComputedAspectRatio,
+    ComputedGap, ComputedLengthPercentageOrAuto, ComputedSize, ComputedSizeKind, ComputedStyleValueHandle,
+    EffectsValues, FontLayoutFacts, FontValues, GridValues, InheritedListValues, InheritedSVGValues,
+    InheritedTextLayoutFacts, InheritedTextValues, InheritedUIValues, MaskValues, MiscResetValues,
+    STYLE_GROUP_INDEX_ALIGNMENT, STYLE_GROUP_INDEX_ANCHOR, STYLE_GROUP_INDEX_BACKGROUND, STYLE_GROUP_INDEX_BORDER,
+    STYLE_GROUP_INDEX_BOX, STYLE_GROUP_INDEX_EFFECTS, STYLE_GROUP_INDEX_FONT, STYLE_GROUP_INDEX_GRID,
+    STYLE_GROUP_INDEX_INHERITED_BOX, STYLE_GROUP_INDEX_INHERITED_LIST, STYLE_GROUP_INDEX_INHERITED_SVG,
+    STYLE_GROUP_INDEX_INHERITED_TABLE, STYLE_GROUP_INDEX_INHERITED_TEXT, STYLE_GROUP_INDEX_INHERITED_UI,
+    STYLE_GROUP_INDEX_MASK, STYLE_GROUP_INDEX_MISC_RESET, STYLE_GROUP_INDEX_SIZING, STYLE_GROUP_INDEX_SURROUND,
+    STYLE_GROUP_INDEX_SVG_RESET, STYLE_GROUP_INDEX_TEXT_RESET, STYLE_GROUP_INDEX_TRANSFORM, SVGResetValues,
+    SizingValues, SurroundValues, TextResetValues, TransformValues,
 };
 use crate::css::computed_values::{InheritedBoxValues, InheritedTableValues};
 use crate::css::css_enums::{direction, writing_mode};
@@ -536,6 +537,11 @@ impl<'a> ComputedValuesView<'a> {
     #[inline]
     pub(crate) fn grid_values(self) -> &'a GridValues {
         self.native_group(STYLE_GROUP_INDEX_GRID)
+    }
+
+    #[inline]
+    pub(crate) fn anchor(self) -> &'a AnchorValues {
+        self.native_group(STYLE_GROUP_INDEX_ANCHOR)
     }
 
     #[inline]

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -695,6 +695,139 @@ impl AbsposEngine {
 
         Some(resolved)
     }
+
+    fn span_all_position_area_layout_inputs(
+        &self,
+        positioned_box: Node,
+        containing_block_geometry: &ContainingBlockGeometry,
+        entry_coordinate_space_box: Node,
+        mut containing_block_info: abspos_inputs::AbsposContainingBlockInfo,
+    ) -> Option<(
+        abspos_inputs::StaticPositionRect,
+        abspos_inputs::AbsposContainingBlockInfo,
+        ContainingBlockGeometry,
+        Node,
+    )> {
+        let style = self.style(positioned_box);
+        let position_area = style.anchor().position_area.as_slice();
+
+        // https://drafts.csswg.org/css-anchor-position/#valdef-position-area-span-all
+        // A lone span-all applies to both axes and selects all three tracks in each axis.
+        if position_area != [position_area::SPAN_ALL]
+            && position_area != [position_area::SPAN_ALL, position_area::SPAN_ALL]
+        {
+            return None;
+        }
+        if !style.has_position_anchor() {
+            return None;
+        }
+
+        let anchor_box = self.anchor_lookup(positioned_box, style.position_anchor_name())?;
+        let containing_block = self.callbacks.containing_block(positioned_box);
+        let anchor_rect = self.anchor_rect(
+            anchor_box,
+            containing_block,
+            Some(containing_block_geometry),
+            entry_coordinate_space_box,
+        );
+
+        // anchor_rect() is padding-box-relative, while containing_block_info.rect is content-box-relative. Normalize
+        // them before comparing their edges.
+        let anchor_inline_offset = anchor_rect.left() - containing_block_geometry.padding_left;
+        let anchor_block_offset = anchor_rect.top() - containing_block_geometry.padding_top;
+        let anchor_inline_end = anchor_rect.right() - containing_block_geometry.padding_left;
+        let anchor_block_end = anchor_rect.bottom() - containing_block_geometry.padding_top;
+        let containing_block_end = geometry::LogicalOffset {
+            inline_offset: containing_block_info.rect.offset.inline_offset
+                + containing_block_info.rect.size.inline_size,
+            block_offset: containing_block_info.rect.offset.block_offset + containing_block_info.rect.size.block_size,
+        };
+
+        // https://drafts.csswg.org/css-anchor-position/#position-area-grid-resolution
+        // The outer grid lines use the more outward edge of the pre-modification containing block and default anchor.
+        let inline_offset = containing_block_info
+            .rect
+            .offset
+            .inline_offset
+            .min(anchor_inline_offset);
+        let block_offset = containing_block_info.rect.offset.block_offset.min(anchor_block_offset);
+        let inline_end = containing_block_end.inline_offset.max(anchor_inline_end);
+        let block_end = containing_block_end.block_offset.max(anchor_block_end);
+        let inline_size = inline_end - inline_offset;
+        let block_size = block_end - block_offset;
+
+        // https://drafts.csswg.org/css-anchor-position/#position-area
+        // The selected position area becomes the box's containing block, so insets and percentage sizes resolve
+        // against this rectangle.
+        containing_block_info.rect = geometry::LogicalRect {
+            offset: geometry::LogicalOffset {
+                inline_offset,
+                block_offset,
+            },
+            size: geometry::LogicalSize {
+                inline_size,
+                block_size,
+            },
+        };
+        containing_block_info.inline_axis_mode = abspos_inputs::AbsposAxisMode::InsetFromRect;
+        containing_block_info.block_axis_mode = abspos_inputs::AbsposAxisMode::InsetFromRect;
+
+        // https://drafts.csswg.org/css-anchor-position/#position-area-alignment
+        // Selecting all three tracks changes normal self-alignment to anchor-center. Explicit alignment is unchanged.
+        if matches!(
+            containing_block_info.inline_alignment,
+            None | Some(AbsposAlignment::Normal)
+        ) {
+            containing_block_info.inline_alignment = Some(AbsposAlignment::AnchorCenter);
+        }
+        if matches!(
+            containing_block_info.block_alignment,
+            None | Some(AbsposAlignment::Normal)
+        ) {
+            containing_block_info.block_alignment = Some(AbsposAlignment::AnchorCenter);
+        }
+
+        containing_block_info.derives_from_own_computed_values = true;
+
+        let position_area_geometry = ContainingBlockGeometry {
+            content_origin_in_entry_space: formatting_context::point_add(
+                containing_block_geometry.content_origin_in_entry_space,
+                FfiCssPixelPoint {
+                    x: inline_offset,
+                    y: block_offset,
+                },
+            ),
+            padding_left: CssPixels::default(),
+            padding_right: CssPixels::default(),
+            padding_top: CssPixels::default(),
+            padding_bottom: CssPixels::default(),
+            content_inline_size: inline_size,
+            content_block_size: block_size,
+        };
+
+        Some((
+            // https://drafts.csswg.org/css-anchor-position/#anchor-center
+            // Express the anchor in the new containing block's coordinate space so anchor-center can center over it.
+            abspos_inputs::StaticPositionRect {
+                rect: geometry::LogicalRect {
+                    offset: geometry::LogicalOffset {
+                        inline_offset: anchor_inline_offset - inline_offset,
+                        block_offset: anchor_block_offset - block_offset,
+                    },
+                    size: geometry::LogicalSize {
+                        inline_size: anchor_rect.width,
+                        block_size: anchor_rect.height,
+                    },
+                },
+                inline_alignment: StaticPositionAlignment::Center,
+                block_alignment: StaticPositionAlignment::Center,
+                alignment_derives_from_own_computed_values: true,
+            },
+            containing_block_info,
+            position_area_geometry,
+            anchor_box,
+        ))
+    }
 }
 
 unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shell: *const c_void) -> *const c_void {
@@ -1679,15 +1812,22 @@ impl AbsposEngine {
             {
                 let available = containing_block_size.inline_size - used.margin_box_inline_size(collapsed);
                 match inline_alignment {
+                    AbsposAlignment::AnchorCenter => {
+                        let inset = self.static_offset(node, inputs.static_position_rect).inline_offset;
+                        used.inset_left.set(inset);
+                        used.inset_right.set(available - inset);
+                    }
                     AbsposAlignment::Center => {
                         used.inset_left.set(available / 2);
                         used.inset_right.set(available / 2);
                     }
                     AbsposAlignment::Start => {
+                        used.inset_left.set(CssPixels::default());
                         used.inset_right.set(available);
                     }
                     AbsposAlignment::End => {
                         used.inset_left.set(available);
+                        used.inset_right.set(CssPixels::default());
                     }
                     _ => {}
                 }
@@ -1698,15 +1838,22 @@ impl AbsposEngine {
             {
                 let available = containing_block_size.block_size - used.margin_box_block_size(collapsed);
                 match block_alignment {
+                    AbsposAlignment::AnchorCenter => {
+                        let inset = self.static_offset(node, inputs.static_position_rect).block_offset;
+                        used.inset_top.set(inset);
+                        used.inset_bottom.set(available - inset);
+                    }
                     AbsposAlignment::Center => {
                         used.inset_top.set(available / 2);
                         used.inset_bottom.set(available / 2);
                     }
                     AbsposAlignment::Start | AbsposAlignment::SelfStart => {
+                        used.inset_top.set(CssPixels::default());
                         used.inset_bottom.set(available);
                     }
                     AbsposAlignment::End | AbsposAlignment::SelfEnd => {
                         used.inset_top.set(available);
+                        used.inset_bottom.set(CssPixels::default());
                     }
                     _ => {}
                 }
@@ -1783,8 +1930,6 @@ impl AbsposEngine {
         self.records
             .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
         let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
-        let resolved =
-            self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
         let inline_containing_block_rect =
             self.inline_containing_block_rect_for_pending_child(&child, &containing_block_geometry);
         let translation_into_containing_block_space = formatting_context::point_sub(
@@ -1795,23 +1940,64 @@ impl AbsposEngine {
             child.static_position_rect,
             translation_into_containing_block_space,
         );
+        let containing_block_info_override = child.containing_block_info_override.or_else(|| {
+            self.fragments
+                .as_deref()
+                .and_then(|fragments| fragments.find_abspos_containing_block_info(child_box))
+        });
+        let unresolved_containing_block_info = containing_block_info_override.unwrap_or_else(|| {
+            self.base_containing_block_info(
+                child_box,
+                inline_containing_block_rect,
+                &containing_block_geometry,
+                None,
+            )
+        });
+        let position_area_inputs = self.span_all_position_area_layout_inputs(
+            child_box,
+            &containing_block_geometry,
+            child.coordinate_space_box,
+            unresolved_containing_block_info,
+        );
+        let (containing_block_info, resolved) = if let Some((
+            static_position_rect,
+            position_area_containing_block_info,
+            position_area_geometry,
+            anchor_box,
+        )) = position_area_inputs
+        {
+            child.static_position_rect = static_position_rect;
+            let resolved =
+                self.resolve_anchor_insets(child_box, Some(&position_area_geometry), child.coordinate_space_box);
+            // https://drafts.csswg.org/css-anchor-position/#scroll
+            // A non-none position-area makes the box compensate for its default anchor's scroll in both axes.
+            // SAFETY: Both boxes remain live throughout this synchronous layout pass.
+            unsafe {
+                (self.callbacks.set_default_scroll_shift)(
+                    self.callbacks.context,
+                    self.callbacks.shell(child_box),
+                    self.callbacks.shell(anchor_box),
+                    true,
+                    true,
+                );
+            }
+            (position_area_containing_block_info, resolved)
+        } else {
+            let resolved =
+                self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
+            let containing_block_info = containing_block_info_override.unwrap_or_else(|| {
+                self.base_containing_block_info(
+                    child_box,
+                    inline_containing_block_rect,
+                    &containing_block_geometry,
+                    resolved.as_ref(),
+                )
+            });
+            (containing_block_info, resolved)
+        };
         let inputs = abspos_inputs::AbsposLayoutInputs {
             static_position_rect: child.static_position_rect,
-            containing_block_info: child
-                .containing_block_info_override
-                .or_else(|| {
-                    self.fragments
-                        .as_deref()
-                        .and_then(|fragments| fragments.find_abspos_containing_block_info(child_box))
-                })
-                .unwrap_or_else(|| {
-                    self.base_containing_block_info(
-                        child_box,
-                        inline_containing_block_rect,
-                        &containing_block_geometry,
-                        resolved.as_ref(),
-                    )
-                }),
+            containing_block_info,
             resolved_anchor_insets: resolved,
         };
         self.layout_element(run, child_box, inputs);

--- a/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
@@ -29,6 +29,7 @@ pub(crate) enum AbsposAxisMode {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AbsposAlignment {
+    AnchorCenter,
     Baseline,
     Center,
     End,

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -142,6 +142,7 @@ impl FlexItem<'_> {
     }
 }
 
+#[derive(Clone)]
 struct FlexLine {
     items: Vec<usize>,
     cross_size: CssPixels,
@@ -2738,24 +2739,53 @@ impl<'pass> FlexFormattingContext<'pass> {
 
     // https://drafts.csswg.org/css-flexbox-1/#intrinsic-sizes
     fn determine_intrinsic_size_of_flex_container(&mut self) {
-        if self
-            .available_space_for_items
-            .unwrap()
-            .main
-            .is_intrinsic_sizing_constraint()
-        {
+        let available_space = self.available_space_for_items.unwrap();
+        if available_space.main.is_intrinsic_sizing_constraint() {
+            let flex_lines = self.flex_lines.clone();
             let size = self.calculate_intrinsic_main_size_of_flex_container();
+            self.flex_lines = flex_lines;
             self.set_container_main_size(size);
         }
-        if self
-            .available_space_for_items
-            .unwrap()
-            .cross
-            .is_intrinsic_sizing_constraint()
-        {
+        if available_space.cross.is_intrinsic_sizing_constraint() {
             let size = self.calculate_intrinsic_cross_size_of_flex_container();
             self.set_container_cross_size(size);
         }
+
+        self.resolve_own_auto_block_size_for_intrinsic_inline_measurement();
+    }
+
+    fn resolve_own_auto_block_size_for_intrinsic_inline_measurement(&mut self) {
+        // Intrinsic inline measurement also caches an inline-level root's block size and baseline. Resolve its
+        // indefinite block axis before alignment so those cached values are derived from the box's actual used size.
+        let available_space = self.available_space_for_items.unwrap().space;
+        if !available_space.inline_size.is_intrinsic_sizing_constraint()
+            || available_space.block_size != AvailableSize::Indefinite
+            || !self.facts(self.flex_container).display().is_inline_outside()
+        {
+            return;
+        }
+
+        let resolution_space = AvailableSpace {
+            inline_size: AvailableSize::definite(self.container_used().content_inline_size.get()),
+            block_size: AvailableSize::Indefinite,
+        };
+        let constraints = self.layout_input.unwrap().containing_block_constraints;
+        if !self
+            .sizing()
+            .should_treat_block_size_as_auto(self.flex_container, resolution_space, constraints)
+        {
+            return;
+        }
+
+        let automatic_block_size = if self.main_axis_is_horizontal() {
+            self.automatic_block_size_from_line_cross_sizes()
+        } else {
+            let flex_lines = self.flex_lines.clone();
+            let size = self.calculate_intrinsic_main_size_of_flex_container();
+            self.flex_lines = flex_lines;
+            size
+        };
+        self.resolve_own_auto_block_size(automatic_block_size, resolution_space);
     }
 
     fn resolve_own_auto_block_size_from_max_content_main_size(&mut self) {
@@ -2793,6 +2823,10 @@ impl<'pass> FlexFormattingContext<'pass> {
         if self.cross_axis_is_horizontal() {
             return;
         }
+        self.resolve_own_auto_block_size(self.automatic_block_size_from_line_cross_sizes(), resolution_space);
+    }
+
+    fn automatic_block_size_from_line_cross_sizes(&self) -> CssPixels {
         // https://drafts.csswg.org/css-align-3/#gap-percent
         // In Flex Layout: Cyclic percentage sizes resolve against zero in all cases.
         let style = self.style(self.flex_container);
@@ -2807,7 +2841,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             .iter()
             .fold(CssPixels::default(), |sum, line| sum + line.cross_size);
         line_cross_size_sum += cross_gap_resolved_against_zero * self.flex_lines.len().saturating_sub(1);
-        self.resolve_own_auto_block_size(line_cross_size_sum, resolution_space);
+        line_cross_size_sum
     }
 
     fn resolve_own_auto_block_size(&self, automatic_block_size: CssPixels, resolution_space: AvailableSpace) {
@@ -3137,6 +3171,13 @@ impl<'pass> FlexFormattingContext<'pass> {
 
         // 11. Determine the used cross size of each flex item.
         self.determine_used_cross_size_of_each_flex_item();
+        let is_intrinsic_sizing = available_space.inline_size.is_intrinsic_sizing_constraint()
+            || available_space.block_size.is_intrinsic_sizing_constraint();
+        if is_intrinsic_sizing {
+            // Alignment offsets depend on the container's used size, so intrinsic sizing must resolve that size before
+            // the item-placement phases below.
+            self.determine_intrinsic_size_of_flex_container();
+        }
         // 12. Distribute any remaining free space.
         self.distribute_any_remaining_free_space();
         // 13. Resolve cross-axis auto margins.
@@ -3163,41 +3204,45 @@ impl<'pass> FlexFormattingContext<'pass> {
         // 16. Align all flex lines (per align-content)
         self.align_all_flex_lines();
 
-        if available_space.inline_size.is_intrinsic_sizing_constraint()
-            || available_space.block_size.is_intrinsic_sizing_constraint()
-        {
+        if is_intrinsic_sizing {
             // We're computing intrinsic size for the flex container. This happens at the end of run().
-            // We're computing intrinsic size for the flex container.
-            self.determine_intrinsic_size_of_flex_container();
+            if self.facts(self.flex_container).display().is_inline_outside() {
+                // The parent inline formatting context needs the container's content-derived baseline.
+                self.layout_items_and_derive_baselines(run);
+            }
         } else {
-            // AD-HOC: Finally, layout the inside of all flex items.
-            self.copy_dimensions_from_flex_items_to_boxes();
-            for index in 0..self.flex_items.len() {
-                self.layout_inside_item(run, index);
-            }
-            self.resolve_baseline_aligned_items();
-            for index in 0..self.flex_items.len() {
-                let item = &self.flex_items[index];
-                let offset = if self.main_axis_is_horizontal() {
-                    FfiCssPixelPoint {
-                        x: item.main_offset,
-                        y: item.cross_offset,
-                    }
-                } else {
-                    FfiCssPixelPoint {
-                        x: item.cross_offset,
-                        y: item.main_offset,
-                    }
-                };
-                formatting_context::place_child(&self.formatting_context_run(), item.box_, offset, None);
-            }
-            self.derived_baselines_of_root_box =
-                formatting_context::derive_baselines(&self.records, &self.callbacks, self.flex_container, true);
+            self.layout_items_and_derive_baselines(run);
         }
 
         if self.should_collect_devtools_layout_data {
             self.save_flex_layout_data();
         }
+    }
+
+    // AD-HOC: Layout the inside of all flex items after resolving their dimensions.
+    fn layout_items_and_derive_baselines(&mut self, run: &FormattingContextRun) {
+        self.copy_dimensions_from_flex_items_to_boxes();
+        for index in 0..self.flex_items.len() {
+            self.layout_inside_item(run, index);
+        }
+        self.resolve_baseline_aligned_items();
+        for index in 0..self.flex_items.len() {
+            let item = &self.flex_items[index];
+            let offset = if self.main_axis_is_horizontal() {
+                FfiCssPixelPoint {
+                    x: item.main_offset,
+                    y: item.cross_offset,
+                }
+            } else {
+                FfiCssPixelPoint {
+                    x: item.cross_offset,
+                    y: item.main_offset,
+                }
+            };
+            formatting_context::place_child(&self.formatting_context_run(), item.box_, offset, None);
+        }
+        self.derived_baselines_of_root_box =
+            formatting_context::derive_baselines(&self.records, &self.callbacks, self.flex_container, true);
     }
 
     pub(super) fn parent_did_dimension(&self) {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -776,18 +776,7 @@ impl LayoutNodeArena {
     fn node_is_capable_of_forming_a_containing_block(&self, id: NodeSlotId) -> bool {
         // SAFETY: data() validated that id names a live slot.
         let data = unsafe { &*self.data(id) };
-        if super::node_facts::kind_is_block_container(data.kind)
-            && !crate::painting::fragment_ownership::node_is_fragmented_inline(self, id)
-        {
-            return true;
-        }
-        if let Some(style) = self.node_style_if_live(id) {
-            let display = style.display();
-            if display.is_flex_inside() || display.is_grid_inside() {
-                return true;
-            }
-        }
-        super::node_facts::kind_is_replaced_box(data.kind) && super::node_facts::node_can_have_children(data)
+        super::node_facts::node_forms_containing_block_for_children(data, self.node_style_if_live(id))
     }
 
     fn nearest_ancestor_capable_of_forming_a_containing_block(&self, node: NodeSlotId) -> NodeSlotId {

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -356,6 +356,13 @@ impl<'pass> NodeFacts<'pass> {
         kind_is_replaced_box(self.data().kind)
     }
 
+    pub(crate) fn is_native_form_control_box(&self) -> bool {
+        matches!(
+            self.data().kind,
+            NodeKind::RangeInputBox | NodeKind::TextAreaBox | NodeKind::TextInputBox
+        )
+    }
+
     pub(crate) fn is_replaced_box_with_children(&self) -> bool {
         let data = self.data();
         kind_is_replaced_box(data.kind) && node_can_have_children(data)

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -22,14 +22,25 @@ pub(crate) fn node_may_have_replaced_content_facts_including_size_containment(da
     if node_may_have_replaced_content_facts(data) {
         return true;
     }
-    if !kind_is_box(data.kind) || data.style.is_null() {
+    if !kind_is_box(data.kind) {
         return false;
+    }
+    let Some(style) = node_style_view(data) else {
+        return false;
+    };
+    style.has_size_containment() || style.is_size_container()
+}
+
+/// The node's own computed style, read off the style container the node data points at. Callers inside a layout pass go
+/// through the pass callbacks instead; this is for the node-data entry points the C++ side calls directly.
+pub(crate) fn node_style_view(data: &NodeData) -> Option<ComputedValuesView<'_>> {
+    if data.style.is_null() {
+        return None;
     }
     // SAFETY: A non-null style pointer addresses the container's group
     // pointer array, which FfiStylePayloads mirrors exactly.
     let payloads = unsafe { &*data.style.cast::<crate::layout::FfiStylePayloads>() };
-    let style = ComputedValuesView::new(&payloads.groups);
-    style.has_size_containment() || style.is_size_container()
+    Some(ComputedValuesView::new(&payloads.groups))
 }
 
 pub(crate) fn node_is_out_of_flow(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
@@ -80,6 +91,48 @@ pub(crate) fn node_can_have_children(data: &NodeData) -> bool {
     }
 }
 
+/// Whether a box's in-flow descendants name it as their containing block. This is the question LayoutNodeArena answers
+/// when it assigns containing blocks, so anything that walks past a box on behalf of an enclosing formatting context
+/// has to ask it too: the boxes inside such a box are laid out against it, not against the block container of the
+/// context the walk started in.
+pub(crate) fn node_forms_containing_block_for_children(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
+    if kind_is_block_container(data.kind) && !node_is_fragmented_inline(data, style) {
+        return true;
+    }
+    if let Some(style) = style {
+        let display = style.display();
+        if display.is_flex_inside() || display.is_grid_inside() {
+            return true;
+        }
+    }
+    kind_is_replaced_box(data.kind) && node_can_have_children(data)
+}
+
+/// https://drafts.csswg.org/css-display/#atomic-inline
+/// An inline-level box laid out as a single opaque box on the line rather than as a fragmented inline. Inline flow
+/// boxes are otherwise walked into by inline layout, which would lay the boxes inside out against the containing block
+/// of the enclosing inline formatting context: a box that is its own children's containing block has to be laid out as
+/// one box instead. Elements whose box type does not follow from their display reach that case, since <legend> and
+/// <fieldset> get a block container box whatever their computed display says.
+pub(crate) fn node_is_atomic_inline(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
+    has_flag(data, NodeFlag::IsReplacedElement)
+        || data.kind == NodeKind::ListItemMarkerBox
+        || style.is_some_and(|style| {
+            let display = style.display();
+            display.is_inline_outside()
+                && (!display.is_flow_inside() || node_forms_containing_block_for_children(data, Some(style)))
+        })
+}
+
+pub(crate) fn node_is_fragmented_inline(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
+    data.kind == NodeKind::InlineNode
+        || (data.kind == NodeKind::ListItemBox
+            && style.is_some_and(|style| {
+                let display = style.display();
+                display.is_inline_outside() && display.is_flow_inside()
+            }))
+}
+
 pub(crate) fn node_has_auto_content_box_size(data: &NodeData) -> bool {
     (kind_is_replaced_box(data.kind) && data.kind != NodeKind::AudioBox)
         || matches!(
@@ -111,6 +164,15 @@ pub(crate) fn node_creates_block_formatting_context(
         }
         if (style.is_floating() && !has_flag(data, NodeFlag::IsFlexItem))
             || style.own_style_establishes_block_formatting_context()
+        {
+            return true;
+        }
+        // An inline flow box that is its own children's containing block is laid out as an atomic inline, and an atomic
+        // inline establishes an independent formatting context: the boxes inside it belong to a context it establishes
+        // rather than to the one its line is part of.
+        if display.is_inline_outside()
+            && display.is_flow_inside()
+            && node_forms_containing_block_for_children(data, Some(style))
         {
             return true;
         }
@@ -331,13 +393,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_atomic_inline(&self) -> bool {
-        let data = self.data();
-        has_flag(data, NodeFlag::IsReplacedElement)
-            || data.kind == NodeKind::ListItemMarkerBox
-            || self.computed_values_view_if_styled().is_some_and(|style| {
-                let display = style.display();
-                display.is_inline_outside() && !display.is_flow_inside()
-            })
+        node_is_atomic_inline(self.data(), self.computed_values_view_if_styled())
     }
 
     pub(crate) fn has_box_model_metrics(&self) -> bool {
@@ -353,13 +409,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_fragmented_inline(&self) -> bool {
-        let data = self.data();
-        data.kind == NodeKind::InlineNode
-            || (data.kind == NodeKind::ListItemBox
-                && self.computed_values_view_if_styled().is_some_and(|style| {
-                    let display = style.display();
-                    display.is_inline_outside() && display.is_flow_inside()
-                }))
+        node_is_fragmented_inline(self.data(), self.computed_values_view_if_styled())
     }
 
     /// A box whose committed geometry is its own single box record; a

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1270,14 +1270,28 @@ impl SizingContext {
         if self.box_is_sized_as_replaced_element(node, available_space, constraints) {
             let inline_size = self.compute_inline_size_for_replaced_element(node, available_space, constraints);
             self.used(node).set_content_inline_size(inline_size);
+
             let block_size = self.compute_block_size_for_replaced_element(node, available_space, constraints);
             self.used(node).set_content_block_size(block_size);
+
+            // Native form controls lay out their internal shadow contents against the concrete size produced by
+            // replaced sizing. That size remains definite when a min/max constraint clamps the automatic preferred
+            // height, unless the preferred height is itself an intrinsic sizing constraint.
+            let native_control_block_size_constraint_is_active = facts.is_native_form_control_box()
+                && facts.has_auto_content_height()
+                && !style.height().is_intrinsic_sizing_constraint()
+                && ((!style.min_height().is_auto() && block_size > facts.auto_content_height())
+                    || (!style.max_height().is_auto()
+                        && !self.should_treat_max_block_size_as_none(node, available_space.block_size, constraints)
+                        && block_size < facts.auto_content_height()));
+
             let block_size_is_automatic =
                 style.height().is_auto() || self.should_treat_block_size_as_auto(node, available_space, constraints);
-            if self.used(node).has_definite_inline_size()
+            let block_size_is_definite_from_aspect_ratio = self.used(node).has_definite_inline_size()
                 && facts.has_preferred_aspect_ratio()
-                && block_size_is_automatic
-            {
+                && block_size_is_automatic;
+
+            if native_control_block_size_constraint_is_active || block_size_is_definite_from_aspect_ratio {
                 self.used(node).has_definite_block_size.set(true);
             }
             return;

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -2367,6 +2367,20 @@ pub unsafe extern "C" fn layout_node_data_can_have_children(data: *const NodeDat
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_node_data_is_atomic_inline(data: *const NodeData) -> bool {
+    // SAFETY: The C++ caller passes the node's live arena slot.
+    let data = unsafe { &*data };
+    node_facts::node_is_atomic_inline(data, node_facts::node_style_view(data))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_node_data_is_fragmented_inline(data: *const NodeData) -> bool {
+    // SAFETY: The C++ caller passes the node's live arena slot.
+    let data = unsafe { &*data };
+    node_facts::node_is_fragmented_inline(data, node_facts::node_style_view(data))
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_node_data_may_have_replaced_content_facts(data: *const NodeData) -> bool {
     // SAFETY: The C++ caller passes the node's live arena slot.
     node_facts::node_may_have_replaced_content_facts_including_size_containment(unsafe { &*data })
@@ -2397,12 +2411,7 @@ fn node_has_replaced_element_table_display_adjustment(host: &TreeBuilderHost<'_>
 
 fn node_is_fragmented_inline(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     let data = host.data(node);
-    data.kind == NodeKind::InlineNode
-        || (data.kind == NodeKind::ListItemBox
-            && host.style(node).is_some_and(|style| {
-                let display = style.display();
-                display.is_inline_outside() && display.is_flow_inside()
-            }))
+    node_facts::node_is_fragmented_inline(data, host.style(node))
 }
 
 impl TreeBuilderHost<'_> {

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -5,7 +5,8 @@
  */
 
 use crate::layout::LayoutNodeArena;
-use crate::layout::node_data::{NodeKind, NodeSlotId};
+use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_facts;
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_rows::PaintableRowsRead;
 use crate::painting::stacking_context::NO_STACKING_CONTEXT;
@@ -68,13 +69,9 @@ pub(crate) fn is_self_painting_inline(layout_arena: &impl PaintableRowsRead, pai
 }
 
 pub(crate) fn node_is_fragmented_inline(layout_arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
-    match layout_arena.node_kind_if_live(node) {
-        Some(NodeKind::InlineNode) => true,
-        Some(NodeKind::ListItemBox) => layout_arena
-            .node_style_if_live(node)
-            .is_some_and(|style| style.display().is_inline_outside() && style.display().is_flow_inside()),
-        _ => false,
-    }
+    layout_arena
+        .node_data_if_live(node)
+        .is_some_and(|data| node_facts::node_is_fragmented_inline(data, layout_arena.node_style_if_live(node)))
 }
 
 pub(crate) fn nearest_fragmented_inline_ancestor(

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -7,7 +7,7 @@
 use super::{PaintPhase, PaintRecorder};
 use crate::css::css_enums;
 use crate::css::css_pixels::{CssPixelRect, CssPixels};
-use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::layout::node_facts;
 use crate::painting::display_list::commands::ContextRef;
 use crate::painting::fragment_ownership;
@@ -100,14 +100,7 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn is_atomic_inline(&self, paintable: NodeSlotId) -> bool {
-        if crate::painting::style_queries::is_replaced_element(self.layout_arena, paintable) {
-            return true;
-        }
-        if self.layout_kind(paintable) == Some(NodeKind::ListItemMarkerBox) {
-            return true;
-        }
-        let display = self.display(paintable);
-        display.is_inline_outside() && !display.is_flow_inside()
+        crate::painting::style_queries::is_atomic_inline(self.layout_arena, paintable)
     }
 
     pub(crate) fn record_foreign_object_descendant_hit_test_items(&mut self, paintable: NodeSlotId) {

--- a/Libraries/LibWeb/Rust/src/painting/style_queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/style_queries.rs
@@ -310,6 +310,12 @@ pub(crate) fn has_css_transform(arena: &LayoutNodeArena, node: NodeSlotId, style
     has_transform && is_transformable(arena, node)
 }
 
+pub(crate) fn is_atomic_inline(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
+    arena
+        .node_data_if_live(node)
+        .is_some_and(|data| node_facts::node_is_atomic_inline(data, arena.node_style_if_live(node)))
+}
+
 pub(crate) fn is_transformable(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     let Some(kind) = arena.node_kind_if_live(node) else {
         return false;
@@ -347,10 +353,7 @@ pub(crate) fn is_transformable(arena: &LayoutNodeArena, node: NodeSlotId) -> boo
         if display.is_table_column() || display.is_table_column_group() {
             return false;
         }
-        let is_atomic_inline = has_flag(arena, node, NodeFlag::IsReplacedElement)
-            || kind == NodeKind::ListItemMarkerBox
-            || (display.is_inline_outside() && !display.is_flow_inside());
-        if display.is_inline_outside() && !is_atomic_inline {
+        if display.is_inline_outside() && !is_atomic_inline(arena, node) {
             return false;
         }
         return true;
@@ -489,13 +492,7 @@ pub(crate) fn is_text_decoration_propagation_boundary(arena: &LayoutNodeArena, n
     if arena.node_is_out_of_flow_if_live(node) {
         return true;
     }
-    if has_flag(arena, node, NodeFlag::IsReplacedElement) || kind == NodeKind::ListItemMarkerBox {
-        return true;
-    }
-    arena.node_style_if_live(node).is_some_and(|style| {
-        let display = style.display();
-        display.is_inline_outside() && !display.is_flow_inside()
-    })
+    is_atomic_inline(arena, node)
 }
 
 pub(crate) fn z_index(arena: &LayoutNodeArena, node: NodeSlotId) -> Option<i32> {
@@ -548,10 +545,6 @@ pub(crate) fn is_flex_or_grid_item(arena: &LayoutNodeArena, node: NodeSlotId) ->
 
 pub(crate) fn is_anonymous(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
     has_flag(arena, node, NodeFlag::Anonymous)
-}
-
-pub(crate) fn is_replaced_element(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {
-    has_flag(arena, node, NodeFlag::IsReplacedElement)
 }
 
 pub(crate) fn is_replaced_box(arena: &LayoutNodeArena, node: NodeSlotId) -> bool {

--- a/Tests/LibWeb/Crash/Layout/fieldset-display-inline-after-restyle.html
+++ b/Tests/LibWeb/Crash/Layout/fieldset-display-inline-after-restyle.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!-- The fieldset box's "behave as inline-block" adjustment is applied when the box is created, and a
+     restyle that keeps the box republishes the element's computed display over it. The box is left
+     with an inline outer display while still being its children's containing block, which inline
+     layout must treat as an atomic inline. -->
+<style>
+    #fieldset {
+        display: inline;
+    }
+</style>
+<div style="display: flex">
+    <div style="width: max-content">
+        before
+        <fieldset id="fieldset">
+            text
+            <div>block</div>
+        </fieldset>
+        after
+    </div>
+</div>
+<script>
+    document.body.offsetHeight;
+    document.getElementById("fieldset").style.color = "red";
+    document.body.offsetHeight;
+</script>

--- a/Tests/LibWeb/Crash/Layout/legend-display-inline-with-block-child.html
+++ b/Tests/LibWeb/Crash/Layout/legend-display-inline-with-block-child.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<!-- A <legend> gets a block container box whatever its computed display is, so an inline outer
+     display leaves a box that is still its children's containing block. Inline layout has to lay it
+     out as one box on the line: walking into it would lay the block inside out against the block
+     container of the flex item's inline formatting context instead. -->
+<style>
+    #legend {
+        display: inline;
+        overflow: hidden;
+    }
+</style>
+<div style="display: flex">
+    <fieldset>
+        <legend id="legend"><div></div></legend>
+    </fieldset>
+</div>

--- a/Tests/LibWeb/Layout/expected/css/anchor-positioning-fixed-span-all.txt
+++ b/Tests/LibWeb/Layout/expected/css/anchor-positioning-fixed-span-all.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div#fixed-anchor> at [300,100] positioned [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#fixed-target> at [250,160] positioned [0+0+0 200 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#padded-containing-block> at [90,290] positioned [0+0+40 300 40+0+0] [0+0+40 160 40+0+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#padded-anchor> at [150,290] positioned [0+0+0 80 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#padded-target> at [110,295] positioned [0+0+0 160 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      BlockContainer <div#overhanging-containing-block> at [500,300] positioned [0+0+0 200 0+0+0] [0+0+0 150 0+0+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#overhanging-anchor> at [400,240] positioned [0+0+0 40 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#overhanging-target> at [410,270] positioned [0+0+0 150 0+0+0] [0+0+0 105 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      Box <div#grid> at [50,480] positioned [0+0+0 300 0+0+0] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div#grid-anchor> at [100,500] positioned [0+0+0 40 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div#grid-target> at [190,480] positioned [0+0+0 60 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#fixed-anchor) [300,100 100x50]
+      PaintableWithLines (BlockContainer<DIV>#fixed-target) [250,160 200x40]
+      PaintableWithLines (BlockContainer<DIV>#padded-containing-block) [50,250 380x240]
+        PaintableWithLines (BlockContainer<DIV>#padded-anchor) [150,290 80x40]
+        PaintableWithLines (BlockContainer<DIV>#padded-target) [110,295 160x30]
+      PaintableWithLines (BlockContainer<DIV>#overhanging-containing-block) [500,300 200x150]
+        PaintableWithLines (BlockContainer<DIV>#overhanging-anchor) [400,240 40x20]
+        PaintableWithLines (BlockContainer<DIV>#overhanging-target) [410,270 150x105]
+      Paintable (Box<DIV>#grid) [50,480 300x100]
+        PaintableWithLines (BlockContainer<DIV>#grid-anchor) [100,500 40x20]
+        PaintableWithLines (BlockContainer<DIV>#grid-target) [190,480 60x20]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] (z-index: auto)
+  SC for BlockContainer<DIV>#fixed-target [250,160 200x40] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-intrinsic-baseline.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-intrinsic-baseline.txt
@@ -1,0 +1,111 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 124 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 108 0+0+8] children: not-inline
+      Box <div.control> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] [FFC] children: not-inline
+        BlockContainer <span> at [8,0] flex-item [0+0+0 80 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
+          Box <span.trigger> at [8,0] flex-container(row) [0+0+0 80 0+0+0] [0+0+0 52 0+0+0] [FFC] children: not-inline
+            BlockContainer <span> at [8,0] flex-item [0+0+0 80 0+0+0] [0+0+0 52 0+0+0] [BFC] children: inline
+              frag 0 from Box start: 0, length: 0, rect: [8,0 64x26] baseline: 17.796875
+              frag 1 from Box start: 0, length: 0, rect: [72,0 16x52] baseline: 17.796875
+              Box <span.label> at [8,0] flex-container(row) [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [8,0] flex-item [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [8,5 64x16] baseline: 12.796875
+                      "High"
+                  TextNode <#text> (not painted)
+              Box <span.label.column> at [72,0] flex-container(column) [0+0+0 16 0+0+0] [0+0+0 52 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [72,0] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,5 16x16] baseline: 12.796875
+                      "A"
+                  TextNode <#text> (not painted)
+                BlockContainer <span> at [72,26] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,31 16x16] baseline: 12.796875
+                      "B"
+                  TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.control> at [8,44] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] [FFC] children: not-inline
+        BlockContainer <span> at [8,23] flex-item [0+0+0 80 0+0+0] [0+0+0 78 0+0+0] [BFC] children: not-inline
+          Box <span.trigger> at [8,23] flex-container(row) [0+0+0 80 0+0+0] [0+0+0 78 0+0+0] [FFC] children: not-inline
+            BlockContainer <span> at [8,23] flex-item [0+0+0 80 0+0+0] [0+0+0 78 0+0+0] [BFC] children: inline
+              frag 0 from Box start: 0, length: 0, rect: [8,36 64x26] baseline: 17.796875
+              frag 1 from Box start: 0, length: 0, rect: [72,23 16x78] baseline: 30.796875
+              Box <span.label> at [8,36] flex-container(row) [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [8,36] flex-item [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [8,41 64x16] baseline: 12.796875
+                      "High"
+                  TextNode <#text> (not painted)
+              Box <span.label.column.min-tall> at [72,23] flex-container(column) [0+0+0 16 0+0+0] [0+0+0 78 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [72,36] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,41 16x16] baseline: 12.796875
+                      "A"
+                  TextNode <#text> (not painted)
+                BlockContainer <span> at [72,62] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,67 16x16] baseline: 12.796875
+                      "B"
+                  TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.control> at [8,80] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] [FFC] children: not-inline
+        BlockContainer <span> at [8,59] flex-item [0+0+0 96 0+0+0] [0+0+0 78 0+0+0] [BFC] children: not-inline
+          Box <span.trigger> at [8,59] flex-container(row) [0+0+0 96 0+0+0] [0+0+0 78 0+0+0] [FFC] children: not-inline
+            BlockContainer <span> at [8,59] flex-item [0+0+0 96 0+0+0] [0+0+0 78 0+0+0] [BFC] children: inline
+              frag 0 from Box start: 0, length: 0, rect: [8,72 64x26] baseline: 17.796875
+              frag 1 from Box start: 0, length: 0, rect: [72,59 32x78] baseline: 30.796875
+              Box <span.label> at [8,72] flex-container(row) [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [8,72] flex-item [0+0+0 64 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [8,77 64x16] baseline: 12.796875
+                      "High"
+                  TextNode <#text> (not painted)
+              Box <span.label.wrapped> at [72,59] flex-container(row) [0+0+0 32 0+0+0] [0+0+0 78 0+0+0] [FFC] children: not-inline
+                BlockContainer <span> at [72,72] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,77 16x16] baseline: 12.796875
+                      "A"
+                  TextNode <#text> (not painted)
+                BlockContainer <span> at [88,72] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [88,77 16x16] baseline: 12.796875
+                      "B"
+                  TextNode <#text> (not painted)
+                BlockContainer <span> at [72,98] flex-item [0+0+0 16 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72,103 16x16] baseline: 12.796875
+                      "C"
+                  TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,116] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x124]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x108]
+      Paintable (Box<DIV>.control) [8,8 784x36]
+        PaintableWithLines (BlockContainer<SPAN>) [8,0 80x52]
+          Paintable (Box<SPAN>.trigger) [8,0 80x52]
+            PaintableWithLines (BlockContainer<SPAN>) [8,0 80x52]
+              Paintable (Box<SPAN>.label) [8,0 64x26]
+                PaintableWithLines (BlockContainer<SPAN>) [8,0 64x26]
+              Paintable (Box<SPAN>.label.column) [72,0 16x52]
+                PaintableWithLines (BlockContainer<SPAN>) [72,0 16x26]
+                PaintableWithLines (BlockContainer<SPAN>) [72,26 16x26]
+      PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]
+      Paintable (Box<DIV>.control) [8,44 784x36]
+        PaintableWithLines (BlockContainer<SPAN>) [8,23 80x78]
+          Paintable (Box<SPAN>.trigger) [8,23 80x78]
+            PaintableWithLines (BlockContainer<SPAN>) [8,23 80x78]
+              Paintable (Box<SPAN>.label) [8,36 64x26]
+                PaintableWithLines (BlockContainer<SPAN>) [8,36 64x26]
+              Paintable (Box<SPAN>.label.column.min-tall) [72,23 16x78]
+                PaintableWithLines (BlockContainer<SPAN>) [72,36 16x26]
+                PaintableWithLines (BlockContainer<SPAN>) [72,62 16x26]
+      PaintableWithLines (BlockContainer(anonymous)) [8,80 784x0]
+      Paintable (Box<DIV>.control) [8,80 784x36]
+        PaintableWithLines (BlockContainer<SPAN>) [8,59 96x78]
+          Paintable (Box<SPAN>.trigger) [8,59 96x78]
+            PaintableWithLines (BlockContainer<SPAN>) [8,59 96x78]
+              Paintable (Box<SPAN>.label) [8,72 64x26]
+                PaintableWithLines (BlockContainer<SPAN>) [8,72 64x26]
+              Paintable (Box<SPAN>.label.wrapped) [72,59 32x78]
+                PaintableWithLines (BlockContainer<SPAN>) [72,72 16x26]
+                PaintableWithLines (BlockContainer<SPAN>) [88,72 16x26]
+                PaintableWithLines (BlockContainer<SPAN>) [72,98 16x26]
+      PaintableWithLines (BlockContainer(anonymous)) [8,116 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x124] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/inline-fieldset-positioning-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/inline-fieldset-positioning-containing-block.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 123.390625 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 123.390625 0+0+0] children: inline
+      frag 0 from FieldSetBox start: 0, length: 0, rect: [14,7 100x100] baseline: 119.59375
+      FieldSetBox <fieldset> at [64,7] positioned inline-block [0+2+12 100 12+2+0] [0+2+5.59375 100 10+2+0] [BFC] children: not-inline
+        BlockContainer <div> at [52,1.40625] positioned [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x123.390625]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x123.390625]
+      FieldSetPaintable (FieldSetBox<FIELDSET>) [50,-0.59375 128x119.59375]
+        PaintableWithLines (BlockContainer<DIV>) [52,1.40625 20x20]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x123.390625] (z-index: auto)
+  SC for FieldSetBox<FIELDSET> [64,7 100x100] (z-index: auto), has_transform
+   SC for BlockContainer<DIV> [52,1.40625 20x20] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/input-placeholder-min-height-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/input-placeholder-min-height-alignment.txt
@@ -1,0 +1,42 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 44 0+0+8] children: inline
+      frag 0 from TextInputBox start: 0, length: 0, rect: [25,10 307x40] baseline: 32
+      frag 1 from TextNode start: 0, length: 1, rect: [349,27 8x16] baseline: 12.796875
+          " "
+      frag 2 from TextInputBox start: 0, length: 0, rect: [374,23 307x14] baseline: 19
+      TextInputBox <input.minimum> at [25,10] inline-block [0+1+16 307 16+1+0] [0+1+1 40 1+1+0] [BFC] children: not-inline
+        Box <div> at [25,10] flex-container(row) [0+0+0 307 0+0+0] [0+0+0 40 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [25,20] flex-item [0+0+0 307 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 0, rect: [25,22 0x16] baseline: 12.796875
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [25,20] flex-item [-307+0+0 307 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 13, rect: [25,22 208x16] baseline: 12.796875
+                "Email address"
+            TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      TextInputBox <input.maximum> at [374,23] inline-block [0+1+16 307 16+1+0] [0+1+1 14 1+1+0] [BFC] children: not-inline
+        Box <div> at [374,23] flex-container(row) [0+0+0 307 0+0+0] [0+0+0 14 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [374,20] flex-item [0+0+0 307 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 0, rect: [374,22 0x16] baseline: 12.796875
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [374,20] flex-item [-307+0+0 307 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 13, rect: [374,22 208x16] baseline: 12.796875
+                "Email address"
+            TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
+      PaintableWithLines (TextInputBox<INPUT>.minimum) [8,8 341x44]
+        Paintable (Box<DIV>) [25,10 307x40]
+          PaintableWithLines (BlockContainer<DIV>) [25,20 307x20]
+          PaintableWithLines (BlockContainer<DIV>) [25,20 307x20]
+      PaintableWithLines (TextInputBox<INPUT>.maximum) [357,21 341x18]
+        Paintable (Box<DIV>) [374,23 307x14]
+          PaintableWithLines (BlockContainer<DIV>) [374,20 307x20]
+          PaintableWithLines (BlockContainer<DIV>) [374,20 307x20]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x60] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/css/anchor-positioning-fixed-span-all.html
+++ b/Tests/LibWeb/Layout/input/css/anchor-positioning-fixed-span-all.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<style>
+    * {
+        margin: 0;
+    }
+
+    #fixed-anchor {
+        position: absolute;
+        left: 300px;
+        top: 100px;
+        width: 100px;
+        height: 50px;
+        anchor-name: --anchor;
+        background: green;
+    }
+
+    #fixed-target {
+        position: fixed;
+        position-anchor: --anchor;
+        position-area: span-all;
+        top: calc(anchor(bottom) + 10px);
+        width: 200px;
+        height: 40px;
+        background: blue;
+    }
+
+    #padded-containing-block {
+        position: absolute;
+        left: 50px;
+        top: 250px;
+        width: 300px;
+        height: 160px;
+        padding: 40px;
+    }
+
+    #padded-anchor {
+        position: absolute;
+        left: 100px;
+        top: 40px;
+        width: 80px;
+        height: 40px;
+        anchor-name: --padded-anchor;
+        background: green;
+    }
+
+    #padded-target {
+        position: absolute;
+        position-anchor: --padded-anchor;
+        position-area: span-all;
+        width: 160px;
+        height: 30px;
+        background: blue;
+    }
+
+    #overhanging-containing-block {
+        position: absolute;
+        left: 500px;
+        top: 300px;
+        width: 200px;
+        height: 150px;
+    }
+
+    #overhanging-anchor {
+        position: absolute;
+        left: -100px;
+        top: -60px;
+        width: 40px;
+        height: 20px;
+        anchor-name: --overhanging-anchor;
+        background: green;
+    }
+
+    #overhanging-target {
+        position: absolute;
+        position-anchor: --overhanging-anchor;
+        position-area: span-all;
+        left: 10px;
+        top: calc(anchor(bottom) + 10px);
+        width: 50%;
+        height: 50%;
+        background: blue;
+    }
+
+    #grid {
+        position: absolute;
+        display: grid;
+        left: 50px;
+        top: 480px;
+        width: 300px;
+        height: 100px;
+        grid-template-columns: 200px 100px;
+        grid-template-rows: 100px;
+    }
+
+    #grid-anchor {
+        position: absolute;
+        left: 50px;
+        top: 20px;
+        width: 40px;
+        height: 20px;
+        anchor-name: --grid-anchor;
+        background: green;
+    }
+
+    #grid-target {
+        position: absolute;
+        grid-column-start: 1;
+        grid-column-end: 2;
+        grid-row-start: 1;
+        grid-row-end: 2;
+        position-anchor: --grid-anchor;
+        position-area: span-all;
+        justify-self: end;
+        align-self: start;
+        width: 60px;
+        height: 20px;
+        background: blue;
+    }
+</style>
+<div id="fixed-anchor"></div>
+<div id="fixed-target"></div>
+<div id="padded-containing-block">
+    <div id="padded-anchor"></div>
+    <div id="padded-target"></div>
+</div>
+<div id="overhanging-containing-block">
+    <div id="overhanging-anchor"></div>
+    <div id="overhanging-target"></div>
+</div>
+<div id="grid">
+    <div id="grid-anchor"></div>
+    <div id="grid-target"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/flex/inline-flex-intrinsic-baseline.html
+++ b/Tests/LibWeb/Layout/input/flex/inline-flex-intrinsic-baseline.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    .control {
+        display: flex;
+        align-items: center;
+        height: 36px;
+        font: 16px/26px Ahem;
+    }
+
+    .trigger {
+        display: flex;
+        align-items: center;
+    }
+
+    .label {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .column {
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .min-tall {
+        min-height: 78px;
+    }
+
+    .wrapped {
+        align-content: center;
+        flex-wrap: wrap;
+        min-height: 78px;
+        width: 32px;
+    }
+</style>
+<div class="control"><span><span class="trigger"><span><span class="label"><span>High</span></span><span class="label column"><span>A</span><span>B</span></span></span></span></span></div>
+<div class="control"><span><span class="trigger"><span><span class="label"><span>High</span></span><span class="label column min-tall"><span>A</span><span>B</span></span></span></span></span></div>
+<div class="control"><span><span class="trigger"><span><span class="label"><span>High</span></span><span class="label wrapped"><span>A</span><span>B</span><span>C</span></span></span></span></span></div>

--- a/Tests/LibWeb/Layout/input/inline-fieldset-positioning-containing-block.html
+++ b/Tests/LibWeb/Layout/input/inline-fieldset-positioning-containing-block.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+    * {
+        margin: 0;
+    }
+
+    fieldset {
+        display: inline;
+        position: relative;
+        left: 50px;
+        width: 100px;
+        height: 100px;
+        transform: translateX(10px);
+    }
+
+    div {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 20px;
+        height: 20px;
+        background: green;
+    }
+</style>
+<fieldset><div></div></fieldset>

--- a/Tests/LibWeb/Layout/input/input-placeholder-min-height-alignment.html
+++ b/Tests/LibWeb/Layout/input/input-placeholder-min-height-alignment.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../../Ref/data/fonts/Ahem.ttf");
+    }
+
+    input {
+        box-sizing: border-box;
+        width: 341px;
+        border: 1px solid black;
+        padding: 1px 16px;
+        font: 16px/20px Ahem;
+    }
+
+    input::placeholder {
+        color: black;
+        opacity: 1;
+    }
+
+    .minimum {
+        min-height: 44px;
+    }
+
+    .maximum {
+        max-height: 18px;
+    }
+</style>
+<input class="minimum" placeholder="Email address" />
+<input class="maximum" placeholder="Email address" />

--- a/Tests/LibWeb/Ref/expected/anchor-positioning-span-all-scroll-ref.html
+++ b/Tests/LibWeb/Ref/expected/anchor-positioning-span-all-scroll-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        position: relative;
+        width: 300px;
+        height: 150px;
+        background: red;
+    }
+
+    #target {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 40px;
+        height: 40px;
+        background: green;
+    }
+</style>
+<div id="scroller"><div id="target"></div></div>

--- a/Tests/LibWeb/Ref/input/anchor-positioning-span-all-scroll.html
+++ b/Tests/LibWeb/Ref/input/anchor-positioning-span-all-scroll.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<link rel="match" href="../expected/anchor-positioning-span-all-scroll-ref.html" />
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        position: relative;
+        width: 300px;
+        height: 150px;
+        overflow: scroll;
+        background: red;
+    }
+
+    #content {
+        position: relative;
+        width: 700px;
+        height: 700px;
+    }
+
+    #anchor {
+        position: absolute;
+        left: 400px;
+        top: 400px;
+        width: 40px;
+        height: 40px;
+        anchor-name: --anchor;
+        background: green;
+    }
+
+    #target {
+        position: fixed;
+        position-anchor: --anchor;
+        position-area: span-all;
+        width: 40px;
+        height: 40px;
+        background: green;
+    }
+</style>
+<div id="scroller">
+    <div id="content"><div id="anchor"></div></div>
+</div>
+<div id="target"></div>
+<script>
+    const scroller = document.querySelector("#scroller");
+    scroller.scrollLeft = 300;
+    scroller.scrollTop = 300;
+</script>


### PR DESCRIPTION
In order, the commits fix the following:

1. An assertion crash on the logged-in ChatGPT page.
2. Layout of the "Email address" placeholder in the login form
3. Layout of the effort toggle in the prompt input box
4. Layout of the tooltip over effort toggle

| | Before | After |
|--|--|--|
| 2. | <img width="455" height="518" alt="before1" src="https://github.com/user-attachments/assets/8c3dc030-fac6-4b15-abb9-20d4f0f7434f" /> | <img width="455" height="518" alt="after1" src="https://github.com/user-attachments/assets/35bff744-d3af-40a1-9eb4-552eacb58c47" /> |
| 3. | <img width="791" height="143" alt="before2" src="https://github.com/user-attachments/assets/c430e242-2006-4937-a0a5-b874979dd986" /> | <img width="791" height="143" alt="after2" src="https://github.com/user-attachments/assets/1226a0b7-e1b5-494c-84d0-b3da7f049093" /> |
| 4. | <img width="1343" height="251" alt="before3" src="https://github.com/user-attachments/assets/8f6de64f-16ed-4789-9d4d-ae9a20a6862b" /> | <img width="794" height="252" alt="after3" src="https://github.com/user-attachments/assets/650da55e-11f2-4a16-9506-725917758715" /> |


