### PR TITLE
LibWeb: Resolve sticky insets in the visual context build

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2677,41 +2677,6 @@ void Document::set_needs_animated_style_update()
     page().client().request_frame();
 }
 
-static void rebuild_sticky_insets(Layout::Node const& root)
-{
-    root.for_each_in_inclusive_subtree([&](auto& layout_node) {
-        auto const* node_with_style = as_if<Layout::NodeWithStyle>(layout_node);
-        if (!node_with_style || !node_with_style->is_sticky_position())
-            return TraversalDecision::Continue;
-
-        if (!Painting::has_committed_box(layout_node))
-            return TraversalDecision::Continue;
-
-        // https://drafts.csswg.org/css-position/#insets
-        // For sticky positioned boxes, the inset is instead relative to the relevant scrollport’s size.
-        // Negative values are allowed.
-
-        auto sticky_insets = make<Painting::StickyInsets>();
-        auto inset = node_with_style->inset();
-
-        auto nearest_scrollable_ancestor = Painting::nearest_scrollable_ancestor(layout_node);
-        CSSPixelSize scrollport_size;
-        if (nearest_scrollable_ancestor)
-            scrollport_size = Painting::absolute_rect(*nearest_scrollable_ancestor).size();
-
-        if (!inset.top().is_auto())
-            sticky_insets->top = inset.top().to_px_or_zero(scrollport_size.height());
-        if (!inset.right().is_auto())
-            sticky_insets->right = inset.right().to_px_or_zero(scrollport_size.width());
-        if (!inset.bottom().is_auto())
-            sticky_insets->bottom = inset.bottom().to_px_or_zero(scrollport_size.height());
-        if (!inset.left().is_auto())
-            sticky_insets->left = inset.left().to_px_or_zero(scrollport_size.width());
-        Painting::set_sticky_insets(layout_node, move(sticky_insets));
-        return TraversalDecision::Continue;
-    });
-}
-
 void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates, ReadonlySpan<Layout::Box const*> boxes_needing_eager_measurement)
 {
     // For every box that will be re-measured, the overflow data it had before, so the diff below
@@ -2866,10 +2831,8 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
     if (m_needs_accumulated_visual_contexts_update) {
         m_needs_accumulated_visual_contexts_update = false;
         m_boxes_needing_visual_context_value_update.clear_with_capacity();
-        if (has_committed_viewport_box()) {
-            rebuild_sticky_insets(*m_layout_root);
+        if (has_committed_viewport_box())
             paint_state().assign_accumulated_visual_contexts(*this);
-        }
     } else if (!m_boxes_needing_visual_context_value_update.is_empty()) {
         auto boxes = move(m_boxes_needing_visual_context_value_update);
         if (has_committed_viewport_box()) {

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -500,27 +500,6 @@ SelectionStyle selection_style(Layout::Node const& node)
     return selection_style_for_node(node, node.dom_node());
 }
 
-bool has_sticky_insets(Layout::Node const& node)
-{
-    auto const* row = committed_row(node);
-    return row && row->has_sticky_insets;
-}
-
-StickyInsets sticky_insets(Layout::Node const& node)
-{
-    auto const* row = committed_row(node);
-    if (!row)
-        return {};
-    VERIFY(row->has_sticky_insets);
-    auto const& insets = row->sticky_insets;
-    auto side = [](CSSPixels value, bool present) -> Optional<CSSPixels> {
-        if (!present)
-            return {};
-        return value;
-    };
-    return { side(insets.top, insets.has_top), side(insets.right, insets.has_right), side(insets.bottom, insets.has_bottom), side(insets.left, insets.has_left) };
-}
-
 bool should_paint_cursor(Layout::Node const& node)
 {
     if (!has_committed_box(node))
@@ -992,22 +971,6 @@ void clear_overflow_data(Layout::Node const& node)
 void clear_cached_overflow_data(Layout::Node const& node)
 {
     Layout::RustFFI::layout_arena_paintable_clear_cached_overflow_data(node.arena_handle(), committed_row_slot(node));
-}
-
-void set_sticky_insets(Layout::Node const& node, OwnPtr<StickyInsets> sticky_insets)
-{
-    Layout::RustFFI::FfiStickyInsets ffi_insets {};
-    if (sticky_insets) {
-        auto pack = [](Optional<CSSPixels> const& value, CSSPixels& output, bool& present) {
-            present = value.has_value();
-            output = value.value_or({});
-        };
-        pack(sticky_insets->top, ffi_insets.top, ffi_insets.has_top);
-        pack(sticky_insets->right, ffi_insets.right, ffi_insets.has_right);
-        pack(sticky_insets->bottom, ffi_insets.bottom, ffi_insets.has_bottom);
-        pack(sticky_insets->left, ffi_insets.left, ffi_insets.has_left);
-    }
-    Layout::RustFFI::layout_arena_paintable_set_sticky_insets(node.arena_handle(), committed_row_slot(node), ffi_insets, !!sticky_insets);
 }
 
 void inline_piece_border_box_rects(Layout::Node const& node, Vector<CSSPixelRect>& rects)

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -112,9 +112,6 @@ WEB_API void repaint_after_style_change(Layout::Node const&, CSS::RequiredInvali
 WEB_API void invalidate_stacking_context(Layout::Node const&);
 WEB_API void clear_overflow_data(Layout::Node const&);
 WEB_API void clear_cached_overflow_data(Layout::Node const&);
-WEB_API void set_sticky_insets(Layout::Node const&, OwnPtr<StickyInsets>);
-WEB_API StickyInsets sticky_insets(Layout::Node const&);
-WEB_API bool has_sticky_insets(Layout::Node const&);
 
 WEB_API void inline_piece_border_box_rects(Layout::Node const&, Vector<CSSPixelRect>&);
 WEB_API CSSPixelPoint cumulative_scroll_compensation(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -543,6 +543,8 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             inputs.visual_viewport_offset_y = offset.y();
             inputs.visual_viewport_scale = visual_viewport.scale();
             inputs.may_have_default_scroll_shift_anchor = document.may_have_default_scroll_shift_anchor();
+            inputs.viewport_wheel_overflow_x = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)));
+            inputs.viewport_wheel_overflow_y = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)));
             return inputs;
         },
         .scroll_offset = [](void*, void* layout_node_shell) -> CSSPixelPoint {

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -18,13 +18,6 @@
 
 namespace Web::Painting {
 
-struct StickyInsets {
-    Optional<CSSPixels> top;
-    Optional<CSSPixels> right;
-    Optional<CSSPixels> bottom;
-    Optional<CSSPixels> left;
-};
-
 // Device-pixel offsets keyed by SpatialNodeIndex: the scroll containers' offsets as produced by
 // the document, plus the sticky nodes' offsets that resolve_sticky_offsets() derives from them
 // and the tree. Stored dense in process so display list replay and hit testing index it directly;

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -417,27 +417,6 @@ pub unsafe extern "C" fn layout_arena_selection_clear(arena: *mut c_void, viewpo
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_set_sticky_insets(
-    arena: *mut c_void,
-    slot: NodeSlotId,
-    insets: FfiStickyInsets,
-    has_insets: bool,
-) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let mut paintable_rows = arena.paintable_rows_mut();
-        if paintable_rows.paintable_row_is_populated(slot) {
-            let data = paintable_rows.paintable_data_mut(slot);
-            data.sticky_insets = insets;
-            data.has_sticky_insets = has_insets;
-        }
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle_mut(arena) };
@@ -1021,7 +1000,7 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
                 &paintable_rows,
                 &state.scroll_state,
                 tree,
-                callbacks.tree_inputs().device_pixels_per_css_pixel,
+                &callbacks.tree_inputs(),
             );
         }
         state.needs_to_refresh_scroll_state = true;

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -32,6 +32,8 @@ pub struct FfiVisualContextTreeInputs {
     pub visual_viewport_offset_y: f64,
     pub visual_viewport_scale: f64,
     pub may_have_default_scroll_shift_anchor: bool,
+    pub viewport_wheel_overflow_x: u8,
+    pub viewport_wheel_overflow_y: u8,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -31,19 +31,6 @@ pub struct FfiPixelBox {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
-pub struct FfiStickyInsets {
-    pub top: CssPixels,
-    pub right: CssPixels,
-    pub bottom: CssPixels,
-    pub left: CssPixels,
-    pub has_top: bool,
-    pub has_right: bool,
-    pub has_bottom: bool,
-    pub has_left: bool,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
 pub struct FfiOverflowData {
     pub rect: used_values::FfiCssPixelRect,
     pub has_scrollable_overflow: bool,
@@ -65,8 +52,6 @@ pub struct PaintableData {
     pub overflow_relative_to_padding_box: FfiOverflowData,
     pub overflow_measured_this_commit: bool,
     pub overflow_valid_across_recommits: bool,
-    pub sticky_insets: FfiStickyInsets,
-    pub has_sticky_insets: bool,
 
     pub stacking_context: u32,
 
@@ -99,8 +84,6 @@ impl Default for PaintableData {
             overflow_relative_to_padding_box: FfiOverflowData::default(),
             overflow_measured_this_commit: false,
             overflow_valid_across_recommits: false,
-            sticky_insets: FfiStickyInsets::default(),
-            has_sticky_insets: false,
             stacking_context: u32::MAX,
             enclosing_scroll_node_index: SpatialNodeIndex::default(),
             own_scroll_node_index: SpatialNodeIndex::default(),

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -353,8 +353,6 @@ where
             data.offset = used_values::FfiCssPixelPoint::default();
             data.content_size = used_values::FfiCssPixelSize::default();
             data.overflow_measured_this_commit = false;
-            data.sticky_insets = FfiStickyInsets::default();
-            data.has_sticky_insets = false;
             data.local_padding_box_union = used_values::FfiCssPixelRect::default();
             data.local_border_box_union = used_values::FfiCssPixelRect::default();
             data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -9,7 +9,7 @@ use super::refresh::compute_sticky_data;
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
 use super::*;
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
-use crate::painting::host::FfiVisualContextHostCallbacks;
+use crate::painting::host::{FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
@@ -282,6 +282,7 @@ struct Builder<'a, Arena> {
     paintables_with_mask_nodes: Vec<NodeSlotId>,
     assignments: Vec<Option<PaintableVisualContextAssignment>>,
     pixel_ratio: f64,
+    tree_inputs: FfiVisualContextTreeInputs,
     root_background_source: crate::painting::host::FfiRootBackgroundSource,
     may_have_default_scroll_shift_anchor: bool,
 }
@@ -351,7 +352,7 @@ impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
             self.layout_arena,
             &self.scroll_state,
             slot,
-            self.pixel_ratio,
+            &self.tree_inputs,
         ));
     }
 
@@ -374,7 +375,6 @@ impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
         let is_fixed = position == crate::css::css_enums::positioning::FIXED;
         let is_absolute = position == crate::css::css_enums::positioning::ABSOLUTE;
         let is_sticky = position == crate::css::css_enums::positioning::STICKY;
-        let has_sticky_insets = self.layout_arena.paintable_data(slot).has_sticky_insets;
         let layout_node = slot;
         {
             let assignment = self.assignment_mut(slot);
@@ -406,7 +406,7 @@ impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
             self.assignment_mut(slot).enclosing_scroll_node_index = nearest_ancestor_scroll_node_index;
         }
 
-        let creates_sticky_scroll_node = is_sticky && has_sticky_insets;
+        let creates_sticky_scroll_node = is_sticky;
 
         let inherited_state = if is_fixed {
             inherited.fixed_position
@@ -828,6 +828,7 @@ pub(crate) fn build_visual_context_tree(
         paintables_with_mask_nodes: Vec::new(),
         assignments: vec![None; layout_arena.paintable_row_count()],
         pixel_ratio: inputs.device_pixels_per_css_pixel,
+        tree_inputs: inputs,
         root_background_source: callbacks.root_background_source(),
         may_have_default_scroll_shift_anchor: inputs.may_have_default_scroll_shift_anchor,
     };

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
@@ -6,12 +6,75 @@
 
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
 use super::{SpatialData, StickyData, VisualContextTree};
+use crate::css::computed_value_types::ComputedLengthPercentageOrAuto;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect, CssPixelSize, CssPixels};
 use crate::layout::node_data::NodeSlotId;
-use crate::painting::host::FfiVisualContextHostCallbacks;
+use crate::painting::chrome_geometry;
+use crate::painting::host::{FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::PaintableRowsRead;
+use crate::painting::style_queries;
 use libgfx_rust::{FloatPoint, FloatRect, FloatSize};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ResolvedStickyInsets {
+    pub top: Option<CssPixels>,
+    pub right: Option<CssPixels>,
+    pub bottom: Option<CssPixels>,
+    pub left: Option<CssPixels>,
+}
+
+fn nearest_wheel_scrollable_ancestor_along_containing_blocks(
+    layout_arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    tree_inputs: &FfiVisualContextTreeInputs,
+) -> Option<NodeSlotId> {
+    let mut block = layout_arena.paintable_data(slot).containing_block;
+    while !block.is_invalid() {
+        if !layout_arena.paintable_row_is_populated(block) {
+            return None;
+        }
+        let axes = chrome_geometry::wheel_scrollable_axes(
+            layout_arena,
+            block,
+            tree_inputs.viewport_wheel_overflow_x,
+            tree_inputs.viewport_wheel_overflow_y,
+        );
+        if axes.horizontal || axes.vertical {
+            return Some(block);
+        }
+        if style_queries::is_fixed_position(layout_arena, block) {
+            return None;
+        }
+        block = layout_arena.paintable_data(block).containing_block;
+    }
+    None
+}
+
+// https://drafts.csswg.org/css-position/#insets
+pub(crate) fn resolve_sticky_insets_in_css_pixels(
+    layout_arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    tree_inputs: &FfiVisualContextTreeInputs,
+) -> ResolvedStickyInsets {
+    let Some(style) = layout_arena.node_style_if_live(slot) else {
+        return ResolvedStickyInsets::default();
+    };
+    let scrollport_size = nearest_wheel_scrollable_ancestor_along_containing_blocks(layout_arena, slot, tree_inputs)
+        .map_or(CssPixelSize::default(), |scroller| {
+            paintable_geometry::absolute_rect(layout_arena, scroller).size()
+        });
+    let resolve_side = |side: &ComputedLengthPercentageOrAuto, scrollport_extent: CssPixels| {
+        (!side.is_auto()).then(|| side.to_px(scrollport_extent))
+    };
+    let inset = &style.surround().inset;
+    ResolvedStickyInsets {
+        top: resolve_side(&inset.top, scrollport_size.height),
+        right: resolve_side(&inset.right, scrollport_size.width),
+        bottom: resolve_side(&inset.bottom, scrollport_size.height),
+        left: resolve_side(&inset.left, scrollport_size.width),
+    }
+}
 
 // The geometry stays zero while either row has been replaced by a subtree relayout: the pending
 // tree rebuild recreates the node before anything reads it.
@@ -19,8 +82,9 @@ pub(crate) fn compute_sticky_data(
     layout_arena: &impl PaintableRowsRead,
     scroll_state: &ScrollState,
     sticky_slot: ScrollStateSlot,
-    device_pixels_per_css_pixel: f64,
+    tree_inputs: &FfiVisualContextTreeInputs,
 ) -> StickyData {
+    let device_pixels_per_css_pixel = tree_inputs.device_pixels_per_css_pixel;
     let sticky_state = scroll_state.state_at_slot(sticky_slot);
     let scroller_slot = scroll_state.nearest_scrolling_ancestor_slot(sticky_slot);
     let parent_sticky = (sticky_state.parent_slot != NO_SCROLL_STATE_SLOT
@@ -66,8 +130,8 @@ pub(crate) fn compute_sticky_data(
         width: size.width.to_float() * scale,
         height: size.height.to_float() * scale,
     };
-    let device_inset = |inset: CssPixels, present: bool| present.then_some(inset.to_float() * scale);
-    let insets = layout_arena.paintable_data(paintable).sticky_insets;
+    let device_inset = |inset: Option<CssPixels>| inset.map(|inset| inset.to_float() * scale);
+    let insets = resolve_sticky_insets_in_css_pixels(layout_arena, paintable, tree_inputs);
     let region_location = device_point(containing_block_region.location());
     let region_size = device_size(containing_block_region.size());
 
@@ -84,10 +148,10 @@ pub(crate) fn compute_sticky_data(
         height: region_size.height,
     };
     data.needs_parent_offset_adjustment = needs_parent_offset_adjustment;
-    data.inset_top = device_inset(insets.top, insets.has_top);
-    data.inset_right = device_inset(insets.right, insets.has_right);
-    data.inset_bottom = device_inset(insets.bottom, insets.has_bottom);
-    data.inset_left = device_inset(insets.left, insets.has_left);
+    data.inset_top = device_inset(insets.top);
+    data.inset_right = device_inset(insets.right);
+    data.inset_bottom = device_inset(insets.bottom);
+    data.inset_left = device_inset(insets.left);
     data
 }
 
@@ -95,19 +159,15 @@ pub(crate) fn refresh_sticky_constraints(
     layout_arena: &impl PaintableRowsRead,
     scroll_state: &ScrollState,
     tree: &mut VisualContextTree,
-    device_pixels_per_css_pixel: f64,
+    tree_inputs: &FfiVisualContextTreeInputs,
 ) {
     for slot in 0..scroll_state.slot_count() {
         let state = scroll_state.state_at_slot(slot);
         if !state.is_sticky {
             continue;
         }
-        tree.spatial_nodes[state.node_index.0 as usize].data = SpatialData::Sticky(compute_sticky_data(
-            layout_arena,
-            scroll_state,
-            slot,
-            device_pixels_per_css_pixel,
-        ));
+        tree.spatial_nodes[state.node_index.0 as usize].data =
+            SpatialData::Sticky(compute_sticky_data(layout_arena, scroll_state, slot, tree_inputs));
     }
 }
 


### PR DESCRIPTION
Sticky insets were resolved by a C++ pass over the whole layout tree (rebuild_sticky_insets) right before every full visual context build, stored on the paintable rows and zeroed again whenever a row was recommitted, so the visual context build could only run after that pass. Resolve them where they are consumed instead: compute_sticky_data walks the containing block chain to the nearest wheel-scrollable box and resolves the inset sides against its scrollport size, the same way the C++ pass did, using the viewport's wheel overflow values that the tree inputs now carry. A sticky box creates its sticky node unconditionally, which is what the pass already guaranteed since it installed insets for every sticky box with a committed row.

This removes the sticky inset fields from the paintable rows, the FFI setter and the C++ accessors, and lets a later change refresh a sticky box's constraints without a document-wide pre-pass.