### PR TITLE
LibWeb: Implement the `overflow-wrap` property

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -120,22 +120,6 @@ static Optional<Appearance> appearance_without_compat_from_keyword(Keyword keywo
     }
 }
 
-// overflow-wrap has no generated keyword converter; the mapping matches the
-// switch in create().
-static Optional<OverflowWrap> overflow_wrap_from_keyword(Keyword keyword)
-{
-    switch (keyword) {
-    case Keyword::Normal:
-        return OverflowWrap::Normal;
-    case Keyword::BreakWord:
-        return OverflowWrap::BreakWord;
-    case Keyword::Anywhere:
-        return OverflowWrap::Anywhere;
-    default:
-        return {};
-    }
-}
-
 // The properties the core's bespoke grid group build consumes from the
 // longhand table.
 static constexpr Array grid_group_properties {
@@ -291,7 +275,7 @@ static void register_style_group_field_descriptors()
     add(inherited_text, PropertyID::TabSize, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
     add(inherited_text, PropertyID::WhiteSpaceCollapse, offsetof(InheritedText, white_space_collapse), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_white_space_collapse>());
     add(inherited_text, PropertyID::WordBreak, offsetof(InheritedText, word_break), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_word_break>());
-    add(inherited_text, PropertyID::OverflowWrap, offsetof(InheritedText, overflow_wrap), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<overflow_wrap_from_keyword>());
+    add(inherited_text, PropertyID::OverflowWrap, offsetof(InheritedText, overflow_wrap), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_overflow_wrap>());
     add(inherited_text, PropertyID::WordSpacing, offsetof(InheritedText, word_spacing), GROUP_FIELD_CSS_PIXELS, 0, nullptr);
     add(inherited_text, PropertyID::WordSpacing, offsetof(InheritedText, word_spacing_style_value), GROUP_FIELD_RETAINED_DATA, 0, nullptr);
     add(inherited_text, PropertyID::LetterSpacing, offsetof(InheritedText, letter_spacing), GROUP_FIELD_CSS_PIXELS, 0, nullptr);

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -432,12 +432,6 @@ struct ComputedFontStyle {
     bool operator==(ComputedFontStyle const&) const = default;
 };
 
-enum class OverflowWrap : u8 {
-    Normal,
-    BreakWord,
-    Anywhere,
-};
-
 class InitialValues {
 public:
     static AspectRatio aspect_ratio() { return AspectRatio { true, {}, true, {} }; }

--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -40,6 +40,9 @@ textarea {
     overflow: auto;
     font-family: monospace;
     resize: both;
+    /* This matches the behavior of other engines.
+     * Spec issue: https://github.com/whatwg/html/issues/953 */
+    overflow-wrap: break-word;
 }
 
 input::placeholder, textarea::placeholder {

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -810,6 +810,11 @@
     "scroll",
     "visible"
   ],
+  "overflow-wrap": [
+    "normal",
+    "break-word",
+    "anywhere"
+  ],
   "page-size": [
     "a5",
     "a4",

--- a/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_views.rs
@@ -753,6 +753,10 @@ impl<'a> ComputedValuesView<'a> {
             .expect("computed y lost its style value")
     }
 
+    pub(crate) fn overflow_wrap(self) -> u8 {
+        self.inherited_text().overflow_wrap
+    }
+
     pub(crate) fn text_indent(self) -> LengthPercentageRef<'a> {
         self.inherited_text_facts()
             .text_indent

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -2760,8 +2760,7 @@ impl InheritedTextValues {
                 is_auto: true,
                 value: ComputedStyleValueHandle::empty(),
             },
-            // OverflowWrap::Normal.
-            overflow_wrap: 0,
+            overflow_wrap: enum_value(css_enums::keyword_to_overflow_wrap(css_enums::keyword::NORMAL)),
             word_spacing_style_value: ComputedStyleValueHandle::empty(),
             letter_spacing_style_value: ComputedStyleValueHandle::empty(),
             orphans: 2,

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -123,6 +123,13 @@ impl BlockMarginState {
         self.pending_top_margin_groups.last().is_some_and(|group| group.open)
     }
 
+    pub(crate) fn pending_margin_for_next_box(&self) -> CssPixels {
+        if self.has_open_top_margin_group() {
+            return CssPixels::default();
+        }
+        self.current_collapsed_margin()
+    }
+
     pub(crate) fn update_open_top_margin_group(&mut self) {
         if self.has_open_top_margin_group() {
             let collapsed = self.current_collapsed_margin();
@@ -1598,14 +1605,19 @@ impl BlockFormattingContext {
 
         if facts.is_absolutely_positioned() {
             if self.layout_mode == LayoutMode::Normal {
+                // The static position sits where the next in-flow box would be placed, so the
+                // collapsed margin pending from preceding siblings applies to it as well.
+                let pending_margin = self.margin_state.borrow().pending_margin_for_next_box();
                 // NB: An originally-inline absolutely positioned box never reaches this path; the tree
                 //     builder keeps out-of-flow boxes in inline context, where static position markers
                 //     pin them at their exact flow position.
                 self.register_contained_abspos_child(
                     node,
-                    self.block_offset_of_current_block_container
-                        .get()
-                        .expect("a block container flow cursor is active"),
+                    pending_margin
+                        + self
+                            .block_offset_of_current_block_container
+                            .get()
+                            .expect("a block container flow cursor is active"),
                     block_container,
                 );
             }
@@ -1638,14 +1650,7 @@ impl BlockFormattingContext {
                 .block_offset_of_current_block_container
                 .get()
                 .expect("a block container flow cursor is active");
-            let margin_top = {
-                let margin_state = self.margin_state.borrow();
-                if margin_state.has_open_top_margin_group() {
-                    CssPixels::default()
-                } else {
-                    margin_state.current_collapsed_margin()
-                }
-            };
+            let margin_top = self.margin_state.borrow().pending_margin_for_next_box();
             self.layout_floating_box(run, node, input, margin_top + block_offset, None);
             if let Some(floating_box) = self.floats.borrow().last() {
                 *bottom_of_lowest_margin_box = (*bottom_of_lowest_margin_box).max(floating_box.bottom_margin_edge);
@@ -1697,11 +1702,8 @@ impl BlockFormattingContext {
             return;
         }
 
-        let mut margin_top = self.margin_state.borrow().current_collapsed_margin();
-        if self.margin_state.borrow().has_open_top_margin_group() {
-            // If first child margin top will collapse with margin-top of containing block then margin-top of child is 0
-            margin_top = CssPixels::default();
-        }
+        // If first child margin top will collapse with margin-top of containing block then margin-top of child is 0
+        let margin_top = self.margin_state.borrow().pending_margin_for_next_box();
 
         let box_opens_top_margin_group = !has_independent_formatting_context
             && self.used(node).border_top.get() == CssPixels::default()

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1351,12 +1351,12 @@ impl<'context> InlineFormattingContext<'context> {
                             line_builder.set_trailing_whitespace_on_previous_line();
                             continue;
                         }
-                        let line_is_empty = self
+                        let line_is_empty_or_ends_in_whitespace = self
                             .line_data()
                             .line_boxes
                             .last()
-                            .is_some_and(line_box::LineBoxData::is_empty);
-                        if !is_whitespace && (item.can_break_before || line_is_empty) {
+                            .is_some_and(line_box::LineBoxData::is_empty_or_ends_in_whitespace);
+                        if !is_whitespace && (item.can_break_before || line_is_empty_or_ends_in_whitespace) {
                             line_builder.break_if_needed(item.border_box_inline_size());
                         }
                     }

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1172,7 +1172,11 @@ impl<'context> InlineFormattingContext<'context> {
                     if item.length_in_node == 0 && item.inline_size == CssPixels::default() {
                         continue;
                     }
-                    let wraps = self.style(self.parent_node(item.node)).text_wrap_mode() == text_wrap_mode::WRAP;
+                    let parent_style = self.style(self.parent_node(item.node));
+                    let wraps = parent_style.text_wrap_mode() == text_wrap_mode::WRAP;
+                    if wraps && breaks_between_graphemes(parent_style) {
+                        return None;
+                    }
                     if !wraps {
                         current += item.inline_size;
                         line_has_content = true;
@@ -1210,6 +1214,60 @@ impl<'context> InlineFormattingContext<'context> {
         Some(maximum)
     }
 
+    pub(crate) fn overflow_break_applies(&self, text_node: Node) -> bool {
+        self.overflow_break_applies_to_style(self.style(self.parent_node(text_node)))
+    }
+
+    pub(crate) fn overflow_break_applies_to_style(&self, style: StyleValues<'_>) -> bool {
+        if style.text_wrap_mode() != text_wrap_mode::WRAP {
+            return false;
+        }
+        breaks_between_graphemes(style)
+            || (style.overflow_wrap() == overflow_wrap::BREAK_WORD
+                && self.input.available_space.inline_size != AvailableSize::MinContent)
+    }
+
+    fn break_overflowing_text_item(
+        &self,
+        line_builder: &mut line_builder::LineBuilder<'_, '_>,
+        item: &mut inline_level_iterator::Item,
+    ) {
+        let style = self.style(self.parent_node(item.node));
+        let text_content = self.callbacks.text_content(item.node);
+        let letter_spacing = style.letter_spacing().to_double() as f32;
+        let word_spacing = style.word_spacing().to_double() as f32;
+        loop {
+            let Some(remaining_inline_size) = line_builder.remaining_inline_size_for_overflow_break() else {
+                return;
+            };
+            if item.border_box_inline_size() <= remaining_inline_size {
+                return;
+            }
+            let line_is_empty = self.line_data().line_boxes.last().is_some_and(|line| line.is_empty());
+            if line_is_empty && line_builder.current_line_has_no_space_left_by_floats() {
+                line_builder.break_line(line_builder::ForcedBreak::No, None);
+                continue;
+            }
+            let split_item = item.split_for_overflow_break(
+                &text_content.text,
+                text_content.grapheme_segmenter(),
+                letter_spacing,
+                word_spacing,
+                remaining_inline_size,
+                line_is_empty,
+            );
+            let Some(mut prefix) = split_item else {
+                if line_is_empty {
+                    return;
+                }
+                line_builder.break_line(line_builder::ForcedBreak::No, Some(item.border_box_inline_size()));
+                continue;
+            };
+            line_builder.append_text_item(&mut prefix, style.line_height());
+            line_builder.break_line(line_builder::ForcedBreak::No, None);
+        }
+    }
+
     pub(crate) fn generate_line_boxes(&mut self) {
         let mut iterator = inline_level_iterator::InlineLevelIterator::new(self);
         self.min_content_inline_size_from_max_content_layout =
@@ -1239,7 +1297,10 @@ impl<'context> InlineFormattingContext<'context> {
         let mut leading_padding = CssPixels::default();
         let mut absolute_boxes = Vec::new();
 
+        let mut previous_text_item_allows_overflow_break_after = false;
         while let Some(mut item) = iterator.next() {
+            let can_break_after_previous_overflow_item =
+                std::mem::take(&mut previous_text_item_allows_overflow_break_after);
             let line_starts_with_whitespace = self
                 .line_data()
                 .line_boxes
@@ -1325,7 +1386,7 @@ impl<'context> InlineFormattingContext<'context> {
                     self.create_used_values(item.node, self.input.containing_block_constraints);
                     self.clear_floating_boxes(item.node);
                     line_builder.set_unbreakable_run_inline_size_interrupted_by_float(
-                        iterator.next_non_whitespace_sequence_inline_size(self),
+                        iterator.next_unbreakable_run_inline_size(self),
                     );
                     self.parent.layout_floating_box(
                         self.run,
@@ -1337,43 +1398,49 @@ impl<'context> InlineFormattingContext<'context> {
                 }
                 inline_level_iterator::ItemType::Text => {
                     line_builder.prepare_to_append_inline_content();
-                    if self.style(self.parent_node(item.node)).text_wrap_mode() == text_wrap_mode::WRAP {
+                    let style = self.style(self.parent_node(item.node));
+                    if style.text_wrap_mode() == text_wrap_mode::WRAP {
                         let is_whitespace = item.is_collapsible_whitespace || item.is_ascii_whitespace(self);
+                        let item_inline_size = item.border_box_inline_size();
                         let next_inline_size = if is_whitespace {
                             iterator.next_non_whitespace_sequence_inline_size(self)
                         } else {
                             CssPixels::default()
                         };
-                        if is_whitespace
-                            && next_inline_size > CssPixels::default()
-                            && line_builder.break_if_needed(item.border_box_inline_size() + next_inline_size)
-                        {
-                            line_builder.set_trailing_whitespace_on_previous_line();
-                            continue;
+                        if is_whitespace && next_inline_size > CssPixels::default() {
+                            let sequence_inline_size = item_inline_size + next_inline_size;
+                            let broke_line = if iterator.next_non_whitespace_text_allows_overflow_break(self) {
+                                line_builder.break_if_needed_before_overflow_breakable_item(sequence_inline_size)
+                            } else {
+                                line_builder.break_if_needed(sequence_inline_size)
+                            };
+                            if broke_line {
+                                line_builder.set_trailing_whitespace_on_previous_line();
+                                continue;
+                            }
                         }
+                        let overflow_break_allowed = !is_whitespace && self.overflow_break_applies_to_style(style);
                         let line_is_empty_or_ends_in_whitespace = self
                             .line_data()
                             .line_boxes
                             .last()
                             .is_some_and(line_box::LineBoxData::is_empty_or_ends_in_whitespace);
-                        if !is_whitespace && (item.can_break_before || line_is_empty_or_ends_in_whitespace) {
-                            line_builder.break_if_needed(item.border_box_inline_size());
+                        let can_break_before_item = item.can_break_before
+                            || (can_break_after_previous_overflow_item && !overflow_break_allowed)
+                            || line_is_empty_or_ends_in_whitespace;
+                        if !is_whitespace && can_break_before_item {
+                            if overflow_break_allowed {
+                                line_builder.break_if_needed_before_overflow_breakable_item(item_inline_size);
+                            } else {
+                                line_builder.break_if_needed(item_inline_size);
+                            }
+                        }
+                        if overflow_break_allowed {
+                            self.break_overflowing_text_item(&mut line_builder, &mut item);
+                            previous_text_item_allows_overflow_break_after = true;
                         }
                     }
-                    let line_height = self.style(self.parent_node(item.node)).line_height();
-                    line_builder.append_text_chunk(
-                        item.node,
-                        item.offset_in_node,
-                        item.length_in_node,
-                        item.border_start + item.padding_start,
-                        item.padding_end + item.border_end,
-                        item.margin_start,
-                        item.margin_end,
-                        item.inline_size,
-                        line_height,
-                        item.glyphs.take().unwrap(),
-                        item.trailing_whitespace,
-                    );
+                    line_builder.append_text_item(&mut item, style.line_height());
                 }
             }
         }
@@ -1580,6 +1647,10 @@ impl EllipsisFontProvider for InlineFormattingContext<'_> {
 pub(crate) struct SpaceUsedByFloats {
     pub left: CssPixels,
     pub right: CssPixels,
+}
+
+fn breaks_between_graphemes(style: StyleValues<'_>) -> bool {
+    style.overflow_wrap() == overflow_wrap::ANYWHERE || style.word_break() == word_break::BREAK_WORD
 }
 
 pub(crate) fn line_physical_horizontal_extent(line: &line_box::LineBoxData) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -38,6 +38,28 @@ pub(crate) struct Item {
     pub(crate) trailing_whitespace: line_box_fragment::TrailingWhitespace,
 }
 
+fn shape_glyph_data(
+    text: &[u16],
+    font: *const c_void,
+    text_type: u8,
+    baseline_start_x: f32,
+    letter_spacing: f32,
+    word_spacing: f32,
+) -> (line_box_fragment::GlyphData, line_box_fragment::TrailingWhitespace) {
+    let shaped = font::shape_text_with_font(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
+    let glyph_data = line_box_fragment::GlyphData {
+        glyphs: shaped.glyphs,
+        font,
+        text_type,
+        width: shaped.width,
+    };
+    let trailing_whitespace = line_box_fragment::TrailingWhitespace {
+        length_in_code_units: shaped.trailing_whitespace_length_in_code_units,
+        inline_size: CssPixels::nearest_value_for_f32(shaped.trailing_whitespace_advance),
+    };
+    (glyph_data, trailing_whitespace)
+}
+
 impl Item {
     fn new(type_: ItemType, node: Node) -> Self {
         Self {
@@ -87,6 +109,185 @@ impl Item {
         assert_eq!(self.type_, ItemType::Text);
         let text = &context.callbacks.text_content(self.node).text;
         text[self.offset_in_node..self.offset_in_node + self.length_in_node].contains(&(b'\t' as u16))
+    }
+
+    pub(crate) fn allows_overflow_break(
+        &self,
+        context: &inline_formatting_context::InlineFormattingContext<'_>,
+    ) -> bool {
+        self.type_ == ItemType::Text
+            && !self.is_collapsible_whitespace
+            && !self.is_ascii_whitespace(context)
+            && context.overflow_break_applies(self.node)
+    }
+
+    pub(crate) fn split_for_overflow_break(
+        &mut self,
+        text: &[u16],
+        segmenter: &text_chunker::GraphemeSegmenter,
+        letter_spacing: f32,
+        word_spacing: f32,
+        max_border_box_inline_size: CssPixels,
+        take_first_grapheme_when_none_fits: bool,
+    ) -> Option<Item> {
+        assert_eq!(self.type_, ItemType::Text);
+        self.split_at_shaped_glyph(
+            segmenter,
+            max_border_box_inline_size,
+            take_first_grapheme_when_none_fits,
+        )
+        .or_else(|| {
+            self.split_by_reshaping(
+                text,
+                segmenter,
+                letter_spacing,
+                word_spacing,
+                max_border_box_inline_size,
+                take_first_grapheme_when_none_fits,
+            )
+        })
+    }
+
+    fn take_prefix_before(
+        &mut self,
+        split_offset_in_node: usize,
+        prefix_glyphs: line_box_fragment::GlyphData,
+        remainder_glyphs: line_box_fragment::GlyphData,
+    ) -> Item {
+        let mut prefix = Item::new(ItemType::Text, self.node);
+        prefix.offset_in_node = self.offset_in_node;
+        prefix.length_in_node = split_offset_in_node - self.offset_in_node;
+        prefix.inline_size = CssPixels::nearest_value_for_f32(prefix_glyphs.width);
+        prefix.margin_start = self.margin_start;
+        prefix.border_start = self.border_start;
+        prefix.padding_start = self.padding_start;
+        prefix.can_break_before = self.can_break_before;
+        prefix.glyphs = Some(prefix_glyphs);
+
+        self.length_in_node -= prefix.length_in_node;
+        self.offset_in_node = split_offset_in_node;
+        self.inline_size = CssPixels::nearest_value_for_f32(remainder_glyphs.width);
+        self.glyphs = Some(remainder_glyphs);
+        self.margin_start = CssPixels::default();
+        self.border_start = CssPixels::default();
+        self.padding_start = CssPixels::default();
+        self.can_break_before = false;
+
+        prefix
+    }
+
+    fn split_at_shaped_glyph(
+        &mut self,
+        segmenter: &text_chunker::GraphemeSegmenter,
+        max_border_box_inline_size: CssPixels,
+        take_first_grapheme_when_none_fits: bool,
+    ) -> Option<Item> {
+        let glyph_data = self.glyphs.as_ref()?;
+        if glyph_data.text_type == line_box_fragment::GLYPH_TEXT_TYPE_RTL || glyph_data.glyphs.len() < 2 {
+            return None;
+        }
+        let shaped_length_in_code_units: usize = glyph_data.glyphs.iter().map(|glyph| glyph.length_in_code_units).sum();
+        if shaped_length_in_code_units != self.length_in_node {
+            return None;
+        }
+
+        let leading_edge_inline_size = self.margin_start + self.border_start + self.padding_start;
+        let mut split: Option<(usize, usize)> = None;
+        let mut code_units = glyph_data.glyphs[0].length_in_code_units;
+        for (glyph_index, glyph) in glyph_data.glyphs.iter().enumerate().skip(1) {
+            let offset = self.offset_in_node + code_units;
+            if segmenter.next_boundary(offset, true) == Some(offset) {
+                let prefix_inline_size = CssPixels::nearest_value_for_f32(glyph.x);
+                if leading_edge_inline_size + prefix_inline_size > max_border_box_inline_size {
+                    if split.is_none() && take_first_grapheme_when_none_fits {
+                        split = Some((glyph_index, code_units));
+                    }
+                    break;
+                }
+                split = Some((glyph_index, code_units));
+            }
+            code_units += glyph.length_in_code_units;
+        }
+        let (split_glyph_index, split_code_units) = split?;
+
+        let glyph_data = self.glyphs.as_mut().unwrap();
+        let split_x = glyph_data.glyphs[split_glyph_index].x;
+        let font = glyph_data.font;
+        let text_type = glyph_data.text_type;
+        let remainder_glyphs = glyph_data.glyphs.split_off(split_glyph_index);
+        let prefix_glyphs = std::mem::replace(&mut glyph_data.glyphs, remainder_glyphs);
+        for glyph in &mut glyph_data.glyphs {
+            glyph.x -= split_x;
+        }
+        let remainder_width = glyph_data.width - split_x;
+        let remainder_glyphs = std::mem::take(&mut glyph_data.glyphs);
+
+        Some(self.take_prefix_before(
+            self.offset_in_node + split_code_units,
+            line_box_fragment::GlyphData {
+                glyphs: prefix_glyphs,
+                font,
+                text_type,
+                width: split_x,
+            },
+            line_box_fragment::GlyphData {
+                glyphs: remainder_glyphs,
+                font,
+                text_type,
+                width: remainder_width,
+            },
+        ))
+    }
+
+    fn split_by_reshaping(
+        &mut self,
+        text: &[u16],
+        segmenter: &text_chunker::GraphemeSegmenter,
+        letter_spacing: f32,
+        word_spacing: f32,
+        max_border_box_inline_size: CssPixels,
+        take_first_grapheme_when_none_fits: bool,
+    ) -> Option<Item> {
+        let glyph_data = self.glyphs.as_ref()?;
+        if glyph_data.text_type == line_box_fragment::GLYPH_TEXT_TYPE_RTL {
+            return None;
+        }
+        let font = glyph_data.font;
+        let text_type = glyph_data.text_type;
+        let start = self.offset_in_node;
+        let end = start + self.length_in_node;
+
+        let mut boundaries = Vec::with_capacity(end - start);
+        let mut boundary = segmenter.next_boundary(start, false)?;
+        while boundary < end {
+            boundaries.push(boundary);
+            let Some(next) = segmenter.next_boundary(boundary, false) else {
+                break;
+            };
+            boundary = next;
+        }
+        if boundaries.is_empty() {
+            return None;
+        }
+
+        let shape =
+            |text_range: &[u16]| shape_glyph_data(text_range, font, text_type, 0.0, letter_spacing, word_spacing).0;
+
+        let leading_edge_inline_size = self.margin_start + self.border_start + self.padding_start;
+        let prefix_fits = |boundary: usize| {
+            let shaped = shape(&text[start..boundary]);
+            leading_edge_inline_size + CssPixels::nearest_value_for_f32(shaped.width) <= max_border_box_inline_size
+        };
+        let mut fitting_count = boundaries.partition_point(|boundary| prefix_fits(*boundary));
+        if fitting_count == 0 {
+            if !take_first_grapheme_when_none_fits {
+                return None;
+            }
+            fitting_count = 1;
+        }
+        let split = boundaries[fitting_count - 1];
+
+        Some(self.take_prefix_before(split, shape(&text[start..split]), shape(&text[split..end])))
     }
 }
 
@@ -382,29 +583,6 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
             .unwrap_or(line_box_fragment::GLYPH_TEXT_TYPE_CONTEXT_DEPENDENT)
     }
 
-    fn shape_text(
-        &mut self,
-        text: &[u16],
-        font: *const c_void,
-        text_type: u8,
-        baseline_start_x: f32,
-        letter_spacing: f32,
-        word_spacing: f32,
-    ) -> (line_box_fragment::GlyphData, line_box_fragment::TrailingWhitespace) {
-        let shaped = font::shape_text_with_font(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
-        let glyph_data = line_box_fragment::GlyphData {
-            glyphs: shaped.glyphs,
-            font,
-            text_type,
-            width: shaped.width,
-        };
-        let trailing_whitespace = line_box_fragment::TrailingWhitespace {
-            length_in_code_units: shaped.trailing_whitespace_length_in_code_units,
-            inline_size: CssPixels::nearest_value_for_f32(shaped.trailing_whitespace_advance),
-        };
-        (glyph_data, trailing_whitespace)
-    }
-
     fn add_extra_box_model_metrics_to_item(
         &mut self,
         item: &mut Item,
@@ -519,7 +697,7 @@ impl<'iterator, 'context> InlineLevelIteratorGenerator<'iterator, 'context> {
             inline_offset = tab_stop_distance.to_double() as f32;
         }
         let shaped_text = &full_text[shaped_start..shaped_start + shaped_length];
-        let (glyphs, shaped_trailing_whitespace) = self.shape_text(
+        let (glyphs, shaped_trailing_whitespace) = shape_glyph_data(
             shaped_text,
             chunk.font,
             text_type,
@@ -662,6 +840,21 @@ impl InlineLevelIterator {
         &self,
         context: &inline_formatting_context::InlineFormattingContext<'_>,
     ) -> CssPixels {
+        self.next_sequence_inline_size(context, false)
+    }
+
+    pub(crate) fn next_unbreakable_run_inline_size(
+        &self,
+        context: &inline_formatting_context::InlineFormattingContext<'_>,
+    ) -> CssPixels {
+        self.next_sequence_inline_size(context, true)
+    }
+
+    fn next_sequence_inline_size(
+        &self,
+        context: &inline_formatting_context::InlineFormattingContext<'_>,
+        stop_at_overflow_breakable_text: bool,
+    ) -> CssPixels {
         let mut size = CssPixels::default();
         for item in &self.items[self.next_item_index..] {
             if matches!(item.type_, ItemType::ForcedBreak | ItemType::BlockLevelBox) {
@@ -675,10 +868,22 @@ impl InlineLevelIterator {
                 if item.is_ascii_whitespace(context) {
                     break;
                 }
+                if stop_at_overflow_breakable_text && context.overflow_break_applies(item.node) {
+                    break;
+                }
             }
             size += item.border_box_inline_size();
         }
         size
+    }
+
+    pub(crate) fn next_non_whitespace_text_allows_overflow_break(
+        &self,
+        context: &inline_formatting_context::InlineFormattingContext<'_>,
+    ) -> bool {
+        self.items
+            .get(self.next_item_index)
+            .is_some_and(|item| item.allows_overflow_break(context))
     }
 
     pub(crate) fn take_visited_fragmented_inlines(&mut self) -> Vec<Node> {

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -237,12 +237,56 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         }
     }
 
+    pub(crate) fn current_line_is_empty(&mut self) -> bool {
+        self.line_count() == 0 || self.line(self.line_count() - 1).is_empty()
+    }
+
+    fn remaining_inline_size_on_current_line(&mut self) -> Option<CssPixels> {
+        let AvailableSize::Definite(available) = self.available_inline_size_for_current_line else {
+            return None;
+        };
+        let line_index = self.ensure_last_line_index();
+        Some(available - self.line(line_index).physical_horizontal_extent())
+    }
+
+    pub(crate) fn remaining_inline_size_for_overflow_break(&mut self) -> Option<CssPixels> {
+        match self.available_inline_size_for_current_line {
+            AvailableSize::Definite(_) => self.remaining_inline_size_on_current_line(),
+            AvailableSize::MinContent => Some(CssPixels::default()),
+            AvailableSize::MaxContent | AvailableSize::Indefinite => None,
+        }
+    }
+
     pub(crate) fn break_if_needed(&mut self, next_item_inline_size: CssPixels) -> bool {
         if !self.should_break(next_item_inline_size) {
             return false;
         }
         self.break_line(ForcedBreak::No, Some(next_item_inline_size));
         true
+    }
+
+    pub(crate) fn break_if_needed_before_overflow_breakable_item(&mut self, next_item_inline_size: CssPixels) -> bool {
+        if self.current_line_is_empty() {
+            return false;
+        }
+        if !self.should_break(next_item_inline_size) {
+            return false;
+        }
+        self.break_line(ForcedBreak::No, None);
+        true
+    }
+
+    pub(crate) fn current_line_has_no_space_left_by_floats(&mut self) -> bool {
+        let Some(remaining) = self.remaining_inline_size_on_current_line() else {
+            return false;
+        };
+        if remaining > CssPixels::default() {
+            return false;
+        }
+        let line_height = self.containing_style().line_height();
+        let block_start = self.current_block_offset;
+        let block_end = block_start + self.max_block_size_on_current_line.max(line_height);
+        self.context().any_floats_intrude_in_block_range(block_start, block_end)
     }
 
     pub(crate) fn append_box(
@@ -285,6 +329,22 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         );
         self.line_mut(line_index).fragments[fragment_index].content_baselines = Some(content_baselines);
         self.max_block_size_on_current_line = self.max_block_size_on_current_line.max(margin_block_size);
+    }
+
+    pub(crate) fn append_text_item(&mut self, item: &mut inline_level_iterator::Item, content_block_size: CssPixels) {
+        self.append_text_chunk(
+            item.node,
+            item.offset_in_node,
+            item.length_in_node,
+            item.border_start + item.padding_start,
+            item.padding_end + item.border_end,
+            item.margin_start,
+            item.margin_end,
+            item.inline_size,
+            content_block_size,
+            item.glyphs.take().unwrap(),
+            item.trailing_whitespace,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -479,7 +539,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         if self.available_inline_size_for_current_line == AvailableSize::MaxContent {
             return false;
         }
-        if self.line_count() == 0 || self.line(self.line_count() - 1).is_empty() {
+        if self.current_line_is_empty() {
             let line_height = self.containing_style().line_height();
             if !self
                 .context()

--- a/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/crashtests/overflow-wrap-leading-floats-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/crashtests/overflow-wrap-leading-floats-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link ref="help" href="crbug.com/1510579">
+<style>
+#container {
+  width: 0;
+  text-indent: 1em;
+  overflow-wrap: anywhere;
+}
+</style>
+<div id="container">
+  <div style="float: left"></div>
+  12
+</div>

--- a/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-long-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-long-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Text Test: very long line with `overflow-wrap: break-word` should not crash</title>
+<link rel="help" href="https://crbug.com/961987">
+<link rel="author" title="Koji Ishii" href="kojii@chromium.org">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+html, body {
+  margin: 0;
+}
+body {
+  overflow-wrap: break-word;
+  width: 2147483648px;
+}
+div {
+  /* Double the width in case CSS parser clamps the body width. */
+  width: 200%;
+}
+span {
+  border-left: 2147483648px solid;
+}
+</style>
+<body>
+  <div><span>x</span></div>
+<script>
+test(() => { document.body.offsetTop; });
+</script>
+</body>

--- a/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Text Test: A combination of `overflow-wrap: break-word` and `white-space` should not crash</title>
+<link rel="help" href="https://crbug.com/988832">
+<link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+div {
+  width: 10ch;
+  border: 1px blue solid;
+  overflow-wrap: break-word;
+}
+inline-block {
+  display: inline-block;
+  position: relative;
+  width: 3ch;
+  height: 1em;
+  background: orange;
+}
+</style>
+<body>
+<div>
+  123 56 <span style="white-space: pre"><inline-block></inline-block> <span style="white-space: normal">Flash</span></span> and
+</div>
+<script>
+test(() => { });
+</script>
+</body>

--- a/Tests/LibWeb/Layout/expected/overflow-wrap-around-floats.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-wrap-around-floats.txt
@@ -1,0 +1,63 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 376 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 360 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [108,8 89.140625x20] baseline: 16
+            "AAAAA"
+        frag 1 from TextNode start: 5, length: 5, rect: [108,28 89.140625x20] baseline: 16
+            "AAAAA"
+        frag 2 from TextNode start: 10, length: 5, rect: [108,48 89.140625x20] baseline: 16
+            "AAAAA"
+        frag 3 from TextNode start: 15, length: 11, rect: [8,68 196.109375x20] baseline: 16
+            "AAAAAAAAAAA"
+        frag 4 from TextNode start: 26, length: 4, rect: [8,88 71.3125x20] baseline: 16
+            "AAAA"
+        BlockContainer <span.float> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,108] [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [108,108 23.375x20] baseline: 16
+            "aa"
+        frag 1 from TextNode start: 3, length: 5, rect: [108,128 89.140625x20] baseline: 16
+            "AAAAA"
+        frag 2 from TextNode start: 8, length: 5, rect: [108,148 89.140625x20] baseline: 16
+            "AAAAA"
+        frag 3 from TextNode start: 13, length: 11, rect: [8,168 196.109375x20] baseline: 16
+            "AAAAAAAAAAA"
+        frag 4 from TextNode start: 24, length: 9, rect: [8,188 160.453125x20] baseline: 16
+            "AAAAAAAAA"
+        BlockContainer <span.float> at [8,108] floating [0+0+0 100 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,208] [0+0+0 200 0+0+584] [0+0+0 80 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 4, rect: [108,208 71.3125x20] baseline: 16
+            "AAAA"
+        frag 1 from TextNode start: 0, length: 2, rect: [179.3125,208 23.375x20] baseline: 16
+            "BB"
+        frag 2 from TextNode start: 2, length: 8, rect: [108,228 93.5x20] baseline: 16
+            "BBBBBBBB"
+        frag 3 from TextNode start: 10, length: 8, rect: [108,248 93.5x20] baseline: 16
+            "BBBBBBBB"
+        frag 4 from TextNode start: 18, length: 8, rect: [8,268 93.5x20] baseline: 16
+            "BBBBBBBB"
+        TextNode <#text> (not painted)
+        BlockContainer <span.float> at [8,208] floating [0+0+0 100 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,288] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,288] [0+0+0 200 0+0+584] [0+0+0 80 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [108,288 23.375x20] baseline: 16
+            "aa"
+        BlockContainer <span.float> at [8,288] floating [0+0+0 100 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [8,348] [0+0+0 463.53125 0+0+0] [0+0+0 20 0+0+0]
+          frag 0 from TextNode start: 0, length: 26, rect: [8,348 463.53125x20] baseline: 16
+              "AAAAAAAAAAAAAAAAAAAAAAAAAA"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,368] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x376] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
@@ -1,24 +1,30 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 55 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 39 0+0+8] children: not-inline
-      BlockContainer <div> at [8,8] [0+0+0 100 0+0+684] [0+0+0 39 0+0+0] children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 111.59375x13] baseline: 10.390625
-        frag 1 from BlockContainer start: 0, length: 0, rect: [8,21 119.1875x13] baseline: 10.390625
-        frag 2 from BlockContainer start: 0, length: 0, rect: [8,34 127.5625x13] baseline: 10.390625
-        BlockContainer <span> at [8,8] inline-block [0+0+0 111.59375 0+0+0] [0+0+0 13 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 2, rect: [8,8 111.59375x13] baseline: 10.390625
-              "	A"
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 94 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 78 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 100 0+0+684] [0+0+0 78 0+0+0] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 100x26] baseline: 23.390625
+        frag 1 from BlockContainer start: 0, length: 0, rect: [8,34 100x26] baseline: 23.390625
+        frag 2 from BlockContainer start: 0, length: 0, rect: [8,60 100x26] baseline: 23.390625
+        BlockContainer <span> at [8,8] inline-block [0+0+0 100 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 100x13] baseline: 10.390625
+              "	"
+          frag 1 from TextNode start: 1, length: 1, rect: [8,21 11.59375x13] baseline: 10.390625
+              "A"
           TextNode <#text> (not painted)
-        BlockContainer <span> at [8,21] inline-block [0+0+0 119.1875 0+0+0] [0+0+0 13 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [8,21 119.1875x13] baseline: 10.390625
-              "	AB"
+        BlockContainer <span> at [8,34] inline-block [0+0+0 100 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,34 100x13] baseline: 10.390625
+              "	"
+          frag 1 from TextNode start: 1, length: 2, rect: [8,47 19.1875x13] baseline: 10.390625
+              "AB"
           TextNode <#text> (not painted)
-        BlockContainer <span> at [8,34] inline-block [0+0+0 127.5625 0+0+0] [0+0+0 13 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 4, rect: [8,34 127.5625x13] baseline: 10.390625
-              "	ABC"
+        BlockContainer <span> at [8,60] inline-block [0+0+0 100 0+0+0] [0+0+0 26 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,60 100x13] baseline: 10.390625
+              "	"
+          frag 1 from TextNode start: 1, length: 3, rect: [8,73 27.5625x13] baseline: 10.390625
+              "ABC"
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,47] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,86] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x55] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x94] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/textarea-overflow-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/textarea-overflow-wrap.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 85.203125 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 69.203125 0+0+8] children: inline
+      frag 0 from TextAreaBox start: 0, length: 0, rect: [11,11 100x60] baseline: 66
+      frag 1 from TextNode start: 0, length: 1, rect: [114,61 8x16] baseline: 12.796875
+          " "
+      frag 2 from TextAreaBox start: 0, length: 0, rect: [125,11 100x60] baseline: 66
+      TextAreaBox <textarea> at [11,11] inline-block [0+1+2 100 2+1+0] [0+1+2 60 2+1+0] [BFC] children: not-inline overflow: [9,9 104x68]
+        Box <div> at [11,11] flex-container(row) [0+0+0 100 0+0+0] [0+0+0 64 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [11,11] flex-item [0+0+0 100 0+0+0] [0+0+0 64 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 7, rect: [11,11 99.859375x16] baseline: 12.796875
+                "AAAAAAA"
+            frag 1 from TextNode start: 7, length: 7, rect: [11,27 99.859375x16] baseline: 12.796875
+                "AAAAAAA"
+            frag 2 from TextNode start: 14, length: 7, rect: [11,43 99.859375x16] baseline: 12.796875
+                "AAAAAAA"
+            frag 3 from TextNode start: 21, length: 7, rect: [11,59 99.859375x16] baseline: 12.796875
+                "AAAAAAA"
+            TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      TextAreaBox <textarea> at [125,11] inline-block [0+1+2 100 2+1+0] [0+1+2 60 2+1+0] [BFC] children: not-inline overflow: [123,9 401.4375x64]
+        Box <div> at [125,11] flex-container(row) [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [125,11] flex-item [0+0+0 100 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 28, rect: [125,11 399.4375x16] baseline: 12.796875
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x85.203125] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/overflow-wrap-around-floats.html
+++ b/Tests/LibWeb/Layout/input/overflow-wrap-around-floats.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 200px;
+        font: 20px monospace;
+        overflow-wrap: anywhere;
+    }
+    .float {
+        float: left;
+        width: 100px;
+        height: 60px;
+    }
+</style>
+<div><span class="float"></span>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</div>
+<div><span class="float"></span>aa AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</div>
+<div>AAAA<span class="float"></span>BBBBBBBBBBBBBBBBBBBBBBBBBB</div>
+<div><span class="float"></span>aa <span style="white-space: nowrap">AAAAAAAAAAAAAAAAAAAAAAAAAA</span></div>

--- a/Tests/LibWeb/Layout/input/tab-size-text-wrap.html
+++ b/Tests/LibWeb/Layout/input/tab-size-text-wrap.html
@@ -5,7 +5,6 @@
         font-family: monospace;
         tab-size: 100px;
         width: 100px;
-        /* FIXME: The layout here is incorrect until the text-wrap property is implemented. */
         text-wrap: wrap;
         background-color: khaki;
     }

--- a/Tests/LibWeb/Layout/input/textarea-overflow-wrap.html
+++ b/Tests/LibWeb/Layout/input/textarea-overflow-wrap.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    textarea {
+        width: 100px;
+        height: 60px;
+        font-size: 16px;
+    }
+</style>
+<textarea>AAAAAAAAAAAAAAAAAAAAAAAAAAAA</textarea>
+<textarea style="overflow-wrap: normal">AAAAAAAAAAAAAAAAAAAAAAAAAAAA</textarea>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test Reference File</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #test {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box is within the orange box.</p>
+  <p id="test">FillerText<br>FillerText<br>FillerText<br>FillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test Reference File</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #ref {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    width: 200px;
+  }
+  #test {
+    border: 5px solid blue;
+    font: 20px/1 Ahem;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box overflows the blue border box, but fits within the orange border box.</p>
+  <p id="ref">FillerText<br>FillerText<br>FillerText<br>FillerText</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Reference File</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div></div>
+</body>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-cluster-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-cluster-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+  div {
+    font-size: 4em;
+    width: 4em;
+  }
+</style>
+
+<p>Test passes if there are four identical lines of text below.
+<div lang=hi>&#x0937;&#x093F;</div>
+<div lang=hi>&#x0937;&#x093F;</div>
+<div lang=hi>&#x0937;&#x093F;</div>
+<div lang=hi>&#x0937;&#x093F;</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="stylesheet" type="text/css" href="../../../../../../data/fonts/ahem.css">
+<style>
+div {
+  font: 20px/1 Ahem;
+  position: absolute;
+  background: green;
+  color: transparent;
+}
+</style>
+
+<p>Test passes if there is a green box below and no red.
+<div>X<br>X<br>X<br>X</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-002-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test reference</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<style>
+#test {
+  float: left;
+  border: 2px solid blue;
+}
+</style>
+
+<p>Test passes if the glyphs are completely inside the blue box.
+<div id="wrapper">
+  <div id="test">&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;<br>&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;</div>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-003-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test reference</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<meta name="flags" content="ahem">
+<link rel="stylesheet" type="text/css" href="../../../../../../data/fonts/ahem.css" />
+<style>
+#wrapper {
+  width: 0px;
+  font: 16px / 1 Ahem;
+  color: green;
+}
+#test {
+  float: left;
+}
+#reference {
+  position: absolute;
+  width: 16px;
+  height: 128px;
+  background: red;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a vertical green bar below.
+<div id="wrapper">
+  <div id="reference"></div>
+  <div id="test">X<br>X<br>X<br>X<br>X<br>X<br>X<br>X</div>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-004-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-004-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="stylesheet" type="text/css" href="../../../../../../data/fonts/ahem.css">
+<style>
+div {
+  font: 20px/1 Ahem;
+  position: absolute;
+  background: green;
+  color: transparent;
+}
+</style>
+
+<p>Test passes if there is a green box below and no red.
+<div>XXXX</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Reference File</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div></div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap - break-word (basic)</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="The 'overflow-wrap' property set 'break-word' breaks the word at an arbitrary point">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #test {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    overflow-wrap: break-word;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box is within the orange box.</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap - break-word and white-space - nowrap</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#white-space">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="Test checks that the 'overflow-wrap' property has effect if and only if the 'white-space' allows wrapping">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #ref {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    overflow-wrap: break-word;
+    width: 200px;
+  }
+  #test {
+    border: 5px solid blue;
+    font: 20px/1 Ahem;
+    overflow-wrap: break-word;
+    white-space: nowrap;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box overflows the blue border box, but fits within the orange border box.</p>
+  <p id="ref">FillerTextFillerTextFillerTextFillerText</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="sequences of nbsp characters that would cause overflow are expected to be broken when overflow-wrap is anywhere">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  font-family: Ahem;
+  color: red;
+  overflow-wrap: anywhere;
+  font-size: 25px;
+  line-height: 27px;
+}
+div::after{
+  content: "";
+  position: absolute;
+  top: 0; left: 0; bottom: 0; right: 0;
+  background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-004.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 5ch;
+
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"><br>XXXXX</div>
+  <div class="test"> XXXXX </div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-005.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.fail {
+  position: absolute;
+  color: red;
+  z-index: -1;
+}
+span { color: green; }
+.test {
+  color: green;
+  width: 5ch;
+
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="fail">XXX<span>XX<br></span><span>XXXXX<br></span>XXXXX<br>XXXX<span>X<br></span><span>XXXXX</span></div>
+  <div class="test">XXX
+ XXXXXXXXX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-006.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="The word shouldn't be broken, honoring word-break: keep-all, but 'overflow-wrap: anywhere introduces additional soft wrap opportunities.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 5ch;
+
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red">XXXXX<br>XXX</div>
+  <div class="test">XXXXXXXX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-007.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap - anywhere (basic)</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="The 'overflow-wrap' property set 'anywhere' breaks the word at an arbitrary point">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #test {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    overflow-wrap: anywhere;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box is within the orange box.</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-008.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-008.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap - anywhere and white-space - nowrap</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
+<link rel="help" title="3 White Space and Wrapping: the white-space property" href="https://drafts.csswg.org/css-text-3/#white-space-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-nowrap">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="Test checks that the 'overflow-wrap' property has effect if and only if the 'white-space' allows wrapping">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #ref {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    overflow-wrap: anywhere;
+    width: 200px;
+  }
+  #test {
+    border: 5px solid blue;
+    font: 20px/1 Ahem;
+    overflow-wrap: anywhere;
+    white-space: nowrap;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box overflows the blue border box, but fits within the orange border box.</p>
+  <p id="ref">FillerTextFillerTextFillerTextFillerText</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-009.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-009.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<meta name="flags" content="Ahem">
+<meta name="assert" content="The text is wrapped into two lines, since there is no need to break the second line using the space in the middle.">
+<style>
+div {
+  position: relative;
+  font: 25px / 1 Ahem;
+}
+.ref {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 3ch;
+
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="ref">XXX<br>X X</div>
+  <div class="test">XXXX<span> </span>X</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-010.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-010.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<meta name="flags" content="Ahem">
+<meta name="assert" content="'overflow-wrap: anywhere' applies correctly when there is styled text using 'span' elements.">
+<style>
+div {
+  position: relative;
+  font: 25px / 1 Ahem;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: transparent;
+  width: 4ch;
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"><span style="color: green">XX</span>XX<br>XX</div>
+  <div class="test">XX<span style="color: green">XXXX</span>XX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-001.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>overlfow-wrap: anywhere on inline element</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="Ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="'overflow-wrap: anywhwre' allows breaking before punctuation characters">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+    font: 50px / 1 Ahem;
+}
+.fail {
+    position: absolute;
+    background: green;
+    color: red;
+    width: 100px;
+    z-index: -1;
+}
+.test {
+    color: green;
+    width: 1em;
+
+    overflow-wrap: anywhere;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">X<br>X</div>
+<div class="test"><span>X</span><span>.</span></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>overlfow-wrap: anywhere on inline element</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="Ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="'overflow-wrap: anywhere' works when specified on inline element">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div, span {
+    font: 10px / 1 Ahem;
+    color: green;
+}
+.fail {
+    position: absolute;
+    background: green;
+    color: red;
+    height: 100px;
+    z-index: -1;
+}
+.testdiv {
+    width: 5ch;
+}
+.test {
+    overflow-wrap: anywhere;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">XXXXXXXXXX<br>XXXXX<br>XXXX<br>XXX</div>
+<div class="testdiv">XXXXXXXXXX<span class="test">XXXXXXXXX</span>XXX</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>overlfow-wrap: anywhere on inline element</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="Ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="'overflow-wrap: anywhere' allows to break before the first character of the inline-block it applies to">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div, span {
+    font: 50px / 1 Ahem;
+    color: green;
+}
+.fail {
+    position: absolute;
+    color: red;
+    z-index: -1;
+}
+.testdiv {
+    width: 2ch;
+}
+.test {
+    overflow-wrap: anywhere;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">XX<br>XX</div>
+<div class="testdiv">XX<span class="test">XX</span></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>overlfow-wrap: anywhere on inline element</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="Ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="'overflow-wrap: anywhere' should break after the last character of the inline-block it applies to">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div, span {
+    font: 25px / 1 Ahem;
+    color: green;
+}
+.fail {
+    position: absolute;
+    background: green;
+    color: red;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+}
+.testdiv {
+    width: 2ch;
+}
+.test {
+    overflow-wrap: anywhere;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">XX<br>X<br>XX<br></div>
+<div class="testdiv">X<span class="test">XX</span>XX</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="sequences of nbsp characters that would cause overflow are expected to be broken when overflow-wrap is break-word">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  font-family: Ahem;
+  color: red;
+  overflow-wrap: break-word;
+  font-size: 25px;
+  line-height: 27px;
+}
+div::after{
+  content: "";
+  position: absolute;
+  top: 0; left: 0; bottom: 0; right: 0;
+  background: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-004.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 5ch;
+
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"><br>XXXXX</div>
+  <div class="test"> XXXXX </div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-005.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: pre-wrap' property, that must prevent the word to be broken.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.fail {
+  position: absolute;
+  color: red;
+  z-index: -1;
+}
+span { color: green; }
+.test {
+  color: green;
+  width: 5ch;
+
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="fail">XXX<span>XX<br></span><span>XXXXX<br></span>XXXXX<br>XXXX<span>X<br></span><span>XXXXX</span></div>
+  <div class="test">XXX
+ XXXXXXXXX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-006.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="A Single leading white-space constitutes a soft breaking opportunity, honoring the 'white-space: break-spaces' property, that must prevent the word to be broken.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 5ch;
+
+  white-space: break-spaces;
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"><br>XXXXX</div>
+  <div class="test"> XXXXX </div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-009.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-009.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<meta name="flags" content="Ahem">
+<meta name="assert" content="The text is wrapped into two lines, since there is no need to break the second line using the space in the middle.">
+<style>
+div {
+  position: relative;
+  font: 25px / 1 Ahem;
+}
+.ref {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: green;
+  width: 3ch;
+
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="ref">XXX<br>X X</div>
+  <div class="test">XXXX<span> </span>X</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-010.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-010.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<meta name="flags" content="Ahem">
+<meta name="assert" content="'overflow-wrap: break-word' applies correctly when there is styled text using 'span' elements.">
+<style>
+div {
+  position: relative;
+  font: 25px / 1 Ahem;
+}
+.ref {
+  position: absolute;
+  background: green;
+  color: red;
+  height: 100px;
+  z-index: -1;
+}
+.test {
+  color: transparent;
+  width: 4ch;
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="ref"><span style="color: green">XX</span>XX<br>XX</div>
+  <div class="test">XX<span style="color: green">XXXX</span>XX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-cluster-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-cluster-001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: overflow-wrap:break-word and grapheme clusters</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-cluster-001-ref.html">
+<meta name="assert" content="grapheme clusters must stay together as one unit when a line is broken by overflow-wrap:break-word">
+<style>
+  div {
+    font-size: 4em;
+    width: 4em;
+  }
+  #test {
+    overflow-wrap: break-word;
+    width: 0;
+  }
+</style>
+
+<p>Test passes if there are four identical lines of text below.
+<div lang=hi id=ref>&#x0937;&#x093F;<br>&#x0937;&#x093F;</div>
+<div lang=hi id=test>&#x0937;&#x093F;&#x0937;&#x093F;</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-cluster-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-cluster-002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: overflow-wrap:anywhere and grapheme clusters</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-cluster-001-ref.html">
+<meta name="assert" content="grapheme clusters must stay together as one unit when a line is broken by overflow-wrap:anywhere">
+<style>
+  div {
+    font-size: 4em;
+    width: 4em;
+  }
+  #test {
+    overflow-wrap: anywhere;
+    width: 0;
+  }
+</style>
+
+<p>Test passes if there are four identical lines of text below.
+<div lang=hi id=ref>&#x0937;&#x093F;<br>&#x0937;&#x093F;</div>
+<div lang=hi id=test>&#x0937;&#x093F;&#x0937;&#x093F;</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere and intrinsic sizing</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-002-ref.html">
+<meta name="assert" content="overflow-wrap:anywhere doesn't break grapheme cluster and min-content intrinsic size should take that into account.">
+<style>
+#wrapper {
+  width: 0px;
+  overflow-wrap: anywhere;
+}
+#test {
+  float: left;
+  border: 2px solid blue;
+}
+</style>
+
+<p>Test passes if the glyphs are completely inside the blue box.
+<div id="wrapper">
+  <div id="test">&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;</div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere and intrinsic sizing</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-003-ref.html">
+<meta name="assert" content="overflow-wrap:anywhere breaks at edge of inline elements.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+#wrapper {
+  width: 0px;
+  font: 16px / 1 Ahem;
+  overflow-wrap: anywhere;
+  color: green;
+}
+#test {
+  float: left;
+}
+#reference {
+  position: absolute;
+  width: 16px;
+  height: 128px;
+  background: red;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a vertical green bar below.
+<div id="wrapper">
+  <div id="reference"></div>
+  <div id="test"><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-005.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-001-ref.html">
+<meta name="assert" content="The word shouldn't be broken, honoring word-break: keep-all, but 'overflow-wrap: anywhere' introduce additional soft wrap opportunities, which **are** considered when calculating min-content intrinsic sizes.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font: 20px/1 Ahem;
+}
+#red {
+  position: absolute;
+  z-index: -1;
+  background: red;
+  color: transparent;
+}
+.test {
+  background: green;
+  color: transparent;
+  width: min-content;
+
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+</style>
+<body>
+  <p>Test passes if there is a green box below and no red.
+  <div id=red>X<br>X<br>X<br>X</div>
+  <div class="test">XXXX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-006.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: anywhere and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-keep-all">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-min-content-size-004-ref.html">
+<meta name="assert" content="The word shouldn't be broken, honoring word-break: keep-all, but 'overflow-wrap: break-word' introduce additional soft wrap opportunities, which **are not** considered when calculating min-content intrinsic sizes.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font: 20px/1 Ahem;
+}
+#red {
+  position: absolute;
+  z-index: -1;
+  background: red;
+  color: transparent;
+}
+.test {
+  background: green;
+  color: transparent;
+  width: min-content;
+
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a green box below and no red.
+  <div id=red>XXXX</div>
+  <div class="test">XXXX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-min-content-size-007.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" title="5.5. Overflow Wrapping: the overflow-wrap/word-wrap property " href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-anywhere">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-001-ref.html">
+<meta name="assert" content="'overflow-wrap: anywhere' allows breaking before punctuation characters and it should be considered when computing the min-content size.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+    font: 50px / 1 Ahem;
+}
+.fail {
+    position: absolute;
+    background: green;
+    color: red;
+    width: 100px;
+    z-index: -1;
+}
+.test {
+    color: green;
+    width: min-content;
+    overflow-wrap: anywhere;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">X<br>X</div>
+<div class="test"><span>X</span><span>.</span></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/word-wrap-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/word-wrap-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-wrap - break-word (basic)</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-001-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="The 'word-wrap' property set 'break-word' breaks the word at an arbitrary point">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #test {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    word-wrap: break-word;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box is within the orange box.</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/word-wrap-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/overflow-wrap/word-wrap-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-wrap - break-word and white-space - nowrap</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#overflow-wrap-property">
+<link rel="help" href="http://www.w3.org/TR/css-text-3/#white-space">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-002-ref.html">
+<meta name="flags" content="ahem">
+<meta name="assert" content="Test checks that the 'word-wrap' property has effect if and only if the 'white-space' allows wrapping">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+  #ref {
+    border: 5px solid orange;
+    font: 20px/1 Ahem;
+    word-wrap: break-word;
+    width: 200px;
+  }
+  #test {
+    border: 5px solid blue;
+    font: 20px/1 Ahem;
+    word-wrap: break-word;
+    white-space: nowrap;
+    width: 200px;
+  }
+</style>
+<body>
+  <p class="instructions">Test passes if the black box overflows the blue border box, but fits within the orange border box.</p>
+  <p id="ref">FillerTextFillerTextFillerTextFillerText</p>
+  <p id="test">FillerTextFillerTextFillerTextFillerText</p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-break-all-011.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-break-all-011.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-all</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-all">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-wrap">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html">
+<meta name="assert" content="A single leading white-space should account as soft breaking opportunity, honoring the 'white-space: pre-wrap', on top to the ones provided by 'word-break: break-all'.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+  white-space: pre;
+}
+span { color: green; }
+.test {
+  color: green;
+  width: 1ch;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"> <br>X<br>X</div>
+  <div class="test"> XX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-break-all-013.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-break-all-013.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-all</title>
+<link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-all">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-break-spaces">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html">
+<meta name="assert" content="A single leading white-space should account as soft breaking opportunity, honoring the 'white-space: break-spaces', on top to the ones provided by 'word-break: break-all'.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+  position: relative;
+  font-size: 20px;
+  font-family: Ahem;
+  line-height: 1em;
+}
+.red {
+  position: absolute;
+  background: green;
+  color: red;
+  width: 100px;
+  height: 100px;
+  z-index: -1;
+  white-space: pre;
+}
+.test {
+  color: green;
+  width: 1ch;
+  white-space: break-spaces;
+  word-break: break-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div class="red"> <br>X<br>X</div>
+  <div class="test"> XX</div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/../overflow-wrap/reference/overflow-wrap-min-content-size-003-ref.html">
+<meta name="assert" content="word-break: break-word should behave as overflow-wrap: anywhere, so breaks at edge of inline elements.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+#wrapper {
+  width: 0px;
+  font: 16px / 1 Ahem;
+  word-break: break-word;
+  color: green;
+}
+#test {
+  float: left;
+}
+#reference {
+  position: absolute;
+  width: 16px;
+  height: 128px;
+  background: red;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a vertical green bar below.
+<div id="wrapper">
+  <div id="reference"></div>
+  <div id="test"><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-003.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html">
+<meta name="assert" content="word-break: break-all shouldn't allow breaking before punctuation characters.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+    font: 50px / 1 Ahem;
+}
+.fail {
+    background: red;
+    position: absolute;
+    color: green;
+    z-index: -1;
+}
+.test {
+    color: green;
+    width: min-content;
+    word-break: break-all;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail"><br>XX</div>
+<div class="test"><span>X</span><span>.</span></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-004.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/reference/word-break-break-all-010-ref.html">
+<meta name="assert" content="'word-break: break-word' allows breaking before punctuation characters and it should be considered when computing the min-content size.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+div {
+    font: 50px / 1 Ahem;
+}
+.fail {
+    background: green;
+    position: absolute;
+    color: red;
+    width: 100px;
+    z-index: -1;
+}
+.test {
+    color: green;
+    width: min-content;
+    word-break: break-word;
+}
+</style>
+
+<p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+<div class="fail">X<br>X</div>
+<div class="test"><span>X</span><span>.</span></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-005.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Javier Fernandez" href="mailto:jfernandez@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#word-break-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-word-break-break-word">
+<meta name="flags" content="ahem">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/../overflow-wrap/reference/overflow-wrap-min-content-size-003-ref.html">
+<meta name="assert" content="word-break: break-word should behave as overflow-wrap: anywhere, so breaks at edge of inline elements.">
+<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+<style>
+#wrapper {
+  width: 0px;
+  font: 16px / 1 Ahem;
+  word-break: break-word;
+  color: green;
+}
+#test {
+  float: left;
+}
+#reference {
+  position: absolute;
+  width: 16px;
+  height: 128px;
+  background: red;
+  z-index: -1;
+}
+</style>
+
+<p>Test passes if there is a vertical green bar below.
+<div id="wrapper">
+  <div id="reference"></div>
+  <div id="test"><span>XX</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span><span>X</span></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/word-break/word-break-min-content-006.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: word-break: break-word and intrinsic sizing</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org/">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/word-break/../overflow-wrap/reference/overflow-wrap-min-content-size-002-ref.html">
+<meta name="assert" content="'word-break: break-word' doesn't break grapheme cluster and min-content intrinsic size should take that into account.">
+<style>
+#wrapper {
+  width: 0px;
+  word-break: break-word;
+}
+#test {
+  float: left;
+  border: 2px solid blue;
+}
+</style>
+
+<p>Test passes if the glyphs are completely inside the blue box.
+<div id="wrapper">
+  <div id="test">&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;&#x0ba8;&#x0bbf;&#x0bbf;&#x0bbf;&#x0bbf;</div>
+</div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash-002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash-002.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	CSS Text Test: A combination of `overflow-wrap: break-word` and `white-space` should not crash

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-text/overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>CSS Text Test: A combination of `overflow-wrap: break-word` and `white-space` should not crash</title>
+<link rel="help" href="https://crbug.com/1001359">
+<link rel="author" title="Koji Ishii" href="mailto:kojii@chromium.org">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+.container {
+  font-family: sans-serif;
+  font-size: 14px;
+  width: 680px;
+  word-wrap: break-word;
+}
+
+spacer {
+  display: inline-block;
+  width: 620px;
+}
+
+pre-wrap {
+  white-space: pre-wrap;
+}
+
+nowrap {
+  white-space: nowrap;
+}
+
+inline-block {
+  display: inline-block;
+}
+</style>
+<body>
+  <div class="container">
+    <spacer></spacer>
+    <nowrap><span><pre-wrap><inline-block></inline-block></pre-wrap></span>123456</nowrap>987654321
+</div>
+<script>
+test(() => { });
+</script>
+</body>


### PR DESCRIPTION
Previously, `overflow-wrap` was parsed but otherwise ignored by layout, so an unbreakable sequence longer than its line overflowed its containing block. When `break-word` or `anywhere` applies and an item does not fit the space left on the line, we now split off the longest prefix that fits at a grapheme cluster boundary, place it, and continue on the next line. The shaped glyph run is divided without reshaping. Runs whose glyphs cannot be mapped back to text offsets are reshaped around the chosen boundary instead. The legacy `word-break: break-word` value behaves the same as `overflow-wrap: anywhere`.

Fixes #11404

Known gaps:
* RTL text is currently never emergency broken - so a long word in an RTL script can still overflow its container. Splitting shaped right-to-left text correctly requires mapping glyphs back to their positions in the original text, which the current text-shaping data does not allow.
* Breaking a word at a ligature may cause the text to be rendered incoorrectly
* No interaction with white-space: break-spaces yet. When preserved spaces are kept at the end of a line, the rules for where a word may break next to those spaces are not implemented, so several combinations of `break-spaces` and `overflow-wrap` currently behave incorrectly.

This improves the appearance of [Google Transalte](https://translate.google.com/\?sl\=auto\&tl\=en\&text\=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\&op\=translate) when using long words:

Before:

<img width="1079" height="520" alt="image" src="https://github.com/user-attachments/assets/245451e0-18b3-4a71-98fe-6ba7bcf25b70" />

After:

<img width="1079" height="542" alt="image" src="https://github.com/user-attachments/assets/36ecc522-0a06-40b5-92a5-2856ba096d89" />