### PR TITLE
LibWebView: Ignore input after browsing context closure

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -730,6 +730,9 @@ void ViewImplementation::reset_zoom()
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)
 {
+    if (!m_client_state.client)
+        return;
+
     auto* key_event = event.get_pointer<Web::KeyEvent>();
     auto* mouse_event = event.get_pointer<Web::MouseEvent>();
     auto* pinch_event = event.get_pointer<Web::PinchEvent>();

--- a/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
+++ b/Tests/LibWebView/TestBrowserHistoryTraversal.cpp
@@ -200,6 +200,19 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Core::EventLoop::current().spin_until([&] { return history_boundary_traversal_ready; });
     VERIFY(browser_history_traversals_completed == completed_traversals_before_history_boundary + 1);
 
+    // Closing a view may synchronously cause the UI to generate an input event while removing the view from its
+    // container. Input received after the browsing context closes must be discarded.
+    bool did_close = false;
+    view->on_close = [&] {
+        Web::MouseEvent event {};
+        event.type = Web::MouseEvent::Type::MouseLeave;
+        view->enqueue_input_event(move(event));
+        did_close = true;
+    };
+    view->request_close();
+    Core::EventLoop::current().spin_until([&] { return did_close; });
+    Core::EventLoop::current().spin_until([&] { return app->has_ready_spare_web_content_process(); });
+
     outln("PASS: browser history traversal");
     return 0;
 }


### PR DESCRIPTION
A frontend can synchronously generate input while its close callback removes the view from its container. The browsing context is already closed at that point, so the view no longer has a WebContent client to receive the event.

Discard such input instead of accessing the cleared client. Cover this close callback ordering with the LibWebView integration test.