### PR TITLE
LibJS: Transition dense dictionaries back to packed storage

### DIFF
--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -2008,6 +2008,18 @@ void Object::transition_to_dictionary()
     m_indexed_storage_kind = IndexedStorageKind::Dictionary;
 }
 
+NEVER_INLINE COLD void Object::transition_to_packed()
+{
+    auto* dictionary = indexed_dictionary();
+    auto* elements = allocate_indexed_elements(m_indexed_array_like_size);
+    for (auto const& entry : dictionary->sparse_elements())
+        elements[entry.key] = entry.value.value;
+
+    delete dictionary;
+    m_indexed_elements = elements;
+    m_indexed_storage_kind = IndexedStorageKind::Packed;
+}
+
 Optional<ValueAndAttributes> Object::indexed_get(u32 index) const
 {
     switch (m_indexed_storage_kind) {
@@ -2031,6 +2043,21 @@ Optional<ValueAndAttributes> Object::indexed_get(u32 index) const
     VERIFY_NOT_REACHED();
 }
 
+NEVER_INLINE COLD void Object::indexed_put_into_dictionary(u32 index, Value value, PropertyAttributes attributes)
+{
+    auto* dictionary = indexed_dictionary();
+    auto had_missing_entries = dictionary->size() < dictionary->array_like_size();
+    dictionary->put(index, value, attributes);
+    m_indexed_array_like_size = dictionary->array_like_size();
+    if (!had_missing_entries || dictionary->size() < dictionary->array_like_size())
+        return;
+    for (auto const& entry : dictionary->sparse_elements()) {
+        if (entry.value.attributes != default_attributes || entry.value.value.is_special_empty_value())
+            return;
+    }
+    transition_to_packed();
+}
+
 void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
 {
     bool const storing_hole = value.is_special_empty_value();
@@ -2039,8 +2066,7 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
         materialized_elements = min(m_indexed_array_like_size, indexed_elements_capacity());
 
     if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
-        indexed_dictionary()->put(index, value, attributes);
-        m_indexed_array_like_size = indexed_dictionary()->array_like_size();
+        indexed_put_into_dictionary(index, value, attributes);
         return;
     }
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -465,6 +465,8 @@ private:
     void ensure_indexed_elements(u32 needed_capacity);
     void grow_indexed_elements(u32 needed_capacity);
     void transition_to_dictionary();
+    NEVER_INLINE COLD void transition_to_packed();
+    NEVER_INLINE COLD void indexed_put_into_dictionary(u32, Value, PropertyAttributes);
     void free_indexed_elements();
     void ensure_named_storage_capacity(u32 needed);
     bool named_storage_is_inline() const { return m_named_properties == m_inline_named_storage; }


### PR DESCRIPTION
Arrays that temporarily became sparse stayed in dictionary storage after their last missing index was filled. Subsequent indexed reads continued to pay for hash table lookups.

Transition eligible dictionaries back to packed storage when a write fills their last missing entry. Only inspect entries at that boundary to avoid repeated linear scans for dense dictionaries.

Improves [Minecraft4k](<https://theintraclinic.com/archive/minecraft4k-js/>) from 10.2 to 14.5 FPS on my machine. A specific MicroBench test case `array-dictionary-to-packed.js` was added which goes from running in 248ms down to 95ms (2.6x faster).

<details>
<summary>Full js-benchmarks before/after</summary>

```
Suite           Test                                      Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
SunSpider       3d-cube.js                                1.102      0.040 ± 0.040 … 0.040              0.036 ± 0.036 … 0.037              +0.1% (+0.0 MB)
SunSpider       3d-morph.js                               1.116      0.040 ± 0.039 … 0.040              0.035 ± 0.035 … 0.036              +0.0% (+0.0 MB)
SunSpider       3d-raytrace.js                            1.122      0.043 ± 0.042 … 0.045              0.038 ± 0.038 … 0.039              +0.0% (+0.0 MB)
SunSpider       access-binary-trees.js                    1.102      0.038 ± 0.037 … 0.039              0.035 ± 0.034 … 0.035              -0.0% (-0.0 MB)
SunSpider       access-fannkuch.js                        1.081      0.043 ± 0.042 … 0.043              0.039 ± 0.039 … 0.041              +0.1% (+0.0 MB)
SunSpider       access-nbody.js                           1.098      0.039 ± 0.038 … 0.040              0.036 ± 0.035 … 0.036              -0.1% (-0.0 MB)
SunSpider       access-nsieve.js                          1.103      0.037 ± 0.036 … 0.037              0.033 ± 0.032 … 0.034              -0.0% (-0.0 MB)
SunSpider       bitops-3bit-bits-in-byte.js               0.997      0.032 ± 0.031 … 0.033              0.032 ± 0.031 … 0.033              +0.0% (+0.0 MB)
SunSpider       bitops-bits-in-byte.js                    0.956      0.033 ± 0.032 … 0.034              0.034 ± 0.033 … 0.036              -0.0% (-0.0 MB)
SunSpider       bitops-bitwise-and.js                     1.071      0.040 ± 0.039 … 0.041              0.037 ± 0.036 … 0.038              -0.1% (-0.0 MB)
SunSpider       bitops-nsieve-bits.js                     1.089      0.038 ± 0.037 … 0.038              0.035 ± 0.034 … 0.035              +0.1% (+0.0 MB)
SunSpider       controlflow-recursive.js                  1.088      0.035 ± 0.034 … 0.037              0.032 ± 0.032 … 0.033              +0.1% (+0.0 MB)
SunSpider       crypto-aes.js                             1.108      0.040 ± 0.039 … 0.040              0.036 ± 0.036 … 0.037              +0.0% (+0.0 MB)
SunSpider       crypto-md5.js                             1.094      0.036 ± 0.036 … 0.037              0.033 ± 0.032 … 0.034              -0.1% (-0.0 MB)
SunSpider       crypto-sha1.js                            1.105      0.036 ± 0.035 … 0.037              0.033 ± 0.032 … 0.033              +0.1% (+0.0 MB)
SunSpider       date-format-tofte.js                      1.074      0.073 ± 0.072 … 0.074              0.068 ± 0.067 … 0.068              +0.0% (+0.0 MB)
SunSpider       date-format-xparb.js                      1.049      0.053 ± 0.053 … 0.053              0.051 ± 0.050 … 0.052              +0.0% (+0.0 MB)
SunSpider       math-cordic.js                            1.072      0.042 ± 0.042 … 0.043              0.039 ± 0.038 … 0.041              +0.1% (+0.0 MB)
SunSpider       math-partial-sums.js                      1.136      0.038 ± 0.037 … 0.038              0.033 ± 0.033 … 0.034              -0.1% (-0.0 MB)
SunSpider       math-spectral-norm.js                     1.109      0.037 ± 0.036 … 0.038              0.033 ± 0.033 … 0.034              +0.1% (+0.0 MB)
SunSpider       regexp-dna.js                             1.001      0.169 ± 0.168 … 0.171              0.169 ± 0.168 … 0.170              -0.1% (-0.0 MB)
SunSpider       string-base64.js                          1.098      0.040 ± 0.039 … 0.040              0.036 ± 0.035 … 0.037              +0.2% (+0.0 MB)
SunSpider       string-fasta.js                           1.075      0.046 ± 0.046 … 0.046              0.043 ± 0.043 … 0.043              +0.0% (+0.0 MB)
SunSpider       string-tagcloud.js                        1.066      0.060 ± 0.058 … 0.061              0.056 ± 0.056 … 0.056              +0.1% (+0.0 MB)
SunSpider       string-unpack-code.js                     1.052      0.065 ± 0.065 … 0.065              0.062 ± 0.061 … 0.062              +0.1% (+0.0 MB)
SunSpider       string-validate-input.js                  1.093      0.040 ± 0.039 … 0.042              0.037 ± 0.037 … 0.037              -0.0% (-0.0 MB)
LongSpider      3d-cube.js                                0.990      2.914 ± 2.873 … 2.941              2.942 ± 2.935 … 2.954              -0.3% (-0.1 MB)
LongSpider      3d-morph.js                               0.997      1.137 ± 1.137 … 1.138              1.140 ± 1.136 … 1.144              +0.2% (+0.0 MB)
LongSpider      3d-raytrace.js                            0.983      2.123 ± 2.120 … 2.124              2.159 ± 2.148 … 2.167              -0.1% (-0.0 MB)
LongSpider      access-binary-trees.js                    0.998      6.900 ± 6.872 … 6.949              6.913 ± 6.875 … 6.945              -0.5% (-0.9 MB)
LongSpider      access-fannkuch.js                        0.990      1.107 ± 1.106 … 1.109              1.118 ± 1.110 … 1.131              +0.0% (+0.0 MB)
LongSpider      access-nbody.js                           0.998      3.097 ± 3.091 … 3.105              3.103 ± 3.101 … 3.105              +0.1% (+0.0 MB)
LongSpider      access-nsieve.js                          1.002      0.905 ± 0.897 … 0.911              0.903 ± 0.892 … 0.916              +0.0% (+0.1 MB)
LongSpider      bitops-3bit-bits-in-byte.js               1.005      0.270 ± 0.270 … 0.271              0.269 ± 0.267 … 0.271              +0.1% (+0.0 MB)
LongSpider      bitops-bits-in-byte.js                    1.000      0.406 ± 0.381 … 0.429              0.405 ± 0.382 … 0.452              -0.1% (-0.0 MB)
LongSpider      bitops-nsieve-bits.js                     1.007      1.185 ± 1.183 … 1.188              1.177 ± 1.175 … 1.178              -0.0% (-0.0 MB)
LongSpider      controlflow-recursive.js                  0.993      1.773 ± 1.751 … 1.790              1.785 ± 1.757 … 1.800              -0.2% (-0.0 MB)
LongSpider      crypto-aes.js                             0.996      3.413 ± 3.396 … 3.434              3.425 ± 3.397 … 3.452              -0.1% (-0.0 MB)
LongSpider      crypto-md5.js                             1.008      3.352 ± 3.340 … 3.372              3.325 ± 3.313 … 3.334              -0.0% (-0.0 MB)
LongSpider      crypto-sha1.js                            1.014      6.153 ± 6.132 … 6.172              6.069 ± 6.057 … 6.086              +0.0% (+0.0 MB)
LongSpider      date-format-tofte.js                      1.000      4.688 ± 4.682 … 4.694              4.688 ± 4.670 … 4.711              +0.0% (+0.1 MB)
LongSpider      date-format-xparb.js                      1.003      4.106 ± 4.083 … 4.130              4.093 ± 4.086 … 4.099              +0.1% (+0.0 MB)
LongSpider      hash-map.js                               0.997      0.860 ± 0.855 … 0.864              0.862 ± 0.859 … 0.868              -0.0% (-0.0 MB)
LongSpider      math-cordic.js                            0.990      4.024 ± 3.998 … 4.062              4.066 ± 4.029 … 4.098              +0.1% (+0.0 MB)
LongSpider      math-partial-sums.js                      0.995      0.547 ± 0.546 … 0.548              0.549 ± 0.545 … 0.555              +0.0% (+0.0 MB)
LongSpider      math-spectral-norm.js                     1.001      3.239 ± 3.208 … 3.266              3.235 ± 3.219 … 3.263              +0.1% (+0.0 MB)
LongSpider      string-base64.js                          1.000      0.979 ± 0.977 … 0.981              0.979 ± 0.973 … 0.982              -0.0% (-0.0 MB)
LongSpider      string-fasta.js                           1.002      1.265 ± 1.263 … 1.269              1.262 ± 1.258 … 1.264              -0.0% (-0.0 MB)
LongSpider      string-tagcloud.js                        0.989      0.576 ± 0.572 … 0.579              0.582 ± 0.581 … 0.583              -0.1% (-0.1 MB)
Kraken          ai-astar.js                               0.988      0.437 ± 0.434 … 0.438              0.442 ± 0.441 … 0.442              +0.0% (+0.0 MB)
Kraken          audio-beat-detection.js                   1.139      0.384 ± 0.383 … 0.385              0.337 ± 0.336 … 0.338              +0.1% (+0.1 MB)
Kraken          audio-dft.js                              0.991      0.272 ± 0.270 … 0.274              0.275 ± 0.274 … 0.276              +0.0% (+0.0 MB)
Kraken          audio-fft.js                              1.114      0.319 ± 0.317 … 0.320              0.286 ± 0.283 … 0.287              +0.0% (+0.0 MB)
Kraken          audio-oscillator.js                       0.987      0.299 ± 0.298 … 0.299              0.303 ± 0.302 … 0.304              +0.0% (+0.0 MB)
Kraken          imaging-darkroom.js                       0.991      0.460 ± 0.456 … 0.463              0.464 ± 0.463 … 0.465              +0.0% (+0.0 MB)
Kraken          imaging-desaturate.js                     0.996      0.442 ± 0.438 … 0.444              0.443 ± 0.440 … 0.447              +0.0% (+0.0 MB)
Kraken          imaging-gaussian-blur.js                  0.997      1.882 ± 1.880 … 1.886              1.888 ± 1.885 … 1.891              +0.0% (+0.0 MB)
Kraken          json-parse-financial.js                   0.965      0.072 ± 0.072 … 0.074              0.075 ± 0.074 … 0.076              +0.1% (+0.0 MB)
Kraken          json-stringify-tinderbox.js               0.988      0.077 ± 0.076 … 0.077              0.078 ± 0.076 … 0.080              +0.1% (+0.0 MB)
Kraken          stanford-crypto-aes.js                    0.982      0.175 ± 0.175 … 0.176              0.178 ± 0.176 … 0.180              +0.0% (+0.0 MB)
Kraken          stanford-crypto-ccm.js                    0.980      0.141 ± 0.140 … 0.142              0.143 ± 0.143 … 0.144              +0.2% (+0.1 MB)
Kraken          stanford-crypto-pbkdf2.js                 1.004      0.317 ± 0.315 … 0.319              0.316 ± 0.315 … 0.317              +0.1% (+0.0 MB)
Kraken          stanford-crypto-sha256-iterative.js       0.970      0.133 ± 0.133 … 0.134              0.137 ± 0.134 … 0.140              +0.0% (+0.0 MB)
Octane          box2d.js                                  0.991      10196.667 ± 10180.000 … 10210.000  10106.667 ± 10100.000 … 10110.000  +0.2% (+0.2 MB)
Octane          code-load.js                              0.990      29816.000 ± 29685.000 … 29903.000  29518.000 ± 29487.000 … 29535.000  +0.0% (+0.9 MB)
Octane          crypto.js                                 1.003      5091.333 ± 5060.000 … 5131.000     5104.333 ± 5101.000 … 5110.000     +1.0% (+0.4 MB)
Octane          deltablue.js                              0.997      2257.667 ± 2244.000 … 2277.000     2251.667 ± 2241.000 … 2259.000     +0.3% (+0.1 MB)
Octane          earley-boyer.js                           1.001      5419.667 ± 5394.000 … 5449.000     5425.333 ± 5412.000 … 5436.000     +0.8% (+0.4 MB)
Octane          gbemu.js                                  1.000      20687.000 ± 20538.000 … 20823.000  20686.333 ± 20618.000 … 20823.000  +0.0% (+0.0 MB)
Octane          mandreel.js                               1.002      23815.000 ± 23739.000 … 23967.000  23853.000 ± 23853.000 … 23853.000  +0.0% (+0.1 MB)
Octane          navier-stokes.js                          0.978      6034.000 ± 6024.000 … 6048.000     5902.667 ± 5895.000 … 5918.000     -0.1% (-0.0 MB)
Octane          pdfjs.js                                  0.987      10869.667 ± 10792.000 … 10951.000  10730.333 ± 10607.000 … 10792.000  +0.3% (+0.4 MB)
Octane          raytrace.js                               0.995      3457.667 ± 3394.000 … 3493.000     3439.000 ± 3364.000 … 3479.000     +0.4% (+0.2 MB)
Octane          regexp.js                                 0.993      2483.667 ± 2474.000 … 2501.000     2467.000 ± 2460.000 … 2481.000     +0.0% (+0.0 MB)
Octane          richards.js                               0.994      2519.667 ± 2510.000 … 2531.000     2504.333 ± 2503.000 … 2506.000     +0.2% (+0.0 MB)
Octane          splay.js                                  0.986      12415.667 ± 12354.000 … 12451.000  12237.667 ± 12197.000 … 12299.000  +0.2% (+0.7 MB)
Octane          typescript.js                             1.003      29884.667 ± 29502.000 … 30108.000  29961.667 ± 29882.000 … 30100.000  +0.6% (+1.9 MB)
Octane          zlib.js                                   1.001      9014.667 ± 9004.000 … 9026.000     9021.667 ± 9013.000 … 9028.000     +0.1% (+0.1 MB)
GarBench        array-of-objects.js                       1.016      0.518 ± 0.517 … 0.520              0.510 ± 0.510 … 0.511              +0.0% (+0.0 MB)
GarBench        closures.js                               1.011      0.783 ± 0.777 … 0.786              0.775 ± 0.774 … 0.775              +0.0% (+0.0 MB)
GarBench        cyclic-graph.js                           1.064      1.415 ± 1.410 … 1.419              1.330 ± 1.323 … 1.338              +0.0% (+0.0 MB)
GarBench        deep-linked-list.js                       1.014      0.525 ± 0.524 … 0.527              0.518 ± 0.518 … 0.518              -0.0% (-0.0 MB)
GarBench        finalization.js                           1.023      0.727 ± 0.721 … 0.732              0.711 ± 0.706 … 0.718              +0.0% (+0.0 MB)
GarBench        many-properties.js                        1.004      1.605 ± 1.600 … 1.611              1.598 ± 1.592 … 1.606              -0.0% (-0.3 MB)
GarBench        marking-stress.js                         1.022      1.703 ± 1.693 … 1.709              1.666 ± 1.661 … 1.669              +0.0% (+0.0 MB)
GarBench        mixed-sizes.js                            1.011      0.715 ± 0.712 … 0.721              0.707 ± 0.703 … 0.710              -0.0% (-0.0 MB)
GarBench        sparse-arrays.js                          1.003      1.648 ± 1.644 … 1.655              1.644 ± 1.641 … 1.648              +0.0% (+0.0 MB)
GarBench        string-heavy.js                           1.021      0.848 ± 0.846 … 0.850              0.831 ± 0.831 … 0.832              +0.0% (+0.0 MB)
GarBench        wide-tree.js                              1.020      0.802 ± 0.801 … 0.803              0.786 ± 0.784 … 0.788              -0.0% (-0.0 MB)
JetStream       bigfib.cpp.js                             1.001      2.852 ± 2.849 … 2.854              2.849 ± 2.847 … 2.850              -0.0% (-0.1 MB)
JetStream       cdjs.js                                   1.005      1.821 ± 1.816 … 1.826              1.812 ± 1.806 … 1.817              +0.2% (+0.1 MB)
JetStream       container.cpp.js                          1.001      16.268 ± 16.209 … 16.326           16.255 ± 16.200 … 16.283           +0.0% (+0.0 MB)
JetStream       dry.c.js                                  0.991      6.649 ± 6.626 … 6.662              6.712 ± 6.708 … 6.714              +0.1% (+0.0 MB)
JetStream       float-mm.c.js                             0.990      9.774 ± 9.707 … 9.821              9.870 ± 9.829 … 9.910              +0.0% (+0.0 MB)
JetStream       gcc-loops.cpp.js                          1.001      40.404 ± 40.232 … 40.559           40.348 ± 39.961 … 41.012           +0.0% (+0.0 MB)
JetStream       hash-map.js                               0.998      0.846 ± 0.843 … 0.849              0.848 ± 0.841 … 0.856              +0.1% (+0.0 MB)
JetStream       n-body.c.js                               1.004      12.198 ± 12.138 … 12.230           12.147 ± 11.993 … 12.285           +0.0% (+0.0 MB)
JetStream       quicksort.c.js                            0.992      2.156 ± 2.148 … 2.161              2.173 ± 2.170 … 2.178              -0.0% (-0.0 MB)
JetStream       towers.c.js                               1.013      4.994 ± 4.985 … 5.002              4.932 ± 4.917 … 4.945              -0.2% (-0.1 MB)
JetStream3      js-tokens.js                              0.987      0.242 ± 0.240 … 0.246              0.245 ± 0.245 … 0.245              -0.1% (-0.0 MB)
JetStream3      lazy-collections.js                       1.012      0.715 ± 0.709 … 0.722              0.707 ± 0.704 … 0.709              +0.2% (+0.1 MB)
JetStream3      raytrace-private-class-fields.js          1.007      3.340 ± 3.332 … 3.345              3.318 ± 3.299 … 3.329              +1.9% (+0.7 MB)
JetStream3      raytrace-public-class-fields.js           1.001      2.515 ± 2.505 … 2.527              2.514 ± 2.511 … 2.515              +0.1% (+0.0 MB)
JetStream3      sync-file-system.js                       1.011      1.375 ± 1.367 … 1.384              1.360 ± 1.348 … 1.367              -1.3% (-0.4 MB)
JetStreamExtra  FlightPlanner.js                          1.004      0.698 ± 0.693 … 0.704              0.695 ± 0.691 … 0.698              -0.0% (-0.0 MB)
JetStreamExtra  OfflineAssembler.js                       1.000      1.107 ± 1.104 … 1.109              1.107 ± 1.105 … 1.108              -0.5% (-0.4 MB)
JetStreamExtra  UniPoker.js                               0.997      1.610 ± 1.605 … 1.614              1.614 ± 1.611 … 1.618              +0.5% (+0.2 MB)
JetStreamExtra  async-fs.js                               1.003      1.219 ± 1.215 … 1.224              1.214 ± 1.209 … 1.224              -0.0% (-0.0 MB)
JetStreamExtra  babylonjs-startup-es5.js                  0.997      0.658 ± 0.657 … 0.658              0.660 ± 0.658 … 0.663              +0.0% (+0.1 MB)
JetStreamExtra  babylonjs-startup-es6.js                  0.997      0.781 ± 0.779 … 0.783              0.783 ± 0.781 … 0.787              -0.0% (-0.0 MB)
JetStreamExtra  bigint-bigdenary.js                       1.018      1.461 ± 1.453 … 1.473              1.436 ± 1.429 … 1.443              +0.0% (+0.0 MB)
JetStreamExtra  bigint-noble-bls12-381.js                 1.008      1.635 ± 1.617 … 1.646              1.621 ± 1.612 … 1.628              -0.2% (-0.1 MB)
JetStreamExtra  bigint-noble-ed25519.js                   1.001      1.479 ± 1.475 … 1.486              1.477 ± 1.473 … 1.481              -0.1% (-0.1 MB)
JetStreamExtra  bigint-noble-secp256k1.js                 0.991      1.397 ± 1.394 … 1.399              1.410 ± 1.405 … 1.413              +0.1% (+0.1 MB)
JetStreamExtra  bigint-paillier.js                        1.004      1.539 ± 1.527 … 1.546              1.533 ± 1.531 … 1.535              +0.5% (+0.4 MB)
JetStreamExtra  doxbee-async.js                           0.999      4.352 ± 4.332 … 4.379              4.356 ± 4.349 … 4.367              -0.2% (-0.2 MB)
JetStreamExtra  doxbee-promise.js                         1.001      3.623 ± 3.616 … 3.627              3.620 ± 3.613 … 3.631              +0.1% (+0.2 MB)
JetStreamExtra  first-inspector-code-load.js              1.005      1.301 ± 1.295 … 1.306              1.295 ± 1.286 … 1.300              +0.0% (+0.2 MB)
JetStreamExtra  jsdom-d3-startup.js                       0.991      1.007 ± 1.004 … 1.009              1.015 ± 1.013 … 1.018              +0.0% (+0.1 MB)
JetStreamExtra  json-parse-inspector.js                   1.005      0.742 ± 0.742 … 0.742              0.739 ± 0.735 … 0.742              -0.0% (-0.0 MB)
JetStreamExtra  json-stringify-inspector.js               1.007      0.511 ± 0.508 … 0.514              0.507 ± 0.505 … 0.509              +0.0% (+0.0 MB)
JetStreamExtra  mobx-startup.js                           0.993      1.332 ± 1.327 … 1.341              1.342 ± 1.337 … 1.348              +0.6% (+0.5 MB)
JetStreamExtra  multi-inspector-code-load.js              1.001      1.299 ± 1.296 … 1.303              1.297 ± 1.297 … 1.298              +0.0% (+0.0 MB)
JetStreamExtra  prismjs-startup-es5.js                    1.002      1.385 ± 1.377 … 1.392              1.382 ± 1.377 … 1.386              -0.0% (-0.0 MB)
JetStreamExtra  prismjs-startup-es6.js                    0.997      1.382 ± 1.380 … 1.384              1.386 ± 1.379 … 1.390              -1.6% (-0.9 MB)
JetStreamExtra  proxy-mobx.js                             0.995      1.139 ± 1.132 … 1.147              1.144 ± 1.138 … 1.154              +0.2% (+0.1 MB)
JetStreamExtra  proxy-vue.js                              1.006      0.067 ± 0.066 … 0.069              0.066 ± 0.065 … 0.068              +0.3% (+0.1 MB)
JetStreamExtra  threejs.js                                0.993      1.395 ± 1.392 … 1.399              1.405 ± 1.400 … 1.408              +0.0% (+0.0 MB)
JetStreamExtra  typescript-lib.js                         0.995      0.515 ± 0.511 … 0.520              0.518 ± 0.517 … 0.520              -1.5% (-6.5 MB)
JetStreamExtra  validatorjs.js                            1.001      1.156 ± 1.154 … 1.159              1.154 ± 1.150 … 1.157              -0.1% (-0.1 MB)
JetStreamExtra  web-ssr.js                                0.993      1.328 ± 1.325 … 1.333              1.337 ± 1.335 … 1.339              -0.2% (-0.5 MB)
ARES-6          Air.js                                    1.002      1.307 ± 1.295 … 1.317              1.304 ± 1.296 … 1.312              +0.9% (+2.1 MB)
ARES-6          Babylon.js                                0.994      0.997 ± 0.993 … 1.000              1.003 ± 1.000 … 1.005              +0.2% (+0.2 MB)
ARES-6          Basic.js                                  0.996      1.162 ± 1.158 … 1.167              1.167 ± 1.155 … 1.189              +0.0% (+0.0 MB)
ARES-6          ML.js                                     1.006      1.279 ± 1.278 … 1.281              1.272 ± 1.271 … 1.273              +0.5% (+0.3 MB)
RegExp          speedometer-jquery-regexp-1.js            0.987      0.182 ± 0.181 … 0.183              0.185 ± 0.184 … 0.185              +0.1% (+0.0 MB)
RegExp          speedometer-jquery-regexp-2.js            0.986      0.099 ± 0.099 … 0.101              0.101 ± 0.100 … 0.102              +0.1% (+0.0 MB)
MicroBench      array-destructuring-assignment-rest.js    1.010      0.292 ± 0.291 … 0.293              0.289 ± 0.286 … 0.292              -0.1% (-0.0 MB)
MicroBench      array-destructuring-assignment.js         1.007      1.797 ± 1.790 … 1.811              1.786 ± 1.773 … 1.800              +0.0% (+0.0 MB)
MicroBench      array-dictionary-to-packed.js             2.608      0.248 ± 0.239 … 0.258              0.095 ± 0.094 … 0.097              +0.9% (+0.5 MB)
MicroBench      array-prototype-map.js                    1.011      1.098 ± 1.096 … 1.100              1.087 ± 1.076 … 1.093              +0.0% (+0.0 MB)
MicroBench      array-prototype-shift.js                  1.080      0.038 ± 0.037 … 0.039              0.035 ± 0.035 … 0.035              -0.0% (-0.0 MB)
MicroBench      bound-call-00-args.js                     1.015      1.246 ± 1.236 … 1.258              1.228 ± 1.225 … 1.229              -0.0% (-0.0 MB)
MicroBench      bound-call-04-args.js                     1.009      1.439 ± 1.432 … 1.451              1.426 ± 1.418 … 1.437              -0.1% (-0.0 MB)
MicroBench      bound-call-16-args.js                     1.005      1.589 ± 1.584 … 1.591              1.580 ± 1.566 … 1.607              -0.1% (-0.0 MB)
MicroBench      call-00-args.js                           1.007      0.315 ± 0.312 … 0.319              0.313 ± 0.303 … 0.319              +0.0% (+0.0 MB)
MicroBench      call-01-args.js                           1.034      0.351 ± 0.349 … 0.355              0.340 ± 0.338 … 0.343              -0.1% (-0.0 MB)
MicroBench      call-02-args.js                           1.042      0.359 ± 0.357 … 0.363              0.345 ± 0.344 … 0.346              -0.0% (-0.0 MB)
MicroBench      call-03-args.js                           1.060      0.373 ± 0.372 … 0.374              0.352 ± 0.352 … 0.353              -0.0% (-0.0 MB)
MicroBench      call-04-args.js                           1.069      0.387 ± 0.385 … 0.388              0.362 ± 0.361 … 0.362              +0.0% (+0.0 MB)
MicroBench      call-16-args.js                           1.017      0.497 ± 0.491 … 0.501              0.489 ± 0.487 … 0.490              +0.1% (+0.0 MB)
MicroBench      call-32-args.js                           1.001      0.688 ± 0.684 … 0.694              0.688 ± 0.685 … 0.689              -0.0% (-0.0 MB)
MicroBench      for-in-indexed-properties.js              1.061      0.180 ± 0.178 … 0.181              0.169 ± 0.169 … 0.170              -0.0% (-0.0 MB)
MicroBench      for-in-named-properties.js                1.023      0.163 ± 0.162 … 0.163              0.159 ± 0.158 … 0.160              +0.1% (+0.0 MB)
MicroBench      for-of.js                                 0.999      0.433 ± 0.431 … 0.435              0.434 ± 0.432 … 0.438              +0.0% (+0.0 MB)
MicroBench      object-keys.js                            0.976      0.754 ± 0.749 … 0.757              0.772 ± 0.768 … 0.778              -0.0% (-0.0 MB)
MicroBench      object-set-with-rope-strings.js           1.012      0.450 ± 0.447 … 0.454              0.444 ± 0.442 … 0.446              +0.1% (+0.0 MB)
MicroBench      object-spread.js                          1.028      0.272 ± 0.272 … 0.272              0.265 ± 0.264 … 0.266              -0.1% (-0.0 MB)
MicroBench      pic-add-own.js                            1.010      0.564 ± 0.563 … 0.564              0.558 ± 0.558 … 0.558              -0.5% (-0.2 MB)
MicroBench      pic-get-absent.js                         1.003      0.275 ± 0.273 … 0.276              0.274 ± 0.267 … 0.288              +0.1% (+0.0 MB)
MicroBench      pic-get-own.js                            1.008      0.400 ± 0.397 … 0.404              0.396 ± 0.395 … 0.397              -0.0% (-0.0 MB)
MicroBench      pic-get-pchain.js                         0.999      0.402 ± 0.401 … 0.402              0.402 ± 0.401 … 0.404              -0.0% (-0.0 MB)
MicroBench      pic-put-own.js                            1.002      0.392 ± 0.392 … 0.393              0.391 ± 0.381 … 0.401              -0.0% (-0.0 MB)
MicroBench      pic-put-pchain.js                         1.010      1.445 ± 1.433 … 1.463              1.431 ± 1.428 … 1.432              -0.0% (-0.0 MB)
MicroBench      proxy-call-00-args.js                     1.004      1.435 ± 1.431 … 1.438              1.430 ± 1.423 … 1.433              -0.7% (-0.2 MB)
MicroBench      proxy-call-01-args.js                     1.004      1.294 ± 1.288 … 1.303              1.289 ± 1.283 … 1.298              -0.0% (-0.0 MB)
MicroBench      proxy-call-04-args.js                     1.004      1.301 ± 1.286 … 1.311              1.296 ± 1.289 … 1.308              -0.0% (-0.0 MB)
MicroBench      proxy-call-no-trap.js                     1.011      0.598 ± 0.595 … 0.600              0.592 ± 0.590 … 0.596              -0.1% (-0.0 MB)
MicroBench      proxy-get-trap-with-bind.js               1.027      6.294 ± 6.232 … 6.354              6.127 ± 6.111 … 6.137              -0.3% (-0.1 MB)
MicroBench      proxy-get-trap.js                         1.005      1.074 ± 1.056 … 1.087              1.070 ± 1.067 … 1.073              +0.0% (+0.0 MB)
MicroBench      proxy-nested-call.js                      1.013      3.372 ± 3.330 … 3.408              3.328 ± 3.321 … 3.337              -0.3% (-0.1 MB)
MicroBench      setter-in-prototype-chain.js              1.007      1.582 ± 1.578 … 1.588              1.572 ± 1.569 … 1.573              +0.0% (+0.0 MB)
MicroBench      short-string-concat.js                    0.973      0.263 ± 0.257 … 0.273              0.271 ± 0.260 … 0.284              +0.1% (+0.0 MB)
MicroBench      strictly-equals-object.js                 1.018      0.608 ± 0.605 … 0.611              0.597 ± 0.594 … 0.601              +0.0% (+0.0 MB)
MicroBench      typed-array-prototype-set-equal-width.js  1.104      0.041 ± 0.040 … 0.041              0.037 ± 0.036 … 0.037              +0.0% (+0.0 MB)
AsyncBench      async-call-return.js                      1.009      0.158 ± 0.157 … 0.159              0.157 ± 0.156 … 0.157              +1.4% (+0.4 MB)
AsyncBench      async-class-method.js                     0.993      0.303 ± 0.301 … 0.304              0.305 ± 0.304 … 0.305              +1.1% (+0.4 MB)
AsyncBench      async-fan-out.js                          0.995      0.110 ± 0.109 … 0.111              0.111 ± 0.110 … 0.111              +0.2% (+0.0 MB)
AsyncBench      async-generator.js                        0.991      0.188 ± 0.185 … 0.191              0.190 ± 0.189 … 0.191              -0.4% (-0.1 MB)
AsyncBench      async-iife.js                             0.997      0.252 ± 0.251 … 0.255              0.253 ± 0.252 … 0.255              +0.6% (+0.2 MB)
AsyncBench      async-nested-calls.js                     1.002      0.413 ± 0.410 … 0.416              0.412 ± 0.410 … 0.415              +0.0% (+0.0 MB)
AsyncBench      async-pipeline.js                         0.995      0.213 ± 0.212 … 0.215              0.214 ± 0.212 … 0.216              -1.6% (-0.5 MB)
AsyncBench      async-sequential-awaits.js                0.979      0.125 ± 0.123 … 0.128              0.128 ± 0.127 … 0.129              +0.3% (+0.1 MB)
AsyncBench      async-try-catch-reject.js                 1.016      0.772 ± 0.764 … 0.787              0.759 ± 0.756 … 0.762              -0.1% (-0.0 MB)
AsyncBench      await-primitive.js                        0.994      0.059 ± 0.057 … 0.061              0.059 ± 0.058 … 0.061              +0.0% (+0.0 MB)
AsyncBench      await-resolved-promise.js                 1.003      0.107 ± 0.106 … 0.110              0.107 ± 0.106 … 0.109              -0.6% (-0.2 MB)
AsyncBench      await-thenable.js                         0.994      0.466 ± 0.465 … 0.467              0.469 ± 0.465 … 0.475              -0.5% (-0.2 MB)
AsyncBench      promise-all.js                            1.000      0.271 ± 0.269 … 0.274              0.271 ± 0.270 … 0.273              +0.4% (+0.1 MB)
AsyncBench      promise-allSettled.js                     0.998      0.338 ± 0.336 … 0.340              0.339 ± 0.336 … 0.342              -3.2% (-0.9 MB)
AsyncBench      promise-chain.js                          1.010      0.145 ± 0.142 … 0.148              0.143 ± 0.141 … 0.144              -0.0% (-0.0 MB)
AsyncBench      promise-new-resolve.js                    0.992      0.222 ± 0.221 … 0.224              0.224 ± 0.219 … 0.228              -2.0% (-0.6 MB)
AsyncBench      promise-race.js                           0.986      0.302 ± 0.300 … 0.303              0.306 ± 0.305 … 0.307              -0.8% (-0.3 MB)
SunSpider       Total                                     1.069      1.231                              1.152                              +0.0% (+0.1 MB)
LongSpider      Total                                     0.999      55.018                             55.052                             -0.1% (-1.1 MB)
Kraken          Total                                     1.008      5.409                              5.366                              +0.1% (+0.4 MB)
Octane          Total                                     0.996      173963.000                         173209.667                         +0.1% (+5.6 MB)
GarBench        Total                                     1.019      11.290                             11.076                             -0.0% (-0.3 MB)
JetStream       Total                                     1.000      97.962                             97.945                             +0.0% (+0.1 MB)
JetStream3      Total                                     1.005      8.187                              8.144                              +0.2% (+0.4 MB)
JetStreamExtra  Total                                     1.000      36.116                             36.113                             -0.1% (-6.8 MB)
ARES-6          Total                                     1.000      4.745                              4.746                              +0.6% (+2.6 MB)
RegExp          Total                                     0.987      0.282                              0.285                              +0.1% (+0.0 MB)
MicroBench      Total                                     1.018      34.310                             33.716                             -0.0% (-0.1 MB)
AsyncBench      Total                                     0.999      4.444                              4.447                              -0.2% (-1.6 MB)
All Suites      Total                                     1.003      310.592                            309.637                            -0.0% (-0.7 MB)
```
</details>