### PR TITLE
LibWeb: Avoid unnecessary content blocker work in tests

### DIFF
--- a/Libraries/LibWeb/Loader/ContentBlocker.cpp
+++ b/Libraries/LibWeb/Loader/ContentBlocker.cpp
@@ -151,6 +151,16 @@ ErrorOr<void> ContentBlocker::set_patterns(ReadonlySpan<String> patterns)
 
 ErrorOr<void> ContentBlocker::set_rules_from_bytes(ReadonlyBytes rules_bytes)
 {
+    // OPTIMIZATION: Building an engine costs the same tokenizing and flatbuffer work whether or not there are any
+    //               rules to put in it, and every caller already treats a missing engine as "nothing is blocked".
+    //               Drop the engine instead of rebuilding an empty one.
+    if (rules_bytes.is_empty()) {
+        ContentBlocking::FFI::rust_content_blocker_free(m_engine);
+        m_engine = nullptr;
+        m_has_cosmetic_rules = false;
+        return {};
+    }
+
     auto* engine = ContentBlocking::FFI::rust_content_blocker_create(
         rules_bytes.data(),
         rules_bytes.size());

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -685,6 +685,10 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         m_web_content_options.expose_experimental_interfaces = ExposeExperimentalInterfaces::Yes;
         m_web_content_options.expose_internals_object = ExposeInternalsObject::Yes;
         m_web_content_options.force_cpu_painting = ForceCPUPainting::Yes;
+
+        // Test results must not depend on the content blocking the developer running the tests happens to have
+        // configured for normal browsing, and compiling those lists into every renderer is not cheap.
+        m_browser_options.content_blocker_list_paths.clear();
     }
 
     if (m_web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)

--- a/Tests/LibWeb/TestContentBlocker.cpp
+++ b/Tests/LibWeb/TestContentBlocker.cpp
@@ -83,6 +83,24 @@ TEST_CASE(invalid_filter_bytes_keep_previous_rules)
     EXPECT(blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
 }
 
+TEST_CASE(empty_rules_clear_previous_rules)
+{
+    Vector<String> rules = {
+        { "||ads.example.com^"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
+
+    EXPECT(blocker.has_rules());
+    EXPECT(blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
+
+    MUST(blocker.set_rules_from_bytes({}));
+
+    EXPECT(!blocker.has_rules());
+    EXPECT(!blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
+}
+
 TEST_CASE(disable_filtering)
 {
     Vector<String> rules = {


### PR DESCRIPTION
Avoid building a content blocker engine for an empty rule set, and add coverage ensuring that empty rules clear any previously installed rules.

Ignore developer-configured content blocker lists in test mode. This keeps test results independent of local browser configuration and avoids compiling large filter lists for every renderer started by the test runner.

With EasyList and one supplementary list configured, this reduces a full test-web run from 222 seconds to 210 seconds (on my crappy Linux box) and lowers WebContent process swap time from 232 ms to 135 ms.