### PR TITLE
CI: Do not update the Rust toolchain with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,3 @@ updates:
     groups:
       actions:
         group-by: dependency-name
-
-  - package-ecosystem: "rust-toolchain"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "CI:"


### PR DESCRIPTION
Dependabot will update the version, but there are too many additional steps needed afterwards:

* Updating the Docker VERSION file
* A follow-up PR to update container versions in CI workflows
* Handling all the cargo linter updates

Dependabot PRs are practically guaranteed to fail here.