### PR TITLE
LibWeb+Tests: Dispatch mouse events at layout nodes chosen in hit tests 

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9322,7 +9322,7 @@ Optional<Painting::HitTestResult> Document::hit_test(CSSPixelPoint position)
             return {};
         return Painting::HitTestResult {
             .node = element,
-            .box = Painting::committed_row_slot(*layout_node),
+            .paintable = Painting::committed_row_slot(*layout_node),
             .arena = layout_node->node_arena(),
         };
     };

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -9312,24 +9312,26 @@ Optional<Painting::HitTestResult> Document::hit_test(CSSPixelPoint position)
     if (!hit_test_display_list)
         return {};
     paint_state().refresh_scroll_state(*this);
+    // https://w3c.github.io/pointerevents/#hit-test
+    // 1. Let pos be the x,y coordinates relative to the viewport
+    // 2. Return [CSSOM-View]'s elementFromPoint() with pos (the frontmost DOM element at pos)
+
+    // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
+    // 1. If either argument is negative, x is greater than the viewport width excluding the size of a rendered scroll
+    //    bar (if any), or y is greater than the viewport height excluding the size of a rendered scroll bar (if any),
+    //    or there is no viewport associated with the document, return null and terminate these steps.
+    // NB: The viewport is its own box in the display list, and its children are clipped to it.
+    // 2. If there is a box in the viewport that would be a target for hit testing at coordinates x,y, when applying
+    //    the transforms that apply to the descendants of the viewport, return the associated element and terminate
+    //    these steps.
     auto result = hit_test_display_list->hit_test(position, *this, page().client().device_pixels_per_css_pixel(), page().chrome_metrics());
     if (result.has_value() && (result->chrome_widget || result->node))
         return result;
 
-    auto fallback_result = [](Element* element) -> Optional<Painting::HitTestResult> {
-        auto* layout_node = element ? element->unsafe_layout_node() : nullptr;
-        if (!layout_node || !Painting::has_committed_box(*layout_node))
-            return {};
-        return Painting::HitTestResult {
-            .node = element,
-            .paintable = Painting::committed_row_slot(*layout_node),
-            .arena = layout_node->node_arena(),
-        };
-    };
-    if (auto result = fallback_result(body()); result.has_value())
-        return result;
-    if (auto result = fallback_result(document_element()); result.has_value())
-        return result;
+    // 3. If the document has a root element, return the root element and terminate these steps.
+    // NB: Hit testing already redirects hits that fall through to the viewport onto the root element instead.
+
+    // 4. Return null.
     return {};
 }
 

--- a/Libraries/LibWeb/HTML/HyperlinkElementUtils.h
+++ b/Libraries/LibWeb/HTML/HyperlinkElementUtils.h
@@ -46,10 +46,10 @@ public:
     Utf16String hash() const;
     void set_hash(Utf16View);
 
-protected:
     virtual DOM::Element& hyperlink_element_utils_element() = 0;
     virtual DOM::Element const& hyperlink_element_utils_element() const = 0;
 
+protected:
     // https://html.spec.whatwg.org/multipage/links.html#update-href
     virtual void update_href() = 0;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1703,6 +1703,35 @@ static GC::Ref<JS::Object> create_hit_testing_result(JS::Realm& realm, Painting:
     return hit_testing_result;
 }
 
+static Utf16String context_menu_kind_to_string(Page::ContextMenuRequest::Kind kind)
+{
+    switch (kind) {
+    case Page::ContextMenuRequest::Kind::Page:
+        return "page"_utf16;
+    case Page::ContextMenuRequest::Kind::Image:
+        return "image"_utf16;
+    case Page::ContextMenuRequest::Kind::Link:
+        return "link"_utf16;
+    case Page::ContextMenuRequest::Kind::Media:
+        return "media"_utf16;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+GC::Ptr<JS::Object> Internals::take_context_menu_request()
+{
+    auto request = page().take_context_menu_request();
+    if (!request.has_value())
+        return nullptr;
+
+    auto& realm = HTML::relevant_realm(window());
+    auto object = JS::Object::create(realm, nullptr);
+    object->define_direct_property("kind"_utf16_fly_string, JS::PrimitiveString::create(vm(), context_menu_kind_to_string(request->kind)), JS::default_attributes);
+    auto target = Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, request->target);
+    object->define_direct_property("target"_utf16_fly_string, target, JS::default_attributes);
+    return object;
+}
+
 GC::Ptr<JS::Object> Internals::hit_test_result(double x, double y)
 {
     auto& realm = HTML::relevant_realm(window());

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -66,6 +66,7 @@ public:
     GC::Ref<XHR::XMLHttpRequest> create_xml_http_request_for_document(DOM::Document&);
     Optional<Painting::HitTestResult> hit_test(double x, double y);
     GC::Ptr<JS::Object> hit_test_result(double x, double y);
+    GC::Ptr<JS::Object> take_context_menu_request();
 
     void send_text(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers);
     void send_key(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers, WebIDL::UnsignedLong repeat_count);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -23,6 +23,7 @@ interface Internals {
     boolean messagePortsAreDirectlyEntangled(MessagePort first, MessagePort second);
     XMLHttpRequest createXMLHttpRequestForDocument(Document document);
     [ImplementedAs=hit_test_result] object hitTest(double x, double y);
+    object? takeContextMenuRequest();
 
     const unsigned short MOD_NONE = 0;
     const unsigned short MOD_ALT = 1;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -368,7 +368,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     //     matching other engines. The page can still suppress the native context menu by cancelling the
     //     contextmenu event itself.
     if (is_context_menu_trigger && dispatch_result != PointerEventDispatchResult::SwallowedByChromeWidget)
-        maybe_show_context_menu(*node, *target, coordinates, screen_position, viewport_position, buttons, modifiers);
+        maybe_show_context_menu(*node, coordinates, screen_position, viewport_position, buttons, modifiers);
 
     if (dispatch_result != PointerEventDispatchResult::RunDefaultActions)
         return EventResult::Cancelled;
@@ -2547,7 +2547,7 @@ void EventHandler::run_activation_behavior(GC::Ref<DOM::Node> node, unsigned but
 }
 
 // https://w3c.github.io/uievents/#maybe-show-context-menu
-void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Target const& target, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
+void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
 {
     // AD-HOC: Allow the user to bypass custom context menus by holding shift, like Firefox.
     if ((modifiers & UIEvents::Mod_Shift) == 0) {
@@ -2573,8 +2573,28 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Target const
     // NB: Event dispatches above may have run JS that invalidated layout.
     document->update_layout(DOM::UpdateLayoutReason::EventHandlerShowContextMenu);
 
+    // AD-HOC: Retarget the user-agent context menu now that layout has potentially changed.
+    //
+    //         We also prioritize the layout node's DOM node. This gives us the parent of a text fragment instead of
+    //         the containing block. It also gives us the <img> element instead of an associated <map> element that
+    //         other events target, matching how Chromium and WebKit behave.
+    //
+    //         Firefox does not do this retargeting, and also opts not to target an <img> element when the cursor is
+    //         above a <map> element.
+    auto hit = document->hit_test(coordinates.visual_viewport_position);
+    if (!hit.has_value())
+        return;
+    GC::Ref<DOM::Node> node_under_pointer = *hit->dom_node();
+    GC::Ref<DOM::Node> node_of_box_under_pointer = node_under_pointer;
+    if (auto* dom_node = hit->layout_node()->dom_node())
+        node_of_box_under_pointer = *dom_node;
+    else if (!is<DOM::Element>(*node_under_pointer)) {
+        if (auto* parent_element = node_under_pointer->parent_or_shadow_host_element())
+            node_of_box_under_pointer = *parent_element;
+    }
+
     auto top_level_viewport_position = m_navigable->to_top_level_position(viewport_position);
-    if (auto const* link = node->enclosing_link_element()) {
+    if (auto const* link = node_under_pointer->enclosing_link_element()) {
         auto href = link->href();
         auto url = document->encoding_parse_url(href);
         if (url.has_value()) {
@@ -2585,21 +2605,12 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Target const
         // AD-HOC: Skip up the tree to the first ancestor that is not a UA shadow DOM node, and use its context menu.
         //         Media elements' controls' shadow DOM nodes should not have their own context menu, but rather
         //         activate their parent media element's menu.
-        auto context_menu_node = node;
+        auto context_menu_node = node_of_box_under_pointer;
         while (auto shadow_root = context_menu_node->containing_shadow_root()) {
             if (!shadow_root->is_user_agent_internal())
                 break;
             VERIFY(shadow_root->host() != nullptr);
             context_menu_node = *shadow_root->host();
-        }
-
-        // AD-HOC: Area elements are never rendered, so use the image over which the context menu was requested
-        //         instead. This keeps the image context menu available over image maps.
-        if (is<HTML::HTMLAreaElement>(*context_menu_node)) {
-            if (auto* layout_node = target.layout_node()) {
-                if (auto* image_element = as_if<HTML::HTMLImageElement>(layout_node->dom_node()))
-                    context_menu_node = *image_element;
-            }
         }
 
         if (is<HTML::HTMLImageElement>(*context_menu_node)) {

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -201,18 +201,9 @@ EventHandler::EventHandler(Badge<HTML::LocalNavigable>, HTML::LocalNavigable& na
 
 EventHandler::~EventHandler() = default;
 
-static Layout::Node* layout_node_for_target(DOM::Document& document, Layout::RustFFI::NodeSlotId paintable)
+Layout::Node* EventHandler::Target::layout_node() const
 {
-    return Painting::layout_node_for_committed_slot(document.layout_node_arena(), paintable);
-}
-
-static CSS::PointerEvents pointer_events_for_hit_target(bool is_text_fragment, DOM::Node const* hit_dom_node, Layout::Node const& target_layout_node)
-{
-    if (is_text_fragment && hit_dom_node) {
-        if (auto const* text_layout_node = hit_dom_node->layout_node(); text_layout_node && text_layout_node->parent())
-            return text_layout_node->parent()->pointer_events();
-    }
-    return as<Layout::NodeWithStyle>(target_layout_node).pointer_events();
+    return Painting::layout_node_for_committed_slot(*arena, hit_node);
 }
 
 void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
@@ -255,7 +246,7 @@ static Optional<EventResult> dispatch_event_to_nested_navigable(Layout::Node con
 
 static bool parent_element_for_event_dispatch(Layout::Node& target_layout_node, GC::Ptr<DOM::Node>& node, Layout::Node*& layout_node)
 {
-    layout_node = node && node->layout_node() ? node->layout_node() : &target_layout_node;
+    layout_node = &target_layout_node;
     if (target_layout_node.is_generated_for_backdrop_pseudo_element()
         || target_layout_node.is_generated_for_after_pseudo_element()
         || target_layout_node.is_generated_for_before_pseudo_element()) {
@@ -272,11 +263,15 @@ static bool parent_element_for_event_dispatch(Layout::Node& target_layout_node, 
         }
     } while ((current_ancestor_node = current_ancestor_node->parent()));
 
-    while (layout_node && node && !node->is_element() && layout_node->parent()) {
-        layout_node = layout_node->parent();
-        if (layout_node->is_anonymous())
+    while (layout_node && node && !node->is_element()) {
+        auto* dom_node = layout_node->is_anonymous() ? nullptr : layout_node->dom_node();
+        if (dom_node && dom_node != node.ptr()) {
+            node = dom_node;
             continue;
-        node = layout_node->dom_node();
+        }
+        if (!layout_node->parent())
+            break;
+        layout_node = layout_node->parent();
     }
     return node && layout_node;
 }
@@ -321,14 +316,9 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
         return EventResult::Dropped;
     }
 
-    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+    auto* target_layout_node = target->layout_node();
     if (!target_layout_node)
         return EventResult::Dropped;
-
-    auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
-    // FIXME: Handle other values for pointer-events.
-    if (pointer_events == CSS::PointerEvents::None)
-        return EventResult::Cancelled;
 
     if (!node)
         return EventResult::Dropped;
@@ -378,7 +368,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     //     matching other engines. The page can still suppress the native context menu by cancelling the
     //     contextmenu event itself.
     if (is_context_menu_trigger && dispatch_result != PointerEventDispatchResult::SwallowedByChromeWidget)
-        maybe_show_context_menu(*node, target->paintable, coordinates, screen_position, viewport_position, buttons, modifiers);
+        maybe_show_context_menu(*node, *target, coordinates, screen_position, viewport_position, buttons, modifiers);
 
     if (dispatch_result != PointerEventDispatchResult::RunDefaultActions)
         return EventResult::Cancelled;
@@ -508,14 +498,9 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         if (!node)
             return EventResult::Dropped;
 
-        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+        auto* target_layout_node = target->layout_node();
         if (!target_layout_node)
             return EventResult::Dropped;
-
-        auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
-        // FIXME: Handle other values for pointer-events.
-        if (pointer_events == CSS::PointerEvents::None)
-            return EventResult::Cancelled;
 
         auto dispath_result = dispatch_event_to_nested_navigable(*target_layout_node, node, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
             return event_handler.handle_mousemove(position, screen_position, buttons, modifiers);
@@ -640,13 +625,9 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
         return EventResult::Dropped;
     }
 
-    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+    auto* target_layout_node = target->layout_node();
     if (!target_layout_node)
         return EventResult::Dropped;
-
-    auto pointer_events = pointer_events_for_hit_target(target->is_text_fragment, target->dom_node.ptr(), *target_layout_node);
-    if (pointer_events == CSS::PointerEvents::None)
-        return EventResult::Cancelled;
 
     if (!node)
         return EventResult::Dropped;
@@ -821,7 +802,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     };
 
     auto wheel_step_selects_a_snap_position = [&] {
-        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+        auto* target_layout_node = target->layout_node();
         if (!target_layout_node)
             return false;
         auto* scrolling_box = scrolling_box_for_scroll_step(*target_layout_node, wheel_step_delta);
@@ -869,7 +850,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     auto handled_event = EventResult::Dropped;
 
     if (target.has_value()) {
-        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+        auto* target_layout_node = target->layout_node();
         if (!target_layout_node)
             return EventResult::Dropped;
 
@@ -883,7 +864,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 return nullptr;
 
             if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
-                return layout_node_for_target(*document, result->paintable);
+                return result->layout_node();
             return nullptr;
         };
 
@@ -919,7 +900,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 result.has_value()) {
                 if (result.value() == EventResult::Handled || result.value() == EventResult::Cancelled)
                     return result.value();
-                target_layout_node = layout_node_for_target(*document, target->paintable);
+                target_layout_node = target->layout_node();
                 if (!target_layout_node)
                     return EventResult::Dropped;
             }
@@ -987,7 +968,7 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
     if (!target.has_value())
         return EventResult::Dropped;
 
-    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+    auto* target_layout_node = target->layout_node();
     if (!target_layout_node || !target->dom_node)
         return EventResult::Dropped;
 
@@ -997,7 +978,7 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
         result.has_value()) {
         if (result.value() == EventResult::Handled || result.value() == EventResult::Cancelled)
             return result.value();
-        target_layout_node = layout_node_for_target(*document, target->paintable);
+        target_layout_node = target->layout_node();
         if (!target_layout_node)
             return EventResult::Dropped;
     }
@@ -1080,7 +1061,7 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     if (!node)
         return;
 
-    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
+    auto* target_layout_node = target->layout_node();
     if (!target_layout_node)
         return;
 
@@ -1571,7 +1552,7 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
     if (!node)
         return EventResult::Dropped;
 
-    auto* target_layout_node = layout_node_for_target(document, target->paintable);
+    auto* target_layout_node = target->layout_node();
     if (!target_layout_node)
         return EventResult::Dropped;
 
@@ -2240,10 +2221,9 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
         return {};
 
     if (auto result = document->hit_test(position); result.has_value()) {
-        if (!layout_node_for_target(*document, result->paintable))
-            return {};
         return Target {
-            .paintable = result->paintable,
+            .hit_node = result->hit_node,
+            .arena = result->arena,
             .chrome_widget = result->chrome_widget,
             .dom_node = result->dom_node(),
             .index_in_node = result->index_in_node,
@@ -2426,7 +2406,7 @@ bool EventHandler::select_word_for_dictionary_lookup(CSSPixelPoint visual_viewpo
     if (!result.has_value())
         return false;
 
-    auto* target_layout_node = layout_node_for_target(*document, result->paintable);
+    auto* target_layout_node = result->layout_node();
     if (!target_layout_node)
         return false;
 
@@ -2567,7 +2547,7 @@ void EventHandler::run_activation_behavior(GC::Ref<DOM::Node> node, unsigned but
 }
 
 // https://w3c.github.io/uievents/#maybe-show-context-menu
-void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::RustFFI::NodeSlotId paintable, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
+void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Target const& target, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
 {
     // AD-HOC: Allow the user to bypass custom context menus by holding shift, like Firefox.
     if ((modifiers & UIEvents::Mod_Shift) == 0) {
@@ -2616,7 +2596,7 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::Rust
         // AD-HOC: Area elements are never rendered, so use the image over which the context menu was requested
         //         instead. This keeps the image context menu available over image maps.
         if (is<HTML::HTMLAreaElement>(*context_menu_node)) {
-            if (auto* layout_node = layout_node_for_target(*document, paintable)) {
+            if (auto* layout_node = target.layout_node()) {
                 if (auto* image_element = as_if<HTML::HTMLImageElement>(layout_node->dom_node()))
                     context_menu_node = *image_element;
             }
@@ -3583,8 +3563,6 @@ void EventHandler::update_cursor(Layout::Node const* layout_node, GC::Ptr<DOM::N
             auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
             auto const& node_with_style = as<Layout::NodeWithStyle>(*layout_node);
             auto const* cursor_values_owner = &node_with_style;
-            if (hit_text_fragment && host_layout_node)
-                cursor_values_owner = &as<Layout::NodeWithStyle>(*host_layout_node);
             auto cursor_data = cursor_values_owner->cursor();
 
             auto* host_node_with_style = host_layout_node ? as_if<Layout::NodeWithStyle>(*host_layout_node) : nullptr;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2597,8 +2597,10 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::Rust
     if (auto const* link = node->enclosing_link_element()) {
         auto href = link->href();
         auto url = document->encoding_parse_url(href);
-        if (url.has_value())
+        if (url.has_value()) {
+            m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Link, .target = const_cast<DOM::Element&>(link->hyperlink_element_utils_element()) });
             m_navigable->page().client().page_did_request_link_context_menu(top_level_viewport_position, *url, link->target().to_byte_string(), modifiers);
+        }
     } else {
         // AD-HOC: Skip up the tree to the first ancestor that is not a UA shadow DOM node, and use its context menu.
         //         Media elements' controls' shadow DOM nodes should not have their own context menu, but rather
@@ -2628,6 +2630,7 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::Rust
                 if (auto frame = image_element.current_image_frame(); frame.has_value())
                     bitmap = &frame->bitmap();
 
+                m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Image, .target = image_element });
                 m_navigable->page().client().page_did_request_image_context_menu(top_level_viewport_position, *image_url, "", modifiers, bitmap);
             }
         } else if (is<HTML::HTMLMediaElement>(*context_menu_node)) {
@@ -2644,11 +2647,13 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::Rust
                 .is_fullscreen = is_video && media_element.is_fullscreen_element(),
             };
 
+            m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Media, .target = media_element });
             m_navigable->page().did_request_media_context_menu(media_element.unique_id(), top_level_viewport_position, "", modifiers, menu);
         } else {
             select_context_menu_text(document, coordinates.visual_viewport_position);
 
             auto for_input_events_target = document->active_input_events_target() ? ContextMenuForInputEventsTarget::Yes : ContextMenuForInputEventsTarget::No;
+            m_navigable->page().record_context_menu_request({}, { .kind = Page::ContextMenuRequest::Kind::Page, .target = context_menu_node });
             m_navigable->page().client().page_did_request_context_menu(top_level_viewport_position, for_input_events_target);
         }
     }
@@ -3635,6 +3640,7 @@ void EventHandler::clear_per_test_input_state(Badge<Internals::Internals>)
     m_effective_legacy_mouse_pointer_position = nullptr;
     m_drag_and_drop_event_handler->reset();
     m_mousemove_previous_screen_position.clear();
+    m_navigable->page().clear_context_menu_request();
 }
 
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -174,7 +174,7 @@ static Optional<Painting::CaretPosition> caret_position_from_editable_hit_node(D
         return {};
 
     return Painting::CaretPosition {
-        .box = Painting::committed_row_slot(*layout_node),
+        .paintable = Painting::committed_row_slot(*layout_node),
         .arena = layout_node->node_arena(),
         .boundary = { *boundary_node, 0 },
     };
@@ -201,9 +201,9 @@ EventHandler::EventHandler(Badge<HTML::LocalNavigable>, HTML::LocalNavigable& na
 
 EventHandler::~EventHandler() = default;
 
-static Layout::Node* layout_node_for_target(DOM::Document& document, Layout::RustFFI::NodeSlotId box)
+static Layout::Node* layout_node_for_target(DOM::Document& document, Layout::RustFFI::NodeSlotId paintable)
 {
-    return Painting::layout_node_for_committed_slot(document.layout_node_arena(), box);
+    return Painting::layout_node_for_committed_slot(document.layout_node_arena(), paintable);
 }
 
 static CSS::PointerEvents pointer_events_for_hit_target(bool is_text_fragment, DOM::Node const* hit_dom_node, Layout::Node const& target_layout_node)
@@ -321,7 +321,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
         return EventResult::Dropped;
     }
 
-    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
     if (!target_layout_node)
         return EventResult::Dropped;
 
@@ -378,7 +378,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     //     matching other engines. The page can still suppress the native context menu by cancelling the
     //     contextmenu event itself.
     if (is_context_menu_trigger && dispatch_result != PointerEventDispatchResult::SwallowedByChromeWidget)
-        maybe_show_context_menu(*node, target->box, coordinates, screen_position, viewport_position, buttons, modifiers);
+        maybe_show_context_menu(*node, target->paintable, coordinates, screen_position, viewport_position, buttons, modifiers);
 
     if (dispatch_result != PointerEventDispatchResult::RunDefaultActions)
         return EventResult::Cancelled;
@@ -508,7 +508,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         if (!node)
             return EventResult::Dropped;
 
-        auto* target_layout_node = layout_node_for_target(*document, target->box);
+        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
         if (!target_layout_node)
             return EventResult::Dropped;
 
@@ -640,7 +640,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
         return EventResult::Dropped;
     }
 
-    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
     if (!target_layout_node)
         return EventResult::Dropped;
 
@@ -821,7 +821,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     };
 
     auto wheel_step_selects_a_snap_position = [&] {
-        auto* target_layout_node = layout_node_for_target(*document, target->box);
+        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
         if (!target_layout_node)
             return false;
         auto* scrolling_box = scrolling_box_for_scroll_step(*target_layout_node, wheel_step_delta);
@@ -869,7 +869,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     auto handled_event = EventResult::Dropped;
 
     if (target.has_value()) {
-        auto* target_layout_node = layout_node_for_target(*document, target->box);
+        auto* target_layout_node = layout_node_for_target(*document, target->paintable);
         if (!target_layout_node)
             return EventResult::Dropped;
 
@@ -883,7 +883,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 return nullptr;
 
             if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
-                return layout_node_for_target(*document, result->box);
+                return layout_node_for_target(*document, result->paintable);
             return nullptr;
         };
 
@@ -919,7 +919,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 result.has_value()) {
                 if (result.value() == EventResult::Handled || result.value() == EventResult::Cancelled)
                     return result.value();
-                target_layout_node = layout_node_for_target(*document, target->box);
+                target_layout_node = layout_node_for_target(*document, target->paintable);
                 if (!target_layout_node)
                     return EventResult::Dropped;
             }
@@ -987,7 +987,7 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
     if (!target.has_value())
         return EventResult::Dropped;
 
-    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
     if (!target_layout_node || !target->dom_node)
         return EventResult::Dropped;
 
@@ -997,7 +997,7 @@ EventResult EventHandler::dispatch_synthetic_pinch_wheel_event(CSSPixelPoint vis
         result.has_value()) {
         if (result.value() == EventResult::Handled || result.value() == EventResult::Cancelled)
             return result.value();
-        target_layout_node = layout_node_for_target(*document, target->box);
+        target_layout_node = layout_node_for_target(*document, target->paintable);
         if (!target_layout_node)
             return EventResult::Dropped;
     }
@@ -1080,7 +1080,7 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     if (!node)
         return;
 
-    auto* target_layout_node = layout_node_for_target(*document, target->box);
+    auto* target_layout_node = layout_node_for_target(*document, target->paintable);
     if (!target_layout_node)
         return;
 
@@ -1571,7 +1571,7 @@ EventResult EventHandler::handle_drag_and_drop_event(DragEvent::Type type, CSSPi
     if (!node)
         return EventResult::Dropped;
 
-    auto* target_layout_node = layout_node_for_target(document, target->box);
+    auto* target_layout_node = layout_node_for_target(document, target->paintable);
     if (!target_layout_node)
         return EventResult::Dropped;
 
@@ -2240,10 +2240,10 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
         return {};
 
     if (auto result = document->hit_test(position); result.has_value()) {
-        if (!layout_node_for_target(*document, result->box))
+        if (!layout_node_for_target(*document, result->paintable))
             return {};
         return Target {
-            .box = result->box,
+            .paintable = result->paintable,
             .chrome_widget = result->chrome_widget,
             .dom_node = result->dom_node(),
             .index_in_node = result->index_in_node,
@@ -2426,7 +2426,7 @@ bool EventHandler::select_word_for_dictionary_lookup(CSSPixelPoint visual_viewpo
     if (!result.has_value())
         return false;
 
-    auto* target_layout_node = layout_node_for_target(*document, result->box);
+    auto* target_layout_node = layout_node_for_target(*document, result->paintable);
     if (!target_layout_node)
         return false;
 
@@ -2567,7 +2567,7 @@ void EventHandler::run_activation_behavior(GC::Ref<DOM::Node> node, unsigned but
 }
 
 // https://w3c.github.io/uievents/#maybe-show-context-menu
-void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::RustFFI::NodeSlotId box, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
+void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::RustFFI::NodeSlotId paintable, MouseEventCoordinates const& coordinates, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers)
 {
     // AD-HOC: Allow the user to bypass custom context menus by holding shift, like Firefox.
     if ((modifiers & UIEvents::Mod_Shift) == 0) {
@@ -2616,7 +2616,7 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, Layout::Rust
         // AD-HOC: Area elements are never rendered, so use the image over which the context menu was requested
         //         instead. This keeps the image context menu available over image maps.
         if (is<HTML::HTMLAreaElement>(*context_menu_node)) {
-            if (auto* layout_node = layout_node_for_target(*document, box)) {
+            if (auto* layout_node = layout_node_for_target(*document, paintable)) {
                 if (auto* image_element = as_if<HTML::HTMLImageElement>(layout_node->dom_node()))
                     context_menu_node = *image_element;
             }

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -9,6 +9,7 @@
 
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <LibGC/Ptr.h>
@@ -111,11 +112,14 @@ private:
     CSSPixelPoint compute_mouse_event_movement(CSSPixelPoint screen_position) const;
 
     struct Target {
-        Layout::RustFFI::NodeSlotId paintable;
+        Layout::RustFFI::NodeSlotId hit_node;
+        NonnullRefPtr<Layout::NodeArena> arena;
         RefPtr<Painting::ChromeWidget> chrome_widget;
         GC::Ptr<DOM::Node> dom_node;
         Optional<int> index_in_node;
         bool is_text_fragment { false };
+
+        Layout::Node* layout_node() const;
     };
     Optional<Target> target_for_mouse_position(CSSPixelPoint position);
     GC::Ptr<DOM::Node> focus_candidate_for_position(CSSPixelPoint) const;
@@ -123,7 +127,7 @@ private:
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
 
-    void maybe_show_context_menu(GC::Ref<DOM::Node>, Layout::RustFFI::NodeSlotId paintable, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    void maybe_show_context_menu(GC::Ref<DOM::Node>, Target const&, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -111,7 +111,7 @@ private:
     CSSPixelPoint compute_mouse_event_movement(CSSPixelPoint screen_position) const;
 
     struct Target {
-        Layout::RustFFI::NodeSlotId box;
+        Layout::RustFFI::NodeSlotId paintable;
         RefPtr<Painting::ChromeWidget> chrome_widget;
         GC::Ptr<DOM::Node> dom_node;
         Optional<int> index_in_node;
@@ -123,7 +123,7 @@ private:
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
 
-    void maybe_show_context_menu(GC::Ref<DOM::Node>, Layout::RustFFI::NodeSlotId, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    void maybe_show_context_menu(GC::Ref<DOM::Node>, Layout::RustFFI::NodeSlotId paintable, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -127,7 +127,7 @@ private:
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
 
-    void maybe_show_context_menu(GC::Ref<DOM::Node>, Target const&, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    void maybe_show_context_menu(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -93,6 +93,8 @@ Compositor::CompositorHost const& Page::compositor_host() const
 void Page::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    if (m_context_menu_request.has_value())
+        visitor.visit(m_context_menu_request->target);
     visitor.visit(m_top_level_traversable);
     visitor.visit(m_client);
     visitor.visit(m_window_rect_observer);
@@ -821,6 +823,18 @@ void Page::notify_all_webgl_contexts_lost()
     for_each_canvas_element([](auto& canvas_element) {
         canvas_element.notify_compositor_connection_lost();
     });
+}
+
+void Page::record_context_menu_request(Badge<EventHandler>, ContextMenuRequest request)
+{
+    m_context_menu_request = request;
+}
+
+Optional<Page::ContextMenuRequest> Page::take_context_menu_request()
+{
+    auto request = m_context_menu_request;
+    m_context_menu_request.clear();
+    return request;
 }
 
 void Page::did_request_media_context_menu(UniqueNodeID media_id, CSSPixelPoint position, ByteString const& target, unsigned modifiers, MediaContextMenu const& menu)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -268,6 +268,20 @@ public:
     void notify_all_canvas_elements_of_lost_backing_storage();
     void notify_all_webgl_contexts_lost();
 
+    struct ContextMenuRequest {
+        enum class Kind : u8 {
+            Page,
+            Image,
+            Link,
+            Media,
+        };
+        Kind kind { Kind::Page };
+        GC::Ref<DOM::Node> target;
+    };
+    void record_context_menu_request(Badge<EventHandler>, ContextMenuRequest);
+    void clear_context_menu_request() { m_context_menu_request.clear(); }
+    Optional<ContextMenuRequest> take_context_menu_request();
+
     struct MediaContextMenu {
         URL::URL media_url;
         bool is_video { false };
@@ -409,6 +423,8 @@ private:
     Optional<UniqueNodeID> m_media_context_menu_element_id;
 
     Web::HTML::MuteState m_mute_state { Web::HTML::MuteState::Unmuted };
+
+    Optional<ContextMenuRequest> m_context_menu_request;
     size_t m_active_screen_wake_lock_count { 0 };
 
     Optional<Utf16String> m_user_style_sheet_source;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -104,7 +104,7 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
         }
         list->m_items.unchecked_append(Item {
             .kind = static_cast<ItemKind>(exported.kind),
-            .box = exported.paintable,
+            .paintable = exported.paintable,
             .chrome_widget_kind = static_cast<ChromeWidgetKind>(exported.chrome_widget_kind),
             .text_fragment_index = exported.text_fragment_index,
             .caret_node = exported.caret_node_shell ? static_cast<Layout::Node const*>(exported.caret_node_shell)->dom_node() : nullptr,
@@ -330,11 +330,11 @@ HitTestDisplayList::ClosestLine HitTestDisplayList::find_closest_line(CSSPixelPo
     return closest_line;
 }
 
-static Layout::RustFFI::FfiFragmentTextFacts fragment_text_facts(void* arena_handle, Layout::RustFFI::NodeSlotId box, Optional<u32> const& text_fragment_index)
+static Layout::RustFFI::FfiFragmentTextFacts fragment_text_facts(void* arena_handle, Layout::RustFFI::NodeSlotId paintable, Optional<u32> const& text_fragment_index)
 {
     if (!text_fragment_index.has_value())
         return {};
-    return Layout::RustFFI::layout_arena_paintable_fragment_text_facts(arena_handle, box, *text_fragment_index);
+    return Layout::RustFFI::layout_arena_paintable_fragment_text_facts(arena_handle, paintable, *text_fragment_index);
 }
 
 static Layout::Node const* fragment_layout_node(Layout::RustFFI::FfiFragmentTextFacts const& facts)
@@ -344,7 +344,7 @@ static Layout::Node const* fragment_layout_node(Layout::RustFFI::FfiFragmentText
 
 Layout::Node const* HitTestDisplayList::layout_node_for_item(Item const& item) const
 {
-    return layout_node_for_committed_slot(*m_arena, item.box);
+    return layout_node_for_committed_slot(*m_arena, item.paintable);
 }
 
 RefPtr<ChromeWidget> HitTestDisplayList::chrome_widget_for_item(Item const& item) const
@@ -353,11 +353,11 @@ RefPtr<ChromeWidget> HitTestDisplayList::chrome_widget_for_item(Item const& item
     case ChromeWidgetKind::None:
         return nullptr;
     case ChromeWidgetKind::ResizeHandle:
-        return m_chrome_widget_registry->resize_handle(item.box);
+        return m_chrome_widget_registry->resize_handle(item.paintable);
     case ChromeWidgetKind::HorizontalScrollbar:
-        return m_chrome_widget_registry->scrollbar(item.box, ScrollDirection::Horizontal);
+        return m_chrome_widget_registry->scrollbar(item.paintable, ScrollDirection::Horizontal);
     case ChromeWidgetKind::VerticalScrollbar:
-        return m_chrome_widget_registry->scrollbar(item.box, ScrollDirection::Vertical);
+        return m_chrome_widget_registry->scrollbar(item.paintable, ScrollDirection::Vertical);
     }
     VERIFY_NOT_REACHED();
 }
@@ -366,7 +366,7 @@ bool HitTestDisplayList::item_can_produce_caret_position(Item const& item) const
 {
     switch (item.kind) {
     case ItemKind::TextFragment: {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index));
+        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
         return layout_node && layout_node->dom_node();
     }
     case ItemKind::EmptyLine:
@@ -403,7 +403,7 @@ DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
         return layout_node ? layout_node->dom_node() : nullptr;
     }
     case ItemKind::TextFragment: {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index));
+        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
         return layout_node ? layout_node->dom_node() : nullptr;
     }
     case ItemKind::EmptyLine:
@@ -415,7 +415,7 @@ DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
 DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(Item const& item) const
 {
     if (item.kind == ItemKind::TextFragment) {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index));
+        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
         if (!layout_node)
             return nullptr;
         if (auto const* node = layout_node->dom_node())
@@ -428,7 +428,7 @@ DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(Item const
     if (item.kind == ItemKind::EmptyLine)
         return item_dom_node(item);
 
-    auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.box);
+    auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.paintable);
     return layout_node_shell ? static_cast<Layout::Node const*>(layout_node_shell)->dom_node() : nullptr;
 }
 
@@ -466,29 +466,29 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
             node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item));
         return HitTestResult {
             .node = node,
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
         };
     }
     case ItemKind::SvgPath:
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
         };
     case ItemKind::TextFragment: {
         VERIFY(item.text_fragment_index.has_value());
         GC::Ptr<DOM::Node> node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item));
         if (!node) {
-            auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.box);
+            auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.paintable);
             node = layout_node_shell ? static_cast<Layout::Node*>(layout_node_shell)->dom_node() : nullptr;
         }
         return HitTestResult {
             .node = node,
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .index_in_node = Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
-                m_arena->handle(), item.box, *item.text_fragment_index,
+                m_arena->handle(), item.paintable, *item.text_fragment_index,
                 local_point.x(), local_point.y()),
             .is_text_fragment = true,
         };
@@ -497,20 +497,20 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
         // NB: Not reachable through regular hit testing; see item_contains().
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
         };
     case ItemKind::EmptyEditable:
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .index_in_node = 0,
         };
     case ItemKind::ChromeWidget:
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .chrome_widget = chrome_widget_for_item(item),
         };
@@ -523,7 +523,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
     switch (item.kind) {
     case ItemKind::TextFragment: {
         VERIFY(item.text_fragment_index.has_value());
-        auto facts = fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index);
+        auto facts = fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index);
         auto const* fragment_layout = fragment_layout_node(facts);
         auto const* fragment_dom_node = fragment_layout ? fragment_layout->dom_node() : nullptr;
         if (!fragment_dom_node)
@@ -537,7 +537,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
                 return facts.dom_end_offset_with_trailing_whitespace;
             case CaretPositionType::Closest:
                 return Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
-                    m_arena->handle(), item.box, *item.text_fragment_index,
+                    m_arena->handle(), item.paintable, *item.text_fragment_index,
                     local_point.x(), local_point.y());
             }
             VERIFY_NOT_REACHED();
@@ -550,9 +550,9 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             : TextAffinity::Downstream;
 
         auto debug_rect = Layout::RustFFI::layout_arena_paintable_fragment_caret_range_rect(
-            m_arena->handle(), item.box, *item.text_fragment_index, index_in_node);
+            m_arena->handle(), item.paintable, *item.text_fragment_index, index_in_node);
         return CaretPosition {
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .boundary = { const_cast<DOM::Node&>(*fragment_dom_node), static_cast<WebIDL::UnsignedLong>(index_in_node) },
             .affinity = affinity,
@@ -565,7 +565,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             return {};
         // An empty line has a single caret position regardless of where on the line the point is.
         return CaretPosition {
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .boundary = { const_cast<DOM::Node&>(*dom_node), static_cast<WebIDL::UnsignedLong>(item.caret_offset) },
             .debug_rect = item.caret_rect,
@@ -577,7 +577,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
         if (!dom_node)
             return {};
         return CaretPosition {
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .boundary = { *dom_node, 0 },
             .debug_rect = item.caret_rect,
@@ -604,7 +604,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& 
             VERIFY_NOT_REACHED();
         }();
         return CaretPosition {
-            .box = item.box,
+            .paintable = item.paintable,
             .arena = *m_arena,
             .boundary = point_is_before_box ? before_boundary : after_boundary,
             .secondary_boundary = point_is_before_box ? after_boundary : before_boundary,
@@ -625,7 +625,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_hit_container(Ite
         return {};
 
     return CaretPosition {
-        .box = item.box,
+        .paintable = item.paintable,
         .arena = *m_arena,
         .boundary = { const_cast<DOM::Node&>(*dom_node), 0 },
         .debug_rect = item.caret_rect,
@@ -637,14 +637,14 @@ bool HitTestDisplayList::item_contains_caret_position(Item const& item, DOM::Nod
     switch (item.kind) {
     case ItemKind::TextFragment: {
         VERIFY(item.text_fragment_index.has_value());
-        auto facts = fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index);
+        auto facts = fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index);
         auto const* fragment_layout = fragment_layout_node(facts);
         auto const* fragment_dom_node = fragment_layout ? fragment_layout->dom_node() : nullptr;
         if (!fragment_dom_node)
             return false;
         if (fragment_dom_node == &node) {
             return Layout::RustFFI::layout_arena_paintable_fragment_caret_match(
-                       m_arena->handle(), item.box, *item.text_fragment_index,
+                       m_arena->handle(), item.paintable, *item.text_fragment_index,
                        offset, affinity == TextAffinity::Downstream)
                 != Layout::RustFFI::FfiCaretMatch::None;
         }
@@ -701,10 +701,10 @@ Optional<size_t> HitTestDisplayList::caret_line_index_for_position(DOM::Node con
                 if (!item_contains_caret_position(item, node, offset, affinity))
                     continue;
                 if (!allow_soft_wrap_fallback && item.kind == ItemKind::TextFragment && item.text_fragment_index.has_value()) {
-                    auto const* fragment_layout = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.box, item.text_fragment_index));
+                    auto const* fragment_layout = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
                     if (fragment_layout && fragment_layout->dom_node() == &node
                         && Layout::RustFFI::layout_arena_paintable_fragment_caret_match(
-                               m_arena->handle(), item.box, *item.text_fragment_index,
+                               m_arena->handle(), item.paintable, *item.text_fragment_index,
                                offset, affinity == TextAffinity::Downstream)
                             == Layout::RustFFI::FfiCaretMatch::SoftWrapFallback)
                         continue;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -89,6 +89,7 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
     for (auto const& exported : exported_items) {
         VERIFY(exported.paintable.index != Layout::RustFFI::INVALID_NODE_SLOT_INDEX);
         VERIFY(Layout::RustFFI::layout_arena_paintable_row(arena_handle, exported.paintable));
+        VERIFY(Layout::RustFFI::layout_arena_paintable_row(arena_handle, exported.hit_node));
         switch (static_cast<ChromeWidgetKind>(exported.chrome_widget_kind)) {
         case ChromeWidgetKind::None:
             break;
@@ -105,6 +106,7 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
         list->m_items.unchecked_append(Item {
             .kind = static_cast<ItemKind>(exported.kind),
             .paintable = exported.paintable,
+            .hit_node = exported.hit_node,
             .chrome_widget_kind = static_cast<ChromeWidgetKind>(exported.chrome_widget_kind),
             .text_fragment_index = exported.text_fragment_index,
             .caret_node = exported.caret_node_shell ? static_cast<Layout::Node const*>(exported.caret_node_shell)->dom_node() : nullptr,
@@ -330,11 +332,11 @@ HitTestDisplayList::ClosestLine HitTestDisplayList::find_closest_line(CSSPixelPo
     return closest_line;
 }
 
-static Layout::RustFFI::FfiFragmentTextFacts fragment_text_facts(void* arena_handle, Layout::RustFFI::NodeSlotId paintable, Optional<u32> const& text_fragment_index)
+static Layout::RustFFI::FfiFragmentTextFacts fragment_text_facts(void* arena_handle, Layout::RustFFI::NodeSlotId box, Optional<u32> const& text_fragment_index)
 {
     if (!text_fragment_index.has_value())
         return {};
-    return Layout::RustFFI::layout_arena_paintable_fragment_text_facts(arena_handle, paintable, *text_fragment_index);
+    return Layout::RustFFI::layout_arena_paintable_fragment_text_facts(arena_handle, box, *text_fragment_index);
 }
 
 static Layout::Node const* fragment_layout_node(Layout::RustFFI::FfiFragmentTextFacts const& facts)
@@ -457,23 +459,46 @@ static GC::Ptr<DOM::Node> image_map_area_for_point(Layout::Node const& layout_no
 
 HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSSPixelPoint local_point) const
 {
+    auto const* paintable_layout_node = layout_node_for_item(item);
+    auto hit_node = item.hit_node;
+
+    auto const* named_layout_node = layout_node_for_committed_slot(*m_arena, hit_node);
+    VERIFY(named_layout_node && as<Layout::NodeWithStyle>(*named_layout_node).pointer_events() != CSS::PointerEvents::None);
+
+    // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
+    // 2. If there is a box in the viewport that would be a target for hit testing at coordinates x,y, when applying
+    //    the transforms that apply to the descendants of the viewport, return the associated element and terminate
+    //    these steps.
+    // 3. If the document has a root element, return the root element and terminate these steps.
+    // AD-HOC: Our viewport refers to the document instead of the root element. The steps above imply that we should
+    //         not hit test the viewport as a box, and report the root element as hit when we otherwise miss, so we
+    //         correct those hits here. This is where both pointer event hit testing and elementFromPoint() converge.
+    GC::Ptr<DOM::Node> root_element;
+    if (paintable_layout_node && paintable_layout_node->kind() == Layout::RustFFI::NodeKind::Viewport) {
+        auto* named_element = const_cast<DOM::Element*>(paintable_layout_node->document().document_element());
+        if (auto* root_layout_node = named_element ? named_element->unsafe_layout_node() : nullptr; root_layout_node && has_committed_box(*root_layout_node)) {
+            root_element = named_element;
+            hit_node = committed_row_slot(*root_layout_node);
+        }
+    }
+
     switch (item.kind) {
     case ItemKind::Box: {
-        GC::Ptr<DOM::Node> node;
-        if (auto const* layout_node = layout_node_for_item(item))
-            node = image_map_area_for_point(*layout_node, local_point);
+        GC::Ptr<DOM::Node> node = root_element;
+        if (!node && paintable_layout_node)
+            node = image_map_area_for_point(*paintable_layout_node, local_point);
         if (!node)
             node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item));
         return HitTestResult {
             .node = node,
-            .paintable = item.paintable,
+            .hit_node = hit_node,
             .arena = *m_arena,
         };
     }
     case ItemKind::SvgPath:
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .paintable = item.paintable,
+            .hit_node = hit_node,
             .arena = *m_arena,
         };
     case ItemKind::TextFragment: {
@@ -485,7 +510,7 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
         }
         return HitTestResult {
             .node = node,
-            .paintable = item.paintable,
+            .hit_node = hit_node,
             .arena = *m_arena,
             .index_in_node = Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
                 m_arena->handle(), item.paintable, *item.text_fragment_index,
@@ -497,20 +522,20 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
         // NB: Not reachable through regular hit testing; see item_contains().
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .paintable = item.paintable,
+            .hit_node = hit_node,
             .arena = *m_arena,
         };
     case ItemKind::EmptyEditable:
         return HitTestResult {
             .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .paintable = item.paintable,
+            .hit_node = hit_node,
             .arena = *m_arena,
             .index_in_node = 0,
         };
     case ItemKind::ChromeWidget:
         return HitTestResult {
-            .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .paintable = item.paintable,
+            .node = root_element ? root_element : const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
+            .hit_node = hit_node,
             .arena = *m_arena,
             .chrome_widget = chrome_widget_for_item(item),
         };

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -78,6 +78,7 @@ private:
     struct Item {
         ItemKind kind;
         Layout::RustFFI::NodeSlotId paintable;
+        Layout::RustFFI::NodeSlotId hit_node;
         ChromeWidgetKind chrome_widget_kind { ChromeWidgetKind::None };
         Optional<u32> text_fragment_index;
         GC::Ptr<DOM::Node const> caret_node { nullptr };

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -77,7 +77,7 @@ private:
 
     struct Item {
         ItemKind kind;
-        Layout::RustFFI::NodeSlotId box;
+        Layout::RustFFI::NodeSlotId paintable;
         ChromeWidgetKind chrome_widget_kind { ChromeWidgetKind::None };
         Optional<u32> text_fragment_index;
         GC::Ptr<DOM::Node const> caret_node { nullptr };

--- a/Libraries/LibWeb/Painting/HitTestResult.h
+++ b/Libraries/LibWeb/Painting/HitTestResult.h
@@ -22,7 +22,7 @@ namespace Web::Painting {
 
 struct HitTestResult {
     GC::Ptr<DOM::Node> node;
-    Layout::RustFFI::NodeSlotId paintable;
+    Layout::RustFFI::NodeSlotId hit_node;
     NonnullRefPtr<Layout::NodeArena> arena;
     RefPtr<ChromeWidget> chrome_widget {};
     size_t index_in_node { 0 };
@@ -30,7 +30,7 @@ struct HitTestResult {
 
     DOM::Node* dom_node() { return node.ptr(); }
     DOM::Node const* dom_node() const { return node.ptr(); }
-    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, paintable); }
+    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, hit_node); }
 };
 
 struct CaretPosition {

--- a/Libraries/LibWeb/Painting/HitTestResult.h
+++ b/Libraries/LibWeb/Painting/HitTestResult.h
@@ -22,7 +22,7 @@ namespace Web::Painting {
 
 struct HitTestResult {
     GC::Ptr<DOM::Node> node;
-    Layout::RustFFI::NodeSlotId box;
+    Layout::RustFFI::NodeSlotId paintable;
     NonnullRefPtr<Layout::NodeArena> arena;
     RefPtr<ChromeWidget> chrome_widget {};
     size_t index_in_node { 0 };
@@ -30,18 +30,18 @@ struct HitTestResult {
 
     DOM::Node* dom_node() { return node.ptr(); }
     DOM::Node const* dom_node() const { return node.ptr(); }
-    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, box); }
+    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, paintable); }
 };
 
 struct CaretPosition {
-    Layout::RustFFI::NodeSlotId box;
+    Layout::RustFFI::NodeSlotId paintable;
     NonnullRefPtr<Layout::NodeArena> arena;
     DOM::BoundaryPoint boundary;
     TextAffinity affinity { TextAffinity::Downstream };
     Optional<DOM::BoundaryPoint> secondary_boundary {};
     Optional<CSSPixelRect> debug_rect {};
 
-    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, box); }
+    Layout::Node* layout_node() const { return layout_node_for_committed_slot(*arena, paintable); }
 };
 
 }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2460,9 +2460,14 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
                 arena.paintable_row_is_populated(item.paintable),
                 "exporting a hit-test item for a non-live paintable"
             );
+            assert!(
+                arena.paintable_row_is_populated(item.hit_node),
+                "exporting a hit-test item that names a non-live paintable"
+            );
             *output = crate::painting::host::FfiHitTestItemExport {
                 kind: item.kind as u8,
                 paintable: item.paintable,
+                hit_node: item.hit_node,
                 chrome_widget_kind: item.chrome_widget_kind,
                 text_fragment_index: item.text_fragment_index.into(),
                 caret_node_shell: arena.shell_if_live(item.caret_node),

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
@@ -37,6 +37,8 @@ pub use crate::painting::border_radii::BorderRadii;
 pub struct HitTestItem {
     pub kind: HitTestItemKind,
     pub paintable: NodeSlotId,
+    /// The node whose style admitted this hit: a text fragment's parent, otherwise the paintable itself.
+    pub hit_node: NodeSlotId,
     pub chrome_widget_kind: u8,
     pub text_fragment_index: Option<u32>,
     pub caret_node: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -171,6 +171,7 @@ pub struct FfiAdjacentLine {
 pub struct FfiHitTestItemExport {
     pub kind: u8,
     pub paintable: NodeSlotId,
+    pub hit_node: NodeSlotId,
     pub chrome_widget_kind: u8,
     pub text_fragment_index: OptionalU32,
     pub caret_node_shell: *mut c_void,

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -358,37 +358,35 @@ impl<'a> PaintRecorder<'a> {
         text_fragment::is_block_level_box(self.layout_arena, &self.fragment(owner, index))
     }
 
-    fn text_fragment_is_hit_testable(&mut self, fragment: &FragmentRecord) -> bool {
+    // A text node has no style of its own, so its parent both decides whether the fragment can be hit and is what an
+    // event dispatched from it resolves against. Returns that node, or None when the fragment is not hit-testable.
+    fn hit_node_for_text_fragment(&mut self, fragment: &FragmentRecord) -> Option<NodeSlotId> {
         let node = fragment.layout_node;
-        let Some(kind) = self.layout_arena.node_kind_if_live(node) else {
-            return false;
-        };
-        if !node_facts::kind_is_text(kind) {
-            return false;
+        if !node_facts::kind_is_text(self.layout_arena.node_kind_if_live(node)?) {
+            return None;
         }
-        let Some(parent) = self.layout_arena.node_parent_if_live(node) else {
-            return false;
-        };
+        let parent = self.layout_arena.node_parent_if_live(node)?;
         let parent_visible = self
             .layout_arena
             .node_style_if_live(parent)
             .is_none_or(|style| style.visibility() == css_enums::visibility::VISIBLE);
         if !parent_visible {
-            return false;
+            return None;
         }
-        let Some(parent_style) = self.layout_arena.node_style_if_live(parent) else {
-            return false;
-        };
+        let parent_style = self.layout_arena.node_style_if_live(parent)?;
         if parent_style.effects().opacity == 0.0
             || parent_style.inherited_ui().pointer_events == css_enums::pointer_events::NONE
         {
-            return false;
+            return None;
         }
-        let facts = self.text_node_facts(node);
-        if facts.is_inert {
-            return false;
+        if self.text_node_facts(node).is_inert {
+            return None;
         }
-        true
+        // Resolving the hit needs a committed paintable row; without one there is nothing to resolve against.
+        if !self.layout_arena.paintable_row_is_populated(parent) {
+            return None;
+        }
+        Some(parent)
     }
 
     fn containing_block_margin_rect(&self, containing_block: NodeSlotId) -> Option<CssPixelRect> {
@@ -507,6 +505,7 @@ impl<'a> PaintRecorder<'a> {
         HitTestItem {
             kind,
             paintable: target,
+            hit_node: target,
             chrome_widget_kind: CHROME_WIDGET_NONE,
             text_fragment_index: None,
             caret_node: NodeSlotId::INVALID,
@@ -547,9 +546,9 @@ impl<'a> PaintRecorder<'a> {
 
     fn append_text_fragment(&mut self, owner: NodeSlotId, fragment_index: u32, context: ContextRef) {
         let fragment = self.fragment(owner, fragment_index as usize);
-        if !self.text_fragment_is_hit_testable(&fragment) {
+        let Some(hit_node) = self.hit_node_for_text_fragment(&fragment) else {
             return;
-        }
+        };
         let layout_arena = self.layout_arena;
         let first_available_font = || text_fragment::first_available_font(layout_arena, &fragment);
         let item = HitTestItem {
@@ -563,6 +562,7 @@ impl<'a> PaintRecorder<'a> {
                 .node_containing_block_if_live(fragment.layout_node)
                 .unwrap_or(NodeSlotId::INVALID),
             can_produce_caret_position: self.node_has_dom_node(fragment.layout_node),
+            hit_node,
             ..self.base_hit_test_item(HitTestItemKind::TextFragment, owner, context)
         };
         self.list.append(item);
@@ -578,9 +578,9 @@ impl<'a> PaintRecorder<'a> {
         context: ContextRef,
     ) {
         let fragment = self.fragment(owner, sibling_fragment_index as usize);
-        if !self.text_fragment_is_hit_testable(&fragment) {
+        let Some(hit_node) = self.hit_node_for_text_fragment(&fragment) else {
             return;
-        }
+        };
         // Empty lines are only reachable through caret lines, never through regular hit testing,
         // so they are recorded with the base's empty rect and stay out of the spatial index.
         let item = HitTestItem {
@@ -596,6 +596,7 @@ impl<'a> PaintRecorder<'a> {
                 .node_containing_block_if_live(fragment.layout_node)
                 .unwrap_or(NodeSlotId::INVALID),
             can_produce_caret_position: self.node_has_dom_node(fragment.layout_node),
+            hit_node,
             ..self.base_hit_test_item(HitTestItemKind::EmptyLine, owner, context)
         };
         self.list.append(item);

--- a/Tests/LibWeb/Text/expected/UIEvents/context-menu-suppression.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/context-menu-suppression.txt
@@ -1,0 +1,4 @@
+without a listener: page target=DIV
+listener calls preventDefault: no request
+preventDefault, but shift held: page target=DIV
+listener removed: page target=DIV

--- a/Tests/LibWeb/Text/expected/UIEvents/context-menu-target.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/context-menu-target.txt
@@ -1,0 +1,8 @@
+right-click #text: page target=DIV#text
+right-click #link: link target=A#link
+right-click #image: image target=IMG#image
+right-click #media: media target=VIDEO#media
+right-click text inside a span: page target=SPAN#span
+right-click text in an anonymous block: page target=DIV#anonymous
+right-click ::before generated text: page target=DIV#generated
+right-click text in a shadow root's anonymous block: page target=DIV#shadow-host

--- a/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target-after-mutation.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target-after-mutation.txt
@@ -1,0 +1,5 @@
+removed: page target=AREA#area-removed
+removed-over-link: page target=AREA#area-link
+moved: page target=AREA#area-moved
+hidden: page target=AREA#area-hidden
+restyled: image target=IMG#img-restyled

--- a/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target-after-mutation.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target-after-mutation.txt
@@ -1,5 +1,5 @@
-removed: page target=AREA#area-removed
-removed-over-link: page target=AREA#area-link
-moved: page target=AREA#area-moved
-hidden: page target=AREA#area-hidden
+removed: page target=DIV#behind-removed
+removed-over-link: link target=A#behind-link
+moved: page target=DIV#behind-moved
+hidden: page target=DIV#behind-hidden
 restyled: image target=IMG#img-restyled

--- a/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/image-map-context-menu-target.txt
@@ -1,0 +1,2 @@
+right-click #mapped: image target=IMG#mapped
+right-click #linkmapped: link target=AREA#linkarea

--- a/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-outside-viewport.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-outside-viewport.txt
@@ -1,0 +1,1 @@
+mousemove delivered to: nothing

--- a/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-pseudo-island.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/pointer-events-none-pseudo-island.txt
@@ -1,0 +1,1 @@
+mousemove delivered to: island

--- a/Tests/LibWeb/Text/expected/hit_testing/click-outside-of-box-with-hidden-overflow.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/click-outside-of-box-with-hidden-overflow.txt
@@ -1,1 +1,1 @@
-<#document>
+<HTML>

--- a/Tests/LibWeb/Text/expected/hit_testing/click-outside-of-box-with-lines-and-hidden-overflow.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/click-outside-of-box-with-lines-and-hidden-overflow.txt
@@ -1,1 +1,1 @@
-<#document>
+<HTML>

--- a/Tests/LibWeb/Text/expected/hit_testing/text-fragment-cursor-inline-override.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/text-fragment-cursor-inline-override.txt
@@ -1,0 +1,1 @@
+cursor over inline text: Hand

--- a/Tests/LibWeb/Text/input/UIEvents/context-menu-suppression.html
+++ b/Tests/LibWeb/Text/input/UIEvents/context-menu-suppression.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>body { margin: 0; font: 20px/40px monospace }</style>
+<div id="target">right-click me</div>
+<script>
+    test(() => {
+        const describe = () => {
+            const request = internals.takeContextMenuRequest();
+            if (!request)
+                return 'no request';
+            return `${request.kind} target=${request.target.nodeName}`;
+        };
+        const rightClick = modifiers => {
+            internals.mouseDown(20, 20, 1, 2, modifiers);
+            internals.mouseUp(20, 20, 2, modifiers);
+        };
+        const SHIFT = 4;
+
+        rightClick(0);
+        println(`without a listener: ${describe()}`);
+
+        const cancel = event => event.preventDefault();
+        document.addEventListener('contextmenu', cancel);
+        rightClick(0);
+        println(`listener calls preventDefault: ${describe()}`);
+
+        rightClick(SHIFT);
+        println(`preventDefault, but shift held: ${describe()}`);
+
+        document.removeEventListener('contextmenu', cancel);
+        rightClick(0);
+        println(`listener removed: ${describe()}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/context-menu-target.html
+++ b/Tests/LibWeb/Text/input/UIEvents/context-menu-target.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; font: 20px/40px monospace }
+    img { display: block; width: 200px; height: 100px }
+    video { display: block; width: 200px; height: 100px; background: #ccc }
+    #generated::before { content: "generated text" }
+</style>
+<div id="text">plain text</div>
+<div id="anonymous">bare text<div id="anonymous-child">block child</div></div>
+<div id="inline-parent">plain <span id="span">span text</span></div>
+<div id="generated"></div>
+<div id="shadow-host"></div>
+<a id="link" href="https://example.com/link">a link</a>
+<img id="image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4YWMDAAMQAUEiFmcFAAAAAElFTkSuQmCC">
+<video id="media" src="does-not-exist.webm"></video>
+<script>
+    test(() => {
+        const describe = () => {
+            const request = internals.takeContextMenuRequest();
+            if (!request)
+                return 'no request';
+            const target = request.target;
+            return `${request.kind} target=${target.id ? `${target.nodeName}#${target.id}` : target.nodeName}`;
+        };
+        const rightClickAt = element => {
+            const rect = element.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            internals.mouseDown(x, y, 1, 2);
+            internals.mouseUp(x, y, 2);
+        };
+
+        for (const id of ['text', 'link', 'image', 'media']) {
+            rightClickAt(document.getElementById(id));
+            println(`right-click #${id}: ${describe()}`);
+        }
+
+        // The menu describes the element whose box was hit, which for text is the box of its parent rather than
+        // the text itself. Bare text beside a block child sits in an anonymous block and generated content has no
+        // node at all, so both fall back to the nearest element.
+        const rightClickText = node => {
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            const rect = range.getBoundingClientRect();
+            internals.mouseDown(rect.left + 5, rect.top + rect.height / 2, 1, 2);
+            internals.mouseUp(rect.left + 5, rect.top + rect.height / 2, 2);
+        };
+
+        rightClickText(document.getElementById('span').firstChild);
+        println(`right-click text inside a span: ${describe()}`);
+
+        rightClickText(document.getElementById('anonymous').firstChild);
+        println(`right-click text in an anonymous block: ${describe()}`);
+
+        rightClickAt(document.getElementById('generated'));
+        println(`right-click ::before generated text: ${describe()}`);
+
+        // Inside a shadow root the anonymous block's fallback has to cross the shadow boundary to reach an element.
+        const shadow = document.getElementById('shadow-host').attachShadow({ mode: 'open' });
+        shadow.innerHTML = 'bare text<div>block child</div>';
+        document.body.offsetWidth;
+        rightClickText(shadow.firstChild);
+        println(`right-click text in a shadow root's anonymous block: ${describe()}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/image-map-context-menu-target-after-mutation.html
+++ b/Tests/LibWeb/Text/input/UIEvents/image-map-context-menu-target-after-mutation.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; font: 20px/40px monospace }
+    .stack { position: relative; width: 200px; height: 100px }
+    .stack > * { position: absolute; inset: 0 }
+    img { width: 200px; height: 100px }
+</style>
+<div class="stack" id="removed"><div id="behind-removed">behind</div>
+    <img id="img-removed" usemap="#map-removed" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4YWMDAAMQAUEiFmcFAAAAAElFTkSuQmCC"></div>
+<map name="map-removed"><area id="area-removed" shape="rect" coords="0,0,200,100" alt="area"></map>
+
+<div class="stack" id="removed-over-link"><a id="behind-link" href="https://example.com/behind">behind</a>
+    <img id="img-link" usemap="#map-link" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOwmRYAAAI0ASPPlc6iAAAAAElFTkSuQmCC"></div>
+<map name="map-link"><area id="area-link" shape="rect" coords="0,0,200,100" alt="area"></map>
+
+<div class="stack" id="moved"><div id="behind-moved">behind</div>
+    <img id="img-moved" usemap="#map-moved" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOwiToBAAI0AV8p3ELTAAAAAElFTkSuQmCC"></div>
+<map name="map-moved"><area id="area-moved" shape="rect" coords="0,0,200,100" alt="area"></map>
+<div id="elsewhere"></div>
+
+<div class="stack" id="hidden"><div id="behind-hidden">behind</div>
+    <img id="img-hidden" usemap="#map-hidden" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGO406MBAAPYAZFIKp08AAAAAElFTkSuQmCC"></div>
+<map name="map-hidden"><area id="area-hidden" shape="rect" coords="0,0,200,100" alt="area"></map>
+
+<div class="stack" id="restyled"><div id="behind-restyled">behind</div>
+    <img id="img-restyled" usemap="#map-restyled" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGPocdsCAALoAYfjAOf9AAAAAElFTkSuQmCC"></div>
+<map name="map-restyled"><area id="area-restyled" shape="rect" coords="0,0,200,100" alt="area"></map>
+
+<script>
+    test(() => {
+        const describe = () => {
+            const request = internals.takeContextMenuRequest();
+            if (!request)
+                return 'no request';
+            const target = request.target;
+            return `${request.kind} target=${target.id ? `${target.nodeName}#${target.id}` : target.nodeName}`;
+        };
+
+        // Each listener is on the <area>: the <img> is never in the event's propagation path.
+        const cases = [
+            ['removed', image => image.remove()],
+            ['removed-over-link', image => image.remove()],
+            ['moved', image => document.getElementById('elsewhere').appendChild(image)],
+            ['hidden', image => { image.style.display = 'none'; }],
+            ['restyled', image => { image.style.width = '150px'; }],
+        ];
+
+        for (const [id, mutate] of cases) {
+            const stack = document.getElementById(id);
+            const image = stack.querySelector('img');
+            const rect = image.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+
+            const area = document.querySelector(`map[name="${image.getAttribute('usemap').slice(1)}"] area`);
+            area.addEventListener('contextmenu', () => {
+                mutate(image);
+                // Force layout so the image's box is really gone before the menu is decided.
+                document.body.offsetHeight;
+            });
+
+            internals.mouseDown(x, y, 1, 2);
+            internals.mouseUp(x, y, 2);
+            println(`${id}: ${describe()}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/image-map-context-menu-target.html
+++ b/Tests/LibWeb/Text/input/UIEvents/image-map-context-menu-target.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; font: 20px/40px monospace }
+    .stack { position: relative; width: 200px; height: 100px }
+    .stack > * { position: absolute; inset: 0 }
+    img { width: 200px; height: 100px }
+</style>
+<div class="stack">
+    <img id="mapped" usemap="#plainmap" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOwmRYAAAI0ASPPlc6iAAAAAElFTkSuQmCC">
+</div>
+<map name="plainmap"><area id="plainarea" shape="rect" coords="0,0,200,100" alt="plain area"></map>
+<div class="stack">
+    <img id="linkmapped" usemap="#linkmap" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGOwiToBAAI0AV8p3ELTAAAAAElFTkSuQmCC">
+</div>
+<map name="linkmap"><area id="linkarea" shape="rect" coords="0,0,200,100" href="https://example.com/area"></map>
+<script>
+    test(() => {
+        // An <area> is never rendered, so a right-click over an image map hit-tests to the area while the user agent
+        // menu describes the image whose box was hit - unless the area is itself a link, which wins.
+        const describe = () => {
+            const request = internals.takeContextMenuRequest();
+            if (!request)
+                return 'no request';
+            const target = request.target;
+            return `${request.kind} target=${target.id ? `${target.nodeName}#${target.id}` : target.nodeName}`;
+        };
+        const rightClickAt = element => {
+            const rect = element.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            internals.mouseDown(x, y, 1, 2);
+            internals.mouseUp(x, y, 2);
+        };
+
+        for (const id of ['mapped', 'linkmapped']) {
+            rightClickAt(document.getElementById(id));
+            println(`right-click #${id}: ${describe()}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-outside-viewport.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-outside-viewport.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; pointer-events: none }
+</style>
+<script>
+    asyncTest(done => {
+        // A position outside the viewport box hits nothing, so the hit test falls back to the body - which the
+        // recording filter never got a say over. The UA keeps sending such positions while a drag leaves the window.
+        const seen = [];
+        document.addEventListener('mousemove', event => seen.push(event.target.id || event.target.nodeName), true);
+        internals.mouseMove(5000, 5000);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            println(`mousemove delivered to: ${seen.length ? seen.join(', ') : 'nothing'}`);
+            done();
+        }));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-pseudo-island.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-events-none-pseudo-island.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0 }
+    #none { position: absolute; left: 0; top: 0; width: 300px; height: 100px; pointer-events: none; font: 40px/100px monospace }
+    #island::before { content: "ISLAND"; pointer-events: auto }
+</style>
+<div id="none"><span id="island"></span></div>
+<script>
+    asyncTest(done => {
+        // Generated text in a pointer-events:auto pseudo-element inside a pointer-events:none block is hit-testable,
+        // and its events are dispatched to the pseudo-element's originating element.
+        const seen = [];
+        document.addEventListener('mousemove', event => seen.push(event.target.id || event.target.nodeName), true);
+        internals.mouseMove(60, 50);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            println(`mousemove delivered to: ${seen.length ? seen.join(', ') : 'nothing'}`);
+            done();
+        }));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/hit_testing/text-fragment-cursor-inline-override.html
+++ b/Tests/LibWeb/Text/input/hit_testing/text-fragment-cursor-inline-override.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; font: 20px SerenitySans, sans-serif; line-height: 32px }
+    #block { cursor: default }
+    #inline { cursor: pointer }
+</style>
+<div id="block">outside <span id="inline">hover this</span></div>
+<script>
+    test(() => {
+        // The text's hit-test item is recorded against the block that owns the line, but its cursor comes from the
+        // inline that contains it.
+        const range = document.createRange();
+        range.selectNodeContents(document.getElementById("inline").firstChild);
+        const rect = range.getBoundingClientRect();
+
+        internals.mouseMove(rect.left + 5, rect.top + rect.height / 2);
+        println(`cursor over inline text: ${internals.currentCursor()}`);
+    });
+</script>


### PR DESCRIPTION
Instead of trying to fix up the hit target in EventHandler, thread the actual layout node whose style was consulted to determine whether it could be hit all the way to EventHandler to be used there. The hit testing itself now produces a text fragment's parent for event dispatching, instead of leaving that to EventHandler. The hit testing can also adopt the assertion that was removed in https://github.com/LadybirdBrowser/ladybird/commit/7e373c6bbd0e89b60660999f00bf50e4ace15b1f.

Hits that miss all elements and hit the viewport are now considered to have hit the root element instead of the document element, matching the spec's verbage and other browsers' behavior.

The UA context menu is also retargeted after the `contextmenu` event fires, which brings us in line with Chromium and WebKit, both in what the Inspect menu item targets when elements are moved/removed, and how an `<img>` element is targeted when it is covered by a `<map>` element.

We can now directly test what the UA context menu targets via `internals.takeContextMenuRequest()`, which is used to pin down the targets in a number of niche DOM scenarios, particularly around mutation in `contextmenu`.