### PR TITLE
LibWeb: Preserve table rows during insertion

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -251,6 +251,44 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
     if (first_letter_owner)
         return false;
 
+    if (parent_lays_out_table_rows) {
+        enum class SiblingDirection {
+            Previous,
+            Next,
+        };
+        auto has_table_row_sibling = [&](DOM::Node const* sibling, SiblingDirection direction) {
+            for (; sibling; sibling = direction == SiblingDirection::Next ? sibling->next_sibling() : sibling->previous_sibling()) {
+                if (auto const* sibling_layout_node = sibling->unsafe_layout_node()) {
+                    auto const* node_with_style = as_if<NodeWithStyle>(*sibling_layout_node);
+                    return sibling_layout_node->parent() == layout_node && node_with_style && node_with_style->display().is_table_row();
+                }
+
+                if (auto const* sibling_element = as_if<DOM::Element>(*sibling)) {
+                    auto computed_style = sibling_element->computed_style();
+                    if (!computed_style)
+                        return false;
+                    if (!computed_style->display().is_none())
+                        return sibling->needs_layout_tree_update() && computed_style->display().is_table_row();
+                } else if (auto const* sibling_text = as_if<DOM::Text>(*sibling); sibling_text && !sibling_text->data().is_ascii_whitespace()) {
+                    return false;
+                }
+            }
+            return false;
+        };
+
+        // NB: Table fixup discards whitespace at the edge of a row group. Inserting a row outside
+        //     that whitespace makes it interior, so only a rebuild can create its anonymous table-row box.
+        for (auto const* child = node.first_child(); child; child = child->next_sibling()) {
+            auto const* text = as_if<DOM::Text>(*child);
+            if (!text || child->unsafe_layout_node() || child->needs_layout_tree_update() || !text->data().is_ascii_whitespace())
+                continue;
+            if (has_table_row_sibling(child->previous_sibling(), SiblingDirection::Previous)
+                && has_table_row_sibling(child->next_sibling(), SiblingDirection::Next)) {
+                return false;
+            }
+        }
+    }
+
     bool will_insert_inline_child = false;
     bool will_insert_block_child = false;
     bool has_indirect_existing_child = false;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -242,7 +242,10 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
         && (layout_node->children_are_inline() || !parent_has_children);
     auto parent_lays_out_block_children = (parent_display.is_flow_inside() || parent_display.is_flow_root_inside())
         && !layout_node->children_are_inline();
-    if (!parent_lays_out_flex_or_grid_children && !parent_lays_out_inline_children && !parent_lays_out_block_children) {
+    auto parent_lays_out_table_rows = parent_display.is_table_row_group()
+        || parent_display.is_table_header_group()
+        || parent_display.is_table_footer_group();
+    if (!parent_lays_out_flex_or_grid_children && !parent_lays_out_inline_children && !parent_lays_out_block_children && !parent_lays_out_table_rows) {
         return false;
     }
     if (first_letter_owner)
@@ -276,6 +279,8 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
         if (child_element->rendered_in_top_layer() || is<SVG::SVGElement>(*child_element))
             return false;
         if (parent_lays_out_flex_or_grid_children)
+            continue;
+        if (parent_lays_out_table_rows && child_display.is_table_row())
             continue;
         if (parent_lays_out_block_children && child_display.is_block_outside()) {
             will_insert_block_child = true;

--- a/Tests/LibWeb/Text/expected/layout-tree-update/table-row-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/table-row-insertion-preservation.txt
@@ -1,0 +1,32 @@
+PASS: append row | preserve row group
+PASS: append row | preserve existing row
+PASS: append row | preserve existing cell
+PASS: append row | create inserted row
+PASS: append row | intrinsic measurements=4
+PASS: append row | incremental tree matches full rebuild
+PASS: prepend row | preserve row group
+PASS: prepend row | preserve existing row
+PASS: prepend row | preserve existing cell
+PASS: prepend row | create inserted row
+PASS: prepend row | intrinsic measurements=4
+PASS: prepend row | incremental tree matches full rebuild
+PASS: insert middle row | preserve row group
+PASS: insert middle row | preserve existing row
+PASS: insert middle row | preserve existing cell
+PASS: insert middle row | create inserted row
+PASS: insert middle row | intrinsic measurements=4
+PASS: insert middle row | incremental tree matches full rebuild
+PASS: append header row | preserve row group
+PASS: append header row | preserve existing row
+PASS: append header row | preserve existing cell
+PASS: append header row | create inserted row
+PASS: append header row | intrinsic measurements=4
+PASS: append header row | incremental tree matches full rebuild
+PASS: append footer row | preserve row group
+PASS: append footer row | preserve existing row
+PASS: append footer row | preserve existing cell
+PASS: append footer row | create inserted row
+PASS: append footer row | intrinsic measurements=4
+PASS: append footer row | incremental tree matches full rebuild
+PASS: non-row insertion | rebuild row group
+PASS: non-row insertion | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/expected/layout-tree-update/table-row-insertion-preservation.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/table-row-insertion-preservation.txt
@@ -30,3 +30,177 @@ PASS: append footer row | intrinsic measurements=4
 PASS: append footer row | incremental tree matches full rebuild
 PASS: non-row insertion | rebuild row group
 PASS: non-row insertion | incremental tree matches full rebuild
+PASS: prepend multiple rows | preserve existing rows
+PASS: prepend multiple rows | create inserted rows
+PASS: prepend multiple rows | incremental tree matches full rebuild
+PASS: insert multiple rows | preserve existing rows
+PASS: insert multiple rows | create inserted rows
+PASS: insert multiple rows | incremental tree matches full rebuild
+PASS: append multiple rows | preserve existing rows
+PASS: append multiple rows | create inserted rows
+PASS: append multiple rows | incremental tree matches full rebuild
+PASS: insert CSS table row | preserve existing rows
+PASS: insert CSS table row | create inserted rows
+PASS: insert CSS table row | incremental tree matches full rebuild
+PASS: insert absolutely positioned row | rebuild existing rows
+PASS: insert absolutely positioned row | create inserted rows
+PASS: insert absolutely positioned row | incremental tree matches full rebuild
+PASS: insert floating row | rebuild existing rows
+PASS: insert floating row | create inserted rows
+PASS: insert floating row | incremental tree matches full rebuild
+PASS: insert interior whitespace | preserve row group
+PASS: insert interior whitespace | incremental tree matches full rebuild
+PASS: insert interior multiple whitespace nodes | rebuild row group
+PASS: insert interior multiple whitespace nodes | incremental tree matches full rebuild
+PASS: insert interior whitespace around comment | rebuild row group
+PASS: insert interior whitespace around comment | incremental tree matches full rebuild
+PASS: insert interior whitespace around hidden element | rebuild row group
+PASS: insert interior whitespace around hidden element | incremental tree matches full rebuild
+PASS: prepend edge whitespace | preserve row group
+PASS: prepend edge whitespace | incremental tree matches full rebuild
+PASS: append edge whitespace | preserve row group
+PASS: append edge whitespace | incremental tree matches full rebuild
+PASS: tbody prepend outside whitespace | rebuild row group
+PASS: tbody prepend outside whitespace | incremental tree matches full rebuild
+PASS: tbody prepend outside multiple whitespace nodes | rebuild row group
+PASS: tbody prepend outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody prepend outside whitespace around comment | rebuild row group
+PASS: tbody prepend outside whitespace around comment | incremental tree matches full rebuild
+PASS: tbody prepend outside whitespace around hidden element | rebuild row group
+PASS: tbody prepend outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tbody prepend inside whitespace | preserve row group
+PASS: tbody prepend inside whitespace | incremental tree matches full rebuild
+PASS: tbody prepend inside multiple whitespace nodes | preserve row group
+PASS: tbody prepend inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody prepend inside whitespace around comment | preserve row group
+PASS: tbody prepend inside whitespace around comment | incremental tree matches full rebuild
+PASS: tbody prepend inside whitespace around hidden element | preserve row group
+PASS: tbody prepend inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tbody prepend opposite whitespace | preserve row group
+PASS: tbody prepend opposite whitespace | incremental tree matches full rebuild
+PASS: tbody prepend opposite multiple whitespace nodes | preserve row group
+PASS: tbody prepend opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody prepend opposite whitespace around comment | preserve row group
+PASS: tbody prepend opposite whitespace around comment | incremental tree matches full rebuild
+PASS: tbody prepend opposite whitespace around hidden element | preserve row group
+PASS: tbody prepend opposite whitespace around hidden element | incremental tree matches full rebuild
+PASS: tbody append outside whitespace | rebuild row group
+PASS: tbody append outside whitespace | incremental tree matches full rebuild
+PASS: tbody append outside multiple whitespace nodes | rebuild row group
+PASS: tbody append outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody append outside whitespace around comment | rebuild row group
+PASS: tbody append outside whitespace around comment | incremental tree matches full rebuild
+PASS: tbody append outside whitespace around hidden element | rebuild row group
+PASS: tbody append outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tbody append inside whitespace | preserve row group
+PASS: tbody append inside whitespace | incremental tree matches full rebuild
+PASS: tbody append inside multiple whitespace nodes | preserve row group
+PASS: tbody append inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody append inside whitespace around comment | preserve row group
+PASS: tbody append inside whitespace around comment | incremental tree matches full rebuild
+PASS: tbody append inside whitespace around hidden element | preserve row group
+PASS: tbody append inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tbody append opposite whitespace | preserve row group
+PASS: tbody append opposite whitespace | incremental tree matches full rebuild
+PASS: tbody append opposite multiple whitespace nodes | preserve row group
+PASS: tbody append opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tbody append opposite whitespace around comment | preserve row group
+PASS: tbody append opposite whitespace around comment | incremental tree matches full rebuild
+PASS: tbody append opposite whitespace around hidden element | preserve row group
+PASS: tbody append opposite whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead prepend outside whitespace | rebuild row group
+PASS: thead prepend outside whitespace | incremental tree matches full rebuild
+PASS: thead prepend outside multiple whitespace nodes | rebuild row group
+PASS: thead prepend outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead prepend outside whitespace around comment | rebuild row group
+PASS: thead prepend outside whitespace around comment | incremental tree matches full rebuild
+PASS: thead prepend outside whitespace around hidden element | rebuild row group
+PASS: thead prepend outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead prepend inside whitespace | preserve row group
+PASS: thead prepend inside whitespace | incremental tree matches full rebuild
+PASS: thead prepend inside multiple whitespace nodes | preserve row group
+PASS: thead prepend inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead prepend inside whitespace around comment | preserve row group
+PASS: thead prepend inside whitespace around comment | incremental tree matches full rebuild
+PASS: thead prepend inside whitespace around hidden element | preserve row group
+PASS: thead prepend inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead prepend opposite whitespace | preserve row group
+PASS: thead prepend opposite whitespace | incremental tree matches full rebuild
+PASS: thead prepend opposite multiple whitespace nodes | preserve row group
+PASS: thead prepend opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead prepend opposite whitespace around comment | preserve row group
+PASS: thead prepend opposite whitespace around comment | incremental tree matches full rebuild
+PASS: thead prepend opposite whitespace around hidden element | preserve row group
+PASS: thead prepend opposite whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead append outside whitespace | rebuild row group
+PASS: thead append outside whitespace | incremental tree matches full rebuild
+PASS: thead append outside multiple whitespace nodes | rebuild row group
+PASS: thead append outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead append outside whitespace around comment | rebuild row group
+PASS: thead append outside whitespace around comment | incremental tree matches full rebuild
+PASS: thead append outside whitespace around hidden element | rebuild row group
+PASS: thead append outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead append inside whitespace | preserve row group
+PASS: thead append inside whitespace | incremental tree matches full rebuild
+PASS: thead append inside multiple whitespace nodes | preserve row group
+PASS: thead append inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead append inside whitespace around comment | preserve row group
+PASS: thead append inside whitespace around comment | incremental tree matches full rebuild
+PASS: thead append inside whitespace around hidden element | preserve row group
+PASS: thead append inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: thead append opposite whitespace | preserve row group
+PASS: thead append opposite whitespace | incremental tree matches full rebuild
+PASS: thead append opposite multiple whitespace nodes | preserve row group
+PASS: thead append opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: thead append opposite whitespace around comment | preserve row group
+PASS: thead append opposite whitespace around comment | incremental tree matches full rebuild
+PASS: thead append opposite whitespace around hidden element | preserve row group
+PASS: thead append opposite whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot prepend outside whitespace | rebuild row group
+PASS: tfoot prepend outside whitespace | incremental tree matches full rebuild
+PASS: tfoot prepend outside multiple whitespace nodes | rebuild row group
+PASS: tfoot prepend outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot prepend outside whitespace around comment | rebuild row group
+PASS: tfoot prepend outside whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot prepend outside whitespace around hidden element | rebuild row group
+PASS: tfoot prepend outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot prepend inside whitespace | preserve row group
+PASS: tfoot prepend inside whitespace | incremental tree matches full rebuild
+PASS: tfoot prepend inside multiple whitespace nodes | preserve row group
+PASS: tfoot prepend inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot prepend inside whitespace around comment | preserve row group
+PASS: tfoot prepend inside whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot prepend inside whitespace around hidden element | preserve row group
+PASS: tfoot prepend inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot prepend opposite whitespace | preserve row group
+PASS: tfoot prepend opposite whitespace | incremental tree matches full rebuild
+PASS: tfoot prepend opposite multiple whitespace nodes | preserve row group
+PASS: tfoot prepend opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot prepend opposite whitespace around comment | preserve row group
+PASS: tfoot prepend opposite whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot prepend opposite whitespace around hidden element | preserve row group
+PASS: tfoot prepend opposite whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot append outside whitespace | rebuild row group
+PASS: tfoot append outside whitespace | incremental tree matches full rebuild
+PASS: tfoot append outside multiple whitespace nodes | rebuild row group
+PASS: tfoot append outside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot append outside whitespace around comment | rebuild row group
+PASS: tfoot append outside whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot append outside whitespace around hidden element | rebuild row group
+PASS: tfoot append outside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot append inside whitespace | preserve row group
+PASS: tfoot append inside whitespace | incremental tree matches full rebuild
+PASS: tfoot append inside multiple whitespace nodes | preserve row group
+PASS: tfoot append inside multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot append inside whitespace around comment | preserve row group
+PASS: tfoot append inside whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot append inside whitespace around hidden element | preserve row group
+PASS: tfoot append inside whitespace around hidden element | incremental tree matches full rebuild
+PASS: tfoot append opposite whitespace | preserve row group
+PASS: tfoot append opposite whitespace | incremental tree matches full rebuild
+PASS: tfoot append opposite multiple whitespace nodes | preserve row group
+PASS: tfoot append opposite multiple whitespace nodes | incremental tree matches full rebuild
+PASS: tfoot append opposite whitespace around comment | preserve row group
+PASS: tfoot append opposite whitespace around comment | incremental tree matches full rebuild
+PASS: tfoot append opposite whitespace around hidden element | preserve row group
+PASS: tfoot append opposite whitespace around hidden element | incremental tree matches full rebuild

--- a/Tests/LibWeb/Text/input/layout-tree-update/table-row-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/table-row-insertion-preservation.html
@@ -62,6 +62,121 @@
         println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: non-row insertion | incremental tree matches full rebuild`);
     }
 
+    function createBoundaryNodes(kind) {
+        switch (kind) {
+        case "whitespace":
+            return [document.createTextNode("  \n")];
+        case "multiple whitespace nodes":
+            return [document.createTextNode(" "), document.createTextNode("\n"), document.createTextNode("\t")];
+        case "whitespace around comment":
+            return [document.createTextNode(" "), document.createComment("boundary"), document.createTextNode("\n")];
+        case "whitespace around hidden element": {
+            const hidden = document.createElement("span");
+            hidden.style.display = "none";
+            return [document.createTextNode(" "), hidden, document.createTextNode("\n")];
+        }
+        }
+    }
+
+    function runWhitespaceBoundaryCase(groupTag, direction, boundaryKind, insertionPosition) {
+        const fixture = document.getElementById("fixture");
+        fixture.replaceChildren();
+        const table = document.createElement("table");
+        const body = document.createElement(groupTag);
+        const existingRow = createRow("existing");
+        const boundaryNodes = createBoundaryNodes(boundaryKind);
+        if (direction === "prepend")
+            body.append(...boundaryNodes, existingRow);
+        else
+            body.append(existingRow, ...boundaryNodes);
+        table.appendChild(body);
+        fixture.appendChild(table);
+        document.body.offsetHeight;
+
+        const bodyIdentity = internals.layoutNodeIdentity(body);
+        const insertedRow = createRow("inserted");
+        if (insertionPosition === "outside") {
+            if (direction === "prepend")
+                body.prepend(insertedRow);
+            else
+                body.append(insertedRow);
+        } else if (insertionPosition === "inside") {
+            if (direction === "prepend")
+                body.insertBefore(insertedRow, existingRow);
+            else
+                body.insertBefore(insertedRow, boundaryNodes[0]);
+        } else if (direction === "prepend") {
+            body.append(insertedRow);
+        } else {
+            body.prepend(insertedRow);
+        }
+        document.body.offsetHeight;
+
+        const shouldPreserve = insertionPosition !== "outside";
+        const preserved = internals.layoutNodeIdentity(body) === bodyIdentity;
+        const name = `${groupTag} ${direction} ${insertionPosition} ${boundaryKind}`;
+        println(`${preserved === shouldPreserve ? "PASS" : "FAIL"}: ${name} | ${shouldPreserve ? "preserve" : "rebuild"} row group`);
+        println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${name} | incremental tree matches full rebuild`);
+    }
+
+    function runRowInsertionCase(name, createInsertedRows, insert, shouldPreserve = true) {
+        const fixture = document.getElementById("fixture");
+        fixture.replaceChildren();
+        const table = document.createElement("table");
+        const body = document.createElement("tbody");
+        const before = createRow("before");
+        const after = createRow("after");
+        body.append(before, after);
+        table.appendChild(body);
+        fixture.appendChild(table);
+        document.body.offsetHeight;
+
+        const bodyIdentity = internals.layoutNodeIdentity(body);
+        const beforeIdentity = internals.layoutNodeIdentity(before);
+        const insertedRows = createInsertedRows();
+        insert(body, after, insertedRows);
+        document.body.offsetHeight;
+
+        const preserved = internals.layoutNodeIdentity(body) === bodyIdentity
+            && internals.layoutNodeIdentity(before) === beforeIdentity;
+        println(`${preserved === shouldPreserve ? "PASS" : "FAIL"}: ${name} | ${shouldPreserve ? "preserve" : "rebuild"} existing rows`);
+        println(`${insertedRows.every(row => internals.layoutNodeIdentity(row) !== 0) ? "PASS" : "FAIL"}: ${name} | create inserted rows`);
+        println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${name} | incremental tree matches full rebuild`);
+    }
+
+    function createCustomRow() {
+        const row = document.createElement("div");
+        row.style.display = "table-row";
+        for (let column = 0; column < 2; ++column) {
+            const cell = document.createElement("div");
+            cell.style.display = "table-cell";
+            cell.textContent = `custom-${column}`;
+            row.appendChild(cell);
+        }
+        return row;
+    }
+
+    function runWhitespaceInsertionCase(name, boundaryKind, insert, shouldPreserve) {
+        const fixture = document.getElementById("fixture");
+        fixture.replaceChildren();
+        const table = document.createElement("table");
+        const body = document.createElement("tbody");
+        const before = createRow("before");
+        const after = createRow("after");
+        body.append(before, after);
+        table.appendChild(body);
+        fixture.appendChild(table);
+        document.body.offsetHeight;
+
+        const bodyIdentity = internals.layoutNodeIdentity(body);
+        insert(body, after, createBoundaryNodes(boundaryKind));
+        document.body.offsetHeight;
+
+        const preserved = internals.layoutNodeIdentity(body) === bodyIdentity;
+        println(`${preserved === shouldPreserve ? "PASS" : "FAIL"}: ${name} | ${shouldPreserve ? "preserve" : "rebuild"} row group`);
+        println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${name} | incremental tree matches full rebuild`);
+    }
+
     test(() => {
         runPreservationCase("append row", (body, row) => body.appendChild(row));
         runPreservationCase("prepend row", (body, row) => body.insertBefore(row, body.firstChild));
@@ -69,5 +184,42 @@
         runPreservationCase("append header row", (body, row) => body.appendChild(row), "thead");
         runPreservationCase("append footer row", (body, row) => body.appendChild(row), "tfoot");
         runFallbackCase();
+        runRowInsertionCase("prepend multiple rows", () => [createRow("first"), createRow("second")], (body, after, rows) => body.prepend(...rows));
+        runRowInsertionCase("insert multiple rows", () => [createRow("first"), createRow("second")], (body, after, rows) => {
+            const fragment = new DocumentFragment();
+            fragment.append(...rows);
+            body.insertBefore(fragment, after);
+        });
+        runRowInsertionCase("append multiple rows", () => [createRow("first"), createRow("second")], (body, after, rows) => body.append(...rows));
+        runRowInsertionCase("insert CSS table row", () => [createCustomRow()], (body, after, rows) => body.insertBefore(rows[0], after));
+        runRowInsertionCase("insert absolutely positioned row", () => {
+            const row = createRow("absolute");
+            row.style.position = "absolute";
+            return [row];
+        }, (body, after, rows) => body.insertBefore(rows[0], after), false);
+        runRowInsertionCase("insert floating row", () => {
+            const row = createRow("float");
+            row.style.cssFloat = "left";
+            return [row];
+        }, (body, after, rows) => body.insertBefore(rows[0], after), false);
+
+        for (const boundaryKind of ["whitespace", "multiple whitespace nodes", "whitespace around comment", "whitespace around hidden element"]) {
+            runWhitespaceInsertionCase(`insert interior ${boundaryKind}`, boundaryKind, (body, after, nodes) => {
+                const fragment = new DocumentFragment();
+                fragment.append(...nodes);
+                body.insertBefore(fragment, after);
+            }, boundaryKind === "whitespace");
+        }
+        runWhitespaceInsertionCase("prepend edge whitespace", "whitespace", (body, after, nodes) => body.prepend(...nodes), true);
+        runWhitespaceInsertionCase("append edge whitespace", "whitespace", (body, after, nodes) => body.append(...nodes), true);
+
+        for (const groupTag of ["tbody", "thead", "tfoot"]) {
+            for (const direction of ["prepend", "append"]) {
+                for (const insertionPosition of ["outside", "inside", "opposite"]) {
+                    for (const boundaryKind of ["whitespace", "multiple whitespace nodes", "whitespace around comment", "whitespace around hidden element"])
+                        runWhitespaceBoundaryCase(groupTag, direction, boundaryKind, insertionPosition);
+                }
+            }
+        }
     });
 </script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/table-row-insertion-preservation.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/table-row-insertion-preservation.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="fixture"></div>
+<script>
+    function createRow(label) {
+        const row = document.createElement("tr");
+        for (let column = 0; column < 2; ++column) {
+            const cell = document.createElement("td");
+            cell.textContent = `${label}-${column}`;
+            row.appendChild(cell);
+        }
+        return row;
+    }
+
+    function runPreservationCase(name, insert, groupTag = "tbody") {
+        const fixture = document.getElementById("fixture");
+        fixture.replaceChildren();
+        const table = document.createElement("table");
+        const body = document.createElement(groupTag);
+        body.append(createRow("before"), createRow("middle"), createRow("after"));
+        table.appendChild(body);
+        fixture.appendChild(table);
+        document.body.offsetHeight;
+
+        const firstRow = body.rows[0];
+        const firstCell = firstRow.cells[0];
+        const bodyIdentity = internals.layoutNodeIdentity(body);
+        const firstRowIdentity = internals.layoutNodeIdentity(firstRow);
+        const firstCellIdentity = internals.layoutNodeIdentity(firstCell);
+        const intrinsicMeasurementsBefore = internals.intrinsicMeasurementCount();
+
+        const insertedRow = createRow("inserted");
+        insert(body, insertedRow);
+        document.body.offsetHeight;
+
+        println(`${internals.layoutNodeIdentity(body) === bodyIdentity ? "PASS" : "FAIL"}: ${name} | preserve row group`);
+        println(`${internals.layoutNodeIdentity(firstRow) === firstRowIdentity ? "PASS" : "FAIL"}: ${name} | preserve existing row`);
+        println(`${internals.layoutNodeIdentity(firstCell) === firstCellIdentity ? "PASS" : "FAIL"}: ${name} | preserve existing cell`);
+        println(`${internals.layoutNodeIdentity(insertedRow) !== 0 ? "PASS" : "FAIL"}: ${name} | create inserted row`);
+        const intrinsicMeasurements = internals.intrinsicMeasurementCount() - intrinsicMeasurementsBefore;
+        println(`${intrinsicMeasurements === 4 ? "PASS" : "FAIL"}: ${name} | intrinsic measurements=${intrinsicMeasurements}`);
+        println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: ${name} | incremental tree matches full rebuild`);
+    }
+
+    function runFallbackCase() {
+        const fixture = document.getElementById("fixture");
+        fixture.replaceChildren();
+        const table = document.createElement("table");
+        const body = document.createElement("tbody");
+        body.append(createRow("before"), createRow("after"));
+        table.appendChild(body);
+        fixture.appendChild(table);
+        document.body.offsetHeight;
+
+        const bodyIdentity = internals.layoutNodeIdentity(body);
+        const row = createRow("inserted");
+        row.style.display = "block";
+        body.appendChild(row);
+        document.body.offsetHeight;
+
+        println(`${internals.layoutNodeIdentity(body) !== bodyIdentity ? "PASS" : "FAIL"}: non-row insertion | rebuild row group`);
+        println(`${internals.compareLayoutTreeWithFullRebuild().matches ? "PASS" : "FAIL"}: non-row insertion | incremental tree matches full rebuild`);
+    }
+
+    test(() => {
+        runPreservationCase("append row", (body, row) => body.appendChild(row));
+        runPreservationCase("prepend row", (body, row) => body.insertBefore(row, body.firstChild));
+        runPreservationCase("insert middle row", (body, row) => body.insertBefore(row, body.rows[1]));
+        runPreservationCase("append header row", (body, row) => body.appendChild(row), "thead");
+        runPreservationCase("append footer row", (body, row) => body.appendChild(row), "tfoot");
+        runFallbackCase();
+    });
+</script>


### PR DESCRIPTION
Preserve a table row group’s layout node and existing row subtrees when inserting table rows. This keeps cached intrinsic measurements alive: adding one two-cell row to a three-row table performs 4 intrinsic measurements instead of 16 from rebuilding all four rows.

Fall back to rebuilding for unsupported children, blockified rows, and discarded edge whitespace that becomes interior after insertion. Expand the incremental tree comparison matrix across body, header, and footer groups, insertion positions, boundary whitespace mixed with comments or hidden elements, batched rows, CSS-authored table rows, and out-of-flow rows.