### PR TITLE
LibWeb: Avoid false container size invalidation

### DIFF
--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -331,9 +331,10 @@ static Optional<StyleRangeComparableValue> evaluate_style_range_value(StyleRange
         });
 }
 
-static MatchResult evaluate_style_range(StyleRange const& range, DOM::Document const& document, AbstractOrHypotheticalElement element)
+static MatchResult evaluate_style_range(StyleRange const& range, DOM::Document const& document, AbstractOrHypotheticalElement element, bool& depends_on_viewport_metrics)
 {
     auto computation_context = element.document().style_computer().fallback_computation_context_for_custom_property(element);
+    computation_context.length_resolution_context.set_did_resolve_viewport_relative_length(depends_on_viewport_metrics);
     auto left = evaluate_style_range_value(range.left, element, document, computation_context);
     if (!left.has_value())
         return MatchResult::False;
@@ -356,10 +357,10 @@ static MatchResult evaluate_style_range(StyleRange const& range, DOM::Document c
 }
 
 // https://drafts.csswg.org/css-conditional-5/#style-container
-static MatchResult evaluate_style_feature(EvaluatedStyleFeature const& style_feature, DOM::Document const& document, AbstractOrHypotheticalElement element)
+static MatchResult evaluate_style_feature(EvaluatedStyleFeature const& style_feature, DOM::Document const& document, AbstractOrHypotheticalElement element, bool& depends_on_viewport_metrics)
 {
     if (auto const* range = style_feature.get_pointer<StyleRange>())
-        return evaluate_style_range(*range, document, element);
+        return evaluate_style_range(*range, document, element, depends_on_viewport_metrics);
 
     auto const& feature = style_feature.get<StyleFeaturePlain>();
     auto const& property = feature.property;
@@ -394,6 +395,7 @@ static MatchResult evaluate_style_feature(EvaluatedStyleFeature const& style_fea
 
     // FIXME: We should use the computed style that we are currently computing rather than the fallback (i.e. the previously applied style).
     auto computation_context = element.document().style_computer().fallback_computation_context_for_custom_property(element);
+    computation_context.length_resolution_context.set_did_resolve_viewport_relative_length(depends_on_viewport_metrics);
     auto computed_values = element.abstract_element().computed_style();
     auto const* computed_style_for_custom_property_resolution = computed_values ? document.style_computer().reconstruct_computed_properties(*computed_values).ptr() : nullptr;
 
@@ -552,6 +554,7 @@ static bool container_satisfies_requirements(DOM::Element const& element, Contai
 struct ContainerStyleEvaluationContext {
     GC::Ref<DOM::Document const> document;
     AbstractOrHypotheticalElement element;
+    bool depends_on_viewport_metrics { false };
 };
 
 static Utf16View ffi_utf16_view(Parser::ValueParserFFI::FfiUtf16View const& value)
@@ -657,7 +660,7 @@ static u8 evaluate_container_style_feature(void* context, Parser::ValueParserFFI
     auto& evaluation_context = *static_cast<ContainerStyleEvaluationContext*>(context);
     if (!style_feature.has_value())
         return to_underlying(MatchResult::Unknown);
-    return to_underlying(evaluate_style_feature(*style_feature, *evaluation_context.document, evaluation_context.element));
+    return to_underlying(evaluate_style_feature(*style_feature, *evaluation_context.document, evaluation_context.element, evaluation_context.depends_on_viewport_metrics));
 }
 
 MatchResult evaluate_style_query(RustQueryHandle const& handle, AbstractOrHypotheticalElement element)
@@ -715,6 +718,7 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
                 root->set_is_style_query_container();
         }
 
+        Optional<ComputationContext> computation_context;
         Optional<ComputedValuesFFI::FfiLengthResolutionContext> length_resolution_context;
         Parser::ValueParserFFI::FfiContainerFacts facts {
             .container_available = true,
@@ -731,12 +735,13 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
             facts.width = Painting::content_width(*layout_node).to_double();
             facts.height = Painting::content_height(*layout_node).to_double();
             facts.inline_axis_horizontal = layout_node->writing_mode() == WritingMode::HorizontalTb;
-            auto computation_context = ComputationContext {
+            computation_context = ComputationContext {
                 .length_resolution_context = Length::ResolutionContext::for_layout_node(*layout_node),
                 .abstract_element = DOM::AbstractElement { *container },
             };
+            computation_context->reset_viewport_metric_dependency_tracking();
             length_resolution_context = to_ffi_length_resolution_context_with_container_bases(
-                computation_context.length_resolution_context, all_container_relative_length_units_mask);
+                computation_context->length_resolution_context, all_container_relative_length_units_mask);
             facts.length_resolution_context = &*length_resolution_context;
         } else if (!container->document().layout_is_up_to_date()) {
             const_cast<DOM::Document&>(container->document()).set_needs_container_query_evaluation_after_layout(*container);
@@ -745,6 +750,8 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
         ContainerStyleEvaluationContext style_context { element.document(), DOM::AbstractElement { *container } };
         facts.style_context = &style_context;
         auto result = Parser::ValueParserFFI::css_query_evaluate_container(m_rust_query_handle.data(), facts);
+        if ((computation_context.has_value() && computation_context->depends_on_viewport_metrics()) || style_context.depends_on_viewport_metrics)
+            const_cast<DOM::Element&>(element.element()).set_style_depends_on_viewport_metrics();
         VERIFY(result <= to_underlying(MatchResult::Unknown));
         return static_cast<MatchResult>(result);
     }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4093,6 +4093,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_and_share_computed_valu
             && !element.style_uses_if_css_function()
             && !element.style_uses_custom_function()
             && !element.style_uses_tree_counting_function()
+            && !element.style_depends_on_viewport_metrics()
             && !element.style_depends_on_size_container_query()
             && !element.style_depends_on_style_container_query()
             && !has_monospace_font_size_recascade
@@ -4694,6 +4695,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         bool style_uses_custom_function { false };
         bool style_uses_inherit_css_function { false };
         bool style_uses_tree_counting_function { false };
+        bool style_depends_on_viewport_metrics { false };
         bool style_depends_on_size_container_query { false };
         bool style_depends_on_style_container_query { false };
         u32 explicitly_inherited_non_inherited_style_groups { 0 };
@@ -4724,6 +4726,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         record->style_uses_custom_function = false;
         record->style_uses_inherit_css_function = false;
         record->style_uses_tree_counting_function = false;
+        record->style_depends_on_viewport_metrics = false;
         record->style_depends_on_size_container_query = false;
         record->style_depends_on_style_container_query = false;
         record->explicitly_inherited_non_inherited_style_groups = 0;
@@ -4779,6 +4782,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                 record->style_uses_custom_function = previous->style_uses_custom_function;
                 record->style_uses_inherit_css_function = previous->style_uses_inherit_css_function;
                 record->style_uses_tree_counting_function = previous->style_uses_tree_counting_function;
+                record->style_depends_on_viewport_metrics = previous->style_depends_on_viewport_metrics;
                 record->style_depends_on_size_container_query = previous->style_depends_on_size_container_query;
                 record->style_depends_on_style_container_query = previous->style_depends_on_style_container_query;
                 record->explicitly_inherited_non_inherited_style_groups = previous->explicitly_inherited_non_inherited_style_groups;
@@ -4796,6 +4800,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                         .style_uses_custom_function = previous->style_uses_custom_function,
                         .style_uses_inherit_css_function = previous->style_uses_inherit_css_function,
                         .style_uses_tree_counting_function = previous->style_uses_tree_counting_function,
+                        .style_depends_on_viewport_metrics = previous->style_depends_on_viewport_metrics,
                         .style_depends_on_size_container_query = previous->style_depends_on_size_container_query,
                         .style_depends_on_style_container_query = previous->style_depends_on_style_container_query,
                         .explicitly_inherited_non_inherited_style_groups = previous->explicitly_inherited_non_inherited_style_groups,
@@ -4818,6 +4823,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
                     .style_uses_custom_function = previous->style_uses_custom_function,
                     .style_uses_inherit_css_function = previous->style_uses_inherit_css_function,
                     .style_uses_tree_counting_function = previous->style_uses_tree_counting_function,
+                    .style_depends_on_viewport_metrics = previous->style_depends_on_viewport_metrics,
                     .style_depends_on_size_container_query = previous->style_depends_on_size_container_query,
                     .style_depends_on_style_container_query = previous->style_depends_on_style_container_query,
                     .explicitly_inherited_non_inherited_style_groups = previous->explicitly_inherited_non_inherited_style_groups,
@@ -4870,6 +4876,8 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
             element.set_style_uses_inherit_css_function();
         if (record.style_uses_tree_counting_function)
             element.set_style_uses_tree_counting_function();
+        if (record.style_depends_on_viewport_metrics)
+            element.set_style_depends_on_viewport_metrics();
         if (record.style_depends_on_size_container_query)
             element.set_style_depends_on_size_container_query();
         if (record.style_depends_on_style_container_query)
@@ -5112,6 +5120,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         new_style_input_record->style_uses_custom_function = previous_computation->style_uses_custom_function;
         new_style_input_record->style_uses_inherit_css_function = previous_computation->style_uses_inherit_css_function;
         new_style_input_record->style_uses_tree_counting_function = previous_computation->style_uses_tree_counting_function;
+        new_style_input_record->style_depends_on_viewport_metrics = previous_computation->style_depends_on_viewport_metrics;
         new_style_input_record->style_depends_on_size_container_query = previous_computation->style_depends_on_size_container_query;
         new_style_input_record->style_depends_on_style_container_query = previous_computation->style_depends_on_style_container_query;
         new_style_input_record->explicitly_inherited_non_inherited_style_groups = previous_computation->explicitly_inherited_non_inherited_style_groups;

--- a/Libraries/LibWeb/CSS/StyleInputRecord.h
+++ b/Libraries/LibWeb/CSS/StyleInputRecord.h
@@ -52,6 +52,7 @@ struct StyleInputRecord {
     bool style_uses_custom_function { false };
     bool style_uses_inherit_css_function { false };
     bool style_uses_tree_counting_function { false };
+    bool style_depends_on_viewport_metrics { false };
     bool style_depends_on_size_container_query { false };
     bool style_depends_on_style_container_query { false };
     u32 explicitly_inherited_non_inherited_style_groups { 0 };

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2623,7 +2623,9 @@ void Document::invalidate_style_for_viewport_change()
             return TraversalDecision::Continue;
 
         // Descendants that inherit changed values are reached by the normal inherited-style reaction path.
-        if (element->style_uses_if_css_function())
+        // Container query conditions that resolved a container unit against the viewport have no
+        // computed-value dependency for the retained style engine to discover.
+        if (element->style_uses_if_css_function() || element->style_depends_on_viewport_metrics())
             element->document().style_computer().style_engine().record_element_style_input_change(element->style_node_id());
 
         return TraversalDecision::Continue;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2071,6 +2071,7 @@ void Element::finish_recording_style_custom_property_references()
     m_style_input_record->style_uses_custom_function = m_style_uses_custom_function;
     m_style_input_record->style_uses_inherit_css_function = m_style_uses_inherit_css_function;
     m_style_input_record->style_uses_tree_counting_function = m_style_uses_tree_counting_function;
+    m_style_input_record->style_depends_on_viewport_metrics = m_style_depends_on_viewport_metrics;
     m_style_input_record->style_depends_on_size_container_query = m_style_depends_on_size_container_query;
     m_style_input_record->style_depends_on_style_container_query = m_style_depends_on_style_container_query;
     auto& references = m_style_input_record->custom_property_references;
@@ -2154,6 +2155,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
         m_style_uses_custom_function = false;
         m_style_uses_inherit_css_function = false;
         m_style_uses_tree_counting_function = false;
+        m_style_depends_on_viewport_metrics = false;
         m_style_depends_on_size_container_query = false;
         m_style_depends_on_style_container_query = false;
         reusable_style_engine_matches = &style_engine_matches;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -540,6 +540,8 @@ public:
 
     bool style_uses_if_css_function() const { return m_style_uses_if_css_function; }
     void set_style_uses_if_css_function() { m_style_uses_if_css_function = true; }
+    bool style_depends_on_viewport_metrics() const { return m_style_depends_on_viewport_metrics; }
+    void set_style_depends_on_viewport_metrics() { m_style_depends_on_viewport_metrics = true; }
     bool style_uses_inherit_css_function() const { return m_style_uses_inherit_css_function; }
     void set_style_uses_inherit_css_function() { m_style_uses_inherit_css_function = true; }
     bool style_depends_on_size_container_query() const { return m_style_depends_on_size_container_query; }
@@ -921,6 +923,7 @@ private:
     bool m_style_uses_attr_css_function : 1 { false };
     bool m_style_uses_var_css_function : 1 { false };
     bool m_style_uses_if_css_function : 1 { false };
+    bool m_style_depends_on_viewport_metrics : 1 { false };
     bool m_style_uses_custom_function : 1 { false };
     bool m_style_uses_inherit_css_function : 1 { false };
     bool m_style_depends_on_size_container_query : 1 { false };

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -220,17 +220,12 @@ impl<'a> PaintableCommit<'a> {
                 )
             })
         });
-        let previous_content_size_for_diff = if reuses_committed_subtree {
-            old_content_size
-        } else {
-            used_values::FfiCssPixelSize::default()
-        };
-        if previous_content_size_for_diff != new_content_size {
+        if old_content_size != new_content_size {
             assert!(
                 !reuses_committed_subtree,
                 "a reused committed subtree changed its content size"
             );
-            content_size_change = Some((previous_content_size_for_diff, new_content_size));
+            content_size_change = Some((old_content_size, new_content_size));
         }
         let committed_fragment_identity_changed = old_identity != fragment.identity;
         let painted_geometry_lives_in_enclosing_line_root =

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/size-query-container-scans.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/size-query-container-scans.txt
@@ -1,4 +1,5 @@
 dependent before: rgb(0, 0, 0)
+elements walked after block-size-only container relayout: 0
 elements walked after resizing a container no query names: 0
 elements walked after resizing the query container: 1
 dependent after: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/style-query-registered-custom-viewport-change.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/style-query-registered-custom-viewport-change.txt
@@ -1,0 +1,2 @@
+initial: rgb(0, 128, 0)
+after resize: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/css/style-invalidation/size-query-container-scans.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/size-query-container-scans.html
@@ -23,6 +23,12 @@
         // all - what the count answers for is which subtrees the resize had to look through.
         println(`dependent before: ${getComputedStyle(dependent).color}`);
 
+        document.body.offsetWidth;
+        resetStyleCounters();
+        queried.style.height = "20px";
+        document.body.offsetWidth;
+        println(`elements walked after block-size-only container relayout: ${styleCounters().sizeQueryContainerScanVisits}`);
+
         flushPendingStyleWork();
         unqueried.style.width = "400px";
         internals.updateStyle();

--- a/Tests/LibWeb/Text/input/css/style-invalidation/style-query-registered-custom-viewport-change.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/style-query-registered-custom-viewport-change.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const iframe = document.createElement("iframe");
+        iframe.style.width = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                @property --length {
+                    syntax: "<length>";
+                    initial-value: 0px;
+                    inherits: false;
+                }
+
+                #container { --length: 100px; }
+                #target { color: red; }
+                @container style(--length: 50vw) {
+                    #target { color: green; }
+                }
+            </style>
+            <div id="container"><div id="target"></div></div>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const target = child.document.getElementById("target");
+        println(`initial: ${child.getComputedStyle(target).color}`);
+
+        iframe.style.width = "400px";
+        document.body.offsetWidth;
+        println(`after resize: ${child.getComputedStyle(target).color}`);
+    });
+</script>


### PR DESCRIPTION
Typing on translate.google.com caused paintable recommits to report container sizes as changing from zero whenever the committed subtree could not be reused, even when the retained fragment had exactly the same size. Each keystroke consequently scanned a roughly 15,500-element container-query subtree and recomputed tens of thousands of styles.

Compare the new content size with the retained fragment size so only genuine changes trigger container-query invalidation. Track viewport metrics consumed by container-query conditions explicitly, preserving container-unit viewport fallback updates without relying on the false resize.

Headless WebDriver measurements while typing on Google Translate improve from:

- `update_style`: 2.80 s to 49 ms
- style recomputations: 51,592 to 319
- longhands computed: 17.47 million to 79,830
- container scan visits: 78,715 to 0

The regression coverage exercises block-size-only relayout of an inline-size container while retaining genuine resize, post-layout query reaction, native container-unit, and viewport-fallback coverage.