### PR TITLE
LibWeb: Recover Speedometer 3 performance

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -837,6 +837,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         NonnullRefPtr<StyleValue const> value;
         StyleValueFFI::FfiAnimationSpecifiedValueSource value_source;
         StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context;
+        bool is_transition { false };
     };
     if (keyframe_declarations.is_empty())
         return;
@@ -871,6 +872,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                                                                                             .value = StyleValue::adopt_rust_style_value_data(StyleValueFFI::rust_style_value_retain(property.value)),
                                                                                             .value_source = property.value_source,
                                                                                             .style_sheet_resource_context = property.style_sheet_resource_context,
+                                                                                            .is_transition = property.is_transition,
                                                                                         });
         }
 
@@ -881,6 +883,10 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             auto keyframe_index = keyframes_for_computation.size();
             keyframes_for_computation.append(keyframe);
             for (auto const& [physical_property_id, selected_value] : selected_values) {
+                // CSS transition endpoints are computed values captured from the before-change
+                // and after-change styles. They do not need another specified-value computation.
+                if (selected_value.is_transition)
+                    continue;
                 auto source_longhand_id = selected_value.source_longhand_id;
                 auto specified_value = [&]() -> NonnullRefPtr<StyleValue const> {
                     switch (selected_value.value_source) {
@@ -1033,6 +1039,12 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         };
         VERIFY(computed_keyframe_batch.value_count == keyframe_longhands.size());
         HashMap<Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame const*, HashMap<PropertyID, RefPtr<StyleValue const>>> computed_keyframe_values;
+        for (auto const& [keyframe, selected_values] : selected_keyframe_values) {
+            for (auto const& [physical_property_id, selected_value] : selected_values) {
+                if (selected_value.is_transition)
+                    computed_keyframe_values.ensure(keyframe).set(physical_property_id, selected_value.value);
+            }
+        }
         for (size_t index = 0; index < keyframe_longhands.size(); ++index) {
             auto const& longhand = keyframe_longhands[index];
             VERIFY(longhand.keyframe_index < keyframes_for_computation.size());

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -504,6 +504,7 @@ struct AnimationPropertyConflictCandidate {
     value: RetainedStyleValueData,
     style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
     use_initial: bool,
+    is_transition: bool,
     suppressed_by_important: bool,
 }
 
@@ -613,6 +614,7 @@ pub struct FfiResolvedAnimationProperty {
     pub value: *const StyleValueData,
     pub value_source: FfiAnimationSpecifiedValueSource,
     pub style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
+    pub is_transition: bool,
 }
 
 #[repr(C)]
@@ -665,6 +667,7 @@ fn resolve_animation_declarations(
                     },
                     style_sheet_resource_context: declaration.style_sheet_resource_context,
                     use_initial: declaration.use_initial,
+                    is_transition: declaration.is_transition,
                     // OPTIMIZATION: Values resulting from animations other than CSS transitions
                     // are overridden by important properties, so there is no need to compute or
                     // evaluate them.
@@ -692,6 +695,7 @@ fn resolve_animation_declarations(
                 value: candidate.value.pointer(),
                 value_source,
                 style_sheet_resource_context: candidate.style_sheet_resource_context,
+                is_transition: candidate.is_transition,
             });
             retained_values.push(candidate.value);
         }
@@ -7053,6 +7057,7 @@ mod tests {
                 style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
+                is_transition: false,
             },
             AnimationPropertyConflictCandidate {
                 keyframe_index: 0,
@@ -7063,6 +7068,7 @@ mod tests {
                 style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
+                is_transition: false,
             },
             AnimationPropertyConflictCandidate {
                 keyframe_index: 0,
@@ -7073,6 +7079,7 @@ mod tests {
                 style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: false,
                 suppressed_by_important: false,
+                is_transition: false,
             },
             AnimationPropertyConflictCandidate {
                 keyframe_index: 0,
@@ -7083,6 +7090,7 @@ mod tests {
                 style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: true,
                 suppressed_by_important: false,
+                is_transition: false,
             },
             AnimationPropertyConflictCandidate {
                 keyframe_index: 1,
@@ -7093,6 +7101,7 @@ mod tests {
                 style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
                 use_initial: true,
                 suppressed_by_important: false,
+                is_transition: false,
             },
         ];
         let mut selected = [false; 5];

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -3321,19 +3321,7 @@ unsafe fn drive_property_computation(
 
         for &property_id in computation_order {
             use crate::css::computed_values::computed_group_output_mask;
-            let required_driver_input = matches!(
-                property_id,
-                prop::COLOR_SCHEME
-                    | prop::DIRECTION
-                    | prop::DISPLAY
-                    | prop::FLOAT
-                    | prop::MATH_DEPTH
-                    | prop::OVERFLOW_X
-                    | prop::OVERFLOW_Y
-                    | prop::POSITION
-                    | prop::TEXT_ALIGN
-                    | prop::WRITING_MODE
-            );
+            let required_driver_input = is_required_driver_input(property_id);
             let output_is_selected = computed_group_output_mask(property_id)
                 .is_none_or(|output_mask| output_mask & computed_group_mask != 0);
             let property_index = usize::from(property_id - crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID);
@@ -4473,6 +4461,23 @@ unsafe fn drive_property_computation(
     })
 }
 
+fn is_required_driver_input(property_id: u16) -> bool {
+    use crate::css::property_metadata::property_id as prop;
+    matches!(
+        property_id,
+        prop::COLOR_SCHEME
+            | prop::DIRECTION
+            | prop::DISPLAY
+            | prop::FLOAT
+            | prop::MATH_DEPTH
+            | prop::OVERFLOW_X
+            | prop::OVERFLOW_Y
+            | prop::POSITION
+            | prop::TEXT_ALIGN
+            | prop::WRITING_MODE
+    )
+}
+
 /// FFI entry for the native longhand driver.
 ///
 /// # Safety
@@ -4606,9 +4611,9 @@ pub unsafe extern "C" fn rust_compute_document_longhands(
 }
 
 /// Computes every selected keyframe longhand through the native longhand
-/// driver. Each keyframe gets a temporary table seeded from the underlying
-/// style, then all of that keyframe's specified values are cascaded together
-/// before its selected properties are evaluated.
+/// driver. Each keyframe gets a temporary table and the driver's coordination
+/// inputs from the underlying style, then all of that keyframe's specified
+/// values are cascaded together before its selected properties are evaluated.
 ///
 /// # Safety
 /// `input` and every range and pointer it contains must remain valid for the
@@ -4664,6 +4669,9 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
             let mut table = ComputedLonghandTable::copied_for_drive(underlying_longhand_table);
             let mut store = CascadedPropertyStore::new();
             for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
+                if !is_required_driver_input(property_id) {
+                    continue;
+                }
                 if let Some(value) = underlying_longhand_table.get(property_id) {
                     store.seed_retained_property(property_id, value.clone_retained(), false, false);
                 }

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -983,31 +983,35 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn calculate_min_content_main_size(&self, index: usize) -> CssPixels {
-        self.select_main(
-            self.calculate_min_content_inline_size(index),
-            self.calculate_min_content_block_size(index, self.intrinsic_block_inline_size(index)),
-        )
+        if self.main_axis_is_horizontal() {
+            self.calculate_min_content_inline_size(index)
+        } else {
+            self.calculate_min_content_block_size(index, self.intrinsic_block_inline_size(index))
+        }
     }
 
     fn calculate_max_content_main_size(&self, index: usize) -> CssPixels {
-        self.select_main(
-            self.calculate_max_content_inline_size(index),
-            self.calculate_max_content_block_size(index, self.intrinsic_block_inline_size(index)),
-        )
+        if self.main_axis_is_horizontal() {
+            self.calculate_max_content_inline_size(index)
+        } else {
+            self.calculate_max_content_block_size(index, self.intrinsic_block_inline_size(index))
+        }
     }
 
     fn calculate_min_content_cross_size(&self, index: usize) -> CssPixels {
-        self.select_cross(
-            self.calculate_min_content_inline_size(index),
-            self.calculate_min_content_block_size(index, self.intrinsic_block_inline_size(index)),
-        )
+        if self.cross_axis_is_horizontal() {
+            self.calculate_min_content_inline_size(index)
+        } else {
+            self.calculate_min_content_block_size(index, self.intrinsic_block_inline_size(index))
+        }
     }
 
     fn calculate_max_content_cross_size(&self, index: usize) -> CssPixels {
-        self.select_cross(
-            self.calculate_max_content_inline_size(index),
-            self.calculate_max_content_block_size(index, self.intrinsic_block_inline_size(index)),
-        )
+        if self.cross_axis_is_horizontal() {
+            self.calculate_max_content_inline_size(index)
+        } else {
+            self.calculate_max_content_block_size(index, self.intrinsic_block_inline_size(index))
+        }
     }
 
     fn calculate_fit_content_main_size(&self, index: usize) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -64,6 +64,10 @@ pub(crate) struct LineBuilder<'builder, 'context> {
     should_advance_to_last_line_box_block_end: bool,
     current_line_committed_pending_margin: bool,
     pending_margin_follows_block_level_box: bool,
+    containing_style: StyleValues<'static>,
+    fragment_facts_cache: Option<(Node, line_box_fragment::FragmentBuildFacts)>,
+    style_cache: Cell<Option<(Node, StyleValues<'static>)>>,
+    facts_cache: Cell<Option<(Node, NodeFacts<'builder>)>>,
 }
 
 impl<'builder, 'context> LineBuilder<'builder, 'context> {
@@ -91,6 +95,10 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             should_advance_to_last_line_box_block_end: false,
             current_line_committed_pending_margin: false,
             pending_margin_follows_block_level_box: false,
+            containing_style: style,
+            fragment_facts_cache: None,
+            style_cache: Cell::new(None),
+            facts_cache: Cell::new(None),
         }
     }
 
@@ -139,26 +147,55 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
     }
 
     fn containing_style(&self) -> StyleValues<'_> {
-        self.context().style(self.context().containing_block)
+        self.containing_style
     }
 
-    fn fragment_facts(&self, node: Node) -> line_box_fragment::FragmentBuildFacts {
+    fn style(&self, node: Node) -> StyleValues<'static> {
+        if let Some((cached_node, style)) = self.style_cache.get()
+            && cached_node == node
+        {
+            return style;
+        }
+        let style = self.context().style(node);
+        self.style_cache.set(Some((node, style)));
+        style
+    }
+
+    fn facts(&self, node: Node) -> NodeFacts<'builder> {
+        if let Some((cached_node, facts)) = self.facts_cache.get()
+            && cached_node == node
+        {
+            return facts;
+        }
+        let facts = NodeFacts::new(&self.context.callbacks, node);
+        self.facts_cache.set(Some((node, facts)));
+        facts
+    }
+
+    fn fragment_facts(&mut self, node: Node) -> line_box_fragment::FragmentBuildFacts {
+        if let Some((cached_node, facts)) = self.fragment_facts_cache
+            && cached_node == node
+        {
+            return facts;
+        }
         let style_source = self.context().style_source(node);
-        let style = self.context().style(style_source);
-        let facts = self.context().facts(node);
+        let style = self.style(style_source);
+        let facts = self.facts(node);
         let (text_utf16, text_length) = if facts.is_text_node() {
             let text = &self.context().callbacks.text_content(node).text;
             (text.as_ptr(), text.len())
         } else {
             (std::ptr::null(), 0)
         };
-        line_box_fragment::FragmentBuildFacts {
+        let facts = line_box_fragment::FragmentBuildFacts {
             style_source,
             is_atomic_inline: facts.is_atomic_inline(),
             white_space_collapse: style.white_space_collapse(),
             text_utf16,
             text_length_in_code_units: text_length,
-        }
+        };
+        self.fragment_facts_cache = Some((node, facts));
+        facts
     }
 
     fn begin_new_line(&mut self, advance: bool, first_in_sequence: bool, forced: ForcedBreak) {
@@ -308,8 +345,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         let line_index = self.ensure_last_line_index();
         let fragment_index = self.line(line_index).fragments.len();
         let fragment_facts = self.fragment_facts(node);
-        let text_align_is_justify =
-            self.context().style(fragment_facts.style_source).text_align() == text_align::JUSTIFY;
+        let text_align_is_justify = self.style(fragment_facts.style_source).text_align() == text_align::JUSTIFY;
         self.line_mut(line_index).add_fragment(
             node,
             0,
@@ -365,7 +401,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         self.prepare_to_append_inline_content();
         let line_index = self.ensure_last_line_index();
         let facts = self.fragment_facts(node);
-        let text_align_is_justify = self.context().style(facts.style_source).text_align() == text_align::JUSTIFY;
+        let text_align_is_justify = self.style(facts.style_source).text_align() == text_align::JUSTIFY;
         self.line_mut(line_index).add_fragment(
             node,
             offset_in_node,
@@ -570,7 +606,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         if parent.is_invalid() {
             self.containing_style()
         } else {
-            self.context().style(parent)
+            self.style(parent)
         }
     }
 
@@ -641,14 +677,11 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
         let containing_block = self.context().containing_block;
         let mut node = style_source;
         while !node.is_invalid() && node != containing_block {
-            if let Some(alignment) = line_relative_alignment(self.context().style(node)) {
+            if let Some(alignment) = line_relative_alignment(self.style(node)) {
                 return Some((node, alignment));
             }
             let parent = self.context().parent_node(node);
-            if !parent.is_invalid()
-                && parent != containing_block
-                && !self.context().facts(parent).is_fragmented_inline()
-            {
+            if !parent.is_invalid() && parent != containing_block && !self.facts(parent).is_fragmented_inline() {
                 break;
             }
             node = parent;
@@ -668,7 +701,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
     }
 
     fn inline_box_alignment_metrics(&self, node: Node) -> VerticalAlignMetrics {
-        let style = self.context().style(node);
+        let style = self.style(node);
         let used = self.context().used(node);
         VerticalAlignMetrics {
             baseline: Self::baseline_for_style(style, style.line_height()),
@@ -740,8 +773,8 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                 let fragment = &self.line(line_index).fragments[fragment_index];
                 (fragment.layout_node, fragment.style_source, fragment.content_baselines)
             };
-            let style = self.context().style(style_source);
-            let fragment_baseline = if self.context().facts(node).is_text_node() {
+            let style = self.style(style_source);
+            let fragment_baseline = if self.facts(node).is_text_node() {
                 Self::baseline_for_style(style, style.line_height())
             } else if let Some(content_baselines) = content_baselines {
                 formatting_context::box_baseline_with_content_baselines(
@@ -769,7 +802,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                 fragment_baseline + style.vertical_align_value().to_px(style.line_height())
             };
             if adjusted_baseline > line_box_baseline {
-                if !self.context().facts(node).is_text_node() && style.vertical_align_is_keyword() {
+                if !self.facts(node).is_text_node() && style.vertical_align_is_keyword() {
                     // https://drafts.csswg.org/css2/#line-height
                     // The minimum height consists of a minimum height above the baseline and a minimum depth below
                     // it, exactly as if each line box starts with a zero-width inline box with the element's font and
@@ -811,7 +844,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                     block_offset: fragment.block_offset,
                 }
             };
-            let style = self.context().style(snapshot.style_source);
+            let style = self.style(snapshot.style_source);
             let mut metrics = VerticalAlignMetrics {
                 baseline: snapshot.baseline,
                 block_size: snapshot.block_size,
@@ -852,9 +885,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                     line_box_baseline,
                 )
             };
-            if snapshot.style_source != containing_block
-                && self.context().facts(snapshot.style_source).is_fragmented_inline()
-            {
+            if snapshot.style_source != containing_block && self.facts(snapshot.style_source).is_fragmented_inline() {
                 inline_box_alignments.push(InlineBoxAlignment {
                     box_: snapshot.style_source,
                     vertical_shift: new_block_offset - baseline_aligned_block_offset,
@@ -867,10 +898,10 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
             };
             while !own_alignment_is_line_relative
                 && !ancestor.is_invalid()
-                && self.context().facts(ancestor).is_fragmented_inline()
+                && self.facts(ancestor).is_fragmented_inline()
                 && ancestor != containing_block
             {
-                let ancestor_style = self.context().style(ancestor);
+                let ancestor_style = self.style(ancestor);
                 if line_relative_alignment(ancestor_style).is_some() {
                     break;
                 }
@@ -957,7 +988,7 @@ impl<'builder, 'context> LineBuilder<'builder, 'context> {
                 latest = latest.max(inline_box_end);
             }
 
-            let is_text_node = self.context().facts(snapshot.layout_node).is_text_node();
+            let is_text_node = self.facts(snapshot.layout_node).is_text_node();
             if is_text_node && self.writing_mode == writing_mode::HORIZONTAL_TB {
                 let font_box_size = normal_line_height(style);
                 let font_baseline = Self::baseline_for_style(style, font_box_size);

--- a/Tests/LibWeb/Text/expected/flex-intrinsic-axis-measurements.txt
+++ b/Tests/LibWeb/Text/expected/flex-intrinsic-axis-measurements.txt
@@ -1,0 +1,1 @@
+intrinsic measurements: 7

--- a/Tests/LibWeb/Text/input/flex-intrinsic-axis-measurements.html
+++ b/Tests/LibWeb/Text/input/flex-intrinsic-axis-measurements.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<script src="include.js"></script>
+<style>
+    #outer {
+        display: flex;
+        width: 100px;
+    }
+
+    #inner {
+        display: flex;
+    }
+
+    #item {
+        width: 100%;
+        overflow-wrap: break-word;
+    }
+</style>
+<div id="outer"><div id="inner"><div id="item">AAAAAAAAAAAAAAAAAAAAAAAAAAAA</div></div></div>
+<script>
+    test(() => {
+        const measurementsBefore = internals.intrinsicMeasurementCount();
+        document.getElementById("outer").offsetWidth;
+        println(`intrinsic measurements: ${internals.intrinsicMeasurementCount() - measurementsBefore}`);
+    });
+</script>


### PR DESCRIPTION
`overflow-wrap: break-word` exposed eager flex intrinsic-size calculations where both axes were evaluated before one result was discarded. Select the relevant axis first and cache repeated line-builder facts.

Avoid cloning every underlying longhand while computing animation keyframes, and use the computed values already stored by CSS transitions instead of recomputing their endpoints.

TipTap Long improved from 303.7 ms to 128.9 ms, and Highlight from 557.4 ms to 195.8 ms. WebComponents completion recovered from 32.4 ms to 30.2 ms, near its 29.6 ms baseline. Across all 58 Speedometer 3 subtests, the sum of medians improved from 7.4791 s to 6.8790 s.