### PR TITLE
LibWeb: Apply visual transforms to Range client rects

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -345,6 +345,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         if (!m_internal_stream_data)
             return;
 
+        NonnullRefPtr protector { *this };
+
         do {
             auto bytes_to_read = buffer_size;
             if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1222,8 +1222,12 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
     if (!start_container()->document().navigable())
         return Geometry::DOMRectList::create({});
 
-    start_container()->document().update_layout(DOM::UpdateLayoutReason::RangeGetClientRects);
+    auto& document = start_container()->document();
+    document.update_layout(DOM::UpdateLayoutReason::RangeGetClientRects);
+
     Vector<GC::Root<Geometry::DOMRect>> rects;
+    bool did_update_paint_and_hit_testing_properties = false;
+
     // FIXME: take Range collapsed into consideration
     // 2. Iterate the node included in Range
     GC::Ptr<Node> start_node = start_container();
@@ -1291,6 +1295,14 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
                 dbgln("FIXME: Failed to get client rects for node {}", node->debug_description());
                 continue;
             }
+
+            auto apply_visual_context_transform = did_update_paint_and_hit_testing_properties;
+            if (!apply_visual_context_transform && !document.can_compute_client_rects_without_accumulated_visual_contexts_update(*mapping.primary())) {
+                document.update_paint_and_hit_testing_properties_if_needed();
+                did_update_paint_and_hit_testing_properties = true;
+                apply_visual_context_transform = true;
+            }
+
             size_t filter_dom_start = 0;
             size_t filter_dom_end = NumericLimits<size_t>::max();
             switch (selection_state) {
@@ -1309,12 +1321,27 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             case Painting::SelectionState::None:
                 VERIFY_NOT_REACHED();
             }
+
             auto text_slots = mapping.slot_ids();
+
+            struct RangeRectContext {
+                Vector<GC::Root<Geometry::DOMRect>>& rects;
+                bool apply_visual_context_transform { false };
+            } context { rects, apply_visual_context_transform };
+
             Layout::RustFFI::layout_arena_text_range_rects(
                 mapping.primary()->arena_handle(), text_slots.data(), text_slots.size(),
                 to_underlying(selection_state), start_offset(), end_offset(), filter_dom_start, filter_dom_end,
-                &rects, [](void* context, CSSPixelRect rect) {
-                    static_cast<Vector<GC::Root<Geometry::DOMRect>>*>(context)->append(Geometry::DOMRect::create(rect.to_type<float>()));
+                &context, [](void* context_pointer, void* containing_block_shell, CSSPixelRect rect) {
+                    auto& context = *static_cast<RangeRectContext*>(context_pointer);
+                    auto transformed_rect = rect;
+
+                    if (context.apply_visual_context_transform) {
+                        if (auto const* containing_block = static_cast<Layout::Node const*>(containing_block_shell))
+                            transformed_rect = Painting::transform_rect_to_viewport(*containing_block, rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+                    }
+
+                    context.rects.append(Geometry::DOMRect::create(transformed_rect.to_type<float>()));
                 });
         }
     }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -506,6 +506,20 @@ void LocalNavigable::handle_as_a_download(GC::Ref<Fetch::Infrastructure::Respons
     start_download_for_response(response, download_url, move(suggested_filename), fetch_controller);
 }
 
+static void stop_or_resume_response_body_delivery(LocalNavigable::NavigationParamsVariant const& navigation_params)
+{
+    // AD-HOC: FetchController::stop_fetch() is an implementation hook for tearing down a paused network body when no
+    //         spec consumer remains.
+    auto const* nav_params = navigation_params.get_pointer<GC::Ref<NavigationParams>>();
+    if (!nav_params)
+        return;
+
+    if ((*nav_params)->fetch_controller)
+        (*nav_params)->fetch_controller->stop_fetch();
+    else
+        (*nav_params)->response->resume_body_delivery();
+}
+
 static bool handle_navigation_response_as_download(GC::Ref<NavigationParams> navigation_params, bool source_allows_downloading, Optional<URL::Origin> interface_origin, Optional<ReadonlyBytes> initial_data = {})
 {
     auto response = navigation_params->response;
@@ -526,7 +540,7 @@ static bool handle_navigation_response_as_download(GC::Ref<NavigationParams> nav
     VERIFY(navigation_params->navigable);
     auto active_window = navigation_params->navigable->active_window();
     if (!active_window) {
-        response->release_request_transfer_lease();
+        stop_or_resume_response_body_delivery(navigation_params);
         return true;
     }
 
@@ -543,7 +557,7 @@ static bool handle_navigation_response_as_download(GC::Ref<NavigationParams> nav
             if (navigation_params->fetch_controller)
                 navigation_params->fetch_controller->stop_fetch();
             else
-                response->release_request_transfer_lease();
+                response->resume_body_delivery();
             return true;
         }
 
@@ -555,20 +569,6 @@ static bool handle_navigation_response_as_download(GC::Ref<NavigationParams> nav
 
     navigation_params->navigable->handle_as_a_download(*response, download_url, navigation_params->fetch_controller, {}, interface_origin);
     return true;
-}
-
-static void stop_or_resume_response_body_delivery(LocalNavigable::NavigationParamsVariant const& navigation_params)
-{
-    // AD-HOC: Fetch controller stop_fetch() is an implementation hook for
-    //         tearing down a paused network body when no spec consumer remains.
-    if (!navigation_params.has<GC::Ref<NavigationParams>>())
-        return;
-
-    auto const& nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
-    if (nav_params->fetch_controller)
-        nav_params->fetch_controller->stop_fetch();
-    else
-        nav_params->response->resume_body_delivery();
 }
 
 void PopulateSessionHistoryEntryDocumentOutput::apply_to(NonnullRefPtr<SessionHistoryEntry> entry)
@@ -2383,6 +2383,7 @@ void LocalNavigable::queue_navigation_and_traversal_task_for_session_history_ent
     queue_global_task(Task::Source::NavigationAndTraversal, HTML::relevant_global_object(*active_window()), GC::create_function(heap(), [this, url, source_allows_downloading, source_interface_origin, user_involvement, navigation_id, navigation_params, csp_navigation_type, output, completion_steps]() mutable {
         // 1. If navigable's ongoing navigation no longer equals navigationId, then run completionSteps and abort these steps.
         if (navigation_id.has_value() && ongoing_navigation() != navigation_id) {
+            stop_or_resume_response_body_delivery(navigation_params);
             if (completion_steps)
                 completion_steps->function()(nullptr);
             return;
@@ -2518,8 +2519,7 @@ void LocalNavigable::queue_navigation_and_traversal_task_for_session_history_ent
                 nav_params->response->resume_body_delivery();
             }
         } else {
-            auto nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
-            nav_params->response->release_request_transfer_lease();
+            stop_or_resume_response_body_delivery(navigation_params);
         }
 
         output->navigation_params = navigation_params;

--- a/Libraries/LibWeb/HTML/NavigationParamsDescriptor.cpp
+++ b/Libraries/LibWeb/HTML/NavigationParamsDescriptor.cpp
@@ -197,6 +197,10 @@ static GC::Ptr<Fetch::Infrastructure::Body> adopt_navigation_response_body(JS::R
     if (!request)
         return {};
 
+    // Navigation may hand this response back to the UI process as a download. Do not consume any of its body before
+    // populate_session_history_entry_document() decides whether to load it as a document or transfer it again.
+    request->set_body_delivery_paused(true);
+
     auto stream = realm.heap().allocate<Streams::ReadableStream>();
     auto pull_algorithm = GC::create_function(realm.heap(), [&realm]() {
         return WebIDL::create_resolved_promise(realm, JS::js_undefined());

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2089,30 +2089,37 @@ pub unsafe extern "C" fn layout_arena_text_range_rects(
     filter_dom_start: usize,
     filter_dom_end: usize,
     context: *mut c_void,
-    push_rect: unsafe extern "C" fn(*mut c_void, FfiCssPixelRect),
+    push_rect: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCssPixelRect),
 ) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let paintable_rows = arena.paintable_rows();
+
         // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
         let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        crate::painting::text_fragment::for_each_fragment_of_nodes(&paintable_rows, node_slots, |_, _, fragment| {
-            let fragment_dom_start = fragment.dom_start_offset_in_node;
-            let fragment_dom_end = fragment.dom_end_offset_in_node;
-            if fragment_dom_end <= filter_dom_start || fragment_dom_start >= filter_dom_end {
-                return true;
-            }
-            let rect = crate::painting::text_fragment::range_rect(
-                &paintable_rows,
-                fragment,
-                selection_state,
-                range_start_offset,
-                range_end_offset,
-            );
-            // SAFETY: The consumer copies the plain-data rect synchronously.
-            unsafe { push_rect(context, rect.into()) };
-            true
-        });
+        crate::painting::text_fragment::for_each_fragment_of_nodes(
+            &paintable_rows,
+            node_slots,
+            |block, _, fragment| {
+                let fragment_dom_start = fragment.dom_start_offset_in_node;
+                let fragment_dom_end = fragment.dom_end_offset_in_node;
+                if fragment_dom_end <= filter_dom_start || fragment_dom_start >= filter_dom_end {
+                    return true;
+                }
+
+                let rect = crate::painting::text_fragment::range_rect(
+                    &paintable_rows,
+                    fragment,
+                    selection_state,
+                    range_start_offset,
+                    range_end_offset,
+                );
+
+                // SAFETY: The consumer handles a null shell and copies the rect synchronously.
+                unsafe { push_rect(context, arena.shell_if_live(block), rect.into()) };
+                true
+            },
+        );
     });
 }
 

--- a/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
+++ b/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
@@ -1,3 +1,5 @@
 [object DOMRectList]
 [object DOMRect]
 PASS
+PASS
+PASS

--- a/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
+++ b/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
@@ -8,10 +8,24 @@
         display: inline-block;
         margin-left: 100px;
     }
+    #scroller {
+        width: 200px;
+        height: 50px;
+        overflow: scroll;
+    }
+    #scroll-content {
+        height: 200px;
+    }
+    #transformed {
+        display: inline-block;
+        transform: translate(20px, 10px) scale(2);
+        transform-origin: 0 0;
+    }
 </style>
 <body>
 <div id="x">x</div>
 <div id="start-container"><span><span>old</span></span></div><span id="following">new</span>
+<div id="scroller"><div id="scroll-content"><span id="transformed">hello</span></div></div>
 <script src="../include.js"></script>
 <script>
     function print_class_string(object) {
@@ -33,6 +47,21 @@
         const firstRangeRect = range.getClientRects()[0];
         const followingRect = following.getBoundingClientRect();
         println(firstRangeRect.left >= followingRect.left && firstRangeRect.left < followingRect.right ? "PASS" : "FAIL");
+
+        const scroller = document.getElementById("scroller");
+        const transformed = document.getElementById("transformed");
+        range.selectNodeContents(transformed.firstChild);
+
+        const rangeMatchesElement = () => {
+            const rangeRect = range.getClientRects()[0];
+            const elementRect = transformed.getBoundingClientRect();
+            return ["x", "y", "width", "height"].every(property =>
+                Math.abs(rangeRect[property] - elementRect[property]) < 0.01);
+        };
+
+        println(rangeMatchesElement() ? "PASS" : "FAIL");
+        scroller.scrollTop = 50;
+        println(rangeMatchesElement() ? "PASS" : "FAIL");
     });
 </script>
 

--- a/UI/Qt/EventLoopImplementationQt.cpp
+++ b/UI/Qt/EventLoopImplementationQt.cpp
@@ -316,11 +316,11 @@ void EventLoopManagerQt::register_notifier(Core::Notifier& notifier)
     default:
         TODO();
     }
+
     auto socket_notifier = make<QSocketNotifier>(notifier.fd(), type);
     QObject::connect(socket_notifier, &QSocketNotifier::activated, [weak_notifier = notifier.make_weak_ptr()] {
-        if (!weak_notifier)
-            return;
-        qt_notifier_activated(static_cast<Core::Notifier&>(*weak_notifier));
+        if (auto notifier = weak_notifier.strong_ref())
+            qt_notifier_activated(static_cast<Core::Notifier&>(*notifier));
     });
 
     {


### PR DESCRIPTION
The first 2 commits were so I can actually download the affected PDF from Ladybird (which I was trying to do via middle clicking the download link).

Fixes #11338

| Before | After |
|--|--|
| <img width="802" height="431" alt="before" src="https://github.com/user-attachments/assets/a54bf53e-caa2-46ba-8058-89fc755de58a" /> | <img width="802" height="431" alt="after" src="https://github.com/user-attachments/assets/c402b7cc-336a-42a7-8745-a3e26d2b76af" /> |
