### PR TITLE
LibWeb: Fix two crashes caused by discarded `display:none` descendant styles

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -5420,13 +5420,13 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
 
         if (step.action == ComputedValuesFFI::FontSizeRecascadeAction::NeedsLengthResolution) {
             bool inherited_font_metrics_depend_on_viewport_metrics = false;
-            auto inherited_line_height = ancestor.element_to_inherit_style_from()
-                                             .map([&](auto&& parent_element) {
-                                                 auto parent_style = parent_element.computed_style();
-                                                 inherited_font_metrics_depend_on_viewport_metrics = parent_style->font_metrics_depend_on_viewport_metrics();
-                                                 return parent_style->line_height();
-                                             })
-                                             .value_or(InitialValues::line_height());
+            auto inherited_line_height = InitialValues::line_height();
+            if (auto parent_element = ancestor.element_to_inherit_style_from(); parent_element.has_value()) {
+                if (auto parent_style = parent_element->computed_style()) {
+                    inherited_font_metrics_depend_on_viewport_metrics = parent_style->font_metrics_depend_on_viewport_metrics();
+                    inherited_line_height = parent_style->line_height();
+                }
+            }
 
             bool did_resolve_viewport_relative_length = false;
             Length::ResolutionContext resolution_context {

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -222,6 +222,9 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
         if (!element)
             continue;
 
+        if (reaction.gap != StyleEngineFFI::FfiStyleDeltaGap::Materialize && !element->has_style())
+            continue;
+
         bool const has_published_style_reaction = reaction.reaction & StyleEngine::PublishedStyle;
         if (has_published_style_reaction) {
             ++document.style_invalidation_counters().style_engine_published_reactions;

--- a/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-inherited-group-swap.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-inherited-group-swap.txt
@@ -1,0 +1,2 @@
+hidden inherited style: square
+visible inherited style: square

--- a/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-monospace-font-recascade.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/display-none-descendant-monospace-font-recascade.txt
@@ -1,0 +1,4 @@
+hidden font size: 13.333333px
+hidden restyled background: fixed
+hidden cleared font size: 13.333333px
+visible font size: 13.333333px

--- a/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-inherited-group-swap.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-inherited-group-swap.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<div id="outer"><div id="inner">x</div></div>
+<script>
+    test(() => {
+        const outer = document.getElementById("outer");
+        const inner = document.getElementById("inner");
+        document.body.offsetWidth;
+
+        outer.style.display = "none";
+        outer.style.setProperty("list-style-type", "square");
+        document.body.offsetWidth;
+
+        println(`hidden inherited style: ${getComputedStyle(inner).listStyleType}`);
+
+        outer.style.display = "block";
+        document.body.offsetWidth;
+
+        println(`visible inherited style: ${getComputedStyle(inner).listStyleType}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-monospace-font-recascade.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/display-none-descendant-monospace-font-recascade.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    * { font: 10pt monospace; }
+</style>
+<div id="cleared"><div id="restyled"><div id="child">x</div></div></div>
+<script>
+    test(() => {
+        const cleared = document.getElementById("cleared");
+        const restyled = document.getElementById("restyled");
+        const child = document.getElementById("child");
+        document.body.offsetWidth;
+
+        restyled.style.setProperty("background-attachment", "fixed");
+        document.body.style.display = "none";
+        document.body.offsetWidth;
+
+        println(`hidden font size: ${getComputedStyle(child).fontSize}`);
+        println(`hidden restyled background: ${getComputedStyle(restyled).backgroundAttachment}`);
+        println(`hidden cleared font size: ${getComputedStyle(cleared).fontSize}`);
+
+        document.body.style.display = "block";
+        document.body.offsetWidth;
+
+        println(`visible font size: ${getComputedStyle(child).fontSize}`);
+    });
+</script>


### PR DESCRIPTION
See individual commits for details

Fixes 2 recent regressions introduced by c199312d8aa.

Found with Domato.