### PR TITLE
LibWeb: Retain shared styles for partial computation

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4497,8 +4497,11 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
 
         has_complete_sharing_key = true;
         if (find_shared_style()) {
-            if (auto node = abstract_element.element().style_node_id(); node != 0 && !abstract_element.pseudo_element().has_value())
+            if (auto node = abstract_element.element().style_node_id(); node != 0 && !abstract_element.pseudo_element().has_value()) {
                 const_cast<StyleComputer&>(*this).style_engine().prepare_shared_exact_cascade_state(node);
+                VERIFY(new_style_input_record);
+                new_style_input_record->bind_next_published_style = true;
+            }
             document().style_invalidation_counters().element_style_shared_computations++;
             return {};
         }

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-closure-after-style-sharing.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-closure-after-style-sharing.txt
@@ -1,0 +1,4 @@
+shared initial style: true
+longhand evaluations: 338
+first background: rgba(0, 0, 0, 0)
+second background: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-closure-after-style-sharing.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-closure-after-style-sharing.txt
@@ -1,4 +1,4 @@
 shared initial style: true
-longhand evaluations: 338
+longhand evaluations: 11
 first background: rgba(0, 0, 0, 0)
 second background: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-closure-after-style-sharing.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-closure-after-style-sharing.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .changed { background-color: blue }
+</style>
+<span id="first"></span>
+<span id="second"></span>
+<script>
+    test(() => {
+        internals.updateStyle();
+
+        const before = internals.getStyleInvalidationCounters();
+        second.className = "changed";
+        internals.updateStyle();
+        const after = internals.getStyleInvalidationCounters();
+
+        println(`shared initial style: ${before.elementStyleSharedComputations >= 1}`);
+        println(`longhand evaluations: ${after.computedLonghandEvaluations - before.computedLonghandEvaluations}`);
+        println(`first background: ${getComputedStyle(first).backgroundColor}`);
+        println(`second background: ${getComputedStyle(second).backgroundColor}`);
+    });
+</script>


### PR DESCRIPTION
Bind exact shared style publications to their recipient input records. This
allows an element that later diverges to seed partial computation from its
shared style and evaluate only the affected property closure instead of every
longhand.

Add regression coverage for a background-color mutation after initial style
sharing.

| Benchmark | Score before | Score after | Speedup | Time before | Time after |
| --- | ---: | ---: | ---: | ---: | ---: |
| StyleBench | 115.348 ± 4.653 | 117.665 ± 5.460 | 1.018x | 2.264 ± 0.076 s | 2.223 ± 0.088 s |
| StyleBenchConservative | 89.719 ± 2.243 | 90.646 ± 2.209 | 1.009x | 2.770 ± 0.067 s | 2.744 ± 0.059 s |