### PR TITLE
LibWeb: Keep pseudo-element style reactions sparse

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -70,7 +70,7 @@ static_assert(!IsMoveAssignable<StyleEngine>);
 
 bool StyleEngine::published_style_delta_can_absorb_reaction(PublishedStyleDelta const& delta, u8 reaction, u8 inherited_style_groups)
 {
-    if (delta.pseudo_kind != NumericLimits<u8>::max())
+    if (delta.pseudo_kind != NumericLimits<u8>::max() || (delta.reaction & ExactPseudoInputs))
         return reaction == 0 && inherited_style_groups == 0;
     if (delta.gap == StyleEngineFFI::FfiStyleDeltaGap::Materialize)
         return true;

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -70,6 +70,8 @@ static_assert(!IsMoveAssignable<StyleEngine>);
 
 bool StyleEngine::published_style_delta_can_absorb_reaction(PublishedStyleDelta const& delta, u8 reaction, u8 inherited_style_groups)
 {
+    if (delta.pseudo_kind != NumericLimits<u8>::max())
+        return reaction == 0 && inherited_style_groups == 0;
     if (delta.gap == StyleEngineFFI::FfiStyleDeltaGap::Materialize)
         return true;
     bool const has_additional_reaction = (reaction & ~delta.reaction) != 0;

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -191,6 +191,7 @@ public:
         RecomputeDescendantStyles = 1 << 4,
         AncestorBecameVisible = 1 << 5,
         PseudoInputsMayHaveChanged = 1 << 6,
+        ExactPseudoInputs = 1 << 7,
     };
     void record_element_style_input_change(StyleNodeID style_node, u8 reaction = PublishedStyle | RecomputeStyle, u8 inherited_style_groups = 0);
     void record_flat_tree_descendant_style_input_changes(StyleNodeID style_node, u8 reaction, u8 inherited_style_groups = 0);

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -43,13 +43,25 @@ static void finish_complete_style_update()
 static void update_style(DOM::Document&);
 static bool update_style_for_element(DOM::Document&, DOM::AbstractElement const&, StyleUpdateMode);
 
-static void apply_element_style_invalidation_after_style_change(DOM::Element& element, RequiredInvalidationAfterStyleChange const& invalidation)
+static void apply_element_style_invalidation_after_style_change(DOM::Element& element, RequiredInvalidationAfterStyleChange const& invalidation, Optional<PseudoElement> pseudo_element = {})
 {
-    if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::UpdateValues)
-        element.document().schedule_accumulated_visual_context_value_update(element);
+    if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::UpdateValues) {
+        if (pseudo_element.has_value()) {
+            if (auto* layout_node = element.pseudo_element_unsafe_layout_node(*pseudo_element))
+                element.document().schedule_accumulated_visual_context_value_update(*layout_node);
+        } else {
+            element.document().schedule_accumulated_visual_context_value_update(element);
+        }
+    }
 
-    if (invalidation.needs_scrollable_overflow_recalculation())
-        element.document().schedule_scrollable_overflow_recalculation(element);
+    if (invalidation.needs_scrollable_overflow_recalculation()) {
+        if (pseudo_element.has_value()) {
+            if (auto* layout_node = element.pseudo_element_unsafe_layout_node(*pseudo_element))
+                element.document().schedule_scrollable_overflow_recalculation(*layout_node);
+        } else {
+            element.document().schedule_scrollable_overflow_recalculation(element);
+        }
+    }
 
     if (invalidation.needs_scroll_container_resnap)
         element.document().schedule_scroll_container_resnap();
@@ -192,6 +204,27 @@ static void record_assigned_slottable_style_engine_reactions(DOM::Element& eleme
     }
 }
 
+static void record_direct_child_style_engine_reactions_after_style_change(DOM::Element& element, HashMap<u32, StyleEngine::PublishedStyleDelta*>& reaction_batch, RequiredInvalidationAfterStyleChange const& invalidation, u8 common_child_reaction)
+{
+    auto light_tree_child_reaction = common_child_reaction;
+    u8 light_tree_inherited_style_groups = invalidation.inherited_style_groups_changed();
+    if (!invalidation.is_none() && element.children_explicitly_inherited_non_inherited_style_groups() != 0)
+        light_tree_inherited_style_groups = RequiredInvalidationAfterStyleChange::all_inherited_style_groups;
+    if (light_tree_inherited_style_groups != 0)
+        light_tree_child_reaction |= StyleEngine::InheritedStyle;
+    record_direct_child_style_engine_reactions(element, reaction_batch, light_tree_child_reaction, light_tree_inherited_style_groups);
+
+    if (auto shadow_root = element.shadow_root()) {
+        auto shadow_tree_child_reaction = common_child_reaction;
+        u8 shadow_tree_inherited_style_groups = invalidation.inherited_style_groups_changed();
+        if (!invalidation.is_none() && shadow_root->children_explicitly_inherited_non_inherited_style_groups() != 0)
+            shadow_tree_inherited_style_groups = RequiredInvalidationAfterStyleChange::all_inherited_style_groups;
+        if (shadow_tree_inherited_style_groups != 0)
+            shadow_tree_child_reaction |= StyleEngine::InheritedStyle;
+        record_direct_child_style_engine_reactions(*shadow_root, reaction_batch, shadow_tree_child_reaction, shadow_tree_inherited_style_groups);
+    }
+}
+
 // The static inherited-group swap answers a pure inherited-style reaction without recomputing the element. That
 // is only sound while the element's computed style is a pure function of its cascade inputs and the swapped
 // groups: an element with animations may resolve keyframe values (`inherit`, neutral keyframes) against the
@@ -251,9 +284,27 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
             auto pseudo_element = pseudo_element_from_ffi(reaction.pseudo_kind);
             VERIFY(pseudo_element.has_value());
             VERIFY(*pseudo_element != PseudoElement::UnknownWebKit);
-            auto invalidation = element->apply_style_engine_pseudo_reaction(*pseudo_element);
-            apply_element_style_invalidation_after_style_change(*element, invalidation);
+            bool did_change_custom_properties = false;
+            auto invalidation = element->apply_style_engine_pseudo_reaction(did_change_custom_properties, *pseudo_element);
+            apply_element_style_invalidation_after_style_change(*element, invalidation, *pseudo_element);
             transaction_invalidation |= invalidation;
+            if (is_element_reference_pseudo_element(*pseudo_element)) {
+                auto referenced_pseudo_element = element->get_pseudo_element(*pseudo_element);
+                VERIFY(referenced_pseudo_element.has_value());
+                auto& referenced_element = as<DOM::ElementReferencePseudoElement>(*referenced_pseudo_element).referenced_element();
+                if (!invalidation.is_none() || did_change_custom_properties) {
+                    referenced_element->invalidate_descendant_styles_depending_on_style_container_query();
+                    record_assigned_slottable_style_engine_reactions(referenced_element, reaction_batch);
+                }
+                u8 common_child_reaction = 0;
+                if (did_change_custom_properties)
+                    common_child_reaction |= StyleEngine::InheritedCustomProperties;
+                if (invalidation.needs_layout_tree_rebuild())
+                    common_child_reaction |= StyleEngine::RecomputeStyle;
+                if (invalidation.recompute_descendant_styles)
+                    common_child_reaction |= StyleEngine::RecomputeDescendantStyles;
+                record_direct_child_style_engine_reactions_after_style_change(referenced_element, reaction_batch, invalidation, common_child_reaction);
+            }
             continue;
         }
 
@@ -385,23 +436,7 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                 && !(document.style_computer().style_engine().style_record_dependency_flags(current_style_record) & to_underlying(StyleRecordDependencyFlag::InDisplayNoneSubtree))))
             common_child_reaction |= StyleEngine::AncestorBecameVisible;
 
-        auto light_tree_child_reaction = common_child_reaction;
-        u8 light_tree_inherited_style_groups = invalidation.inherited_style_groups_changed();
-        if (!invalidation.is_none() && element->children_explicitly_inherited_non_inherited_style_groups() != 0)
-            light_tree_inherited_style_groups = RequiredInvalidationAfterStyleChange::all_inherited_style_groups;
-        if (light_tree_inherited_style_groups != 0)
-            light_tree_child_reaction |= StyleEngine::InheritedStyle;
-        record_direct_child_style_engine_reactions(*element, reaction_batch, light_tree_child_reaction, light_tree_inherited_style_groups);
-
-        if (auto shadow_root = element->shadow_root()) {
-            auto shadow_tree_child_reaction = common_child_reaction;
-            u8 shadow_tree_inherited_style_groups = invalidation.inherited_style_groups_changed();
-            if (!invalidation.is_none() && shadow_root->children_explicitly_inherited_non_inherited_style_groups() != 0)
-                shadow_tree_inherited_style_groups = RequiredInvalidationAfterStyleChange::all_inherited_style_groups;
-            if (shadow_tree_inherited_style_groups != 0)
-                shadow_tree_child_reaction |= StyleEngine::InheritedStyle;
-            record_direct_child_style_engine_reactions(*shadow_root, reaction_batch, shadow_tree_child_reaction, shadow_tree_inherited_style_groups);
-        }
+        record_direct_child_style_engine_reactions_after_style_change(*element, reaction_batch, invalidation, common_child_reaction);
     }
 
     return transaction_invalidation;

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -311,6 +311,8 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                     ++document.style_invalidation_counters().element_inherited_style_recomputations;
                 auto recompute_reason = can_use_inherited_style_group_swap
                     ? DOM::Element::StyleEngineRecomputeReason::InheritedOnly
+                    : reaction.reaction & StyleEngine::ExactPseudoInputs
+                    ? DOM::Element::StyleEngineRecomputeReason::ExactPseudoInputs
                     : has_published_style_reaction && !(reaction.reaction & StyleEngine::PseudoInputsMayHaveChanged)
                     ? DOM::Element::StyleEngineRecomputeReason::PseudoInputsUnchanged
                     : DOM::Element::StyleEngineRecomputeReason::General;
@@ -324,7 +326,8 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                 invalidation = element->apply_style_engine_reaction(
                     did_change_custom_properties,
                     recompute_reason,
-                    inherited_style_groups_for_closure);
+                    inherited_style_groups_for_closure,
+                    reaction.pseudo_recompute_mask);
                 if (materializes_inherited_style_reaction && invalidation.is_none() && !did_change_custom_properties)
                     ++document.style_invalidation_counters().element_inherited_style_noop_recomputations;
                 if (needs_regular_style_recompute)
@@ -562,6 +565,7 @@ static void update_style(DOM::Document& document)
                         .inherited_style_groups = 0,
                         .pseudo_kind = NumericLimits<u8>::max(),
                         .gap = StyleEngineFFI::FfiStyleDeltaGap::Materialize,
+                        .pseudo_recompute_mask = 0,
                     });
                     inheritance_closure.append(prerequisite);
                 }
@@ -594,6 +598,7 @@ static void update_style(DOM::Document& document)
                                 .inherited_style_groups = 0,
                                 .pseudo_kind = NumericLimits<u8>::max(),
                                 .gap = StyleEngineFFI::FfiStyleDeltaGap::Materialize,
+                                .pseudo_recompute_mask = 0,
                             });
                             inheritance_closure.append(style_node);
                         }

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -8,6 +8,7 @@
 #include <LibGC/RootVector.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Invalidation/SlotInvalidator.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
@@ -240,6 +241,20 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
             VERIFY(reaction.old_style_record == element->style_record_identity().value());
             VERIFY(reaction.new_style_record != 0);
             VERIFY(reaction.damage == StyleEngineFFI::FfiStyleDeltaDamage::Full);
+        }
+
+        if (reaction.pseudo_kind != NumericLimits<u8>::max()) {
+            VERIFY(reaction.gap == StyleEngineFFI::FfiStyleDeltaGap::Materialize);
+            VERIFY(reaction.reaction & StyleEngine::PublishedStyle);
+            VERIFY((reaction.reaction & ~(StyleEngine::PublishedStyle | StyleEngine::PseudoInputsMayHaveChanged)) == 0);
+            VERIFY(reaction.inherited_style_groups == 0);
+            auto pseudo_element = pseudo_element_from_ffi(reaction.pseudo_kind);
+            VERIFY(pseudo_element.has_value());
+            VERIFY(*pseudo_element != PseudoElement::UnknownWebKit);
+            auto invalidation = element->apply_style_engine_pseudo_reaction(*pseudo_element);
+            apply_element_style_invalidation_after_style_change(*element, invalidation);
+            transaction_invalidation |= invalidation;
+            continue;
         }
 
         auto previous_style_record = element->style_record_identity();

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -112,7 +112,6 @@ static void apply_document_style_invalidation_after_style_change(DOM::Document& 
 struct StyleEngineTransaction {
     Vector<StyleEngine::PublishedStyleDelta> reactions;
     Optional<StyleEngine::PublishedTransactionVersion> published_version;
-    bool prefers_broad_matching_batch { false };
 };
 
 static StyleEngineTransaction take_style_engine_transaction(DOM::Document& document)
@@ -143,12 +142,6 @@ static StyleEngineTransaction take_style_engine_transaction(DOM::Document& docum
         transaction.reactions.append(answer);
     }
     document.style_invalidation_counters().style_engine_planning_microseconds += (MonotonicTime::now() - planning_started_at).to_microseconds();
-
-    // A reaction batch covering more than one sixteenth of the connected elements is dense enough that
-    // packing the scope once is cheaper than repeatedly reconstructing cold facts while matching
-    // the planned elements.
-    transaction.prefers_broad_matching_batch = !published_transaction.is_scoped
-        || transaction.reactions.size() * 16 > style_computer.style_engine().connected_element_count();
 
     return transaction;
 }
@@ -522,12 +515,10 @@ static void update_style(DOM::Document& document)
     document.update_animated_style_if_needed();
 
     auto style_engine_reactions = move(style_engine_transaction.reactions);
-    auto prefers_broad_matching_batch = style_engine_transaction.prefers_broad_matching_batch;
     if (style_engine_reactions.is_empty()
         && document.style_computer().style_engine().has_pending_transaction()) {
         auto feedback_transaction = take_style_engine_transaction(document);
         style_engine_reactions = move(feedback_transaction.reactions);
-        prefers_broad_matching_batch = feedback_transaction.prefers_broad_matching_batch;
     }
 
     // This pass belongs to the current style change event. The outer stabilization epoch advanced
@@ -541,12 +532,11 @@ static void update_style(DOM::Document& document)
 
     bool has_cold_matching_traversal = false;
     if (auto* root = document.document_element(); root && root->style_node_id() != 0) {
-        if (prefers_broad_matching_batch) {
-            has_cold_matching_traversal = document.style_computer().style_engine().begin_cold_matching_batch(root->style_node_id());
-        } else {
-            document.style_computer().style_engine().begin_adaptive_cold_matching_batch(root->style_node_id());
-            has_cold_matching_traversal = true;
-        }
+        // The transaction planner prepares a complete batch when matching actually requires one.
+        // Otherwise retain the sparse topology and answers it published instead of inferring
+        // matching density from the number of style reactions.
+        document.style_computer().style_engine().begin_adaptive_cold_matching_batch(root->style_node_id());
+        has_cold_matching_traversal = true;
     }
     ScopeGuard end_cold_matching_batch = [&] {
         if (has_cold_matching_traversal)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1075,6 +1075,7 @@ public:
         // Semantic output cardinalities, distinct from how many elements entered recomputation.
         u64 element_computed_style_changes { 0 };
         u64 committed_style_observer_consequences { 0 };
+        u64 pseudo_element_layout_style_applications { 0 };
         u64 element_style_shared_computations { 0 };
         // Whether a recomputation could have been answered from what its last one read. The record
         // is the sharing key minus the style being replaced, so a recomputation whose input is

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1546,7 +1546,7 @@ static CSS::StyleComputer::ComputedStyleInvalidation compute_required_invalidati
     return result;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* reusable_matches, PreservedPseudoElementStyles* preserved_pseudo_element_styles)
+CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* reusable_matches, PreservedPseudoElementStyles* preserved_pseudo_element_styles, Optional<CSS::PseudoElement> targeted_pseudo_element)
 {
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
@@ -1654,20 +1654,48 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
             existing_pseudo_element->clear_computed_style(move(style_to_preserve_for_detachment));
     };
 
-    recompute_pseudo_element_style(CSS::PseudoElement::Before);
-    recompute_pseudo_element_style(CSS::PseudoElement::After);
-    recompute_pseudo_element_style(CSS::PseudoElement::FirstLetter);
-    recompute_pseudo_element_style(CSS::PseudoElement::Selection);
-    if (m_rendered_in_top_layer)
+    auto should_recompute = [&](CSS::PseudoElement pseudo_element) {
+        return !targeted_pseudo_element.has_value() || *targeted_pseudo_element == pseudo_element;
+    };
+    if (should_recompute(CSS::PseudoElement::Before))
+        recompute_pseudo_element_style(CSS::PseudoElement::Before);
+    if (should_recompute(CSS::PseudoElement::After))
+        recompute_pseudo_element_style(CSS::PseudoElement::After);
+    if (should_recompute(CSS::PseudoElement::FirstLetter))
+        recompute_pseudo_element_style(CSS::PseudoElement::FirstLetter);
+    if (should_recompute(CSS::PseudoElement::Selection))
+        recompute_pseudo_element_style(CSS::PseudoElement::Selection);
+    if (m_rendered_in_top_layer && should_recompute(CSS::PseudoElement::Backdrop))
         recompute_pseudo_element_style(CSS::PseudoElement::Backdrop);
-    if (had_list_marker || originating_style->display().is_list_item())
+    if ((had_list_marker || originating_style->display().is_list_item()) && should_recompute(CSS::PseudoElement::Marker))
         recompute_pseudo_element_style(CSS::PseudoElement::Marker, true);
     for (auto i = to_underlying(CSS::first_element_reference_pseudo_element); i <= to_underlying(CSS::last_element_reference_pseudo_element); ++i) {
         auto pseudo_element = static_cast<CSS::PseudoElement>(i);
-        if (get_pseudo_element(pseudo_element).has_value())
+        if (should_recompute(pseudo_element) && get_pseudo_element(pseudo_element).has_value())
             recompute_pseudo_element_style(pseudo_element);
     }
 
+    return invalidation;
+}
+
+CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_pseudo_reaction(CSS::PseudoElement pseudo_element)
+{
+    auto originating_style = computed_style();
+    VERIFY(originating_style);
+    VERIFY(has_style(pseudo_element));
+
+    bool did_change_custom_properties = false;
+    CSS::StyleEngineMatchResult style_engine_matches;
+    auto invalidation = recompute_pseudo_element_styles(
+        did_change_custom_properties,
+        originating_style->display().is_list_item(),
+        &*originating_style,
+        &style_engine_matches,
+        nullptr,
+        pseudo_element);
+    if (!invalidation.is_none())
+        document().style_invalidation_counters().committed_style_observer_consequences++;
+    apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation);
     return invalidation;
 }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1684,13 +1684,12 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
     return invalidation;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_pseudo_reaction(CSS::PseudoElement pseudo_element)
+CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_pseudo_reaction(bool& did_change_custom_properties, CSS::PseudoElement pseudo_element)
 {
     auto originating_style = computed_style();
     VERIFY(originating_style);
     VERIFY(has_style(pseudo_element));
 
-    bool did_change_custom_properties = false;
     CSS::StyleEngineMatchResult style_engine_matches;
     auto invalidation = recompute_pseudo_element_styles(
         did_change_custom_properties,
@@ -1701,7 +1700,29 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_pseudo_rea
         pseudo_element);
     if (!invalidation.is_none())
         document().style_invalidation_counters().committed_style_observer_consequences++;
-    apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation);
+    Optional<u8> pseudo_style_application_mask;
+    if (!has_relevant_animations() && !has_css_defined_animations()) {
+        if (CSS::is_synthetic_pseudo_element(pseudo_element)) {
+            auto pseudo_kind = to_underlying(pseudo_element);
+            VERIFY(pseudo_kind < sizeof(u8) * 8);
+            pseudo_style_application_mask = static_cast<u8>(1u << pseudo_kind);
+        } else {
+            pseudo_style_application_mask = 0;
+        }
+    }
+    apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation, pseudo_style_application_mask);
+
+    if (!invalidation.needs_layout_tree_rebuild() && CSS::is_element_reference_pseudo_element(pseudo_element)) {
+        auto referenced_pseudo_element = get_pseudo_element(pseudo_element);
+        VERIFY(referenced_pseudo_element.has_value());
+        auto& referenced_element = as<ElementReferencePseudoElement>(*referenced_pseudo_element).referenced_element();
+        if (auto* layout_node = referenced_element->unsafe_layout_node()) {
+            document().style_invalidation_counters().pseudo_element_layout_style_applications++;
+            layout_node->apply_style(referenced_element->style_record_identity());
+            if (Painting::has_committed_box(*layout_node))
+                Painting::repaint_after_style_change(*layout_node, invalidation);
+        }
+    }
     return invalidation;
 }
 
@@ -1940,7 +1961,7 @@ bool Element::apply_box_presence_change_in_place(SetNeedsLayoutTreeUpdateReason 
     return true;
 }
 
-void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
+void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation, Optional<u8> pseudo_style_application_mask)
 {
     auto* layout_node = unsafe_layout_node();
     if (invalidation.needs_layout_tree_rebuild() || !layout_node)
@@ -1952,19 +1973,24 @@ void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalid
     if (Painting::has_committed_box(*layout_node))
         Painting::repaint_after_style_change(*layout_node, invalidation);
 
-    apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation);
+    apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(invalidation, pseudo_style_application_mask);
 }
 
-void Element::apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
+void Element::apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation, Optional<u8> pseudo_style_application_mask)
 {
     if (invalidation.needs_layout_tree_rebuild())
         return;
 
     for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element_type, SyntheticPseudoElement const& pseudo_element) {
+        auto pseudo_kind = to_underlying(pseudo_element_type);
+        if (pseudo_style_application_mask.has_value()
+            && (pseudo_kind >= sizeof(u8) * 8 || !(*pseudo_style_application_mask & (1u << pseudo_kind))))
+            return;
         if (!has_style(pseudo_element_type))
             return;
 
         if (auto node_with_style = pseudo_element.unsafe_layout_node()) {
+            document().style_invalidation_counters().pseudo_element_layout_style_applications++;
             node_with_style->apply_style(style_record_identity(pseudo_element_type));
             if (Painting::has_committed_box(*node_with_style))
                 Painting::repaint_after_style_change(*node_with_style, invalidation);
@@ -2054,6 +2080,11 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
     auto backdrop_style_needs_materialization = [&] {
         return m_rendered_in_top_layer && !computed_style(CSS::PseudoElement::Backdrop);
     };
+    // Animation overlays can change under an unchanged base style record. Keep publishing every
+    // pseudo style when any animation may have updated one independently of this reaction.
+    auto can_mask_pseudo_style_application = [&] {
+        return !has_relevant_animations() && !has_css_defined_animations();
+    };
     ElementDependentInvalidationState old_state {
         .layout_node = unsafe_layout_node(),
         .content_counter_style_dependencies = {},
@@ -2109,7 +2140,10 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
             counters.element_style_noop_recomputations++;
             return invalidation;
         }
-        apply_computed_style_to_layout_node_if_needed(invalidation);
+        auto pseudo_style_application_mask = can_mask_pseudo_style_application()
+            ? exact_pseudo_recompute_mask
+            : Optional<u8> {};
+        apply_computed_style_to_layout_node_if_needed(invalidation, pseudo_style_application_mask);
         return invalidation;
     }
 
@@ -2254,7 +2288,11 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
         && had_list_marker == new_style->display().is_list_item()
         && style_engine_matches.node != 0
         && style_computer.style_engine().pseudo_cascade_states_are_unchanged(style_engine_matches.node);
-    if (!pseudo_inputs_are_known_unchanged) {
+    Optional<u8> pseudo_style_application_mask;
+    if (pseudo_inputs_are_known_unchanged) {
+        if (can_mask_pseudo_style_application())
+            pseudo_style_application_mask = 0;
+    } else {
         auto exact_pseudo_recompute_mask = recompute_reason == StyleEngineRecomputeReason::ExactPseudoInputs
                 && !backdrop_style_needs_materialization()
                 && !element_custom_properties_changed
@@ -2270,6 +2308,8 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
             &preserved_pseudo_element_styles,
             {},
             exact_pseudo_recompute_mask);
+        if (can_mask_pseudo_style_application())
+            pseudo_style_application_mask = exact_pseudo_recompute_mask;
     }
 
     if (old_computed_values && (element_style_changed || element_custom_properties_changed))
@@ -2281,7 +2321,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
     }
 
     counters.committed_style_observer_consequences++;
-    apply_computed_style_to_layout_node_if_needed(invalidation);
+    apply_computed_style_to_layout_node_if_needed(invalidation, pseudo_style_application_mask);
 
     return invalidation;
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1546,7 +1546,7 @@ static CSS::StyleComputer::ComputedStyleInvalidation compute_required_invalidati
     return result;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* reusable_matches, PreservedPseudoElementStyles* preserved_pseudo_element_styles, Optional<CSS::PseudoElement> targeted_pseudo_element)
+CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* reusable_matches, PreservedPseudoElementStyles* preserved_pseudo_element_styles, Optional<CSS::PseudoElement> targeted_pseudo_element, Optional<u8> pseudo_recompute_mask)
 {
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
@@ -1655,7 +1655,13 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
     };
 
     auto should_recompute = [&](CSS::PseudoElement pseudo_element) {
-        return !targeted_pseudo_element.has_value() || *targeted_pseudo_element == pseudo_element;
+        if (targeted_pseudo_element.has_value())
+            return *targeted_pseudo_element == pseudo_element;
+        if (pseudo_recompute_mask.has_value()) {
+            auto pseudo_kind = to_underlying(pseudo_element);
+            return pseudo_kind < sizeof(u8) * 8 && (*pseudo_recompute_mask & (1u << pseudo_kind));
+        }
+        return true;
     };
     if (should_recompute(CSS::PseudoElement::Before))
         recompute_pseudo_element_style(CSS::PseudoElement::Before);
@@ -2021,7 +2027,7 @@ static bool unregister_current_anchor_names(Element& element, Node& tree_root)
     return true;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason recompute_reason, u8 inherited_style_groups)
+CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason recompute_reason, u8 inherited_style_groups, u8 pseudo_recompute_mask)
 {
     VERIFY(parent());
 
@@ -2088,11 +2094,17 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
             counters.element_style_noop_recomputations++;
             return {};
         }
+        auto exact_pseudo_recompute_mask = recompute_reason == StyleEngineRecomputeReason::ExactPseudoInputs && !backdrop_style_needs_materialization()
+            ? Optional<u8> { pseudo_recompute_mask }
+            : Optional<u8> {};
         auto invalidation = recompute_pseudo_element_styles(
             did_change_custom_properties,
             old_computed_values->display().is_list_item(),
             &*old_computed_values,
-            reusable_style_engine_matches);
+            reusable_style_engine_matches,
+            nullptr,
+            {},
+            exact_pseudo_recompute_mask);
         if (invalidation.is_none()) {
             counters.element_style_noop_recomputations++;
             return invalidation;
@@ -2235,14 +2247,29 @@ CSS::RequiredInvalidationAfterStyleChange Element::apply_style_engine_reaction(b
 
     auto pseudo_inherited_inputs_are_unchanged = old_computed_values
         && old_computed_values->inherited_style_group_identities() == new_style->inherited_style_group_identities();
-    if (recompute_reason != StyleEngineRecomputeReason::PseudoInputsUnchanged
-        || backdrop_style_needs_materialization()
-        || element_custom_properties_changed
-        || !pseudo_inherited_inputs_are_unchanged
-        || had_list_marker != new_style->display().is_list_item()
-        || style_engine_matches.node == 0
-        || !style_computer.style_engine().pseudo_cascade_states_are_unchanged(style_engine_matches.node)) {
-        invalidation |= recompute_pseudo_element_styles(did_change_custom_properties, had_list_marker, old_computed_values ? &*old_computed_values : nullptr, reusable_style_engine_matches, &preserved_pseudo_element_styles);
+    auto pseudo_inputs_are_known_unchanged = recompute_reason == StyleEngineRecomputeReason::PseudoInputsUnchanged
+        && !backdrop_style_needs_materialization()
+        && !element_custom_properties_changed
+        && pseudo_inherited_inputs_are_unchanged
+        && had_list_marker == new_style->display().is_list_item()
+        && style_engine_matches.node != 0
+        && style_computer.style_engine().pseudo_cascade_states_are_unchanged(style_engine_matches.node);
+    if (!pseudo_inputs_are_known_unchanged) {
+        auto exact_pseudo_recompute_mask = recompute_reason == StyleEngineRecomputeReason::ExactPseudoInputs
+                && !backdrop_style_needs_materialization()
+                && !element_custom_properties_changed
+                && pseudo_inherited_inputs_are_unchanged
+                && had_list_marker == new_style->display().is_list_item()
+            ? Optional<u8> { pseudo_recompute_mask }
+            : Optional<u8> {};
+        invalidation |= recompute_pseudo_element_styles(
+            did_change_custom_properties,
+            had_list_marker,
+            old_computed_values ? &*old_computed_values : nullptr,
+            reusable_style_engine_matches,
+            &preserved_pseudo_element_styles,
+            {},
+            exact_pseudo_recompute_mask);
     }
 
     if (old_computed_values && (element_style_changed || element_custom_properties_changed))

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -339,7 +339,7 @@ public:
         ExactPseudoInputs,
     };
     CSS::RequiredInvalidationAfterStyleChange apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason = StyleEngineRecomputeReason::General, u8 inherited_style_groups = 0, u8 pseudo_recompute_mask = 0);
-    CSS::RequiredInvalidationAfterStyleChange apply_style_engine_pseudo_reaction(CSS::PseudoElement);
+    CSS::RequiredInvalidationAfterStyleChange apply_style_engine_pseudo_reaction(bool& did_change_custom_properties, CSS::PseudoElement);
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>);
 
     void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason, CSS::LayoutTreeRebuildRoot);
@@ -878,8 +878,8 @@ private:
 
     void exit_fullscreen_on_element_removal();
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* = nullptr, PreservedPseudoElementStyles* = nullptr, Optional<CSS::PseudoElement> targeted_pseudo_element = {}, Optional<u8> pseudo_recompute_mask = {});
-    void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
-    void apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
+    void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&, Optional<u8> pseudo_style_application_mask = {});
+    void apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const&, Optional<u8> pseudo_style_application_mask = {});
     void replace_style_record(CSS::StyleRecordID);
     void clear_computed_styles_from_display_none_descendants();
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -338,6 +338,7 @@ public:
         PseudoInputsUnchanged,
     };
     CSS::RequiredInvalidationAfterStyleChange apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason = StyleEngineRecomputeReason::General, u8 inherited_style_groups = 0);
+    CSS::RequiredInvalidationAfterStyleChange apply_style_engine_pseudo_reaction(CSS::PseudoElement);
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>);
 
     void set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason, CSS::LayoutTreeRebuildRoot);
@@ -875,7 +876,7 @@ private:
     Utf16FlyString make_html_uppercased_qualified_name() const;
 
     void exit_fullscreen_on_element_removal();
-    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* = nullptr, PreservedPseudoElementStyles* = nullptr);
+    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* = nullptr, PreservedPseudoElementStyles* = nullptr, Optional<CSS::PseudoElement> targeted_pseudo_element = {});
     void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void replace_style_record(CSS::StyleRecordID);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -336,8 +336,9 @@ public:
         General,
         InheritedOnly,
         PseudoInputsUnchanged,
+        ExactPseudoInputs,
     };
-    CSS::RequiredInvalidationAfterStyleChange apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason = StyleEngineRecomputeReason::General, u8 inherited_style_groups = 0);
+    CSS::RequiredInvalidationAfterStyleChange apply_style_engine_reaction(bool& did_change_custom_properties, StyleEngineRecomputeReason = StyleEngineRecomputeReason::General, u8 inherited_style_groups = 0, u8 pseudo_recompute_mask = 0);
     CSS::RequiredInvalidationAfterStyleChange apply_style_engine_pseudo_reaction(CSS::PseudoElement);
     CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles_after_animation_update(Badge<Web::Animations::AnimationUpdateContext>);
 
@@ -876,7 +877,7 @@ private:
     Utf16FlyString make_html_uppercased_qualified_name() const;
 
     void exit_fullscreen_on_element_removal();
-    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* = nullptr, PreservedPseudoElementStyles* = nullptr, Optional<CSS::PseudoElement> targeted_pseudo_element = {});
+    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker, CSS::ComputedValues const* old_originating_style, CSS::StyleEngineMatchResult* = nullptr, PreservedPseudoElementStyles* = nullptr, Optional<CSS::PseudoElement> targeted_pseudo_element = {}, Optional<u8> pseudo_recompute_mask = {});
     void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void apply_computed_pseudo_element_styles_to_layout_nodes_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
     void replace_style_record(CSS::StyleRecordID);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1727,6 +1727,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("elementStyleNoopRecomputations"_utf16_fly_string, JS::Value(counters.element_style_noop_recomputations), JS::default_attributes);
     object->define_direct_property("styleRecordPropertyDamageCacheHits"_utf16_fly_string, JS::Value(counters.style_record_property_damage_cache_hits), JS::default_attributes);
     object->define_direct_property("elementComputedStyleChanges"_utf16_fly_string, JS::Value(counters.element_computed_style_changes), JS::default_attributes);
+    object->define_direct_property("pseudoElementLayoutStyleApplications"_utf16_fly_string, JS::Value(counters.pseudo_element_layout_style_applications), JS::default_attributes);
     object->define_direct_property("elementStyleSharedComputations"_utf16_fly_string, JS::Value(counters.element_style_shared_computations), JS::default_attributes);
     object->define_direct_property("elementStyleInputChangedByParentStyle"_utf16_fly_string, JS::Value(counters.element_style_input_changed_by_parent_style), JS::default_attributes);
     object->define_direct_property("elementStyleInputChangedByParentCustomProperties"_utf16_fly_string, JS::Value(counters.element_style_input_changed_by_parent_custom_properties), JS::default_attributes);

--- a/Libraries/LibWeb/Rust/src/bin/style_replay.rs
+++ b/Libraries/LibWeb/Rust/src/bin/style_replay.rs
@@ -2040,6 +2040,7 @@ fn read_style_transaction_outputs(
                     1 => FfiStyleDeltaGap::Materialize,
                     tag => return Err(format!("unknown style delta gap tag {tag}").into()),
                 },
+                pseudo_recompute_mask: payload.read_u8()?,
             });
         }
         emissions.push(StyleTransactionEmission {
@@ -2082,6 +2083,7 @@ fn write_style_transaction_outputs(outputs: &StyleTransactionOutputs, payload: &
             payload.write_u8(answer.inherited_style_groups);
             payload.write_u8(answer.pseudo_kind);
             payload.write_u8(answer.gap as u8);
+            payload.write_u8(answer.pseudo_recompute_mask);
         }
     }
     payload.write_bool(outputs.style_atoms_swept);

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -122,6 +122,7 @@ pub struct FfiStyleDelta {
     pub inherited_style_groups: u8,
     pub pseudo_kind: u8,
     pub gap: FfiStyleDeltaGap,
+    pub pseudo_recompute_mask: u8,
 }
 
 #[derive(Default)]
@@ -263,6 +264,7 @@ fn write_style_transaction_outputs(
             payload.write_u8(answer.inherited_style_groups);
             payload.write_u8(answer.pseudo_kind);
             payload.write_u8(answer.gap as u8);
+            payload.write_u8(answer.pseudo_recompute_mask);
         }
     }
     payload.write_bool(output.style_atoms_swept);

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -1062,8 +1062,12 @@ impl StyleEngine {
                 identity_repair_nodes.sort_unstable();
                 identity_repair_nodes.dedup();
                 incremental_cascade_answers.sort_unstable_by_key(|answer| answer.node);
-                let prefer_complete_batch =
-                    published_nodes.len().saturating_mul(16) > self.tree.connected_element_count() as usize;
+                // A retained answer can be rebound to the current dispatch without reading its
+                // element's facts. Use the density shortcut only when the transaction cannot reuse
+                // those answers; sparse completion will read facts for its actual misses.
+                let prefer_complete_batch = plan_is_broad
+                    || (!reuse_retained_match_answers
+                        && published_nodes.len().saturating_mul(16) > self.tree.connected_element_count() as usize);
                 let reuse_active_batch_matching_traversal =
                     transaction_reaches_no_selector && self.batch_matching_traversal.is_some();
                 if !reuse_active_batch_matching_traversal {

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -787,6 +787,7 @@ impl StyleEngine {
         let mut incremental_cascade_answers = Vec::new();
         let mut previous_cascade_inputs = Vec::new();
         let mut targeted_pseudo_candidates = Vec::new();
+        let mut exact_pseudo_recompute_masks = Vec::new();
         let mut exact_cascade_stop_nodes = DeltaBatch::default();
         let mut exact_cascade_confirmation_nodes = DeltaBatch::default();
         let mut attribution_scratch: Vec<(RuleID, EntryID)> = Vec::new();
@@ -814,6 +815,7 @@ impl StyleEngine {
             let mut can_stop_at_exact_cascade = false;
             let mut can_confirm_exact_cascade = false;
             let mut targeted_pseudo_kind = None;
+            let mut exact_pseudo_recompute_mask = None;
             let emit_node = match retained_answer_patch.as_mut() {
                 Some(patch) => {
                     let node_is_coarse_covered = patch_cover
@@ -894,6 +896,23 @@ impl StyleEngine {
                                 && rules.iter().all(|&(rule, entry)| rule_is_safe(rule, entry))
                         }
                     };
+                    // Direct signed selector changes name every pseudo target that can have moved.
+                    // Declaration and cascade-order edits can change pseudo inputs without a truth
+                    // delta, so leave those transactions on the conservative all-pseudo path.
+                    if let SelectorTruthPatch::Direct(deltas) = truth_patch
+                        && !deltas.is_empty()
+                        && !patch.always_emit
+                        && !patch.orders_shifted
+                        && patch.cascade_update_properties.is_empty()
+                    {
+                        exact_pseudo_recompute_mask = deltas.iter().try_fold(0_u8, |mask, delta| {
+                            let Some(pseudo) = self.programs.entry(delta.entry).1.pseudo_element else {
+                                return Some(mask);
+                            };
+                            let pseudo_kind = u8::try_from(pseudo.kind.0).ok()?;
+                            (pseudo_kind < u8::BITS as u8).then_some(mask | (1 << pseudo_kind))
+                        });
+                    }
                     can_confirm_exact_cascade = transaction_supports_retained_cascade_stops
                         && !plan_is_broad
                         && !has_direct_action
@@ -988,6 +1007,9 @@ impl StyleEngine {
             if let Some(pseudo_kind) = targeted_pseudo_kind {
                 targeted_pseudo_candidates.push((node, pseudo_kind));
             }
+            if let Some(mask) = exact_pseudo_recompute_mask {
+                exact_pseudo_recompute_masks.push((node, mask));
+            }
             if can_stop_at_exact_cascade {
                 exact_cascade_stop_nodes.push(node);
             }
@@ -1017,8 +1039,11 @@ impl StyleEngine {
         let publish_style_answers = true;
         let targeted_pseudo_candidate_bytes =
             (targeted_pseudo_candidates.capacity() * size_of::<(StyleNodeID, u8)>()) as u64;
+        let exact_pseudo_recompute_mask_bytes =
+            (exact_pseudo_recompute_masks.capacity() * size_of::<(StyleNodeID, u8)>()) as u64;
         {
             targeted_pseudo_candidates.sort_unstable();
+            exact_pseudo_recompute_masks.sort_unstable();
             let published_node_bytes = (published_nodes.capacity() * size_of::<StyleNodeID>()) as u64;
             let previous_cascade_input_bytes =
                 (previous_cascade_inputs.capacity() * size_of::<Option<MatchAnswerID>>()) as u64;
@@ -1029,6 +1054,8 @@ impl StyleEngine {
                 .reserve_required(MemoryCategory::BatchScratch, previous_cascade_input_bytes);
             self.memory
                 .reserve_required(MemoryCategory::BatchScratch, targeted_pseudo_candidate_bytes);
+            self.memory
+                .reserve_required(MemoryCategory::BatchScratch, exact_pseudo_recompute_mask_bytes);
             self.memory
                 .reserve_required(MemoryCategory::BatchScratch, identity_repair_node_bytes);
             if publish_style_answers {
@@ -1322,6 +1349,16 @@ impl StyleEngine {
                         })
                     })
                 });
+                let exact_pseudo_recompute_mask = (!transaction_may_change_all_pseudo_inputs
+                    && style_input_reaction_index.is_none()
+                    && targeted_pseudo_kind.is_none())
+                .then(|| {
+                    exact_pseudo_recompute_masks
+                        .binary_search_by_key(&node, |&(candidate, _)| candidate)
+                        .ok()
+                        .map(|index| exact_pseudo_recompute_masks[index].1)
+                })
+                .flatten();
                 let (reaction, inherited_style_groups) = style_input_reaction_index
                     .map_or((transaction::STYLE_REACTION_PUBLISHED_STYLE, 0), |index| {
                         (style_input_reactions[index].1, style_input_reactions[index].2)
@@ -1382,10 +1419,16 @@ impl StyleEngine {
                             transaction::STYLE_REACTION_PSEUDO_INPUTS_MAY_HAVE_CHANGED
                         } else {
                             0
+                        }
+                        | if exact_pseudo_recompute_mask.is_some() {
+                            transaction::STYLE_REACTION_EXACT_PSEUDO_INPUTS
+                        } else {
+                            0
                         },
                     inherited_style_groups,
                     pseudo_kind: targeted_pseudo_kind.unwrap_or(u8::MAX),
                     gap,
+                    pseudo_recompute_mask: exact_pseudo_recompute_mask.unwrap_or(0),
                 };
                 style_deltas.push(style_delta);
             }
@@ -1404,6 +1447,8 @@ impl StyleEngine {
                 .release(MemoryCategory::BatchScratch, unresolved_inheritance_source_bytes);
             self.memory
                 .release(MemoryCategory::BatchScratch, targeted_pseudo_candidate_bytes);
+            self.memory
+                .release(MemoryCategory::BatchScratch, exact_pseudo_recompute_mask_bytes);
         }
         self.memory
             .release(MemoryCategory::BatchScratch, style_input_reaction_bytes);

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -610,7 +610,7 @@ impl StyleEngine {
                 self.prepared_batch_matching_traversal = Some(prepared);
             }
         }
-        let pseudo_inputs_may_have_changed = transaction
+        let transaction_may_change_all_pseudo_inputs = transaction
             .markers
             .iter()
             .any(|marker| marker.kind == transaction::InputKind::Environment)
@@ -786,6 +786,7 @@ impl StyleEngine {
         let mut identity_repair_nodes = Vec::new();
         let mut incremental_cascade_answers = Vec::new();
         let mut previous_cascade_inputs = Vec::new();
+        let mut targeted_pseudo_candidates = Vec::new();
         let mut exact_cascade_stop_nodes = DeltaBatch::default();
         let mut exact_cascade_confirmation_nodes = DeltaBatch::default();
         let mut attribution_scratch: Vec<(RuleID, EntryID)> = Vec::new();
@@ -812,6 +813,7 @@ impl StyleEngine {
             let mut repair_match_identity = false;
             let mut can_stop_at_exact_cascade = false;
             let mut can_confirm_exact_cascade = false;
+            let mut targeted_pseudo_kind = None;
             let emit_node = match retained_answer_patch.as_mut() {
                 Some(patch) => {
                     let node_is_coarse_covered = patch_cover
@@ -898,6 +900,24 @@ impl StyleEngine {
                         && node_has_safe_exact_cascade_provenance
                         && self.match_answer_is_comparable_across_elements(node);
                     can_stop_at_exact_cascade = transaction_supports_global_exact_cascade_stops;
+                    if !has_direct_action
+                        && let SelectorTruthPatch::Direct(deltas) = truth_patch
+                        && !patch.always_emit
+                        && !patch.orders_shifted
+                        && patch.cascade_update_properties.is_empty()
+                        && let Some(first) = deltas.first()
+                        && let Some(pseudo) = self.programs.entry(first.entry).1.pseudo_element
+                        && let Ok(pseudo_kind) = u8::try_from(pseudo.kind.0)
+                        && deltas
+                            .iter()
+                            .all(|delta| self.programs.entry(delta.entry).1.pseudo_element == Some(pseudo))
+                        && self
+                            .computed_group_sets
+                            .assigned_pseudo_kinds(node)
+                            .any(|assigned| assigned == pseudo_kind)
+                    {
+                        targeted_pseudo_kind = Some(pseudo_kind);
+                    }
                     match self.patch_retained_match_answer(node, patch, truth_patch) {
                         Some(outcome) => {
                             has_output_change = outcome.emit;
@@ -965,6 +985,9 @@ impl StyleEngine {
             node_count += 1;
             published_nodes.push(node);
             previous_cascade_inputs.push(previous_cascade_input);
+            if let Some(pseudo_kind) = targeted_pseudo_kind {
+                targeted_pseudo_candidates.push((node, pseudo_kind));
+            }
             if can_stop_at_exact_cascade {
                 exact_cascade_stop_nodes.push(node);
             }
@@ -992,7 +1015,10 @@ impl StyleEngine {
             self.counters = counters;
         }
         let publish_style_answers = true;
+        let targeted_pseudo_candidate_bytes =
+            (targeted_pseudo_candidates.capacity() * size_of::<(StyleNodeID, u8)>()) as u64;
         {
+            targeted_pseudo_candidates.sort_unstable();
             let published_node_bytes = (published_nodes.capacity() * size_of::<StyleNodeID>()) as u64;
             let previous_cascade_input_bytes =
                 (previous_cascade_inputs.capacity() * size_of::<Option<MatchAnswerID>>()) as u64;
@@ -1001,6 +1027,8 @@ impl StyleEngine {
                 .reserve_required(MemoryCategory::BatchScratch, published_node_bytes);
             self.memory
                 .reserve_required(MemoryCategory::BatchScratch, previous_cascade_input_bytes);
+            self.memory
+                .reserve_required(MemoryCategory::BatchScratch, targeted_pseudo_candidate_bytes);
             self.memory
                 .reserve_required(MemoryCategory::BatchScratch, identity_repair_node_bytes);
             if publish_style_answers {
@@ -1264,7 +1292,7 @@ impl StyleEngine {
             let mut unresolved_inheritance_sources = BitColumn::default();
             let mut unresolved_inheritance_source_bytes = 0;
             for node in published_nodes.iter().copied() {
-                let pseudo_inputs_may_have_changed = pseudo_inputs_may_have_changed
+                let pseudo_inputs_may_have_changed = transaction_may_change_all_pseudo_inputs
                     || !selector_truth_changes.refreshes_for(node).is_empty()
                     || selector_truth_changes
                         .deltas_for(node)
@@ -1276,6 +1304,24 @@ impl StyleEngine {
                 let style_input_reaction_index = style_input_reactions
                     .binary_search_by_key(&node, |&(style_node, _, _)| style_node)
                     .ok();
+                let targeted_pseudo_kind = (!transaction_may_change_all_pseudo_inputs
+                    && style_input_reaction_index.is_none())
+                .then(|| {
+                    targeted_pseudo_candidates
+                        .binary_search_by_key(&node, |&(candidate, _)| candidate)
+                        .ok()
+                        .map(|index| targeted_pseudo_candidates[index].1)
+                })
+                .flatten()
+                .filter(|&pseudo_kind| {
+                    published_match_answers.matches_for(answer).is_some_and(|matches| {
+                        matches.iter().any(|matched| {
+                            matched
+                                .pseudo_element
+                                .is_some_and(|pseudo| u8::try_from(pseudo.kind.0) == Ok(pseudo_kind))
+                        })
+                    })
+                });
                 let (reaction, inherited_style_groups) = style_input_reaction_index
                     .map_or((transaction::STYLE_REACTION_PUBLISHED_STYLE, 0), |index| {
                         (style_input_reactions[index].1, style_input_reactions[index].2)
@@ -1338,7 +1384,7 @@ impl StyleEngine {
                             0
                         },
                     inherited_style_groups,
-                    pseudo_kind: u8::MAX,
+                    pseudo_kind: targeted_pseudo_kind.unwrap_or(u8::MAX),
                     gap,
                 };
                 style_deltas.push(style_delta);
@@ -1356,6 +1402,8 @@ impl StyleEngine {
             );
             self.memory
                 .release(MemoryCategory::BatchScratch, unresolved_inheritance_source_bytes);
+            self.memory
+                .release(MemoryCategory::BatchScratch, targeted_pseudo_candidate_bytes);
         }
         self.memory
             .release(MemoryCategory::BatchScratch, style_input_reaction_bytes);

--- a/Libraries/LibWeb/Rust/src/css/style/prefix.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/prefix.rs
@@ -1502,6 +1502,12 @@ impl<'a, 'b> PrefixEvaluation<'a, 'b> {
     fn facts_are_composite(&self) -> bool {
         !self.evaluator.serves_only_resident_rows()
     }
+
+    // A composite fact view replaces changed rows with sparse overlay rows, but its unchanged
+    // rows still point into the resident fact table and may share local-fact identities normally.
+    fn row_uses_resident_facts(&self, row: MatchFactRow<'_>) -> bool {
+        std::ptr::eq(row.facts, self.facts)
+    }
 }
 
 impl PrefixStates {
@@ -2393,12 +2399,12 @@ impl PrefixStates {
             0
         };
         let local_facts = if local_facts_changed || old.is_none() {
-            let identity = match evaluation.facts_are_composite() {
-                true => {
+            let identity = match evaluation.row_uses_resident_facts(row) {
+                false => {
                     counters.bump(Counter::PrefixLocalFactIdentityMisses);
                     self.local_fact_interner.mint_identity()
                 }
-                false => self.local_fact_interner.intern(row.facts, row.row, counters),
+                true => self.local_fact_interner.intern(row.facts, row.row, counters),
             };
             self.set_local_facts(node, identity);
             identity
@@ -3607,12 +3613,12 @@ impl PrefixTransitionSurface<'_> {
             Self::Retained(states) => match states.local_facts_of(node) {
                 Some(identity) => identity,
                 None => {
-                    let identity = match evaluation.facts_are_composite() {
-                        true => {
+                    let identity = match evaluation.row_uses_resident_facts(row) {
+                        false => {
                             counters.bump(Counter::PrefixLocalFactIdentityMisses);
                             states.local_fact_interner.mint_identity()
                         }
-                        false => states.local_fact_interner.intern(row.facts, row.row, counters),
+                        true => states.local_fact_interner.intern(row.facts, row.row, counters),
                     };
                     states.set_local_facts(node, identity);
                     identity

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2817,9 +2817,53 @@ impl StyleEngine {
             }),
             self.programs.entry_capacity(),
         );
-        let had_retained_prefix_states = self.prefix_caches.borrow().states.is_retained();
+        let retained_prefix_program_available = {
+            let caches = self.prefix_caches.borrow();
+            caches.states.is_retained() && caches.states.lookup(scope_program).sparse().is_ok()
+        };
+        let is_class_addition = |input: &NormalizedInput, node| {
+            matches!(
+                (input.key, input.old, input.new),
+                (
+                    InputKey::LocalFeature(candidate, LocalFeatureKey::Class(_)),
+                    InputValue::Feature(FeatureValue::Absent),
+                    InputValue::Feature(new)
+                ) if candidate == node && new.holds()
+            )
+        };
+        // classList changes publish the class atom and the class attribute value together. A
+        // broad batch anchored entirely on class additions can rebuild the selected prefix
+        // relation once more cheaply than repairing every retained descendant answer reached by
+        // those routes. Coalesced attribute changes on the same nodes are safe here because the
+        // bootstrap evaluators read their exact old and new fact views.
+        let transaction_is_anchored_by_class_additions = transaction.inputs.iter().any(|input| {
+            input
+                .key
+                .style_node()
+                .is_some_and(|node| is_class_addition(input, node))
+        }) && transaction.inputs.iter().all(|input| match input.key {
+            InputKey::LocalFeature(node, LocalFeatureKey::Class(_)) => is_class_addition(input, node),
+            InputKey::LocalFeature(node, LocalFeatureKey::Attribute(_)) => transaction
+                .inputs
+                .iter()
+                .any(|candidate| is_class_addition(candidate, node)),
+            _ => false,
+        });
+        let class_addition_routes_reach_beyond_changed_nodes = transaction.inputs.iter().any(|input| {
+            let InputKey::LocalFeature(node, LocalFeatureKey::Class(class)) = input.key else {
+                return false;
+            };
+            is_class_addition(input, node)
+                && routing.routes_for(RoutingKey::Class(class)).iter().any(|&route| {
+                    pending.head(route) != NO_PENDING_ROUTE && routing.entry_prefix_chain_reaches_beyond_subject(route)
+                })
+        });
+        let bootstrap_prefix_states = transaction_is_anchored_by_class_additions
+            && class_addition_routes_reach_beyond_changed_nodes
+            && !tree_relations_changed
+            && (!retained_prefix_program_available || self.prefix_caches.borrow().states.is_sparse());
         let mut local_prefix_producers: HashMap<StyleNodeID, Vec<PrefixProducer>> = HashMap::default();
-        if had_retained_prefix_states {
+        if retained_prefix_program_available || bootstrap_prefix_states {
             for producer in pending_prefix_producers {
                 local_prefix_producers
                     .entry(producer.node)
@@ -2836,7 +2880,7 @@ impl StyleEngine {
                 + local_prefix_producers.values().map(Vec::capacity).sum::<usize>() * size_of::<PrefixProducer>())
                 as u64;
 
-        if had_retained_prefix_states {
+        if retained_prefix_program_available || bootstrap_prefix_states {
             let prefix_caches = Rc::clone(&self.prefix_caches);
             let mut caches = prefix_caches.borrow_mut();
             let PrefixCaches {
@@ -2845,7 +2889,18 @@ impl StyleEngine {
             } = &mut *caches;
             let cache_is_batch_sparse = retained.is_sparse();
             retained.make_scratch(&mut self.memory);
+            if bootstrap_prefix_states {
+                retained.release();
+                answers.release(&mut self.match_answers);
+            }
             retained.prepare_to_mutate(&mut self.memory);
+            if bootstrap_prefix_states {
+                retained.get_or_insert(
+                    scope_program,
+                    self.facts.primary().generation(),
+                    self.facts.primary().row_count(),
+                );
+            }
             // NB: An incomplete cache under departures used to refuse reuse outright, which
             //     released the cache and stranded every later flush on the from-scratch compare
             //     loop, since nothing reseeds the retained states between full batches. The walk
@@ -2859,7 +2914,9 @@ impl StyleEngine {
                     .as_ref()
                     .expect("prefix planning has a transaction fact view");
                 let resident_facts = self.facts.primary();
-                self.counters.bump(Counter::PrefixTransitionCacheHits);
+                if retained_prefix_program_available && !bootstrap_prefix_states {
+                    self.counters.bump(Counter::PrefixTransitionCacheHits);
+                }
                 let nodes_in_preorder = regions.sort_nodes_for_top_down_walk(&mut pending_nodes, &self.tree);
                 if automaton_has_sibling_steps && !nodes_in_preorder {
                     retained.release();
@@ -2878,7 +2935,7 @@ impl StyleEngine {
                     &self.programs,
                     &old_evaluator,
                     None,
-                    None,
+                    bootstrap_prefix_states.then_some(&selection),
                 );
                 let new_evaluator = MatchEvaluator::new(&self.tree, resident_facts)
                     .with_transaction_fact_view(view, TransactionFactSide::After);
@@ -2889,7 +2946,7 @@ impl StyleEngine {
                     &self.programs,
                     &new_evaluator,
                     None,
-                    None,
+                    bootstrap_prefix_states.then_some(&selection),
                 );
                 let workspace_bytes = |pending_node_capacity: usize,
                                        visited_capacity: usize,
@@ -2925,7 +2982,7 @@ impl StyleEngine {
                     // into an upquery would trade its route's exact delta for a cold rematch,
                     // so leave such roots to their routes and walk only where the cache
                     // compares.
-                    if cache_is_batch_sparse {
+                    if cache_is_batch_sparse && !bootstrap_prefix_states {
                         pending_nodes.retain(|&node| states.has_transition(node));
                     }
                     let mut pending_prefix_nodes: Vec<_> = pending_nodes
@@ -2978,6 +3035,41 @@ impl StyleEngine {
                             .flatten()
                             .map(Vec::as_slice)
                             .filter(|steps| !steps.is_empty());
+                        if bootstrap_prefix_states {
+                            // The comparison replaces this node's transition with the after side.
+                            // Seed every directly dependent old transition first, so downward and
+                            // rightward propagation can still compare against exact old truth.
+                            if !matches!(
+                                states.match_set_for(&old_evaluation, node, &mut self.counters),
+                                PrefixTransitionLookup::Known(_)
+                            ) {
+                                complete = false;
+                                break;
+                            }
+                            let mut children_are_complete = true;
+                            for child in self.tree.children(node) {
+                                if !matches!(
+                                    states.match_set_for(&old_evaluation, child, &mut self.counters),
+                                    PrefixTransitionLookup::Known(_)
+                                ) {
+                                    children_are_complete = false;
+                                    break;
+                                }
+                            }
+                            if children_are_complete
+                                && let Some(next) = self.tree.next_element_sibling(node)
+                                && !matches!(
+                                    states.match_set_for(&old_evaluation, next, &mut self.counters),
+                                    PrefixTransitionLookup::Known(_)
+                                )
+                            {
+                                children_are_complete = false;
+                            }
+                            if !children_are_complete {
+                                complete = false;
+                                break;
+                            }
+                        }
                         let difference = match states.compare_and_update(
                             &new_evaluation,
                             &old_evaluation,
@@ -3125,9 +3217,9 @@ impl StyleEngine {
                     }
                     // Subsumption speaks for a route's whole candidate space, so a walk over a
                     // batch-warmed sparse cache keeps every route; the warmth still cut the
-                    // spine re-derivation. The walk has now refreshed the cache, so the sparse
-                    // origin clears either way.
-                    if !cache_is_batch_sparse {
+                    // spine re-derivation. A selected bootstrap covered every eligible route
+                    // directly even though it did not rebuild the whole prefix program.
+                    if !cache_is_batch_sparse || bootstrap_prefix_states {
                         let mut released_route_bytes = 0;
                         pending.retain(|key, routed_regions| {
                             let keep = eligible_keys.binary_search(&key).is_err();
@@ -3140,14 +3232,22 @@ impl StyleEngine {
                     }
                     self.counters.bump(Counter::PrefixConvergencePasses);
                     self.memory.release(MemoryCategory::BatchScratch, charged_bytes);
-                    // The walk refreshed only the nodes it visited, so a batch-sparse cache
-                    // stays sparse until a completing full-batch retention says otherwise.
-                    retained.mark_current();
+                    // A selected bootstrap is an exact delta relation, not a complete prefix
+                    // relation. Release it before matching so an unaffected prefix cannot be
+                    // mistaken for a non-match while completing the published answer.
+                    if bootstrap_prefix_states {
+                        retained.release();
+                        answers.release(&mut self.match_answers);
+                    } else {
+                        retained.mark_current();
+                    }
                     return PrefixConvergenceOutcome {
-                        sibling_routes_are_covered: !cache_is_batch_sparse
+                        sibling_routes_are_covered: !bootstrap_prefix_states
+                            && !cache_is_batch_sparse
                             && automaton_has_sibling_steps
                             && tree_relations_changed,
-                        positional_routes_are_covered: !cache_is_batch_sparse
+                        positional_routes_are_covered: !bootstrap_prefix_states
+                            && !cache_is_batch_sparse
                             && !dispatch.prefixes().positional_tests().is_empty()
                             && tree_relations_changed,
                     };
@@ -3167,7 +3267,7 @@ impl StyleEngine {
         }
         // NB: Prefix answers are keyed by identities minted by the transition cache. They are one
         //     coherent cache and cannot outlive a transition cache that failed to become current.
-        if had_retained_prefix_states {
+        if retained_prefix_program_available {
             self.prefix_caches.borrow_mut().answers.release(&mut self.match_answers);
         }
 

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -588,6 +588,7 @@ struct SelectorEntryProperties {
     observes_sibling_relation: bool,
     has_prefix_chain: bool,
     prefix_chain_has_only_local_facts: bool,
+    prefix_chain_reaches_beyond_subject: bool,
 }
 
 /// Immutable routing facts derived from one selector entry's IR.
@@ -669,6 +670,11 @@ impl SelectorEntry {
     #[must_use]
     pub(super) fn prefix_chain_has_only_local_facts(self) -> bool {
         self.properties.prefix_chain_has_only_local_facts
+    }
+
+    #[must_use]
+    pub(super) fn prefix_chain_reaches_beyond_subject(self) -> bool {
+        self.properties.prefix_chain_reaches_beyond_subject
     }
 }
 
@@ -1078,6 +1084,8 @@ impl SelectorProgramBuilder {
                             .iter()
                             .all(|step| self.program.prefix_local_has_canonical_form(step.local))
                     }),
+                    prefix_chain_reaches_beyond_subject: unified_chain
+                        .is_some_and(|chain| chain.iter().any(|step| step.axis != SelectorPrefixAxis::Root)),
                 }
             })
             .collect();
@@ -3141,6 +3149,7 @@ struct EntryRouteFacts {
 
 const ENTRY_HAS_PREFIX_CHAIN: u8 = 1 << 0;
 const ENTRY_PREFIX_CHAIN_HAS_ONLY_LOCAL_FACTS: u8 = 1 << 1;
+const ENTRY_PREFIX_CHAIN_REACHES_BEYOND_SUBJECT: u8 = 1 << 2;
 
 /// Stable identity of one canonical transpose route.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -3940,6 +3949,11 @@ impl RoutingRegistry {
     }
 
     #[must_use]
+    pub fn entry_prefix_chain_reaches_beyond_subject(&self, route: RouteID) -> bool {
+        self.entry_facts_of(route).flags & ENTRY_PREFIX_CHAIN_REACHES_BEYOND_SUBJECT != 0
+    }
+
+    #[must_use]
     pub fn path_of(&self, route: RouteID) -> &[InverseStep] {
         let range = self.routes.paths[route.index()];
         &self.paths[range.offset as usize..(range.offset + range.length) as usize]
@@ -4061,6 +4075,9 @@ impl RoutingRegistry {
         }
         if selector_entry.prefix_chain_has_only_local_facts() {
             flags |= ENTRY_PREFIX_CHAIN_HAS_ONLY_LOCAL_FACTS;
+        }
+        if selector_entry.prefix_chain_reaches_beyond_subject() {
+            flags |= ENTRY_PREFIX_CHAIN_REACHES_BEYOND_SUBJECT;
         }
         if let Some(facts) = self.entry_facts[index] {
             debug_assert_eq!(facts.flags, flags);

--- a/Libraries/LibWeb/Rust/src/css/style/selector/replay.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector/replay.rs
@@ -378,6 +378,7 @@ fn write_entry(entry: SelectorEntry, payload: &mut PayloadWriter) {
     properties |= u8::from(entry.properties.observes_sibling_relation) << 2;
     properties |= u8::from(entry.properties.has_prefix_chain) << 3;
     properties |= u8::from(entry.properties.prefix_chain_has_only_local_facts) << 4;
+    properties |= u8::from(entry.properties.prefix_chain_reaches_beyond_subject) << 5;
     payload.write_u8(properties);
 }
 
@@ -398,7 +399,7 @@ fn read_entry(payload: &mut PayloadReader) -> Result<SelectorEntry, Error> {
         .transpose()?;
     let scope_root = read_optional_node(payload)?;
     let properties = payload.read_u8()?;
-    if properties & !0x1f != 0 {
+    if properties & !0x3f != 0 {
         return Err(Error::InvalidTag {
             category: "selector entry properties",
             value: properties,
@@ -415,6 +416,7 @@ fn read_entry(payload: &mut PayloadReader) -> Result<SelectorEntry, Error> {
             observes_sibling_relation: properties & 4 != 0,
             has_prefix_chain: properties & 8 != 0,
             prefix_chain_has_only_local_facts: properties & 16 != 0,
+            prefix_chain_reaches_beyond_subject: properties & 32 != 0,
         },
     })
 }
@@ -625,6 +627,7 @@ mod tests {
                     observes_sibling_relation: true,
                     has_prefix_chain: true,
                     prefix_chain_has_only_local_facts: false,
+                    prefix_chain_reaches_beyond_subject: true,
                 },
             }],
             relative_queries: vec![RelativeQuery {

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -7280,6 +7280,7 @@ fn a_published_local_reaction_names_its_semantic_provenance() {
     let output_before = engine.counters().get(Counter::PlannedNodesWithOutputChange);
     let upquery_before = engine.counters().get(Counter::PlannedNodesWithUpquery);
     let unattributed_before = engine.counters().get(Counter::PlannedNodesUnattributed);
+    let cold_batch_rows_before = engine.counters().get(Counter::ColdMatchingBatchRows);
     let mut planned = Vec::new();
     assert!(engine.take_style_transaction(nodes[0], |_, _, reactions| {
         planned.extend(reactions.iter().map(|reaction| reaction.style_node));
@@ -7301,6 +7302,10 @@ fn a_published_local_reaction_names_its_semantic_provenance() {
     assert_eq!(
         engine.counters().get(Counter::PlannedNodesUnattributed),
         unattributed_before
+    );
+    assert_eq!(
+        engine.counters().get(Counter::ColdMatchingBatchRows),
+        cold_batch_rows_before
     );
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4805,6 +4805,98 @@ fn retained_prefix_transitions_supply_invalidation_and_matching() {
 }
 
 #[test]
+fn class_additions_rebuild_sparse_prefix_transitions() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    let pseudo = PseudoElementTarget::new(PseudoElementKind(0));
+    let program = engine.programs.add(test_selector_program_with_metadata(
+        ".guard .target",
+        &[("guard", guard), ("target", target)],
+        Some(Specificity {
+            classes: 2,
+            ..Specificity::default()
+        }),
+        Some(pseudo),
+    ));
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    let specific = engine.append_rule(sheet, None, RuleKind::Style);
+    engine.add_routing_rule(specific, program);
+    let mut version = engine.program.rule_version(specific);
+    version.selector_program = Some(program);
+    version.declaration_block = Some(DeclarationBlockID(1));
+    engine.replace_rule_version(specific, version);
+    let base_program = engine.programs.add(test_selector_program_with_metadata(
+        ".target",
+        &[("target", target)],
+        Some(Specificity {
+            classes: 1,
+            ..Specificity::default()
+        }),
+        Some(pseudo),
+    ));
+    let base = engine.append_rule(sheet, None, RuleKind::Style);
+    engine.add_routing_rule(base, base_program);
+    let mut version = engine.program.rule_version(base);
+    version.selector_program = Some(base_program);
+    version.declaration_block = Some(DeclarationBlockID(2));
+    engine.replace_rule_version(base, version);
+    add_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+    discard_transaction(&mut engine);
+
+    assert!(engine.begin_cold_matching_batch(nodes[0]));
+    assert_eq!(
+        engine
+            .match_element_for_cascade(nodes[3])
+            .unwrap()
+            .iter()
+            .map(|matched| matched.rule)
+            .collect::<Vec<_>>(),
+        [base]
+    );
+    engine.end_cold_matching_batch();
+    {
+        let mut caches = engine.prefix_caches.borrow_mut();
+        caches.states.make_scratch(&mut engine.memory);
+        caches.states.mark_sparse();
+    }
+    engine.retain_prefix_states();
+    assert!(engine.prefix_caches.borrow().states.is_sparse());
+
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    engine.record_input(
+        InputKey::LocalFeature(nodes[1], LocalFeatureKey::Attribute(StyleAtomID(202))),
+        InputValue::Feature(FeatureValue::Absent),
+        InputValue::Feature(FeatureValue::Atom(StyleAtomID(203))),
+    );
+    let repairs_before = engine.counters().get(Counter::SelectorTruthRepairUpqueries);
+    let passes_before = engine.counters().get(Counter::PrefixConvergencePasses);
+    let mut planned = Vec::new();
+    assert!(engine.take_style_transaction(nodes[0], |_, _, answers| {
+        planned.extend(answers.iter().map(|answer| answer.style_node));
+    }));
+    assert_eq!(planned, vec![nodes[3].raw()]);
+    assert_eq!(
+        engine
+            .consume_published_match_answer(nodes[3])
+            .unwrap()
+            .iter()
+            .map(|matched| matched.rule)
+            .collect::<Vec<_>>(),
+        [base, specific]
+    );
+    assert_eq!(
+        engine.counters().get(Counter::SelectorTruthRepairUpqueries),
+        repairs_before
+    );
+    assert_eq!(
+        engine.counters().get(Counter::PrefixConvergencePasses),
+        passes_before + 1
+    );
+}
+
+#[test]
 fn covered_prefix_changes_forget_only_the_covered_subtree() {
     let (mut engine, nodes) = nested_document();
     let guard = StyleAtomID(200);

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4863,6 +4863,9 @@ fn class_additions_rebuild_sparse_prefix_transitions() {
     }
     engine.retain_prefix_states();
     assert!(engine.prefix_caches.borrow().states.is_sparse());
+    engine
+        .computed_group_sets
+        .record_pseudo_kind_for_test(nodes[3], pseudo.kind.0 as u8);
 
     add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
     engine.record_input(
@@ -4873,10 +4876,13 @@ fn class_additions_rebuild_sparse_prefix_transitions() {
     let repairs_before = engine.counters().get(Counter::SelectorTruthRepairUpqueries);
     let passes_before = engine.counters().get(Counter::PrefixConvergencePasses);
     let mut planned = Vec::new();
+    let mut pseudo_kinds = Vec::new();
     assert!(engine.take_style_transaction(nodes[0], |_, _, answers| {
         planned.extend(answers.iter().map(|answer| answer.style_node));
+        pseudo_kinds.extend(answers.iter().map(|answer| answer.pseudo_kind));
     }));
     assert_eq!(planned, vec![nodes[3].raw()]);
+    assert_eq!(pseudo_kinds, vec![pseudo.kind.0 as u8]);
     assert_eq!(
         engine
             .consume_published_match_answer(nodes[3])
@@ -4894,6 +4900,53 @@ fn class_additions_rebuild_sparse_prefix_transitions() {
         engine.counters().get(Counter::PrefixConvergencePasses),
         passes_before + 1
     );
+}
+
+#[test]
+fn cascade_changes_suppress_targeted_pseudo_reactions() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    let pseudo = PseudoElementTarget::new(PseudoElementKind(0));
+    let program = engine.programs.add(test_selector_program_with_metadata(
+        ".guard .target",
+        &[("guard", guard), ("target", target)],
+        Some(Specificity {
+            classes: 2,
+            ..Specificity::default()
+        }),
+        Some(pseudo),
+    ));
+    let sheet = engine.add_sheet(StyleSheetObjectID(1), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    let rule = engine.append_rule(sheet, None, RuleKind::Style);
+    engine.add_routing_rule(rule, program);
+    let mut version = engine.program.rule_version(rule);
+    version.selector_program = Some(program);
+    version.declaration_block = Some(DeclarationBlockID(1));
+    engine.replace_rule_version(rule, version);
+    let origin_rule = add_target_rule(&mut engine, StyleSheetObjectID(2), target);
+    add_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+    discard_transaction(&mut engine);
+
+    assert!(engine.begin_cold_matching_batch(nodes[0]));
+    for &node in &nodes {
+        engine.match_element(node).unwrap();
+    }
+    engine.end_cold_matching_batch();
+    engine
+        .computed_group_sets
+        .record_pseudo_kind_for_test(nodes[3], pseudo.kind.0 as u8);
+
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    let mut version = engine.program.rule_version(origin_rule);
+    version.declaration_block = Some(DeclarationBlockID(2));
+    engine.replace_rule_version(origin_rule, version);
+    let mut published = Vec::new();
+    assert!(engine.take_style_transaction(nodes[0], |_, _, answers| published.extend_from_slice(answers)));
+    assert_eq!(published.len(), 1);
+    assert_eq!(published[0].style_node, nodes[3].raw());
+    assert_eq!(published[0].pseudo_kind, u8::MAX);
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4117,11 +4117,18 @@ fn rule_declaration_edits_repair_only_their_property_inventory() {
     assert!(engine.program_staging.base_version.is_some());
     let feature_tests_before = engine.counters().get(Counter::LocalFeatureTests);
 
-    let mut planned = Vec::new();
+    let mut published = Vec::new();
     assert!(engine.take_style_transaction(nodes[0], |_, _, answers| {
-        planned.extend(answers.iter().map(|answer| answer.style_node));
+        published.extend_from_slice(answers);
     }));
-    assert_eq!(planned, vec![nodes[1].raw()]);
+    assert_eq!(
+        published.iter().map(|answer| answer.style_node).collect::<Vec<_>>(),
+        [nodes[1].raw()]
+    );
+    assert_eq!(
+        published[0].reaction & transaction::STYLE_REACTION_EXACT_PSEUDO_INPUTS,
+        0
+    );
     assert_eq!(engine.program.declared_properties_of(rule)[0].property, 2);
     assert_eq!(engine.counters().get(Counter::LocalFeatureTests), feature_tests_before);
     let key = WinnerGroupKey::current(nodes[1], engine.program.version());
@@ -4949,6 +4956,59 @@ fn cascade_changes_suppress_targeted_pseudo_reactions() {
     assert_eq!(published.len(), 1);
     assert_eq!(published[0].style_node, nodes[3].raw());
     assert_eq!(published[0].pseudo_kind, u8::MAX);
+}
+
+#[test]
+fn mixed_origin_and_pseudo_changes_publish_an_exact_pseudo_mask() {
+    let (mut engine, nodes) = nested_document();
+    let guard = StyleAtomID(200);
+    let target = StyleAtomID(201);
+    let pseudo = PseudoElementTarget::new(PseudoElementKind(0));
+    let origin_rule = add_guard_target_rule(&mut engine, guard, target);
+    let pseudo_program = engine.programs.add(test_selector_program_with_metadata(
+        ".guard .target",
+        &[("guard", guard), ("target", target)],
+        Some(Specificity {
+            classes: 2,
+            ..Specificity::default()
+        }),
+        Some(pseudo),
+    ));
+    let sheet = engine.add_sheet(StyleSheetObjectID(2), CascadeOrigin::Author);
+    engine.attach_sheet(sheet, TreeScopeID::DOCUMENT);
+    let pseudo_rule = engine.append_rule(sheet, None, RuleKind::Style);
+    engine.add_routing_rule(pseudo_rule, pseudo_program);
+    let mut version = engine.program.rule_version(pseudo_rule);
+    version.selector_program = Some(pseudo_program);
+    version.declaration_block = Some(DeclarationBlockID(2));
+    engine.replace_rule_version(pseudo_rule, version);
+    add_feature(&mut engine, nodes[3], LocalFeatureKey::Class(target));
+    discard_transaction(&mut engine);
+
+    assert!(engine.begin_cold_matching_batch(nodes[0]));
+    for &node in &nodes {
+        engine.match_element(node).unwrap();
+    }
+    engine.end_cold_matching_batch();
+
+    add_feature(&mut engine, nodes[1], LocalFeatureKey::Class(guard));
+    let mut published = Vec::new();
+    assert!(engine.take_style_transaction(nodes[0], |_, _, answers| published.extend_from_slice(answers)));
+    assert_eq!(published.len(), 1);
+    let answer = published[0];
+    assert_eq!(answer.style_node, nodes[3].raw());
+    assert_eq!(answer.pseudo_kind, u8::MAX);
+    assert_ne!(answer.reaction & transaction::STYLE_REACTION_EXACT_PSEUDO_INPUTS, 0);
+    assert_eq!(answer.pseudo_recompute_mask, 1 << pseudo.kind.0);
+    assert_eq!(
+        engine
+            .consume_published_match_answer(nodes[3])
+            .unwrap()
+            .iter()
+            .map(|matched| matched.rule)
+            .collect::<Vec<_>>(),
+        [origin_rule, pseudo_rule]
+    );
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/tests.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/tests.rs
@@ -4875,6 +4875,7 @@ fn class_additions_rebuild_sparse_prefix_transitions() {
     );
     let repairs_before = engine.counters().get(Counter::SelectorTruthRepairUpqueries);
     let passes_before = engine.counters().get(Counter::PrefixConvergencePasses);
+    let local_fact_identity_hits_before = engine.counters().get(Counter::PrefixLocalFactIdentityHits);
     let mut planned = Vec::new();
     let mut pseudo_kinds = Vec::new();
     assert!(engine.take_style_transaction(nodes[0], |_, _, answers| {
@@ -4900,6 +4901,7 @@ fn class_additions_rebuild_sparse_prefix_transitions() {
         engine.counters().get(Counter::PrefixConvergencePasses),
         passes_before + 1
     );
+    assert!(engine.counters().get(Counter::PrefixLocalFactIdentityHits) > local_fact_identity_hits_before);
 }
 
 #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/transaction.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/transaction.rs
@@ -199,6 +199,7 @@ pub const STYLE_REACTION_PUBLISHED_STYLE: u8 = 1 << 0;
 pub const STYLE_REACTION_RECOMPUTE_STYLE: u8 = 1 << 1;
 pub const STYLE_REACTION_INHERITED_STYLE: u8 = 1 << 2;
 pub const STYLE_REACTION_PSEUDO_INPUTS_MAY_HAVE_CHANGED: u8 = 1 << 6;
+pub const STYLE_REACTION_EXACT_PSEUDO_INPUTS: u8 = 1 << 7;
 
 impl InputKey {
     #[must_use]

--- a/Tests/LibWeb/TestStyleEngineBridge.cpp
+++ b/Tests/LibWeb/TestStyleEngineBridge.cpp
@@ -23,6 +23,7 @@ static Web::CSS::StyleEngine::PublishedStyleDelta make_style_delta(Web::CSS::Sty
         .inherited_style_groups = inherited_style_groups,
         .pseudo_kind = 0xff,
         .gap = gap,
+        .pseudo_recompute_mask = 0,
     };
 }
 
@@ -124,4 +125,7 @@ TEST_CASE(direct_inherited_style_deltas_only_absorb_covered_reactions)
     auto targeted_pseudo_delta = make_style_delta(FfiStyleDeltaGap::Materialize, StyleEngine::PublishedStyle | StyleEngine::PseudoInputsMayHaveChanged, 0);
     targeted_pseudo_delta.pseudo_kind = 0;
     EXPECT(!StyleEngine::published_style_delta_can_absorb_reaction(targeted_pseudo_delta, StyleEngine::InheritedStyle, 0b0010));
+
+    auto exact_pseudo_delta = make_style_delta(FfiStyleDeltaGap::Materialize, StyleEngine::PublishedStyle | StyleEngine::ExactPseudoInputs, 0);
+    EXPECT(!StyleEngine::published_style_delta_can_absorb_reaction(exact_pseudo_delta, StyleEngine::InheritedStyle, 0b0010));
 }

--- a/Tests/LibWeb/TestStyleEngineBridge.cpp
+++ b/Tests/LibWeb/TestStyleEngineBridge.cpp
@@ -120,4 +120,8 @@ TEST_CASE(direct_inherited_style_deltas_only_absorb_covered_reactions)
 
     auto materialized_delta = make_style_delta(FfiStyleDeltaGap::Materialize, StyleEngine::InheritedStyle, 0b0010);
     EXPECT(StyleEngine::published_style_delta_can_absorb_reaction(materialized_delta, StyleEngine::InheritedStyle | StyleEngine::InheritedCustomProperties, 0b0110));
+
+    auto targeted_pseudo_delta = make_style_delta(FfiStyleDeltaGap::Materialize, StyleEngine::PublishedStyle | StyleEngine::PseudoInputsMayHaveChanged, 0);
+    targeted_pseudo_delta.pseudo_kind = 0;
+    EXPECT(!StyleEngine::published_style_delta_can_absorb_reaction(targeted_pseudo_delta, StyleEngine::InheritedStyle, 0b0010));
 }

--- a/Tests/LibWeb/Text/expected/css/style-engine/dense-retained-reactions-stay-sparse.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/dense-retained-reactions-stay-sparse.txt
@@ -1,0 +1,3 @@
+no complete matching batch: true
+first element: rgb(1, 2, 3)
+last element: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/style-engine/element-reference-pseudo-reaction.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/element-reference-pseudo-reaction.txt
@@ -1,0 +1,8 @@
+color: rgb(0, 128, 0)
+content color: rgb(0, 128, 0)
+content background: rgb(4, 5, 6)
+content x delta: 20
+scroll width delta: 20
+element recomputations: 1
+published reactions: 1
+layout style applications: 1

--- a/Tests/LibWeb/Text/expected/css/style-engine/mixed-origin-pseudo-reaction-animation-fallback.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/mixed-origin-pseudo-reaction-animation-fallback.txt
@@ -1,0 +1,6 @@
+origin: rgb(255, 255, 0)
+before: rgb(128, 0, 128)
+after: rgb(0, 0, 255)
+published reactions: 1
+element recomputations: 1
+pseudo layout style applications: 2

--- a/Tests/LibWeb/Text/expected/css/style-engine/mixed-origin-pseudo-reaction.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/mixed-origin-pseudo-reaction.txt
@@ -1,0 +1,5 @@
+origin: rgb(255, 255, 0)
+before: rgb(128, 0, 128)
+after: rgb(0, 0, 255)
+published reactions: 1
+element recomputations: 1

--- a/Tests/LibWeb/Text/expected/css/style-engine/pseudo-only-descendant-reaction.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/pseudo-only-descendant-reaction.txt
@@ -1,0 +1,4 @@
+color: rgb(0, 128, 0)
+published reactions: 1
+element recomputations: 0
+layout style applications: 1

--- a/Tests/LibWeb/Text/expected/css/style-engine/pseudo-only-reaction-animation-fallback.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/pseudo-only-reaction-animation-fallback.txt
@@ -1,0 +1,2 @@
+before: rgb(128, 0, 128)
+after: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/expected/css/style-engine/pseudo-reaction-cascade-change-fallback.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/pseudo-reaction-cascade-change-fallback.txt
@@ -1,0 +1,3 @@
+origin: rgb(0, 128, 0)
+before: rgb(0, 0, 255)
+element recomputations: 1

--- a/Tests/LibWeb/Text/input/css/style-engine/dense-retained-reactions-stay-sparse.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/dense-retained-reactions-stay-sparse.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .changed {
+        color: rgb(1, 2, 3);
+    }
+</style>
+<div id="container"></div>
+<script>
+    const container = document.getElementById("container");
+    for (let i = 0; i < 256; ++i)
+        container.appendChild(document.createElement("div"));
+
+    test(() => {
+        internals.updateStyle();
+
+        const before = internals.styleEngineCounters();
+        for (const element of container.children)
+            element.classList.add("changed");
+        internals.updateStyle();
+        const after = internals.styleEngineCounters();
+
+        const batchRows = after.coldMatchingBatchRows - before.coldMatchingBatchRows;
+        println(`no complete matching batch: ${batchRows === 0}`);
+        println(`first element: ${getComputedStyle(container.firstElementChild).color}`);
+        println(`last element: ${getComputedStyle(container.lastElementChild).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/element-reference-pseudo-reaction.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/element-reference-pseudo-reaction.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    details { width: 80px; overflow: auto; }
+    span { display: inline-block; width: 80px; }
+    .target::details-content { color: red; transform: translateX(1px); --accent: rgb(1, 2, 3); }
+    .changed .target::details-content { color: green; transform: translateX(21px); --accent: rgb(4, 5, 6); }
+    span { background-color: var(--accent); }
+</style>
+<div id="guard"><details id="target" class="target" open><span id="content">content</span></details></div>
+<script>
+    test(() => {
+        const guard = document.getElementById("guard");
+        const target = document.getElementById("target");
+        const content = document.getElementById("content");
+        getComputedStyle(target, "::details-content").color;
+        internals.updateStyle();
+        guard.classList.add("changed");
+        internals.updateStyle();
+        guard.classList.remove("changed");
+        internals.updateStyle();
+        target.offsetWidth;
+        const initialContentX = content.getBoundingClientRect().x;
+        const initialScrollWidth = target.scrollWidth;
+
+        internals.resetStyleInvalidationCounters();
+        guard.classList.add("changed");
+        internals.updateStyle();
+
+        println("color: " + getComputedStyle(target, "::details-content").color);
+        println("content color: " + getComputedStyle(content).color);
+        println("content background: " + getComputedStyle(content).backgroundColor);
+        println("content x delta: " + (content.getBoundingClientRect().x - initialContentX));
+        println("scroll width delta: " + (target.scrollWidth - initialScrollWidth));
+        const counters = internals.getStyleInvalidationCounters();
+        println("element recomputations: " + counters.elementStyleRecomputations);
+        println("published reactions: " + counters.styleEnginePublishedReactions);
+        println("layout style applications: " + counters.pseudoElementLayoutStyleApplications);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/mixed-origin-pseudo-reaction-animation-fallback.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/mixed-origin-pseudo-reaction-animation-fallback.html
@@ -1,9 +1,17 @@
 <!DOCTYPE html>
 <script src="../../include.js"></script>
 <style>
+    @keyframes hold-after-color {
+        from, to { background-color: blue; }
+    }
+
     .target { background-color: red; }
     .target::before { content: "before"; background-color: green; }
-    .target::after { content: "after"; background-color: blue; }
+    .target::after {
+        content: "after";
+        background-color: blue;
+        animation: hold-after-color 1s paused;
+    }
     .guard .target { background-color: yellow; }
     .guard .target::before { background-color: purple; }
 </style>
@@ -24,5 +32,6 @@
         const counters = internals.getStyleInvalidationCounters();
         println("published reactions: " + counters.styleEnginePublishedReactions);
         println("element recomputations: " + counters.elementStyleRecomputations);
+        println("pseudo layout style applications: " + counters.pseudoElementLayoutStyleApplications);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-engine/mixed-origin-pseudo-reaction.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/mixed-origin-pseudo-reaction.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .target { background-color: red; }
+    .target::before { content: "before"; background-color: green; }
+    .target::after { content: "after"; background-color: blue; }
+    .guard .target { background-color: yellow; }
+    .guard .target::before { background-color: purple; }
+</style>
+<div id="guard"><div id="target" class="target"></div></div>
+<script>
+    test(() => {
+        const guard = document.getElementById("guard");
+        const target = document.getElementById("target");
+        internals.updateStyle();
+
+        internals.resetStyleInvalidationCounters();
+        guard.classList.add("guard");
+        internals.updateStyle();
+
+        println("origin: " + getComputedStyle(target).backgroundColor);
+        println("before: " + getComputedStyle(target, "::before").backgroundColor);
+        println("after: " + getComputedStyle(target, "::after").backgroundColor);
+        const counters = internals.getStyleInvalidationCounters();
+        println("published reactions: " + counters.styleEnginePublishedReactions);
+        println("element recomputations: " + counters.elementStyleRecomputations);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-descendant-reaction.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-descendant-reaction.html
@@ -5,6 +5,7 @@
         content: "pseudo";
         color: red;
     }
+    .target::after { content: "unchanged"; }
     .guard .target::before { color: green; }
 </style>
 <div id="guard"><div id="target" class="target"></div></div>

--- a/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-descendant-reaction.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-descendant-reaction.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .target::before {
+        content: "pseudo";
+        color: red;
+    }
+    .guard .target::before { color: green; }
+</style>
+<div id="guard"><div id="target" class="target"></div></div>
+<script>
+    test(() => {
+        const guard = document.getElementById("guard");
+        const target = document.getElementById("target");
+        getComputedStyle(target, "::before").color;
+        guard.classList.add("guard");
+        internals.updateStyle();
+        guard.classList.remove("guard");
+        internals.updateStyle();
+        target.offsetWidth;
+
+        internals.resetStyleInvalidationCounters();
+        guard.classList.add("guard");
+        println("color: " + getComputedStyle(target, "::before").color);
+
+        const counters = internals.getStyleInvalidationCounters();
+        println("published reactions: " + counters.styleEnginePublishedReactions);
+        println("element recomputations: " + counters.elementStyleRecomputations);
+        println("layout style applications: " + counters.pseudoElementLayoutStyleApplications);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-reaction-animation-fallback.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/pseudo-only-reaction-animation-fallback.html
@@ -1,10 +1,16 @@
 <!DOCTYPE html>
 <script src="../../include.js"></script>
 <style>
-    .target { background-color: red; }
+    @keyframes hold-after-color {
+        from, to { background-color: blue; }
+    }
+
     .target::before { content: "before"; background-color: green; }
-    .target::after { content: "after"; background-color: blue; }
-    .guard .target { background-color: yellow; }
+    .target::after {
+        content: "after";
+        background-color: blue;
+        animation: hold-after-color 1s paused;
+    }
     .guard .target::before { background-color: purple; }
 </style>
 <div id="guard"><div id="target" class="target"></div></div>
@@ -18,11 +24,10 @@
         guard.classList.add("guard");
         internals.updateStyle();
 
-        println("origin: " + getComputedStyle(target).backgroundColor);
         println("before: " + getComputedStyle(target, "::before").backgroundColor);
         println("after: " + getComputedStyle(target, "::after").backgroundColor);
         const counters = internals.getStyleInvalidationCounters();
-        println("published reactions: " + counters.styleEnginePublishedReactions);
-        println("element recomputations: " + counters.elementStyleRecomputations);
+        if (counters.elementStyleRecomputations === 0 && counters.pseudoElementLayoutStyleApplications !== 2)
+            throw new Error("the animation fallback should apply both pseudo styles");
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-engine/pseudo-reaction-cascade-change-fallback.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/pseudo-reaction-cascade-change-fallback.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    .target { color: red; }
+    .target::before { content: "before"; color: red; }
+    .guard .target::before { color: blue; }
+</style>
+<div id="guard"><div id="target" class="target"></div></div>
+<script>
+    test(() => {
+        target.offsetWidth;
+
+        internals.resetStyleInvalidationCounters();
+        guard.classList.add("guard");
+        document.styleSheets[0].cssRules[0].style.color = "green";
+        internals.updateStyle();
+
+        println("origin: " + getComputedStyle(target).color);
+        println("before: " + getComputedStyle(target, "::before").color);
+        const counters = internals.getStyleInvalidationCounters();
+        println("element recomputations: " + counters.elementStyleRecomputations);
+    });
+</script>


### PR DESCRIPTION
Preserve exact pseudo-element targets and reaction masks throughout style invalidation, recomputation, and layout publication. This avoids recomputing originating elements or reapplying unchanged pseudo-element styles while retaining conservative fallbacks for animations and broader style changes.

Also rebuild sparse prefix state directly for class additions, reuse resident fact identities, and avoid expanding dense retained reactions into complete matching batches.

In focused workloads, pseudo-only changes reduce originating-element recomputations from 1 to 0, mixed origin/pseudo changes reduce pseudo layout applications from 2 to 1, and a 256-element retained-reaction batch performs 0 complete matching rows.