### PR TITLE
LibWebView: Recover from WebContent crashes without a synthetic document 

### DIFF
--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -16,8 +16,6 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Range.h>
-#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
-#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventNames.h>
@@ -148,31 +146,6 @@ void Page::load_html(StringView html, Utf16String navigation_id)
         .document_resource = Utf16String::from_utf8(html),
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI,
         .navigation_id = move(navigation_id) });
-}
-
-void Page::load_html(StringView html, URL::URL const& url, Utf16String navigation_id)
-{
-    // FIXME: #23909 Figure out why GC threshold does not stay low when repeatedly loading html from the WebView
-    heap().collect_garbage();
-
-    auto document = top_level_traversable()->active_document();
-    auto& realm = document->relevant_settings_object().realm();
-    auto html_string = String::from_utf8(html).release_value_but_fixme_should_propagate_errors();
-
-    auto response = Fetch::Infrastructure::Response::create();
-    response->url_list().append(url);
-    response->header_list()->append({ "Content-Type"sv, "text/html"sv });
-    response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, html_string.bytes()));
-
-    HTML::LocalNavigable::NavigateParams params { .url = url,
-        .response = response,
-        .user_involvement = HTML::UserNavigationInvolvement::BrowserUI,
-        .navigation_id = move(navigation_id) };
-
-    if (url == URL::about_srcdoc())
-        params.document_resource = Utf16String::from_utf8(html);
-
-    (void)top_level_traversable()->navigate(move(params));
 }
 
 void Page::reload()

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -124,7 +124,6 @@ public:
 
     void load(URL::URL const&, Bindings::NavigationHistoryBehavior, Utf16String navigation_id);
     void load_html(StringView, Utf16String navigation_id);
-    void load_html(StringView, URL::URL const&, Utf16String navigation_id);
 
     void reload();
 

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -129,6 +129,7 @@ public:
     void set_current_session_history_entry_identity(Optional<Web::HTML::SessionHistoryEntryIdentity> identity) { m_current_session_history_entry_identity = move(identity); }
     void set_active_session_history_entry(Web::HTML::SessionHistoryEntryDescriptor const&);
     void set_active_session_history_entry_identity(Web::HTML::SessionHistoryEntryIdentity identity) { m_active_session_history_entry_identity = move(identity); }
+    void clear_active_session_history_entry_identity() { m_active_session_history_entry_identity = {}; }
     bool current_session_history_entry_is(Web::HTML::SessionHistoryEntryDescriptor const&) const;
     bool active_document_is(Web::HTML::SessionHistoryEntryDescriptor const&) const;
 

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -370,6 +370,9 @@ void CanonicalTraversable::traverse_the_history(TraversableSessionHistory::Trave
 void CanonicalTraversable::abandon_after_web_content_process_crash()
 {
     abandon_history_operations();
+    // The canonical current entry survives, but no live document hosts it. Clearing only the active identity makes
+    // the next traversal reconstruct the entry instead of treating it as a same-document update.
+    clear_active_session_history_entry_identity();
 }
 
 void CanonicalTraversable::reset_session_history_for_testing(
@@ -1793,8 +1796,16 @@ void CanonicalTraversable::finalize_a_cross_document_navigation(HistoryOperation
     auto entry_to_replace = parameters.history_handling == Web::HTML::HistoryHandlingBehavior::Replace
         ? navigable->active_session_history_entry_identity()
         : Optional<Web::HTML::SessionHistoryEntryIdentity> {};
+    auto view = ViewImplementation::find_view_for_traversable(*this);
+    auto may_append_from_replacement_initial_document = !entry_to_replace.has_value()
+        && navigable->is_top_level_traversable()
+        && view.has_value()
+        && !view->m_client_state.hosts_committed_entry;
+    // A replacement renderer navigates from its non-canonical initial about:blank with "replace" handling. With no
+    // canonical active entry to replace, that specific navigation must append after the preserved current entry.
     if (parameters.history_handling == Web::HTML::HistoryHandlingBehavior::Replace
-        && !entry_to_replace.has_value()) {
+        && !entry_to_replace.has_value()
+        && !may_append_from_replacement_initial_document) {
         finish_history_operation(operation.operation_id, Web::HTML::HistoryStepResult::NoMatchingEntry, {});
         return;
     }

--- a/Libraries/LibWebView/ErrorHTML.h
+++ b/Libraries/LibWebView/ErrorHTML.h
@@ -68,12 +68,6 @@ constexpr inline auto ERROR_HTML_HEADER = R"~~~(
         </header>
 )~~~"sv;
 
-// Declaring an icon prevents the spec's fallback /favicon.ico fetch. The empty
-// data URL is local and intentionally does not decode as an icon.
-constexpr inline auto NO_FALLBACK_FAVICON_LINK = R"~~~(
-        <link rel="icon" href="data:," />
-)~~~"sv;
-
 constexpr inline auto ERROR_HTML_FOOTER = R"~~~(
     </body>
     </html>
@@ -83,13 +77,6 @@ constexpr inline auto ERROR_SVG = R"~~~(
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.5 21.5">
         <path d="M11.75.75h-9c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-13l-5-5z" />
         <path d="M10.75.75v4c0 1.1.9 2 2 2h4M5.75 9.75v2M11.75 9.75v2M5.75 16.75c1-2.67 5-2.67 6 0" />
-    </svg>
-)~~~"sv;
-
-constexpr inline auto CRASH_ERROR_SVG = R"~~~(
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.5 21.5">
-        <path class="b" d="M11.75.75h-9c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-13l-5-5z" />
-        <path class="b" d="M10.75.75v4c0 1.1.9 2 2 2h4M4.75 9.75l2 2M10.75 9.75l2 2M12.75 9.75l-2 2M6.75 9.75l-2 2M5.75 16.75c1-2.67 5-2.67 6 0" />
     </svg>
 )~~~"sv;
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -489,7 +489,6 @@ void ViewImplementation::reload()
         return;
     }
 
-    auto const* current_entry = m_top_level_traversable.session_history().current_entry();
     if (m_crash_state.has_value() && m_crash_state->navigation_to_retry.has_value()) {
         load(m_crash_state->navigation_to_retry.release_value());
         return;
@@ -499,6 +498,7 @@ void ViewImplementation::reload()
         on_before_browser_initiated_navigation();
 
     set_loading_state(true);
+    auto const* current_entry = m_top_level_traversable.session_history().current_entry();
     Optional<URL::URL> ongoing_url;
     if (m_top_level_traversable.ongoing_navigation().has_value())
         ongoing_url = move(m_top_level_traversable.ongoing_navigation()->url);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -188,8 +188,7 @@ void ViewImplementation::set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitm
         if (m_favicon_hash.has_value()) {
             if (m_is_private == IsPrivate::No)
                 Application::bookmark_store().update_favicon(m_url, *m_favicon_hash);
-            if (!m_should_suppress_history_for_current_load)
-                Application::history_store(m_is_private).update_favicon(m_url, *m_favicon_hash);
+            Application::history_store(m_is_private).update_favicon(m_url, *m_favicon_hash);
         }
     }
 
@@ -258,8 +257,6 @@ bool ViewImplementation::create_new_process_for_cross_site_navigation(Utf16Strin
     if (!navigation_still_awaits_population())
         return false;
 
-    m_should_suppress_history_for_current_load = false;
-    m_should_suppress_history_for_next_load = false;
     set_loading_state(true);
     m_last_stopped_load_url.clear();
     set_url(url);
@@ -333,6 +330,8 @@ void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id
 
     if (did_swap_bitmap)
         did_accept_presented_backing_store(bitmap_id, damage_rect);
+    if (did_swap_bitmap && m_crash_state.has_value() && m_crash_state->recovery_started && m_client_state.hosts_committed_entry)
+        set_crash_state({});
     if (did_swap_bitmap && on_ready_to_paint)
         on_ready_to_paint();
 }
@@ -366,10 +365,8 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     if (on_before_browser_initiated_navigation)
         on_before_browser_initiated_navigation();
 
+    prepare_for_navigation_after_crash(url);
     set_loading_state(true);
-    m_is_showing_crash_page = false;
-    m_should_suppress_history_for_current_load = false;
-    m_should_suppress_history_for_next_load = false;
     auto navigation_id = generate_navigation_id();
     m_top_level_traversable.set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
         .url = url,
@@ -457,10 +454,8 @@ void ViewImplementation::load_html(StringView html)
     if (on_before_browser_initiated_navigation)
         on_before_browser_initiated_navigation();
 
+    prepare_for_navigation_after_crash();
     set_loading_state(true);
-    m_is_showing_crash_page = false;
-    m_should_suppress_history_for_current_load = false;
-    m_should_suppress_history_for_next_load = false;
     auto navigation_id = generate_navigation_id();
     m_top_level_traversable.set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
         .url = URL::about_srcdoc(),
@@ -469,23 +464,6 @@ void ViewImplementation::load_html(StringView html)
     });
     m_last_stopped_load_url.clear();
     client().async_load_html(page_id(), html, navigation_id.utf16_view());
-}
-
-void ViewImplementation::load_crash_page_html(StringView html, URL::URL const& crashed_url)
-{
-    set_loading_state(true);
-    m_is_showing_crash_page = true;
-    m_should_suppress_history_for_current_load = true;
-    m_should_suppress_history_for_next_load = true;
-    auto navigation_id = generate_navigation_id();
-    m_top_level_traversable.set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
-        .url = crashed_url,
-        .navigation_id = navigation_id,
-        .sequence_number = m_top_level_traversable.next_sequence_number(),
-    });
-    m_last_stopped_load_url.clear();
-    set_url(crashed_url);
-    client().async_load_html_with_url(page_id(), html, crashed_url, navigation_id.utf16_view());
 }
 
 void ViewImplementation::load_navigation_error_page(StringView text)
@@ -501,9 +479,6 @@ void ViewImplementation::load_navigation_error_page(StringView text)
 
 void ViewImplementation::reload()
 {
-    if (on_before_browser_initiated_navigation)
-        on_before_browser_initiated_navigation();
-
     m_history_visit_transition_for_next_load = HistoryVisitTransition::Reload;
 
     if (m_last_stopped_load_url.has_value()) {
@@ -514,27 +489,31 @@ void ViewImplementation::reload()
         return;
     }
 
+    auto const* current_entry = m_top_level_traversable.session_history().current_entry();
+    if (m_crash_state.has_value() && m_crash_state->navigation_to_retry.has_value()) {
+        load(m_crash_state->navigation_to_retry.release_value());
+        return;
+    }
+
+    if (on_before_browser_initiated_navigation)
+        on_before_browser_initiated_navigation();
+
     set_loading_state(true);
     Optional<URL::URL> ongoing_url;
     if (m_top_level_traversable.ongoing_navigation().has_value())
         ongoing_url = move(m_top_level_traversable.ongoing_navigation()->url);
-    else if (auto const* current_entry = m_top_level_traversable.session_history().current_entry())
+    else if (current_entry)
         ongoing_url = current_entry->url;
     m_top_level_traversable.set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
         .url = move(ongoing_url),
         .sequence_number = m_top_level_traversable.next_sequence_number(),
     });
-    if (m_is_showing_crash_page) {
-        m_is_showing_crash_page = false;
-        m_should_suppress_history_for_current_load = false;
-        m_should_suppress_history_for_next_load = false;
+    if (m_crash_state.has_value()) {
+        prepare_for_navigation_after_crash();
         recover_current_session_history_entry_with_history_operation();
         return;
     }
 
-    m_is_showing_crash_page = false;
-    m_should_suppress_history_for_current_load = false;
-    m_should_suppress_history_for_next_load = false;
     m_top_level_traversable.prepare_for_reload();
     update_navigation_action_state();
     dump_session_history("reload-mark-current-entry-reload-pending"sv);
@@ -567,6 +546,7 @@ void ViewImplementation::traverse_the_history_by_delta(
     if (on_before_browser_initiated_navigation)
         on_before_browser_initiated_navigation();
 
+    prepare_for_navigation_after_crash();
     m_top_level_traversable.traverse_the_history_by_delta(delta, check_for_cancelation, move(on_ready));
 }
 
@@ -586,13 +566,12 @@ void ViewImplementation::traverse_the_history_to_step(
     if (on_before_browser_initiated_navigation)
         on_before_browser_initiated_navigation();
 
+    prepare_for_navigation_after_crash();
     m_top_level_traversable.traverse_the_history_to_step(step, check_for_cancelation, move(on_ready));
 }
 
 void ViewImplementation::will_apply_history_traversal_step(Web::HTML::CrossProcessId operation_id)
 {
-    m_should_suppress_history_for_current_load = false;
-    m_should_suppress_history_for_next_load = false;
     m_history_visit_transition_for_next_load = HistoryVisitTransition::Restore;
     if (m_webdriver_navigation_observation.has_value()
         && m_webdriver_navigation_observation->completion_source == WebDriverNavigationCompletionSource::CrashRecovery) {
@@ -2340,19 +2319,7 @@ void ViewImplementation::did_start_navigation(Optional<Utf16String> navigation_i
     ongoing.has_started = true;
 
     set_loading_state(true);
-    if (m_should_suppress_history_for_next_load || m_should_suppress_history_for_current_load)
-        return;
-
-    auto was_showing_crash_page = exchange(m_is_showing_crash_page, false);
-    auto started_from_crash_page = false;
-    if (was_showing_crash_page) {
-        auto const* current_entry = m_top_level_traversable.session_history().current_entry();
-        started_from_crash_page = current_entry && current_entry->url == url;
-    }
-
-    auto dump_reason = started_from_crash_page ? "did-start-navigation-from-crash-page"sv : "did-start-navigation"sv;
-
-    dump_session_history(dump_reason);
+    dump_session_history("did-start-navigation"sv);
 }
 
 bool ViewImplementation::did_cancel_navigation(Optional<Utf16String> const& navigation_id)
@@ -2413,10 +2380,6 @@ void ViewImplementation::did_finish_navigation()
     auto navigation_id = m_webdriver_navigation_observation->navigation_id;
     switch (m_webdriver_navigation_observation->completion_source) {
     case WebDriverNavigationCompletionSource::CrashRecovery:
-        // A replacement process's bootstrap about:blank finishes before the recovery has populated its
-        // document; only a load finishing once the process hosts the committed entry is the recovery's.
-        if (!m_client_state.hosts_committed_entry)
-            break;
         m_webdriver_navigation_observation->load_completed = true;
         if (m_webdriver_navigation_observation->history_operation_completed)
             complete_webdriver_navigation(navigation_id);
@@ -2476,6 +2439,11 @@ void ViewImplementation::apply_webdriver_session_config(WebDriverSessionConfig c
 
 void ViewImplementation::run_webdriver_content_command(u64 command_id, String const& name, JsonValue payload, Vector<String> arguments)
 {
+    if (m_crash_state.has_value() && !m_crash_state->recovery_started) {
+        Application::the().complete_webdriver_content_command(command_id, Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnknownError, "WebContent has crashed"sv));
+        return;
+    }
+
     if (name == "crash_current_page"sv)
         m_pending_webdriver_crash_command_ids.set(command_id);
     else
@@ -2535,6 +2503,12 @@ void ViewImplementation::did_close_browsing_context(Badge<WebContentClient>)
 
 void ViewImplementation::run_webdriver_user_prompt_handling(Function<void(Web::WebDriver::Response)> on_complete)
 {
+    // A dormant replacement process cannot have a user prompt belonging to the crashed document.
+    if (m_crash_state.has_value()) {
+        on_complete(JsonValue {});
+        return;
+    }
+
     auto request_id = m_next_webdriver_user_prompt_request_id++;
     m_pending_webdriver_user_prompt_requests.set(request_id, move(on_complete));
     client().async_run_webdriver_user_prompt_handling(page_id(), request_id);
@@ -2557,6 +2531,7 @@ Optional<ViewImplementation&> ViewImplementation::find_view_by_handle(StringView
 
 void ViewImplementation::load_for_webdriver_navigation(URL::URL const& url)
 {
+    prepare_for_navigation_after_crash(url);
     auto navigation_id = generate_navigation_id();
     m_top_level_traversable.set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
         .url = url,
@@ -2658,6 +2633,7 @@ JsonValue ViewImplementation::webdriver_session_history() const
     serialized.set("webContentProcessID"sv, client().pid());
     serialized.set("backButtonEnabled"sv, m_navigate_back_action->enabled());
     serialized.set("forwardButtonEnabled"sv, m_navigate_forward_action->enabled());
+    serialized.set("crashOverlayActive"sv, crash_overlay_active());
     serialized.set("hasOnlyTopLevelUsedSteps"sv, m_top_level_traversable.session_history().has_only_top_level_used_steps());
 
     if (auto current_used_step_index = m_top_level_traversable.session_history().current_used_step_index(); current_used_step_index.has_value())
@@ -2950,8 +2926,14 @@ void ViewImplementation::dump_session_history(StringView reason, SessionHistoryD
         history_log_entries(m_top_level_traversable.session_history()));
 }
 
-void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_error_page)
+void ViewImplementation::handle_web_content_process_crash()
 {
+    auto failed_url = m_url;
+    Optional<URL::URL> navigation_to_retry;
+    auto const* current_entry = m_top_level_traversable.session_history().current_entry();
+    if (!current_entry || current_entry->url != failed_url)
+        navigation_to_retry = failed_url;
+
     reject_pending_selection_requests();
 
     set_loading_state(false);
@@ -2967,42 +2949,71 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     for (auto command_id : pending_command_ids)
         Application::the().complete_webdriver_content_command(command_id, Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnknownError, "WebContent crashed while executing the command"sv));
 
-    auto const headless_mode = Application::browser_options().headless_mode.has_value();
+    auto crashed_during_recovery = m_webdriver_navigation_observation.has_value()
+        && m_webdriver_navigation_observation->completion_source == WebDriverNavigationCompletionSource::CrashRecovery;
+    m_webdriver_navigation_observation.clear();
+    auto pending_navigation_completion_requests = move(m_pending_webdriver_navigation_completion_requests);
+    for (auto& request : pending_navigation_completion_requests) {
+        if (request.value->timer)
+            request.value->timer->stop();
+        request.value->on_complete(Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnknownError, "WebContent crashed while waiting for navigation"sv));
+    }
 
-    if (!headless_mode) {
-        dbgln("\033[31;1mWebContent process crashed!\033[0m Last page loaded: {}", m_url);
+    enum class RecoveryMode {
+        ShowOverlay,
+        Restore,
+        PrepareForNextNavigation,
+    };
+
+    auto recovery_mode = RecoveryMode::ShowOverlay;
+    if (auto const& headless_mode = Application::browser_options().headless_mode; headless_mode.has_value())
+        recovery_mode = *headless_mode == HeadlessMode::Test ? RecoveryMode::PrepareForNextNavigation : RecoveryMode::Restore;
+
+    if (recovery_mode == RecoveryMode::ShowOverlay) {
+        dbgln("\033[31;1mWebContent process crashed!\033[0m Last page loaded: {}", failed_url);
         dbgln("Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues/new/choose");
     }
 
-    ++m_crash_count;
     reset_page_media_state();
 
     constexpr size_t max_reasonable_crash_count = 5U;
-    if (m_crash_count >= max_reasonable_crash_count) {
-        if (!headless_mode) {
-            dbgln("WebContent has crashed {} times in quick succession! Not restarting...", m_crash_count);
-            m_repeated_crash_timer->stop();
-            for (auto command_id : pending_crash_command_ids)
-                Application::the().complete_webdriver_content_command(command_id, Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnknownError, "WebContent crashed repeatedly and was not restarted"sv));
-            if (auto queue_promise = move(m_pending_session_history_reset_queue_promise))
-                queue_promise->resolve({});
-            return;
-        }
-        // In headless mode, always respawn - tests need a working WebContent for each test.
-        // Reset the crash count so we can continue running tests.
-        m_crash_count = 0;
+    auto crashed_repeatedly = false;
+    if (recovery_mode == RecoveryMode::Restore) {
+        // Only count crashes from the replacement page towards the loop limit. Separate, explicitly triggered
+        // crashes may happen close together without indicating that automatic restoration is crash-looping.
+        if (!crashed_during_recovery)
+            m_crash_count = 0;
+        crashed_repeatedly = ++m_crash_count >= max_reasonable_crash_count;
+        m_repeated_crash_timer->restart();
     }
-    m_repeated_crash_timer->restart();
-
-    // In headless mode, respawn WebContent but skip the error page.
-    if (headless_mode)
-        load_error_page = LoadErrorPage::No;
 
     auto crashed_endpoint = CanonicalTraversable::HistoryJobEndpoint {
         m_client_state.client,
         page_id(),
     };
 
+    respawn_web_content_process_after_crash();
+
+    // A repeatedly crashing headless page is left dormant so the next WebDriver test or explicit navigation can
+    // proceed without feeding an automatic restore loop.
+    if (recovery_mode == RecoveryMode::Restore && !crashed_repeatedly) {
+        recover_current_session_history_entry_with_history_operation(move(crashed_endpoint));
+    } else if (recovery_mode == RecoveryMode::ShowOverlay) {
+        m_top_level_traversable.abandon_after_web_content_process_crash();
+        set_crash_state(CrashState {
+            .failed_url = move(failed_url),
+            .navigation_to_retry = move(navigation_to_retry),
+        });
+    } else {
+        m_top_level_traversable.abandon_after_web_content_process_crash();
+    }
+
+    for (auto command_id : pending_crash_command_ids)
+        Application::the().complete_webdriver_content_command(command_id, JsonValue {});
+}
+
+void ViewImplementation::respawn_web_content_process_after_crash()
+{
     m_history_operation_handling_for_next_client = HistoryOperationHandling::Preserve;
     Optional<Web::HTML::CrossProcessId> initial_document_state_id;
     Optional<URL::URL> process_site_url;
@@ -3025,24 +3036,28 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     m_backup_shared_image_buffer = nullptr;
 
     handle_resize();
+}
 
-    if (load_error_page == LoadErrorPage::Yes) {
-        m_top_level_traversable.abandon_after_web_content_process_crash();
-        auto escaped_url = escape_html_entities(m_url.serialize());
+void ViewImplementation::prepare_for_navigation_after_crash(Optional<URL::URL> navigation_to_retry)
+{
+    if (!m_crash_state.has_value())
+        return;
 
-        StringBuilder builder;
-        builder.appendff(ERROR_HTML_HEADER, NO_FALLBACK_FAVICON_LINK, CRASH_ERROR_SVG, "Ladybird flew off-course!"sv);
-        builder.appendff("<p>The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.</p>", escaped_url, escaped_url);
-        builder.append(ERROR_HTML_FOOTER);
-        load_crash_page_html(builder.string_view(), m_url);
-    } else {
-        m_should_suppress_history_for_current_load = false;
-        m_should_suppress_history_for_next_load = false;
-        recover_current_session_history_entry_with_history_operation(move(crashed_endpoint));
-    }
+    m_crash_state->navigation_to_retry = move(navigation_to_retry);
+    m_crash_state->recovery_started = true;
+}
 
-    for (auto command_id : pending_crash_command_ids)
-        Application::the().complete_webdriver_content_command(command_id, JsonValue {});
+void ViewImplementation::set_crash_state(Optional<CrashState> state)
+{
+    auto active = state.has_value();
+    m_crash_state = move(state);
+    if (on_crash_overlay_state_change)
+        on_crash_overlay_state_change(active);
+}
+
+String ViewImplementation::crash_overlay_failed_url() const
+{
+    return m_crash_state.has_value() ? m_crash_state->failed_url.serialize() : m_url.serialize();
 }
 
 void ViewImplementation::default_zoom_level_factor_changed()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -130,6 +130,12 @@ public:
     bool is_loading() const { return m_is_loading; }
     bool cancel_uncommitted_top_level_navigation_for_browser_traversal();
 
+    bool crash_overlay_active() const { return m_crash_state.has_value(); }
+    static constexpr StringView crash_overlay_title() { return "Ladybird flew off-course!"sv; }
+    static constexpr StringView crash_overlay_message() { return "The web page has crashed.\nYou can reload the page to try again."sv; }
+    static constexpr StringView crash_overlay_reload_button_text() { return "Reload Page"sv; }
+    String crash_overlay_failed_url() const;
+
     struct SessionHistoryTraversalMenuItem {
         i32 step { 0 };
         String title;
@@ -460,6 +466,7 @@ public:
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void(Web::ScreenWakeLockState)> on_screen_wake_lock_state_changed;
     Function<void()> on_web_content_crashed;
+    Function<void(bool)> on_crash_overlay_state_change;
     Function<void()> on_web_content_process_change_for_cross_site_navigation;
 
     Menu& page_context_menu() { return *m_page_context_menu; }
@@ -553,7 +560,6 @@ protected:
     void set_page_background_color_to_system_canvas(bool dark);
     void set_page_background_color(Gfx::Color);
     Gfx::Color preferred_canvas_background_color() const;
-    void load_crash_page_html(StringView, URL::URL const& crashed_url);
 
     enum class CreateNewClient {
         No,
@@ -563,11 +569,11 @@ protected:
     void cancel_all_native_geolocation_requests();
     void reset_page_media_state();
 
-    enum class LoadErrorPage {
-        No,
-        Yes,
-    };
-    void handle_web_content_process_crash(LoadErrorPage = LoadErrorPage::Yes);
+    struct CrashState;
+    void handle_web_content_process_crash();
+    void respawn_web_content_process_after_crash();
+    void prepare_for_navigation_after_crash(Optional<URL::URL> navigation_to_retry = {});
+    void set_crash_state(Optional<CrashState>);
 
     virtual void default_zoom_level_factor_changed() override;
     virtual void zoom_per_host_changed(StringView host) override;
@@ -627,7 +633,13 @@ protected:
     URL::URL m_url;
     Utf16String m_title;
     Optional<String> m_favicon_hash;
-    bool m_is_showing_crash_page { false };
+
+    struct CrashState {
+        URL::URL failed_url;
+        Optional<URL::URL> navigation_to_retry;
+        bool recovery_started { false };
+    };
+    Optional<CrashState> m_crash_state;
 
     double m_zoom_level { 1.0 };
     double m_device_pixel_ratio { 1.0 };
@@ -717,8 +729,6 @@ protected:
     Gfx::Color m_system_canvas_background_color { 255, 255, 255 };
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
-    bool m_should_suppress_history_for_current_load { false };
-    bool m_should_suppress_history_for_next_load { false };
     HistoryVisitTransition m_history_visit_transition_for_current_load { HistoryVisitTransition::Link };
     HistoryVisitTransition m_history_visit_transition_for_next_load { HistoryVisitTransition::Link };
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -903,8 +903,6 @@ void WebContentClient::begin_top_level_load(ViewImplementation& view, u64 page_i
 
     view.m_history_visit_transition_for_current_load = view.m_history_visit_transition_for_next_load;
     view.m_history_visit_transition_for_next_load = HistoryVisitTransition::Link;
-    view.m_should_suppress_history_for_current_load = view.m_should_suppress_history_for_next_load;
-    view.m_should_suppress_history_for_next_load = false;
     view.did_start_navigation(move(navigation_id), url);
 
     view.set_url({}, url);
@@ -1023,30 +1021,31 @@ void WebContentClient::did_finish_loading(u64 page_id, Optional<Utf16String> nav
         if (!view->matches_ongoing_navigation(navigation_id))
             return;
 
+        // A replacement process's bootstrap about:blank finishes before the process hosts the committed
+        // entry; it must not surface in the view or overwrite the crashed page's URL.
+        if (!view->m_client_state.hosts_committed_entry)
+            return;
+
         auto client_url = url;
-        // Browser-generated pages can finish with an internal document URL. Keep exposing the URL accepted at load
-        // start for suppressed loads. Documents created for inline error content finish with about:error; keep the URL
-        // the view already shows, which for a failed navigation is the URL that failed to load, including any redirects
-        // the navigation was taken through. Firefox/Chromium likewise never surface their internal error-document URLs.
-        if (view->m_should_suppress_history_for_current_load || url == URL::about_error())
+        // Documents created for inline error content finish with the internal about:error URL; keep the URL the view
+        // already shows, which for a failed navigation is the URL that failed to load, including any redirects the
+        // navigation was taken through. Firefox/Chromium likewise never surface their internal error-document URLs.
+        if (url == URL::about_error())
             client_url = view->url();
         else
             view->set_url({}, url);
-        auto should_update_history = !view->m_should_suppress_history_for_current_load;
         auto title = history_title(view->title(), url);
 
-        if (should_update_history) {
-            dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Load finished for page {} at '{}' with title '{}'",
-                page_id,
-                url,
-                title.has_value() ? title->bytes_as_string_view() : "<none>"sv);
+        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Load finished for page {} at '{}' with title '{}'",
+            page_id,
+            url,
+            title.has_value() ? title->bytes_as_string_view() : "<none>"sv);
 
-            maybe_record_history_visit_for_current_load(page_id, url, title, "load finish"sv);
-            if (title.has_value())
-                Application::history_store(m_is_private).update_title(url, *title);
-            if (view->favicon_hash().has_value())
-                Application::history_store(m_is_private).update_favicon(url, *view->favicon_hash());
-        }
+        maybe_record_history_visit_for_current_load(page_id, url, title, "load finish"sv);
+        if (title.has_value())
+            Application::history_store(m_is_private).update_title(url, *title);
+        if (view->favicon_hash().has_value())
+            Application::history_store(m_is_private).update_favicon(url, *view->favicon_hash());
 
         view->did_finish_navigation();
 
@@ -1122,7 +1121,7 @@ void WebContentClient::did_change_title(u64 page_id, Utf16String title)
         process->set_title(title);
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (!title.is_empty() && !view->m_should_suppress_history_for_current_load) {
+        if (!title.is_empty()) {
             auto title_utf8 = title.to_utf8();
 
             maybe_record_history_visit_for_current_load(page_id, view->url(), title_utf8, "title change"sv);
@@ -1699,8 +1698,7 @@ void WebContentClient::did_change_favicon(u64 page_id, Gfx::ShareableBitmap favi
     }
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (!view->m_should_suppress_history_for_current_load)
-            maybe_record_history_visit_for_current_load(page_id, view->url(), history_title(view->title(), view->url()), "favicon change"sv);
+        maybe_record_history_visit_for_current_load(page_id, view->url(), history_title(view->title(), view->url()), "favicon change"sv);
         view->set_favicon({}, *favicon.bitmap());
     }
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -347,12 +347,6 @@ void ConnectionFromClient::load_html(u64 page_id, ByteString html, Utf16String n
         page->page().load_html(html, move(navigation_id));
 }
 
-void ConnectionFromClient::load_html_with_url(u64 page_id, ByteString html, URL::URL url, Utf16String navigation_id)
-{
-    if (auto page = this->page(page_id); page.has_value())
-        page->page().load_html(html, url, move(navigation_id));
-}
-
 void ConnectionFromClient::reload(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -96,7 +96,6 @@ private:
     virtual void load_url(u64 page_id, URL::URL, Web::Bindings::NavigationHistoryBehavior, Utf16String navigation_id) override;
     virtual void populate_navigation(u64 page_id, Web::HTML::NavigationPopulationRequest, Web::HTML::NavigationPopulationResult) override;
     virtual void load_html(u64 page_id, ByteString, Utf16String navigation_id) override;
-    virtual void load_html_with_url(u64 page_id, ByteString, URL::URL, Utf16String navigation_id) override;
     virtual void reload(u64 page_id) override;
     virtual void stop_loading(u64 page_id) override;
     virtual void cancel_download(u64 page_id, u64 download_id) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -72,7 +72,6 @@ endpoint WebContentServer
     load_url(u64 page_id, URL::URL url, Web::Bindings::NavigationHistoryBehavior history_handling, Utf16String navigation_id) =|
     populate_navigation(u64 page_id, Web::HTML::NavigationPopulationRequest request, Web::HTML::NavigationPopulationResult result) =|
     load_html(u64 page_id, ByteString html, Utf16String navigation_id) =|
-    load_html_with_url(u64 page_id, ByteString html, URL::URL url, Utf16String navigation_id) =|
     reload(u64 page_id) =|
     stop_loading(u64 page_id) =|
     cancel_download(u64 page_id, u64 download_id) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -141,9 +141,13 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @property (nonatomic, strong) NSMenu* media_context_menu;
 @property (nonatomic, strong) NSMenu* select_dropdown;
 @property (nonatomic, strong) NSTextField* status_label;
+@property (nonatomic, strong) NSBox* crash_overlay;
+@property (nonatomic, strong) NSTextField* crash_overlay_url;
 @property (nonatomic, strong) NSAlert* dialog;
 @property (nonatomic, strong) NSAlert* external_url_confirmation_dialog;
+@property (nonatomic, strong) NSOpenPanel* file_picker;
 @property (nonatomic, strong) NSMagnificationGestureRecognizer* pinch_recognizer;
+@property (nonatomic, assign) BOOL suppress_select_dropdown_close;
 
 // NSEvent does not provide a way to mark whether it has been handled, nor can we attach user data to the event. So
 // when we dispatch the event for a second time after WebContent has had a chance to handle it, we must track that
@@ -159,9 +163,13 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
 @end
 
+// NSColorPanel only exposes a target setter, so track the owner of its shared instance ourselves.
+static __weak LadybirdWebView* s_color_panel_owner;
+
 @implementation LadybirdWebView
 
 @synthesize status_label = _status_label;
+@synthesize crash_overlay = _crash_overlay;
 
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer
            isPrivate:(WebView::IsPrivate)is_private
@@ -430,6 +438,56 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         }
     };
 
+    m_web_view_bridge->on_crash_overlay_state_change = [weak_self](bool active) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+        if (active) {
+            auto* overlay = self.crash_overlay;
+            [self.crash_overlay_url setStringValue:Ladybird::string_to_ns_string(self->m_web_view_bridge->crash_overlay_failed_url())];
+            [overlay setHidden:NO];
+            [self addSubview:overlay positioned:NSWindowAbove relativeTo:nil];
+        } else if (self->_crash_overlay != nil) {
+            [self.crash_overlay setHidden:YES];
+        }
+    };
+
+    m_web_view_bridge->on_web_content_crashed = [weak_self]() {
+        LadybirdWebView* self = weak_self;
+        if (self == nil)
+            return;
+
+        if (self.dialog != nil) {
+            auto* dialog = self.dialog;
+            self.dialog = nil;
+            [[self window] endSheet:[dialog window] returnCode:NSModalResponseCancel];
+        }
+        if (self.file_picker != nil) {
+            auto* file_picker = self.file_picker;
+            self.file_picker = nil;
+            [[self window] endSheet:file_picker returnCode:NSModalResponseCancel];
+        }
+        if (self.external_url_confirmation_dialog != nil) {
+            // NB: Not cleared first; its completion handler stays in the UI process and must still run to
+            //     complete the pending external URL request.
+            [[self window] endSheet:[self.external_url_confirmation_dialog window] returnCode:NSModalResponseCancel];
+        }
+        if (self.select_dropdown != nil) {
+            self.suppress_select_dropdown_close = YES;
+            [self.select_dropdown cancelTracking];
+        }
+
+        auto* color_panel = [NSColorPanel sharedColorPanel];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:color_panel];
+        if (s_color_panel_owner == self) {
+            s_color_panel_owner = nil;
+            [color_panel setTarget:nil];
+            [color_panel setAction:nil];
+            [color_panel orderOut:nil];
+        }
+    };
+
     m_web_view_bridge->on_loading_state_change = [weak_self](bool is_loading) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
@@ -681,14 +739,17 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         }
         auto* ns_message = Ladybird::utf16_string_to_ns_string(message);
 
-        self.dialog = [[NSAlert alloc] init];
-        [self.dialog setMessageText:ns_message];
+        auto* dialog = [[NSAlert alloc] init];
+        self.dialog = dialog;
+        [dialog setMessageText:ns_message];
 
-        [self.dialog beginSheetModalForWindow:[self window]
-                            completionHandler:^(NSModalResponse) {
-                                m_web_view_bridge->alert_closed();
-                                self.dialog = nil;
-                            }];
+        [dialog beginSheetModalForWindow:[self window]
+                       completionHandler:^(NSModalResponse) {
+                           if (self.dialog != dialog)
+                               return;
+                           m_web_view_bridge->alert_closed();
+                           self.dialog = nil;
+                       }];
     };
 
     m_web_view_bridge->on_request_confirm = [weak_self](auto const& message) {
@@ -698,16 +759,19 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         }
         auto* ns_message = Ladybird::utf16_string_to_ns_string(message);
 
-        self.dialog = [[NSAlert alloc] init];
-        [[self.dialog addButtonWithTitle:@"OK"] setTag:NSModalResponseOK];
-        [[self.dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
-        [self.dialog setMessageText:ns_message];
+        auto* dialog = [[NSAlert alloc] init];
+        self.dialog = dialog;
+        [[dialog addButtonWithTitle:@"OK"] setTag:NSModalResponseOK];
+        [[dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
+        [dialog setMessageText:ns_message];
 
-        [self.dialog beginSheetModalForWindow:[self window]
-                            completionHandler:^(NSModalResponse response) {
-                                m_web_view_bridge->confirm_closed(response == NSModalResponseOK);
-                                self.dialog = nil;
-                            }];
+        [dialog beginSheetModalForWindow:[self window]
+                       completionHandler:^(NSModalResponse response) {
+                           if (self.dialog != dialog)
+                               return;
+                           m_web_view_bridge->confirm_closed(response == NSModalResponseOK);
+                           self.dialog = nil;
+                       }];
     };
 
     m_web_view_bridge->on_request_prompt = [weak_self](auto const& message, auto const& default_) {
@@ -721,25 +785,28 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         auto* input = [[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, 200, 24)];
         [input setStringValue:ns_default];
 
-        self.dialog = [[NSAlert alloc] init];
-        [[self.dialog addButtonWithTitle:@"OK"] setTag:NSModalResponseOK];
-        [[self.dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
-        [self.dialog setMessageText:ns_message];
-        [self.dialog setAccessoryView:input];
+        auto* dialog = [[NSAlert alloc] init];
+        self.dialog = dialog;
+        [[dialog addButtonWithTitle:@"OK"] setTag:NSModalResponseOK];
+        [[dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
+        [dialog setMessageText:ns_message];
+        [dialog setAccessoryView:input];
 
-        self.dialog.window.initialFirstResponder = input;
+        dialog.window.initialFirstResponder = input;
 
-        [self.dialog beginSheetModalForWindow:[self window]
-                            completionHandler:^(NSModalResponse response) {
-                                Optional<Utf16String> text;
+        [dialog beginSheetModalForWindow:[self window]
+                       completionHandler:^(NSModalResponse response) {
+                           if (self.dialog != dialog)
+                               return;
+                           Optional<Utf16String> text;
 
-                                if (response == NSModalResponseOK) {
-                                    text = Ladybird::ns_string_to_utf16_string([input stringValue]);
-                                }
+                           if (response == NSModalResponseOK) {
+                               text = Ladybird::ns_string_to_utf16_string([input stringValue]);
+                           }
 
-                                m_web_view_bridge->prompt_closed(move(text));
-                                self.dialog = nil;
-                            }];
+                           m_web_view_bridge->prompt_closed(move(text));
+                           self.dialog = nil;
+                       }];
     };
 
     m_web_view_bridge->on_request_set_prompt_text = [weak_self](auto const& message) {
@@ -820,10 +887,16 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         auto* panel = [NSColorPanel sharedColorPanel];
         [panel setColor:Ladybird::gfx_color_to_ns_color(current_color)];
         [panel setShowsAlpha:NO];
+
+        NSNotificationCenter* notification_center = [NSNotificationCenter defaultCenter];
+        LadybirdWebView* previous_owner = s_color_panel_owner;
+        if (previous_owner != nil)
+            [notification_center removeObserver:previous_owner name:NSWindowWillCloseNotification object:panel];
+
+        s_color_panel_owner = self;
         [panel setTarget:self];
         [panel setAction:@selector(colorPickerUpdate:)];
 
-        NSNotificationCenter* notification_center = [NSNotificationCenter defaultCenter];
         [notification_center addObserver:self
                                 selector:@selector(colorPickerClosed:)
                                     name:NSWindowWillCloseNotification
@@ -838,6 +911,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
             return;
         }
         auto* panel = [NSOpenPanel openPanel];
+        self.file_picker = panel;
         [panel setCanChooseFiles:YES];
         [panel setCanChooseDirectories:NO];
 
@@ -888,6 +962,9 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
         [panel beginSheetModalForWindow:[self window]
                       completionHandler:^(NSInteger result) {
+                          if (self.file_picker != panel)
+                              return;
+                          self.file_picker = nil;
                           Vector<Web::HTML::SelectedFile> selected_files;
 
                           auto create_selected_file = [&](NSString* ns_file_path) {
@@ -917,6 +994,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         if (self == nil) {
             return;
         }
+        self.suppress_select_dropdown_close = NO;
         [self.select_dropdown removeAllItems];
         self.select_dropdown.minimumWidth = minimum_width;
 
@@ -1091,6 +1169,10 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
 - (void)menuDidClose:(NSMenu*)menu
 {
+    if (self.suppress_select_dropdown_close) {
+        self.suppress_select_dropdown_close = NO;
+        return;
+    }
     if (!menu.highlightedItem)
         m_web_view_bridge->select_dropdown_closed({});
 }
@@ -1102,7 +1184,15 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
 - (void)colorPickerClosed:(NSNotification*)notification
 {
-    m_web_view_bridge->color_picker_update(Ladybird::ns_color_to_gfx_color([NSColorPanel sharedColorPanel].color), Web::HTML::ColorPickerUpdateState::Closed);
+    if (s_color_panel_owner != self)
+        return;
+
+    auto* color_panel = [NSColorPanel sharedColorPanel];
+    s_color_panel_owner = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:color_panel];
+    [color_panel setTarget:nil];
+    [color_panel setAction:nil];
+    m_web_view_bridge->color_picker_update(Ladybird::ns_color_to_gfx_color(color_panel.color), Web::HTML::ColorPickerUpdateState::Closed);
 }
 
 #pragma mark - Properties
@@ -1115,10 +1205,129 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         [_status_label setBordered:YES];
         [_status_label setHidden:YES];
 
-        [self addSubview:_status_label];
+        if (_crash_overlay != nil)
+            [self addSubview:_status_label positioned:NSWindowBelow relativeTo:_crash_overlay];
+        else
+            [self addSubview:_status_label];
     }
 
     return _status_label;
+}
+
+// Sad-page glyph, stroked from 17.5x21.5 source coordinates at 64px tall.
+static NSImage* crash_overlay_icon()
+{
+    static NSImage* icon;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        icon = [NSImage imageWithSize:NSMakeSize(52, 64)
+                              flipped:YES
+                       drawingHandler:^BOOL(NSRect destination) {
+                           auto* transform = [NSAffineTransform transform];
+                           [transform scaleXBy:destination.size.width / 17.5 yBy:destination.size.height / 21.5];
+
+                           auto* page_outline = [NSBezierPath bezierPath];
+                           [page_outline moveToPoint:NSMakePoint(11.75, 0.75)];
+                           [page_outline lineToPoint:NSMakePoint(2.75, 0.75)];
+                           [page_outline curveToPoint:NSMakePoint(0.75, 2.75) controlPoint1:NSMakePoint(1.65, 0.75) controlPoint2:NSMakePoint(0.75, 1.65)];
+                           [page_outline lineToPoint:NSMakePoint(0.75, 18.75)];
+                           [page_outline curveToPoint:NSMakePoint(2.75, 20.75) controlPoint1:NSMakePoint(0.75, 19.85) controlPoint2:NSMakePoint(1.65, 20.75)];
+                           [page_outline lineToPoint:NSMakePoint(14.75, 20.75)];
+                           [page_outline curveToPoint:NSMakePoint(16.75, 18.75) controlPoint1:NSMakePoint(15.85, 20.75) controlPoint2:NSMakePoint(16.75, 19.85)];
+                           [page_outline lineToPoint:NSMakePoint(16.75, 5.75)];
+                           [page_outline closePath];
+
+                           auto* page_details = [NSBezierPath bezierPath];
+                           [page_details moveToPoint:NSMakePoint(10.75, 0.75)];
+                           [page_details lineToPoint:NSMakePoint(10.75, 4.75)];
+                           [page_details curveToPoint:NSMakePoint(12.75, 6.75) controlPoint1:NSMakePoint(10.75, 5.85) controlPoint2:NSMakePoint(11.65, 6.75)];
+                           [page_details lineToPoint:NSMakePoint(16.75, 6.75)];
+                           [page_details moveToPoint:NSMakePoint(4.75, 9.75)];
+                           [page_details lineToPoint:NSMakePoint(6.75, 11.75)];
+                           [page_details moveToPoint:NSMakePoint(6.75, 9.75)];
+                           [page_details lineToPoint:NSMakePoint(4.75, 11.75)];
+                           [page_details moveToPoint:NSMakePoint(10.75, 9.75)];
+                           [page_details lineToPoint:NSMakePoint(12.75, 11.75)];
+                           [page_details moveToPoint:NSMakePoint(12.75, 9.75)];
+                           [page_details lineToPoint:NSMakePoint(10.75, 11.75)];
+                           [page_details moveToPoint:NSMakePoint(5.75, 16.75)];
+                           [page_details curveToPoint:NSMakePoint(11.75, 16.75) controlPoint1:NSMakePoint(6.75, 14.08) controlPoint2:NSMakePoint(10.75, 14.08)];
+
+                           for (NSBezierPath* path in @[ page_outline, page_details ]) {
+                               [path transformUsingAffineTransform:transform];
+                               [path setLineWidth:1.5 * destination.size.height / 21.5];
+                               [path setLineCapStyle:NSLineCapStyleRound];
+                               [path setLineJoinStyle:NSLineJoinStyleRound];
+                               [[NSColor blackColor] setStroke];
+                               [path stroke];
+                           }
+                           return YES;
+                       }];
+        [icon setTemplate:YES];
+    });
+    return icon;
+}
+
+- (NSBox*)crash_overlay
+{
+    if (!_crash_overlay) {
+        auto* icon_view = [NSImageView imageViewWithImage:crash_overlay_icon()];
+        [icon_view setContentTintColor:[NSColor labelColor]];
+
+        auto* title = [NSTextField labelWithString:Ladybird::string_to_ns_string(WebView::ViewImplementation::crash_overlay_title())];
+        [title setFont:[NSFont boldSystemFontOfSize:24]];
+        [title setAlignment:NSTextAlignmentCenter];
+        [title setSelectable:YES];
+
+        self.crash_overlay_url = [NSTextField labelWithString:@""];
+        [self.crash_overlay_url setAlignment:NSTextAlignmentCenter];
+        [self.crash_overlay_url setTextColor:[NSColor secondaryLabelColor]];
+        [self.crash_overlay_url setLineBreakMode:NSLineBreakByTruncatingMiddle];
+        [self.crash_overlay_url setSelectable:YES];
+        [self.crash_overlay_url setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+                                                         forOrientation:NSLayoutConstraintOrientationHorizontal];
+
+        auto* message = [NSTextField wrappingLabelWithString:Ladybird::string_to_ns_string(WebView::ViewImplementation::crash_overlay_message())];
+        [message setAlignment:NSTextAlignmentCenter];
+        [message setTextColor:[NSColor secondaryLabelColor]];
+
+        auto* reload_button = [NSButton buttonWithTitle:Ladybird::string_to_ns_string(WebView::ViewImplementation::crash_overlay_reload_button_text())
+                                                 target:self
+                                                 action:@selector(reloadFromCrashOverlay:)];
+        [reload_button setKeyEquivalent:@"\r"];
+
+        auto* stack = [NSStackView stackViewWithViews:@[ icon_view, title, self.crash_overlay_url, message, reload_button ]];
+        [stack setOrientation:NSUserInterfaceLayoutOrientationVertical];
+        [stack setAlignment:NSLayoutAttributeCenterX];
+        [stack setSpacing:12];
+        [stack setCustomSpacing:32 afterView:icon_view];
+        [stack setCustomSpacing:16 afterView:title];
+        [stack setCustomSpacing:24 afterView:message];
+        [stack setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+        _crash_overlay = [[NSBox alloc] init];
+        [_crash_overlay setBoxType:NSBoxCustom];
+        [_crash_overlay setBorderWidth:0];
+        [_crash_overlay setFillColor:[NSColor windowBackgroundColor]];
+        [_crash_overlay setTransparent:NO];
+        [_crash_overlay setHidden:YES];
+
+        [_crash_overlay addSubview:stack];
+        [[stack centerXAnchor] constraintEqualToAnchor:[_crash_overlay centerXAnchor]].active = YES;
+        [[stack centerYAnchor] constraintEqualToAnchor:[_crash_overlay centerYAnchor]].active = YES;
+        [[stack widthAnchor] constraintLessThanOrEqualToAnchor:[_crash_overlay widthAnchor] constant:-40].active = YES;
+
+        [_crash_overlay setFrame:[self bounds]];
+        [_crash_overlay setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [self addSubview:_crash_overlay positioned:NSWindowAbove relativeTo:nil];
+    }
+
+    return _crash_overlay;
+}
+
+- (void)reloadFromCrashOverlay:(id)sender
+{
+    m_web_view_bridge->reload();
 }
 
 #pragma mark - NSView

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -897,6 +897,24 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_web_content_crashed = [this] {
         m_suppress_javascript_dialogs_until_navigation = false;
         m_javascript_dialog->reset();
+
+        // Close pickers owned by the crashed renderer with their completion signals disconnected; they
+        // must not reply to its replacement.
+        if (m_color_picker_dialog) {
+            auto* dialog = m_color_picker_dialog.data();
+            m_color_picker_dialog = nullptr;
+            QObject::disconnect(dialog, nullptr, this, nullptr);
+            dialog->close();
+            dialog->deleteLater();
+        }
+        if (m_file_picker_dialog) {
+            auto* dialog = m_file_picker_dialog.data();
+            m_file_picker_dialog = nullptr;
+            QObject::disconnect(dialog, nullptr, this, nullptr);
+            dialog->close();
+        }
+        if (m_external_url_confirmation_dialog)
+            m_external_url_confirmation_dialog->close();
     };
 
     view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
@@ -967,17 +985,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     view().on_request_file_picker = [this](auto const& accepted_file_types, auto allow_multiple_files) {
-        Vector<Web::HTML::SelectedFile> selected_files;
-
-        auto create_selected_file = [&](auto const& qfile_path) {
-            auto file_path = ak_byte_string_from_qstring(qfile_path);
-
-            if (auto file = WebView::create_selected_file(file_path); file.is_error())
-                warnln("Unable to open file {}: {}", file_path, file.error());
-            else
-                selected_files.append(file.release_value());
-        };
-
         QStringList accepted_file_filters;
         QMimeDatabase mime_database;
 
@@ -1023,18 +1030,32 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         accepted_file_filters.size() > 1 ? accepted_file_filters.prepend("All files (*)") : accepted_file_filters.append("All files (*)");
         auto filters = accepted_file_filters.join(";;");
 
-        if (allow_multiple_files == Web::HTML::AllowMultipleFiles::Yes) {
-            auto paths = QFileDialog::getOpenFileNames(this, "Select files", QDir::homePath(), filters);
-            selected_files.ensure_capacity(static_cast<size_t>(paths.size()));
+        auto allow_multiple = allow_multiple_files == Web::HTML::AllowMultipleFiles::Yes;
+        auto* dialog = new QFileDialog(this, allow_multiple ? "Select files" : "Select file", QDir::homePath(), filters);
+        m_file_picker_dialog = dialog;
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->setFileMode(allow_multiple ? QFileDialog::ExistingFiles : QFileDialog::ExistingFile);
 
-            for (auto const& path : paths)
-                create_selected_file(path);
-        } else {
-            auto path = QFileDialog::getOpenFileName(this, "Select file", QDir::homePath(), filters);
-            create_selected_file(path);
-        }
+        QObject::connect(dialog, &QDialog::finished, this, [this, dialog = QPointer<QFileDialog> { dialog }](int result) {
+            Vector<Web::HTML::SelectedFile> selected_files;
 
-        view().file_picker_closed(std::move(selected_files));
+            if (dialog && result == QDialog::Accepted) {
+                for (auto const& path : dialog->selectedFiles()) {
+                    auto file_path = ak_byte_string_from_qstring(path);
+
+                    if (auto file = WebView::create_selected_file(file_path); file.is_error())
+                        warnln("Unable to open file {}: {}", file_path, file.error());
+                    else
+                        selected_files.append(file.release_value());
+                }
+            }
+
+            if (m_file_picker_dialog == dialog)
+                m_file_picker_dialog = nullptr;
+            view().file_picker_closed(std::move(selected_files));
+        });
+
+        dialog->open();
     };
 
     view().on_find_in_page = [this](auto current_match_index, auto const& total_match_count) {

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -28,6 +28,7 @@
 
 class QTimer;
 class QColorDialog;
+class QFileDialog;
 class QMessageBox;
 namespace Ladybird {
 
@@ -191,6 +192,7 @@ private:
 
     JavaScriptDialog* m_javascript_dialog { nullptr };
     QPointer<QColorDialog> m_color_picker_dialog;
+    QPointer<QFileDialog> m_file_picker_dialog;
     QPointer<QMessageBox> m_external_url_confirmation_dialog;
 
     bool m_suppress_javascript_dialogs_until_navigation { false };

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -39,21 +39,26 @@
 #include <QCursor>
 #include <QEvent>
 #include <QGuiApplication>
-#include <QIcon>
 #include <QInputDevice>
 #include <QKeySequence>
+#include <QLabel>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QNativeGestureEvent>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPainterPath>
+#include <QPainterPathStroker>
 #include <QPalette>
 #include <QPixmap>
+#include <QPushButton>
 #include <QScrollBar>
+#include <QShortcut>
 #include <QStyleHints>
 #include <QTextEdit>
 #include <QTimer>
 #include <QToolTip>
+#include <QVBoxLayout>
 #include <QWheelEvent>
 
 namespace Ladybird {
@@ -153,6 +158,12 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
         update_cursor(cursor);
     };
 
+    on_crash_overlay_state_change = [this](bool active) {
+        if (active)
+            close_select_dropdown_after_crash();
+        set_crash_overlay_visible(active);
+    };
+
 #ifdef AK_OS_MACOS
     on_request_dictionary_lookup = [this](auto const& lookup, auto position) {
         show_appkit_dictionary_lookup(*this, lookup, position);
@@ -197,11 +208,14 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 
     m_select_dropdown = new QMenu("Select Dropdown", this);
     QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
+        if (exchange(m_suppress_select_dropdown_close, false))
+            return;
         if (!m_select_dropdown->activeAction())
             select_dropdown_closed({});
     });
 
     on_request_select_dropdown = [this](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
+        m_suppress_select_dropdown_close = false;
         m_select_dropdown->clear();
         m_select_dropdown->setMinimumWidth(minimum_width);
 
@@ -934,9 +948,178 @@ Optional<QPixmap> WebContentView::tab_preview_pixmap(QSize const& maximum_size) 
     return preview;
 }
 
+namespace {
+
+static void draw_crash_overlay_icon(QPainter& painter, QColor const& color)
+{
+    auto draw_path = [&](QPainterPath const& path) {
+        QPainterPathStroker stroker;
+        stroker.setWidth(1.5);
+        stroker.setCapStyle(Qt::RoundCap);
+        stroker.setJoinStyle(Qt::RoundJoin);
+        painter.fillPath(stroker.createStroke(path), color);
+    };
+
+    QPainterPath page_outline(QPointF(11.75, 0.75));
+    page_outline.lineTo(2.75, 0.75);
+    page_outline.cubicTo(1.65, 0.75, 0.75, 1.65, 0.75, 2.75);
+    page_outline.lineTo(0.75, 18.75);
+    page_outline.cubicTo(0.75, 19.85, 1.65, 20.75, 2.75, 20.75);
+    page_outline.lineTo(14.75, 20.75);
+    page_outline.cubicTo(15.85, 20.75, 16.75, 19.85, 16.75, 18.75);
+    page_outline.lineTo(16.75, 5.75);
+    page_outline.closeSubpath();
+    draw_path(page_outline);
+
+    QPainterPath page_details(QPointF(10.75, 0.75));
+    page_details.lineTo(10.75, 4.75);
+    page_details.cubicTo(10.75, 5.85, 11.65, 6.75, 12.75, 6.75);
+    page_details.lineTo(16.75, 6.75);
+    page_details.moveTo(4.75, 9.75);
+    page_details.lineTo(6.75, 11.75);
+    page_details.moveTo(6.75, 9.75);
+    page_details.lineTo(4.75, 11.75);
+    page_details.moveTo(10.75, 9.75);
+    page_details.lineTo(12.75, 11.75);
+    page_details.moveTo(12.75, 9.75);
+    page_details.lineTo(10.75, 11.75);
+    page_details.moveTo(5.75, 16.75);
+    page_details.cubicTo(6.75, 14.08, 10.75, 14.08, 11.75, 16.75);
+    draw_path(page_details);
+}
+
+class CrashOverlayIcon final : public QWidget {
+public:
+    explicit CrashOverlayIcon(QWidget* parent)
+        : QWidget(parent)
+    {
+        setFixedSize(52, 64);
+    }
+
+protected:
+    virtual void paintEvent(QPaintEvent*) override
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.scale(width() / 17.5, height() / 21.5);
+        draw_crash_overlay_icon(painter, palette().color(QPalette::WindowText));
+    }
+};
+
+}
+
+class CrashOverlayUrlLabel final : public QLabel {
+public:
+    explicit CrashOverlayUrlLabel(QWidget* parent)
+        : QLabel(parent)
+    {
+        setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        setAlignment(Qt::AlignCenter);
+        setForegroundRole(QPalette::PlaceholderText);
+    }
+
+    void set_url_text(QString const& text)
+    {
+        m_url_text = text;
+        update_elided_text();
+    }
+
+private:
+    virtual void resizeEvent(QResizeEvent* event) override
+    {
+        QLabel::resizeEvent(event);
+        update_elided_text();
+    }
+
+    void update_elided_text()
+    {
+        setText(fontMetrics().elidedText(m_url_text, Qt::ElideMiddle, width()));
+    }
+
+    QString m_url_text;
+};
+
+void WebContentView::close_select_dropdown_after_crash()
+{
+    if (!m_select_dropdown->isVisible())
+        return;
+    m_suppress_select_dropdown_close = true;
+    m_select_dropdown->close();
+}
+
+void WebContentView::set_crash_overlay_visible(bool visible)
+{
+    if (!visible) {
+        if (m_crash_overlay) {
+            auto reload_button_had_focus = m_crash_overlay_reload_button->hasFocus();
+            m_crash_overlay->hide();
+            if (reload_button_had_focus)
+                setFocus(Qt::OtherFocusReason);
+        }
+        schedule_repaint();
+        return;
+    }
+
+    if (!m_crash_overlay) {
+        m_crash_overlay = new QWidget(this);
+        m_crash_overlay->setAutoFillBackground(true);
+        m_crash_overlay->setBackgroundRole(QPalette::Window);
+
+        auto* icon = new CrashOverlayIcon(m_crash_overlay);
+
+        auto* title = new QLabel(qstring_from_ak_string(crash_overlay_title()), m_crash_overlay);
+        auto title_font = title->font();
+        title_font.setPointSizeF(title_font.pointSizeF() * 1.5);
+        title_font.setBold(true);
+        title->setFont(title_font);
+        title->setAlignment(Qt::AlignCenter);
+        title->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        m_crash_overlay_url = new CrashOverlayUrlLabel(m_crash_overlay);
+
+        auto* message = new QLabel(qstring_from_ak_string(crash_overlay_message()), m_crash_overlay);
+        message->setAlignment(Qt::AlignCenter);
+        message->setWordWrap(true);
+        message->setForegroundRole(QPalette::PlaceholderText);
+        message->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        m_crash_overlay_reload_button = new QPushButton(qstring_from_ak_string(crash_overlay_reload_button_text()), m_crash_overlay);
+        QObject::connect(m_crash_overlay_reload_button, &QPushButton::clicked, this, [this] {
+            reload();
+        });
+
+        auto* reload_shortcut = new QShortcut(QKeySequence(Qt::Key_Return), m_crash_overlay);
+        reload_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+        QObject::connect(reload_shortcut, &QShortcut::activated, m_crash_overlay_reload_button, &QPushButton::click);
+
+        auto* layout = new QVBoxLayout(m_crash_overlay);
+        layout->setContentsMargins(20, 20, 20, 20);
+        layout->setSpacing(12);
+        layout->addStretch();
+        layout->addWidget(icon, 0, Qt::AlignHCenter);
+        layout->addSpacing(20);
+        layout->addWidget(title);
+        layout->addSpacing(4);
+        layout->addWidget(m_crash_overlay_url);
+        layout->addWidget(message);
+        layout->addSpacing(12);
+        layout->addWidget(m_crash_overlay_reload_button, 0, Qt::AlignHCenter);
+        layout->addStretch();
+    }
+
+    m_crash_overlay_url->set_url_text(qstring_from_ak_string(crash_overlay_failed_url()));
+    m_crash_overlay->setGeometry(rect());
+    m_crash_overlay->show();
+    m_crash_overlay->raise();
+    m_crash_overlay_reload_button->setFocus(Qt::OtherFocusReason);
+    schedule_repaint();
+}
+
 void WebContentView::resizeEvent(QResizeEvent* event)
 {
     WebContentViewBase::resizeEvent(event);
+    if (m_crash_overlay)
+        m_crash_overlay->setGeometry(rect());
 #ifdef LADYBIRD_QT_USE_RHI_WIDGET
     m_force_full_repaint = true;
 #endif

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -43,6 +43,7 @@
 #endif
 
 class QKeyEvent;
+class QPushButton;
 class QSinglePointEvent;
 class QCursor;
 
@@ -63,6 +64,8 @@ using WebContentViewBase = QRhiWidget;
 #else
 using WebContentViewBase = QWidget;
 #endif
+
+class CrashOverlayUrlLabel;
 
 struct WebContentViewInitialState {
     WebView::IsPrivate is_private { WebView::IsPrivate::No };
@@ -111,6 +114,7 @@ public:
     void set_vertical_tab_overlay_insets(int left, int right);
     void prepare_for_window_move();
     void finish_window_move();
+    void close_select_dropdown_after_crash();
 
     enum class PaletteMode {
         Default,
@@ -173,6 +177,8 @@ private:
 
     void update_screen_rects();
 
+    void set_crash_overlay_visible(bool);
+
     bool m_tooltip_override { false };
     Optional<ByteString> m_tooltip_text;
     QTimer m_tooltip_hover_timer;
@@ -184,6 +190,11 @@ private:
     int m_click_count { 0 };
 
     QMenu* m_select_dropdown { nullptr };
+    bool m_suppress_select_dropdown_close { false };
+
+    QWidget* m_crash_overlay { nullptr };
+    CrashOverlayUrlLabel* m_crash_overlay_url { nullptr };
+    QPushButton* m_crash_overlay_reload_button { nullptr };
 
 #ifdef AK_OS_MACOS
     bool prepare_metal_renderer(unsigned long render_target_pixel_format);

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -1007,6 +1007,16 @@ bool WebContentView::current_paintable_can_use_vulkan_window() const
 
 void WebContentView::schedule_vulkan_window_update()
 {
+    if (crash_overlay_active()) {
+        QTimer::singleShot(0, this, [this] {
+            if (!crash_overlay_active())
+                return;
+            set_vulkan_window_container_visible(false);
+            update();
+        });
+        return;
+    }
+
     if (m_vulkan_window) {
         if (!current_paintable_can_use_vulkan_window()) {
             set_vulkan_window_container_visible(false);


### PR DESCRIPTION
A WebContent crash previously loaded a synthetic crash document
into the replacement process. Although displayed like ordinary
browser content, the document had no corresponding canonical
session history entry. Keeping it out of history required
crash-specific exceptions in navigation finalization and session
history updates. Treating it like ordinary content instead would
replace the page that crashed and affect the user's back/forward
history.

Keep the existing canonical entry as the source of truth after
WebContent exits. Headless browsers restore it through a normal
history operation, test-web starts its next test with a clean
process, and headed browsers leave the replacement process dormant
until the user chooses a recovery action.

Remove the synthetic crash document and remember any interrupted
navigation URL so Reload can retry it. Ignore load completions from
a replacement process until it hosts the committed entry. This
prevents its bootstrap about:blank document from replacing the
crashed page's URL in the location bar.

This does have fallout of needing to build UI chrome specific crash
pages as we can now longer display a crash page as HTML. While
this ends up being more code, I believe this will be a lot simpler to
maintain by keeping session history simpler. 

Example of the widget with my bad UI skills running from Qt if loading the full html spec:
<img width="1492" height="877" alt="image" src="https://github.com/user-attachments/assets/d761fec4-95ce-427f-941e-8f32604a16e3" />
