### PR TITLE
LibWeb: Reduce incremental table layout work

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1849,6 +1849,7 @@ impl BlockFormattingContext {
                     } else {
                         None
                     },
+                    block_parent_resolved_content_inline_size: probe.content_inline_size,
                     table_box_content_block_offset_in_wrapper: is_table_formatting_context
                         .then_some(content_block_offset),
                     float_avoidance_inline_size,
@@ -2393,10 +2394,13 @@ impl BlockFormattingContext {
         )
     }
 
-    // Run-prelude inline sizing for a block-level root: reproduces the
-    // parent's winning float-avoidance probe candidate from the directive
-    // carried by the input, and commits it.
+    // Run-prelude inline sizing for a block-level root: commits the result of the parent's winning
+    // float-avoidance probe, or reproduces that probe when it did not resolve an inline size.
     pub(crate) fn commit_block_level_root_inline_size(&self, node: Node, input: &LayoutInput) {
+        if let Some(content_inline_size) = input.sizing.block_parent_resolved_content_inline_size {
+            self.used(node).set_content_inline_size(content_inline_size);
+            return;
+        }
         if let Some(content_inline_size) = self.resolve_root_inline_metrics_and_content_size(
             node,
             input.available_space,

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -89,6 +89,7 @@ fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectiv
         forced_content_inline_size,
         forced_content_block_size,
         forced_min_border_box_block_size,
+        block_parent_resolved_content_inline_size,
         table_cell_intrinsic_block_padding,
         table_box_content_block_offset_in_wrapper,
         adopt_automatic_content_block_size,
@@ -100,6 +101,7 @@ fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectiv
     forced_content_inline_size == b.forced_content_inline_size
         && forced_content_block_size == b.forced_content_block_size
         && forced_min_border_box_block_size == b.forced_min_border_box_block_size
+        && block_parent_resolved_content_inline_size == b.block_parent_resolved_content_inline_size
         && table_cell_intrinsic_block_padding == b.table_cell_intrinsic_block_padding
         && table_box_content_block_offset_in_wrapper == b.table_box_content_block_offset_in_wrapper
         && adopt_automatic_content_block_size == b.adopt_automatic_content_block_size

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -192,6 +192,7 @@ impl MeasurementState {
             self.callbacks,
             input,
             None,
+            None,
         )
     }
 
@@ -1591,6 +1592,7 @@ pub(super) fn run_formatting_context(
     callbacks: FfiLayoutFcCallbacks,
     input: LayoutInput,
     parent_block: Option<&block_formatting_context::BlockFormattingContext>,
+    table_inline_layout: Option<table_formatting_context::TableInlineLayout>,
 ) -> ChildLayoutResult {
     let root_cells = used_values::UsedValuesCellState::capture(parent_used);
     let cache_attempt = match fc_run_cache::FcRunCacheAttempt::probe(
@@ -1632,6 +1634,7 @@ pub(super) fn run_formatting_context(
         input,
         parent_block,
         previous_line_data,
+        table_inline_layout,
     );
     cache_attempt.conclude(&callbacks, box_, &outputs);
     absorb_run_outputs(parent_fragments, parent_used, box_, outputs, false)
@@ -1650,6 +1653,7 @@ fn execute_formatting_context_run(
     input: LayoutInput,
     parent_block: Option<&block_formatting_context::BlockFormattingContext>,
     previous_line_data: Option<std::rc::Rc<used_values::LineData>>,
+    table_inline_layout: Option<table_formatting_context::TableInlineLayout>,
 ) -> RunOutputs {
     assert!(!box_.is_invalid());
     let root_used = std::rc::Rc::new(root_cells.materialize_record());
@@ -1673,6 +1677,10 @@ fn execute_formatting_context_run(
         previous_line_data,
     };
     let run = &run;
+    if let Some(table_inline_layout) = table_inline_layout {
+        run.records
+            .store_table_inline_layout(table_inline_layout.table_box(), table_inline_layout);
+    }
     let body_input = apply_root_sizing_directives(run, &input);
 
     let cached_atomic_block_size = if matches!(
@@ -1747,7 +1755,7 @@ fn execute_formatting_context_run(
                 }
             }
             FormattingContextImplementation::Table(context) => {
-                context.run(run, body_input);
+                context.run(run, body_input, run.records.take_table_inline_layout(run.box_));
                 let baselines = context.derived_baselines_of_root_box();
                 store_derived_baselines(&run.records.used_values(run.box_), baselines);
                 ChildLayoutResult {
@@ -2035,6 +2043,7 @@ pub(crate) fn layout_inside_child(
         run.callbacks,
         input,
         parent_block,
+        run.records.take_table_inline_layout(child),
     );
     propagate_percentage_block_size_dependency_to_containing_block(
         &run.records,
@@ -2203,6 +2212,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             callbacks,
             input,
             None,
+            None,
         );
         place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default(), None);
         drain_and_commit_entry_pass(
@@ -2314,6 +2324,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             false,
             callbacks,
             input,
+            None,
             None,
         );
         entry_fragments.normalize_arrivals_for_placement(root);

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -120,6 +120,9 @@ pub(crate) struct RootSizingDirectives {
     pub(crate) forced_content_inline_size: Option<CssPixels>,
     pub(crate) forced_content_block_size: Option<CssPixels>,
     pub(crate) forced_min_border_box_block_size: Option<CssPixels>,
+    // Input-only: the parent block formatting context supplies the inline size it resolved while
+    // positioning an independent child, so the child's run prelude can commit it without resolving it again.
+    pub(crate) block_parent_resolved_content_inline_size: Option<CssPixels>,
     // Input-only: the table formatting context supplies the cell's intrinsic block padding
     // (the vertical-alignment stretch) before laying out the cell's contents.
     pub(crate) table_cell_intrinsic_block_padding: Option<(CssPixels, CssPixels)>,

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -163,6 +163,7 @@ pub enum NodeFlag {
     InsetsUseAnchorFunctions = 1 << 25,
     HasCommittedFragmentLink = 1 << 26,
     HasPreserve3dTransformStyle = 1 << 27,
+    IsMissingTableCell = 1 << 28,
 }
 
 #[repr(C)]

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -70,6 +70,7 @@ pub(super) fn layout_replaced_with_children(
             participation: geometry::ParticipationInParentFormattingContext::Item,
         },
         None,
+        None,
     );
     formatting_context::propagate_percentage_block_size_dependency_to_containing_block(
         &run.records,

--- a/Libraries/LibWeb/Rust/src/layout/run_records.rs
+++ b/Libraries/LibWeb/Rust/src/layout/run_records.rs
@@ -16,6 +16,9 @@ pub(crate) struct RunRecords {
     arena: *mut c_void,
     nonce: u64,
     undo: RefCell<Vec<UndoEntry>>,
+    // Wrapper sizing hands this state to the wrapper's child run, which consumes it while laying
+    // out the table box. Keeping it on the run prevents measurement state from escaping a pass.
+    table_inline_layouts: RefCell<HashMap<Node, table_formatting_context::TableInlineLayout>>,
 }
 
 struct UndoEntry {
@@ -39,6 +42,7 @@ impl RunRecords {
             arena,
             nonce,
             undo: RefCell::new(Vec::new()),
+            table_inline_layouts: RefCell::new(HashMap::default()),
         }
     }
 
@@ -88,6 +92,14 @@ impl RunRecords {
 
     pub(crate) fn root(&self) -> Node {
         self.root
+    }
+
+    pub(crate) fn store_table_inline_layout(&self, table: Node, layout: table_formatting_context::TableInlineLayout) {
+        self.table_inline_layouts.borrow_mut().insert(table, layout);
+    }
+
+    pub(crate) fn take_table_inline_layout(&self, table: Node) -> Option<table_formatting_context::TableInlineLayout> {
+        self.table_inline_layouts.borrow_mut().remove(&table)
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -2251,6 +2251,8 @@ impl SizingContext {
         );
 
         let table_used_inline_size = table_used.border_box_inline_size(table_used.uses_collapsing_borders_model.get());
+        self.records
+            .store_table_inline_layout(wrapper, table.take_inline_layout());
         if table_wrapper_inline_size_mode
             == formatting_context::TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto
             && !table_style.width().is_auto()

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -646,6 +646,20 @@ pub(crate) struct TableGrid {
     pub(crate) occupancy: HashSet<(usize, usize)>,
 }
 
+pub(crate) struct TableInlineLayout {
+    table_box: Node,
+    table_constraints: ContainingBlockConstraints,
+    cells: Vec<TableCell>,
+    columns: Vec<Column>,
+    rows: Vec<Row>,
+}
+
+impl TableInlineLayout {
+    pub(crate) fn table_box(&self) -> Node {
+        self.table_box
+    }
+}
+
 fn matching_children<T: TableTree>(tree: &T, parent: Node, predicate: impl Fn(FfiDisplay) -> bool) -> Vec<Node> {
     let mut result = Vec::new();
     let mut child = tree.first_child(parent);
@@ -916,6 +930,52 @@ impl TableFormattingContext {
             collapsed_border_grid: None,
             derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
         }
+    }
+
+    pub(super) fn take_inline_layout(&mut self) -> TableInlineLayout {
+        TableInlineLayout {
+            table_box: self.table_box,
+            table_constraints: self.table_constraints,
+            cells: std::mem::take(&mut self.cells),
+            columns: std::mem::take(&mut self.columns),
+            rows: std::mem::take(&mut self.rows),
+        }
+    }
+
+    fn reuse_inline_layout(&mut self, input: LayoutInput, layout: TableInlineLayout) -> bool {
+        if layout.table_box != self.table_box || layout.table_constraints != input.containing_block_constraints {
+            return false;
+        }
+
+        self.available_space = input.available_space;
+        self.table_constraints = input.containing_block_constraints;
+        self.participant_constraints = ContainingBlockConstraints {
+            percentage_basis_inline_size: self.table_constraints.percentage_basis_inline_size,
+            percentage_basis_block_size: if self.style(self.table_box).height().is_auto() {
+                None
+            } else {
+                self.table_constraints.percentage_basis_block_size
+            },
+            quirks_mode_percentage_basis_block_size: self.table_constraints.quirks_mode_percentage_basis_block_size,
+        };
+        self.cells = layout.cells;
+        self.columns = layout.columns;
+        self.rows = layout.rows;
+
+        // The wrapper sizing pass deliberately omits intrinsic row measurement. Reusing its
+        // inline result is only sufficient when the committing pass would omit it as well.
+        if !self.can_skip_row_intrinsic_measurement() {
+            return false;
+        }
+
+        self.cell_inside_layout_inputs = vec![AvailableSpace::default(); self.cells.len()];
+        self.cell_pre_layout_content_block_sizes = vec![CssPixels::default(); self.cells.len()];
+        self.deferred_cell_inside_layouts = vec![false; self.cells.len()];
+        self.needs_fixed_mode_row_measurement = false;
+        self.seed_table_participant_used_values();
+        self.border_conflict_resolution();
+        self.compute_table_inline_size();
+        true
     }
 
     fn sizing(&self) -> sizing_context::SizingContext {
@@ -2066,7 +2126,7 @@ impl TableFormattingContext {
         {
             ChildLayoutOutcome::Created(result) => result.baselines,
             ChildLayoutOutcome::ReenterCurrent => {
-                self.run(run, layout_input);
+                self.run(run, layout_input, None);
                 self.used_values(cell.box_).content_baselines_from_cells()
             }
             ChildLayoutOutcome::Skipped => self.used_values(cell.box_).content_baselines_from_cells(),
@@ -2656,14 +2716,21 @@ impl TableFormattingContext {
         }
     }
 
-    pub(super) fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
+    pub(super) fn run(
+        &mut self,
+        run: &FormattingContextRun,
+        input: LayoutInput,
+        inline_layout: Option<TableInlineLayout>,
+    ) {
         self.available_space = input.available_space;
         self.min_border_box_block_size_from_flex_item = input.sizing.forced_min_border_box_block_size;
         self.table_box_content_block_offset_in_wrapper = input
             .sizing
             .table_box_content_block_offset_in_wrapper
             .unwrap_or_default();
-        self.run_until_inline_size_calculation(input, false);
+        if inline_layout.is_none_or(|layout| !self.reuse_inline_layout(input, layout)) {
+            self.run_until_inline_size_calculation(input, false);
+        }
         if matches!(
             self.available_space.inline_size,
             AvailableSize::MinContent | AvailableSize::MaxContent

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -129,6 +129,12 @@ pub(crate) struct OwnedCollapsedTableBorders {
     pub(crate) vertical_edges: Vec<CollapsedBorderEdge>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TableParticipantPreparation {
+    CreateUsedValues,
+    TrackPercentageDependenciesOnly,
+}
+
 fn grid_line_offsets(sizes: impl ExactSizeIterator<Item = CssPixels>) -> Vec<CssPixels> {
     let mut offsets = Vec::with_capacity(sizes.len() + 1);
     let mut offset = CssPixels::default();
@@ -972,7 +978,7 @@ impl TableFormattingContext {
         self.cell_pre_layout_content_block_sizes = vec![CssPixels::default(); self.cells.len()];
         self.deferred_cell_inside_layouts = vec![false; self.cells.len()];
         self.needs_fixed_mode_row_measurement = false;
-        self.seed_table_participant_used_values();
+        self.prepare_table_participants(TableParticipantPreparation::CreateUsedValues);
         self.border_conflict_resolution();
         self.compute_table_inline_size();
         true
@@ -1227,17 +1233,18 @@ impl TableFormattingContext {
 
     // Participants resolve percentages against the table's input basis inside this context, so
     // their dependency is charged here rather than through child runs.
-    fn seed_table_participant_used_values(&mut self) {
-        let participants: Vec<Node> = self
-            .matching_children(self.table_box, |display| display.is_table_row_group_kind())
+    fn prepare_table_participants(&mut self, preparation: TableParticipantPreparation) {
+        let row_groups = self.matching_children(self.table_box, |display| display.is_table_row_group_kind());
+        let participants = row_groups
             .into_iter()
             .chain(self.rows.iter().map(|row| row.box_))
-            .chain(self.cells.iter().map(|cell| cell.box_))
-            .collect();
+            .chain(self.cells.iter().map(|cell| cell.box_));
         let sizing = self.sizing();
         let table_record = self.used_values(self.table_box);
         for participant in participants {
-            self.create_used_values(participant, self.participant_constraints);
+            if preparation == TableParticipantPreparation::CreateUsedValues {
+                self.create_used_values(participant, self.participant_constraints);
+            }
             if sizing.own_style_depends_on_percentage_block_size(participant) {
                 table_record
                     .has_descendant_that_depends_on_percentage_block_size
@@ -1323,9 +1330,9 @@ impl TableFormattingContext {
             let padding_block_end = style.padding_bottom().to_px(block_basis);
             let padding_inline_start = style.padding_left().to_px(inline_basis);
             let padding_inline_end = style.padding_right().to_px(inline_basis);
-            let used = self.used_values(cell.box_);
             // Implement the collapsing border model https://www.w3.org/TR/CSS22/tables.html#collapsing-borders.
             let (border_block_start, border_block_end, border_inline_start, border_inline_end) = if collapsed {
+                let used = self.used_values(cell.box_);
                 (
                     used.border_top_collapsed(true),
                     used.border_bottom_collapsed(true),
@@ -2065,7 +2072,15 @@ impl TableFormattingContext {
             },
             quirks_mode_percentage_basis_block_size: self.table_constraints.quirks_mode_percentage_basis_block_size,
         };
-        self.seed_table_participant_used_values();
+        let participant_preparation =
+            if skip_row_measurement && self.style(self.table_box).border_collapse() == BORDER_COLLAPSE_SEPARATE {
+                // OPTIMIZATION: Wrapper inline sizing measures cell contents in isolated measurement runs and does not
+                //               otherwise read participant UsedValues in the separated-borders model.
+                TableParticipantPreparation::TrackPercentageDependenciesOnly
+            } else {
+                TableParticipantPreparation::CreateUsedValues
+            };
+        self.prepare_table_participants(participant_preparation);
         self.border_conflict_resolution();
 
         let mut include_rows = !skip_row_measurement;

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -3642,7 +3642,11 @@ fn fixup_row(
 fn remove_missing_table_cells(host: &TreeBuilderHost<'_>, table_root: LayoutNode) {
     let mut cells = Vec::new();
     host.for_each_in_inclusive_subtree(table_root, |node| {
-        if node_has_flag(host.data(node), NodeFlag::IsMissingTableCell) {
+        let data = host.data(node);
+        if node != table_root && node_kind_is_box(data.kind) && display_for_table_fixup(host, node).is_table_inside() {
+            return TraversalDecision::SkipChildrenAndContinue;
+        }
+        if node_has_flag(data, NodeFlag::IsMissingTableCell) {
             cells.push(node);
             return TraversalDecision::SkipChildrenAndContinue;
         }

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -22,6 +22,9 @@ pub(crate) struct TreeBuilderState {
     // restructuring that reaches outside every rebuild root downgrades the update to a full one.
     current_rebuild_root: LayoutNode,
     rebuilt_subtree_root_shells: Vec<*mut c_void>,
+    rebuilt_subtree_roots: Vec<LayoutNode>,
+    reused_child_list_update_roots: Vec<LayoutNode>,
+    additional_table_fixup_roots: Vec<LayoutNode>,
     layout_tree_update_escaped_rebuild_roots: bool,
 }
 
@@ -32,6 +35,9 @@ impl Default for TreeBuilderState {
             quote_nesting_level: 0,
             current_rebuild_root: NodeSlotId::INVALID,
             rebuilt_subtree_root_shells: Vec::new(),
+            rebuilt_subtree_roots: Vec::new(),
+            reused_child_list_update_roots: Vec::new(),
+            additional_table_fixup_roots: Vec::new(),
             layout_tree_update_escaped_rebuild_roots: false,
         }
     }
@@ -1521,6 +1527,12 @@ fn update_principal_node_after_entry(
 
         // SAFETY: `has_layout_node` guarantees that the frame owns a live principal layout node.
         let layout_node = unsafe { (host.callbacks.principal_layout_node)(frame) };
+        if entry_facts.needs_layout_tree_update
+            && entry_facts.may_reuse_layout_node_for_child_list_insertion
+            && !entry_decision.should_create_layout_node
+        {
+            update.state.reused_child_list_update_roots.push(layout_node);
+        }
         let adjustment = replaced_element_display_adjustment(&host.layout(), layout_node);
         if adjustment != FfiReplacedElementDisplayAdjustment::None {
             // SAFETY: The frame owns a live NodeWithStyle.
@@ -1556,6 +1568,7 @@ fn update_principal_node_after_entry(
                 .state
                 .rebuilt_subtree_root_shells
                 .push(host.layout().shell(layout_node));
+            update.state.rebuilt_subtree_roots.push(layout_node);
         } else if placement.mark_update_escaped_rebuild_roots {
             update.state.layout_tree_update_escaped_rebuild_roots = true;
         }
@@ -1682,6 +1695,12 @@ fn update_principal_node_after_entry(
             update.state.current_rebuild_root = prior_rebuild_root;
         }
     } else if !construction.handled_display_contents {
+        if !update.old_layout_node.is_invalid() {
+            let old_parent = host.layout().parent(update.old_layout_node);
+            if !old_parent.is_invalid() {
+                update.state.additional_table_fixup_roots.push(old_parent);
+            }
+        }
         // If no layout node was created, remove every stale layout and paint node from the shadow-including subtree.
         // SAFETY: The builder and DOM node remain live throughout cleanup.
         unsafe {
@@ -1786,7 +1805,20 @@ pub unsafe extern "C" fn rust_build_layout_tree(
         // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
         let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
         if !document_layout_node.is_invalid() {
-            fixup_tables(&host.layout(), document_layout_node);
+            let layout_host = host.layout();
+            if entry_facts.document_needs_full_layout_tree_update
+                || !entry_facts.has_layout_node
+                || state.layout_tree_update_escaped_rebuild_roots
+            {
+                fixup_tables(&layout_host, document_layout_node);
+            } else {
+                fixup_tables_in_rebuilt_subtrees(
+                    &layout_host,
+                    &state.rebuilt_subtree_roots,
+                    &state.reused_child_list_update_roots,
+                    &state.additional_table_fixup_roots,
+                );
+            }
         }
 
         // SAFETY: The builder remains live and copies the reported shell pointers before returning.
@@ -3601,8 +3633,22 @@ fn fixup_row(
         // SAFETY: `row` is a live table-row box.
         let cell = host
             .created(unsafe { (host.callbacks.create_missing_table_cell)(host.callbacks.context, host.shell(row)) });
+        host.arena()
+            .set_node_flag(cell.slot(), NodeFlag::IsMissingTableCell, true);
         host.attach_child(row, cell, NodeSlotId::INVALID);
     }
+}
+
+fn remove_missing_table_cells(host: &TreeBuilderHost<'_>, table_root: LayoutNode) {
+    let mut cells = Vec::new();
+    host.for_each_in_inclusive_subtree(table_root, |node| {
+        if node_has_flag(host.data(node), NodeFlag::IsMissingTableCell) {
+            cells.push(node);
+            return TraversalDecision::SkipChildrenAndContinue;
+        }
+        TraversalDecision::Continue
+    });
+    host.remove_nodes(&cells);
 }
 
 fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
@@ -3611,11 +3657,147 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     // cells to fill all the columns of the table, when taking spans into account. New table-cell anonymous boxes must
     // be appended to its rows content until this condition is met.
     for &table_root in table_roots {
+        remove_missing_table_cells(host, table_root);
         let grid = table_formatting_context::calculate_table_grid(host, table_root);
         for (row_index, row) in grid.rows.iter().enumerate() {
             fixup_row(host, row.box_, &grid, row_index);
         }
     }
+}
+
+fn table_child_is_properly_parented(parent_display: FfiDisplay, child_display: FfiDisplay) -> bool {
+    if parent_display.is_table_inside() {
+        return is_table_track_group(child_display)
+            || is_table_track(child_display)
+            || child_display.is_table_caption();
+    }
+    if parent_display.is_table_row_group()
+        || parent_display.is_table_header_group()
+        || parent_display.is_table_footer_group()
+    {
+        return child_display.is_table_row();
+    }
+    if parent_display.is_table_row() {
+        return child_display.is_table_cell();
+    }
+    if parent_display.is_table_column_group() {
+        return child_display.is_table_column();
+    }
+    false
+}
+
+fn table_fixup_scope_for_rebuilt_subtree(host: &TreeBuilderHost<'_>, root: LayoutNode) -> LayoutNode {
+    let parent = host.parent(root);
+    if parent.is_invalid() {
+        return root;
+    }
+
+    let parent_display = display_for_table_fixup(host, parent);
+    let parent_requires_table_children = is_tabular_container(host, parent) || parent_display.is_table_column_group();
+    let root_data = host.data(root);
+    if node_kind_is_text(root_data.kind) || !node_has_flag(root_data, NodeFlag::HasStyle) {
+        let mut ancestor = parent;
+        while !ancestor.is_invalid() {
+            let ancestor_data = host.data(ancestor);
+            let ancestor_display = display_for_table_fixup(host, ancestor);
+            if is_tabular_container(host, ancestor) || ancestor_display.is_table_column_group() {
+                return ancestor;
+            }
+            if !node_has_flag(ancestor_data, NodeFlag::Anonymous) {
+                break;
+            }
+            ancestor = host.parent(ancestor);
+        }
+        return root;
+    }
+
+    let root_display = display_for_table_fixup(host, root);
+    if table_child_is_properly_parented(parent_display, root_display) {
+        return root;
+    }
+    if parent_requires_table_children || is_table_non_root_box_with_display(root_display) {
+        return parent;
+    }
+    root
+}
+
+fn append_unique_node(nodes: &mut Vec<LayoutNode>, node: LayoutNode) {
+    if !nodes.contains(&node) {
+        nodes.push(node);
+    }
+}
+
+fn nearest_table_root(host: &TreeBuilderHost<'_>, node: LayoutNode) -> Option<LayoutNode> {
+    let mut current = node;
+    while !current.is_invalid() {
+        let data = host.data(current);
+        if node_has_flag(data, NodeFlag::HasStyle) && display_for_table_fixup(host, current).is_table_inside() {
+            return Some(current);
+        }
+        current = host.parent(current);
+    }
+    None
+}
+
+fn fixup_tables_in_rebuilt_subtrees(
+    host: &TreeBuilderHost<'_>,
+    rebuilt_subtree_roots: &[LayoutNode],
+    reused_child_list_update_roots: &[LayoutNode],
+    additional_roots: &[LayoutNode],
+) {
+    let mut roots = Vec::new();
+    for &root in rebuilt_subtree_roots {
+        if host.arena().node_data_if_live(root).is_none() || host.parent(root).is_invalid() {
+            continue;
+        }
+        let scope = table_fixup_scope_for_rebuilt_subtree(host, root);
+        append_unique_node(&mut roots, scope);
+    }
+    for &root in reused_child_list_update_roots {
+        if host.arena().node_data_if_live(root).is_none() || host.parent(root).is_invalid() {
+            continue;
+        }
+        let has_live_rebuilt_descendant = rebuilt_subtree_roots.iter().any(|&rebuilt_root| {
+            host.arena().node_data_if_live(rebuilt_root).is_some()
+                && is_inclusive_layout_ancestor_of(host, root, rebuilt_root)
+        });
+        if !has_live_rebuilt_descendant {
+            append_unique_node(&mut roots, root);
+        }
+    }
+    for &root in additional_roots {
+        if host.arena().node_data_if_live(root).is_none() || host.parent(root).is_invalid() {
+            continue;
+        }
+        append_unique_node(&mut roots, root);
+    }
+
+    let candidate_roots = roots.clone();
+    roots.retain(|&candidate| {
+        !candidate_roots
+            .iter()
+            .any(|&other| other != candidate && is_inclusive_layout_ancestor_of(host, other, candidate))
+    });
+
+    let mut table_roots = Vec::new();
+    for &root in &roots {
+        if let Some(table_root) = nearest_table_root(host, root) {
+            append_unique_node(&mut table_roots, table_root);
+        }
+    }
+
+    for &root in &roots {
+        remove_irrelevant_boxes(host, root);
+    }
+    for &root in &roots {
+        generate_missing_child_wrappers(host, root);
+    }
+    for &root in &roots {
+        for table_root in generate_missing_parents(host, root) {
+            append_unique_node(&mut table_roots, table_root);
+        }
+    }
+    missing_cells_fixup(host, &table_roots);
 }
 
 fn fixup_tables(host: &TreeBuilderHost<'_>, root: LayoutNode) {

--- a/Tests/LibWeb/Text/expected/layout-tree-update/table-fixup-incremental.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/table-fixup-incremental.txt
@@ -54,4 +54,7 @@ PASS: table fixup: append row to collapsed table
 PASS: table fixup: append nested table
 PASS: table fixup: append row to nested table
 PASS: table fixup: move nested table between cells
-56 cases; 56 matched; 0 mismatched
+PASS: table fixup: append outer row preserves nested missing cells
+PASS: table fixup: remove outer column preserves nested missing cells
+PASS: table fixup: append outer row preserves deeply nested missing cells
+59 cases; 59 matched; 0 mismatched

--- a/Tests/LibWeb/Text/expected/layout-tree-update/table-fixup-incremental.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/table-fixup-incremental.txt
@@ -1,0 +1,57 @@
+PASS: table fixup: prepend row to tbody
+PASS: table fixup: insert row in tbody
+PASS: table fixup: append row to tbody
+PASS: table fixup: append rows with fragment
+PASS: table fixup: append row to thead
+PASS: table fixup: append row to tfoot
+PASS: table fixup: append direct row to table
+PASS: table fixup: append CSS row to tbody
+PASS: table fixup: append narrower row
+PASS: table fixup: append wider row
+PASS: table fixup: append spanning row
+PASS: table fixup: prepend cell to row
+PASS: table fixup: insert cell in row
+PASS: table fixup: append cell to row
+PASS: table fixup: append CSS cell to row
+PASS: table fixup: remove first cell
+PASS: table fixup: remove last cell
+PASS: table fixup: replace cells with one cell
+PASS: table fixup: change cell colspan
+PASS: table fixup: change cell rowspan
+PASS: table fixup: remove first row
+PASS: table fixup: remove last row
+PASS: table fixup: replace rows
+PASS: table fixup: move row within group
+PASS: table fixup: move row between groups
+PASS: table fixup: move row between tables
+PASS: table fixup: move cell between rows
+PASS: table fixup: append tbody
+PASS: table fixup: prepend thead
+PASS: table fixup: append tfoot
+PASS: table fixup: remove tbody
+PASS: table fixup: move tbody between tables
+PASS: table fixup: prepend caption
+PASS: table fixup: append second caption
+PASS: table fixup: remove caption
+PASS: table fixup: append colgroup
+PASS: table fixup: append column to colgroup
+PASS: table fixup: remove column
+PASS: table fixup: insert cell under table
+PASS: table fixup: insert cell under row group
+PASS: table fixup: insert cell under block
+PASS: table fixup: insert row under cell
+PASS: table fixup: insert row under block
+PASS: table fixup: insert column under row group
+PASS: table fixup: insert caption under row
+PASS: table fixup: insert block under table
+PASS: table fixup: insert block under row group
+PASS: table fixup: insert block under row
+PASS: table fixup: insert text under table
+PASS: table fixup: insert whitespace under table
+PASS: table fixup: insert text under row group
+PASS: table fixup: insert text under row
+PASS: table fixup: append row to collapsed table
+PASS: table fixup: append nested table
+PASS: table fixup: append row to nested table
+PASS: table fixup: move nested table between cells
+56 cases; 56 matched; 0 mismatched

--- a/Tests/LibWeb/Text/input/layout-tree-update/resources/full-rebuild-comparison.js
+++ b/Tests/LibWeb/Text/input/layout-tree-update/resources/full-rebuild-comparison.js
@@ -2299,6 +2299,21 @@ function tableFixupIncrementalCases() {
         '<table><tbody><tr><td><table id="moving"><tbody><tr><td>inner</td></tr></tbody></table></td><td id="target"></td></tr></tbody></table>',
         fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
     );
+    add(
+        "append outer row preserves nested missing cells",
+        '<table><tbody id="target"><tr><td>outer<table><tbody><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></tbody></table></td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(row("outer second"))
+    );
+    add(
+        "remove outer column preserves nested missing cells",
+        '<table><colgroup><col id="target"><col></colgroup><tbody><tr><td>outer<table><tbody><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></tbody></table></td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").remove()
+    );
+    add(
+        "append outer row preserves deeply nested missing cells",
+        '<table><tbody id="target"><tr><td>outer<table><tbody><tr><td>middle<table><tbody><tr><td>A</td><td>B</td></tr><tr><td>C</td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(row("outer second"))
+    );
 
     return cases;
 }

--- a/Tests/LibWeb/Text/input/layout-tree-update/resources/full-rebuild-comparison.js
+++ b/Tests/LibWeb/Text/input/layout-tree-update/resources/full-rebuild-comparison.js
@@ -2067,6 +2067,242 @@ function semanticTableMutationCases() {
     }));
 }
 
+function tableFixupIncrementalCases() {
+    const cases = [];
+    const add = (name, markup, mutate) => {
+        cases.push({
+            name: `table fixup: ${name}`,
+            setup(fixture) {
+                fixture.innerHTML = markup;
+                return () => mutate(fixture);
+            },
+        });
+    };
+    const cell = text => {
+        const element = document.createElement("td");
+        element.textContent = text;
+        return element;
+    };
+    const row = (...texts) => {
+        const element = document.createElement("tr");
+        element.append(...texts.map(cell));
+        return element;
+    };
+    const displayed = (display, text = "inserted") => {
+        const element = document.createElement("div");
+        element.style.display = display;
+        element.textContent = text;
+        return element;
+    };
+
+    const twoRowTable =
+        '<table><tbody id="target"><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></tbody></table>';
+    add("prepend row to tbody", twoRowTable, fixture => fixture.querySelector("#target").prepend(row("E", "F")));
+    add("insert row in tbody", twoRowTable, fixture => {
+        const target = fixture.querySelector("#target");
+        target.insertBefore(row("E", "F"), target.lastElementChild);
+    });
+    add("append row to tbody", twoRowTable, fixture => fixture.querySelector("#target").append(row("E", "F")));
+    add("append rows with fragment", twoRowTable, fixture => {
+        const fragment = new DocumentFragment();
+        fragment.append(row("E", "F"), row("G", "H"));
+        fixture.querySelector("#target").append(fragment);
+    });
+    add("append row to thead", '<table><thead id="target"><tr><td>A</td></tr></thead></table>', fixture =>
+        fixture.querySelector("#target").append(row("B"))
+    );
+    add("append row to tfoot", '<table><tfoot id="target"><tr><td>A</td></tr></tfoot></table>', fixture =>
+        fixture.querySelector("#target").append(row("B"))
+    );
+    add("append direct row to table", '<table id="target"><tr><td>A</td></tr></table>', fixture =>
+        fixture.querySelector("#target").append(row("B"))
+    );
+    add("append CSS row to tbody", twoRowTable, fixture => {
+        const inserted = displayed("table-row", "");
+        inserted.append(displayed("table-cell", "E"), displayed("table-cell", "F"));
+        fixture.querySelector("#target").append(inserted);
+    });
+    add("append narrower row", twoRowTable, fixture => fixture.querySelector("#target").append(row("E")));
+    add("append wider row", twoRowTable, fixture => fixture.querySelector("#target").append(row("E", "F", "G")));
+    add("append spanning row", twoRowTable, fixture => {
+        const inserted = row("spanning");
+        inserted.firstElementChild.colSpan = 3;
+        fixture.querySelector("#target").append(inserted);
+    });
+
+    const twoCellRow = '<table><tbody><tr id="target"><td>A</td><td>B</td></tr></tbody></table>';
+    add("prepend cell to row", twoCellRow, fixture => fixture.querySelector("#target").prepend(cell("C")));
+    add("insert cell in row", twoCellRow, fixture => {
+        const target = fixture.querySelector("#target");
+        target.insertBefore(cell("C"), target.lastElementChild);
+    });
+    add("append cell to row", twoCellRow, fixture => fixture.querySelector("#target").append(cell("C")));
+    add("append CSS cell to row", twoCellRow, fixture =>
+        fixture.querySelector("#target").append(displayed("table-cell", "C"))
+    );
+    add("remove first cell", twoCellRow, fixture => fixture.querySelector("#target").firstElementChild.remove());
+    add("remove last cell", twoCellRow, fixture => fixture.querySelector("#target").lastElementChild.remove());
+    add("replace cells with one cell", twoCellRow, fixture =>
+        fixture.querySelector("#target").replaceChildren(cell("C"))
+    );
+    add("change cell colspan", twoCellRow, fixture => {
+        fixture.querySelector("#target").firstElementChild.colSpan = 3;
+    });
+    add("change cell rowspan", twoCellRow, fixture => {
+        fixture.querySelector("#target").firstElementChild.rowSpan = 3;
+    });
+
+    add("remove first row", twoRowTable, fixture => fixture.querySelector("#target").firstElementChild.remove());
+    add("remove last row", twoRowTable, fixture => fixture.querySelector("#target").lastElementChild.remove());
+    add("replace rows", twoRowTable, fixture => fixture.querySelector("#target").replaceChildren(row("E", "F")));
+    add("move row within group", twoRowTable, fixture => {
+        const target = fixture.querySelector("#target");
+        target.prepend(target.lastElementChild);
+    });
+    add(
+        "move row between groups",
+        '<table><tbody id="source"><tr id="moving"><td>A</td></tr></tbody><tbody id="target"><tr><td>B</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
+    );
+    add(
+        "move row between tables",
+        '<table><tbody><tr id="moving"><td>A</td></tr></tbody></table><table><tbody id="target"><tr><td>B</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
+    );
+    add(
+        "move cell between rows",
+        '<table><tbody><tr><td id="moving">A</td></tr><tr id="target"><td>B</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
+    );
+
+    add("append tbody", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture => {
+        const body = document.createElement("tbody");
+        body.append(row("B"));
+        fixture.querySelector("#target").append(body);
+    });
+    add("prepend thead", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture => {
+        const head = document.createElement("thead");
+        head.append(row("B"));
+        fixture.querySelector("#target").prepend(head);
+    });
+    add("append tfoot", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture => {
+        const foot = document.createElement("tfoot");
+        foot.append(row("B"));
+        fixture.querySelector("#target").append(foot);
+    });
+    add("remove tbody", '<table><tbody id="target"><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").remove()
+    );
+    add(
+        "move tbody between tables",
+        '<table><tbody id="moving"><tr><td>A</td></tr></tbody></table><table id="target"></table>',
+        fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
+    );
+
+    add("prepend caption", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture => {
+        const caption = document.createElement("caption");
+        caption.textContent = "caption";
+        fixture.querySelector("#target").prepend(caption);
+    });
+    add(
+        "append second caption",
+        '<table id="target"><caption>A</caption><tbody><tr><td>B</td></tr></tbody></table>',
+        fixture => {
+            const caption = document.createElement("caption");
+            caption.textContent = "second";
+            fixture.querySelector("#target").append(caption);
+        }
+    );
+    add(
+        "remove caption",
+        '<table><caption id="target">A</caption><tbody><tr><td>B</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").remove()
+    );
+    add("append colgroup", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture => {
+        const group = document.createElement("colgroup");
+        group.append(document.createElement("col"));
+        fixture.querySelector("#target").append(group);
+    });
+    add(
+        "append column to colgroup",
+        '<table><colgroup id="target"><col></colgroup><tbody><tr><td>A</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(document.createElement("col"))
+    );
+    add(
+        "remove column",
+        '<table><colgroup><col id="target"><col></colgroup><tbody><tr><td>A</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").remove()
+    );
+
+    add("insert cell under table", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(cell("B"))
+    );
+    add("insert cell under row group", '<table><tbody id="target"><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(cell("B"))
+    );
+    add("insert cell under block", '<div id="target"></div>', fixture =>
+        fixture.querySelector("#target").append(displayed("table-cell"))
+    );
+    add("insert row under cell", '<table><tbody><tr><td id="target">A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(row("B"))
+    );
+    add("insert row under block", '<div id="target"></div>', fixture =>
+        fixture.querySelector("#target").append(displayed("table-row"))
+    );
+    add("insert column under row group", '<table><tbody id="target"><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(document.createElement("col"))
+    );
+    add("insert caption under row", twoCellRow, fixture => {
+        const caption = document.createElement("caption");
+        caption.textContent = "caption";
+        fixture.querySelector("#target").append(caption);
+    });
+    add("insert block under table", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(document.createElement("div"))
+    );
+    add("insert block under row group", '<table><tbody id="target"><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append(document.createElement("div"))
+    );
+    add("insert block under row", twoCellRow, fixture =>
+        fixture.querySelector("#target").append(document.createElement("div"))
+    );
+    add("insert text under table", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append("text")
+    );
+    add("insert whitespace under table", '<table id="target"><tbody><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append("  \n  ")
+    );
+    add("insert text under row group", '<table><tbody id="target"><tr><td>A</td></tr></tbody></table>', fixture =>
+        fixture.querySelector("#target").append("text")
+    );
+    add("insert text under row", twoCellRow, fixture => fixture.querySelector("#target").append("text"));
+
+    add(
+        "append row to collapsed table",
+        '<table style="border-collapse:collapse"><tbody id="target"><tr><td>A</td><td>B</td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(row("C", "D"))
+    );
+    add("append nested table", '<table><tbody><tr><td id="target">outer</td></tr></tbody></table>', fixture => {
+        const table = document.createElement("table");
+        const body = document.createElement("tbody");
+        body.append(row("inner"));
+        table.append(body);
+        fixture.querySelector("#target").append(table);
+    });
+    add(
+        "append row to nested table",
+        '<table><tbody><tr><td>outer<table><tbody id="target"><tr><td>inner</td></tr></tbody></table></td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(row("second"))
+    );
+    add(
+        "move nested table between cells",
+        '<table><tbody><tr><td><table id="moving"><tbody><tr><td>inner</td></tr></tbody></table></td><td id="target"></td></tr></tbody></table>',
+        fixture => fixture.querySelector("#target").append(fixture.querySelector("#moving"))
+    );
+
+    return cases;
+}
+
 function anonymousWrapperCases() {
     const cases = [];
     for (const inlineDisplay of ["inline", "inline flow", "contents"]) {

--- a/Tests/LibWeb/Text/input/layout-tree-update/table-fixup-incremental.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/table-fixup-incremental.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script src="resources/full-rebuild-comparison.js"></script>
+<div id="fixture"></div>
+<script>
+    test(() => runLayoutTreeFullRebuildComparisonCases(tableFixupIncrementalCases()));
+</script>


### PR DESCRIPTION
Avoid redundant sizing and table-fixup work during incremental layout-tree updates.

Reuse already resolved containing-block inline sizes, avoid allocating unused measurement records, and limit table fixup to affected rebuilt subtrees. Regenerate synthesized missing cells when table grids change while keeping cleanup isolated from nested tables.

Expand incremental-versus-full-rebuild coverage to 59 table mutation cases, including rows, cells, groups, columns, malformed children, collapsed borders, and nested tables.

On `layout/table-append-row`, Ladybird’s median improves from roughly 84 ms to 71.75 ms, about 15% faster, reducing the gap to Chromium from approximately 4.8x to 4.1x.