### PR TITLE
Implement "beforeunload" dialogs on Qt UI

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -237,7 +237,6 @@
 #include <LibWeb/UIEvents/PointerTypes.h>
 #include <LibWeb/UIEvents/TextEvent.h>
 #include <LibWeb/ViewTransition/ViewTransition.h>
-#include <LibWeb/WebDriver/UserPrompt.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -9461,7 +9460,10 @@ bool Document::showing_an_unload_prompt_is_unlikely_to_be_annoying_deceptive_or_
     if (page().is_webdriver_active())
         return false;
 
-    return true;
+    // FIXME: Revisit this approximation of "unlikely to be annoying, deceptive, or pointless".
+    return is_active()
+        && is_fully_active()
+        && visibility_state_value() == HTML::VisibilityState::Visible;
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#steps-to-fire-beforeunload
@@ -9503,12 +9505,17 @@ Document::StepsToFireBeforeunloadResult Document::steps_to_fire_beforeunload(boo
         unload_prompt_shown = true;
 
         // FIXME: 2. Invoke WebDriver BiDi user prompt opened with document's relevant global object, "beforeunload", and "".
-        // FIXME: 3. Ask the user to confirm that they wish to unload the document, and pause while waiting for the user's response.
-
-        auto user_prompt_handler = WebDriver::get_the_prompt_handler(WebDriver::PromptType::BeforeUnload);
+        // 3. Ask the user to confirm that they wish to unload the document, and pause while waiting for the user's response.
+        auto top_level_document = page().top_level_traversable()->active_document();
+        VERIFY(top_level_document);
+        auto source = top_level_document->origin().is_opaque()
+            ? MUST(String::formatted("{}://", top_level_document->url().scheme()))
+            : top_level_document->origin().serialize();
+        HTML::TemporaryExecutionContext context { relevant_settings_object() };
+        auto confirmed = page().did_request_before_unload(source, event_loop);
 
         // 4. If the user did not confirm the page navigation, set unloadPromptCanceled to true.
-        if (user_prompt_handler.handler == WebDriver::PromptHandler::Dismiss)
+        if (!confirmed)
             unload_prompt_canceled = true;
 
         // FIXME: 5. Invoke WebDriver BiDi user prompt closed with document's relevant global object and true if unloadPromptCanceled is false or false otherwise.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9454,6 +9454,16 @@ Unicode::Segmenter& Document::word_segmenter() const
     return *m_word_segmenter;
 }
 
+bool Document::showing_an_unload_prompt_is_unlikely_to_be_annoying_deceptive_or_pointless() const
+{
+    // FIXME: Propagate enough WebDriver session information to test for exactly one active HTTP-only,
+    //        non-BiDi session instead of treating any active WebDriver session as equivalent.
+    if (page().is_webdriver_active())
+        return false;
+
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#steps-to-fire-beforeunload
 Document::StepsToFireBeforeunloadResult Document::steps_to_fire_beforeunload(bool unload_prompt_shown)
 {
@@ -9487,8 +9497,8 @@ Document::StepsToFireBeforeunloadResult Document::steps_to_fire_beforeunload(boo
         && window.has_sticky_activation()
         //    - eventFiringResult is false, or the returnValue attribute of event is not the empty string; and
         && (!event_firing_result || !beforeunload_event->return_value().is_empty())
-        //    - FIXME: showing an unload prompt is unlikely to be annoying, deceptive, or pointless
-    ) {
+        //    - showing an unload prompt is unlikely to be annoying, deceptive, or pointless,
+        && showing_an_unload_prompt_is_unlikely_to_be_annoying_deceptive_or_pointless()) {
         // 1. Set unloadPromptShown to true.
         unload_prompt_shown = true;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1482,6 +1482,7 @@ private:
     void after_layout_commit(LayoutTreeChanged, LayoutCommitScope, ReadonlySpan<Layout::Box const*> boxes_needing_eager_overflow_measurement = {});
 
     void run_unloading_cleanup_steps();
+    bool showing_an_unload_prompt_is_unlikely_to_be_annoying_deceptive_or_pointless() const;
 
     void evaluate_media_rules();
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1153,6 +1153,10 @@ public:
         , m_callback(callback)
         , m_timeout(Platform::Timer::create_single_shot(heap(), TIMEOUT_MS, GC::create_function(heap(), [this] {
             if (!m_completed) {
+                if (has_pending_before_unload_dialog()) {
+                    m_timeout->restart();
+                    return;
+                }
                 dbgln("FIXME: check_if_unloading_is_canceled timed out");
                 finish(Result::Continue);
             }
@@ -1218,6 +1222,18 @@ public:
     }
 
 private:
+    bool has_pending_before_unload_dialog() const
+    {
+        if (m_traversable) {
+            if (auto active_document = m_traversable->active_document(); active_document && active_document->page().pending_dialog() == Page::PendingDialog::BeforeUnload)
+                return true;
+        }
+
+        return m_phase2_documents.find_if([](auto const& document) {
+            return document->page().pending_dialog() == Page::PendingDialog::BeforeUnload;
+        }) != m_phase2_documents.end();
+    }
+
     void start_phase1()
     {
         // 4. Queue a global task on the navigation and traversal task source given traversable's active window to perform the following steps:

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -478,10 +478,10 @@ void Page::did_complete_window_rect_request(u64 completion_id)
 }
 
 template<typename ResponseType>
-static ResponseType spin_event_loop_until_dialog_closed(PageClient& client, Optional<ResponseType>& response, SourceLocation location = SourceLocation::current())
+static ResponseType spin_event_loop_until_dialog_closed(PageClient& client, Optional<ResponseType>& response, HTML::EventLoop* event_loop = nullptr, SourceLocation location = SourceLocation::current())
 {
-    auto& event_loop = Web::HTML::current_settings_object().responsible_event_loop();
-    auto pause_handle = event_loop.pause();
+    auto& responsible_event_loop = event_loop ? *event_loop : Web::HTML::current_settings_object().responsible_event_loop();
+    auto pause_handle = responsible_event_loop.pause();
 
     Web::Platform::EventLoopPlugin::the().spin_until(GC::create_function(GC::Heap::the(), [&]() {
         return response.has_value() || !client.is_connection_open();
@@ -510,6 +510,22 @@ void Page::alert_closed()
 {
     if (m_pending_dialog == PendingDialog::Alert) {
         m_pending_alert_response = Empty {};
+        on_pending_dialog_closed();
+    }
+}
+
+bool Page::did_request_before_unload(String const& source, HTML::EventLoop& event_loop)
+{
+    m_pending_dialog = PendingDialog::BeforeUnload;
+    m_client->page_did_request_before_unload(source);
+
+    return spin_event_loop_until_dialog_closed(*m_client, m_pending_before_unload_response, &event_loop);
+}
+
+void Page::before_unload_closed(bool accepted)
+{
+    if (m_pending_dialog == PendingDialog::BeforeUnload) {
+        m_pending_before_unload_response = accepted;
         on_pending_dialog_closed();
     }
 }
@@ -562,6 +578,7 @@ void Page::dismiss_dialog(GC::Ref<GC::Function<void()>> on_dialog_closed)
     case PendingDialog::Alert:
         m_client->page_did_request_accept_dialog();
         break;
+    case PendingDialog::BeforeUnload:
     case PendingDialog::Confirm:
     case PendingDialog::Prompt:
         m_client->page_did_request_dismiss_dialog();
@@ -577,6 +594,7 @@ void Page::accept_dialog(GC::Ref<GC::Function<void()>> on_dialog_closed)
     case PendingDialog::None:
         break;
     case PendingDialog::Alert:
+    case PendingDialog::BeforeUnload:
     case PendingDialog::Confirm:
     case PendingDialog::Prompt:
         m_client->page_did_request_accept_dialog();

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -206,6 +206,9 @@ public:
     void did_request_alert(Utf16String const& message);
     void alert_closed();
 
+    bool did_request_before_unload(String const& source, HTML::EventLoop&);
+    void before_unload_closed(bool accepted);
+
     bool did_request_confirm(Utf16String const& message);
     void confirm_closed(bool accepted);
 
@@ -215,6 +218,7 @@ public:
     enum class PendingDialog {
         None,
         Alert,
+        BeforeUnload,
         Confirm,
         Prompt,
     };
@@ -386,6 +390,7 @@ private:
     PendingDialog m_pending_dialog { PendingDialog::None };
     Optional<Utf16String> m_pending_dialog_text;
     Optional<Empty> m_pending_alert_response;
+    Optional<bool> m_pending_before_unload_response;
     Optional<bool> m_pending_confirm_response;
     Optional<Optional<Utf16String>> m_pending_prompt_response;
     GC::Ptr<GC::Function<void()>> m_on_pending_dialog_closed;
@@ -556,6 +561,7 @@ public:
     virtual void page_did_unhover_link() { }
     virtual void page_did_change_favicon(Gfx::Bitmap const&) { }
     virtual void page_did_request_alert(Utf16String const&) { }
+    virtual void page_did_request_before_unload(String const&) { }
     virtual void page_did_request_confirm(Utf16String const&) { }
     virtual void page_did_request_prompt(Utf16String const&, Utf16String const&) { }
     virtual void page_did_request_set_prompt_text(Utf16String const&) { }

--- a/Libraries/LibWeb/WebDriver/UserPrompt.cpp
+++ b/Libraries/LibWeb/WebDriver/UserPrompt.cpp
@@ -320,10 +320,12 @@ void handle_any_user_prompts(Page& page, GC::Ref<GC::Function<void(Optional<Erro
     // 3. If the current user prompt is an alert dialog, set type to "alert". Otherwise, if the current user prompt is a
     //    beforeunload dialog, set type to "beforeUnload". Otherwise, if the current user prompt is a confirm dialog,
     //    set type to "confirm". Otherwise, if the current user prompt is a prompt dialog, set type to "prompt".
-    // FIXME: Handle beforeunload dialogs when they are implemented.
     switch (page.pending_dialog()) {
     case Page::PendingDialog::Alert:
         type = PromptType::Alert;
+        break;
+    case Page::PendingDialog::BeforeUnload:
+        type = PromptType::BeforeUnload;
         break;
     case Page::PendingDialog::Confirm:
         type = PromptType::Confirm;

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -122,6 +122,9 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         case Web::Page::PendingDialog::Alert:
             alert_closed();
             break;
+        case Web::Page::PendingDialog::BeforeUnload:
+            before_unload_closed(true);
+            break;
         case Web::Page::PendingDialog::Confirm:
             confirm_closed(true);
             break;
@@ -140,6 +143,9 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
             break;
         case Web::Page::PendingDialog::Alert:
             alert_closed();
+            break;
+        case Web::Page::PendingDialog::BeforeUnload:
+            before_unload_closed(false);
             break;
         case Web::Page::PendingDialog::Confirm:
             confirm_closed(false);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1877,6 +1877,11 @@ void ViewImplementation::alert_closed()
     client().async_alert_closed(page_id());
 }
 
+void ViewImplementation::before_unload_closed(bool accepted)
+{
+    client().async_before_unload_closed(page_id(), accepted);
+}
+
 void ViewImplementation::confirm_closed(bool accepted)
 {
     client().async_confirm_closed(page_id(), accepted);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -288,6 +288,7 @@ public:
     Web::ViewportIsFullscreen is_fullscreen() const { return m_is_fullscreen; }
 
     void alert_closed();
+    void before_unload_closed(bool accepted);
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<Utf16String> const& response);
     void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
@@ -402,6 +403,7 @@ public:
     Function<void(ByteString const&)> on_enter_tooltip_area;
     Function<void()> on_leave_tooltip_area;
     Function<void(Utf16String const& message)> on_request_alert;
+    Function<void(String const& source, Function<void(bool)> on_complete)> on_request_before_unload;
     Function<void(Utf16String const& message)> on_request_confirm;
     Function<void(Utf16String const& message, Utf16String const& default_)> on_request_prompt;
     Function<void(Utf16String const& message)> on_request_set_prompt_text;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1651,6 +1651,23 @@ void WebContentClient::did_request_alert(u64 page_id, Utf16String message)
     }
 }
 
+void WebContentClient::did_request_before_unload(u64 page_id, String source)
+{
+    if (auto view = owning_view_for_page_id(page_id); view.has_value()) {
+        if (view->on_request_before_unload) {
+            auto weak_this = static_cast<Core::EventReceiver&>(*this).make_weak_ptr();
+            view->on_request_before_unload(source, [weak_this, page_id](bool accepted) {
+                if (!weak_this)
+                    return;
+                static_cast<WebContentClient&>(*weak_this.ptr()).async_before_unload_closed(page_id, accepted);
+            });
+            return;
+        }
+    }
+
+    async_before_unload_closed(page_id, true);
+}
+
 void WebContentClient::did_request_confirm(u64 page_id, Utf16String message)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -210,6 +210,7 @@ private:
     virtual void did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo, Optional<Requests::NetworkError>) override;
     virtual void did_change_favicon(u64 page_id, Gfx::ShareableBitmap) override;
     virtual void did_request_alert(u64 page_id, Utf16String) override;
+    virtual void did_request_before_unload(u64 page_id, String) override;
     virtual void did_request_confirm(u64 page_id, Utf16String) override;
     virtual void did_request_prompt(u64 page_id, Utf16String, Utf16String) override;
     virtual void did_request_set_prompt_text(u64 page_id, Utf16String message) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2533,6 +2533,12 @@ void ConnectionFromClient::alert_closed(u64 page_id)
         page->page().alert_closed();
 }
 
+void ConnectionFromClient::before_unload_closed(u64 page_id, bool accepted)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().before_unload_closed(accepted);
+}
+
 void ConnectionFromClient::confirm_closed(u64 page_id, bool accepted)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -205,6 +205,7 @@ private:
     virtual void run_javascript(u64 page_id, String) override;
 
     virtual void alert_closed(u64 page_id) override;
+    virtual void before_unload_closed(u64 page_id, bool accepted) override;
     virtual void confirm_closed(u64 page_id, bool accepted) override;
     virtual void prompt_closed(u64 page_id, Optional<Utf16String> response) override;
     virtual void color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -855,6 +855,14 @@ void PageClient::alert_closed()
     page().alert_closed();
 }
 
+void PageClient::page_did_request_before_unload(String const& source)
+{
+    client().async_did_request_before_unload(m_id, source);
+
+    if (m_webdriver)
+        m_webdriver->page_did_open_dialog({});
+}
+
 void PageClient::page_did_request_confirm(Utf16String const& message)
 {
     client().async_did_request_confirm(m_id, message);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -212,6 +212,7 @@ private:
     virtual void page_did_unregister_download(u64 download_id) override;
     virtual bool page_is_download_canceled(u64 download_id) const override;
     virtual void page_did_request_alert(Utf16String const&) override;
+    virtual void page_did_request_before_unload(String const&) override;
     virtual void page_did_request_confirm(Utf16String const&) override;
     virtual void page_did_request_prompt(Utf16String const&, Utf16String const&) override;
     virtual void page_did_request_set_prompt_text(Utf16String const&) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -92,6 +92,7 @@ endpoint WebContentClient
     did_request_image_context_menu(u64 page_id, Gfx::IntPoint content_position, URL::URL url, ByteString target, unsigned modifiers, Optional<Gfx::ShareableBitmap> bitmap) =|
     did_request_media_context_menu(u64 page_id, Gfx::IntPoint content_position, ByteString target, unsigned modifiers, Web::Page::MediaContextMenu menu) =|
     did_request_alert(u64 page_id, Utf16String message) =|
+    did_request_before_unload(u64 page_id, String source) =|
     did_request_confirm(u64 page_id, Utf16String message) =|
     did_request_prompt(u64 page_id, Utf16String message, Utf16String default_) =|
     did_request_set_prompt_text(u64 page_id, Utf16String message) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -209,6 +209,7 @@ endpoint WebContentServer
     set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|
 
     alert_closed(u64 page_id) =|
+    before_unload_closed(u64 page_id, bool accepted) =|
     confirm_closed(u64 page_id, bool accepted) =|
     prompt_closed(u64 page_id, Optional<Utf16String> response) =|
     color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -2457,7 +2457,8 @@ Web::WebDriver::Response WebDriverConnection::send_alert_text(JsonValue payload)
         break;
 
     // -> Otherwise
-    default:
+    case Web::Page::PendingDialog::BeforeUnload:
+    case Web::Page::PendingDialog::None:
         // Return error with error code unsupported operation.
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::UnsupportedOperation, "Unknown dialog type"sv);
     }

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -51,6 +51,13 @@ if (NOT WIN32)
         target_compile_definitions(TestBrowserHistoryTraversal PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
     endif()
 
+    add_executable(TestBeforeUnload TestBeforeUnload.cpp)
+    add_dependencies(TestBeforeUnload ladybird_build_resource_files ${ladybird_helper_processes})
+    target_link_libraries(TestBeforeUnload PRIVATE AK LibCore LibFileSystem LibGfx LibImageDecoders LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
+    if (APPLE)
+        target_compile_definitions(TestBeforeUnload PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
+    endif()
+
     add_executable(TestInputMethodState TestInputMethodState.cpp)
     add_dependencies(TestInputMethodState ladybird_build_resource_files ${ladybird_helper_processes})
     target_link_libraries(TestInputMethodState PRIVATE AK LibCore LibDiff LibFileSystem LibGfx LibImageDecoders LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
@@ -86,6 +93,9 @@ if (BUILD_TESTING AND NOT WIN32)
 
     add_test(NAME TestBrowserHistoryTraversal COMMAND $<TARGET_FILE:TestBrowserHistoryTraversal>)
     set_tests_properties(TestBrowserHistoryTraversal PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
+
+    add_test(NAME TestBeforeUnload COMMAND $<TARGET_FILE:TestBeforeUnload>)
+    set_tests_properties(TestBeforeUnload PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
 
     add_test(NAME TestInputMethodState COMMAND $<TARGET_FILE:TestInputMethodState>)
     set_tests_properties(TestInputMethodState PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})

--- a/Tests/LibWebView/TestBeforeUnload.cpp
+++ b/Tests/LibWebView/TestBeforeUnload.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <AK/Random.h>
+#include <AK/ScopeGuard.h>
+#include <LibCore/Directory.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/StandardPaths.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibMain/Main.h>
+#include <LibURL/Parser.h>
+#include <LibWeb/Page/InputEvent.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/HeadlessWebView.h>
+#include <LibWebView/Utilities.h>
+#include <stdlib.h>
+
+namespace {
+
+class TestApplication : public WebView::Application {
+    WEB_VIEW_APPLICATION(TestApplication)
+
+public:
+    explicit TestApplication(Optional<ByteString> ladybird_binary_path)
+        : WebView::Application(move(ladybird_binary_path))
+    {
+    }
+
+    virtual void create_platform_options(WebView::BrowserOptions& browser_options, WebView::RequestServerOptions&, WebView::WebContentOptions& web_content_options) override
+    {
+        browser_options.headless_mode = WebView::HeadlessMode::Test;
+        browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
+        web_content_options.is_test_mode = WebView::IsTestMode::Yes;
+    }
+
+    virtual bool should_coordinate_browser_process() const override { return false; }
+};
+
+void click(WebView::ViewImplementation& view)
+{
+    view.enqueue_input_event(Web::MouseEvent {
+        .type = Web::MouseEvent::Type::MouseDown,
+        .position = { 10, 10 },
+        .screen_position = { 10, 10 },
+        .button = Web::UIEvents::MouseButton::Primary,
+        .buttons = Web::UIEvents::MouseButton::Primary,
+        .click_count = 1,
+        .browser_data = nullptr,
+    });
+    view.enqueue_input_event(Web::MouseEvent {
+        .type = Web::MouseEvent::Type::MouseUp,
+        .position = { 10, 10 },
+        .screen_position = { 10, 10 },
+        .button = Web::UIEvents::MouseButton::Primary,
+        .buttons = Web::UIEvents::MouseButton::None,
+        .click_count = 1,
+        .browser_data = nullptr,
+    });
+}
+
+}
+
+ErrorOr<int> ladybird_main(Main::Arguments arguments)
+{
+    auto test_config_directory = ByteString::formatted("{}/Ladybird-TestBeforeUnload-{}", Core::StandardPaths::tempfile_directory(), generate_random_uuid());
+    TRY(Core::Directory::create(test_config_directory, Core::Directory::CreateDirectories::Yes));
+    auto cleanup_test_config_directory = ScopeGuard([&] {
+        MUST(FileSystem::remove(test_config_directory, FileSystem::RecursionMode::Allowed));
+    });
+    VERIFY(setenv("XDG_CONFIG_HOME", test_config_directory.characters(), 1) == 0);
+
+#if defined(LADYBIRD_BINARY_PATH)
+    auto app = TRY(TestApplication::create(arguments, LADYBIRD_BINARY_PATH));
+#else
+    auto app = TRY(TestApplication::create(arguments, OptionalNone {}));
+#endif
+
+    auto theme_path = LexicalPath::join(WebView::s_ladybird_resource_root, "themes"sv, "Default.ini"sv);
+    auto theme = TRY(Gfx::load_system_theme(theme_path.string()));
+    auto view = WebView::HeadlessWebView::create(move(theme), { 800, 600 });
+
+    size_t loads_finished = 0;
+    view->on_load_finish = [&](auto const&) { ++loads_finished; };
+    Core::EventLoop::current().spin_until([&] { return loads_finished == 1; });
+
+    auto source_url = URL::Parser::basic_parse("data:text/html,<title>source</title><button style='width:100px;height:100px' onclick=\"document.title='activated'\">Activate</button><script>onbeforeunload=e=>e.preventDefault()</script>"sv).release_value();
+    auto destination_url = URL::Parser::basic_parse("data:text/html,<title>destination</title>Destination"sv).release_value();
+
+    auto view_is_at = [&](URL::URL const& url) { return view->url().serialize() == url.serialize(); };
+    auto load_and_wait = [&](URL::URL const& url) {
+        auto expected_loads_finished = loads_finished + 1;
+        view->load(url);
+        Core::EventLoop::current().spin_until([&] { return loads_finished >= expected_loads_finished && view_is_at(url); });
+    };
+    auto activate_page = [&] {
+        bool activated = false;
+        view->on_title_change = [&](auto const& title) { activated = title == "activated"sv; };
+        click(*view);
+        Core::EventLoop::current().spin_until([&] { return activated; });
+        view->on_title_change = {};
+    };
+
+    // Frontends without a beforeunload handler must act as if the user chose Leave.
+    load_and_wait(source_url);
+    activate_page();
+    load_and_wait(destination_url);
+
+    size_t prompt_count = 0;
+    bool accept_prompt = false;
+    Optional<String> prompt_source;
+    view->on_request_before_unload = [&](auto const& source, auto on_complete) {
+        ++prompt_count;
+        prompt_source = source;
+        on_complete(accept_prompt);
+    };
+
+    // A cancellation request without sticky activation must not show a prompt.
+    load_and_wait(source_url);
+    load_and_wait(destination_url);
+    VERIFY(prompt_count == 0);
+
+    // Stay cancels the navigation. The opaque data: origin uses the scheme fallback.
+    load_and_wait(source_url);
+    activate_page();
+    auto loads_finished_before_cancellation = loads_finished;
+    view->load(destination_url);
+    Core::EventLoop::current().spin_until([&] { return loads_finished > loads_finished_before_cancellation; });
+    VERIFY(prompt_count == 1);
+    VERIFY(prompt_source == "data://"sv);
+    VERIFY(view_is_at(source_url));
+
+    // A subsequent navigation may ask once again, and Leave allows it to proceed.
+    accept_prompt = true;
+    load_and_wait(destination_url);
+    VERIFY(prompt_count == 2);
+
+    outln("PASS: beforeunload prompt handling");
+    return 0;
+}

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -927,14 +927,15 @@ def refresh(webdriver_port, session_id):
     request(webdriver_port, "POST", f"/session/{session_id}/refresh", {})
 
 
-def create_session(webdriver_port, enable_test_hooks=True):
+def create_session(webdriver_port, enable_test_hooks=True, beforeunload_prompt_handler=None):
     always_match = {
         "ladybird:headless": True,
         "pageLoadStrategy": "normal",
-        "unhandledPromptBehavior": {"beforeUnload": "dismiss"},
     }
     if enable_test_hooks:
         always_match["ladybird:enableTestHooks"] = True
+    if beforeunload_prompt_handler is not None:
+        always_match["unhandledPromptBehavior"] = {"beforeUnload": beforeunload_prompt_handler}
 
     created = request(
         webdriver_port,
@@ -986,6 +987,53 @@ def perform_pointer_click(webdriver_port, session_id, x, y, log):
         },
     )
     log.append(f"clicked viewport at {x},{y}")
+
+
+def install_cancellable_beforeunload_handler(webdriver_port, session_id, label, log):
+    perform_pointer_click(webdriver_port, session_id, 5, 5, log)
+    setup = execute_script(
+        webdriver_port,
+        session_id,
+        f"""
+localStorage.removeItem({json.dumps(label)});
+window.onbeforeunload = event => {{
+    localStorage.setItem({json.dumps(label)}, "fired");
+    event.preventDefault();
+    event.returnValue = "blocked";
+    return "blocked";
+}};
+return navigator.userActivation.hasBeenActive;
+""",
+    )
+    if setup is not True:
+        raise AssertionError(f"Expected sticky activation before {label}\n" + "\n".join(log))
+
+
+def expect_beforeunload_event_recorded(webdriver_port, session_id, source_url, label, log):
+    request(webdriver_port, "POST", f"/session/{session_id}/url", {"url": source_url})
+    recorded = execute_script(
+        webdriver_port,
+        session_id,
+        f"return localStorage.getItem({json.dumps(label)});",
+    )
+    if recorded != "fired":
+        raise AssertionError(
+            f"Expected beforeunload event from {label} to be recorded, got {recorded}\n" + "\n".join(log)
+        )
+
+
+def expect_no_user_prompt(webdriver_port, session_id, label, log):
+    status, payload, response_body = request_raw(
+        webdriver_port,
+        "GET",
+        f"/session/{session_id}/alert/text",
+    )
+    value = payload.get("value")
+    if status == 404 and isinstance(value, dict) and value.get("error") == "no such alert":
+        return
+    raise AssertionError(
+        f"Expected no user prompt after {label}, got HTTP {status}: {response_body}\n" + "\n".join(log)
+    )
 
 
 def session_history(webdriver_port, session_id):
@@ -1109,43 +1157,6 @@ def wait_for_ui_session_history(
     return wait_for_session_history(webdriver_port, session_id, label, matches_expected_history, log)
 
 
-def expect_beforeunload_cancels_webdriver_navigation(
-    webdriver_port,
-    session_id,
-    url,
-    label,
-    expected_url,
-    previous_beforeunload_count,
-    expected_history_snapshot,
-    log,
-):
-    request(webdriver_port, "POST", f"/session/{session_id}/timeouts", {"pageLoad": 1000})
-    request(webdriver_port, "POST", f"/session/{session_id}/url", {"url": url})
-    request(webdriver_port, "POST", f"/session/{session_id}/timeouts", {"pageLoad": 10000})
-    state = execute_script(
-        webdriver_port,
-        session_id,
-        "return [location.href, window.beforeUnloadCount];",
-    )
-    if state[0] != expected_url or state[1] <= previous_beforeunload_count:
-        raise AssertionError(f"Expected beforeunload to cancel {label}, got {state}\n" + "\n".join(log))
-
-    ui_history = expected_history_snapshot["ui"]
-    expect_ui_session_history(
-        webdriver_port,
-        session_id,
-        f"after blocked {label}",
-        history_entry_urls(ui_history),
-        history_used_steps(ui_history),
-        ui_history["currentUsedStepIndex"],
-        ui_history["backButtonEnabled"],
-        ui_history["forwardButtonEnabled"],
-        log,
-        expect_history_idle=True,
-    )
-    return state
-
-
 def expect_javascript_noop_ui_load_does_not_change_history(
     webdriver_port,
     session_id,
@@ -1209,41 +1220,6 @@ def expect_javascript_noop_webdriver_navigation_does_not_change_history(
         log,
         expect_history_idle=True,
     )
-
-
-def expect_beforeunload_cancels_refresh(
-    webdriver_port,
-    session_id,
-    expected_url,
-    previous_beforeunload_count,
-    log,
-):
-    expect_current_ui_entry_reload_pending(webdriver_port, session_id, "before blocked refresh from /b", False, log)
-    request(webdriver_port, "POST", f"/session/{session_id}/timeouts", {"pageLoad": 1000})
-    try:
-        refresh(webdriver_port, session_id)
-    finally:
-        request(webdriver_port, "POST", f"/session/{session_id}/timeouts", {"pageLoad": 10000})
-
-    def refresh_was_canceled_by_beforeunload(result):
-        return (
-            isinstance(result, list)
-            and len(result) == 2
-            and result[0] == expected_url
-            and isinstance(result[1], int)
-            and result[1] > previous_beforeunload_count
-        )
-
-    state = wait_for_script_result(
-        webdriver_port,
-        session_id,
-        "beforeunload-canceled refresh from /b",
-        "return [location.href, window.beforeUnloadCount];",
-        refresh_was_canceled_by_beforeunload,
-        log,
-    )
-    expect_current_ui_entry_reload_pending(webdriver_port, session_id, "after blocked refresh from /b", False, log)
-    return state
 
 
 def expect_current_top_level_history_url(webdriver_port, session_id, label, expected_url, log):
@@ -1951,6 +1927,160 @@ def run_self_contained_navigation_tests(webdriver_port, page_port, url_a):
     run_failed_redirected_navigation_shows_failed_url_test(webdriver_port, page_port, url_a)
 
 
+def run_beforeunload_webdriver_suppression_tests(webdriver_port, page_server, url_a, url_b, url_c, url_d):
+    def run_case(
+        label,
+        expected_url,
+        document_ran_event,
+        start_navigation,
+        expected_entry_urls,
+        expected_current_index,
+        expected_back_enabled,
+        expected_forward_enabled,
+    ):
+        session_id = create_session(webdriver_port, beforeunload_prompt_handler="dismiss")
+        log = [f"{label} initial: {current_url(webdriver_port, session_id)}"]
+        try:
+            page_server.a_document_ran.clear()
+            load_url_from_ui(webdriver_port, session_id, url_a)
+            wait_for_event(page_server.a_document_ran, f"A document before {label}")
+            expect_url(webdriver_port, session_id, f"after {label} setup /a", url_a, log)
+
+            page_server.b_document_ran.clear()
+            load_url_from_ui(webdriver_port, session_id, url_b)
+            wait_for_event(page_server.b_document_ran, f"B document before {label}")
+            expect_url(webdriver_port, session_id, f"after {label} setup /b", url_b, log)
+            expect_ui_session_history(
+                webdriver_port,
+                session_id,
+                f"before {label}",
+                [url_a, url_b],
+                [0, 1],
+                1,
+                True,
+                False,
+                log,
+                expect_history_idle=True,
+            )
+
+            install_cancellable_beforeunload_handler(webdriver_port, session_id, label, log)
+            document_ran_event.clear()
+            start_navigation(session_id)
+            wait_for_event(document_ran_event, f"target document after {label}")
+
+            expect_url(webdriver_port, session_id, f"after {label}", expected_url, log)
+            expect_no_user_prompt(webdriver_port, session_id, label, log)
+            expect_ui_session_history(
+                webdriver_port,
+                session_id,
+                f"after {label}",
+                expected_entry_urls,
+                list(range(len(expected_entry_urls))),
+                expected_current_index,
+                expected_back_enabled,
+                expected_forward_enabled,
+                log,
+                expect_history_idle=True,
+            )
+            expect_beforeunload_event_recorded(webdriver_port, session_id, url_b, label, log)
+        finally:
+            request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+    run_case(
+        "same-site link navigation with beforeunload",
+        url_c,
+        page_server.c_document_ran,
+        lambda session_id: execute_script(
+            webdriver_port,
+            session_id,
+            'document.querySelector("#go").click(); return null;',
+        ),
+        [url_a, url_b, url_c],
+        2,
+        True,
+        False,
+    )
+    run_case(
+        "cross-site link navigation with beforeunload",
+        url_d,
+        page_server.d_document_ran,
+        lambda session_id: execute_script(
+            webdriver_port,
+            session_id,
+            'document.querySelector("#branch").click(); return null;',
+        ),
+        [url_a, url_b, url_d],
+        2,
+        True,
+        False,
+    )
+    run_case(
+        "same-site WebDriver navigation with beforeunload",
+        url_c,
+        page_server.c_document_ran,
+        lambda session_id: request(webdriver_port, "POST", f"/session/{session_id}/url", {"url": url_c}),
+        [url_a, url_b, url_c],
+        2,
+        True,
+        False,
+    )
+    run_case(
+        "cross-site WebDriver navigation with beforeunload",
+        url_d,
+        page_server.d_document_ran,
+        lambda session_id: request(webdriver_port, "POST", f"/session/{session_id}/url", {"url": url_d}),
+        [url_a, url_b, url_d],
+        2,
+        True,
+        False,
+    )
+    run_case(
+        "WebDriver refresh with beforeunload",
+        url_b,
+        page_server.b_document_ran,
+        lambda session_id: refresh(webdriver_port, session_id),
+        [url_a, url_b],
+        1,
+        True,
+        False,
+    )
+    run_case(
+        "browser UI back with beforeunload",
+        url_a,
+        page_server.a_document_ran,
+        lambda session_id: traverse_history_from_ui(
+            webdriver_port,
+            session_id,
+            -1,
+            wait_for_navigation_completion=False,
+        ),
+        [url_a, url_b],
+        0,
+        False,
+        True,
+    )
+    run_case(
+        "WebDriver back with beforeunload",
+        url_a,
+        page_server.a_document_ran,
+        lambda session_id: request(webdriver_port, "POST", f"/session/{session_id}/back", {}),
+        [url_a, url_b],
+        0,
+        False,
+        True,
+    )
+    run_case(
+        "script-initiated history.back() with beforeunload",
+        url_a,
+        page_server.a_document_ran,
+        lambda session_id: execute_script(webdriver_port, session_id, "history.back(); return null;"),
+        [url_a, url_b],
+        0,
+        False,
+        True,
+    )
+
+
 def expect_cross_site_fragment_navigation_from_ui_loads_document(
     webdriver_port,
     session_id,
@@ -2592,6 +2722,7 @@ def run_test(webdriver_binary):
         session_id = None
 
         run_self_contained_navigation_tests(webdriver_port, page_port, url_a)
+        run_beforeunload_webdriver_suppression_tests(webdriver_port, page_server, url_a, url_b, url_c, url_d)
 
         session_id = create_session(webdriver_port)
         log = [f"duplicate URL crash recovery initial: {current_url(webdriver_port, session_id)}"]
@@ -2857,7 +2988,7 @@ return [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.heigh
         request(webdriver_port, "DELETE", f"/session/{session_id}")
         session_id = None
 
-        session_id = create_session(webdriver_port)
+        session_id = create_session(webdriver_port, beforeunload_prompt_handler="dismiss")
         log = [f"blocked process-swap WebDriver back initial: {current_url(webdriver_port, session_id)}"]
         with page_server.process_swap_back_blocked_request_lock:
             page_server.process_swap_back_blocked_request_count = 0
@@ -2882,6 +3013,13 @@ return [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.heigh
             1,
             True,
             False,
+            log,
+        )
+        process_swap_beforeunload_label = "process-swap WebDriver back with beforeunload"
+        install_cancellable_beforeunload_handler(
+            webdriver_port,
+            session_id,
+            process_swap_beforeunload_label,
             log,
         )
 
@@ -2911,6 +3049,7 @@ return [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.heigh
             url_process_swap_back_blocked,
             log,
         )
+        expect_no_user_prompt(webdriver_port, session_id, process_swap_beforeunload_label, log)
         expect_ui_session_history(
             webdriver_port,
             session_id,
@@ -2922,99 +3061,11 @@ return [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.heigh
             True,
             log,
         )
-        request(webdriver_port, "DELETE", f"/session/{session_id}")
-        session_id = None
-
-        session_id = create_session(webdriver_port)
-        log = [f"blocked process-swap WebDriver back beforeunload initial: {current_url(webdriver_port, session_id)}"]
-        with page_server.process_swap_back_blocked_request_lock:
-            page_server.process_swap_back_blocked_request_count = 0
-        page_server.blocked_process_swap_back_requested.clear()
-        page_server.release_blocked_process_swap_back.clear()
-        load_url_from_ui(webdriver_port, session_id, url_process_swap_back_blocked)
-        expect_url(
+        expect_beforeunload_event_recorded(
             webdriver_port,
             session_id,
-            "after blocked process-swap WebDriver beforeunload setup /process-swap-back-blocked",
-            url_process_swap_back_blocked,
-            log,
-        )
-        load_url_from_ui(webdriver_port, session_id, url_b)
-        expect_url(webdriver_port, session_id, "after blocked process-swap WebDriver beforeunload setup /b", url_b, log)
-        before_blocked_process_swap_webdriver_back = expect_session_history_idle(
-            webdriver_port, session_id, "before blocked process-swap WebDriver back from /b", log
-        )
-        beforeunload_setup = execute_script(
-            webdriver_port,
-            session_id,
-            """
-window.beforeUnloadCount = 0;
-window.onbeforeunload = event => {
-    ++window.beforeUnloadCount;
-    event.preventDefault();
-    event.returnValue = "blocked";
-    return "blocked";
-};
-return [location.href, window.beforeUnloadCount];
-""",
-        )
-        if beforeunload_setup != [url_b, 0]:
-            raise AssertionError(
-                f"Expected process-swap WebDriver beforeunload setup on /b to be {[url_b, 0]}, "
-                f"got {beforeunload_setup}\n" + "\n".join(log)
-            )
-        inert_click_point = execute_script(
-            webdriver_port,
-            session_id,
-            """
-const rect = document.querySelector("p").getBoundingClientRect();
-return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.height / 2)];
-""",
-        )
-        perform_pointer_click(webdriver_port, session_id, inert_click_point[0], inert_click_point[1], log)
-
-        webdriver_back_error = []
-
-        def request_blocked_webdriver_back():
-            try:
-                request(webdriver_port, "POST", f"/session/{session_id}/back", {})
-            except Exception as error:
-                webdriver_back_error.append(error)
-
-        webdriver_back_thread = threading.Thread(target=request_blocked_webdriver_back)
-        webdriver_back_thread.start()
-        webdriver_back_thread.join(timeout=EVENT_TIMEOUT_SECONDS)
-        if page_server.blocked_process_swap_back_requested.is_set():
-            page_server.release_blocked_process_swap_back.set()
-            webdriver_back_thread.join(timeout=EVENT_TIMEOUT_SECONDS)
-            raise AssertionError(
-                "Expected beforeunload to cancel process-swap WebDriver back before loading target\n" + "\n".join(log)
-            )
-        if webdriver_back_thread.is_alive():
-            raise AssertionError(
-                "Timed out waiting for blocked process-swap WebDriver back request to finish\n" + "\n".join(log)
-            )
-        if webdriver_back_error:
-            raise webdriver_back_error[0]
-        blocked_process_swap_webdriver_back_state = execute_script(
-            webdriver_port,
-            session_id,
-            "return [location.href, window.beforeUnloadCount];",
-        )
-        if blocked_process_swap_webdriver_back_state != [url_b, 1]:
-            raise AssertionError(
-                f"Expected beforeunload to cancel process-swap WebDriver back from /b, "
-                f"got {blocked_process_swap_webdriver_back_state}\n" + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked process-swap WebDriver back from /b",
-            history_entry_urls(before_blocked_process_swap_webdriver_back["ui"]),
-            history_used_steps(before_blocked_process_swap_webdriver_back["ui"]),
-            before_blocked_process_swap_webdriver_back["ui"]["currentUsedStepIndex"],
-            before_blocked_process_swap_webdriver_back["ui"]["backButtonEnabled"],
-            before_blocked_process_swap_webdriver_back["ui"]["forwardButtonEnabled"],
+            url_b,
+            process_swap_beforeunload_label,
             log,
         )
         request(webdriver_port, "DELETE", f"/session/{session_id}")
@@ -3524,64 +3575,6 @@ return [Math.round(rect.left + rect.width / 2), Math.round(rect.top + rect.heigh
             )
 
         expect_sandboxed_history_back_to_be_blocked(webdriver_port, session_id, url_a, url_b, log)
-
-        before_script_initiated_blocked_back = after_page_initiated_history_forward_to_b
-        perform_pointer_click(webdriver_port, session_id, 5, 5, log)
-        script_beforeunload_setup = execute_script(
-            webdriver_port,
-            session_id,
-            """
-window.scriptBeforeUnloadCount = 0;
-window.onbeforeunload = event => {
-    ++window.scriptBeforeUnloadCount;
-    event.preventDefault();
-    event.returnValue = "blocked";
-    return "blocked";
-};
-return [location.href, window.scriptBeforeUnloadCount, navigator.userActivation.hasBeenActive];
-""",
-        )
-        if script_beforeunload_setup != [url_b, 0, True]:
-            raise AssertionError(
-                f"Expected script beforeunload setup on /b to be {[url_b, 0, True]}, "
-                f"got {script_beforeunload_setup}\n" + "\n".join(log)
-            )
-        execute_script(webdriver_port, session_id, "history.back(); return location.href;")
-
-        def script_back_canceled_by_beforeunload(result):
-            return (
-                isinstance(result, list)
-                and len(result) == 2
-                and result[0] == url_b
-                and isinstance(result[1], int)
-                and result[1] >= 1
-            )
-
-        script_blocked_back_state = wait_for_script_result(
-            webdriver_port,
-            session_id,
-            "blocked script-initiated cross-site history.back() from /b",
-            "return [location.href, window.scriptBeforeUnloadCount];",
-            script_back_canceled_by_beforeunload,
-            log,
-        )
-        if script_blocked_back_state != [url_b, 1]:
-            raise AssertionError(
-                f"Expected beforeunload to cancel script-initiated cross-site history.back(), "
-                f"got {script_blocked_back_state}\n" + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked script-initiated cross-site history.back()",
-            history_entry_urls(before_script_initiated_blocked_back["ui"]),
-            history_used_steps(before_script_initiated_blocked_back["ui"]),
-            before_script_initiated_blocked_back["ui"]["currentUsedStepIndex"],
-            before_script_initiated_blocked_back["ui"]["backButtonEnabled"],
-            before_script_initiated_blocked_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-        execute_script(webdriver_port, session_id, "window.onbeforeunload = null; return null;")
 
         page_server.a_document_ran.clear()
         traverse_history_from_ui(webdriver_port, session_id, -1, wait_for_navigation_completion=False)
@@ -4565,203 +4558,6 @@ return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.heigh
             before_blocked_browser_ui_back,
             log,
         )
-
-        beforeunload_setup = execute_script(
-            webdriver_port,
-            session_id,
-            """
-window.beforeUnloadCount = 0;
-window.onbeforeunload = event => {
-    ++window.beforeUnloadCount;
-    event.preventDefault();
-    event.returnValue = "blocked";
-    return "blocked";
-};
-return [location.href, window.beforeUnloadCount];
-""",
-        )
-        if beforeunload_setup != [url_b, 0]:
-            raise AssertionError(
-                f"Expected beforeunload setup on /b to be {[url_b, 0]}, got {beforeunload_setup}\n" + "\n".join(log)
-            )
-        link_click_point = execute_script(
-            webdriver_port,
-            session_id,
-            """
-const rect = document.querySelector("#go").getBoundingClientRect();
-return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.height / 2)];
-""",
-        )
-        perform_pointer_click(webdriver_port, session_id, link_click_point[0], link_click_point[1], log)
-        user_activation = execute_script(webdriver_port, session_id, "return navigator.userActivation.hasBeenActive;")
-        if user_activation is not True:
-            raise AssertionError("Expected pointer click to give /b sticky activation\n" + "\n".join(log))
-
-        blocked_link_navigation_state = execute_script(
-            webdriver_port,
-            session_id,
-            "return [location.href, window.beforeUnloadCount];",
-        )
-        if blocked_link_navigation_state[0] != url_b or blocked_link_navigation_state[1] < 1:
-            raise AssertionError(
-                f"Expected beforeunload to cancel link navigation from /b, got {blocked_link_navigation_state}\n"
-                + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked link navigation from /b",
-            history_entry_urls(before_blocked_browser_ui_back["ui"]),
-            history_used_steps(before_blocked_browser_ui_back["ui"]),
-            before_blocked_browser_ui_back["ui"]["currentUsedStepIndex"],
-            before_blocked_browser_ui_back["ui"]["backButtonEnabled"],
-            before_blocked_browser_ui_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-
-        blocked_webdriver_navigate_state = expect_beforeunload_cancels_webdriver_navigation(
-            webdriver_port,
-            session_id,
-            url_c,
-            "WebDriver navigation from /b",
-            url_b,
-            blocked_link_navigation_state[1],
-            before_blocked_browser_ui_back,
-            log,
-        )
-
-        blocked_cross_site_webdriver_navigate_state = expect_beforeunload_cancels_webdriver_navigation(
-            webdriver_port,
-            session_id,
-            url_d,
-            "cross-site WebDriver navigation from /b",
-            url_b,
-            blocked_webdriver_navigate_state[1],
-            before_blocked_browser_ui_back,
-            log,
-        )
-
-        blocked_refresh_state = expect_beforeunload_cancels_refresh(
-            webdriver_port,
-            session_id,
-            url_b,
-            blocked_cross_site_webdriver_navigate_state[1],
-            log,
-        )
-
-        traverse_history_from_ui(webdriver_port, session_id, -1)
-        blocked_beforeunload_state = execute_script(
-            webdriver_port,
-            session_id,
-            "return [location.href, window.beforeUnloadCount];",
-        )
-        if blocked_beforeunload_state[0] != url_b or blocked_beforeunload_state[1] <= blocked_refresh_state[1]:
-            raise AssertionError(
-                f"Expected beforeunload to cancel browser UI back from /b, got {blocked_beforeunload_state}\n"
-                + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked browser UI back from /b",
-            history_entry_urls(before_blocked_browser_ui_back["ui"]),
-            history_used_steps(before_blocked_browser_ui_back["ui"]),
-            before_blocked_browser_ui_back["ui"]["currentUsedStepIndex"],
-            before_blocked_browser_ui_back["ui"]["backButtonEnabled"],
-            before_blocked_browser_ui_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-
-        request(webdriver_port, "POST", f"/session/{session_id}/back", {})
-        blocked_webdriver_back_state = execute_script(
-            webdriver_port,
-            session_id,
-            "return [location.href, window.beforeUnloadCount];",
-        )
-        if blocked_webdriver_back_state[0] != url_b or blocked_webdriver_back_state[1] <= blocked_beforeunload_state[1]:
-            raise AssertionError(
-                f"Expected beforeunload to cancel WebDriver back from /b, got {blocked_webdriver_back_state}\n"
-                + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked WebDriver back from /b",
-            history_entry_urls(before_blocked_browser_ui_back["ui"]),
-            history_used_steps(before_blocked_browser_ui_back["ui"]),
-            before_blocked_browser_ui_back["ui"]["currentUsedStepIndex"],
-            before_blocked_browser_ui_back["ui"]["backButtonEnabled"],
-            before_blocked_browser_ui_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-
-        traverse_history_from_ui(webdriver_port, session_id, -1, wait_for_navigation_completion=False)
-
-        def browser_back_was_canceled_by_beforeunload(result):
-            return (
-                isinstance(result, list)
-                and len(result) == 2
-                and result[0] == url_b
-                and isinstance(result[1], int)
-                and result[1] > blocked_webdriver_back_state[1]
-            )
-
-        blocked_browser_back_state = wait_for_script_result(
-            webdriver_port,
-            session_id,
-            "beforeunload-canceled browser back from /b",
-            "return [location.href, window.beforeUnloadCount];",
-            browser_back_was_canceled_by_beforeunload,
-            log,
-        )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked browser back from /b",
-            history_entry_urls(before_blocked_browser_ui_back["ui"]),
-            history_used_steps(before_blocked_browser_ui_back["ui"]),
-            before_blocked_browser_ui_back["ui"]["currentUsedStepIndex"],
-            before_blocked_browser_ui_back["ui"]["backButtonEnabled"],
-            before_blocked_browser_ui_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-
-        cross_site_link_click_point = execute_script(
-            webdriver_port,
-            session_id,
-            """
-const rect = document.querySelector("#branch").getBoundingClientRect();
-return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.height / 2)];
-""",
-        )
-        perform_pointer_click(
-            webdriver_port, session_id, cross_site_link_click_point[0], cross_site_link_click_point[1], log
-        )
-        blocked_cross_site_link_navigation_state = execute_script(
-            webdriver_port,
-            session_id,
-            "return [location.href, window.beforeUnloadCount];",
-        )
-        if (
-            blocked_cross_site_link_navigation_state[0] != url_b
-            or blocked_cross_site_link_navigation_state[1] <= blocked_browser_back_state[1]
-        ):
-            raise AssertionError(
-                f"Expected beforeunload to cancel cross-site link navigation from /b, got {blocked_cross_site_link_navigation_state}\n"
-                + "\n".join(log)
-            )
-        expect_ui_session_history(
-            webdriver_port,
-            session_id,
-            "after blocked cross-site link navigation from /b",
-            history_entry_urls(before_blocked_browser_ui_back["ui"]),
-            history_used_steps(before_blocked_browser_ui_back["ui"]),
-            before_blocked_browser_ui_back["ui"]["currentUsedStepIndex"],
-            before_blocked_browser_ui_back["ui"]["backButtonEnabled"],
-            before_blocked_browser_ui_back["ui"]["forwardButtonEnabled"],
-            log,
-        )
-        execute_script(webdriver_port, session_id, "window.onbeforeunload = null; return null;")
 
         page_server.release_blocked_frame_b.clear()
         page_server.blocked_frame_b_requested.clear()

--- a/Tests/UI/Qt/TestJavaScriptDialog.cpp
+++ b/Tests/UI/Qt/TestJavaScriptDialog.cpp
@@ -14,6 +14,7 @@
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QStackedWidget>
 #include <QVBoxLayout>
@@ -172,6 +173,59 @@ TEST_CASE(prompt_supports_defaults_updates_and_keyboard_completion)
     dialog.show_prompt("https://example.com", "Prompt message", "ignored");
     trigger_shortcut(dialog, Qt::Key_Escape);
     EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::Prompt);
+    EXPECT(!completion.accepted);
+}
+
+TEST_CASE(beforeunload_uses_fixed_copy_and_navigation_button_roles)
+{
+    QWidget web_view;
+    web_view.resize(800, 600);
+    web_view.show();
+
+    Ladybird::JavaScriptDialog dialog(&web_view);
+    Completion completion;
+    record_completions(dialog, completion);
+
+    dialog.show_before_unload("https://example.com");
+    QApplication::processEvents();
+    auto* title_label = dialog.findChild<QLabel*>("LadybirdJavaScriptDialogTitle");
+    auto* message_label = dialog.findChild<QLabel*>("LadybirdJavaScriptDialogMessage");
+    auto* message_area = dialog.findChild<QScrollArea*>("LadybirdJavaScriptDialogMessageArea");
+    auto* button_box = dialog.findChild<QDialogButtonBox*>("LadybirdJavaScriptDialogButtons");
+    VERIFY(title_label);
+    VERIFY(message_label);
+    VERIFY(message_area);
+    VERIFY(button_box);
+    auto* leave_button = button_box->button(QDialogButtonBox::Ok);
+    auto* stay_button = button_box->button(QDialogButtonBox::Cancel);
+    VERIFY(leave_button);
+    VERIFY(stay_button);
+    EXPECT(title_label->text() == "https://example.com");
+    EXPECT(message_label->text() == "Leave this page? Your changes may not be saved.");
+    EXPECT(leave_button->text() == "Leave");
+    EXPECT(stay_button->text() == "Stay");
+    EXPECT(leave_button->isDefault());
+    EXPECT(dialog.focusWidget() == leave_button);
+    EXPECT(!message_area->verticalScrollBar()->isVisible());
+    EXPECT(message_area->viewport()->height() >= message_label->heightForWidth(message_area->viewport()->width()));
+
+    send_key(*leave_button, Qt::Key_Return);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::BeforeUnload);
+    EXPECT(completion.accepted);
+
+    completion = {};
+    dialog.show_before_unload("https://example.com");
+    trigger_shortcut(dialog, Qt::Key_Escape);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::BeforeUnload);
+    EXPECT(!completion.accepted);
+
+    completion = {};
+    dialog.show_before_unload("https://example.com");
+    stay_button = button_box->button(QDialogButtonBox::Cancel);
+    VERIFY(stay_button);
+    stay_button->setFocus();
+    send_key(*stay_button, Qt::Key_Return);
+    EXPECT(completion.type == Ladybird::JavaScriptDialog::Type::BeforeUnload);
     EXPECT(!completion.accepted);
 }
 

--- a/Tests/UI/Qt/TestJavaScriptDialog.cpp
+++ b/Tests/UI/Qt/TestJavaScriptDialog.cpp
@@ -89,10 +89,12 @@ void send_key(QWidget& widget, int key)
 TEST_CASE(alert_and_confirm_report_the_expected_results)
 {
     QWidget web_view;
+    web_view.setCursor(Qt::PointingHandCursor);
     web_view.resize(800, 600);
     web_view.show();
 
     Ladybird::JavaScriptDialog dialog(&web_view);
+    EXPECT_EQ(dialog.cursor().shape(), Qt::ArrowCursor);
     Completion completion;
     record_completions(dialog, completion);
 

--- a/UI/Qt/JavaScriptDialog.cpp
+++ b/UI/Qt/JavaScriptDialog.cpp
@@ -343,6 +343,7 @@ void JavaScriptDialog::resizeEvent(QResizeEvent* event)
 void JavaScriptDialog::showEvent(QShowEvent* event)
 {
     QWidget::showEvent(event);
+    update_geometry_constraints();
     raise();
     focus_dialog();
 }
@@ -378,7 +379,8 @@ void JavaScriptDialog::update_geometry_constraints()
     m_panel->setMinimumWidth(min(DIALOG_MIN_WIDTH, available_width));
     m_panel->setMaximumWidth(min(DIALOG_MAX_WIDTH, available_width));
 
-    auto message_width = max(1, min(DIALOG_MAX_WIDTH - PANEL_HORIZONTAL_PADDING * 2, available_width - PANEL_HORIZONTAL_PADDING * 2));
+    auto maximum_message_width = max(1, available_width - PANEL_HORIZONTAL_PADDING * 2);
+    auto message_width = max(1, min(m_message_scroll_area->width(), maximum_message_width));
     auto desired_message_height = max(0, m_message_label->heightForWidth(message_width));
     m_message_label->setMinimumHeight(desired_message_height);
 

--- a/UI/Qt/JavaScriptDialog.cpp
+++ b/UI/Qt/JavaScriptDialog.cpp
@@ -36,6 +36,7 @@ JavaScriptDialog::JavaScriptDialog(QWidget* parent)
     : QWidget(parent)
 {
     setObjectName("LadybirdJavaScriptDialogOverlay");
+    setCursor(Qt::ArrowCursor);
     setAttribute(Qt::WA_StyledBackground);
 #if defined(AK_OS_MACOS) || defined(USE_DIRECTX) || defined(USE_VULKAN_DMABUF_IMAGES)
     // Native rendering surfaces stack above ordinary child widgets. Match their native stacking level so the dialog

--- a/UI/Qt/JavaScriptDialog.cpp
+++ b/UI/Qt/JavaScriptDialog.cpp
@@ -116,6 +116,11 @@ void JavaScriptDialog::show_alert(QString const& title, QString const& message)
     open(Type::Alert, title, message);
 }
 
+void JavaScriptDialog::show_before_unload(QString const& title)
+{
+    open(Type::BeforeUnload, title, "Leave this page? Your changes may not be saved.");
+}
+
 void JavaScriptDialog::show_confirm(QString const& title, QString const& message)
 {
     open(Type::Confirm, title, message);
@@ -153,6 +158,12 @@ void JavaScriptDialog::open(Type type, QString const& title, QString const& mess
     }
     auto* ok_button = m_button_box->button(QDialogButtonBox::Ok);
     auto* cancel_button = m_button_box->button(QDialogButtonBox::Cancel);
+    if (type == Type::BeforeUnload) {
+        VERIFY(ok_button);
+        VERIFY(cancel_button);
+        ok_button->setText("Leave");
+        cancel_button->setText("Stay");
+    }
     if (ok_button)
         ok_button->setDefault(type != Type::Prompt);
 

--- a/UI/Qt/JavaScriptDialog.h
+++ b/UI/Qt/JavaScriptDialog.h
@@ -24,6 +24,7 @@ class JavaScriptDialog final : public QWidget {
 public:
     enum class Type {
         Alert,
+        BeforeUnload,
         Confirm,
         Prompt,
     };
@@ -33,6 +34,7 @@ public:
     bool is_open() const { return m_type.has_value(); }
 
     void show_alert(QString const& title, QString const& message);
+    void show_before_unload(QString const& title);
     void show_confirm(QString const& title, QString const& message);
     void show_prompt(QString const& title, QString const& message, QString const& default_text);
     void set_prompt_text(QString const& text);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -877,6 +877,8 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         case JavaScriptDialog::Type::Alert:
             view().alert_closed();
             break;
+        case JavaScriptDialog::Type::BeforeUnload:
+            VERIFY_NOT_REACHED();
         case JavaScriptDialog::Type::Confirm:
             view().confirm_closed(accepted);
             break;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -852,6 +852,11 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_javascript_dialog->show_alert(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
+    view().on_request_before_unload = [this](auto const& source, auto on_complete) {
+        m_before_unload_completion = AK::move(on_complete);
+        m_javascript_dialog->show_before_unload(qstring_from_ak_string(source));
+    };
+
     view().on_request_confirm = [this, javascript_dialog_title](auto const& message) {
         if (m_suppress_javascript_dialogs_until_navigation) {
             view().confirm_closed(false);
@@ -877,8 +882,16 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         case JavaScriptDialog::Type::Alert:
             view().alert_closed();
             break;
-        case JavaScriptDialog::Type::BeforeUnload:
-            VERIFY_NOT_REACHED();
+        case JavaScriptDialog::Type::BeforeUnload: {
+            auto on_complete = AK::move(m_before_unload_completion);
+            VERIFY(on_complete);
+            on_complete(accepted);
+            if (!accepted) {
+                m_already_requested_close = false;
+                m_suppress_javascript_dialogs_until_navigation = false;
+            }
+            break;
+        }
         case JavaScriptDialog::Type::Confirm:
             view().confirm_closed(accepted);
             break;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -849,10 +849,12 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
             view().alert_closed();
             return;
         }
+        hide_hover_label();
         m_javascript_dialog->show_alert(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
     view().on_request_before_unload = [this](auto const& source, auto on_complete) {
+        hide_hover_label();
         m_before_unload_completion = AK::move(on_complete);
         m_javascript_dialog->show_before_unload(qstring_from_ak_string(source));
     };
@@ -862,6 +864,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
             view().confirm_closed(false);
             return;
         }
+        hide_hover_label();
         m_javascript_dialog->show_confirm(javascript_dialog_title(), qstring_from_utf16_string(message));
     };
 
@@ -870,6 +873,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
             view().prompt_closed({});
             return;
         }
+        hide_hover_label();
         m_javascript_dialog->show_prompt(javascript_dialog_title(), qstring_from_utf16_string(message), qstring_from_utf16_string(default_));
     };
 
@@ -919,6 +923,8 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
             on_complete(false);
             return;
         }
+
+        hide_hover_label();
 
         auto initiator = initiator_origin.is_opaque() ? "This page"_string : initiator_origin.serialize();
         auto application_name = handler.application_name().is_empty() ? "another application"sv : handler.application_name().bytes_as_string_view();
@@ -1412,6 +1418,11 @@ void Tab::update_hover_label()
         m_hover_label->move(left_position);
 
     m_hover_label->raise();
+}
+
+void Tab::hide_hover_label()
+{
+    m_hover_label->hide();
 }
 
 bool Tab::event(QEvent* event)

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -133,6 +133,7 @@ private:
     void position_downloads_popover();
     void show_private_session_popover();
     void position_private_session_popover();
+    void hide_hover_label();
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -190,6 +190,7 @@ private:
     QString m_downloads_button_tooltip;
 
     JavaScriptDialog* m_javascript_dialog { nullptr };
+    Function<void(bool)> m_before_unload_completion;
     QPointer<QColorDialog> m_color_picker_dialog;
     QPointer<QMessageBox> m_external_url_confirmation_dialog;
 


### PR DESCRIPTION
<img width="1122" height="808" alt="Screenshot_20260828_123137" src="https://github.com/user-attachments/assets/e9d3d5e0-f036-4682-bcb9-9f406994f5a4" />

We had *some* amount of `beforeunload`-related code already, but didn't actually show any dialogs. This PR adds them, shows them when relevant, and fixes up some hacks we had to work around their absence. Also includes a couple of fixes to the dialogs code which showed up while I was testing this.

Known limitations:
- No AppKit implementation yet. (It acts as if the dialog was confirmed.)
- Closing the window does not trigger `beforeunload`. That's a heftier change that I'll PR later.