### PR TITLE
LibWeb: Keep style computation in Rust across more phases

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -811,12 +811,9 @@ void AnimationEffect::visit_edges(GC::Cell::Visitor& visitor)
 
 static CSS::StyleValue const* animated_property_value(CSS::AnimatedProperties const* properties, CSS::PropertyID property_id)
 {
-    if (!properties)
+    if (!properties || !properties->has_property(property_id))
         return nullptr;
-    auto value = properties->values().get(property_id);
-    if (!value.has_value())
-        return nullptr;
-    return value.value();
+    return &properties->property(property_id);
 }
 
 struct AnimatedPropertyInvalidation {
@@ -832,12 +829,12 @@ static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_p
     auto old_and_new_properties = MUST(Bitmap::create(CSS::number_of_longhand_properties, 0));
     bool text_decoration_line_animated = false;
     if (old_properties) {
-        for (auto const& [property_id, _] : old_properties->values())
-            old_and_new_properties.set(to_underlying(property_id) - to_underlying(CSS::first_longhand_property_id), 1);
+        for (auto const& entry : old_properties->entries())
+            old_and_new_properties.set(entry.property - to_underlying(CSS::first_longhand_property_id), 1);
     }
     if (new_properties) {
-        for (auto const& [property_id, _] : new_properties->values())
-            old_and_new_properties.set(to_underlying(property_id) - to_underlying(CSS::first_longhand_property_id), 1);
+        for (auto const& entry : new_properties->entries())
+            old_and_new_properties.set(entry.property - to_underlying(CSS::first_longhand_property_id), 1);
     }
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         if (!old_and_new_properties.get(i - to_underlying(CSS::first_longhand_property_id)))
@@ -932,7 +929,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 return target->document().style_computer().build_animated_computed_values(*style, element, element.style_scope(), *previous_values);
             return target->document().style_computer().build_computed_values(*style, element, element.style_scope());
         }();
-        if (animated_properties_after_update && !animated_properties_after_update->values().is_empty()
+        if (animated_properties_after_update && !animated_properties_after_update->is_empty()
             && target->document().is_in_style_stabilization_epoch()
             && (target->document().style_stabilization_has_style_reactions() || animated_property_invalidation.requires_base_style_recomputation)) {
             target->document().style_computer().record_transition_stabilization_baseline(element);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/RedBlackTree.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/RootVector.h>
@@ -78,6 +79,10 @@ public:
     };
 
     struct KeyFrameSet : public RefCounted<KeyFrameSet> {
+        struct StyleSheetResourceContext {
+            String base_url;
+            bool origin_clean { false };
+        };
         struct UseInitial { };
         struct ResolvedKeyFrame {
             // These style values can be unresolved, as they may be generated from a @keyframes rule, well
@@ -87,6 +92,7 @@ public:
             Variant<Empty, CSS::EasingFunction, CSS::RustStyleValueHandle> easing {};
         };
         RedBlackTree<u64, ResolvedKeyFrame> keyframes_by_key;
+        Optional<StyleSheetResourceContext> style_sheet_resource_context;
     };
     static void generate_initial_and_final_frames(RefPtr<KeyFrameSet>, HashTable<CSS::PropertyID> const& animated_properties);
 

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -170,7 +170,7 @@ AnimatedProperties::AnimatedProperties()
 AnimatedProperties::AnimatedProperties(AnimatedProperties const& other)
     : m_identity(s_next_animated_properties_identity.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
     , m_overlay(ComputedValuesFFI::rust_animated_overlay_clone(other.m_overlay))
-    , m_values(other.m_values)
+    , m_wrapper_cache(other.m_wrapper_cache)
 {
 }
 
@@ -206,29 +206,33 @@ AnimatedProperties& ComputedStyleWorkingSet::mutable_animated_properties()
     return *m_animated_properties;
 }
 
-bool AnimatedProperties::has_property(PropertyID property_id) const
+ReadonlySpan<ComputedValuesFFI::FfiAnimatedOverlayEntry> AnimatedProperties::entries() const
 {
-    return ComputedValuesFFI::rust_animated_overlay_has(m_overlay, to_underlying(property_id));
+    size_t count = 0;
+    auto const* entries = ComputedValuesFFI::rust_animated_overlay_entries(m_overlay, &count);
+    return { entries, count };
 }
 
-bool AnimatedProperties::is_property_inherited(PropertyID property_id) const
+ComputedValuesFFI::FfiAnimatedOverlayEntry const* AnimatedProperties::entry(PropertyID property_id) const
 {
-    return ComputedValuesFFI::rust_animated_overlay_is_inherited(m_overlay, to_underlying(property_id));
-}
-
-bool AnimatedProperties::is_property_result_of_transition(PropertyID property_id) const
-{
-    return ComputedValuesFFI::rust_animated_overlay_is_result_of_transition(m_overlay, to_underlying(property_id));
+    for (auto const& entry : entries()) {
+        if (entry.property == to_underlying(property_id))
+            return &entry;
+    }
+    return nullptr;
 }
 
 StyleValue const& AnimatedProperties::property(PropertyID property_id) const
 {
     VERIFY(property_id >= first_longhand_property_id && property_id <= last_longhand_property_id);
-    VERIFY(has_property(property_id));
+    auto const* animated_entry = entry(property_id);
+    VERIFY(animated_entry);
 
-    auto animated_value = m_values.get(property_id);
-    VERIFY(animated_value.has_value());
-    return *animated_value.value();
+    if (auto wrapper = m_wrapper_cache.get(property_id); wrapper.has_value())
+        return *wrapper.value();
+    auto wrapper = wrap_computed_longhand_slot(animated_entry->value, nullptr);
+    m_wrapper_cache.set(property_id, wrapper);
+    return *wrapper;
 }
 
 void AnimatedProperties::set_property(PropertyID id, NonnullRefPtr<StyleValue const> value, AnimatedPropertyResultOfTransition animated_property_result_of_transition, ComputedStyleWorkingSet::Inherited inherited)
@@ -238,23 +242,13 @@ void AnimatedProperties::set_property(PropertyID id, NonnullRefPtr<StyleValue co
     ComputedValuesFFI::rust_animated_overlay_set(m_overlay, to_underlying(id), value->rust_style_value_data(),
         inherited == ComputedStyleWorkingSet::Inherited::Yes,
         animated_property_result_of_transition == AnimatedPropertyResultOfTransition::Yes);
-    m_values.set(id, move(value));
-}
-
-void AnimatedProperties::remove_property(PropertyID id)
-{
-    VERIFY(id >= first_longhand_property_id && id <= last_longhand_property_id);
-
-    m_values.remove(id);
-    ComputedValuesFFI::rust_animated_overlay_remove(m_overlay, to_underlying(id));
+    m_wrapper_cache.set(id, move(value));
 }
 
 void AnimatedProperties::reset_non_inherited_properties()
 {
-    for (auto property_id : m_values.keys()) {
-        if (!is_property_inherited(property_id))
-            remove_property(property_id);
-    }
+    ComputedValuesFFI::rust_animated_overlay_reset_non_inherited(m_overlay);
+    m_wrapper_cache.clear();
 }
 
 bool ComputedStyleWorkingSet::is_property_important(PropertyID property_id) const
@@ -453,6 +447,20 @@ void ComputedStyleWorkingSet::set_animated_property(Badge<StyleComputer>, Proper
     set_animated_property_internal(id, move(value), animated_property_result_of_transition, inherited);
 }
 
+ComputedValuesFFI::AnimatedOverlay* ComputedStyleWorkingSet::prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer>)
+{
+    auto& animated_properties = mutable_animated_properties();
+    animated_properties.clear_wrapper_cache();
+    clear_computed_font_list_cache();
+    return const_cast<ComputedValuesFFI::AnimatedOverlay*>(animated_properties.overlay());
+}
+
+void ComputedStyleWorkingSet::finish_animated_overlay_rust_mutation(Badge<StyleComputer>)
+{
+    if (m_animated_properties && m_animated_properties->is_empty())
+        m_animated_properties = nullptr;
+}
+
 void ComputedStyleWorkingSet::clear_animated_properties(Badge<StyleComputer>)
 {
     if (!m_animated_properties)
@@ -466,11 +474,11 @@ void ComputedStyleWorkingSet::reset_non_inherited_animated_properties(Badge<Anim
 {
     bool has_non_inherited_property = false;
     bool should_clear_computed_font_list_cache = false;
-    for (auto const& property : animated_properties().values()) {
-        if (is_animated_property_inherited(property.key))
+    for (auto const& property : animated_properties().entries()) {
+        if (property.inherited)
             continue;
         has_non_inherited_property = true;
-        if (property_affects_computed_font_list(property.key)) {
+        if (property_affects_computed_font_list(static_cast<PropertyID>(property.property))) {
             should_clear_computed_font_list_cache = true;
             break;
         }

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -455,10 +455,34 @@ ComputedValuesFFI::AnimatedOverlay* ComputedStyleWorkingSet::prepare_animated_ov
     return const_cast<ComputedValuesFFI::AnimatedOverlay*>(animated_properties.overlay());
 }
 
+ComputedValuesFFI::AnimatedOverlay* ComputedStyleWorkingSet::prepare_animated_overlay_for_rust_finalization(Badge<StyleComputer>, CreateAnimatedOverlay create)
+{
+    if (!m_animated_properties && create == CreateAnimatedOverlay::No)
+        return nullptr;
+    auto& animated_properties = mutable_animated_properties();
+    animated_properties.clear_wrapper_cache();
+    return const_cast<ComputedValuesFFI::AnimatedOverlay*>(animated_properties.overlay());
+}
+
 void ComputedStyleWorkingSet::finish_animated_overlay_rust_mutation(Badge<StyleComputer>)
 {
     if (m_animated_properties && m_animated_properties->is_empty())
         m_animated_properties = nullptr;
+}
+
+void ComputedStyleWorkingSet::did_apply_style_finalization_from_rust(u16 invalidated_longhands)
+{
+    auto invalidate = [&](u16 flag, PropertyID property_id) {
+        if (invalidated_longhands & flag)
+            did_store_property_data_from_drive(property_id, nullptr);
+    };
+    invalidate(ComputedValuesFFI::FINALIZED_FLOAT, PropertyID::Float);
+    invalidate(ComputedValuesFFI::FINALIZED_DISPLAY, PropertyID::Display);
+    invalidate(ComputedValuesFFI::FINALIZED_LINE_HEIGHT, PropertyID::LineHeight);
+    invalidate(ComputedValuesFFI::FINALIZED_POSITION, PropertyID::Position);
+    invalidate(ComputedValuesFFI::FINALIZED_TEXT_ALIGN, PropertyID::TextAlign);
+    invalidate(ComputedValuesFFI::FINALIZED_OVERFLOW_X, PropertyID::OverflowX);
+    invalidate(ComputedValuesFFI::FINALIZED_OVERFLOW_Y, PropertyID::OverflowY);
 }
 
 void ComputedStyleWorkingSet::clear_animated_properties(Badge<StyleComputer>)

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -125,6 +125,8 @@ public:
     bool in_display_none_subtree() const { return m_in_display_none_subtree; }
     bool has_pseudo_element_style(PseudoElement) const;
     void set_animated_property(Badge<StyleComputer>, PropertyID, NonnullRefPtr<StyleValue const> value, AnimatedPropertyResultOfTransition, Inherited = Inherited::No);
+    ComputedValuesFFI::AnimatedOverlay* prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer>);
+    void finish_animated_overlay_rust_mutation(Badge<StyleComputer>);
     void clear_animated_properties(Badge<StyleComputer>);
     StyleValue const& property(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
     void const* effective_property_data(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
@@ -256,33 +258,41 @@ private:
 
 class AnimatedProperties final : public RefCounted<AnimatedProperties> {
 public:
-    using PropertyMap = HashMap<PropertyID, NonnullRefPtr<StyleValue const>>;
-
     AnimatedProperties();
     AnimatedProperties(AnimatedProperties const&);
     ~AnimatedProperties();
 
     u64 identity() const { return m_identity; }
-    bool is_empty() const { return m_values.is_empty(); }
-    PropertyMap const& values() const { return m_values; }
+    bool is_empty() const { return entries().is_empty(); }
+    ReadonlySpan<ComputedValuesFFI::FfiAnimatedOverlayEntry> entries() const;
 
-    // The Rust overlay carrying the sampled values and their flags; the map above is only the
-    // wrapper identity cache for property().
+    // The Rust overlay is the authoritative store. C++ wrappers are minted lazily and cached
+    // only for native readers that ask for property().
     ComputedValuesFFI::AnimatedOverlay const* overlay() const { return m_overlay; }
 
-    bool has_property(PropertyID) const;
-    bool is_property_inherited(PropertyID) const;
-    bool is_property_result_of_transition(PropertyID) const;
+    bool has_property(PropertyID property_id) const { return entry(property_id); }
+    bool is_property_inherited(PropertyID property_id) const
+    {
+        auto const* animated_entry = entry(property_id);
+        return animated_entry && animated_entry->inherited;
+    }
+    bool is_property_result_of_transition(PropertyID property_id) const
+    {
+        auto const* animated_entry = entry(property_id);
+        return animated_entry && animated_entry->result_of_transition;
+    }
     StyleValue const& property(PropertyID) const;
 
     void set_property(PropertyID, NonnullRefPtr<StyleValue const>, AnimatedPropertyResultOfTransition, ComputedStyleWorkingSet::Inherited);
-    void remove_property(PropertyID);
     void reset_non_inherited_properties();
+    void clear_wrapper_cache() { m_wrapper_cache.clear(); }
 
 private:
+    ComputedValuesFFI::FfiAnimatedOverlayEntry const* entry(PropertyID) const;
+
     u64 m_identity;
     ComputedValuesFFI::AnimatedOverlay* m_overlay { nullptr };
-    PropertyMap m_values;
+    mutable HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_wrapper_cache;
 };
 
 // Mints a C++ StyleValue wrapper for a record or table slot's value data, stamping it with the

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -64,6 +64,11 @@ public:
         Yes
     };
 
+    enum class CreateAnimatedOverlay {
+        No,
+        Yes,
+    };
+
     static NonnullRefPtr<ComputedStyleWorkingSet> create();
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedStyleWorkingSet const&);
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedValues const&);
@@ -126,7 +131,9 @@ public:
     bool has_pseudo_element_style(PseudoElement) const;
     void set_animated_property(Badge<StyleComputer>, PropertyID, NonnullRefPtr<StyleValue const> value, AnimatedPropertyResultOfTransition, Inherited = Inherited::No);
     ComputedValuesFFI::AnimatedOverlay* prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer>);
+    ComputedValuesFFI::AnimatedOverlay* prepare_animated_overlay_for_rust_finalization(Badge<StyleComputer>, CreateAnimatedOverlay);
     void finish_animated_overlay_rust_mutation(Badge<StyleComputer>);
+    void did_apply_style_finalization_from_rust(u16 invalidated_longhands);
     void clear_animated_properties(Badge<StyleComputer>);
     StyleValue const& property(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
     void const* effective_property_data(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -5389,10 +5389,8 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
     for (auto ancestor = abstract_element.element_to_inherit_style_from(); ancestor.has_value(); ancestor = ancestor->element_to_inherit_style_from())
         ancestors.append(*ancestor);
 
-    NonnullRefPtr<StyleValue const> new_font_size = CSS::LengthStyleValue::create(CSS::Length::make_px(default_monospace_font_size_in_px));
-    CSSPixels current_size_in_px = default_monospace_font_size_in_px;
-    bool current_size_depends_on_viewport_metrics = false;
-
+    GC::ConservativeVector<DOM::AbstractElement> recascade_ancestors;
+    Vector<void const*> raw_cascaded_font_sizes;
     for (auto& ancestor : ancestors.in_reverse()) {
         auto ancestor_computed_values = ancestor.computed_style();
         if (!ancestor_computed_values)
@@ -5402,71 +5400,71 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
         if (!font_size_value)
             continue;
 
-        // The per-value step lives in the Rust style computation core. A length value needs a
-        // resolution context, which is built lazily on request since it involves font work the
-        // other value types never need.
-        auto step = ComputedValuesFFI::rust_recascade_font_size_step(
-            font_size_value->rust_style_value_data(),
-            current_size_in_px.raw_value(),
+        recascade_ancestors.append(ancestor);
+        raw_cascaded_font_sizes.append(font_size_value->rust_style_value_data());
+    }
+
+    auto run_recascade_batch = [&](size_t start_index, CSSPixels current_size, bool current_size_depends_on_viewport_metrics, ComputedValuesFFI::FfiLengthResolutionContext const* length_resolution_context) {
+        return ComputedValuesFFI::rust_recascade_font_size_batch(
+            raw_cascaded_font_sizes.data(),
+            raw_cascaded_font_sizes.size(),
+            start_index,
+            current_size.raw_value(),
             current_size_depends_on_viewport_metrics,
             default_monospace_font_size_in_px.raw_value(),
-            nullptr);
-
-        if (step.action == ComputedValuesFFI::FontSizeRecascadeAction::NeedsLengthResolution) {
-            bool inherited_font_metrics_depend_on_viewport_metrics = false;
-            auto inherited_line_height = InitialValues::line_height();
-            if (auto parent_element = ancestor.element_to_inherit_style_from(); parent_element.has_value()) {
-                if (auto parent_style = parent_element->computed_style()) {
-                    inherited_font_metrics_depend_on_viewport_metrics = parent_style->font_metrics_depend_on_viewport_metrics();
-                    inherited_line_height = parent_style->line_height();
-                }
-            }
-
-            bool did_resolve_viewport_relative_length = false;
-            Length::ResolutionContext resolution_context {
-                .viewport_rect = viewport_rect(),
-                .font_metrics = { current_size_in_px, monospace_font.with_size(current_size_in_px * 0.75f)->pixel_metrics(), inherited_line_height },
-                .root_font_metrics = m_root_element_font_metrics,
-                .font_metrics_depend_on_viewport_metrics = current_size_depends_on_viewport_metrics || inherited_font_metrics_depend_on_viewport_metrics,
-                .root_font_metrics_depend_on_viewport_metrics = m_root_element_font_metrics_depend_on_viewport_metrics,
-                .subject_inline_axis_is_horizontal = ancestor.computed_style()->writing_mode() == WritingMode::HorizontalTb,
-                .subject_element = &ancestor.element(),
-            };
-            auto ffi_resolution_context = to_ffi_length_resolution_context(resolution_context);
-            step = ComputedValuesFFI::rust_recascade_font_size_step(
-                font_size_value->rust_style_value_data(),
-                current_size_in_px.raw_value(),
-                current_size_depends_on_viewport_metrics,
-                default_monospace_font_size_in_px.raw_value(),
-                &ffi_resolution_context);
-
-            if (step.action == ComputedValuesFFI::FontSizeRecascadeAction::NeedsLengthResolution) {
-                // A length unit the core cannot resolve; resolve it here instead.
-                VERIFY(font_size_value->is_length());
-                resolution_context.set_did_resolve_viewport_relative_length(did_resolve_viewport_relative_length);
-                current_size_in_px = font_size_value->as_length().length().to_px(resolution_context);
-                current_size_depends_on_viewport_metrics = did_resolve_viewport_relative_length;
-                continue;
-            }
-        }
-
-        switch (step.action) {
-        case ComputedValuesFFI::FontSizeRecascadeAction::Unchanged:
-            break;
-        case ComputedValuesFFI::FontSizeRecascadeAction::Set:
-            current_size_in_px = CSSPixels::from_raw(step.new_size_raw);
-            current_size_depends_on_viewport_metrics = step.depends_on_viewport_metrics;
-            break;
-        case ComputedValuesFFI::FontSizeRecascadeAction::CalcSkipped:
-            dbgln("FIXME: Support calc() when time-traveling for monospace font-size");
-            break;
-        case ComputedValuesFFI::FontSizeRecascadeAction::NeedsLengthResolution:
-            VERIFY_NOT_REACHED();
-        }
+            length_resolution_context);
     };
 
-    depends_on_viewport_metrics = current_size_depends_on_viewport_metrics;
-    return CSS::LengthStyleValue::create(CSS::Length::make_px(current_size_in_px));
+    auto batch = run_recascade_batch(0, default_monospace_font_size_in_px, false, nullptr);
+    bool skipped_calculated_value = batch.skipped_calculated_value;
+    while (batch.status != ComputedValuesFFI::FontSizeRecascadeStatus::Complete) {
+        VERIFY(batch.status == ComputedValuesFFI::FontSizeRecascadeStatus::NeedsLengthResolution);
+        VERIFY(batch.next_index < recascade_ancestors.size());
+        auto& ancestor = recascade_ancestors[batch.next_index];
+        auto ancestor_computed_values = ancestor.computed_style();
+        VERIFY(ancestor_computed_values);
+        auto font_size_value = ancestor_computed_values->raw_cascaded_font_size();
+        VERIFY(font_size_value);
+        auto current_size_in_px = CSSPixels::from_raw(batch.current_size_raw);
+
+        bool inherited_font_metrics_depend_on_viewport_metrics = false;
+        auto inherited_line_height = InitialValues::line_height();
+        if (auto parent_element = ancestor.element_to_inherit_style_from(); parent_element.has_value()) {
+            if (auto parent_style = parent_element->computed_style()) {
+                inherited_font_metrics_depend_on_viewport_metrics = parent_style->font_metrics_depend_on_viewport_metrics();
+                inherited_line_height = parent_style->line_height();
+            }
+        }
+
+        bool did_resolve_viewport_relative_length = false;
+        Length::ResolutionContext resolution_context {
+            .viewport_rect = viewport_rect(),
+            .font_metrics = { current_size_in_px, monospace_font.with_size(current_size_in_px * 0.75f)->pixel_metrics(), inherited_line_height },
+            .root_font_metrics = m_root_element_font_metrics,
+            .font_metrics_depend_on_viewport_metrics = batch.depends_on_viewport_metrics || inherited_font_metrics_depend_on_viewport_metrics,
+            .root_font_metrics_depend_on_viewport_metrics = m_root_element_font_metrics_depend_on_viewport_metrics,
+            .subject_inline_axis_is_horizontal = ancestor_computed_values->writing_mode() == WritingMode::HorizontalTb,
+            .subject_element = &ancestor.element(),
+        };
+        auto ffi_resolution_context = to_ffi_length_resolution_context(resolution_context);
+        auto resumed_batch = run_recascade_batch(batch.next_index, current_size_in_px, batch.depends_on_viewport_metrics, &ffi_resolution_context);
+        skipped_calculated_value |= resumed_batch.skipped_calculated_value;
+        if (resumed_batch.status == ComputedValuesFFI::FontSizeRecascadeStatus::NeedsCppLengthResolution) {
+            VERIFY(resumed_batch.next_index == batch.next_index);
+            VERIFY(font_size_value->is_length());
+            resolution_context.set_did_resolve_viewport_relative_length(did_resolve_viewport_relative_length);
+            current_size_in_px = font_size_value->as_length().length().to_px(resolution_context);
+            batch = run_recascade_batch(batch.next_index + 1, current_size_in_px, did_resolve_viewport_relative_length, nullptr);
+            skipped_calculated_value |= batch.skipped_calculated_value;
+        } else {
+            batch = resumed_batch;
+        }
+    }
+
+    if (skipped_calculated_value)
+        dbgln("FIXME: Support calc() when time-traveling for monospace font-size");
+    depends_on_viewport_metrics = batch.depends_on_viewport_metrics;
+    return CSS::LengthStyleValue::create(CSS::Length::make_px(CSSPixels::from_raw(batch.current_size_raw)));
 }
 
 void StyleComputer::ensure_style_metadata_tables_installed()

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -5664,14 +5664,6 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         }
     };
 
-    Optional<ComputedValuesFFI::FfiDisplay> display_before_adjustments;
-    Optional<Keyword> float_before_adjustments;
-    Optional<Keyword> overflow_x_before_adjustments;
-    Optional<Keyword> overflow_y_before_adjustments;
-    Optional<Keyword> text_align_before_adjustments;
-    Optional<Keyword> position_before_adjustments;
-    RefPtr<StyleValue const> line_height_before_adjustments;
-
     auto execute_computation_batch = [&](ComputedValuesFFI::FfiComputedStoreEntry const* entries, size_t count, i16 effective_color_scheme) {
         for (size_t i = 0; i < count; ++i) {
             auto const& entry = entries[i];
@@ -5718,7 +5710,8 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         .explicitly_inherited_non_inherited_property = false,
         .uses_tree_counting_function = false,
         .effective_color_scheme = -1,
-        .post_compute_adjustment = {},
+        .display_before_box_type_transformation = {},
+        .post_adjusted_longhands = 0,
     };
     auto box_type_input = make_box_type_transformation_input(
         abstract_element, InitialValues::display(), Keyword::Static, Keyword::None);
@@ -5795,13 +5788,13 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         .initial_font_size_raw = InitialValues::font_size().raw_value(),
         .default_font_size_raw = default_user_font_size().raw_value(),
     };
-    auto drive_longhand_phase = [&](u8 phase, Optional<PropertyID> context_property) {
+    auto drive_longhand_phase = [&](u8 phase, Optional<PropertyID> context_property, ComputedValuesFFI::FfiInputLineHeightMetrics const* input_line_height_metrics = nullptr, void const* line_height_before_adjustments = nullptr) {
         Optional<ComputedValuesFFI::FfiLengthResolutionContext> length_resolution_context;
         if (context_property.has_value()) {
             auto const& computation_context = get_computation_context_for_property(*context_property, computed_style, abstract_element);
             length_resolution_context = to_ffi_length_resolution_context_with_container_bases(computation_context.length_resolution_context, computation_requirements.container_relative_length_unit_mask);
         }
-        auto store_batch = ComputedValuesFFI::rust_drive_property_computation(computed_style.mutable_computed_longhand_table(), cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &computation_environment, computed_group_mask, computed_properties_to_evaluate, phase, length_resolution_context.has_value() ? &*length_resolution_context : nullptr, &driver_results);
+        auto store_batch = ComputedValuesFFI::rust_drive_property_computation(computed_style.mutable_computed_longhand_table(), cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &computation_environment, computed_group_mask, computed_properties_to_evaluate, phase, length_resolution_context.has_value() ? &*length_resolution_context : nullptr, input_line_height_metrics, line_height_before_adjustments, &driver_results);
         ScopeGuard destroy_store_batch = [&] {
             ComputedValuesFFI::rust_longhand_store_batch_destroy(store_batch.storage);
         };
@@ -5817,25 +5810,17 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
     apply_font_metric_dependencies();
     drive_longhand_phase(ComputedValuesFFI::LONGHAND_DRIVE_PHASE_LINE_HEIGHT, PropertyID::LineHeight);
     apply_font_metric_dependencies();
+    auto line_height_metrics = input_line_height_metrics(computed_style, abstract_element, box_type_input.check_input_line_height);
+    auto const* line_height_before_adjustments = computed_style.effective_property_data(PropertyID::LineHeight);
     drive_longhand_phase(ComputedValuesFFI::LONGHAND_DRIVE_PHASE_COLOR_SCHEME, {});
-    drive_longhand_phase(ComputedValuesFFI::LONGHAND_DRIVE_PHASE_REMAINING, PropertyID::Color);
-    auto const& post_compute_adjustment = driver_results.post_compute_adjustment;
-    display_before_adjustments = post_compute_adjustment.display_before;
-    float_before_adjustments = static_cast<Keyword>(post_compute_adjustment.float_before);
-    overflow_x_before_adjustments = static_cast<Keyword>(post_compute_adjustment.overflow_x_before);
-    overflow_y_before_adjustments = static_cast<Keyword>(post_compute_adjustment.overflow_y_before);
-    text_align_before_adjustments = static_cast<Keyword>(post_compute_adjustment.text_align_before);
-    position_before_adjustments = static_cast<Keyword>(post_compute_adjustment.position_before);
-    line_height_before_adjustments = computed_style.property(PropertyID::LineHeight);
-    computed_style.set_display_before_box_type_transformation(display_from_ffi_display(post_compute_adjustment.display_before));
-    auto line_height_metrics = input_line_height_metrics(computed_style, abstract_element, post_compute_adjustment.element_style_adjustment.check_input_line_height);
-    auto post_adjusted_longhands = ComputedValuesFFI::rust_apply_post_compute_adjustments(computed_style.mutable_computed_longhand_table(), &post_compute_adjustment, &line_height_metrics);
+    drive_longhand_phase(ComputedValuesFFI::LONGHAND_DRIVE_PHASE_REMAINING, PropertyID::Color, &line_height_metrics, line_height_before_adjustments);
+    computed_style.set_display_before_box_type_transformation(display_from_ffi_display(driver_results.display_before_box_type_transformation));
     document().style_invalidation_counters().computed_longhand_evaluations += driver_results.longhand_evaluations;
     if (driver_results.uses_tree_counting_function)
         abstract_element.element().set_style_uses_tree_counting_function();
 
     auto invalidate_post_adjusted_longhand = [&](u8 flag, PropertyID property_id) {
-        if (post_adjusted_longhands & flag)
+        if (driver_results.post_adjusted_longhands & flag)
             computed_style.did_store_property_data_from_drive(property_id, nullptr);
     };
     invalidate_post_adjusted_longhand(ComputedValuesFFI::POST_ADJUSTED_FLOAT, PropertyID::Float);
@@ -5892,24 +5877,15 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
     // Add or modify CSS-defined animations
     process_animation_definitions(computed_style, cascaded_properties, abstract_element);
 
-    auto restore_values_before_post_compute_adjustments = [&] {
-        VERIFY(display_before_adjustments.has_value());
-        VERIFY(float_before_adjustments.has_value());
-        VERIFY(overflow_x_before_adjustments.has_value());
-        VERIFY(overflow_y_before_adjustments.has_value());
-        VERIFY(text_align_before_adjustments.has_value());
-        VERIFY(position_before_adjustments.has_value());
-        VERIFY(line_height_before_adjustments);
-        computed_style.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(*display_before_adjustments)));
-        computed_style.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*float_before_adjustments));
-        computed_style.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*overflow_x_before_adjustments));
-        computed_style.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*overflow_y_before_adjustments));
-        computed_style.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*text_align_before_adjustments));
-        computed_style.set_property_without_modifying_flags(PropertyID::Position, KeywordStyleValue::create(*position_before_adjustments));
-        computed_style.set_property_without_modifying_flags(PropertyID::LineHeight, *line_height_before_adjustments);
+    auto restore_values_before_post_compute_adjustments = [&](ComputedValuesFFI::FfiStyleFinalizationMode mode) {
+        ComputedValuesFFI::FfiStyleFinalizationInput input {};
+        input.mode = mode;
+        auto finalization = ComputedValuesFFI::rust_finalize_style(
+            &input, computed_style.mutable_computed_longhand_table(), nullptr, nullptr);
+        computed_style.did_apply_style_finalization_from_rust(finalization.invalidated_longhands);
     };
     if (animation_values_applied)
-        restore_values_before_post_compute_adjustments();
+        restore_values_before_post_compute_adjustments(ComputedValuesFFI::FfiStyleFinalizationMode::RestorePostCompute);
 
     m_keyframes_inherited_non_inherited_style_groups = 0;
     auto animations = abstract_element.element().get_animations_internal(
@@ -5929,7 +5905,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         }
         if (!effects.is_empty()) {
             if (!animation_values_applied)
-                restore_values_before_post_compute_adjustments();
+                restore_values_before_post_compute_adjustments(ComputedValuesFFI::FfiStyleFinalizationMode::RestorePostCompute);
             animation_values_applied = true;
             collect_animations_into(abstract_element, effects.span(), computed_style, AnimationRefresh::No);
         }
@@ -5943,8 +5919,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         }
     }
     if (parent_text_align_input_is_animated && !animation_values_applied) {
-        VERIFY(text_align_before_adjustments.has_value());
-        computed_style.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*text_align_before_adjustments));
+        restore_values_before_post_compute_adjustments(ComputedValuesFFI::FfiStyleFinalizationMode::RestorePostComputeTextAlign);
     }
 
     // Run automatic box type transformations again after animations have been applied.

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -339,11 +339,6 @@ private:
 
 GC_DEFINE_ALLOCATOR(StyleComputer);
 
-static bool property_affects_font_metrics(PropertyID property_id)
-{
-    return property_id == PropertyID::FontSize || property_id == PropertyID::LineHeight;
-}
-
 // What a rule contributes, for the two rule types that carry a declaration block.
 static CSSStyleProperties const& declaration_of_rule(CSSRule const& rule)
 {
@@ -777,6 +772,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         size_t keyframe_index { 0 };
         PropertyID property_id;
         RustStyleValueHandle value;
+        StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context {};
         bool use_initial { false };
         bool is_transition { false };
     };
@@ -786,9 +782,20 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         auto animation = effect->associated_animation();
         if (!animation || !effect->transformed_progress().has_value() || !effect->key_frame_set())
             continue;
-        auto& keyframes = effect->key_frame_set()->keyframes_by_key;
+        auto const& key_frame_set = *effect->key_frame_set();
+        auto& keyframes = key_frame_set.keyframes_by_key;
         if (keyframes.size() < 2)
             continue;
+        StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context {};
+        if (key_frame_set.style_sheet_resource_context.has_value()) {
+            auto bytes = key_frame_set.style_sheet_resource_context->base_url.bytes();
+            style_sheet_resource_context = {
+                .base_url = bytes.data(),
+                .base_url_length = bytes.size(),
+                .has_value = true,
+                .origin_clean = key_frame_set.style_sheet_resource_context->origin_clean,
+            };
+        }
         for (auto it = keyframes.begin(); it != keyframes.end(); ++it) {
             auto keyframe_index = keyframes_by_index.size();
             keyframes_by_index.append(&*it);
@@ -820,6 +827,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                     .keyframe_index = keyframe_index,
                     .property_id = property_id,
                     .value = move(style_value),
+                    .style_sheet_resource_context = style_sheet_resource_context,
                     .use_initial = is_use_initial,
                     .is_transition = animation->is_css_transition(),
                 });
@@ -831,6 +839,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         PropertyID source_longhand_id;
         NonnullRefPtr<StyleValue const> value;
         StyleValueFFI::FfiAnimationSpecifiedValueSource value_source;
+        StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context;
     };
     if (keyframe_declarations.is_empty())
         return;
@@ -842,6 +851,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             .keyframe_index = declaration.keyframe_index,
             .property_id = to_underlying(declaration.property_id),
             .value = declaration.value.data(),
+            .style_sheet_resource_context = declaration.style_sheet_resource_context,
             .use_initial = declaration.use_initial,
             .is_transition = declaration.is_transition,
         });
@@ -854,7 +864,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     Vector<StyleValueFFI::FfiAnimatedProperty> ffi_results;
     Vector<Vector<StyleValueFFI::FfiAnimationKeyframeValue>> ffi_keyframes;
     Vector<Vector<Vector<StyleValueFFI::FfiLinearEasingPoint>>> linear_easing_points;
-    auto compute_animation_values = [&](ReadonlySpan<StyleValueFFI::FfiResolvedAnimationProperty> resolved_properties) -> StyleValueFFI::FfiComputedAnimationBatch {
+    auto compute_animation_values = [&](ReadonlySpan<StyleValueFFI::FfiResolvedAnimationProperty> resolved_properties, StyleValueFFI::FfiResolvedAnimationProperties const& resolved_batch) -> StyleValueFFI::FfiComputedAnimationBatch {
         HashMap<Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame const*, HashMap<PropertyID, SelectedKeyframeValue>> selected_keyframe_values;
         for (auto const& property : resolved_properties) {
             VERIFY(property.keyframe_index < keyframes_by_index.size());
@@ -864,10 +874,183 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                                                                                             .source_longhand_id = static_cast<PropertyID>(property.source_longhand_id),
                                                                                             .value = StyleValue::adopt_rust_style_value_data(StyleValueFFI::rust_style_value_retain(property.value)),
                                                                                             .value_source = property.value_source,
+                                                                                            .style_sheet_resource_context = property.style_sheet_resource_context,
                                                                                         });
         }
 
         VERIFY(computation_context_cache_is_empty());
+        Vector<Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame const*> keyframes_for_computation;
+        Vector<ComputedValuesFFI::FfiAnimationKeyframeLonghand> keyframe_longhands;
+        for (auto const& [keyframe, selected_values] : selected_keyframe_values) {
+            auto keyframe_index = keyframes_for_computation.size();
+            keyframes_for_computation.append(keyframe);
+            for (auto const& [physical_property_id, selected_value] : selected_values) {
+                auto source_longhand_id = selected_value.source_longhand_id;
+                auto specified_value = [&]() -> NonnullRefPtr<StyleValue const> {
+                    switch (selected_value.value_source) {
+                    case StyleValueFFI::FfiAnimationSpecifiedValueSource::Inherited:
+                        // A keyframe-borne `inherit` on a non-inherited property reads the
+                        // half of the parent's style ordinary inheritance does not carry,
+                        // exactly like an explicitly inherited declaration.
+                        if (!is_inherited_property(source_longhand_id))
+                            m_keyframes_inherited_non_inherited_style_groups |= ComputedValues::style_group_bit_of_property(source_longhand_id);
+                        if (auto inherited_animated_value = get_animated_inherit_value(source_longhand_id, abstract_element); inherited_animated_value.has_value())
+                            return inherited_animated_value->value;
+                        return get_non_animated_inherit_value(source_longhand_id, abstract_element);
+                    case StyleValueFFI::FfiAnimationSpecifiedValueSource::Initial:
+                        return property_initial_value(source_longhand_id);
+                    case StyleValueFFI::FfiAnimationSpecifiedValueSource::Underlying:
+                        return computed_properties.property(source_longhand_id);
+                    case StyleValueFFI::FfiAnimationSpecifiedValueSource::Value:
+                        return selected_value.value;
+                    }
+                    VERIFY_NOT_REACHED();
+                }();
+                keyframe_longhands.append({
+                    .keyframe_index = keyframe_index,
+                    .property_id = to_underlying(physical_property_id),
+                    .value = specified_value->rust_style_value_data(),
+                    .style_sheet_resource_context = selected_value.value_source == StyleValueFFI::FfiAnimationSpecifiedValueSource::Value
+                        ? ComputedValuesFFI::FfiStyleSheetResourceContext {
+                              .base_url = selected_value.style_sheet_resource_context.base_url,
+                              .base_url_length = selected_value.style_sheet_resource_context.base_url_length,
+                              .has_value = selected_value.style_sheet_resource_context.has_value,
+                              .origin_clean = selected_value.style_sheet_resource_context.origin_clean,
+                          }
+                        : ComputedValuesFFI::FfiStyleSheetResourceContext {},
+                });
+            }
+        }
+
+        Optional<DOM::AbstractElement::TreeCountingFunctionResolutionContext> tree_counting_context;
+        if (resolved_batch.uses_tree_counting_function)
+            tree_counting_context = abstract_element.tree_counting_function_resolution_context();
+        Vector<ComputedValuesFFI::FfiRandomBaseValue> random_base_values;
+        random_base_values.ensure_capacity(resolved_batch.unfixed_random_sharing_count);
+        for (auto const& sharing : ReadonlySpan<StyleValueFFI::FfiAnimationUnfixedRandomSharing> { resolved_batch.unfixed_random_sharings, resolved_batch.unfixed_random_sharing_count }) {
+            VERIFY(sharing.name != 0);
+            RandomCachingKey random_caching_key {
+                .name = Utf16FlyString::from_raw(sharing.name),
+                .element_id = sharing.element_shared
+                    ? Optional<UniqueNodeID> { OptionalNone {} }
+                    : Optional<UniqueNodeID> { abstract_element.element().unique_id() },
+            };
+            random_base_values.empend(sharing.source, const_cast<DOM::Element&>(abstract_element.element()).ensure_css_random_base_value(random_caching_key));
+        }
+        String document_base_url;
+        if (resolved_batch.needs_document_base_url)
+            document_base_url = abstract_element.document().base_url().to_string();
+        auto document_base_url_bytes = document_base_url.bytes();
+        Vector<u8> document_supported_color_scheme_codes;
+        auto document_supported_color_schemes = document().supported_color_schemes();
+        if (document_supported_color_schemes.has_value()) {
+            document_supported_color_scheme_codes.ensure_capacity(document_supported_color_schemes->size());
+            for (auto const& scheme : *document_supported_color_schemes)
+                document_supported_color_scheme_codes.unchecked_append(to_underlying(preferred_color_scheme_from_string(scheme)));
+        }
+        ComputedValuesFFI::FfiStyleComputationEnvironment const computation_environment {
+            .box_type_input = {},
+            .color_scheme_input = {
+                .preferred_color_scheme = static_cast<u8>(to_underlying(document().page().preferred_color_scheme())),
+                .has_document_supported_schemes = document_supported_color_schemes.has_value(),
+                .document_supported_scheme_codes = document_supported_color_scheme_codes.data(),
+                .document_supported_scheme_count = document_supported_color_scheme_codes.size(),
+            },
+            .is_th_element = false,
+            .has_new_font_size = false,
+            .has_animated_inheritance_parent = false,
+            .has_tree_counting_context = tree_counting_context.has_value(),
+            .sibling_count = tree_counting_context.has_value() ? static_cast<u64>(tree_counting_context->sibling_count) : 0,
+            .sibling_index = tree_counting_context.has_value() ? static_cast<u64>(tree_counting_context->sibling_index) : 0,
+            .random_base_values = random_base_values.data(),
+            .random_base_value_count = random_base_values.size(),
+            .document_base_url = document_base_url_bytes.data(),
+            .document_base_url_length = document_base_url_bytes.size(),
+            .style_sheet_resource_contexts = nullptr,
+            .style_sheet_resource_context_count = 0,
+            .device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel(),
+            .initial_font_size_raw = InitialValues::font_size().raw_value(),
+            .default_font_size_raw = default_user_font_size().raw_value(),
+        };
+        auto font_length_resolution_context = to_ffi_length_resolution_context_with_container_bases(
+            get_computation_context_for_property(PropertyID::FontFamily, computed_properties, abstract_element).length_resolution_context,
+            resolved_batch.container_relative_length_unit_mask);
+        auto line_height_length_resolution_context = to_ffi_length_resolution_context_with_container_bases(
+            get_computation_context_for_property(PropertyID::LineHeight, computed_properties, abstract_element).length_resolution_context,
+            resolved_batch.container_relative_length_unit_mask);
+        auto remaining_length_resolution_context = to_ffi_length_resolution_context_with_container_bases(
+            get_computation_context_for_property(PropertyID::Color, computed_properties, abstract_element).length_resolution_context,
+            resolved_batch.container_relative_length_unit_mask);
+
+        auto inheritance_parent = abstract_element.element_to_inherit_style_from();
+        auto inheritance_parent_style = inheritance_parent.has_value() ? inheritance_parent->computed_style() : ComputedStyleRecordView {};
+        Vector<u16, 8> parent_override_properties;
+        Vector<void const*, 8> parent_override_values;
+        Optional<ComputedValuesFFI::FfiParentSnapshot> parent_snapshot;
+        if (inheritance_parent_style) {
+            auto const& parent_base = inheritance_parent_style->base_values();
+            auto parent_longhand_values = parent_base.computed_longhand_values();
+            VERIFY(!parent_longhand_values.is_empty());
+            if (auto const* animated_properties = inheritance_parent_style->animated_properties()) {
+                for (auto const& entry : animated_properties->entries()) {
+                    auto property_id = static_cast<PropertyID>(entry.property);
+                    if (!ComputedValuesFFI::rust_animated_overlay_effective_value(animated_properties->overlay(), entry.property, inheritance_parent_style->is_property_important(property_id)))
+                        continue;
+                    parent_override_properties.append(entry.property);
+                    parent_override_values.append(entry.value);
+                }
+            }
+            for (auto const& entry : parent_base.inheritance_dependent_specified_values()) {
+                if (!entry.value->depends_on_current_color())
+                    continue;
+                parent_override_properties.append(to_underlying(entry.key));
+                parent_override_values.append(entry.value->rust_style_value_data());
+            }
+            for (auto const& entry : parent_base.borrowed_inheritance_dependent_values()) {
+                if (!StyleValueFFI::rust_style_value_depends_on_current_color(static_cast<StyleValueFFI::StyleValueData const*>(entry.value)))
+                    continue;
+                parent_override_properties.append(entry.property);
+                parent_override_values.append(entry.value);
+            }
+            parent_snapshot = ComputedValuesFFI::FfiParentSnapshot {
+                .table_values = parent_longhand_values.data(),
+                .table_value_count = parent_longhand_values.size(),
+                .override_properties = parent_override_properties.data(),
+                .override_values = parent_override_values.data(),
+                .override_count = parent_override_properties.size(),
+                .font_metrics_depend_on_viewport_metrics = inheritance_parent_style->font_metrics_depend_on_viewport_metrics(),
+            };
+        }
+        ComputedValuesFFI::FfiAnimationKeyframeLonghandInput const keyframe_input {
+            .underlying_longhand_table = computed_properties.computed_longhand_table(),
+            .parent_snapshot = parent_snapshot.has_value() ? &*parent_snapshot : nullptr,
+            .longhands = keyframe_longhands.data(),
+            .longhand_count = keyframe_longhands.size(),
+            .environment = &computation_environment,
+            .font_length_resolution_context = &font_length_resolution_context,
+            .line_height_length_resolution_context = &line_height_length_resolution_context,
+            .remaining_length_resolution_context = &remaining_length_resolution_context,
+        };
+        auto computed_keyframe_batch = ComputedValuesFFI::rust_compute_animation_keyframe_longhands(&keyframe_input);
+        ScopeGuard destroy_computed_keyframe_batch = [&] {
+            ComputedValuesFFI::rust_animation_keyframe_longhands_destroy(computed_keyframe_batch.storage);
+        };
+        VERIFY(computed_keyframe_batch.value_count == keyframe_longhands.size());
+        HashMap<Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame const*, HashMap<PropertyID, RefPtr<StyleValue const>>> computed_keyframe_values;
+        for (size_t index = 0; index < keyframe_longhands.size(); ++index) {
+            auto const& longhand = keyframe_longhands[index];
+            VERIFY(longhand.keyframe_index < keyframes_for_computation.size());
+            VERIFY(computed_keyframe_batch.values[index]);
+            computed_keyframe_values.ensure(keyframes_for_computation[longhand.keyframe_index])
+                .set(static_cast<PropertyID>(longhand.property_id), StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(computed_keyframe_batch.values[index])));
+        }
+        if (computed_keyframe_batch.depends_on_viewport_metrics)
+            computed_properties.set_depends_on_viewport_metrics();
+        if (computed_keyframe_batch.font_metrics_depend_on_viewport_metrics)
+            computed_properties.set_font_metrics_depend_on_viewport_metrics();
+        if (resolved_batch.uses_tree_counting_function)
+            const_cast<DOM::Element&>(abstract_element.element()).set_style_uses_tree_counting_function();
+
         for (auto effect : effects) {
             auto animation = effect->associated_animation();
             if (!animation)
@@ -936,63 +1119,6 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                 return CSS::EasingFunction::linear();
             };
 
-            auto compute_keyframe_values = [&computed_properties, &abstract_element, &selected_keyframe_values, this](auto const& keyframe_values) {
-                HashMap<PropertyID, RefPtr<StyleValue const>> result;
-                HashMap<PropertyID, RefPtr<StyleValue const>> specified_values;
-                if (auto selected_values = selected_keyframe_values.get(&keyframe_values); selected_values.has_value()) {
-                    for (auto const& [physical_property_id, selected_value] : *selected_values) {
-                        auto longhand_id = selected_value.source_longhand_id;
-                        auto specified_value = [&]() -> NonnullRefPtr<StyleValue const> {
-                            switch (selected_value.value_source) {
-                            case StyleValueFFI::FfiAnimationSpecifiedValueSource::Inherited:
-                                // A keyframe-borne `inherit` on a non-inherited property reads the
-                                // half of the parent's style ordinary inheritance does not carry,
-                                // exactly like an explicitly inherited declaration.
-                                if (!is_inherited_property(longhand_id))
-                                    m_keyframes_inherited_non_inherited_style_groups |= ComputedValues::style_group_bit_of_property(longhand_id);
-                                if (auto inherited_animated_value = get_animated_inherit_value(longhand_id, abstract_element); inherited_animated_value.has_value())
-                                    return inherited_animated_value->value;
-                                return get_non_animated_inherit_value(longhand_id, abstract_element);
-                            case StyleValueFFI::FfiAnimationSpecifiedValueSource::Initial:
-                                return property_initial_value(longhand_id);
-                            case StyleValueFFI::FfiAnimationSpecifiedValueSource::Underlying:
-                                return computed_properties.property(longhand_id);
-                            case StyleValueFFI::FfiAnimationSpecifiedValueSource::Value:
-                                return selected_value.value;
-                            }
-                            VERIFY_NOT_REACHED();
-                        }();
-                        specified_values.set(physical_property_id, specified_value);
-                    }
-                }
-
-                // NOTE: This doesn't necessarily return the specified value if we reach into computed_properties but that
-                //       doesn't matter as a computed value is always valid as a specified value.
-                Function<NonnullRefPtr<StyleValue const>(PropertyID)> get_property_specified_value = [&](PropertyID property_id) -> NonnullRefPtr<StyleValue const> {
-                    if (auto keyframe_value = specified_values.get(property_id); keyframe_value.has_value() && keyframe_value.value())
-                        return *keyframe_value.value();
-
-                    return computed_properties.property(property_id);
-                };
-
-                for (auto const& [property_id, style_value] : specified_values) {
-                    if (!style_value)
-                        continue;
-
-                    auto const& computation_context = get_computation_context_for_property(property_id, computed_properties, abstract_element);
-
-                    computation_context.reset_viewport_metric_dependency_tracking();
-                    result.set(property_id, compute_value_of_property(property_id, *style_value, get_property_specified_value, computation_context, m_document->page().client().device_pixels_per_css_pixel()));
-                    if (computation_context.depends_on_viewport_metrics()) {
-                        computed_properties.set_depends_on_viewport_metrics();
-                        if (property_affects_font_metrics(property_id))
-                            computed_properties.set_font_metrics_depend_on_viewport_metrics();
-                    }
-                }
-
-                return result;
-            };
-
             auto to_composite_operation = [&](Bindings::CompositeOperationOrAuto composite_operation_or_auto) {
                 switch (composite_operation_or_auto) {
                 case Bindings::CompositeOperationOrAuto::Accumulate:
@@ -1009,12 +1135,10 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
 
             auto is_result_of_transition = animation->is_css_transition() ? AnimatedPropertyResultOfTransition::Yes : AnimatedPropertyResultOfTransition::No;
 
-            Vector<HashMap<PropertyID, RefPtr<StyleValue const>>> keyframe_computed_values;
-            keyframe_computed_values.resize(ordered_keyframes.size());
             auto computed_values_for_keyframe = [&](size_t index) -> HashMap<PropertyID, RefPtr<StyleValue const>> const& {
-                if (keyframe_computed_values[index].is_empty())
-                    keyframe_computed_values[index] = compute_keyframe_values(*ordered_keyframes[index].frame);
-                return keyframe_computed_values[index];
+                auto values = computed_keyframe_values.get(ordered_keyframes[index].frame);
+                VERIFY(values.has_value());
+                return *values;
             };
 
             for (auto const& [property_id, specifying_keyframes] : keyframes_specifying_property) {
@@ -1205,7 +1329,8 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     StyleValueFFI::FfiComputedAnimationBatch computed_batch {};
     if (resolved_properties.count > 0) {
         computed_batch = compute_animation_values(ReadonlySpan<StyleValueFFI::FfiResolvedAnimationProperty> {
-            resolved_properties.properties, resolved_properties.count });
+                                                      resolved_properties.properties, resolved_properties.count },
+            resolved_properties);
     }
     auto result_count = StyleValueFFI::rust_evaluate_animations(&computed_batch);
     VERIFY(result_count == prepared_values.size());
@@ -6478,261 +6603,6 @@ void StyleComputer::compute_custom_properties(ComputedStyleWorkingSet& computed_
     abstract_element.set_custom_property_data(move(resolved));
 }
 
-// https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
-static CSSPixels snap_a_length_as_a_border_width(double device_pixels_per_css_pixel, CSSPixels length)
-{
-    // 1. Assert: len is non-negative.
-    VERIFY(length >= 0);
-
-    // 2. If len is an integer number of device pixels, do nothing.
-    auto device_pixels = length.to_double() * device_pixels_per_css_pixel;
-    if (device_pixels == trunc(device_pixels))
-        return length;
-
-    // 3. If len is greater than zero, but less than 1 device pixel, round len up to 1 device pixel.
-    if (device_pixels > 0 && device_pixels < 1)
-        return CSSPixels::nearest_value_for(1 / device_pixels_per_css_pixel);
-
-    // 4. If len is greater than 1 device pixel, round it down to the nearest integer number of device pixels.
-    if (device_pixels > 1)
-        return CSSPixels::nearest_value_for(floor(device_pixels) / device_pixels_per_css_pixel);
-
-    return length;
-}
-
-static NonnullRefPtr<StyleValue const> compute_style_value_list(NonnullRefPtr<StyleValue const> const& style_value, Function<NonnullRefPtr<StyleValue const>(NonnullRefPtr<StyleValue const> const&)> const& compute_entry)
-{
-    StyleValueVector computed_entries;
-
-    for (auto const& entry : style_value->as_value_list().values())
-        computed_entries.append(compute_entry(entry));
-
-    return StyleValueList::create(move(computed_entries), StyleValueList::Separator::Comma);
-}
-
-static NonnullRefPtr<StyleValue const> compute_svg_number_as_length(NonnullRefPtr<StyleValue const> const& style_value)
-{
-    if (!style_value->is_number())
-        return style_value;
-    return LengthStyleValue::create(Length::make_px(style_value->as_number().number()));
-}
-
-// https://drafts.csswg.org/css-contain-2/#contain-property
-static NonnullRefPtr<StyleValue const> collapse_containment_list(NonnullRefPtr<StyleValue const> const& style_value)
-{
-    auto const* containment_list = as_if<StyleValueList>(*style_value);
-    if (!containment_list)
-        return style_value;
-
-    bool contains_size = false;
-    bool contains_layout = false;
-    bool contains_style = false;
-    bool contains_paint = false;
-
-    for (auto const& containment : containment_list->values()) {
-        switch (containment->to_keyword()) {
-        case Keyword::Size:
-            contains_size = true;
-            break;
-        case Keyword::Layout:
-            contains_layout = true;
-            break;
-        case Keyword::Style:
-            contains_style = true;
-            break;
-        case Keyword::Paint:
-            contains_paint = true;
-            break;
-        default:
-            return style_value;
-        }
-    }
-
-    if (!contains_layout || !contains_style || !contains_paint)
-        return style_value;
-
-    return KeywordStyleValue::create(contains_size ? Keyword::Strict : Keyword::Content);
-}
-
-static NonnullRefPtr<StyleValue const> repeat_style_value_list_to_n_elements(NonnullRefPtr<StyleValue const> const& style_value, size_t n)
-{
-    auto const& value_list = style_value->as_value_list();
-
-    if (value_list.size() == n)
-        return style_value;
-
-    StyleValueVector repeated_values;
-    repeated_values.ensure_capacity(n);
-
-    for (size_t i = 0; i < n; ++i)
-        repeated_values.unchecked_append(value_list.value_at(i, true));
-
-    return StyleValueList::create(move(repeated_values), value_list.separator());
-}
-
-NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(
-    PropertyID property_id,
-    NonnullRefPtr<StyleValue const> const& specified_value,
-    Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value,
-    ComputationContext const& computation_context,
-    double device_pixels_per_css_pixel)
-{
-    auto const& absolutized_value = specified_value->absolutized(computation_context);
-
-    auto inheritance_parent = [&]() {
-        return computation_context.abstract_element
-            .map([](auto const& abstract_element) { return abstract_element.element_to_inherit_style_from(); })
-            .value_or(OptionalNone {});
-    };
-
-    switch (property_id) {
-    case PropertyID::AnimationName:
-        return compute_animation_name(absolutized_value);
-    // NB: The background properties are coordinated at compute time rather than use time, unlike other coordinating list property groups
-    case PropertyID::BackgroundAttachment:
-    case PropertyID::BackgroundClip:
-    case PropertyID::BackgroundOrigin:
-    case PropertyID::BackgroundPositionX:
-    case PropertyID::BackgroundPositionY:
-    case PropertyID::BackgroundRepeat:
-    case PropertyID::BackgroundSize:
-        return repeat_style_value_list_to_n_elements(absolutized_value, get_property_specified_value(PropertyID::BackgroundImage)->as_value_list().size());
-    case PropertyID::BorderBottomWidth:
-    case PropertyID::BorderLeftWidth:
-    case PropertyID::BorderRightWidth:
-    case PropertyID::BorderTopWidth:
-    case PropertyID::OutlineWidth:
-        return compute_border_or_outline_width(absolutized_value, device_pixels_per_css_pixel);
-    case PropertyID::BorderSpacing: {
-        if (absolutized_value->is_value_list())
-            return absolutized_value;
-        return StyleValueList::create(StyleValueVector { absolutized_value, absolutized_value }, StyleValueList::Separator::Space);
-    }
-    case PropertyID::Contain:
-        return collapse_containment_list(absolutized_value);
-    case PropertyID::CornerBottomLeftShape:
-    case PropertyID::CornerBottomRightShape:
-    case PropertyID::CornerTopLeftShape:
-    case PropertyID::CornerTopRightShape:
-        return compute_corner_shape(absolutized_value);
-    case PropertyID::FontSize: {
-        auto parent = inheritance_parent();
-        if (ComputedValuesFFI::rust_value_depends_on_inherited_info_for_property(absolutized_value->rust_style_value_data(), to_underlying(PropertyID::FontSize)) && parent.has_value()) {
-            auto parent_values = parent->computed_style();
-            if (parent_values && parent_values->font_metrics_depend_on_viewport_metrics())
-                computation_context.length_resolution_context.record_viewport_relative_length_resolution();
-        }
-        return compute_font_size(absolutized_value, get_property_specified_value(PropertyID::MathDepth)->as_integer().integer(), parent);
-    }
-    case PropertyID::FontStyle:
-        return compute_font_style(absolutized_value);
-    case PropertyID::FontWeight:
-        return compute_font_weight(absolutized_value, inheritance_parent());
-    case PropertyID::FontWidth:
-        return compute_font_width(absolutized_value);
-    case PropertyID::FontFeatureSettings:
-    case PropertyID::FontVariationSettings:
-        return compute_font_feature_tag_value_list(absolutized_value);
-    case PropertyID::LetterSpacing:
-    case PropertyID::WordSpacing: {
-        // The normal-keyword-to-zero-length rule lives in the Rust style computation core.
-        auto result = ComputedValuesFFI::rust_compute_letter_or_word_spacing(absolutized_value->rust_style_value_data());
-        if (result.unchanged)
-            return absolutized_value;
-        return LengthStyleValue::create(Length::make_px(result.value));
-    }
-    case PropertyID::LineHeight:
-        return compute_line_height(absolutized_value, computation_context.length_resolution_context.font_metrics.font_size);
-    case PropertyID::MathDepth:
-        return compute_math_depth(absolutized_value, inheritance_parent());
-    case PropertyID::StrokeDasharray:
-        // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
-        // as comma separated list of absolute lengths or percentages, numbers converted to
-        // absolute lengths first, or keyword specified
-        if (!absolutized_value->is_value_list())
-            return absolutized_value;
-        return compute_style_value_list(absolutized_value, [](NonnullRefPtr<StyleValue const> const& dash) {
-            return compute_svg_number_as_length(dash);
-        });
-    case PropertyID::StrokeDashoffset:
-    case PropertyID::StrokeWidth:
-        // https://svgwg.org/svg2-draft/painting.html#StrokeWidth
-        // an absolute length or percentage, numbers converted to absolute lengths first
-        return compute_svg_number_as_length(absolutized_value);
-    case PropertyID::TransformOrigin:
-        return compute_transform_origin(absolutized_value);
-    default:
-        return absolutized_value;
-    }
-
-    VERIFY_NOT_REACHED();
-}
-
-NonnullRefPtr<StyleValue const> StyleComputer::compute_animation_name(NonnullRefPtr<StyleValue const> const& absolutized_value)
-{
-    // https://drafts.csswg.org/css-animations-1/#animation-name
-    // list, each item either a case-sensitive css identifier or the keyword none
-
-    return compute_style_value_list(absolutized_value, [](NonnullRefPtr<StyleValue const> const& entry) -> NonnullRefPtr<StyleValue const> {
-        // none | <custom-ident>
-        if (entry->to_keyword() == Keyword::None || entry->is_custom_ident())
-            return entry;
-
-        // <string>
-        if (entry->is_string()) {
-            auto const& string_value = entry->as_string().string_value();
-
-            // AD-HOC: We shouldn't convert strings that aren't valid <custom-ident>s
-            if (!is_valid_animation_name_custom_ident(string_value))
-                return entry;
-
-            return CustomIdentStyleValue::create(entry->as_string().string_value());
-        }
-
-        VERIFY_NOT_REACHED();
-    });
-}
-
-// https://drafts.csswg.org/css-fonts-4/#font-variation-settings-def
-// https://drafts.csswg.org/css-fonts/#font-feature-settings-prop
-NonnullRefPtr<StyleValue const> StyleComputer::compute_font_feature_tag_value_list(NonnullRefPtr<StyleValue const> const& absolutized_value)
-{
-    // NB: The computation logic is the same for both font-feature-settings and font-variation-settings, first we
-    //     deduplicate feature tags (with latter taking precedence), then we sort them in ascending order by code unit
-    if (absolutized_value->is_keyword())
-        return absolutized_value;
-
-    return StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(
-        ComputedValuesFFI::rust_compute_font_feature_settings(absolutized_value->rust_style_value_data())));
-}
-
-NonnullRefPtr<StyleValue const> StyleComputer::compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, double device_pixels_per_css_pixel)
-{
-    // The line-width keywords and the border-width snapping live in the Rust style computation core.
-    auto result = ComputedValuesFFI::rust_compute_border_or_outline_width(absolutized_value->rust_style_value_data(), device_pixels_per_css_pixel);
-    if (result.handled)
-        return LengthStyleValue::create(Length::make_px(result.value));
-
-    auto const absolute_length = Length::from_style_value(absolutized_value, {}).absolute_length_to_px();
-    return LengthStyleValue::create(Length::make_px(snap_a_length_as_a_border_width(device_pixels_per_css_pixel, absolute_length)));
-}
-
-// https://drafts.csswg.org/css-borders-4/#propdef-corner-top-left-shape
-NonnullRefPtr<StyleValue const> StyleComputer::compute_corner_shape(NonnullRefPtr<StyleValue const> const& absolutized_value)
-{
-    // The keyword-to-superellipse mapping lives in the Rust style computation core.
-    auto result = ComputedValuesFFI::rust_compute_corner_shape_parameter(absolutized_value->rust_style_value_data());
-    VERIFY(result.handled);
-    if (result.unchanged)
-        return absolutized_value;
-
-    // NB: The round value is cached since it is the initial value of the corner-*-shape properties.
-    if (result.value == 1) {
-        static auto const& cached_round_value = SuperellipseStyleValue::create(NumberStyleValue::create(1)).leak_ref();
-        return cached_round_value;
-    }
-    return SuperellipseStyleValue::create(NumberStyleValue::create(result.value));
-}
 NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<StyleValue const> const& absolutized_value, int computed_math_depth, Optional<DOM::AbstractElement> const& inheritance_parent, CSSPixels initial_font_size)
 {
     auto inherited_font_size = inheritance_parent.has_value() && inheritance_parent->has_style()
@@ -6808,61 +6678,6 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_width(NonnullRefPtr<
     // AD-HOC: We support calculated percentages as well
     VERIFY(absolutized_value->is_calculated());
     return PercentageStyleValue::create(absolutized_value->as_calculated().resolve_percentage({}).value());
-}
-NonnullRefPtr<StyleValue const> StyleComputer::compute_line_height(NonnullRefPtr<StyleValue const> const& absolutized_value, CSSPixels computed_font_size)
-{
-    // The line-height rules live in the Rust style computation core, including calc
-    // resolution against the computed font size.
-    auto result = ComputedValuesFFI::rust_compute_line_height(absolutized_value->rust_style_value_data(), computed_font_size.raw_value());
-    if (result.handled) {
-        if (result.unchanged)
-            return absolutized_value;
-        if (result.is_number)
-            return NumberStyleValue::create(result.value);
-        return LengthStyleValue::create(Length::make_px(result.value));
-    }
-
-    // NOTE: We also support calc()'d lengths (percentages resolve to lengths so we don't have to handle them separately)
-    if (absolutized_value->is_calculated() && absolutized_value->as_calculated().resolves_to_length_percentage())
-        return LengthStyleValue::create(absolutized_value->as_calculated().resolve_length({ .percentage_basis = Length::make_px(computed_font_size) }).value());
-
-    // NOTE: We also support calc()'d numbers
-    VERIFY(absolutized_value->is_calculated() && absolutized_value->as_calculated().resolves_to_number());
-    return NumberStyleValue::create(absolutized_value->as_calculated().resolve_number({ .percentage_basis = Length::make_px(computed_font_size) }).value());
-}
-
-// https://w3c.github.io/mathml-core/#propdef-math-depth
-NonnullRefPtr<StyleValue const> StyleComputer::compute_math_depth(NonnullRefPtr<StyleValue const> const& absolutized_value, Optional<DOM::AbstractElement> const& inheritance_parent)
-{
-    auto inherited_math_depth = inheritance_parent.has_value() && inheritance_parent->has_style()
-        ? inheritance_parent->computed_style()->math_depth()
-        : InitialValues::math_depth();
-
-    auto inherited_math_style = inheritance_parent.has_value() && inheritance_parent->has_style()
-        ? inheritance_parent->computed_style()->math_style()
-        : InitialValues::math_style();
-
-    // The math-depth rules live in the Rust style computation core.
-    auto result = ComputedValuesFFI::rust_compute_math_depth(absolutized_value->rust_style_value_data(), inherited_math_depth, inherited_math_style == MathStyle::Compact);
-    if (result.handled)
-        return IntegerStyleValue::create(static_cast<i64>(result.value));
-
-    // - If the specified value of math-depth is of the form add(<integer>) then the computed value of
-    //   math-depth of the element is its inherited value plus the specified integer.
-    if (absolutized_value->is_function())
-        return IntegerStyleValue::create(AK::saturating_add(inherited_math_depth, int_from_style_value(absolutized_value->as_function().value())));
-
-    VERIFY(absolutized_value->is_calculated());
-    return IntegerStyleValue::create(int_from_style_value(absolutized_value));
-}
-
-// https://drafts.csswg.org/css-transforms/#transform-origin-property
-NonnullRefPtr<StyleValue const> StyleComputer::compute_transform_origin(NonnullRefPtr<StyleValue const> const& absolutized_value)
-{
-    auto const* computed_value = ComputedValuesFFI::rust_compute_transform_origin(absolutized_value->rust_style_value_data());
-    if (!computed_value)
-        return absolutized_value;
-    return StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(computed_value));
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -5699,17 +5699,16 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
     };
     auto box_type_input = make_box_type_transformation_input(
         abstract_element, InitialValues::display(), Keyword::Static, Keyword::None);
-    Optional<DOM::AbstractElement::TreeCountingFunctionResolutionContext> tree_counting_context;
-    if (ComputedValuesFFI::rust_cascaded_properties_uses_tree_counting_function(cascaded_properties.rust_store()))
-        tree_counting_context = abstract_element.tree_counting_function_resolution_context();
-    auto const container_relative_length_unit_mask = ComputedValuesFFI::rust_cascaded_properties_container_relative_length_unit_mask(cascaded_properties.rust_store());
-    auto unfixed_random_sharings = ComputedValuesFFI::rust_cascaded_properties_unfixed_random_sharings(cascaded_properties.rust_store());
-    ScopeGuard release_unfixed_random_sharings = [&] {
-        ComputedValuesFFI::rust_cascaded_properties_unfixed_random_sharings_release(unfixed_random_sharings.storage, unfixed_random_sharings.entry_count);
+    auto computation_requirements = ComputedValuesFFI::rust_cascaded_properties_computation_requirements(cascaded_properties.rust_store());
+    ScopeGuard destroy_computation_requirements = [&] {
+        ComputedValuesFFI::rust_style_computation_requirements_destroy(computation_requirements.storage, computation_requirements.unfixed_random_sharing_count);
     };
+    Optional<DOM::AbstractElement::TreeCountingFunctionResolutionContext> tree_counting_context;
+    if (computation_requirements.uses_tree_counting_function)
+        tree_counting_context = abstract_element.tree_counting_function_resolution_context();
     Vector<ComputedValuesFFI::FfiRandomBaseValue> random_base_values;
-    random_base_values.ensure_capacity(unfixed_random_sharings.entry_count);
-    for (auto const& sharing : ReadonlySpan<ComputedValuesFFI::FfiUnfixedRandomSharing> { unfixed_random_sharings.entries, unfixed_random_sharings.entry_count }) {
+    random_base_values.ensure_capacity(computation_requirements.unfixed_random_sharing_count);
+    for (auto const& sharing : ReadonlySpan<ComputedValuesFFI::FfiUnfixedRandomSharing> { computation_requirements.unfixed_random_sharings, computation_requirements.unfixed_random_sharing_count }) {
         VERIFY(sharing.name != 0);
         RandomCachingKey random_caching_key {
             .name = Utf16FlyString::from_raw(sharing.name),
@@ -5719,10 +5718,9 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         };
         random_base_values.empend(sharing.source, const_cast<DOM::Element&>(abstract_element.element()).ensure_css_random_base_value(random_caching_key));
     }
-    auto const environment_requirements = ComputedValuesFFI::rust_cascaded_properties_environment_requirements(cascaded_properties.rust_store());
     Vector<String> style_sheet_base_urls;
     Vector<ComputedValuesFFI::FfiStyleSheetResourceContext> style_sheet_resource_contexts;
-    if (environment_requirements & ComputedValuesFFI::CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT) {
+    if (computation_requirements.environment_requirements & ComputedValuesFFI::CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT) {
         style_sheet_base_urls.resize(cascaded_properties.source_slot_count());
         style_sheet_resource_contexts.resize(cascaded_properties.source_slot_count());
         for (size_t slot = 0; slot < cascaded_properties.source_slot_count(); ++slot) {
@@ -5752,7 +5750,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         }
     }
     String document_base_url;
-    if (environment_requirements & ComputedValuesFFI::CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL)
+    if (computation_requirements.environment_requirements & ComputedValuesFFI::CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL)
         document_base_url = abstract_element.document().base_url().to_string();
     auto document_base_url_bytes = document_base_url.bytes();
     ComputedValuesFFI::FfiStyleComputationEnvironment const computation_environment {
@@ -5778,7 +5776,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
         Optional<ComputedValuesFFI::FfiLengthResolutionContext> length_resolution_context;
         if (context_property.has_value()) {
             auto const& computation_context = get_computation_context_for_property(*context_property, computed_style, abstract_element);
-            length_resolution_context = to_ffi_length_resolution_context_with_container_bases(computation_context.length_resolution_context, container_relative_length_unit_mask);
+            length_resolution_context = to_ffi_length_resolution_context_with_container_bases(computation_context.length_resolution_context, computation_requirements.container_relative_length_unit_mask);
         }
         auto store_batch = ComputedValuesFFI::rust_drive_property_computation(computed_style.mutable_computed_longhand_table(), cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &computation_environment, computed_group_mask, computed_properties_to_evaluate, phase, length_resolution_context.has_value() ? &*length_resolution_context : nullptr, &driver_results);
         ScopeGuard destroy_store_batch = [&] {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -751,7 +751,7 @@ void StyleComputer::collect_animations_into(DOM::AbstractElement abstract_elemen
             parent->add_children_explicitly_inherited_non_inherited_style_groups(m_keyframes_inherited_non_inherited_style_groups);
         m_keyframes_inherited_non_inherited_style_groups = 0;
     }
-    adjust_animated_element_style_if_needed(computed_properties, abstract_element);
+    finalize_style(computed_properties, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::AnimatedBoxType);
 }
 
 void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract_element, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>> effects, ComputedStyleWorkingSet& computed_properties) const
@@ -3451,49 +3451,50 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
     }
 }
 
-void StyleComputer::resolve_effective_overflow_values(ComputedStyleWorkingSet& style) const
+static void prepare_overflow_finalization(ComputedStyleWorkingSet const& style, ComputedValuesFFI::FfiStyleFinalizationInput& input)
 {
-    // The css-overflow-3 rule pairing the two axes lives in the Rust style computation core.
-    auto effective_overflow = ComputedValuesFFI::rust_resolve_effective_overflow_keywords(
-        to_underlying(style.property(PropertyID::OverflowX).to_keyword()),
-        to_underlying(style.property(PropertyID::OverflowY).to_keyword()));
+    input.overflow_x = to_underlying(style.property(PropertyID::OverflowX).to_keyword());
+    input.overflow_y = to_underlying(style.property(PropertyID::OverflowY).to_keyword());
+}
+
+static void apply_overflow_finalization(ComputedStyleWorkingSet& style, ComputedValuesFFI::FfiEffectiveOverflow const& effective_overflow)
+{
     if (effective_overflow.changed_x)
         style.set_property(PropertyID::OverflowX, KeywordStyleValue::create(static_cast<Keyword>(effective_overflow.x_keyword)));
     if (effective_overflow.changed_y)
         style.set_property(PropertyID::OverflowY, KeywordStyleValue::create(static_cast<Keyword>(effective_overflow.y_keyword)));
 }
 
-static void compute_text_align(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element)
+static bool prepare_text_align_finalization(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiStyleFinalizationInput& input)
 {
     auto text_align_keyword = style.property(PropertyID::TextAlign).to_keyword();
 
     // NB: Only these two keywords trigger an adjustment in the Rust decision below; the early
     //     return avoids fetching the parent's computed values for every element.
     if (text_align_keyword != Keyword::MatchParent && text_align_keyword != Keyword::LibwebInheritOrCenter)
-        return;
+        return false;
+
+    input.text_align = to_underlying(text_align_keyword);
+    input.is_th_element = abstract_element.element().local_name() == HTML::TagNames::th;
 
     // The resolved value does not remember that it read the parent's direction and text alignment.
     // Keep the specified keyword so inherited-style refresh can resolve it again when either moves.
     style.add_inheritance_dependent_specified_value(PropertyID::TextAlign, style.property(PropertyID::TextAlign));
 
     auto const parent = abstract_element.element_to_inherit_style_from();
-    bool has_parent_with_computed_values = parent.has_value() && parent->has_style();
-    u16 parent_text_align = 0;
-    bool parent_direction_is_ltr = true;
-    if (has_parent_with_computed_values) {
+    input.has_parent_with_computed_values = parent.has_value() && parent->has_style();
+    input.parent_direction_is_ltr = true;
+    if (input.has_parent_with_computed_values) {
         auto parent_style = parent->computed_style();
         auto const& parent_values = *parent_style;
-        parent_text_align = to_underlying(to_keyword(parent_values.text_align()));
-        parent_direction_is_ltr = parent_values.direction() == Direction::Ltr;
+        input.parent_text_align = to_underlying(to_keyword(parent_values.text_align()));
+        input.parent_direction_is_ltr = parent_values.direction() == Direction::Ltr;
     }
+    return true;
+}
 
-    // The adjustment decision lives in the Rust style computation core.
-    auto adjustment = ComputedValuesFFI::rust_compute_text_align(
-        to_underlying(text_align_keyword),
-        abstract_element.element().local_name() == HTML::TagNames::th,
-        has_parent_with_computed_values,
-        parent_text_align,
-        parent_direction_is_ltr);
+static void apply_text_align_finalization(ComputedStyleWorkingSet& style, ComputedValuesFFI::FfiTextAlignAdjustment const& adjustment)
+{
     if (adjustment.changed) {
         style.set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(adjustment.keyword)),
             adjustment.inherited ? ComputedStyleWorkingSet::Inherited::Yes : ComputedStyleWorkingSet::Inherited::No);
@@ -3627,69 +3628,60 @@ static void apply_element_style_adjustments(ComputedStyleWorkingSet const& style
 }
 
 // https://drafts.csswg.org/css-display/#transformations
-void StyleComputer::adjust_element_style_if_needed(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element) const
+void StyleComputer::finalize_style(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode mode) const
 {
-    auto input = make_box_type_transformation_input(
-        abstract_element,
-        style.display(),
-        style.property(PropertyID::Position).to_keyword(),
-        style.property(PropertyID::Float).to_keyword());
-    auto adjustments = ComputedValuesFFI::rust_adjust_element_style(
-        &input, to_underlying(style.property(PropertyID::TextAlign).to_keyword()));
+    bool const animated_box_type = mode == ComputedValuesFFI::FfiStyleFinalizationMode::AnimatedBoxType;
+    bool const finalize_box_type = mode != ComputedValuesFFI::FfiStyleFinalizationMode::TextAlign
+        && mode != ComputedValuesFFI::FfiStyleFinalizationMode::Overflow;
+    ComputedValuesFFI::FfiStyleFinalizationInput input {};
+    input.mode = mode;
+    input.text_align = to_underlying(style.property(PropertyID::TextAlign).to_keyword());
+    if (finalize_box_type) {
+        auto display = animated_box_type && !style.has_animated_property(PropertyID::Display)
+            ? style.display_before_box_type_transformation()
+            : style.display();
+        input.box_type = make_box_type_transformation_input(
+            abstract_element,
+            display,
+            style.property(PropertyID::Position).to_keyword(),
+            style.property(PropertyID::Float).to_keyword());
+    }
+    if (mode == ComputedValuesFFI::FfiStyleFinalizationMode::All) {
+        prepare_overflow_finalization(style, input);
+        prepare_text_align_finalization(style, abstract_element, input);
+    } else if (mode == ComputedValuesFFI::FfiStyleFinalizationMode::TextAlign && !prepare_text_align_finalization(style, abstract_element, input)) {
+        return;
+    }
 
-    auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
-        // Animated values are stored separately from the builder's base values, so post-compute
-        // adjustments must replace the sampled value as well.
-        if (style.has_animated_property(property_id)) {
-            auto is_result_of_transition = style.is_animated_property_result_of_transition(property_id)
+    auto finalization = ComputedValuesFFI::rust_finalize_style(&input);
+    if (finalize_box_type) {
+        auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
+            if (animated_box_type) {
+                if (style.property(property_id).equals(*value))
+                    return;
+            } else if (!style.has_animated_property(property_id)) {
+                style.set_property(property_id, move(value));
+                return;
+            }
+            auto is_result_of_transition = style.has_animated_property(property_id) && style.is_animated_property_result_of_transition(property_id)
                 ? AnimatedPropertyResultOfTransition::Yes
                 : AnimatedPropertyResultOfTransition::No;
-            auto inherited = style.is_animated_property_inherited(property_id)
+            auto inherited = style.has_animated_property(property_id) && style.is_animated_property_inherited(property_id)
                 ? ComputedStyleWorkingSet::Inherited::Yes
                 : ComputedStyleWorkingSet::Inherited::No;
             style.set_animated_property(Badge<StyleComputer> {}, property_id, value, is_result_of_transition, inherited);
-        }
-        style.set_property(property_id, move(value));
-    };
+            if (!animated_box_type)
+                style.set_property(property_id, move(value));
+        };
 
-    style.set_display_before_box_type_transformation(display_from_ffi_display(input.display));
-    apply_element_style_adjustments(style, abstract_element, adjustments, set_adjusted_property);
-}
-
-void StyleComputer::adjust_animated_element_style_if_needed(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element) const
-{
-    auto display = style.has_animated_property(PropertyID::Display)
-        ? style.display()
-        : style.display_before_box_type_transformation();
-    auto input = make_box_type_transformation_input(
-        abstract_element,
-        display,
-        style.property(PropertyID::Position).to_keyword(),
-        style.property(PropertyID::Float).to_keyword());
-    auto adjustments = ComputedValuesFFI::rust_adjust_element_style(
-        &input, to_underlying(style.property(PropertyID::TextAlign).to_keyword()));
-
-    auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
-        if (style.property(property_id).equals(*value))
-            return;
-        auto is_result_of_transition = style.has_animated_property(property_id) && style.is_animated_property_result_of_transition(property_id)
-            ? AnimatedPropertyResultOfTransition::Yes
-            : AnimatedPropertyResultOfTransition::No;
-        auto inherited = style.has_animated_property(property_id) && style.is_animated_property_inherited(property_id)
-            ? ComputedStyleWorkingSet::Inherited::Yes
-            : ComputedStyleWorkingSet::Inherited::No;
-        style.set_animated_property(Badge<StyleComputer> {}, property_id, move(value), is_result_of_transition, inherited);
-    };
-    if (!style.has_animated_property(PropertyID::Display))
-        set_adjusted_property(PropertyID::Display, DisplayStyleValue::create(display));
-    apply_element_style_adjustments(style, abstract_element, adjustments, set_adjusted_property);
-}
-
-void StyleComputer::apply_post_compute_adjustments(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element) const
-{
-    adjust_element_style_if_needed(style, abstract_element);
-    resolve_effective_overflow_values(style);
-    compute_text_align(style, abstract_element);
+        if (animated_box_type && !style.has_animated_property(PropertyID::Display))
+            set_adjusted_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(input.box_type.display)));
+        if (!animated_box_type)
+            style.set_display_before_box_type_transformation(display_from_ffi_display(input.box_type.display));
+        apply_element_style_adjustments(style, abstract_element, finalization.element_style, set_adjusted_property);
+    }
+    apply_overflow_finalization(style, finalization.overflow);
+    apply_text_align_finalization(style, finalization.text_align);
 }
 
 NonnullRefPtr<ComputedValues const> StyleComputer::create_document_style() const
@@ -4319,9 +4311,11 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
     auto base_values = ComputedValues::Builder { previous_values.base_values() }.build();
     auto animated_values = ComputedValues::create_over_base(computed_properties, document(), style_scope, move(color_resolution_context), *base_values, groups_to_apply);
     ComputedValues::Builder builder { *animated_values };
-    auto effective_overflow = ComputedValuesFFI::rust_resolve_effective_overflow_keywords(
-        to_underlying(to_keyword(animated_values->overflow_x())),
-        to_underlying(to_keyword(animated_values->overflow_y())));
+    ComputedValuesFFI::FfiStyleFinalizationInput finalization_input {};
+    finalization_input.mode = ComputedValuesFFI::FfiStyleFinalizationMode::Overflow;
+    finalization_input.overflow_x = to_underlying(to_keyword(animated_values->overflow_x()));
+    finalization_input.overflow_y = to_underlying(to_keyword(animated_values->overflow_y()));
+    auto effective_overflow = ComputedValuesFFI::rust_finalize_style(&finalization_input).overflow;
     if (effective_overflow.changed_x)
         builder->set_overflow_x(keyword_to_overflow(static_cast<Keyword>(effective_overflow.x_keyword)).value());
     if (effective_overflow.changed_y)
@@ -4563,7 +4557,7 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
         VERIFY(inherited_pseudo_element_style);
         auto style = ComputedStyleWorkingSet::create_with_base_values_from(*inherited_pseudo_element_style);
 
-        adjust_element_style_if_needed(*style, abstract_element);
+        finalize_style(*style, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::BoxType);
         style->freeze_computed_longhand_table();
         return style;
     }
@@ -5934,9 +5928,9 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
 
     // Run automatic box type transformations again after animations have been applied.
     if (animation_values_applied)
-        apply_post_compute_adjustments(computed_style, abstract_element);
+        finalize_style(computed_style, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::All);
     else if (parent_text_align_input_is_animated)
-        compute_text_align(computed_style, abstract_element);
+        finalize_style(computed_style, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::TextAlign);
 
     bool parent_style_in_display_none_subtree = false;
     if (auto parent = abstract_element.element_to_inherit_style_from(); parent.has_value()) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -526,9 +526,6 @@ void StyleComputer::visit_edges(Visitor& visitor)
     for (auto const& entry : m_constructed_rule_ids)
         visitor.visit(entry.key);
 
-    if (m_active_custom_property_resolution.has_value())
-        m_active_custom_property_resolution->visit_edges(visitor);
-
     if (m_cached_font_computation_context.has_value())
         m_cached_font_computation_context->visit_edges(visitor);
     if (m_cached_line_height_computation_context.has_value())
@@ -3195,21 +3192,6 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
         .evaluate_condition = [](void* context, u8 kind, ComputedValuesFFI::FfiUtf16View source) -> u8 {
             auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
             return evaluate_condition_for_substitution(bulk_context.abstract_element, kind, source);
-        },
-        .lookup_final_custom_property = [](void* context, ComputedValuesFFI::FfiUtf16View name) -> void const* {
-            auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
-            auto& document = bulk_context.abstract_element.document();
-            auto& style_computer = document.style_computer();
-            auto name_view = utf16_view(name);
-            if (style_computer.m_active_custom_property_resolution.has_value()
-                && style_computer.m_active_custom_property_resolution->element == bulk_context.abstract_element) {
-                if (auto finalized = style_computer.m_active_custom_property_resolution->finalized.get(Utf16FlyString::from_utf16(name_view)); finalized.has_value()) {
-                    document.style_invalidation_counters().custom_property_overlay_hits++;
-                    return finalized.value()->rust_style_value_data();
-                }
-                document.style_invalidation_counters().custom_property_value_computations++;
-            }
-            return nullptr;
         },
         .note_substitution = [](void* context, void const* unresolved_data) {
             auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
@@ -6051,30 +6033,21 @@ NonnullRefPtr<StyleValue const> StyleComputer::resolve_unresolved_style_value(Ab
             auto& element = *static_cast<AbstractOrHypotheticalElement*>(context);
             return evaluate_condition_for_substitution(element, kind, source);
         },
-        .lookup_final_custom_property = [](void* context, ComputedValuesFFI::FfiUtf16View name) -> void const* {
-            auto& element = *static_cast<AbstractOrHypotheticalElement*>(context);
-            auto& document = element.document();
-            auto& style_computer = document.style_computer();
-            auto name_view = utf16_view(name);
-            if (style_computer.m_active_custom_property_resolution.has_value()
-                && element.has<DOM::AbstractElement>()
-                && style_computer.m_active_custom_property_resolution->element == element.get<DOM::AbstractElement>()) {
-                if (auto finalized = style_computer.m_active_custom_property_resolution->finalized.get(Utf16FlyString::from_utf16(name_view)); finalized.has_value()) {
-                    document.style_invalidation_counters().custom_property_overlay_hits++;
-                    return finalized.value()->rust_style_value_data();
-                }
-                document.style_invalidation_counters().custom_property_value_computations++;
-            }
-            return nullptr;
-        },
         .note_substitution = nullptr,
         .lookup_cached_substitution = nullptr,
         .cache_parsed_substitution = nullptr,
     };
-    auto* result = ComputedValuesFFI::rust_resolve_unresolved_style_value(
-        &resolution_context, to_underlying(property.id()), unresolved.rust_style_value_data());
-    VERIFY(result);
-    return StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(result));
+    ComputedValuesFFI::FfiUnresolvedStyleValue input {
+        .property_id = to_underlying(property.id()),
+        .root_custom_property_name = resolution_context.root_custom_property_name,
+        .data = unresolved.rust_style_value_data(),
+        .resolve_substitutions = true,
+    };
+    ComputedValuesFFI::FfiResolvedStyleValue output {};
+    ComputedValuesFFI::rust_resolve_unresolved_style_values(
+        &resolution_context, &input, 1, &output, nullptr, nullptr);
+    VERIFY(output.data);
+    return StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(output.data));
 }
 
 NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(ComputedStyleWorkingSet const* computed_style_for_custom_property_resolution, AbstractOrHypotheticalElement const& element, Utf16FlyString const& name) const
@@ -6084,21 +6057,19 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(
     // FIXME: These should probably be part of the computed style itself.
     auto& document = element.document();
 
-    // While this element's own properties resolve in dependency order, everything a value can name is final before
-    // the value resolves, so a nested lookup reads the finished answer instead of resolving its value again.
-    if (m_active_custom_property_resolution.has_value() && element.has<DOM::AbstractElement>()
-        && element.get<DOM::AbstractElement>() == m_active_custom_property_resolution->element) {
-        if (auto finalized = m_active_custom_property_resolution->finalized.get(name); finalized.has_value()) {
-            document.style_invalidation_counters().custom_property_overlay_hits++;
-            return *finalized.value();
-        }
-    }
-
     document.style_invalidation_counters().custom_property_value_computations++;
     auto registration = element.get_registered_custom_property(name);
 
     auto value = element.get_custom_property(name);
     auto resolved_value = value ? value.release_nonnull() : initial_custom_property_value(registration, document);
+
+    return finalize_custom_property_value(computed_style_for_custom_property_resolution, element, name, move(resolved_value));
+}
+
+NonnullRefPtr<StyleValue const> StyleComputer::finalize_custom_property_value(ComputedStyleWorkingSet const* computed_style_for_custom_property_resolution, AbstractOrHypotheticalElement const& element, Utf16FlyString const& name, NonnullRefPtr<StyleValue const> resolved_value) const
+{
+    auto& document = element.document();
+    auto registration = element.get_registered_custom_property(name);
 
     if (resolved_value->is_css_wide_keyword())
         resolved_value = resolve_css_wide_keyword_for_custom_property(registration, element, name, move(resolved_value), computed_style_for_custom_property_resolution);
@@ -6233,73 +6204,6 @@ StyleComputer::CustomPropertyReferenceScan const& StyleComputer::custom_property
     });
 }
 
-// Tarjan's strongly-connected-components algorithm, iterative because reference chains are as deep as a stylesheet
-// wants. Components come out in dependency order: every component a member references outside its own is emitted
-// before it.
-static Vector<Vector<u32>> strongly_connected_components_in_dependency_order(Vector<Vector<u32>> const& edges)
-{
-    auto const node_count = edges.size();
-    constexpr u32 unvisited = NumericLimits<u32>::max();
-    Vector<u32> discovery_index;
-    discovery_index.resize(node_count);
-    discovery_index.fill(unvisited);
-    Vector<u32> lowlink;
-    lowlink.resize(node_count);
-    Vector<bool> on_stack;
-    on_stack.resize(node_count);
-    Vector<u32> component_stack;
-    Vector<Vector<u32>> components;
-    u32 next_discovery_index = 0;
-
-    struct Frame {
-        u32 node;
-        u32 next_edge;
-    };
-    Vector<Frame> walk_stack;
-
-    for (u32 root = 0; root < node_count; ++root) {
-        if (discovery_index[root] != unvisited)
-            continue;
-        walk_stack.append({ root, 0 });
-        while (!walk_stack.is_empty()) {
-            auto& frame = walk_stack.last();
-            auto node = frame.node;
-            if (frame.next_edge == 0) {
-                discovery_index[node] = lowlink[node] = next_discovery_index++;
-                component_stack.append(node);
-                on_stack[node] = true;
-            }
-            bool descended = false;
-            while (frame.next_edge < edges[node].size()) {
-                auto target = edges[node][frame.next_edge++];
-                if (discovery_index[target] == unvisited) {
-                    walk_stack.append({ target, 0 });
-                    descended = true;
-                    break;
-                }
-                if (on_stack[target])
-                    lowlink[node] = min(lowlink[node], discovery_index[target]);
-            }
-            if (descended)
-                continue;
-            if (lowlink[node] == discovery_index[node]) {
-                Vector<u32> component;
-                u32 popped = 0;
-                do {
-                    popped = component_stack.take_last();
-                    on_stack[popped] = false;
-                    component.append(popped);
-                } while (popped != node);
-                components.append(move(component));
-            }
-            walk_stack.take_last();
-            if (!walk_stack.is_empty())
-                lowlink[walk_stack.last().node] = min(lowlink[walk_stack.last().node], lowlink[node]);
-        }
-    }
-    return components;
-}
-
 void StyleComputer::compute_custom_properties(ComputedStyleWorkingSet& computed_style, DOM::AbstractElement abstract_element) const
 {
     // https://drafts.csswg.org/css-variables/#propdef-
@@ -6339,22 +6243,8 @@ void StyleComputer::compute_custom_properties(ComputedStyleWorkingSet& computed_
 
     document().style_invalidation_counters().custom_property_elements++;
     document().style_invalidation_counters().custom_property_resolutions += data->declared_count();
+    document().style_invalidation_counters().custom_property_value_computations += data->declared_count();
 
-    // Resolving a value that names another of this element's own properties walks into that value and resolves it,
-    // and the walk repeats for every value naming it. Deciding an order first makes each own value resolve once:
-    // Tarjan's algorithm over the scanned references emits every component after the components it depends on, so by
-    // the time a value resolves, everything it can name is final and a nested lookup reads the finished answer.
-    //
-    // A reference cycle is the one thing that must not read finished answers: a member handed one would take a var()
-    // fallback where the specification makes the whole cycle invalid. So a component's members resolve the
-    // independent way, with the substitution guards deciding what is cyclic, and their answers are published only
-    // once the whole component is done. A value whose references are not in its tokens - attr() substitutes
-    // attribute text that can name custom properties, if() reads them through style() queries, a custom function's
-    // body reads what it likes, and a var() name slot can itself be substituted - is given an edge to every own
-    // name, which puts it after everything it could read and in a component with everything that names it back.
-    // The order only matters when some own value names another own value that itself needs resolving; a value naming
-    // only inherited or plain own properties reads answers that are final before it resolves. That is most elements
-    // on most pages, so decide first, from the cached scans alone, whether there is anything here to order.
     auto const& own_values = data->own_values();
     auto for_each_declared_value = [&](auto callback) {
         size_t declared = 0;
@@ -6367,25 +6257,6 @@ void StyleComputer::compute_custom_properties(ComputedStyleWorkingSet& computed_
     auto needs_resolution = [](StyleValue const& value) {
         return value.is_unresolved() && value.as_unresolved().contains_arbitrary_substitution_function();
     };
-    bool has_own_reference = false;
-    for_each_declared_value([&](auto const&, auto const& style_property) {
-        auto const& value = *style_property.value;
-        if (!needs_resolution(value))
-            return;
-        auto const& unresolved = value.as_unresolved();
-        if (unresolved.includes_attr_function() || unresolved.includes_if_function() || unresolved.includes_dashed_function())
-            return;
-        auto const& scan = custom_property_reference_scan(style_property.value);
-        if (!scan.all_references_visible)
-            return;
-        for (auto const& referenced_name : scan.references) {
-            if (auto referenced = own_values.find(referenced_name); referenced != own_values.end() && needs_resolution(*referenced->value.value)) {
-                has_own_reference = true;
-                break;
-            }
-        }
-    });
-
     OrderedHashMap<Utf16FlyString, StyleProperty> resolved_own;
     auto keep_resolved_value = [&](Utf16FlyString const& name, StyleProperty const& style_property, NonnullRefPtr<StyleValue const> resolved_value) {
         if (parent_data) {
@@ -6401,69 +6272,93 @@ void StyleComputer::compute_custom_properties(ComputedStyleWorkingSet& computed_
             });
     };
 
-    if (!has_own_reference) {
-        for_each_declared_value([&](auto const& name, auto const& style_property) {
-            keep_resolved_value(name, style_property, compute_value_of_custom_property(&computed_style, abstract_element, name));
+    struct CustomPropertyToResolve {
+        Utf16FlyString name;
+        StyleProperty const* property;
+        NonnullRefPtr<StyleValue const> resolved;
+    };
+    Vector<CustomPropertyToResolve> properties;
+    Vector<ComputedValuesFFI::FfiUnresolvedStyleValue> inputs;
+    Vector<ComputedValuesFFI::FfiResolvedStyleValue> outputs;
+    auto& dom_element = abstract_element.element();
+    for_each_declared_value([&](auto const& name, auto const& style_property) {
+        auto resolve_substitutions = needs_resolution(*style_property.value);
+        if (resolve_substitutions) {
+            auto const& unresolved = style_property.value->as_unresolved();
+            if (unresolved.includes_var_function())
+                dom_element.set_style_uses_var_css_function();
+            if (unresolved.includes_attr_function())
+                dom_element.set_style_uses_attr_css_function();
+            if (unresolved.includes_if_function())
+                dom_element.set_style_uses_if_css_function();
+            if (unresolved.includes_inherit_function())
+                dom_element.set_style_uses_inherit_css_function();
+            if (unresolved.includes_dashed_function())
+                dom_element.set_style_uses_custom_function();
+            for (auto const& reference : custom_property_reference_scan(style_property.value).references)
+                dom_element.record_style_custom_property_reference(reference);
+        }
+        properties.append({ name, &style_property, GuaranteedInvalidStyleValue::create() });
+        inputs.append({
+            .property_id = to_underlying(PropertyID::Custom),
+            .root_custom_property_name = ffi_utf16_view(properties.last().name),
+            .data = style_property.value->rust_style_value_data(),
+            .resolve_substitutions = resolve_substitutions,
         });
-    } else {
-        struct OwnCustomProperty {
-            Utf16FlyString name;
-            StyleProperty const* property;
+        outputs.empend();
+    });
+    for (size_t i = 0; i < inputs.size(); ++i)
+        inputs[i].root_custom_property_name = ffi_utf16_view(properties[i].name);
+
+    if (!inputs.is_empty()) {
+        AbstractOrHypotheticalElement resolution_element { abstract_element };
+        SubstitutionData substitution_data { resolution_element, true, true };
+        auto inheritance_data = inherit_from.map([](auto const& parent) { return parent.custom_property_data(); }).value_or(nullptr);
+        ComputedValuesFFI::FfiCascadeResolutionContext resolution_context {
+            .parse_context = &substitution_data.parse_context,
+            .custom_property_store = data->rust_store(),
+            .inheritance_custom_property_store = inheritance_data ? inheritance_data->rust_store() : nullptr,
+            .custom_property_registry = document().rust_custom_property_registry(),
+            .root_custom_property_name = {},
+            .attributes = substitution_data.ffi_attributes.data(),
+            .attribute_count = substitution_data.ffi_attributes.size(),
+            .attribute_names_are_ascii_case_insensitive = dom_element.namespace_uri() == Namespace::HTML && document().is_html_document(),
+            .custom_functions = substitution_data.ffi_functions.data(),
+            .custom_function_count = substitution_data.ffi_functions.size(),
+            .custom_function_scope_identity = bit_cast<FlatPtr>(&resolution_element.style_scope()),
+            .callback_context = &resolution_element,
+            .resolve_custom_function = resolve_custom_function_for_substitution,
+            .evaluate_condition = [](void* context, u8 kind, ComputedValuesFFI::FfiUtf16View source) -> u8 {
+                return evaluate_condition_for_substitution(*static_cast<AbstractOrHypotheticalElement*>(context), kind, source);
+            },
+            .note_substitution = nullptr,
+            .lookup_cached_substitution = nullptr,
+            .cache_parsed_substitution = nullptr,
         };
-        Vector<OwnCustomProperty> own;
-        own.ensure_capacity(data->declared_count());
-        HashMap<Utf16FlyString, u32> own_index;
-        for_each_declared_value([&](auto const& name, auto const& style_property) {
-            own_index.set(name, static_cast<u32>(own.size()));
-            own.append({ name, &style_property });
-        });
-
-        Vector<Vector<u32>> references;
-        references.resize(own.size());
-        for (size_t i = 0; i < own.size(); ++i) {
-            auto const& value = *own[i].property->value;
-            if (!value.is_unresolved())
-                continue;
-            auto const& unresolved = value.as_unresolved();
-            if (!unresolved.contains_arbitrary_substitution_function())
-                continue;
-            bool references_visible = !unresolved.includes_attr_function() && !unresolved.includes_if_function() && !unresolved.includes_dashed_function();
-            if (references_visible) {
-                auto const& scan = custom_property_reference_scan(own[i].property->value);
-                references_visible = scan.all_references_visible;
-                if (references_visible) {
-                    for (auto const& referenced_name : scan.references) {
-                        if (auto index = own_index.get(referenced_name); index.has_value())
-                            references[i].append(*index);
-                    }
+        struct FinalizationContext {
+            GC::Ref<StyleComputer const> style_computer;
+            ComputedStyleWorkingSet const& computed_style;
+            DOM::AbstractElement element;
+            Vector<CustomPropertyToResolve>& properties;
+        } finalization_context { *this, computed_style, abstract_element, properties };
+        auto resolution_stats = ComputedValuesFFI::rust_resolve_unresolved_style_values(
+            &resolution_context, inputs.data(), inputs.size(), outputs.data(), &finalization_context,
+            [](void* context, u32 const* members, size_t member_count, ComputedValuesFFI::FfiResolvedStyleValue* resolved) {
+                auto& finalization = *static_cast<FinalizationContext*>(context);
+                for (auto member : ReadonlySpan<u32> { members, member_count }) {
+                    auto substituted = StyleValue::adopt_rust_style_value_data(
+                        static_cast<StyleValueFFI::StyleValueData const*>(resolved[member].data));
+                    auto& property = finalization.properties[member];
+                    property.resolved = finalization.style_computer->finalize_custom_property_value(
+                        &finalization.computed_style, finalization.element, property.name, move(substituted));
+                    resolved[member].data = property.resolved->rust_style_value_data();
                 }
-            }
-            if (!references_visible) {
-                references[i].clear_with_capacity();
-                references[i].ensure_capacity(own.size());
-                for (u32 target = 0; target < own.size(); ++target)
-                    references[i].append(target);
-            }
-        }
-
-        auto previous_active_resolution = move(m_active_custom_property_resolution);
-        m_active_custom_property_resolution = ActiveCustomPropertyResolution { abstract_element, {} };
-        ScopeGuard restore_active_resolution { [&] { m_active_custom_property_resolution = move(previous_active_resolution); } };
-
-        Vector<RefPtr<StyleValue const>> resolved_values;
-        resolved_values.resize(own.size());
-        for (auto& component : strongly_connected_components_in_dependency_order(references)) {
-            if (component.size() > 1 || references[component[0]].contains_slow(component[0]))
-                document().style_invalidation_counters().custom_property_cycle_participants += component.size();
-            quick_sort(component);
-            for (auto member : component)
-                resolved_values[member] = compute_value_of_custom_property(&computed_style, abstract_element, own[member].name);
-            for (auto member : component)
-                m_active_custom_property_resolution->finalized.set(own[member].name, *resolved_values[member]);
-        }
-
-        for (size_t i = 0; i < own.size(); ++i)
-            keep_resolved_value(own[i].name, *own[i].property, resolved_values[i].release_nonnull());
+            });
+        document().style_invalidation_counters().custom_property_overlay_hits += resolution_stats.final_value_hits;
+        document().style_invalidation_counters().custom_property_value_computations += resolution_stats.final_value_misses;
+        document().style_invalidation_counters().custom_property_cycle_participants += resolution_stats.cycle_participants;
+        for (auto const& property : properties)
+            keep_resolved_value(property.name, *property.property, property.resolved);
     }
 
     // What a resolution is allowed to read beyond the environment says whether the answer belongs to

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3278,40 +3278,6 @@ CSSPixels StyleComputer::absolute_size_mapping(AbsoluteSize absolute_size, CSSPi
     VERIFY_NOT_REACHED();
 }
 
-void StyleComputer::compute_property_values(ComputedStyleWorkingSet& style, Optional<DOM::AbstractElement> abstract_element) const
-{
-    VERIFY(computation_context_cache_is_empty());
-    // NOTE: This doesn't necessarily return the specified value if we have already computed this property but that
-    //       doesn't matter as a computed value is always valid as a specified value.
-    Function<NonnullRefPtr<StyleValue const>(PropertyID)> const get_property_specified_value = [&](auto property_id) -> NonnullRefPtr<StyleValue const> {
-        return style.property(property_id);
-    };
-
-    auto device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel();
-    for (auto const& property_id : property_computation_order()) {
-        auto const& computation_context = get_computation_context_for_property(property_id, style, abstract_element);
-
-        auto const& specified_value = style.property(property_id, ComputedStyleWorkingSet::WithAnimationsApplied::No);
-
-        computation_context.reset_viewport_metric_dependency_tracking();
-        auto const& computed_value = compute_value_of_property(property_id, specified_value, get_property_specified_value, computation_context, device_pixels_per_css_pixel);
-        if (computation_context.depends_on_viewport_metrics()) {
-            style.set_depends_on_viewport_metrics();
-            if (property_affects_font_metrics(property_id))
-                style.set_font_metrics_depend_on_viewport_metrics();
-        }
-
-        style.set_property_without_modifying_flags(property_id, computed_value);
-    }
-
-    clear_computation_context_caches();
-
-    if (abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element())) {
-        m_root_element_font_metrics = calculate_root_element_font_metrics(style);
-        m_root_element_font_metrics_depend_on_viewport_metrics = style.font_metrics_depend_on_viewport_metrics();
-    }
-}
-
 ComputationContext StyleComputer::make_computation_context_for_property(PropertyID property_id, ComputedStyleWorkingSet const& style, Optional<DOM::AbstractElement> abstract_element) const
 {
     auto subject_inline_axis_is_horizontal = [&]() {
@@ -3332,9 +3298,9 @@ ComputationContext StyleComputer::make_computation_context_for_property(Property
     }();
 
     switch (property_id) {
-    // FIXME: While `color-scheme` doesn't actually require a computation context (since it only takes keyword values)
-    //        we still try to generate one in `compute_property_values()` and since we need `color-scheme` to be
-    //        computed before creating a generic computation context we use the font one instead.
+    // FIXME: While `color-scheme` doesn't actually require a computation context (since it only takes keyword values),
+    //        callers request one uniformly. Since `color-scheme` must be computed before creating a generic computation
+    //        context, use the font context instead.
     case PropertyID::ColorScheme:
     case PropertyID::FontFamily:
     case PropertyID::FontFeatureSettings:
@@ -3686,13 +3652,34 @@ void StyleComputer::finalize_style(ComputedStyleWorkingSet& style, DOM::Abstract
 
 NonnullRefPtr<ComputedValues const> StyleComputer::create_document_style() const
 {
+    ensure_style_metadata_tables_installed();
     auto computed_properties = CSS::ComputedStyleWorkingSet::create();
-    for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
-        auto property_id = static_cast<PropertyID>(i);
-        computed_properties->set_property(property_id, property_initial_value(property_id));
-    }
 
-    compute_property_values(*computed_properties, {});
+    Vector<u8> document_supported_color_scheme_codes;
+    auto document_supported_color_schemes = document().supported_color_schemes();
+    if (document_supported_color_schemes.has_value()) {
+        document_supported_color_scheme_codes.ensure_capacity(document_supported_color_schemes->size());
+        for (auto const& scheme : *document_supported_color_schemes)
+            document_supported_color_scheme_codes.unchecked_append(to_underlying(preferred_color_scheme_from_string(scheme)));
+    }
+    auto length_resolution_context = CSS::Length::ResolutionContext::for_document(document());
+    ComputedValuesFFI::FfiDocumentLonghandInput const input {
+        .color_scheme_input = {
+            .preferred_color_scheme = static_cast<u8>(to_underlying(document().page().preferred_color_scheme())),
+            .has_document_supported_schemes = document_supported_color_schemes.has_value(),
+            .document_supported_scheme_codes = document_supported_color_scheme_codes.data(),
+            .document_supported_scheme_count = document_supported_color_scheme_codes.size(),
+        },
+        .length_resolution_context = to_ffi_length_resolution_context(length_resolution_context),
+        .device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel(),
+        .initial_font_size_raw = InitialValues::font_size().raw_value(),
+        .default_font_size_raw = default_user_font_size().raw_value(),
+    };
+    auto result = ComputedValuesFFI::rust_compute_document_longhands(computed_properties->mutable_computed_longhand_table(), &input);
+    if (result.depends_on_viewport_metrics)
+        computed_properties->set_depends_on_viewport_metrics();
+    if (result.font_metrics_depend_on_viewport_metrics)
+        computed_properties->set_font_metrics_depend_on_viewport_metrics();
     computed_properties->set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().width())));
     computed_properties->set_property(CSS::PropertyID::Height, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().height())));
     computed_properties->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)));

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -861,7 +861,6 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     important_property_bitmap.append(computed_properties.property_importance_bitmap().data(), computed_properties.property_importance_bitmap().size());
 
     Vector<StyleValueFFI::FfiAnimationValueInput> ffi_values;
-    Vector<StyleValueFFI::FfiAnimatedProperty> ffi_results;
     Vector<Vector<StyleValueFFI::FfiAnimationKeyframeValue>> ffi_keyframes;
     Vector<Vector<Vector<StyleValueFFI::FfiLinearEasingPoint>>> linear_easing_points;
     auto compute_animation_values = [&](ReadonlySpan<StyleValueFFI::FfiResolvedAnimationProperty> resolved_properties, StyleValueFFI::FfiResolvedAnimationProperties const& resolved_batch) -> StyleValueFFI::FfiComputedAnimationBatch {
@@ -1264,6 +1263,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             }
             ffi_values.unchecked_append({
                 .property_id = to_underlying(value.property_id),
+                .result_of_transition = value.is_result_of_transition == AnimatedPropertyResultOfTransition::Yes,
                 .underlying = value.underlying->rust_style_value_data(),
                 .initial = value.initial->rust_style_value_data(),
                 .current_key = value.current_key,
@@ -1304,13 +1304,11 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             animation_context.transform_reference_box_width = reference_box.width().to_double();
             animation_context.transform_reference_box_height = reference_box.height().to_double();
         }
-        ffi_results.resize(ffi_values.size());
         return StyleValueFFI::FfiComputedAnimationBatch {
             .context = animation_context,
             .values = ffi_values.data(),
             .value_count = ffi_values.size(),
-            .results = ffi_results.data(),
-            .result_capacity = ffi_results.size(),
+            .overlay = computed_properties.prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer> {}),
         };
     };
 
@@ -1334,22 +1332,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     }
     auto result_count = StyleValueFFI::rust_evaluate_animations(&computed_batch);
     VERIFY(result_count == prepared_values.size());
-    VERIFY(result_count == ffi_results.size());
-    for (size_t index = 0; index < result_count; ++index) {
-        auto const& value = ffi_results[index];
-        auto& prepared_value = prepared_values[index];
-        VERIFY(value.property_id == to_underlying(prepared_value.property_id));
-        VERIFY(value.handled);
-        if (!value.apply)
-            continue;
-        if (value.value) {
-            auto style_value = StyleValue::adopt_rust_style_value_data(value.value);
-            computed_properties.set_animated_property(Badge<StyleComputer> {}, prepared_value.property_id, style_value, prepared_value.is_result_of_transition);
-        } else {
-            // NB: If interpolation fails, the element should not be rendered.
-            computed_properties.set_animated_property(Badge<StyleComputer> {}, PropertyID::Visibility, KeywordStyleValue::create(Keyword::Hidden), prepared_value.is_result_of_transition);
-        }
-    }
+    computed_properties.finish_animated_overlay_rust_mutation(Badge<StyleComputer> {});
 
     clear_computation_context_caches();
 }
@@ -3346,16 +3329,12 @@ Optional<StyleComputer::AnimatedInheritValue> StyleComputer::get_animated_inheri
     if (!animated_properties || !animated_properties->has_property(property_id))
         return {};
 
-    if (auto animated_value = animated_properties->values().get(property_id); animated_value.has_value()) {
-        return AnimatedInheritValue {
-            .value = *animated_value.value(),
-            .is_result_of_transition = animated_properties->is_property_result_of_transition(property_id)
-                ? AnimatedPropertyResultOfTransition::Yes
-                : AnimatedPropertyResultOfTransition::No
-        };
-    }
-
-    return {};
+    return AnimatedInheritValue {
+        .value = animated_properties->property(property_id),
+        .is_result_of_transition = animated_properties->is_property_result_of_transition(property_id)
+            ? AnimatedPropertyResultOfTransition::Yes
+            : AnimatedPropertyResultOfTransition::No
+    };
 }
 
 Length::FontMetrics StyleComputer::calculate_root_element_font_metrics(ComputedStyleWorkingSet const& style) const
@@ -4395,9 +4374,10 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
     u32 groups_to_apply = 0;
     bool touched_groups_known = animated_properties && !animated_properties->is_empty();
     if (touched_groups_known) {
-        for (auto const& entry : animated_properties->values()) {
-            auto group = ComputedValues::style_group_of_property(entry.key);
-            if (!group.has_value() || entry.key == PropertyID::Color) {
+        for (auto const& entry : animated_properties->entries()) {
+            auto property_id = static_cast<PropertyID>(entry.property);
+            auto group = ComputedValues::style_group_of_property(property_id);
+            if (!group.has_value() || property_id == PropertyID::Color) {
                 touched_groups_known = false;
                 break;
             }
@@ -4457,11 +4437,12 @@ void StyleComputer::apply_animated_properties_to_reconstruction(ComputedStyleWor
     auto const* animated_properties = computed_values.animated_properties();
     if (!animated_properties)
         return;
-    for (auto const& [property_id, value] : animated_properties->values()) {
+    for (auto const& entry : animated_properties->entries()) {
+        auto property_id = static_cast<PropertyID>(entry.property);
         style.set_animated_property(
-            Badge<StyleComputer> {}, property_id, value,
-            animated_properties->is_property_result_of_transition(property_id) ? AnimatedPropertyResultOfTransition::Yes : AnimatedPropertyResultOfTransition::No,
-            animated_properties->is_property_inherited(property_id) ? ComputedStyleWorkingSet::Inherited::Yes : ComputedStyleWorkingSet::Inherited::No);
+            Badge<StyleComputer> {}, property_id, animated_properties->property(property_id),
+            entry.result_of_transition ? AnimatedPropertyResultOfTransition::Yes : AnimatedPropertyResultOfTransition::No,
+            entry.inherited ? ComputedStyleWorkingSet::Inherited::Yes : ComputedStyleWorkingSet::Inherited::No);
     }
 }
 
@@ -5737,12 +5718,10 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
     // FIXME: Do we need to recompute animated inherited values?
     auto copy_animated_inherited_value = [&](PropertyID property_id, PropertyID inherited_property_id) {
         if (auto const* animated_properties = computed_values_to_inherit_from->animated_properties(); animated_properties && animated_properties->has_property(inherited_property_id)) {
-            auto animated_value = animated_properties->values().get(inherited_property_id);
-            VERIFY(animated_value.has_value());
             computed_style.set_animated_property(
                 Badge<StyleComputer> {},
                 property_id,
-                *animated_value.value(),
+                animated_properties->property(inherited_property_id),
                 animated_properties->is_property_result_of_transition(inherited_property_id)
                     ? AnimatedPropertyResultOfTransition::Yes
                     : AnimatedPropertyResultOfTransition::No,

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3521,20 +3521,6 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
     }
 }
 
-static void prepare_overflow_finalization(ComputedStyleWorkingSet const& style, ComputedValuesFFI::FfiStyleFinalizationInput& input)
-{
-    input.overflow_x = to_underlying(style.property(PropertyID::OverflowX).to_keyword());
-    input.overflow_y = to_underlying(style.property(PropertyID::OverflowY).to_keyword());
-}
-
-static void apply_overflow_finalization(ComputedStyleWorkingSet& style, ComputedValuesFFI::FfiEffectiveOverflow const& effective_overflow)
-{
-    if (effective_overflow.changed_x)
-        style.set_property(PropertyID::OverflowX, KeywordStyleValue::create(static_cast<Keyword>(effective_overflow.x_keyword)));
-    if (effective_overflow.changed_y)
-        style.set_property(PropertyID::OverflowY, KeywordStyleValue::create(static_cast<Keyword>(effective_overflow.y_keyword)));
-}
-
 static bool prepare_text_align_finalization(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiStyleFinalizationInput& input)
 {
     auto text_align_keyword = style.property(PropertyID::TextAlign).to_keyword();
@@ -3547,10 +3533,6 @@ static bool prepare_text_align_finalization(ComputedStyleWorkingSet& style, DOM:
     input.text_align = to_underlying(text_align_keyword);
     input.is_th_element = abstract_element.element().local_name() == HTML::TagNames::th;
 
-    // The resolved value does not remember that it read the parent's direction and text alignment.
-    // Keep the specified keyword so inherited-style refresh can resolve it again when either moves.
-    style.add_inheritance_dependent_specified_value(PropertyID::TextAlign, style.property(PropertyID::TextAlign));
-
     auto const parent = abstract_element.element_to_inherit_style_from();
     input.has_parent_with_computed_values = parent.has_value() && parent->has_style();
     input.parent_direction_is_ltr = true;
@@ -3561,14 +3543,6 @@ static bool prepare_text_align_finalization(ComputedStyleWorkingSet& style, DOM:
         input.parent_direction_is_ltr = parent_values.direction() == Direction::Ltr;
     }
     return true;
-}
-
-static void apply_text_align_finalization(ComputedStyleWorkingSet& style, ComputedValuesFFI::FfiTextAlignAdjustment const& adjustment)
-{
-    if (adjustment.changed) {
-        style.set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(adjustment.keyword)),
-            adjustment.inherited ? ComputedStyleWorkingSet::Inherited::Yes : ComputedStyleWorkingSet::Inherited::No);
-    }
 }
 
 static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transformation_input(
@@ -3676,27 +3650,6 @@ static ComputedValuesFFI::FfiInputLineHeightMetrics input_line_height_metrics(Co
     return line_height_metrics;
 }
 
-template<typename SetProperty>
-static void apply_element_style_adjustments(ComputedStyleWorkingSet const& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustments const& adjustments, SetProperty set_property)
-{
-    if (adjustments.box_type.set_float_none)
-        set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
-    if (adjustments.box_type.changed_display)
-        set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(adjustments.box_type.display)));
-
-    auto const& element_style = adjustments.element_style;
-    if (element_style.changed_display)
-        set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(element_style.display)));
-    if (element_style.set_position_static)
-        set_property(PropertyID::Position, KeywordStyleValue::create(Keyword::Static));
-    if (element_style.changed_text_align)
-        set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(element_style.text_align)));
-
-    auto line_height_metrics = input_line_height_metrics(style, abstract_element, element_style.check_input_line_height);
-    if (element_style.set_line_height_normal || (element_style.check_input_line_height && line_height_metrics.current_line_height < line_height_metrics.minimum_line_height))
-        set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
-}
-
 // https://drafts.csswg.org/css-display/#transformations
 void StyleComputer::finalize_style(ComputedStyleWorkingSet& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode mode) const
 {
@@ -3717,41 +3670,22 @@ void StyleComputer::finalize_style(ComputedStyleWorkingSet& style, DOM::Abstract
             style.property(PropertyID::Float).to_keyword());
     }
     if (mode == ComputedValuesFFI::FfiStyleFinalizationMode::All) {
-        prepare_overflow_finalization(style, input);
+        input.overflow_x = to_underlying(style.property(PropertyID::OverflowX).to_keyword());
+        input.overflow_y = to_underlying(style.property(PropertyID::OverflowY).to_keyword());
         prepare_text_align_finalization(style, abstract_element, input);
     } else if (mode == ComputedValuesFFI::FfiStyleFinalizationMode::TextAlign && !prepare_text_align_finalization(style, abstract_element, input)) {
         return;
     }
 
-    auto finalization = ComputedValuesFFI::rust_finalize_style(&input);
-    if (finalize_box_type) {
-        auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
-            if (animated_box_type) {
-                if (style.property(property_id).equals(*value))
-                    return;
-            } else if (!style.has_animated_property(property_id)) {
-                style.set_property(property_id, move(value));
-                return;
-            }
-            auto is_result_of_transition = style.has_animated_property(property_id) && style.is_animated_property_result_of_transition(property_id)
-                ? AnimatedPropertyResultOfTransition::Yes
-                : AnimatedPropertyResultOfTransition::No;
-            auto inherited = style.has_animated_property(property_id) && style.is_animated_property_inherited(property_id)
-                ? ComputedStyleWorkingSet::Inherited::Yes
-                : ComputedStyleWorkingSet::Inherited::No;
-            style.set_animated_property(Badge<StyleComputer> {}, property_id, value, is_result_of_transition, inherited);
-            if (!animated_box_type)
-                style.set_property(property_id, move(value));
-        };
-
-        if (animated_box_type && !style.has_animated_property(PropertyID::Display))
-            set_adjusted_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(input.box_type.display)));
-        if (!animated_box_type)
-            style.set_display_before_box_type_transformation(display_from_ffi_display(input.box_type.display));
-        apply_element_style_adjustments(style, abstract_element, finalization.element_style, set_adjusted_property);
-    }
-    apply_overflow_finalization(style, finalization.overflow);
-    apply_text_align_finalization(style, finalization.text_align);
+    if (finalize_box_type && !animated_box_type)
+        style.set_display_before_box_type_transformation(display_from_ffi_display(input.box_type.display));
+    auto line_height_metrics = input_line_height_metrics(style, abstract_element, finalize_box_type && input.box_type.check_input_line_height);
+    auto* animated_overlay = style.prepare_animated_overlay_for_rust_finalization(
+        Badge<StyleComputer> {}, animated_box_type ? ComputedStyleWorkingSet::CreateAnimatedOverlay::Yes : ComputedStyleWorkingSet::CreateAnimatedOverlay::No);
+    auto finalization = ComputedValuesFFI::rust_finalize_style(
+        &input, style.mutable_computed_longhand_table(), animated_overlay, &line_height_metrics);
+    style.did_apply_style_finalization_from_rust(finalization.invalidated_longhands);
+    style.finish_animated_overlay_rust_mutation(Badge<StyleComputer> {});
 }
 
 NonnullRefPtr<ComputedValues const> StyleComputer::create_document_style() const
@@ -4407,7 +4341,7 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
     finalization_input.mode = ComputedValuesFFI::FfiStyleFinalizationMode::Overflow;
     finalization_input.overflow_x = to_underlying(to_keyword(animated_values->overflow_x()));
     finalization_input.overflow_y = to_underlying(to_keyword(animated_values->overflow_y()));
-    auto effective_overflow = ComputedValuesFFI::rust_finalize_style(&finalization_input).overflow;
+    auto effective_overflow = ComputedValuesFFI::rust_finalize_style(&finalization_input, nullptr, nullptr, nullptr).overflow;
     if (effective_overflow.changed_x)
         builder->set_overflow_x(keyword_to_overflow(static_cast<Keyword>(effective_overflow.x_keyword)).value());
     if (effective_overflow.changed_y)

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -165,7 +165,6 @@ public:
     // see, which decides whether its answer can be offered to another element.
     [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, ComputedValues const* previous_values = nullptr, u32 computed_group_mask = ComputedValues::all_style_groups, u64 const* computed_properties_to_evaluate = nullptr, ComputedValues const* inheritance_parent_values = nullptr, bool stop_after_longhand_drive = false) const;
 
-    void compute_property_values(ComputedStyleWorkingSet&, Optional<DOM::AbstractElement>) const;
     void process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element) const;
 
     NonnullRefPtr<StyleValue const> compute_value_of_custom_property(ComputedStyleWorkingSet const*, AbstractOrHypotheticalElement const&, Utf16FlyString const& name) const;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -171,18 +171,10 @@ public:
     NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(AbstractOrHypotheticalElement, PropertyNameAndID const&, UnresolvedStyleValue const&) const;
     ComputationContext fallback_computation_context_for_custom_property(AbstractOrHypotheticalElement const&) const;
 
-    static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, ComputationContext const&, double device_pixels_per_css_pixel);
-    static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, double device_pixels_per_css_pixel);
-    static NonnullRefPtr<StyleValue const> compute_corner_shape(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_font_feature_tag_value_list(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_math_depth(NonnullRefPtr<StyleValue const> const& absolutized_value, Optional<DOM::AbstractElement> const& inheritance_parent);
     static NonnullRefPtr<StyleValue const> compute_font_size(NonnullRefPtr<StyleValue const> const& absolutized_value, int computed_math_depth, Optional<DOM::AbstractElement> const& inheritance_parent, CSSPixels initial_font_size = InitialValues::font_size());
     static NonnullRefPtr<StyleValue const> compute_font_style(NonnullRefPtr<StyleValue const> const& absolutized_value);
     static NonnullRefPtr<StyleValue const> compute_font_weight(NonnullRefPtr<StyleValue const> const& absolutized_value, Optional<DOM::AbstractElement> const& inheritance_parent);
     static NonnullRefPtr<StyleValue const> compute_font_width(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_line_height(NonnullRefPtr<StyleValue const> const& absolutized_value, CSSPixels computed_font_size);
-    static NonnullRefPtr<StyleValue const> compute_transform_origin(NonnullRefPtr<StyleValue const> const& absolutized_value);
 
     [[nodiscard]] NonnullRefPtr<ComputedValues const> build_computed_values(ComputedStyleWorkingSet&, DOM::AbstractElement, StyleScope const&, ComputedValues const* previous_base = nullptr, u32 groups_to_apply = ComputedValues::all_style_groups) const;
     // The animation-frame variant: keep the previous style's base and rebuild only the groups the

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -166,7 +166,6 @@ public:
     [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> compute_properties(DOM::AbstractElement, CascadedProperties&, u64 matching_pseudo_element_styles, u32* explicitly_inherited_non_inherited_style_groups = nullptr, ComputedValues const* previous_values = nullptr, u32 computed_group_mask = ComputedValues::all_style_groups, u64 const* computed_properties_to_evaluate = nullptr, ComputedValues const* inheritance_parent_values = nullptr, bool stop_after_longhand_drive = false) const;
 
     void compute_property_values(ComputedStyleWorkingSet&, Optional<DOM::AbstractElement>) const;
-    void apply_post_compute_adjustments(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
     void process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element) const;
 
     NonnullRefPtr<StyleValue const> compute_value_of_custom_property(ComputedStyleWorkingSet const*, AbstractOrHypotheticalElement const&, Utf16FlyString const& name) const;
@@ -303,9 +302,7 @@ private:
     void collect_animation_effects_into(DOM::AbstractElement, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>>, ComputedStyleWorkingSet&) const;
     void compute_custom_properties(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
     Vector<GC::Ref<Animations::KeyframeEffect>> start_needed_transitions(ComputedValues const& old_style, ComputedStyleWorkingSet& new_style, DOM::AbstractElement) const;
-    void resolve_effective_overflow_values(ComputedStyleWorkingSet&) const;
-    void adjust_element_style_if_needed(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
-    void adjust_animated_element_style_if_needed(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
+    void finalize_style(ComputedStyleWorkingSet&, DOM::AbstractElement, ComputedValuesFFI::FfiStyleFinalizationMode) const;
 
     [[nodiscard]] CSSPixelRect viewport_rect() const { return m_viewport_rect; }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -341,6 +341,7 @@ public:
 
 private:
     [[nodiscard]] Length::FontMetrics calculate_root_element_font_metrics(ComputedStyleWorkingSet const&) const;
+    NonnullRefPtr<StyleValue const> finalize_custom_property_value(ComputedStyleWorkingSet const*, AbstractOrHypotheticalElement const&, Utf16FlyString const&, NonnullRefPtr<StyleValue const>) const;
 
     GC::Ref<DOM::Document> m_document;
 
@@ -457,21 +458,6 @@ private:
     mutable u64 m_parsed_substitution_registration_generation { 0 };
     [[nodiscard]] u64 parsed_substitution_cache_bytes() const;
     void settle_parsed_substitution_cache() const;
-
-    // While one element's own custom properties resolve in dependency order, the values already final for it. A
-    // nested var() naming one reads the finished answer instead of resolving the value again. Members of a reference
-    // cycle are never in here while their cycle resolves, so the substitution guards remain the only thing that
-    // decides what a cycle is.
-    struct ActiveCustomPropertyResolution {
-        DOM::AbstractElement element;
-        HashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> finalized;
-
-        void visit_edges(GC::Cell::Visitor& visitor) const
-        {
-            element.visit(visitor);
-        }
-    };
-    mutable Optional<ActiveCustomPropertyResolution> m_active_custom_property_resolution;
 
     // The cascade input a match signature names, expanded once and answered from for every other
     // element the traversal proves has the same one. Keyed by the signature and what is being

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/ComputedValuesRustFFI.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
@@ -379,6 +380,17 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
         // Loosely based on https://drafts.csswg.org/css-animations-2/#keyframe-processing
         sheet.for_each_effective_keyframes_at_rule([&](CSSKeyframesRule const& rule) {
             auto keyframe_set = adopt_ref(*new Animations::KeyframeEffect::KeyFrameSet);
+            auto base_url = sheet.base_url()
+                                .value_or_lazy_evaluated_optional([&]() { return sheet.location(); })
+                                .value_or_lazy_evaluated_optional([&]() -> Optional<::URL::URL> {
+                                    if (auto document = sheet.owning_document())
+                                        return HTML::relevant_settings_object(*document).api_base_url();
+                                    return {};
+                                });
+            keyframe_set->style_sheet_resource_context = {
+                .base_url = base_url.has_value() ? base_url->to_string() : String {},
+                .origin_clean = sheet.is_origin_clean(),
+            };
             HashTable<PropertyID> animated_properties;
 
             // Forwards pass, resolve all the user-specified keyframe properties.

--- a/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
@@ -8,13 +8,13 @@
 //! style, held as shared style value data with the inheritance and
 //! transition flags the overlay read rule needs.
 //!
-//! The C++ `AnimatedProperties` object owns exactly one overlay and writes
-//! every mutation through it; the wrapper map it keeps besides this is only
-//! the identity cache for handing out `StyleValue&`. The overlay read rule -
-//! important base values override animated but not transitioned properties -
-//! is implemented once here, in [`overlay_wins`], and consumed through the
-//! per-longhand effective-value queries on both the overlay itself and the
-//! computed longhand table.
+//! The C++ `AnimatedProperties` object owns exactly one overlay and only keeps
+//! a lazy identity cache for handing out `StyleValue&`. Animation evaluation
+//! writes sampled values here directly. The overlay read rule - important base
+//! values override animated but not transitioned properties - is implemented
+//! once here, in [`overlay_wins`], and consumed through the per-longhand
+//! effective-value queries on both the overlay itself and the computed
+//! longhand table.
 
 use std::ffi::c_void;
 
@@ -23,6 +23,7 @@ use crate::css::style_value::RetainedStyleValueData;
 
 pub struct AnimatedOverlay {
     entries: Vec<AnimatedOverlayEntry>,
+    ffi_entries: Vec<FfiAnimatedOverlayEntry>,
 }
 
 pub(crate) struct AnimatedOverlayEntry {
@@ -32,6 +33,14 @@ pub(crate) struct AnimatedOverlayEntry {
     pub(crate) result_of_transition: bool,
 }
 
+#[repr(C)]
+pub struct FfiAnimatedOverlayEntry {
+    pub property: u16,
+    pub value: *const c_void,
+    pub inherited: bool,
+    pub result_of_transition: bool,
+}
+
 impl AnimatedOverlay {
     pub(crate) fn get(&self, property: u16) -> Option<&AnimatedOverlayEntry> {
         self.entries.iter().find(|entry| entry.property == property)
@@ -39,6 +48,38 @@ impl AnimatedOverlay {
 
     pub(crate) fn entries(&self) -> &[AnimatedOverlayEntry] {
         &self.entries
+    }
+
+    pub(crate) fn set_owned(
+        &mut self,
+        property: u16,
+        value: RetainedStyleValueData,
+        inherited: bool,
+        result_of_transition: bool,
+    ) {
+        let entry = AnimatedOverlayEntry {
+            property,
+            value,
+            inherited,
+            result_of_transition,
+        };
+        match self.entries.iter_mut().find(|entry| entry.property == property) {
+            Some(existing) => *existing = entry,
+            None => self.entries.push(entry),
+        }
+    }
+
+    pub(crate) fn refresh_ffi_entries(&mut self) {
+        self.ffi_entries = self
+            .entries
+            .iter()
+            .map(|entry| FfiAnimatedOverlayEntry {
+                property: entry.property,
+                value: entry.value.pointer().cast(),
+                inherited: entry.inherited,
+                result_of_transition: entry.result_of_transition,
+            })
+            .collect();
     }
 }
 
@@ -50,7 +91,12 @@ pub(crate) fn overlay_wins(entry: &AnimatedOverlayEntry, base_value_is_important
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_animated_overlay_create() -> *mut AnimatedOverlay {
-    abort_on_panic(|| Box::into_raw(Box::new(AnimatedOverlay { entries: Vec::new() })))
+    abort_on_panic(|| {
+        Box::into_raw(Box::new(AnimatedOverlay {
+            entries: Vec::new(),
+            ffi_entries: Vec::new(),
+        }))
+    })
 }
 
 /// Returns a new overlay holding retained copies of `overlay`'s entries.
@@ -70,7 +116,12 @@ pub unsafe extern "C" fn rust_animated_overlay_clone(overlay: *const AnimatedOve
                 result_of_transition: entry.result_of_transition,
             })
             .collect();
-        Box::into_raw(Box::new(AnimatedOverlay { entries }))
+        let mut overlay = AnimatedOverlay {
+            entries,
+            ffi_entries: Vec::new(),
+        };
+        overlay.refresh_ffi_entries();
+        Box::into_raw(Box::new(overlay))
     })
 }
 
@@ -98,61 +149,39 @@ pub unsafe extern "C" fn rust_animated_overlay_set(
         let retained = unsafe {
             RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
         };
-        let entry = AnimatedOverlayEntry {
-            property,
-            value: retained,
-            inherited,
-            result_of_transition,
-        };
         let overlay = unsafe { &mut *overlay };
-        match overlay.entries.iter_mut().find(|entry| entry.property == property) {
-            Some(existing) => *existing = entry,
-            None => overlay.entries.push(entry),
-        }
+        overlay.set_owned(property, retained, inherited, result_of_transition);
+        overlay.refresh_ffi_entries();
     });
 }
 
+/// Removes every non-inherited entry from the overlay.
+///
 /// # Safety
 /// `overlay` must be a valid overlay.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_animated_overlay_remove(overlay: *mut AnimatedOverlay, property: u16) {
+pub unsafe extern "C" fn rust_animated_overlay_reset_non_inherited(overlay: *mut AnimatedOverlay) {
     abort_on_panic(|| {
-        unsafe { &mut *overlay }
-            .entries
-            .retain(|entry| entry.property != property);
+        let overlay = unsafe { &mut *overlay };
+        overlay.entries.retain(|entry| entry.inherited);
+        overlay.refresh_ffi_entries();
     });
 }
 
-/// # Safety
-/// `overlay` must be a valid overlay.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_animated_overlay_has(overlay: *const AnimatedOverlay, property: u16) -> bool {
-    abort_on_panic(|| unsafe { &*overlay }.get(property).is_some())
-}
-
-/// Whether the overlay entry for a longhand is inherited; false when absent.
+/// Returns the overlay's borrowed entries, valid until its next mutation.
 ///
 /// # Safety
-/// `overlay` must be a valid overlay.
+/// `overlay` and `count` must be valid. The returned entries must not outlive
+/// the overlay or a subsequent mutation.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_animated_overlay_is_inherited(overlay: *const AnimatedOverlay, property: u16) -> bool {
-    abort_on_panic(|| unsafe { &*overlay }.get(property).is_some_and(|entry| entry.inherited))
-}
-
-/// Whether the overlay entry for a longhand is the result of a transition;
-/// false when absent.
-///
-/// # Safety
-/// `overlay` must be a valid overlay.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_animated_overlay_is_result_of_transition(
+pub unsafe extern "C" fn rust_animated_overlay_entries(
     overlay: *const AnimatedOverlay,
-    property: u16,
-) -> bool {
+    count: *mut usize,
+) -> *const FfiAnimatedOverlayEntry {
     abort_on_panic(|| {
-        unsafe { &*overlay }
-            .get(property)
-            .is_some_and(|entry| entry.result_of_transition)
+        let entries = &unsafe { &*overlay }.ffi_entries;
+        unsafe { *count = entries.len() };
+        entries.as_ptr()
     })
 }
 

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -428,6 +428,7 @@ pub struct FfiAnimationKeyframeValue {
 #[repr(C)]
 pub struct FfiAnimationValueInput {
     pub property_id: u16,
+    pub result_of_transition: bool,
     pub underlying: *const StyleValueData,
     pub initial: *const StyleValueData,
     pub current_key: f64,
@@ -450,8 +451,7 @@ pub struct FfiComputedAnimationBatch {
     pub context: FfiAnimationContext,
     pub values: *const FfiAnimationValueInput,
     pub value_count: usize,
-    pub results: *mut FfiAnimatedProperty,
-    pub result_capacity: usize,
+    pub overlay: *mut std::ffi::c_void,
 }
 
 #[repr(C)]
@@ -6942,11 +6942,11 @@ pub unsafe extern "C" fn rust_resolved_animation_properties_destroy(storage: *mu
 }
 
 /// Evaluate and compose every prepared animation interval without consulting C++ or the DOM.
-/// Results are written into caller-owned storage, transferring every non-null result value.
+/// Applied results are stored directly in the Rust-owned animated overlay.
 ///
 /// # Safety
 /// `computed` must point to a live batch whose input style values remain live for the call. Its
-/// result storage must have room for every input value, and C++ must adopt every non-null result.
+/// `overlay` must point at a live, uniquely owned animated overlay.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAnimationBatch) -> usize {
     crate::abort_on_panic(|| {
@@ -6956,25 +6956,40 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
             return 0;
         }
         let inputs = unsafe { std::slice::from_raw_parts(computed.values, computed.value_count) };
-        assert!(computed.result_capacity >= inputs.len());
-        assert!(!computed.results.is_null());
+        let overlay = unsafe { &mut *computed.overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
 
         // https://www.w3.org/TR/web-animations-1/#effect-stacks
         // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
         //     next effect affecting the same property.
         let mut previous_values = Vec::<(u16, *const StyleValueData)>::new();
-        for (index, input) in inputs.iter().enumerate() {
+        for input in inputs {
             let previous_value = previous_values
                 .iter()
                 .rev()
                 .find(|(property_id, _)| *property_id == input.property_id)
                 .map(|(_, value)| unsafe { &**value });
             let result = evaluate_animation_value(&computed.context, input, previous_value);
-            if result.apply && !result.value.is_null() {
-                previous_values.push((input.property_id, result.value));
+            if !result.apply {
+                assert!(result.value.is_null());
+                continue;
             }
-            unsafe { computed.results.add(index).write(result) };
+            if !result.value.is_null() {
+                previous_values.push((input.property_id, result.value));
+                let value = unsafe { RetainedStyleValueData::from_retained_pointer(result.value) };
+                overlay.set_owned(input.property_id, value, false, input.result_of_transition);
+            } else {
+                let value = RetainedStyleValueData::from_owned(StyleValueData::Keyword {
+                    keyword: crate::css::css_enums::keyword::HIDDEN,
+                });
+                overlay.set_owned(
+                    crate::css::property_metadata::property_id::VISIBILITY,
+                    value,
+                    false,
+                    input.result_of_transition,
+                );
+            }
         }
+        overlay.refresh_ffi_entries();
         inputs.len()
     })
 }

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -466,10 +466,32 @@ pub struct FfiAnimatedProperty {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiAnimationStyleSheetResourceContext {
+    pub base_url: *const u8,
+    pub base_url_length: usize,
+    pub has_value: bool,
+    pub origin_clean: bool,
+}
+
+impl FfiAnimationStyleSheetResourceContext {
+    #[cfg(test)]
+    const fn empty() -> Self {
+        Self {
+            base_url: std::ptr::null(),
+            base_url_length: 0,
+            has_value: false,
+            origin_clean: false,
+        }
+    }
+}
+
+#[repr(C)]
 pub struct FfiAnimationDeclaration {
     pub keyframe_index: usize,
     pub property_id: u16,
     pub value: *const StyleValueData,
+    pub style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
     pub use_initial: bool,
     pub is_transition: bool,
 }
@@ -480,6 +502,7 @@ struct AnimationPropertyConflictCandidate {
     source_property_id: u16,
     source_longhand_id: u16,
     value: RetainedStyleValueData,
+    style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
     use_initial: bool,
     suppressed_by_important: bool,
 }
@@ -589,13 +612,26 @@ pub struct FfiResolvedAnimationProperty {
     pub source_longhand_id: u16,
     pub value: *const StyleValueData,
     pub value_source: FfiAnimationSpecifiedValueSource,
+    pub style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
 }
 
 #[repr(C)]
 pub struct FfiResolvedAnimationProperties {
     pub properties: *const FfiResolvedAnimationProperty,
     pub count: usize,
+    pub uses_tree_counting_function: bool,
+    pub container_relative_length_unit_mask: u8,
+    pub needs_document_base_url: bool,
+    pub unfixed_random_sharings: *const FfiAnimationUnfixedRandomSharing,
+    pub unfixed_random_sharing_count: usize,
     pub storage: *mut std::ffi::c_void,
+}
+
+#[repr(C)]
+pub struct FfiAnimationUnfixedRandomSharing {
+    pub source: *const StyleValueData,
+    pub name: usize,
+    pub element_shared: bool,
 }
 
 fn resolve_animation_declarations(
@@ -627,6 +663,7 @@ fn resolve_animation_declarations(
                             data.cast(),
                         ))
                     },
+                    style_sheet_resource_context: declaration.style_sheet_resource_context,
                     use_initial: declaration.use_initial,
                     // OPTIMIZATION: Values resulting from animations other than CSS transitions
                     // are overridden by important properties, so there is no need to compute or
@@ -654,19 +691,70 @@ fn resolve_animation_declarations(
                 source_longhand_id: candidate.source_longhand_id,
                 value: candidate.value.pointer(),
                 value_source,
+                style_sheet_resource_context: candidate.style_sheet_resource_context,
             });
             retained_values.push(candidate.value);
         }
     }
+    let mut uses_tree_counting_function = false;
+    let mut container_relative_length_unit_mask = 0;
+    let mut needs_document_base_url = false;
+    let mut random_sharing_sources = Vec::new();
+    for property in &properties {
+        if property.value_source != FfiAnimationSpecifiedValueSource::Value {
+            continue;
+        }
+        let value = unsafe { &*property.value };
+        if matches!(
+            value,
+            StyleValueData::Unresolved { .. } | StyleValueData::PendingSubstitution { .. }
+        ) {
+            continue;
+        }
+        let dependencies = crate::css::style_compute::external_value_dependencies(value);
+        uses_tree_counting_function |= dependencies.uses_tree_counting_function;
+        container_relative_length_unit_mask |= dependencies.container_relative_length_unit_mask;
+        needs_document_base_url |= dependencies.needs_document_base_url;
+        if dependencies.has_unfixed_random_sharing {
+            crate::css::style_compute::collect_unfixed_random_sharings_in_value(value, &mut random_sharing_sources);
+        }
+    }
+    let unfixed_random_sharings = random_sharing_sources
+        .into_iter()
+        .map(|source| {
+            let StyleValueData::RandomValueSharing {
+                has_name,
+                name,
+                element_shared,
+                ..
+            } = (unsafe { &*source })
+            else {
+                unreachable!();
+            };
+            FfiAnimationUnfixedRandomSharing {
+                source,
+                name: if *has_name { name.raw() } else { 0 },
+                element_shared: *element_shared,
+            }
+        })
+        .collect();
     ResolvedAnimationDeclarations {
         properties,
         _retained_values: retained_values,
+        uses_tree_counting_function,
+        container_relative_length_unit_mask,
+        needs_document_base_url,
+        unfixed_random_sharings,
     }
 }
 
 struct ResolvedAnimationDeclarations {
     properties: Vec<FfiResolvedAnimationProperty>,
     _retained_values: Vec<RetainedStyleValueData>,
+    uses_tree_counting_function: bool,
+    container_relative_length_unit_mask: u8,
+    needs_document_base_url: bool,
+    unfixed_random_sharings: Vec<FfiAnimationUnfixedRandomSharing>,
 }
 
 #[repr(u8)]
@@ -6820,6 +6908,11 @@ pub unsafe extern "C" fn rust_resolve_animation_declarations(
             return FfiResolvedAnimationProperties {
                 properties: std::ptr::null(),
                 count: 0,
+                uses_tree_counting_function: false,
+                container_relative_length_unit_mask: 0,
+                needs_document_base_url: false,
+                unfixed_random_sharings: std::ptr::null(),
+                unfixed_random_sharing_count: 0,
                 storage: std::ptr::null_mut(),
             };
         }
@@ -6829,6 +6922,11 @@ pub unsafe extern "C" fn rust_resolve_animation_declarations(
         FfiResolvedAnimationProperties {
             properties,
             count,
+            uses_tree_counting_function: resolved.uses_tree_counting_function,
+            container_relative_length_unit_mask: resolved.container_relative_length_unit_mask,
+            needs_document_base_url: resolved.needs_document_base_url,
+            unfixed_random_sharings: resolved.unfixed_random_sharings.as_ptr(),
+            unfixed_random_sharing_count: resolved.unfixed_random_sharings.len(),
             storage: Box::into_raw(resolved).cast(),
         }
     })
@@ -6937,6 +7035,7 @@ mod tests {
                 source_property_id: property_id::BORDER,
                 source_longhand_id: property_id::BORDER_TOP_COLOR,
                 value: value(),
+                style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
             },
@@ -6946,6 +7045,7 @@ mod tests {
                 source_property_id: property_id::BORDER_TOP,
                 source_longhand_id: property_id::BORDER_TOP_COLOR,
                 value: value(),
+                style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
             },
@@ -6955,6 +7055,7 @@ mod tests {
                 source_property_id: property_id::BORDER_TOP_COLOR,
                 source_longhand_id: property_id::BORDER_TOP_COLOR,
                 value: value(),
+                style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
             },
@@ -6964,6 +7065,7 @@ mod tests {
                 source_property_id: property_id::BORDER_TOP_COLOR,
                 source_longhand_id: property_id::BORDER_TOP_COLOR,
                 value: value(),
+                style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: true,
                 suppressed_by_important: false,
             },
@@ -6973,6 +7075,7 @@ mod tests {
                 source_property_id: property_id::BORDER,
                 source_longhand_id: property_id::BORDER_TOP_COLOR,
                 value: value(),
+                style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: true,
                 suppressed_by_important: false,
             },
@@ -7025,6 +7128,7 @@ mod tests {
             keyframe_index: 0,
             property_id: crate::css::property_metadata::property_id::BORDER,
             value: &raw const *pending,
+            style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
             use_initial: false,
             is_transition: false,
         };
@@ -7179,6 +7283,7 @@ mod tests {
         ];
         let input = FfiAnimationValueInput {
             property_id: crate::css::property_metadata::property_id::FLEX_GROW,
+            result_of_transition: false,
             underlying: &raw const underlying,
             initial: &raw const underlying,
             current_key: 75.0,
@@ -7229,6 +7334,7 @@ mod tests {
             ];
             let input = FfiAnimationValueInput {
                 property_id: crate::css::property_metadata::property_id::FLEX_GROW,
+                result_of_transition: false,
                 underlying: Arc::as_ptr(&underlying),
                 initial: Arc::as_ptr(&initial),
                 current_key: 50.0,

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -984,6 +984,7 @@ pub struct FfiCascadedCustomProperties {
 
 /// Main-thread services used while resolving substituted values inside the Rust cascade.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiCascadeResolutionContext {
     pub parse_context: *const c_void,
     pub custom_property_store: *const c_void,
@@ -999,10 +1000,31 @@ pub struct FfiCascadeResolutionContext {
     pub callback_context: *mut c_void,
     pub resolve_custom_function: Option<unsafe extern "C" fn(usize, FfiUtf16View) -> usize>,
     pub evaluate_condition: Option<unsafe extern "C" fn(*mut c_void, u8, FfiUtf16View) -> u8>,
-    pub lookup_final_custom_property: Option<unsafe extern "C" fn(*mut c_void, FfiUtf16View) -> *const c_void>,
     pub note_substitution: Option<unsafe extern "C" fn(*mut c_void, *const c_void)>,
     pub lookup_cached_substitution: Option<unsafe extern "C" fn(*mut c_void, u32, u16) -> *const c_void>,
     pub cache_parsed_substitution: Option<unsafe extern "C" fn(*mut c_void, u32, u16, *const c_void)>,
+}
+
+/// One unresolved value submitted to the bulk substitution resolver.
+#[repr(C)]
+pub struct FfiUnresolvedStyleValue {
+    pub property_id: u16,
+    pub root_custom_property_name: FfiUtf16View,
+    pub data: *const c_void,
+    pub resolve_substitutions: bool,
+}
+
+/// One retained value produced by the bulk substitution resolver.
+#[repr(C)]
+pub struct FfiResolvedStyleValue {
+    pub data: *const c_void,
+}
+
+#[repr(C)]
+pub struct FfiCustomPropertyResolutionStats {
+    pub final_value_hits: u64,
+    pub final_value_misses: u64,
+    pub cycle_participants: u64,
 }
 
 /// Source assignments produced by a completed cascade.
@@ -1208,6 +1230,7 @@ fn resolve_cascade_value(
     property_id: u16,
     unresolved_data: *const c_void,
     has_style_sheet_context: bool,
+    final_custom_properties: Option<&HashMap<Vec<u16>, *const c_void>>,
 ) -> ResolvedStyleValue {
     let native_resolution = match resolution_environment {
         Some(resolution_environment) => unsafe {
@@ -1222,7 +1245,7 @@ fn resolve_cascade_value(
                 resolution_context.resolve_custom_function,
                 resolution_context.callback_context,
                 resolution_context.evaluate_condition,
-                resolution_context.lookup_final_custom_property,
+                final_custom_properties,
             )
         },
         None => crate::css::custom_properties::NativeVarResolution::NotHandled,
@@ -1320,18 +1343,134 @@ fn resolve_cascade_value(
     }
 }
 
-/// Resolves and parses one unresolved value outside the bulk cascade.
+fn custom_property_components(inputs: &[FfiUnresolvedStyleValue]) -> (Vec<Vec<u32>>, u64, bool) {
+    let mut indices = HashMap::new();
+    for (index, input) in inputs.iter().enumerate() {
+        if let Some(name) = unsafe { input.root_custom_property_name.to_utf16() } {
+            indices.insert(name, index as u32);
+        }
+    }
+
+    let mut edges = vec![Vec::new(); inputs.len()];
+    let mut has_own_reference = false;
+    for (index, input) in inputs.iter().enumerate() {
+        let value = unsafe { &*input.data.cast::<StyleValueData>() };
+        let Some((references, mut all_references_visible)) = crate::css::style_value::custom_property_references(value)
+        else {
+            continue;
+        };
+        if let StyleValueData::Unresolved {
+            presence_attr,
+            presence_dashed_function,
+            presence_if,
+            ..
+        } = value
+        {
+            all_references_visible &= !presence_attr && !presence_dashed_function && !presence_if;
+        }
+        if all_references_visible {
+            for reference in references {
+                if let Some(target) = indices.get(&reference) {
+                    edges[index].push(*target);
+                    has_own_reference |= inputs[*target as usize].resolve_substitutions;
+                }
+            }
+        } else {
+            edges[index].extend(0..inputs.len() as u32);
+        }
+    }
+
+    let unvisited = u32::MAX;
+    let mut discovery_index = vec![unvisited; inputs.len()];
+    let mut lowlink = vec![0; inputs.len()];
+    let mut on_stack = vec![false; inputs.len()];
+    let mut component_stack = Vec::new();
+    let mut components = Vec::new();
+    let mut cycle_participants = 0;
+    let mut next_discovery_index = 0;
+    let mut walk_stack: Vec<(u32, usize)> = Vec::new();
+
+    for root in 0..inputs.len() as u32 {
+        if discovery_index[root as usize] != unvisited {
+            continue;
+        }
+        walk_stack.push((root, 0));
+        while let Some(&(node, next_edge)) = walk_stack.last() {
+            let node_index = node as usize;
+            if next_edge == 0 {
+                discovery_index[node_index] = next_discovery_index;
+                lowlink[node_index] = next_discovery_index;
+                next_discovery_index += 1;
+                component_stack.push(node);
+                on_stack[node_index] = true;
+            }
+            if next_edge < edges[node_index].len() {
+                let target = edges[node_index][next_edge];
+                walk_stack.last_mut().unwrap().1 += 1;
+                if discovery_index[target as usize] == unvisited {
+                    walk_stack.push((target, 0));
+                } else if on_stack[target as usize] {
+                    lowlink[node_index] = lowlink[node_index].min(discovery_index[target as usize]);
+                }
+                continue;
+            }
+            if lowlink[node_index] == discovery_index[node_index] {
+                let mut component = Vec::new();
+                loop {
+                    let popped = component_stack.pop().expect("active custom-property component");
+                    on_stack[popped as usize] = false;
+                    component.push(popped);
+                    if popped == node {
+                        break;
+                    }
+                }
+                if component.len() > 1 || edges[component[0] as usize].contains(&component[0]) {
+                    cycle_participants += component.len() as u64;
+                }
+                components.push(component);
+            }
+            walk_stack.pop();
+            if let Some(&(parent, _)) = walk_stack.last() {
+                lowlink[parent as usize] = lowlink[parent as usize].min(lowlink[node_index]);
+            }
+        }
+    }
+    (
+        components,
+        if has_own_reference { cycle_participants } else { 0 },
+        has_own_reference,
+    )
+}
+
+/// Resolves and parses unresolved values outside the longhand cascade. When a
+/// finalizer is supplied, custom properties are resolved in dependency order
+/// and each component is finalized before later components can read it.
 ///
 /// # Safety
-/// `resolution_context` and `unresolved_data` must remain valid for the duration of this call.
+/// Every pointer must remain valid for this call. `outputs` must have room for
+/// `input_count` entries, and a finalizer must replace each component output
+/// with a live style value pointer before returning.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_resolve_unresolved_style_value(
+pub unsafe extern "C" fn rust_resolve_unresolved_style_values(
     resolution_context: *const FfiCascadeResolutionContext,
-    property_id: u16,
-    unresolved_data: *const c_void,
-) -> *const c_void {
+    inputs: *const FfiUnresolvedStyleValue,
+    input_count: usize,
+    outputs: *mut FfiResolvedStyleValue,
+    finalizer_context: *mut c_void,
+    finalize_component: Option<unsafe extern "C" fn(*mut c_void, *const u32, usize, *mut FfiResolvedStyleValue)>,
+) -> FfiCustomPropertyResolutionStats {
     crate::abort_on_panic(|| {
-        let resolution_context = unsafe { &*resolution_context };
+        let resolution_context = unsafe { *resolution_context };
+        let inputs = if input_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(inputs, input_count) }
+        };
+        let outputs = if input_count == 0 {
+            &mut []
+        } else {
+            unsafe { std::slice::from_raw_parts_mut(outputs, input_count) }
+        };
         let mut resolution_environment = unsafe {
             crate::css::custom_properties::prepare_var_resolution_environment(
                 resolution_context.attributes,
@@ -1341,17 +1480,61 @@ pub unsafe extern "C" fn rust_resolve_unresolved_style_value(
                 resolution_context.custom_function_scope_identity,
             )
         };
-        let resolved = resolve_cascade_value(
-            resolution_context,
-            resolution_environment.as_mut(),
-            0,
-            property_id,
-            unresolved_data,
-            false,
-        );
-        let pointer = resolved.value.pointer().cast();
-        std::mem::forget(resolved.value);
-        pointer
+        let (components, cycle_participants, use_final_custom_properties) = if finalize_component.is_some() {
+            custom_property_components(inputs)
+        } else {
+            ((0..input_count as u32).map(|index| vec![index]).collect(), 0, false)
+        };
+        let mut final_custom_properties = HashMap::new();
+        for mut component in components {
+            component.sort_unstable();
+            for &member in &component {
+                let input = &inputs[member as usize];
+                if !input.resolve_substitutions {
+                    outputs[member as usize].data = unsafe {
+                        crate::css::style_value::retain_style_value(input.data.cast::<StyleValueData>()).cast()
+                    };
+                    continue;
+                }
+                let mut member_context = resolution_context;
+                member_context.root_custom_property_name = input.root_custom_property_name;
+                let resolved = resolve_cascade_value(
+                    &member_context,
+                    resolution_environment.as_mut(),
+                    0,
+                    input.property_id,
+                    input.data,
+                    false,
+                    use_final_custom_properties.then_some(&final_custom_properties),
+                );
+                outputs[member as usize].data = resolved.value.pointer().cast();
+                std::mem::forget(resolved.value);
+            }
+            if let Some(finalize_component) = finalize_component {
+                unsafe {
+                    finalize_component(
+                        finalizer_context,
+                        component.as_ptr(),
+                        component.len(),
+                        outputs.as_mut_ptr(),
+                    );
+                };
+                for &member in &component {
+                    let name = unsafe { inputs[member as usize].root_custom_property_name.to_utf16() }
+                        .expect("custom-property resolution input name");
+                    final_custom_properties.insert(name, outputs[member as usize].data);
+                }
+            }
+        }
+        FfiCustomPropertyResolutionStats {
+            final_value_hits: resolution_environment
+                .as_ref()
+                .map_or(0, |environment| environment.final_value_hits()),
+            final_value_misses: resolution_environment
+                .as_ref()
+                .map_or(0, |environment| environment.final_value_misses()),
+            cycle_participants,
+        }
     })
 }
 
@@ -1450,6 +1633,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
                         property_id,
                         unresolved_data,
                         has_style_sheet_context,
+                        None,
                     )
                 },
                 block.style_engine_rule_id,

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -514,66 +514,8 @@ pub unsafe extern "C" fn rust_cascaded_properties_has_style_sheet_context(
     })
 }
 
-/// Returns whether any winning declaration needs the element's sibling count or index.
-///
-/// # Safety
-/// `store` must be a valid store.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_cascaded_properties_uses_tree_counting_function(
-    store: *const CascadedPropertyStore,
-) -> bool {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| {
-        unsafe { &*store }
-            .winning_entries()
-            .any(|(_, entry)| entry.dependencies().uses_tree_counting_function)
-    })
-}
-
-/// Returns the container-relative units used by any winning declaration.
-///
-/// # Safety
-/// `store` must be a valid store.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_cascaded_properties_container_relative_length_unit_mask(
-    store: *const CascadedPropertyStore,
-) -> u8 {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| {
-        unsafe { &*store }.winning_entries().fold(0, |mask, (_, entry)| {
-            mask | entry.dependencies().container_relative_length_unit_mask
-        })
-    })
-}
-
 pub const CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL: u8 = 1 << 0;
 pub const CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT: u8 = 1 << 1;
-
-/// Returns which URL-resolution inputs any winning declaration can consume.
-///
-/// # Safety
-/// `store` must be a valid store.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_cascaded_properties_environment_requirements(store: *const CascadedPropertyStore) -> u8 {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| {
-        unsafe { &*store }
-            .winning_entries()
-            .fold(0, |requirements, (_, entry)| {
-                requirements
-                    | if entry.dependencies().needs_document_base_url {
-                        CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL
-                    } else {
-                        0
-                    }
-                    | if entry.has_style_sheet_context {
-                        CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT
-                    } else {
-                        0
-                    }
-            })
-    })
-}
 
 #[repr(C)]
 pub struct FfiUnfixedRandomSharing {
@@ -583,29 +525,44 @@ pub struct FfiUnfixedRandomSharing {
 }
 
 #[repr(C)]
-pub struct FfiUnfixedRandomSharings {
-    pub entries: *const FfiUnfixedRandomSharing,
-    pub entry_count: usize,
+pub struct FfiStyleComputationRequirements {
+    pub uses_tree_counting_function: bool,
+    pub container_relative_length_unit_mask: u8,
+    pub environment_requirements: u8,
+    pub unfixed_random_sharings: *const FfiUnfixedRandomSharing,
+    pub unfixed_random_sharing_count: usize,
     pub storage: *mut c_void,
 }
 
-/// Returns unfixed random sharing values from winning declarations.
+/// Collects the external inputs needed to compute the winning declarations.
 ///
 /// # Safety
 /// `store` must be a valid store.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_cascaded_properties_unfixed_random_sharings(
+pub unsafe extern "C" fn rust_cascaded_properties_computation_requirements(
     store: *const CascadedPropertyStore,
-) -> FfiUnfixedRandomSharings {
+) -> FfiStyleComputationRequirements {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
     abort_on_panic(|| {
+        let mut uses_tree_counting_function = false;
+        let mut container_relative_length_unit_mask = 0;
+        let mut environment_requirements = 0;
         let mut sharings = Vec::new();
         for (_, entry) in unsafe { &*store }.winning_entries() {
-            if entry.dependencies().has_unfixed_random_sharing {
+            let dependencies = entry.dependencies();
+            uses_tree_counting_function |= dependencies.uses_tree_counting_function;
+            container_relative_length_unit_mask |= dependencies.container_relative_length_unit_mask;
+            if dependencies.needs_document_base_url {
+                environment_requirements |= CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL;
+            }
+            if entry.has_style_sheet_context {
+                environment_requirements |= CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT;
+            }
+            if dependencies.has_unfixed_random_sharing {
                 crate::css::style_compute::collect_unfixed_random_sharings_in_value(entry.value.data(), &mut sharings);
             }
         }
-        let entries = sharings
+        let unfixed_random_sharings = sharings
             .into_iter()
             .map(|source| {
                 let StyleValueData::RandomValueSharing {
@@ -625,28 +582,31 @@ pub unsafe extern "C" fn rust_cascaded_properties_unfixed_random_sharings(
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        let entry_count = entries.len();
-        let entries = Box::into_raw(entries);
-        FfiUnfixedRandomSharings {
-            entries: entries.cast(),
-            entry_count,
-            storage: entries.cast(),
+        let unfixed_random_sharing_count = unfixed_random_sharings.len();
+        let unfixed_random_sharings = Box::into_raw(unfixed_random_sharings);
+        FfiStyleComputationRequirements {
+            uses_tree_counting_function,
+            container_relative_length_unit_mask,
+            environment_requirements,
+            unfixed_random_sharings: unfixed_random_sharings.cast(),
+            unfixed_random_sharing_count,
+            storage: unfixed_random_sharings.cast(),
         }
     })
 }
 
 /// # Safety
-/// `storage` must be null or returned by `rust_cascaded_properties_unfixed_random_sharings`.
+/// `storage` must be null or returned by `rust_cascaded_properties_computation_requirements`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_cascaded_properties_unfixed_random_sharings_release(
+pub unsafe extern "C" fn rust_style_computation_requirements_destroy(
     storage: *mut c_void,
-    entry_count: usize,
+    unfixed_random_sharing_count: usize,
 ) {
     if !storage.is_null() {
         drop(unsafe {
             Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 storage.cast::<FfiUnfixedRandomSharing>(),
-                entry_count,
+                unfixed_random_sharing_count,
             ))
         });
     }
@@ -1601,5 +1561,63 @@ mod tests {
 
         let properties: Vec<_> = store.winning_declarations().map(|(property, _, _)| property).collect();
         assert!(properties.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn computation_requirements_aggregate_winning_declarations() {
+        let value = Arc::new(StyleValueData::Number { value: 42.0 });
+        let retained_value = unsafe { RetainedStyleValueData::from_retained_pointer(Arc::into_raw(value)) };
+        let mut store = CascadedPropertyStore::new();
+        let property_id = crate::css::property_metadata::property_id::WIDTH;
+        store.set_property(
+            property_id,
+            retained_value,
+            true,
+            false,
+            CascadeOrigin::Author,
+            LayerName(None),
+            0,
+        );
+        store.last_entry(property_id).unwrap().dependencies.set(Some(
+            crate::css::style_compute::ExternalValueDependencies {
+                uses_tree_counting_function: true,
+                container_relative_length_unit_mask: 0b1001,
+                needs_document_base_url: true,
+                ..Default::default()
+            },
+        ));
+        let other_value = Arc::new(StyleValueData::Number { value: 7.0 });
+        let other_retained_value = unsafe { RetainedStyleValueData::from_retained_pointer(Arc::into_raw(other_value)) };
+        let other_property_id = crate::css::property_metadata::property_id::OPACITY;
+        store.set_property(
+            other_property_id,
+            other_retained_value,
+            false,
+            false,
+            CascadeOrigin::Author,
+            LayerName(None),
+            0,
+        );
+        store.last_entry(other_property_id).unwrap().dependencies.set(Some(
+            crate::css::style_compute::ExternalValueDependencies {
+                container_relative_length_unit_mask: 0b0110,
+                ..Default::default()
+            },
+        ));
+
+        let requirements = unsafe { rust_cascaded_properties_computation_requirements(&store) };
+        assert!(requirements.uses_tree_counting_function);
+        assert_eq!(requirements.container_relative_length_unit_mask, 0b1111);
+        assert_eq!(
+            requirements.environment_requirements,
+            CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL | CASCADED_ENVIRONMENT_NEEDS_STYLE_SHEET_CONTEXT
+        );
+        assert_eq!(requirements.unfixed_random_sharing_count, 0);
+        unsafe {
+            rust_style_computation_requirements_destroy(
+                requirements.storage,
+                requirements.unfixed_random_sharing_count,
+            );
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -58,6 +58,15 @@ pub const EFFECTIVE_LONGHAND_SOURCE_TABLE: u8 = 0;
 pub const EFFECTIVE_LONGHAND_SOURCE_OVERLAY: u8 = 1;
 pub const EFFECTIVE_LONGHAND_SOURCE_SPECIFIED: u8 = 2;
 
+struct PostComputeRestoreValues {
+    values: [Option<(u16, RetainedStyleValueData)>; 7],
+}
+
+pub(crate) struct RestoredPostComputeValues {
+    pub properties: [u16; 7],
+    pub count: usize,
+}
+
 fn bitmap_bit(bits: &[u8; LONGHAND_BITMAP_BYTES], index: usize) -> bool {
     bits[index / 8] & (1 << (index % 8)) != 0
 }
@@ -97,6 +106,9 @@ pub struct ComputedLonghandTable {
     inheritance_dependent_view: Vec<FfiTableInheritanceDependentValue>,
     /// Viewport dependency flags accumulated by the longhand drive.
     dependency_flags: u8,
+    /// Values before automatic post-compute adjustments, retained only while
+    /// animation processing may need to restore them.
+    post_compute_restore_values: Option<Box<PostComputeRestoreValues>>,
     frozen: bool,
 }
 
@@ -112,6 +124,7 @@ impl ComputedLonghandTable {
             inheritance_dependent: Vec::new(),
             inheritance_dependent_view: Vec::new(),
             dependency_flags: 0,
+            post_compute_restore_values: None,
             frozen: false,
         }
     }
@@ -214,6 +227,7 @@ impl ComputedLonghandTable {
         self.dependency_flags = source.dependency_flags;
         self.inheritance_dependent.clone_from(&source.inheritance_dependent);
         self.rebuild_inheritance_dependent_view();
+        self.post_compute_restore_values = None;
     }
 
     pub(crate) fn copied_for_drive(source: &ComputedLonghandTable) -> Self {
@@ -242,6 +256,7 @@ impl ComputedLonghandTable {
         self.dependency_flags = 0;
         self.inheritance_dependent.clear();
         self.inheritance_dependent_view.clear();
+        self.post_compute_restore_values = None;
     }
 
     fn rebuild_inheritance_dependent_view(&mut self) {
@@ -266,6 +281,7 @@ impl ComputedLonghandTable {
         self.evaluated_bits = [0; LONGHAND_BITMAP_BYTES];
         self.inheritance_dependent.clear();
         self.inheritance_dependent_view.clear();
+        self.post_compute_restore_values = None;
     }
 
     pub(crate) fn add_inheritance_dependent_value(&mut self, property_id: u16, value: RetainedStyleValueData) {
@@ -415,7 +431,48 @@ impl ComputedLonghandTable {
         count
     }
 
+    pub(crate) fn set_post_compute_restore_values(&mut self, values: [(u16, RetainedStyleValueData); 7]) {
+        assert!(
+            !self.frozen,
+            "the computed longhand table is immutable once its style is created"
+        );
+        self.post_compute_restore_values = Some(Box::new(PostComputeRestoreValues {
+            values: values.map(Some),
+        }));
+    }
+
+    pub(crate) fn restore_post_compute_values(&mut self, only_property: Option<u16>) -> RestoredPostComputeValues {
+        let mut restored = RestoredPostComputeValues {
+            properties: [0; 7],
+            count: 0,
+        };
+        assert!(
+            !self.frozen,
+            "the computed longhand table is immutable once its style is created"
+        );
+        let Some(mut restore_values) = self.post_compute_restore_values.take() else {
+            return restored;
+        };
+        for entry in &mut restore_values.values {
+            let Some((property_id, _)) = entry.as_ref() else {
+                continue;
+            };
+            if only_property.is_some_and(|only_property| *property_id != only_property) {
+                continue;
+            }
+            let (property_id, value) = entry.take().unwrap();
+            self.set(property_id, value, -1);
+            restored.properties[restored.count] = property_id;
+            restored.count += 1;
+        }
+        if restore_values.values.iter().any(Option::is_some) {
+            self.post_compute_restore_values = Some(restore_values);
+        }
+        restored
+    }
+
     fn freeze(&mut self) {
+        self.post_compute_restore_values = None;
         self.frozen = true;
     }
 

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -340,7 +340,7 @@ impl ComputedLonghandTable {
     /// The effective value property() returns for one longhand: the animated
     /// overlay under the overlay read rule, then an unevaluated longhand's
     /// recorded currentcolor-dependent specified value, then the table slot.
-    fn effective_value(
+    pub(crate) fn effective_value(
         &self,
         overlay: Option<&AnimatedOverlay>,
         property_id: u16,

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -216,6 +216,13 @@ impl ComputedLonghandTable {
         self.rebuild_inheritance_dependent_view();
     }
 
+    pub(crate) fn copied_for_drive(source: &ComputedLonghandTable) -> Self {
+        let mut table = Self::new();
+        table.copy_from(source);
+        table.clear_seeded_state();
+        table
+    }
+
     fn copy_from_values(&mut self, values: &[*const c_void]) {
         assert!(
             !self.frozen,

--- a/Libraries/LibWeb/Rust/src/css/custom_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/custom_properties.rs
@@ -290,11 +290,12 @@ struct VarResolutionContext<'a> {
     resolve_custom_function: Option<unsafe extern "C" fn(usize, FfiUtf16View) -> usize>,
     condition_context: *mut c_void,
     evaluate_condition: Option<unsafe extern "C" fn(*mut c_void, u8, FfiUtf16View) -> u8>,
-    lookup_final_custom_property: Option<unsafe extern "C" fn(*mut c_void, FfiUtf16View) -> *const c_void>,
+    final_custom_properties: Option<&'a HashMap<Vec<u16>, *const c_void>>,
     active_functions: Vec<usize>,
     cyclic_functions: HashSet<usize>,
     function_local_scopes: Vec<FunctionLocalScope>,
     token_cache: Option<&'a mut CustomPropertyTokenCache>,
+    resolution_stats: Option<&'a VarResolutionStats>,
 }
 
 type CustomPropertyTokenCache = HashMap<*const StyleValueData, (Arc<[OwnedToken]>, bool, bool)>;
@@ -303,6 +304,23 @@ pub(crate) struct VarResolutionEnvironment {
     attributes: HashMap<Vec<u16>, Vec<u16>>,
     custom_functions: CustomFunctionRegistry,
     token_cache: CustomPropertyTokenCache,
+    resolution_stats: VarResolutionStats,
+}
+
+#[derive(Default)]
+struct VarResolutionStats {
+    final_value_hits: std::cell::Cell<u64>,
+    final_value_misses: std::cell::Cell<u64>,
+}
+
+impl VarResolutionEnvironment {
+    pub(crate) fn final_value_hits(&self) -> u64 {
+        self.resolution_stats.final_value_hits.get()
+    }
+
+    pub(crate) fn final_value_misses(&self) -> u64 {
+        self.resolution_stats.final_value_misses.get()
+    }
 }
 
 fn matching_close(kind: &OwnedTokenKind) -> Option<OwnedTokenKind> {
@@ -585,6 +603,7 @@ pub(crate) unsafe fn prepare_var_resolution_environment(
         attributes,
         custom_functions,
         token_cache: HashMap::new(),
+        resolution_stats: VarResolutionStats::default(),
     })
 }
 
@@ -866,19 +885,15 @@ fn resolve_custom_property_with_lookup(
         }
     }
     if lookup == CustomPropertyLookup::Normal
-        && let Some(lookup_final) = context.lookup_final_custom_property
+        && let Some(final_values) = context.final_custom_properties
     {
-        let data = unsafe {
-            lookup_final(
-                context.condition_context,
-                FfiUtf16View {
-                    ascii: std::ptr::null(),
-                    utf16: name.as_ptr(),
-                    length: name.len(),
-                },
-            )
-        };
-        if let Some(data) = unsafe { data.cast::<StyleValueData>().as_ref() } {
+        if let Some(data) = final_values
+            .get(name)
+            .and_then(|data| unsafe { data.cast::<StyleValueData>().as_ref() })
+        {
+            if let Some(stats) = context.resolution_stats {
+                stats.final_value_hits.set(stats.final_value_hits.get() + 1);
+            }
             if matches!(data, StyleValueData::GuaranteedInvalid) {
                 return TokenResolution::Invalid;
             }
@@ -891,6 +906,8 @@ fn resolve_custom_property_with_lookup(
             if !includes_substitution {
                 return TokenResolution::Resolved(tokens.to_vec());
             }
+        } else if let Some(stats) = context.resolution_stats {
+            stats.final_value_misses.set(stats.final_value_misses.get() + 1);
         }
     }
     let registration = registry.and_then(|registry| registry.registrations.get(name));
@@ -2248,7 +2265,7 @@ pub(crate) unsafe fn resolve_vars(
     resolve_custom_function: Option<unsafe extern "C" fn(usize, FfiUtf16View) -> usize>,
     condition_context: *mut c_void,
     evaluate_condition: Option<unsafe extern "C" fn(*mut c_void, u8, FfiUtf16View) -> u8>,
-    lookup_final_custom_property: Option<unsafe extern "C" fn(*mut c_void, FfiUtf16View) -> *const c_void>,
+    final_custom_properties: Option<&HashMap<Vec<u16>, *const c_void>>,
 ) -> NativeVarResolution {
     let store = if store.is_null() {
         None
@@ -2274,6 +2291,7 @@ pub(crate) unsafe fn resolve_vars(
         attributes,
         custom_functions,
         token_cache,
+        resolution_stats,
     } = environment;
     let mut context = VarResolutionContext {
         active_names,
@@ -2285,8 +2303,9 @@ pub(crate) unsafe fn resolve_vars(
         resolve_custom_function,
         condition_context,
         evaluate_condition,
-        lookup_final_custom_property,
+        final_custom_properties,
         token_cache: Some(token_cache),
+        resolution_stats: Some(resolution_stats),
         ..Default::default()
     };
     let Some((source, includes_substitution, contains_attr_tainted_values)) =

--- a/Libraries/LibWeb/Rust/src/css/ffi_stats.rs
+++ b/Libraries/LibWeb/Rust/src/css/ffi_stats.rs
@@ -57,6 +57,7 @@ define_ffi_ops! {
     StyleValueSerializeEntry => "styleValueSerializeEntries",
     StyleGroupCloneEntry => "styleGroupCloneEntries",
     StyleGroupFreeEntry => "styleGroupFreeEntries",
+    AnimationKeyframeLonghandEntry => "animationKeyframeLonghandEntries",
     AnimationEvaluationEntry => "animationEvaluationEntries",
     TransitionDecisionEntry => "transitionDecisionEntries",
     SubstitutionCallbackFreeParse => "substitutionCallbackFreeParses",

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -718,117 +718,156 @@ pub unsafe extern "C" fn rust_compute_font_size(
     })
 }
 
-/// What one step of the monospace font-size time travel decided.
+/// Why a monospace font-size recascade batch stopped.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub enum FontSizeRecascadeAction {
-    /// Keep the current size and viewport-dependency flag.
-    Unchanged,
-    /// Replace the current size and viewport-dependency flag.
-    Set,
-    /// The value is a calc, which the traversal does not support yet; skip it.
-    CalcSkipped,
-    /// The value is a length the core cannot resolve, either because no
-    /// resolution context was supplied or because the unit is unsupported;
-    /// the caller resolves it.
+pub enum FontSizeRecascadeStatus {
+    Complete,
+    /// The caller must provide the font and DOM-dependent resolution context
+    /// for `next_index`, then resume there.
     NeedsLengthResolution,
+    /// Rust could not resolve the length at `next_index` with the supplied
+    /// context, so the caller must resolve it and resume at the next value.
+    NeedsCppLengthResolution,
 }
 
 #[repr(C)]
-pub struct FfiFontSizeRecascadeStep {
-    pub action: FontSizeRecascadeAction,
-    pub new_size_raw: i32,
+pub struct FfiFontSizeRecascadeBatch {
+    pub status: FontSizeRecascadeStatus,
+    pub next_index: usize,
+    pub current_size_raw: i32,
     pub depends_on_viewport_metrics: bool,
+    pub skipped_calculated_value: bool,
 }
 
-/// One ancestor step of the time-traveling font-size inheritance applied when
-/// the cascade ends up with `font-family: monospace`: interprets the
-/// ancestor's raw cascaded font-size against the running size, with keyword
-/// sizes mapped against the default monospace font size.
+/// Drives the time-traveling font-size inheritance applied when the cascade
+/// ends up with `font-family: monospace` through as many ancestors as Rust can
+/// resolve without another DOM-dependent length context.
 ///
-/// `length_resolution_context` may be null; a length value then reports
-/// `NeedsLengthResolution` so the caller can build the context lazily and call
-/// again, since building it involves font work the other value types never
-/// need.
+/// A non-null `length_resolution_context` applies only to `values[start_index]`.
+/// Building it involves font work, so the caller does so lazily after a batch
+/// reports `NeedsLengthResolution` and resumes at the reported index.
 ///
 /// # Safety
-/// `value` must point at a valid StyleValueData, and
+/// `values` must contain `value_count` valid StyleValueData pointers, and
 /// `length_resolution_context` must be null or valid.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_recascade_font_size_step(
-    value: *const c_void,
+pub unsafe extern "C" fn rust_recascade_font_size_batch(
+    values: *const *const c_void,
+    value_count: usize,
+    start_index: usize,
     current_size_raw: i32,
     current_depends_on_viewport_metrics: bool,
     default_size_raw: i32,
     length_resolution_context: *const FfiLengthResolutionContext,
-) -> FfiFontSizeRecascadeStep {
+) -> FfiFontSizeRecascadeBatch {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     abort_on_panic(|| {
-        let value = unsafe { &*(value as *const StyleValueData) };
-        let current_size = CssPixels::from_raw(current_size_raw);
+        let values = if value_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(values, value_count) }
+        };
+        assert!(start_index <= values.len());
+        let mut current_size = CssPixels::from_raw(current_size_raw);
+        let mut depends_on_viewport_metrics = current_depends_on_viewport_metrics;
         let default_size = CssPixels::from_raw(default_size_raw);
-        let unchanged = FfiFontSizeRecascadeStep {
-            action: FontSizeRecascadeAction::Unchanged,
-            new_size_raw: current_size_raw,
-            depends_on_viewport_metrics: current_depends_on_viewport_metrics,
-        };
-        let set = |size: CssPixels, depends_on_viewport_metrics: bool| FfiFontSizeRecascadeStep {
-            action: FontSizeRecascadeAction::Set,
-            new_size_raw: size.raw_value(),
-            depends_on_viewport_metrics,
-        };
-        let needs_length_resolution = FfiFontSizeRecascadeStep {
-            action: FontSizeRecascadeAction::NeedsLengthResolution,
-            new_size_raw: current_size_raw,
-            depends_on_viewport_metrics: current_depends_on_viewport_metrics,
-        };
+        let supplied_length_resolution_context = unsafe { length_resolution_context.as_ref() };
+        let mut skipped_calculated_value = false;
+        let stopped =
+            |status, next_index, current_size: CssPixels, depends_on_viewport_metrics, skipped_calculated_value| {
+                FfiFontSizeRecascadeBatch {
+                    status,
+                    next_index,
+                    current_size_raw: current_size.raw_value(),
+                    depends_on_viewport_metrics,
+                    skipped_calculated_value,
+                }
+            };
 
-        match value {
-            StyleValueData::Keyword { keyword } => {
-                if *keyword == keyword::INITIAL || *keyword == keyword::UNSET {
-                    return set(default_size, false);
+        for (index, value) in values.iter().enumerate().skip(start_index) {
+            let value = unsafe { &*value.cast::<StyleValueData>() };
+            match value {
+                StyleValueData::Keyword { keyword } => {
+                    if *keyword == keyword::INITIAL || *keyword == keyword::UNSET {
+                        current_size = default_size;
+                        depends_on_viewport_metrics = false;
+                        continue;
+                    }
+                    if *keyword == keyword::INHERIT {
+                        continue;
+                    }
+                    if let Some(px) = absolute_size_font_mapping(*keyword, default_size) {
+                        current_size = px;
+                        depends_on_viewport_metrics = false;
+                        continue;
+                    }
+                    if let Some(px) = relative_size_font_mapping(*keyword, current_size) {
+                        current_size = px;
+                        continue;
+                    }
+                    // FIXME: Resolve `font-size: math`
+                    if *keyword == keyword::MATH {
+                        continue;
+                    }
                 }
-                if *keyword == keyword::INHERIT {
-                    // Do nothing.
-                    return unchanged;
+                StyleValueData::Percentage { value } => {
+                    current_size = CssPixels::nearest_value_for(value / 100.0 * current_size.to_double());
+                    continue;
                 }
-                if let Some(px) = absolute_size_font_mapping(*keyword, default_size) {
-                    return set(px, false);
+                StyleValueData::Length { value, unit } => {
+                    let Some(length_resolution_context) = (index == start_index)
+                        .then_some(supplied_length_resolution_context)
+                        .flatten()
+                    else {
+                        return stopped(
+                            FontSizeRecascadeStatus::NeedsLengthResolution,
+                            index,
+                            current_size,
+                            depends_on_viewport_metrics,
+                            skipped_calculated_value,
+                        );
+                    };
+                    let result = absolutize_length(*value, *unit as usize, length_resolution_context);
+                    if !result.handled {
+                        return stopped(
+                            FontSizeRecascadeStatus::NeedsCppLengthResolution,
+                            index,
+                            current_size,
+                            depends_on_viewport_metrics,
+                            skipped_calculated_value,
+                        );
+                    }
+                    current_size = CssPixels::nearest_value_for(result.px);
+                    depends_on_viewport_metrics = result.resolved_viewport_relative_length;
+                    continue;
                 }
-                if let Some(px) = relative_size_font_mapping(*keyword, current_size) {
-                    return set(px, current_depends_on_viewport_metrics);
+                StyleValueData::Calculated { .. } => {
+                    skipped_calculated_value = true;
+                    continue;
                 }
-                // FIXME: Resolve `font-size: math`
-                if *keyword == keyword::MATH {
-                    return unchanged;
-                }
-                // Unknown keywords fall through to the caller, which rejects them.
-                needs_length_resolution
+                _ => {}
             }
-            StyleValueData::Percentage { value } => set(
-                CssPixels::nearest_value_for(value / 100.0 * current_size.to_double()),
-                current_depends_on_viewport_metrics,
-            ),
-            StyleValueData::Length { value, unit } => {
-                if length_resolution_context.is_null() {
-                    return needs_length_resolution;
-                }
-                let result = absolutize_length(*value, *unit as usize, unsafe { &*length_resolution_context });
-                if !result.handled {
-                    return needs_length_resolution;
-                }
-                set(
-                    CssPixels::nearest_value_for(result.px),
-                    result.resolved_viewport_relative_length,
-                )
-            }
-            StyleValueData::Calculated { .. } => FfiFontSizeRecascadeStep {
-                action: FontSizeRecascadeAction::CalcSkipped,
-                new_size_raw: current_size_raw,
-                depends_on_viewport_metrics: current_depends_on_viewport_metrics,
-            },
-            _ => needs_length_resolution,
+            let status = if index == start_index && supplied_length_resolution_context.is_some() {
+                FontSizeRecascadeStatus::NeedsCppLengthResolution
+            } else {
+                FontSizeRecascadeStatus::NeedsLengthResolution
+            };
+            return stopped(
+                status,
+                index,
+                current_size,
+                depends_on_viewport_metrics,
+                skipped_calculated_value,
+            );
         }
+        stopped(
+            FontSizeRecascadeStatus::Complete,
+            values.len(),
+            current_size,
+            depends_on_viewport_metrics,
+            skipped_calculated_value,
+        )
     })
 }
 
@@ -5515,6 +5554,54 @@ mod tests {
 
         assert_eq!(absolutize_length(1.0, unit_code("lh"), &context).px, 19.0);
         assert_eq!(absolutize_length(1.0, unit_code("rch"), &context).px, 9.0);
+    }
+
+    #[test]
+    fn font_size_recascade_batches_until_length_context_is_needed() {
+        let percentage = StyleValueData::Percentage { value: 200.0 };
+        let em = StyleValueData::Length {
+            value: 2.0,
+            unit: unit_code("em") as u8,
+        };
+        let final_percentage = StyleValueData::Percentage { value: 50.0 };
+        let values: [*const std::ffi::c_void; 3] = [
+            (&percentage as *const StyleValueData).cast(),
+            (&em as *const StyleValueData).cast(),
+            (&final_percentage as *const StyleValueData).cast(),
+        ];
+        let default_size = CssPixels::from_integer(13);
+
+        let first_batch = unsafe {
+            rust_recascade_font_size_batch(
+                values.as_ptr(),
+                values.len(),
+                0,
+                default_size.raw_value(),
+                false,
+                default_size.raw_value(),
+                std::ptr::null(),
+            )
+        };
+        assert!(first_batch.status == FontSizeRecascadeStatus::NeedsLengthResolution);
+        assert_eq!(first_batch.next_index, 1);
+        assert_eq!(first_batch.current_size_raw, CssPixels::from_integer(26).raw_value());
+
+        let mut context = test_context();
+        context.font_metrics.font_size = 26.0;
+        let resumed_batch = unsafe {
+            rust_recascade_font_size_batch(
+                values.as_ptr(),
+                values.len(),
+                first_batch.next_index,
+                first_batch.current_size_raw,
+                first_batch.depends_on_viewport_metrics,
+                default_size.raw_value(),
+                &context,
+            )
+        };
+        assert!(resumed_batch.status == FontSizeRecascadeStatus::Complete);
+        assert_eq!(resumed_batch.next_index, values.len());
+        assert_eq!(resumed_batch.current_size_raw, CssPixels::from_integer(26).raw_value());
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2772,11 +2772,27 @@ pub struct FfiLonghandStoreBatch {
 /// Document-level inputs to used color-scheme resolution. Scheme values use
 /// the C++ PreferredColorScheme discriminants: auto, dark, and light.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiEffectiveColorSchemeInput {
     pub preferred_color_scheme: u8,
     pub has_document_supported_schemes: bool,
     pub document_supported_scheme_codes: *const u8,
     pub document_supported_scheme_count: usize,
+}
+
+#[repr(C)]
+pub struct FfiDocumentLonghandInput {
+    pub color_scheme_input: FfiEffectiveColorSchemeInput,
+    pub length_resolution_context: FfiLengthResolutionContext,
+    pub device_pixels_per_css_pixel: f64,
+    pub initial_font_size_raw: i32,
+    pub default_font_size_raw: i32,
+}
+
+#[repr(C)]
+pub struct FfiDocumentLonghandResult {
+    pub depends_on_viewport_metrics: bool,
+    pub font_metrics_depend_on_viewport_metrics: bool,
 }
 
 impl FfiEffectiveColorSchemeInput {
@@ -3253,8 +3269,8 @@ fn publish_longhand_store_batch(
 /// `environment` at valid element and document facts,
 /// `length_resolution_context` at the context for this stage or null for the
 /// color-scheme stage, and `results` at a valid results block.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_drive_property_computation(
+#[allow(clippy::too_many_arguments)]
+unsafe fn drive_property_computation(
     longhand_table: *mut ComputedLonghandTable,
     store: *const CascadedPropertyStore,
     parent_snapshot: *const FfiParentSnapshot,
@@ -3265,7 +3281,6 @@ pub unsafe extern "C" fn rust_drive_property_computation(
     length_resolution_context: *const FfiLengthResolutionContext,
     results: *mut FfiLonghandDriverResults,
 ) -> FfiLonghandStoreBatch {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
     abort_on_panic(|| {
         use crate::css::property_metadata::{
             NUMBER_OF_LONGHAND_PROPERTIES, REQUIRES_COMPUTATION_ALWAYS, REQUIRES_COMPUTATION_CASCADED,
@@ -4462,6 +4477,160 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             element_style_adjustment: element_adjustment,
         };
         publish_longhand_store_batch(cpp_store_side_effects, pending_effective_color_scheme)
+    })
+}
+
+/// FFI entry for the native longhand driver.
+///
+/// # Safety
+/// All pointers must satisfy `drive_property_computation`'s contract.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_drive_property_computation(
+    longhand_table: *mut ComputedLonghandTable,
+    store: *const CascadedPropertyStore,
+    parent_snapshot: *const FfiParentSnapshot,
+    environment: *const FfiStyleComputationEnvironment,
+    computed_group_mask: u32,
+    computed_property_words: *const u64,
+    phase: u8,
+    length_resolution_context: *const FfiLengthResolutionContext,
+    results: *mut FfiLonghandDriverResults,
+) -> FfiLonghandStoreBatch {
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
+    unsafe {
+        drive_property_computation(
+            longhand_table,
+            store,
+            parent_snapshot,
+            environment,
+            computed_group_mask,
+            computed_property_words,
+            phase,
+            length_resolution_context,
+            results,
+        )
+    }
+}
+
+/// Computes every initial document longhand in the native driver. Unlike a
+/// normal element drive, no cascade, inheritance, or element-specific
+/// adjustment participates.
+///
+/// # Safety
+/// `longhand_table` must point at a live, empty, mutable table and `input`
+/// must point at a valid input block for the duration of this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compute_document_longhands(
+    longhand_table: *mut ComputedLonghandTable,
+    input: *const FfiDocumentLonghandInput,
+) -> FfiDocumentLonghandResult {
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
+    abort_on_panic(|| {
+        let input = unsafe { &*input };
+        let store = CascadedPropertyStore::new();
+        let environment = FfiStyleComputationEnvironment {
+            box_type_input: FfiBoxTypeTransformationInput {
+                display: FfiDisplay::inline(),
+                position: keyword::STATIC,
+                float_value: keyword::NONE,
+                is_br_element: false,
+                is_document_element: false,
+                is_mathml_element: false,
+                is_mathml_mtable: false,
+                is_mathml_mtr: false,
+                is_mathml_mtd: false,
+                has_parent_display: false,
+                parent_display: FfiDisplay::block(),
+                is_wbr_element: false,
+                disallow_display_contents: false,
+                rewrite_inline_flow: false,
+                is_button_element: false,
+                force_line_height_normal: false,
+                check_input_line_height: false,
+                hide_audio_without_controls: false,
+                is_table_element: false,
+                force_position_static: false,
+                force_symbol_display_inline: false,
+            },
+            color_scheme_input: input.color_scheme_input,
+            is_th_element: false,
+            has_new_font_size: false,
+            has_animated_inheritance_parent: false,
+            has_tree_counting_context: false,
+            sibling_count: 0,
+            sibling_index: 0,
+            random_base_values: std::ptr::null(),
+            random_base_value_count: 0,
+            document_base_url: std::ptr::null(),
+            document_base_url_length: 0,
+            style_sheet_resource_contexts: std::ptr::null(),
+            style_sheet_resource_context_count: 0,
+            device_pixels_per_css_pixel: input.device_pixels_per_css_pixel,
+            initial_font_size_raw: input.initial_font_size_raw,
+            default_font_size_raw: input.default_font_size_raw,
+        };
+        let mut results = FfiLonghandDriverResults {
+            longhand_evaluations: 0,
+            raw_cascaded_font_size_data: std::ptr::null(),
+            depends_on_viewport_metrics: false,
+            font_metrics_depend_on_viewport_metrics: false,
+            explicitly_inherited_non_inherited_property: false,
+            uses_tree_counting_function: false,
+            effective_color_scheme: -1,
+            post_compute_adjustment: FfiPostComputeAdjustment {
+                display_before: FfiDisplay::inline(),
+                float_before: keyword::NONE,
+                overflow_x_before: keyword::VISIBLE,
+                overflow_y_before: keyword::VISIBLE,
+                text_align_before: keyword::START,
+                position_before: keyword::STATIC,
+                box_type_transformation: FfiBoxTypeTransformation {
+                    set_float_none: false,
+                    changed_display: false,
+                    display: FfiDisplay::inline(),
+                },
+                element_style_adjustment: FfiElementStyleAdjustment {
+                    changed_display: false,
+                    display: FfiDisplay::inline(),
+                    set_line_height_normal: false,
+                    check_input_line_height: false,
+                    set_position_static: false,
+                    changed_text_align: false,
+                    text_align: keyword::START,
+                },
+            },
+        };
+        for phase in [
+            LONGHAND_DRIVE_PHASE_FONT,
+            LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
+            LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
+            LONGHAND_DRIVE_PHASE_REMAINING,
+        ] {
+            let length_resolution_context = if phase == LONGHAND_DRIVE_PHASE_COLOR_SCHEME {
+                std::ptr::null()
+            } else {
+                &raw const input.length_resolution_context
+            };
+            let batch = unsafe {
+                drive_property_computation(
+                    longhand_table,
+                    &raw const store,
+                    std::ptr::null(),
+                    &raw const environment,
+                    u32::MAX,
+                    std::ptr::null(),
+                    phase,
+                    length_resolution_context,
+                    &raw mut results,
+                )
+            };
+            assert_eq!(batch.count, 0, "document initialization has no C++ store side effects");
+            unsafe { rust_longhand_store_batch_destroy(batch.storage) };
+        }
+        FfiDocumentLonghandResult {
+            depends_on_viewport_metrics: results.depends_on_viewport_metrics,
+            font_metrics_depend_on_viewport_metrics: results.font_metrics_depend_on_viewport_metrics,
+        }
     })
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -4764,6 +4764,38 @@ pub struct FfiElementStyleAdjustments {
     pub element_style: FfiElementStyleAdjustment,
 }
 
+/// Everything Rust can decide while finalizing a computed style once C++ has
+/// marshalled the DOM-dependent inputs.
+#[repr(C)]
+pub struct FfiStyleFinalizationInput {
+    pub mode: FfiStyleFinalizationMode,
+    pub box_type: FfiBoxTypeTransformationInput,
+    pub overflow_x: u16,
+    pub overflow_y: u16,
+    pub text_align: u16,
+    pub is_th_element: bool,
+    pub has_parent_with_computed_values: bool,
+    pub parent_text_align: u16,
+    pub parent_direction_is_ltr: bool,
+}
+
+#[repr(C)]
+pub struct FfiStyleFinalization {
+    pub element_style: FfiElementStyleAdjustments,
+    pub overflow: FfiEffectiveOverflow,
+    pub text_align: FfiTextAlignAdjustment,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FfiStyleFinalizationMode {
+    BoxType,
+    AnimatedBoxType,
+    TextAlign,
+    All,
+    Overflow,
+}
+
 #[repr(C)]
 pub struct FfiInputLineHeightMetrics {
     pub current_line_height: f64,
@@ -4973,17 +5005,6 @@ fn transform_box_type(input: &FfiBoxTypeTransformationInput) -> FfiBoxTypeTransf
     }
 }
 
-/// # Safety
-/// `input` must be a valid pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_adjust_element_style(
-    input: *const FfiBoxTypeTransformationInput,
-    text_align: u16,
-) -> FfiElementStyleAdjustments {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| compute_element_style_adjustments(unsafe { &*input }, text_align))
-}
-
 /// Result of resolving the effective overflow pair: each axis' possibly
 /// replaced computed keyword.
 #[repr(C)]
@@ -5024,12 +5045,6 @@ fn resolve_effective_overflow_keywords(overflow_x: u16, overflow_y: u16) -> FfiE
         }
     }
     result
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_resolve_effective_overflow_keywords(overflow_x: u16, overflow_y: u16) -> FfiEffectiveOverflow {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| resolve_effective_overflow_keywords(overflow_x, overflow_y))
 }
 
 // https://drafts.csswg.org/css-color-adjust-1/#determine-the-used-color-scheme
@@ -5160,23 +5175,77 @@ fn compute_text_align_adjustment(
     unchanged
 }
 
+/// Runs the independent finalization decisions that remain after property
+/// computation. Callers select the decisions whose results they need.
+///
+/// # Safety
+/// `input` must point at a live `FfiStyleFinalizationInput`.
 #[unsafe(no_mangle)]
-pub extern "C" fn rust_compute_text_align(
-    text_align: u16,
-    is_th_element: bool,
-    has_parent_with_computed_values: bool,
-    parent_text_align: u16,
-    parent_direction_is_ltr: bool,
-) -> FfiTextAlignAdjustment {
+pub unsafe extern "C" fn rust_finalize_style(input: *const FfiStyleFinalizationInput) -> FfiStyleFinalization {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     abort_on_panic(|| {
-        compute_text_align_adjustment(
+        let input = unsafe { &*input };
+        let element_style = if matches!(
+            input.mode,
+            FfiStyleFinalizationMode::BoxType
+                | FfiStyleFinalizationMode::AnimatedBoxType
+                | FfiStyleFinalizationMode::All
+        ) {
+            compute_element_style_adjustments(&input.box_type, input.text_align)
+        } else {
+            FfiElementStyleAdjustments {
+                box_type: FfiBoxTypeTransformation {
+                    set_float_none: false,
+                    changed_display: false,
+                    display: input.box_type.display,
+                },
+                element_style: FfiElementStyleAdjustment {
+                    changed_display: false,
+                    display: input.box_type.display,
+                    set_line_height_normal: false,
+                    check_input_line_height: false,
+                    set_position_static: false,
+                    changed_text_align: false,
+                    text_align: input.text_align,
+                },
+            }
+        };
+        let overflow = if matches!(
+            input.mode,
+            FfiStyleFinalizationMode::All | FfiStyleFinalizationMode::Overflow
+        ) {
+            resolve_effective_overflow_keywords(input.overflow_x, input.overflow_y)
+        } else {
+            FfiEffectiveOverflow {
+                changed_x: false,
+                x_keyword: input.overflow_x,
+                changed_y: false,
+                y_keyword: input.overflow_y,
+            }
+        };
+        let text_align = if matches!(
+            input.mode,
+            FfiStyleFinalizationMode::TextAlign | FfiStyleFinalizationMode::All
+        ) {
+            compute_text_align_adjustment(
+                input.text_align,
+                input.is_th_element,
+                input.has_parent_with_computed_values,
+                input.parent_text_align,
+                input.parent_direction_is_ltr,
+            )
+        } else {
+            FfiTextAlignAdjustment {
+                changed: false,
+                keyword: input.text_align,
+                inherited: false,
+            }
+        };
+        FfiStyleFinalization {
+            element_style,
+            overflow,
             text_align,
-            is_th_element,
-            has_parent_with_computed_values,
-            parent_text_align,
-            parent_direction_is_ltr,
-        )
+        }
     })
 }
 
@@ -5360,6 +5429,34 @@ mod tests {
         assert!(adjustments.box_type.display.is_block_outside());
         assert!(adjustments.element_style.changed_display);
         assert!(adjustments.element_style.display.is_flow_root_inside());
+    }
+
+    #[test]
+    fn style_finalization_batches_selected_decisions() {
+        let mut box_type = element_adjustment_input();
+        box_type.is_button_element = true;
+        box_type.position = keyword::ABSOLUTE;
+        let input = FfiStyleFinalizationInput {
+            mode: FfiStyleFinalizationMode::All,
+            box_type,
+            overflow_x: keyword::VISIBLE,
+            overflow_y: keyword::AUTO,
+            text_align: keyword::MATCH_PARENT,
+            is_th_element: false,
+            has_parent_with_computed_values: true,
+            parent_text_align: keyword::END,
+            parent_direction_is_ltr: true,
+        };
+
+        let finalization = unsafe { rust_finalize_style(&input) };
+        assert!(finalization.element_style.box_type.changed_display);
+        assert!(finalization.element_style.box_type.display.is_block_outside());
+        assert!(finalization.element_style.element_style.changed_display);
+        assert!(finalization.element_style.element_style.display.is_flow_root_inside());
+        assert!(finalization.overflow.changed_x);
+        assert_eq!(finalization.overflow.x_keyword, keyword::AUTO);
+        assert!(finalization.text_align.changed);
+        assert_eq!(finalization.text_align.keyword, keyword::RIGHT);
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -1877,23 +1877,6 @@ fn compute_math_depth(
     }
 }
 
-/// Computes the math-depth property from its absolutized value.
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_math_depth(
-    absolutized_value: *const c_void,
-    inherited_math_depth: i32,
-    inherited_math_style_is_compact: bool,
-) -> FfiComputedNumber {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_math_depth(value, inherited_math_depth, inherited_math_style_is_compact)
-    })
-}
-
 // https://drafts.csswg.org/css-inline-3/#line-height-property
 fn compute_line_height(value: &StyleValueData, computed_font_size: CssPixels) -> FfiComputedLineHeight {
     match value {
@@ -1944,23 +1927,6 @@ fn compute_line_height(value: &StyleValueData, computed_font_size: CssPixels) ->
         }
         _ => LINE_HEIGHT_UNHANDLED,
     }
-}
-
-/// Computes the line-height property from its absolutized value. The computed
-/// font size is a raw CSSPixels value.
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_line_height(
-    absolutized_value: *const c_void,
-    computed_font_size_raw: i32,
-) -> FfiComputedLineHeight {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_line_height(value, CssPixels::from_raw(computed_font_size_raw))
-    })
 }
 
 // https://drafts.csswg.org/css-backgrounds/#border-width
@@ -2031,22 +1997,6 @@ fn snap_a_length_as_a_border_width(device_pixels_per_css_pixel: f64, length: Css
     length
 }
 
-/// Computes a border or outline width property from its absolutized value.
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_border_or_outline_width(
-    absolutized_value: *const c_void,
-    device_pixels_per_css_pixel: f64,
-) -> FfiComputedNumber {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_border_or_outline_width(value, device_pixels_per_css_pixel, None)
-    })
-}
-
 // https://drafts.csswg.org/css-borders-4/#propdef-corner-top-left-shape
 // the corresponding superellipse() value
 fn compute_corner_shape_parameter(value: &StyleValueData) -> FfiComputedNumber {
@@ -2081,19 +2031,6 @@ fn compute_corner_shape_parameter(value: &StyleValueData) -> FfiComputedNumber {
         },
         _ => NUMBER_UNHANDLED,
     }
-}
-
-/// Computes the superellipse parameter for a corner shape property.
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_corner_shape_parameter(absolutized_value: *const c_void) -> FfiComputedNumber {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_corner_shape_parameter(value)
-    })
 }
 
 /// Whether a font-family value is a single monospace keyword, which triggers
@@ -2156,41 +2093,6 @@ fn compute_font_feature_tag_value_list(value: &StyleValueData) -> Arc<StyleValue
     })
 }
 
-/// Computes a font-feature-settings or font-variation-settings value list:
-/// deduplicate by tag with the later occurrence taking precedence, then sort
-/// the survivors ascending by tag.
-/// https://drafts.csswg.org/css-fonts/#font-feature-settings-prop
-///
-/// # Safety
-/// `data` must point at a value list of OpenType tagged values.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_font_feature_settings(data: *const c_void) -> *const c_void {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        Arc::into_raw(compute_font_feature_tag_value_list(unsafe {
-            &*data.cast::<StyleValueData>()
-        }))
-        .cast()
-    })
-}
-
-/// Computes a transform-origin value list over an already absolutized value.
-/// A null return means the absolutized value is already the computed value.
-/// https://drafts.csswg.org/css-transforms/#transform-origin-property
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_transform_origin(absolutized_value: *const c_void) -> *const c_void {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(
-        || match compute_transform_origin(unsafe { &*absolutized_value.cast::<StyleValueData>() }) {
-            Some(value) => Arc::into_raw(value).cast(),
-            None => std::ptr::null(),
-        },
-    )
-}
-
 /// Whether a value contains a percentage, either directly or inside a
 /// calculation tree; the shared core of the two font predicates below.
 fn value_contains_percentage(value: &StyleValueData) -> bool {
@@ -2229,19 +2131,6 @@ pub(crate) fn value_depends_on_inherited_info_for_property(value: &StyleValueDat
     }
 }
 
-/// # Safety
-/// `value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_value_depends_on_inherited_info_for_property(
-    value: *const c_void,
-    property_id: u16,
-) -> bool {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueQueryEntry);
-    abort_on_panic(|| {
-        value_depends_on_inherited_info_for_property(unsafe { &*(value as *const StyleValueData) }, property_id)
-    })
-}
-
 /// The outcome of the font-style computation: whether a keyword was mapped to
 /// a font-style keyword the caller should construct, and that keyword's code.
 #[repr(C)]
@@ -2275,17 +2164,6 @@ pub unsafe extern "C" fn rust_compute_font_style(absolutized_value: *const c_voi
             font_style_keyword: 0,
         }
     })
-}
-
-/// Computes letter-spacing or word-spacing: the normal keyword computes to a
-/// zero length, and any other value is already the computed value.
-///
-/// # Safety
-/// `absolutized_value` must point at a valid StyleValueData.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compute_letter_or_word_spacing(absolutized_value: *const c_void) -> FfiComputedNumber {
-    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| compute_letter_or_word_spacing_value(unsafe { &*(absolutized_value as *const StyleValueData) }))
 }
 
 fn compute_letter_or_word_spacing_value(absolutized_value: &StyleValueData) -> FfiComputedNumber {
@@ -2795,6 +2673,35 @@ pub struct FfiDocumentLonghandResult {
     pub font_metrics_depend_on_viewport_metrics: bool,
 }
 
+#[repr(C)]
+pub struct FfiAnimationKeyframeLonghand {
+    pub keyframe_index: usize,
+    pub property_id: u16,
+    pub value: *const c_void,
+    pub style_sheet_resource_context: FfiStyleSheetResourceContext,
+}
+
+#[repr(C)]
+pub struct FfiAnimationKeyframeLonghandInput {
+    pub underlying_longhand_table: *const ComputedLonghandTable,
+    pub parent_snapshot: *const FfiParentSnapshot,
+    pub longhands: *const FfiAnimationKeyframeLonghand,
+    pub longhand_count: usize,
+    pub environment: *const FfiStyleComputationEnvironment,
+    pub font_length_resolution_context: *const FfiLengthResolutionContext,
+    pub line_height_length_resolution_context: *const FfiLengthResolutionContext,
+    pub remaining_length_resolution_context: *const FfiLengthResolutionContext,
+}
+
+#[repr(C)]
+pub struct FfiAnimationKeyframeLonghandResult {
+    pub values: *const *const c_void,
+    pub value_count: usize,
+    pub depends_on_viewport_metrics: bool,
+    pub font_metrics_depend_on_viewport_metrics: bool,
+    pub storage: *mut c_void,
+}
+
 impl FfiEffectiveColorSchemeInput {
     /// # Safety
     /// The document-supported scheme storage must be valid for the returned
@@ -2817,6 +2724,7 @@ impl FfiEffectiveColorSchemeInput {
 
 /// Stable element and document facts supplied once for a longhand drive.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiStyleComputationEnvironment {
     pub box_type_input: FfiBoxTypeTransformationInput,
     pub color_scheme_input: FfiEffectiveColorSchemeInput,
@@ -2844,11 +2752,23 @@ pub struct FfiRandomBaseValue {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiStyleSheetResourceContext {
     pub base_url: *const u8,
     pub base_url_length: usize,
     pub has_value: bool,
     pub origin_clean: bool,
+}
+
+impl FfiStyleSheetResourceContext {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            base_url: std::ptr::null(),
+            base_url_length: 0,
+            has_value: false,
+            origin_clean: false,
+        }
+    }
 }
 
 /// Whether a value's absolutization is the identity, so the specified value
@@ -3067,6 +2987,40 @@ pub struct FfiPostComputeAdjustment {
     pub element_style_adjustment: FfiElementStyleAdjustment,
 }
 
+fn empty_longhand_driver_results() -> FfiLonghandDriverResults {
+    FfiLonghandDriverResults {
+        longhand_evaluations: 0,
+        raw_cascaded_font_size_data: std::ptr::null(),
+        depends_on_viewport_metrics: false,
+        font_metrics_depend_on_viewport_metrics: false,
+        explicitly_inherited_non_inherited_property: false,
+        uses_tree_counting_function: false,
+        effective_color_scheme: -1,
+        post_compute_adjustment: FfiPostComputeAdjustment {
+            display_before: FfiDisplay::inline(),
+            float_before: keyword::NONE,
+            overflow_x_before: keyword::VISIBLE,
+            overflow_y_before: keyword::VISIBLE,
+            text_align_before: keyword::START,
+            position_before: keyword::STATIC,
+            box_type_transformation: FfiBoxTypeTransformation {
+                set_float_none: false,
+                changed_display: false,
+                display: FfiDisplay::inline(),
+            },
+            element_style_adjustment: FfiElementStyleAdjustment {
+                changed_display: false,
+                display: FfiDisplay::inline(),
+                set_line_height_normal: false,
+                check_input_line_height: false,
+                set_position_static: false,
+                changed_text_align: false,
+                text_align: keyword::START,
+            },
+        },
+    }
+}
+
 pub const POST_ADJUSTED_FLOAT: u8 = 1 << 0;
 pub const POST_ADJUSTED_DISPLAY: u8 = 1 << 1;
 pub const POST_ADJUSTED_LINE_HEIGHT: u8 = 1 << 2;
@@ -3280,6 +3234,7 @@ unsafe fn drive_property_computation(
     phase: u8,
     length_resolution_context: *const FfiLengthResolutionContext,
     results: *mut FfiLonghandDriverResults,
+    coordinate_overflow_keywords: bool,
 ) -> FfiLonghandStoreBatch {
     abort_on_panic(|| {
         use crate::css::property_metadata::{
@@ -4331,27 +4286,30 @@ unsafe fn drive_property_computation(
                     computed_overflow_x = Some(*keyword);
                 }
             } else if property_id == prop::OVERFLOW_Y
-                && let (Some(overflow_x), StyleValueData::Keyword { keyword: overflow_y }) =
-                    (computed_overflow_x, value_data)
+                && let StyleValueData::Keyword { keyword: overflow_y } = value_data
             {
                 computed_overflow_y = Some(*overflow_y);
-                let effective_overflow = resolve_effective_overflow_keywords(overflow_x, *overflow_y);
-                let overflow_x_entry = pending_overflow_x_store
-                    .as_mut()
-                    .expect("overflow-x must precede overflow-y in computation order");
-                if effective_overflow.changed_x {
-                    debug_assert_eq!(overflow_x_entry.computed_kind, COMPUTED_KIND_UNCHANGED);
-                    overflow_x_entry.computed_kind = COMPUTED_KIND_KEYWORD;
-                    overflow_x_entry.value = effective_overflow.x_keyword as f64;
-                    clear_longhand_bit(&mut important_words, prop::OVERFLOW_X);
-                    clear_longhand_bit(&mut inherited_words, prop::OVERFLOW_X);
-                }
-                if effective_overflow.changed_y {
-                    debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_UNCHANGED);
-                    entry.computed_kind = COMPUTED_KIND_KEYWORD;
-                    entry.value = effective_overflow.y_keyword as f64;
-                    clear_longhand_bit(&mut important_words, prop::OVERFLOW_Y);
-                    clear_longhand_bit(&mut inherited_words, prop::OVERFLOW_Y);
+                if coordinate_overflow_keywords {
+                    let overflow_x =
+                        computed_overflow_x.expect("overflow-x must precede overflow-y in computation order");
+                    let effective_overflow = resolve_effective_overflow_keywords(overflow_x, *overflow_y);
+                    let overflow_x_entry = pending_overflow_x_store
+                        .as_mut()
+                        .expect("overflow-x must precede overflow-y in computation order");
+                    if effective_overflow.changed_x {
+                        debug_assert_eq!(overflow_x_entry.computed_kind, COMPUTED_KIND_UNCHANGED);
+                        overflow_x_entry.computed_kind = COMPUTED_KIND_KEYWORD;
+                        overflow_x_entry.value = effective_overflow.x_keyword as f64;
+                        clear_longhand_bit(&mut important_words, prop::OVERFLOW_X);
+                        clear_longhand_bit(&mut inherited_words, prop::OVERFLOW_X);
+                    }
+                    if effective_overflow.changed_y {
+                        debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_UNCHANGED);
+                        entry.computed_kind = COMPUTED_KIND_KEYWORD;
+                        entry.value = effective_overflow.y_keyword as f64;
+                        clear_longhand_bit(&mut important_words, prop::OVERFLOW_Y);
+                        clear_longhand_bit(&mut inherited_words, prop::OVERFLOW_Y);
+                    }
                 }
             } else if property_id == prop::TEXT_ALIGN
                 && let StyleValueData::Keyword { keyword: text_align } = value_data
@@ -4508,6 +4466,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             phase,
             length_resolution_context,
             results,
+            true,
         )
     }
 }
@@ -4569,37 +4528,7 @@ pub unsafe extern "C" fn rust_compute_document_longhands(
             initial_font_size_raw: input.initial_font_size_raw,
             default_font_size_raw: input.default_font_size_raw,
         };
-        let mut results = FfiLonghandDriverResults {
-            longhand_evaluations: 0,
-            raw_cascaded_font_size_data: std::ptr::null(),
-            depends_on_viewport_metrics: false,
-            font_metrics_depend_on_viewport_metrics: false,
-            explicitly_inherited_non_inherited_property: false,
-            uses_tree_counting_function: false,
-            effective_color_scheme: -1,
-            post_compute_adjustment: FfiPostComputeAdjustment {
-                display_before: FfiDisplay::inline(),
-                float_before: keyword::NONE,
-                overflow_x_before: keyword::VISIBLE,
-                overflow_y_before: keyword::VISIBLE,
-                text_align_before: keyword::START,
-                position_before: keyword::STATIC,
-                box_type_transformation: FfiBoxTypeTransformation {
-                    set_float_none: false,
-                    changed_display: false,
-                    display: FfiDisplay::inline(),
-                },
-                element_style_adjustment: FfiElementStyleAdjustment {
-                    changed_display: false,
-                    display: FfiDisplay::inline(),
-                    set_line_height_normal: false,
-                    check_input_line_height: false,
-                    set_position_static: false,
-                    changed_text_align: false,
-                    text_align: keyword::START,
-                },
-            },
-        };
+        let mut results = empty_longhand_driver_results();
         for phase in [
             LONGHAND_DRIVE_PHASE_FONT,
             LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
@@ -4622,6 +4551,7 @@ pub unsafe extern "C" fn rust_compute_document_longhands(
                     phase,
                     length_resolution_context,
                     &raw mut results,
+                    true,
                 )
             };
             assert_eq!(batch.count, 0, "document initialization has no C++ store side effects");
@@ -4632,6 +4562,155 @@ pub unsafe extern "C" fn rust_compute_document_longhands(
             font_metrics_depend_on_viewport_metrics: results.font_metrics_depend_on_viewport_metrics,
         }
     })
+}
+
+/// Computes every selected keyframe longhand through the native longhand
+/// driver. Each keyframe gets a temporary table seeded from the underlying
+/// style, then all of that keyframe's specified values are cascaded together
+/// before its selected properties are evaluated.
+///
+/// # Safety
+/// `input` and every range and pointer it contains must remain valid for the
+/// duration of the call. Every returned value transfers one strong reference
+/// to the caller.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
+    input: *const FfiAnimationKeyframeLonghandInput,
+) -> FfiAnimationKeyframeLonghandResult {
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::AnimationKeyframeLonghandEntry);
+    abort_on_panic(|| {
+        use crate::css::property_metadata::{
+            FIRST_LONGHAND_PROPERTY_ID, LAST_LONGHAND_PROPERTY_ID, NUMBER_OF_LONGHAND_PROPERTIES,
+        };
+
+        let input = unsafe { &*input };
+        let longhands = if input.longhand_count == 0 {
+            &[][..]
+        } else {
+            unsafe { std::slice::from_raw_parts(input.longhands, input.longhand_count) }
+        };
+        if longhands.is_empty() {
+            return FfiAnimationKeyframeLonghandResult {
+                values: std::ptr::null(),
+                value_count: 0,
+                depends_on_viewport_metrics: false,
+                font_metrics_depend_on_viewport_metrics: false,
+                storage: std::ptr::null_mut(),
+            };
+        }
+        assert!(!input.underlying_longhand_table.is_null());
+        assert!(!input.environment.is_null());
+        assert!(!input.font_length_resolution_context.is_null());
+        assert!(!input.line_height_length_resolution_context.is_null());
+        assert!(!input.remaining_length_resolution_context.is_null());
+        let underlying_longhand_table = unsafe { &*input.underlying_longhand_table };
+        let mut longhands_by_keyframe = std::collections::BTreeMap::<usize, Vec<usize>>::new();
+        for (index, longhand) in longhands.iter().enumerate() {
+            assert!((FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&longhand.property_id));
+            assert!(!longhand.value.is_null());
+            longhands_by_keyframe
+                .entry(longhand.keyframe_index)
+                .or_default()
+                .push(index);
+        }
+
+        const LONGHAND_WORD_COUNT: usize = NUMBER_OF_LONGHAND_PROPERTIES.div_ceil(64);
+        let mut values = vec![std::ptr::null(); longhands.len()];
+        let mut depends_on_viewport_metrics = false;
+        let mut font_metrics_depend_on_viewport_metrics = false;
+        for indices in longhands_by_keyframe.values() {
+            let mut table = ComputedLonghandTable::copied_for_drive(underlying_longhand_table);
+            let mut store = CascadedPropertyStore::new();
+            for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
+                if let Some(value) = underlying_longhand_table.get(property_id) {
+                    store.seed_retained_property(property_id, value.clone_retained(), false, false);
+                }
+            }
+            let mut selected_longhands = [0; LONGHAND_WORD_COUNT];
+            let mut style_sheet_resource_contexts = Vec::new();
+            for &index in indices {
+                let longhand = &longhands[index];
+                let value = unsafe {
+                    RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                        longhand.value.cast(),
+                    ))
+                };
+                let has_style_sheet_context = longhand.style_sheet_resource_context.has_value;
+                let source_slot =
+                    store.seed_retained_property(longhand.property_id, value, false, has_style_sheet_context);
+                if has_style_sheet_context {
+                    let source_slot = source_slot as usize;
+                    if style_sheet_resource_contexts.len() <= source_slot {
+                        style_sheet_resource_contexts.resize(source_slot + 1, FfiStyleSheetResourceContext::empty());
+                    }
+                    style_sheet_resource_contexts[source_slot] = longhand.style_sheet_resource_context;
+                }
+                set_longhand_bit(&mut selected_longhands, longhand.property_id);
+            }
+            let mut environment = unsafe { *input.environment };
+            environment.style_sheet_resource_contexts = style_sheet_resource_contexts.as_ptr();
+            environment.style_sheet_resource_context_count = style_sheet_resource_contexts.len();
+
+            let mut results = empty_longhand_driver_results();
+            for phase in [
+                LONGHAND_DRIVE_PHASE_FONT,
+                LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
+                LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
+                LONGHAND_DRIVE_PHASE_REMAINING,
+            ] {
+                let length_resolution_context = match phase {
+                    LONGHAND_DRIVE_PHASE_FONT => input.font_length_resolution_context,
+                    LONGHAND_DRIVE_PHASE_LINE_HEIGHT => input.line_height_length_resolution_context,
+                    LONGHAND_DRIVE_PHASE_COLOR_SCHEME => std::ptr::null(),
+                    LONGHAND_DRIVE_PHASE_REMAINING => input.remaining_length_resolution_context,
+                    _ => unreachable!(),
+                };
+                let batch = unsafe {
+                    drive_property_computation(
+                        &raw mut table,
+                        &raw const store,
+                        input.parent_snapshot,
+                        &raw const environment,
+                        u32::MAX,
+                        selected_longhands.as_ptr(),
+                        phase,
+                        length_resolution_context,
+                        &raw mut results,
+                        false,
+                    )
+                };
+                unsafe { rust_longhand_store_batch_destroy(batch.storage) };
+            }
+            depends_on_viewport_metrics |= results.depends_on_viewport_metrics;
+            font_metrics_depend_on_viewport_metrics |= results.font_metrics_depend_on_viewport_metrics;
+            for &index in indices {
+                let value = table
+                    .get(longhands[index].property_id)
+                    .expect("the keyframe longhand drive must store every selected property");
+                values[index] = unsafe { crate::css::style_value::retain_style_value(value.pointer()) }.cast();
+            }
+        }
+
+        let values = Box::new(values);
+        FfiAnimationKeyframeLonghandResult {
+            values: values.as_ptr(),
+            value_count: values.len(),
+            depends_on_viewport_metrics,
+            font_metrics_depend_on_viewport_metrics,
+            storage: Box::into_raw(values).cast(),
+        }
+    })
+}
+
+/// # Safety
+/// `storage` must be null or returned by
+/// `rust_compute_animation_keyframe_longhands`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_animation_keyframe_longhands_destroy(storage: *mut c_void) {
+    if !storage.is_null() {
+        drop(unsafe { Box::from_raw(storage.cast::<Vec<*const c_void>>()) });
+    }
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2969,23 +2969,20 @@ pub struct FfiLonghandDriverResults {
     /// The used color scheme produced by the color-scheme stage, or -1 until
     /// that stage has run.
     pub effective_color_scheme: i16,
-    /// Inputs for the post-compute continuation. C++ captures the facade state
-    /// that can only be observed between the longhand drive and adjustments,
-    /// then resumes Rust with the requested line-height metrics.
-    pub post_compute_adjustment: FfiPostComputeAdjustment,
+    pub display_before_box_type_transformation: FfiDisplay,
+    pub post_adjusted_longhands: u8,
 }
 
-#[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FfiPostComputeAdjustment {
-    pub display_before: FfiDisplay,
-    pub float_before: u16,
-    pub overflow_x_before: u16,
-    pub overflow_y_before: u16,
-    pub text_align_before: u16,
-    pub position_before: u16,
-    pub box_type_transformation: FfiBoxTypeTransformation,
-    pub element_style_adjustment: FfiElementStyleAdjustment,
+struct PostComputeAdjustment {
+    display_before: FfiDisplay,
+    float_before: u16,
+    overflow_x_before: u16,
+    overflow_y_before: u16,
+    text_align_before: u16,
+    position_before: u16,
+    box_type_transformation: FfiBoxTypeTransformation,
+    element_style_adjustment: FfiElementStyleAdjustment,
 }
 
 fn empty_longhand_driver_results() -> FfiLonghandDriverResults {
@@ -2997,28 +2994,8 @@ fn empty_longhand_driver_results() -> FfiLonghandDriverResults {
         explicitly_inherited_non_inherited_property: false,
         uses_tree_counting_function: false,
         effective_color_scheme: -1,
-        post_compute_adjustment: FfiPostComputeAdjustment {
-            display_before: FfiDisplay::inline(),
-            float_before: keyword::NONE,
-            overflow_x_before: keyword::VISIBLE,
-            overflow_y_before: keyword::VISIBLE,
-            text_align_before: keyword::START,
-            position_before: keyword::STATIC,
-            box_type_transformation: FfiBoxTypeTransformation {
-                set_float_none: false,
-                changed_display: false,
-                display: FfiDisplay::inline(),
-            },
-            element_style_adjustment: FfiElementStyleAdjustment {
-                changed_display: false,
-                display: FfiDisplay::inline(),
-                set_line_height_normal: false,
-                check_input_line_height: false,
-                set_position_static: false,
-                changed_text_align: false,
-                text_align: keyword::START,
-            },
-        },
+        display_before_box_type_transformation: FfiDisplay::inline(),
+        post_adjusted_longhands: 0,
     }
 }
 
@@ -3223,7 +3200,10 @@ fn publish_longhand_store_batch(
 /// valid snapshot or null,
 /// `environment` at valid element and document facts,
 /// `length_resolution_context` at the context for this stage or null for the
-/// color-scheme stage, and `results` at a valid results block.
+/// color-scheme stage, `input_line_height_metrics` at the metrics for the
+/// remaining stage or null when post-compute adjustments are not wanted,
+/// `line_height_before_adjustments` at its effective value for that stage or
+/// null with the metrics, and `results` at a valid results block.
 #[allow(clippy::too_many_arguments)]
 unsafe fn drive_property_computation(
     longhand_table: *mut ComputedLonghandTable,
@@ -3234,6 +3214,8 @@ unsafe fn drive_property_computation(
     computed_property_words: *const u64,
     phase: u8,
     length_resolution_context: *const FfiLengthResolutionContext,
+    input_line_height_metrics: *const FfiInputLineHeightMetrics,
+    line_height_before_adjustments: *const c_void,
     results: *mut FfiLonghandDriverResults,
     coordinate_overflow_keywords: bool,
 ) -> FfiLonghandStoreBatch {
@@ -4424,7 +4406,7 @@ unsafe fn drive_property_computation(
         let adjustments = compute_element_style_adjustments(&box_type_input, text_align);
         let transformation = adjustments.box_type;
         let element_adjustment = adjustments.element_style;
-        results.post_compute_adjustment = FfiPostComputeAdjustment {
+        let post_compute_adjustment = PostComputeAdjustment {
             display_before,
             float_before,
             overflow_x_before: computed_overflow_x.expect("overflow-x must be computed by the longhand driver"),
@@ -4435,6 +4417,58 @@ unsafe fn drive_property_computation(
             box_type_transformation: transformation,
             element_style_adjustment: element_adjustment,
         };
+        results.display_before_box_type_transformation = display_before;
+        if !input_line_height_metrics.is_null() {
+            assert!(!line_height_before_adjustments.is_null());
+            let line_height_before = unsafe {
+                RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                    line_height_before_adjustments.cast(),
+                ))
+            };
+            longhand_table.set_post_compute_restore_values([
+                (
+                    prop::DISPLAY,
+                    retained_new(StyleValueData::Display {
+                        raw: post_compute_adjustment.display_before.encoded(),
+                    }),
+                ),
+                (
+                    prop::FLOAT,
+                    retained_new(StyleValueData::Keyword {
+                        keyword: post_compute_adjustment.float_before,
+                    }),
+                ),
+                (
+                    prop::OVERFLOW_X,
+                    retained_new(StyleValueData::Keyword {
+                        keyword: post_compute_adjustment.overflow_x_before,
+                    }),
+                ),
+                (
+                    prop::OVERFLOW_Y,
+                    retained_new(StyleValueData::Keyword {
+                        keyword: post_compute_adjustment.overflow_y_before,
+                    }),
+                ),
+                (
+                    prop::TEXT_ALIGN,
+                    retained_new(StyleValueData::Keyword {
+                        keyword: post_compute_adjustment.text_align_before,
+                    }),
+                ),
+                (
+                    prop::POSITION,
+                    retained_new(StyleValueData::Keyword {
+                        keyword: post_compute_adjustment.position_before,
+                    }),
+                ),
+                (prop::LINE_HEIGHT, line_height_before),
+            ]);
+            results.post_adjusted_longhands =
+                apply_post_compute_adjustments(longhand_table, &post_compute_adjustment, unsafe {
+                    &*input_line_height_metrics
+                });
+        }
         publish_longhand_store_batch(cpp_store_side_effects, pending_effective_color_scheme)
     })
 }
@@ -4453,6 +4487,8 @@ pub unsafe extern "C" fn rust_drive_property_computation(
     computed_property_words: *const u64,
     phase: u8,
     length_resolution_context: *const FfiLengthResolutionContext,
+    input_line_height_metrics: *const FfiInputLineHeightMetrics,
+    line_height_before_adjustments: *const c_void,
     results: *mut FfiLonghandDriverResults,
 ) -> FfiLonghandStoreBatch {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
@@ -4466,6 +4502,8 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             computed_property_words,
             phase,
             length_resolution_context,
+            input_line_height_metrics,
+            line_height_before_adjustments,
             results,
             true,
         )
@@ -4551,6 +4589,8 @@ pub unsafe extern "C" fn rust_compute_document_longhands(
                     std::ptr::null(),
                     phase,
                     length_resolution_context,
+                    std::ptr::null(),
+                    std::ptr::null(),
                     &raw mut results,
                     true,
                 )
@@ -4677,6 +4717,8 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
                         selected_longhands.as_ptr(),
                         phase,
                         length_resolution_context,
+                        std::ptr::null(),
+                        std::ptr::null(),
                         &raw mut results,
                         false,
                     )
@@ -4721,123 +4763,110 @@ pub unsafe extern "C" fn rust_longhand_store_batch_destroy(storage: *mut c_void)
     abort_on_panic(|| drop(unsafe { Box::from_raw(storage.cast::<Vec<FfiComputedStoreEntry>>()) }));
 }
 
-/// Applies the post-compute box and element adjustments after C++ has captured
-/// the facade state that precedes them.
-///
-/// # Safety
-/// `longhand_table`, `adjustment`, and `input_line_height_metrics` must point at
-/// the live objects for the longhand drive that immediately preceded this call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_apply_post_compute_adjustments(
-    longhand_table: *mut ComputedLonghandTable,
-    adjustment: *const FfiPostComputeAdjustment,
-    input_line_height_metrics: *const FfiInputLineHeightMetrics,
+fn apply_post_compute_adjustments(
+    longhand_table: &mut ComputedLonghandTable,
+    adjustment: &PostComputeAdjustment,
+    input_line_height_metrics: &FfiInputLineHeightMetrics,
 ) -> u8 {
-    abort_on_panic(|| {
-        use crate::css::property_metadata::property_id as prop;
+    use crate::css::property_metadata::property_id as prop;
 
-        let adjustment = unsafe { &*adjustment };
-        let transformation = adjustment.box_type_transformation;
-        let element_adjustment = adjustment.element_style_adjustment;
-        let input_line_height_metrics = unsafe { &*input_line_height_metrics };
-        let clamp_input_line_height = should_clamp_input_line_height(&element_adjustment, input_line_height_metrics);
-        let display_after_box_type_transformation = if transformation.changed_display {
-            transformation.display
-        } else {
-            adjustment.display_before
-        };
-        let adjusted_display = if element_adjustment.changed_display {
-            element_adjustment.display
-        } else {
-            display_after_box_type_transformation
-        };
-        let adjusted_entry = |property_id, computed_kind, value| FfiComputedStoreEntry {
-            property_id,
-            inherited_property_id: property_id,
-            data: initial_value_data(property_id).cast(),
-            source_slot: -1,
-            has_style_sheet_context: false,
-            inheritance_dependent: false,
-            inherited: false,
-            computed_data: std::ptr::null(),
-            computed_kind,
-            value,
-        };
-        let mut post_adjusted_longhands = 0;
-        let mut adjustments = Vec::new();
-        if transformation.set_float_none {
-            post_adjusted_longhands |= POST_ADJUSTED_FLOAT;
-            adjustments.push(adjusted_entry(prop::FLOAT, COMPUTED_KIND_KEYWORD, keyword::NONE as f64));
-        }
-        if adjusted_display != adjustment.display_before {
-            post_adjusted_longhands |= POST_ADJUSTED_DISPLAY;
-            adjustments.push(adjusted_entry(
-                prop::DISPLAY,
-                COMPUTED_KIND_DISPLAY,
-                adjusted_display.encoded() as f64,
-            ));
-        }
-        let line_height_changed = element_adjustment.set_line_height_normal || clamp_input_line_height;
-        if line_height_changed {
-            post_adjusted_longhands |= POST_ADJUSTED_LINE_HEIGHT;
-            adjustments.push(adjusted_entry(
-                prop::LINE_HEIGHT,
-                COMPUTED_KIND_KEYWORD,
-                keyword::NORMAL as f64,
-            ));
-        }
-        if element_adjustment.set_position_static {
-            post_adjusted_longhands |= POST_ADJUSTED_POSITION;
-            adjustments.push(adjusted_entry(
-                prop::POSITION,
-                COMPUTED_KIND_KEYWORD,
-                keyword::STATIC as f64,
-            ));
-        }
-        if element_adjustment.changed_text_align {
-            post_adjusted_longhands |= POST_ADJUSTED_TEXT_ALIGN;
-            adjustments.push(adjusted_entry(
-                prop::TEXT_ALIGN,
-                COMPUTED_KIND_KEYWORD,
-                element_adjustment.text_align as f64,
-            ));
-        }
-        if !adjustments.is_empty() {
-            let longhand_table = unsafe { &mut *longhand_table };
-            for entry in &adjustments {
-                store_computed_value(longhand_table, entry);
-            }
-            longhand_table.finish_drive_inheritance_dependent_values();
-        }
-        if matches!(
-            adjustment.text_align_before,
-            keyword::MATCH_PARENT | keyword::_LIBWEB_INHERIT_OR_CENTER
-        ) {
-            unsafe { &mut *longhand_table }.add_inheritance_dependent_value(
-                prop::TEXT_ALIGN,
-                retained_new(StyleValueData::Keyword {
-                    keyword: adjustment.text_align_before,
-                }),
-            );
-        }
-
-        let longhand_table = unsafe { &mut *longhand_table };
-        let mut clear_adjusted_flags = |changed, property_id| {
-            if changed {
-                longhand_table.set_important(property_id, false);
-                longhand_table.set_inherited(property_id, false);
-            }
-        };
-        clear_adjusted_flags(transformation.set_float_none, prop::FLOAT);
-        clear_adjusted_flags(
-            transformation.changed_display || element_adjustment.changed_display,
+    let transformation = adjustment.box_type_transformation;
+    let element_adjustment = adjustment.element_style_adjustment;
+    let clamp_input_line_height = should_clamp_input_line_height(&element_adjustment, input_line_height_metrics);
+    let display_after_box_type_transformation = if transformation.changed_display {
+        transformation.display
+    } else {
+        adjustment.display_before
+    };
+    let adjusted_display = if element_adjustment.changed_display {
+        element_adjustment.display
+    } else {
+        display_after_box_type_transformation
+    };
+    let adjusted_entry = |property_id, computed_kind, value| FfiComputedStoreEntry {
+        property_id,
+        inherited_property_id: property_id,
+        data: initial_value_data(property_id).cast(),
+        source_slot: -1,
+        has_style_sheet_context: false,
+        inheritance_dependent: false,
+        inherited: false,
+        computed_data: std::ptr::null(),
+        computed_kind,
+        value,
+    };
+    let mut post_adjusted_longhands = 0;
+    let mut adjustments = Vec::new();
+    if transformation.set_float_none {
+        post_adjusted_longhands |= POST_ADJUSTED_FLOAT;
+        adjustments.push(adjusted_entry(prop::FLOAT, COMPUTED_KIND_KEYWORD, keyword::NONE as f64));
+    }
+    if adjusted_display != adjustment.display_before {
+        post_adjusted_longhands |= POST_ADJUSTED_DISPLAY;
+        adjustments.push(adjusted_entry(
             prop::DISPLAY,
+            COMPUTED_KIND_DISPLAY,
+            adjusted_display.encoded() as f64,
+        ));
+    }
+    let line_height_changed = element_adjustment.set_line_height_normal || clamp_input_line_height;
+    if line_height_changed {
+        post_adjusted_longhands |= POST_ADJUSTED_LINE_HEIGHT;
+        adjustments.push(adjusted_entry(
+            prop::LINE_HEIGHT,
+            COMPUTED_KIND_KEYWORD,
+            keyword::NORMAL as f64,
+        ));
+    }
+    if element_adjustment.set_position_static {
+        post_adjusted_longhands |= POST_ADJUSTED_POSITION;
+        adjustments.push(adjusted_entry(
+            prop::POSITION,
+            COMPUTED_KIND_KEYWORD,
+            keyword::STATIC as f64,
+        ));
+    }
+    if element_adjustment.changed_text_align {
+        post_adjusted_longhands |= POST_ADJUSTED_TEXT_ALIGN;
+        adjustments.push(adjusted_entry(
+            prop::TEXT_ALIGN,
+            COMPUTED_KIND_KEYWORD,
+            element_adjustment.text_align as f64,
+        ));
+    }
+    if !adjustments.is_empty() {
+        for entry in &adjustments {
+            store_computed_value(longhand_table, entry);
+        }
+        longhand_table.finish_drive_inheritance_dependent_values();
+    }
+    if matches!(
+        adjustment.text_align_before,
+        keyword::MATCH_PARENT | keyword::_LIBWEB_INHERIT_OR_CENTER
+    ) {
+        longhand_table.add_inheritance_dependent_value(
+            prop::TEXT_ALIGN,
+            retained_new(StyleValueData::Keyword {
+                keyword: adjustment.text_align_before,
+            }),
         );
-        clear_adjusted_flags(line_height_changed, prop::LINE_HEIGHT);
-        clear_adjusted_flags(element_adjustment.set_position_static, prop::POSITION);
-        clear_adjusted_flags(element_adjustment.changed_text_align, prop::TEXT_ALIGN);
-        post_adjusted_longhands
-    })
+    }
+
+    let mut clear_adjusted_flags = |changed, property_id| {
+        if changed {
+            longhand_table.set_important(property_id, false);
+            longhand_table.set_inherited(property_id, false);
+        }
+    };
+    clear_adjusted_flags(transformation.set_float_none, prop::FLOAT);
+    clear_adjusted_flags(
+        transformation.changed_display || element_adjustment.changed_display,
+        prop::DISPLAY,
+    );
+    clear_adjusted_flags(line_height_changed, prop::LINE_HEIGHT);
+    clear_adjusted_flags(element_adjustment.set_position_static, prop::POSITION);
+    clear_adjusted_flags(element_adjustment.changed_text_align, prop::TEXT_ALIGN);
+    post_adjusted_longhands
 }
 
 fn property_affects_font_metrics(property_id: u16) -> bool {
@@ -5091,6 +5120,8 @@ pub enum FfiStyleFinalizationMode {
     TextAlign,
     All,
     Overflow,
+    RestorePostCompute,
+    RestorePostComputeTextAlign,
 }
 
 #[repr(C)]
@@ -5479,7 +5510,7 @@ fn compute_text_align_adjustment(
 /// `input` must point at a live `FfiStyleFinalizationInput`. `longhand_table`
 /// may be null for a decision-only query; otherwise it must be a live mutable
 /// table, `animated_overlay` null or a live mutable overlay, and
-/// `input_line_height_metrics` a live metrics snapshot.
+/// `input_line_height_metrics` a live metrics snapshot when adjustments use it.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_finalize_style(
     input: *const FfiStyleFinalizationInput,
@@ -5559,6 +5590,27 @@ pub unsafe extern "C" fn rust_finalize_style(
         }
 
         let longhand_table = unsafe { &mut *longhand_table };
+        if matches!(
+            input.mode,
+            FfiStyleFinalizationMode::RestorePostCompute | FfiStyleFinalizationMode::RestorePostComputeTextAlign
+        ) {
+            let only_property =
+                (input.mode == FfiStyleFinalizationMode::RestorePostComputeTextAlign).then_some(prop::TEXT_ALIGN);
+            let restored = longhand_table.restore_post_compute_values(only_property);
+            for &property_id in &restored.properties[..restored.count] {
+                finalization.invalidated_longhands |= match property_id {
+                    prop::FLOAT => FINALIZED_FLOAT,
+                    prop::DISPLAY => FINALIZED_DISPLAY,
+                    prop::LINE_HEIGHT => FINALIZED_LINE_HEIGHT,
+                    prop::POSITION => FINALIZED_POSITION,
+                    prop::TEXT_ALIGN => FINALIZED_TEXT_ALIGN,
+                    prop::OVERFLOW_X => FINALIZED_OVERFLOW_X,
+                    prop::OVERFLOW_Y => FINALIZED_OVERFLOW_Y,
+                    _ => unreachable!("only post-compute inputs are restorable"),
+                };
+            }
+            return finalization;
+        }
         let mut animated_overlay = unsafe { animated_overlay.as_mut() };
         let animated_box_type = input.mode == FfiStyleFinalizationMode::AnimatedBoxType;
         let animated_display_missing = animated_box_type

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -19,6 +19,7 @@ use std::ffi::c_void;
 use std::sync::{Arc, OnceLock};
 
 use crate::abort_on_panic;
+use crate::css::animated_overlay::AnimatedOverlay;
 use crate::css::cascaded_properties::CascadedPropertyStore;
 use crate::css::computed_longhand_table::ComputedLonghandTable;
 use crate::css::css_pixels::CssPixels;
@@ -5071,7 +5072,16 @@ pub struct FfiStyleFinalization {
     pub element_style: FfiElementStyleAdjustments,
     pub overflow: FfiEffectiveOverflow,
     pub text_align: FfiTextAlignAdjustment,
+    pub invalidated_longhands: u16,
 }
+
+pub const FINALIZED_FLOAT: u16 = 1 << 0;
+pub const FINALIZED_DISPLAY: u16 = 1 << 1;
+pub const FINALIZED_LINE_HEIGHT: u16 = 1 << 2;
+pub const FINALIZED_POSITION: u16 = 1 << 3;
+pub const FINALIZED_TEXT_ALIGN: u16 = 1 << 4;
+pub const FINALIZED_OVERFLOW_X: u16 = 1 << 5;
+pub const FINALIZED_OVERFLOW_Y: u16 = 1 << 6;
 
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -5466,11 +5476,21 @@ fn compute_text_align_adjustment(
 /// computation. Callers select the decisions whose results they need.
 ///
 /// # Safety
-/// `input` must point at a live `FfiStyleFinalizationInput`.
+/// `input` must point at a live `FfiStyleFinalizationInput`. `longhand_table`
+/// may be null for a decision-only query; otherwise it must be a live mutable
+/// table, `animated_overlay` null or a live mutable overlay, and
+/// `input_line_height_metrics` a live metrics snapshot.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_finalize_style(input: *const FfiStyleFinalizationInput) -> FfiStyleFinalization {
+pub unsafe extern "C" fn rust_finalize_style(
+    input: *const FfiStyleFinalizationInput,
+    longhand_table: *mut ComputedLonghandTable,
+    animated_overlay: *mut AnimatedOverlay,
+    input_line_height_metrics: *const FfiInputLineHeightMetrics,
+) -> FfiStyleFinalization {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     abort_on_panic(|| {
+        use crate::css::property_metadata::property_id as prop;
+
         let input = unsafe { &*input };
         let element_style = if matches!(
             input.mode,
@@ -5528,11 +5548,187 @@ pub unsafe extern "C" fn rust_finalize_style(input: *const FfiStyleFinalizationI
                 inherited: false,
             }
         };
-        FfiStyleFinalization {
+        let mut finalization = FfiStyleFinalization {
             element_style,
             overflow,
             text_align,
+            invalidated_longhands: 0,
+        };
+        if longhand_table.is_null() {
+            return finalization;
         }
+
+        let longhand_table = unsafe { &mut *longhand_table };
+        let mut animated_overlay = unsafe { animated_overlay.as_mut() };
+        let animated_box_type = input.mode == FfiStyleFinalizationMode::AnimatedBoxType;
+        let animated_display_missing = animated_box_type
+            && animated_overlay
+                .as_deref()
+                .is_none_or(|overlay| overlay.get(prop::DISPLAY).is_none());
+        let mut invalidated_longhands = 0;
+        {
+            let mut set_adjusted_property = |property_id: u16, value: RetainedStyleValueData, flag: u16| {
+                let animated_metadata = animated_overlay
+                    .as_deref()
+                    .and_then(|overlay| overlay.get(property_id))
+                    .map(|entry| (entry.inherited, entry.result_of_transition));
+                if animated_box_type {
+                    let effective = longhand_table.effective_value(animated_overlay.as_deref(), property_id, true);
+                    let effective_value = unsafe { &*effective.value.cast::<StyleValueData>() };
+                    if effective_value == value.data() {
+                        return;
+                    }
+                    let (inherited, result_of_transition) = animated_metadata.unwrap_or((false, false));
+                    animated_overlay
+                        .as_deref_mut()
+                        .expect("animated box-type finalization requires an overlay")
+                        .set_owned(property_id, value, inherited, result_of_transition);
+                    return;
+                }
+                if let Some((inherited, result_of_transition)) = animated_metadata {
+                    animated_overlay.as_deref_mut().unwrap().set_owned(
+                        property_id,
+                        value.clone(),
+                        inherited,
+                        result_of_transition,
+                    );
+                }
+                longhand_table.set(property_id, value, -1);
+                longhand_table.set_important(property_id, false);
+                longhand_table.set_inherited(property_id, false);
+                invalidated_longhands |= flag;
+            };
+
+            if matches!(
+                input.mode,
+                FfiStyleFinalizationMode::BoxType
+                    | FfiStyleFinalizationMode::AnimatedBoxType
+                    | FfiStyleFinalizationMode::All
+            ) {
+                if animated_display_missing {
+                    set_adjusted_property(
+                        prop::DISPLAY,
+                        retained_new(StyleValueData::Display {
+                            raw: input.box_type.display.encoded(),
+                        }),
+                        FINALIZED_DISPLAY,
+                    );
+                }
+                if finalization.element_style.box_type.set_float_none {
+                    set_adjusted_property(
+                        prop::FLOAT,
+                        retained_new(StyleValueData::Keyword { keyword: keyword::NONE }),
+                        FINALIZED_FLOAT,
+                    );
+                }
+                if finalization.element_style.box_type.changed_display {
+                    set_adjusted_property(
+                        prop::DISPLAY,
+                        retained_new(StyleValueData::Display {
+                            raw: finalization.element_style.box_type.display.encoded(),
+                        }),
+                        FINALIZED_DISPLAY,
+                    );
+                }
+                let element_style = finalization.element_style.element_style;
+                if element_style.changed_display {
+                    set_adjusted_property(
+                        prop::DISPLAY,
+                        retained_new(StyleValueData::Display {
+                            raw: element_style.display.encoded(),
+                        }),
+                        FINALIZED_DISPLAY,
+                    );
+                }
+                if element_style.set_position_static {
+                    set_adjusted_property(
+                        prop::POSITION,
+                        retained_new(StyleValueData::Keyword {
+                            keyword: keyword::STATIC,
+                        }),
+                        FINALIZED_POSITION,
+                    );
+                }
+                if element_style.changed_text_align {
+                    set_adjusted_property(
+                        prop::TEXT_ALIGN,
+                        retained_new(StyleValueData::Keyword {
+                            keyword: element_style.text_align,
+                        }),
+                        FINALIZED_TEXT_ALIGN,
+                    );
+                }
+                if element_style.set_line_height_normal
+                    || (element_style.check_input_line_height
+                        && should_clamp_input_line_height(&element_style, unsafe { &*input_line_height_metrics }))
+                {
+                    set_adjusted_property(
+                        prop::LINE_HEIGHT,
+                        retained_new(StyleValueData::Keyword {
+                            keyword: keyword::NORMAL,
+                        }),
+                        FINALIZED_LINE_HEIGHT,
+                    );
+                }
+            }
+        }
+        finalization.invalidated_longhands = invalidated_longhands;
+
+        if finalization.overflow.changed_x {
+            longhand_table.set(
+                prop::OVERFLOW_X,
+                retained_new(StyleValueData::Keyword {
+                    keyword: finalization.overflow.x_keyword,
+                }),
+                -1,
+            );
+            longhand_table.set_important(prop::OVERFLOW_X, false);
+            longhand_table.set_inherited(prop::OVERFLOW_X, false);
+            finalization.invalidated_longhands |= FINALIZED_OVERFLOW_X;
+        }
+        if finalization.overflow.changed_y {
+            longhand_table.set(
+                prop::OVERFLOW_Y,
+                retained_new(StyleValueData::Keyword {
+                    keyword: finalization.overflow.y_keyword,
+                }),
+                -1,
+            );
+            longhand_table.set_important(prop::OVERFLOW_Y, false);
+            longhand_table.set_inherited(prop::OVERFLOW_Y, false);
+            finalization.invalidated_longhands |= FINALIZED_OVERFLOW_Y;
+        }
+        if matches!(
+            input.mode,
+            FfiStyleFinalizationMode::TextAlign | FfiStyleFinalizationMode::All
+        ) && matches!(
+            input.text_align,
+            keyword::MATCH_PARENT | keyword::_LIBWEB_INHERIT_OR_CENTER
+        ) {
+            longhand_table.add_inheritance_dependent_value(
+                prop::TEXT_ALIGN,
+                retained_new(StyleValueData::Keyword {
+                    keyword: input.text_align,
+                }),
+            );
+            finalization.invalidated_longhands |= FINALIZED_TEXT_ALIGN;
+        }
+        if finalization.text_align.changed {
+            longhand_table.set(
+                prop::TEXT_ALIGN,
+                retained_new(StyleValueData::Keyword {
+                    keyword: finalization.text_align.keyword,
+                }),
+                -1,
+            );
+            longhand_table.set_important(prop::TEXT_ALIGN, false);
+            longhand_table.set_inherited(prop::TEXT_ALIGN, finalization.text_align.inherited);
+            finalization.invalidated_longhands |= FINALIZED_TEXT_ALIGN;
+        }
+        if let Some(overlay) = animated_overlay {
+            overlay.refresh_ffi_entries();
+        }
+        finalization
     })
 }
 
@@ -5735,7 +5931,8 @@ mod tests {
             parent_direction_is_ltr: true,
         };
 
-        let finalization = unsafe { rust_finalize_style(&input) };
+        let finalization =
+            unsafe { rust_finalize_style(&input, std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null()) };
         assert!(finalization.element_style.box_type.changed_display);
         assert!(finalization.element_style.box_type.display.is_block_outside());
         assert!(finalization.element_style.element_style.changed_display);
@@ -5744,6 +5941,28 @@ mod tests {
         assert_eq!(finalization.overflow.x_keyword, keyword::AUTO);
         assert!(finalization.text_align.changed);
         assert_eq!(finalization.text_align.keyword, keyword::RIGHT);
+    }
+
+    #[test]
+    fn style_finalization_does_not_require_unused_line_height_metrics() {
+        let input = FfiStyleFinalizationInput {
+            mode: FfiStyleFinalizationMode::BoxType,
+            box_type: element_adjustment_input(),
+            overflow_x: keyword::VISIBLE,
+            overflow_y: keyword::VISIBLE,
+            text_align: keyword::START,
+            is_th_element: false,
+            has_parent_with_computed_values: false,
+            parent_text_align: keyword::START,
+            parent_direction_is_ltr: true,
+        };
+        let longhand_table = crate::css::computed_longhand_table::rust_computed_longhand_table_create();
+
+        let finalization =
+            unsafe { rust_finalize_style(&input, longhand_table, std::ptr::null_mut(), std::ptr::null()) };
+
+        assert_eq!(finalization.invalidated_longhands, 0);
+        unsafe { crate::css::computed_longhand_table::rust_computed_longhand_table_release(longhand_table) };
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/Rust/src/css/style_value.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_value.rs
@@ -237,6 +237,20 @@ fn scan_custom_property_references(
     all_references_visible
 }
 
+pub(crate) fn custom_property_references(value: &StyleValueData) -> Option<(Vec<Vec<u16>>, bool)> {
+    let StyleValueData::Unresolved { components, .. } = value else {
+        return None;
+    };
+    let mut references = Vec::new();
+    unsafe extern "C" fn collect(context: *mut c_void, name: *const u16, name_length: usize) {
+        let references = unsafe { &mut *context.cast::<Vec<Vec<u16>>>() };
+        references.push(unsafe { std::slice::from_raw_parts(name, name_length) }.to_vec());
+    }
+    let all_references_visible =
+        scan_custom_property_references(components.as_slice(), (&raw mut references).cast(), collect);
+    Some((references, all_references_visible))
+}
+
 /// Visits the Typed OM reification of an unresolved style value. Event 0 appends a text segment,
 /// event 1 begins a variable reference, and event 2 ends its optional fallback.
 ///

--- a/Tests/LibWeb/Text/expected/css/animation-effect-batch-rust.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-effect-batch-rust.txt
@@ -2,3 +2,4 @@ opacity: 0.5
 width: 20px
 color: rgb(128, 128, 128)
 animation evaluations: 1
+keyframe longhand drives: 1

--- a/Tests/LibWeb/Text/expected/css/animation-keyframe-relative-url.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-keyframe-relative-url.txt
@@ -1,0 +1,1 @@
+stylesheet-relative image loaded: true

--- a/Tests/LibWeb/Text/expected/css/animation-relative-font-keyframes.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-relative-font-keyframes.txt
@@ -1,0 +1,3 @@
+percentage font size: 60px
+larger font size: 37.5px
+bolder font weight: 700

--- a/Tests/LibWeb/Text/input/css/animation-effect-batch-rust.html
+++ b/Tests/LibWeb/Text/input/css/animation-effect-batch-rust.html
@@ -36,5 +36,6 @@
         println(`color: ${style.color}`);
 
         println(`animation evaluations: ${counters.animationEvaluationEntries}`);
+        println(`keyframe longhand drives: ${counters.animationKeyframeLonghandEntries}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animation-keyframe-relative-url.html
+++ b/Tests/LibWeb/Text/input/css/animation-keyframe-relative-url.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="stylesheet" href="resources/animation-keyframe-relative-url.css">
+<script src="../include.js"></script>
+<div id="target"></div>
+<script>
+    const imageURL = new URL("wpt-import/images/anim-gr.gif", new URL("../", document.baseURI)).href;
+
+    promiseTest(async () => {
+        internals.dumpLayoutTree(document);
+        const state = await waitForImageAnimationState(imageURL, state => state.timerActive);
+        println(`stylesheet-relative image loaded: ${state.timerActive}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animation-relative-font-keyframes.html
+++ b/Tests/LibWeb/Text/input/css/animation-relative-font-keyframes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<style>
+    #parent {
+        font-size: 20px;
+        font-weight: 700;
+    }
+</style>
+<div id="parent">
+    <div id="percentage"></div>
+    <div id="larger"></div>
+    <div id="bolder"></div>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const parentElement = document.getElementById("parent");
+        const animations = [
+            parentElement.animate(
+                {
+                    fontSize: ["30px", "30px"],
+                    fontWeight: ["400", "400"],
+                },
+                100
+            ),
+            percentage.animate({ fontSize: ["200%", "200%"] }, 100),
+            larger.animate({ fontSize: ["larger", "larger"] }, 100),
+            bolder.animate({ fontWeight: ["bolder", "bolder"] }, 100),
+        ];
+        for (const animation of animations) {
+            animation.pause();
+            animation.currentTime = 50;
+        }
+
+        println(`percentage font size: ${getComputedStyle(percentage).fontSize}`);
+        println(`larger font size: ${getComputedStyle(larger).fontSize}`);
+        println(`bolder font weight: ${getComputedStyle(bolder).fontWeight}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/resources/animation-keyframe-relative-url.css
+++ b/Tests/LibWeb/Text/input/css/resources/animation-keyframe-relative-url.css
@@ -1,0 +1,11 @@
+@keyframes animated-image {
+    from, to {
+        background-image: url("../../wpt-import/images/anim-gr.gif");
+    }
+}
+
+#target {
+    width: 100px;
+    height: 50px;
+    animation: animated-image 1s paused;
+}


### PR DESCRIPTION
Move multiple `StyleComputer` orchestration phases into the Rust style core so computations remain in Rust across complete phases instead of returning to C++ for each property or value.

Style preflight drops from five FFI operations to two, style finalization drops from three to one, animation keyframes use one Rust longhand drive per animation evaluation, and custom-property graph resolution uses one bulk entry instead of per-value entries. Sampled animation storage, post-compute adjustment, initial document longhands, monospace font-size recascade, and final longhand application now stay in Rust while narrow callbacks retain DOM-dependent and contextual work.

This removes the C++ custom-property graph traversal, active overlay, property replay loops, and obsolete FFI paths. `StyleComputer.cpp` and `StyleComputer.h` lose 451 net lines while preserving existing invalidation counters and custom-property cycle behavior.