### PR TITLE
Make Rust the sole owner of hit-test display list structure

### DIFF
--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -22,100 +22,37 @@
 
 namespace Web::Painting {
 
-static bool writing_mode_is_horizontal(CSS::WritingMode writing_mode)
-{
-    return writing_mode == CSS::WritingMode::HorizontalTb;
-}
-
-static CSSPixels block_axis_start(CSSPixelRect rect, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? rect.top() : rect.left();
-}
-
-static CSSPixels block_axis_end(CSSPixelRect rect, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? rect.bottom() : rect.right();
-}
-
-static CSSPixels block_axis_coordinate(CSSPixelPoint point, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? point.y() : point.x();
-}
-
-static CSSPixels inline_axis_start(CSSPixelRect rect, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? rect.left() : rect.top();
-}
-
-static CSSPixels inline_axis_end(CSSPixelRect rect, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? rect.right() : rect.bottom();
-}
-
-static CSSPixels inline_axis_coordinate(CSSPixelPoint point, CSS::WritingMode writing_mode)
-{
-    return writing_mode_is_horizontal(writing_mode) ? point.x() : point.y();
-}
-
-static bool local_point_is_before_box(Layout::NodeWithStyle const& layout_node, CSSPixelRect rect, CSSPixelPoint local_point)
-{
-    auto const& style_source = layout_node;
-    auto writing_mode = style_source.writing_mode();
-
-    auto block_coordinate = block_axis_coordinate(local_point, writing_mode);
-    if (block_coordinate < block_axis_start(rect, writing_mode))
-        return !style_source.block_axis_is_reverse();
-    if (block_coordinate >= block_axis_end(rect, writing_mode))
-        return style_source.block_axis_is_reverse();
-
-    auto inline_start = inline_axis_start(rect, writing_mode);
-    auto inline_end = inline_axis_end(rect, writing_mode);
-    auto inline_middle = inline_start + (inline_end - inline_start).scaled(0.5);
-    auto inline_coordinate = inline_axis_coordinate(local_point, writing_mode);
-    return style_source.inline_axis_is_reverse()
-        ? inline_coordinate > inline_middle
-        : inline_coordinate <= inline_middle;
-}
-
 NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording(u64 visual_context_tree_version, Layout::NodeArena& arena, ChromeWidgetRegistry& chrome_widget_registry)
 {
     auto* arena_handle = arena.handle();
     auto list = adopt_ref(*new HitTestDisplayList(visual_context_tree_version, arena, chrome_widget_registry, Layout::RustFFI::layout_arena_hit_test_list_generation(arena_handle)));
-    auto item_count = Layout::RustFFI::layout_arena_hit_test_item_count(arena_handle);
-    list->m_items.ensure_capacity(item_count);
-    Vector<Layout::RustFFI::FfiHitTestItemExport> exported_items;
-    exported_items.resize(item_count);
-    Layout::RustFFI::layout_arena_export_hit_test_items(arena_handle, exported_items.data(), exported_items.size());
-    for (auto const& exported : exported_items) {
-        VERIFY(exported.paintable.index != Layout::RustFFI::INVALID_NODE_SLOT_INDEX);
-        VERIFY(Layout::RustFFI::layout_arena_paintable_row(arena_handle, exported.paintable));
-        VERIFY(Layout::RustFFI::layout_arena_paintable_row(arena_handle, exported.hit_node));
-        switch (static_cast<ChromeWidgetKind>(exported.chrome_widget_kind)) {
-        case ChromeWidgetKind::None:
-            break;
-        case ChromeWidgetKind::ResizeHandle:
-            (void)chrome_widget_registry.get_or_create_resize_handle(arena, exported.paintable);
-            break;
-        case ChromeWidgetKind::HorizontalScrollbar:
-            (void)chrome_widget_registry.get_or_create_scrollbar(arena, exported.paintable, ScrollDirection::Horizontal);
-            break;
-        case ChromeWidgetKind::VerticalScrollbar:
-            (void)chrome_widget_registry.get_or_create_scrollbar(arena, exported.paintable, ScrollDirection::Vertical);
-            break;
-        }
-        list->m_items.unchecked_append(Item {
-            .kind = static_cast<ItemKind>(exported.kind),
-            .paintable = exported.paintable,
-            .hit_node = exported.hit_node,
-            .chrome_widget_kind = static_cast<ChromeWidgetKind>(exported.chrome_widget_kind),
-            .text_fragment_index = exported.text_fragment_index,
-            .caret_node = exported.caret_node_shell ? static_cast<Layout::Node const*>(exported.caret_node_shell)->dom_node() : nullptr,
-            .caret_offset = exported.caret_offset,
-            .rect = exported.rect,
-            .caret_rect = exported.caret_rect,
-            .context = exported.context,
+    struct VisitContext {
+        HitTestDisplayList& list;
+        Layout::NodeArena& arena;
+        ChromeWidgetRegistry& chrome_widget_registry;
+    };
+    VisitContext visit_context { *list, arena, chrome_widget_registry };
+    Layout::RustFFI::layout_arena_hit_test_visit_caret_roots_and_chrome_widgets(arena_handle, &visit_context,
+        [](void* sink, Layout::RustFFI::NodeSlotId paintable, u8 chrome_widget_kind, void* caret_node_shell) {
+            auto& context = *static_cast<VisitContext*>(sink);
+            if (caret_node_shell) {
+                if (auto* caret_node = static_cast<Layout::Node*>(caret_node_shell)->dom_node())
+                    context.list.m_caret_node_roots.append(caret_node);
+            }
+            switch (static_cast<ChromeWidgetKind>(chrome_widget_kind)) {
+            case ChromeWidgetKind::None:
+                break;
+            case ChromeWidgetKind::ResizeHandle:
+                (void)context.chrome_widget_registry.get_or_create_resize_handle(context.arena, paintable);
+                break;
+            case ChromeWidgetKind::HorizontalScrollbar:
+                (void)context.chrome_widget_registry.get_or_create_scrollbar(context.arena, paintable, ScrollDirection::Horizontal);
+                break;
+            case ChromeWidgetKind::VerticalScrollbar:
+                (void)context.chrome_widget_registry.get_or_create_scrollbar(context.arena, paintable, ScrollDirection::Vertical);
+                break;
+            }
         });
-    }
     return list;
 }
 
@@ -129,8 +66,7 @@ HitTestDisplayList::HitTestDisplayList(u64 visual_context_tree_version, Layout::
 
 void HitTestDisplayList::visit_edges(GC::Cell::Visitor& visitor)
 {
-    for (auto const& item : m_items)
-        visitor.visit(item.caret_node);
+    visitor.visit(m_caret_node_roots);
 }
 
 bool HitTestDisplayList::is_current() const
@@ -138,29 +74,15 @@ bool HitTestDisplayList::is_current() const
     return m_rust_generation != 0 && Layout::RustFFI::layout_arena_hit_test_list_generation(m_arena->handle()) == m_rust_generation;
 }
 
-void HitTestDisplayList::ensure_caret_lines() const
+HitTestDisplayList::Item HitTestDisplayList::item(size_t index) const
 {
-    if (m_caret_lines_materialized)
-        return;
-    m_caret_lines_materialized = true;
-    if (!is_current())
-        return;
-    auto* arena = m_arena->handle();
-    auto caret_item_count = Layout::RustFFI::layout_arena_hit_test_caret_item_count(arena);
-    m_caret_item_indices.ensure_capacity(caret_item_count);
-    for (size_t index = 0; index < caret_item_count; ++index)
-        m_caret_item_indices.unchecked_append(Layout::RustFFI::layout_arena_hit_test_caret_item_index(arena, index));
-    auto line_count = Layout::RustFFI::layout_arena_hit_test_caret_line_count(arena);
-    m_caret_lines.ensure_capacity(line_count);
-    for (size_t index = 0; index < line_count; ++index) {
-        auto exported = Layout::RustFFI::layout_arena_hit_test_caret_line(arena, index);
-        m_caret_lines.unchecked_append(CaretLine {
-            .rect = exported.rect,
-            .context = exported.context,
-            .first_caret_item_index = exported.first_caret_item_index,
-            .last_caret_item_index = exported.last_caret_item_index,
-        });
-    }
+    return { index, Layout::RustFFI::layout_arena_hit_test_item_facts(m_arena->handle(), index) };
+}
+
+static DOM::Node const* dom_node_for_shell(void* shell)
+{
+    auto const* layout_node = static_cast<Layout::Node const*>(shell);
+    return layout_node ? layout_node->dom_node() : nullptr;
 }
 
 static Optional<Gfx::FloatPoint> local_float_point_for_visual_context(ContextRef context, CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, AccumulatedVisualContextTree::ClipBehavior clip_behavior)
@@ -221,10 +143,11 @@ struct HitTestDisplayList::QueryContext {
                 *out = *local_point;
                 return true;
             },
-            .line_in_scope = [](void* context_pointer, size_t line_index) -> bool {
+            .shell_in_scope = [](void* context_pointer, void* shell) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
                 VERIFY(context.scope);
-                return context.list.line_contains_descendant_of(context.list.m_caret_lines[line_index], *context.scope);
+                auto const* dom_node = dom_node_for_shell(shell);
+                return dom_node && context.scope->is_inclusive_ancestor_of(*dom_node);
             },
             .sorting_context_group = [](void* context_pointer, SpatialNodeIndex spatial, size_t* out) -> bool {
                 auto& context = *static_cast<QueryContext*>(context_pointer);
@@ -268,6 +191,47 @@ struct HitTestDisplayList::QueryContext {
             callbacks.viewport_wheel_overflow_y = to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(*document, ScrollDirection::Vertical));
         }
         return callbacks;
+    }
+};
+
+struct CaretPositionQueryContext {
+    GC::Ref<DOM::Node const> node;
+    size_t offset { 0 };
+
+    Layout::RustFFI::FfiCaretPositionQueryCallbacks callbacks()
+    {
+        return {
+            .context = this,
+            .shell_is_query_node = [](void* context_pointer, void* shell) -> bool {
+                auto& context = *static_cast<CaretPositionQueryContext*>(context_pointer);
+                return dom_node_for_shell(shell) == context.node.ptr();
+            },
+            .query_boundary_descends_to_shell = [](void* context_pointer, void* shell) -> bool {
+                auto& context = *static_cast<CaretPositionQueryContext*>(context_pointer);
+                auto const* shell_dom_node = dom_node_for_shell(shell);
+                if (!shell_dom_node)
+                    return false;
+                auto* node_after_boundary = context.node->child_at_index(context.offset);
+                while (node_after_boundary && node_after_boundary != shell_dom_node)
+                    node_after_boundary = node_after_boundary->first_child();
+                return node_after_boundary == shell_dom_node;
+            },
+            .query_boundary_follows_shell_end = [](void* context_pointer, void* shell, size_t end_offset_with_whitespace) -> bool {
+                auto& context = *static_cast<CaretPositionQueryContext*>(context_pointer);
+                auto const* shell_dom_node = dom_node_for_shell(shell);
+                return shell_dom_node
+                    && context.offset > 0
+                    && context.node->child_at_index(context.offset - 1) == shell_dom_node
+                    && end_offset_with_whitespace == shell_dom_node->length();
+            },
+            .query_is_adjacent_to_shell = [](void* context_pointer, void* shell) -> bool {
+                auto& context = *static_cast<CaretPositionQueryContext*>(context_pointer);
+                auto const* shell_dom_node = dom_node_for_shell(shell);
+                return shell_dom_node
+                    && shell_dom_node->parent() == context.node.ptr()
+                    && (context.offset == shell_dom_node->index() || context.offset == shell_dom_node->index() + 1);
+            },
+        };
     }
 };
 
@@ -332,112 +296,52 @@ HitTestDisplayList::ClosestLine HitTestDisplayList::find_closest_line(CSSPixelPo
     return closest_line;
 }
 
-static Layout::RustFFI::FfiFragmentTextFacts fragment_text_facts(void* arena_handle, Layout::RustFFI::NodeSlotId box, Optional<u32> const& text_fragment_index)
+Layout::Node const* HitTestDisplayList::layout_node_for_item(Item item) const
 {
-    if (!text_fragment_index.has_value())
-        return {};
-    return Layout::RustFFI::layout_arena_paintable_fragment_text_facts(arena_handle, box, *text_fragment_index);
+    return layout_node_for_committed_slot(*m_arena, item.paintable());
 }
 
-static Layout::Node const* fragment_layout_node(Layout::RustFFI::FfiFragmentTextFacts const& facts)
+RefPtr<ChromeWidget> HitTestDisplayList::chrome_widget_for_item(Item item) const
 {
-    return static_cast<Layout::Node const*>(facts.layout_node);
-}
-
-Layout::Node const* HitTestDisplayList::layout_node_for_item(Item const& item) const
-{
-    return layout_node_for_committed_slot(*m_arena, item.paintable);
-}
-
-RefPtr<ChromeWidget> HitTestDisplayList::chrome_widget_for_item(Item const& item) const
-{
-    switch (item.chrome_widget_kind) {
+    switch (item.chrome_widget_kind()) {
     case ChromeWidgetKind::None:
         return nullptr;
     case ChromeWidgetKind::ResizeHandle:
-        return m_chrome_widget_registry->resize_handle(item.paintable);
+        return m_chrome_widget_registry->resize_handle(item.paintable());
     case ChromeWidgetKind::HorizontalScrollbar:
-        return m_chrome_widget_registry->scrollbar(item.paintable, ScrollDirection::Horizontal);
+        return m_chrome_widget_registry->scrollbar(item.paintable(), ScrollDirection::Horizontal);
     case ChromeWidgetKind::VerticalScrollbar:
-        return m_chrome_widget_registry->scrollbar(item.paintable, ScrollDirection::Vertical);
+        return m_chrome_widget_registry->scrollbar(item.paintable(), ScrollDirection::Vertical);
     }
     VERIFY_NOT_REACHED();
 }
 
-bool HitTestDisplayList::item_can_produce_caret_position(Item const& item) const
+DOM::Node const* HitTestDisplayList::item_dom_node(size_t item_index) const
 {
-    switch (item.kind) {
-    case ItemKind::TextFragment: {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
-        return layout_node && layout_node->dom_node();
-    }
-    case ItemKind::EmptyLine:
-        return !!item.caret_node;
-    case ItemKind::EmptyEditable: {
-        auto const* layout_node = layout_node_for_item(item);
-        return layout_node && layout_node->dom_node();
-    }
-    case ItemKind::Box: {
-        auto const* layout_node = layout_node_for_item(item);
-        if (!layout_node)
-            return false;
-        if (Painting::effective_z_index(*layout_node).value_or(0) < 0)
-            return false;
-        return layout_node->dom_node()
-            && layout_node->dom_node()->parent()
-            && (layout_node->is_atomic_inline() || layout_node->is_replaced_box());
-    }
-    case ItemKind::SvgPath:
-    case ItemKind::ChromeWidget:
-        return false;
-    }
-    VERIFY_NOT_REACHED();
+    return dom_node_for_shell(Layout::RustFFI::layout_arena_hit_test_item_target_shell(m_arena->handle(), item_index));
 }
 
-DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
+static DOM::Node const* dom_node_for_dispatch_shell(void* shell, bool allow_pseudo_fallback)
 {
-    switch (item.kind) {
-    case ItemKind::Box:
-    case ItemKind::SvgPath:
-    case ItemKind::EmptyEditable:
-    case ItemKind::ChromeWidget: {
-        auto const* layout_node = layout_node_for_item(item);
-        return layout_node ? layout_node->dom_node() : nullptr;
-    }
-    case ItemKind::TextFragment: {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
-        return layout_node ? layout_node->dom_node() : nullptr;
-    }
-    case ItemKind::EmptyLine:
-        return item.caret_node.ptr();
-    }
-    VERIFY_NOT_REACHED();
+    if (auto const* node = dom_node_for_shell(shell))
+        return node;
+    auto const* layout_node = static_cast<Layout::Node const*>(shell);
+    if (allow_pseudo_fallback && layout_node && layout_node->is_generated_for_pseudo_element())
+        return layout_node->pseudo_element_generator().ptr();
+    return nullptr;
 }
 
-DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(Item const& item) const
+DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(size_t item_index) const
 {
-    if (item.kind == ItemKind::TextFragment) {
-        auto const* layout_node = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
-        if (!layout_node)
-            return nullptr;
-        if (auto const* node = layout_node->dom_node())
-            return node;
-        if (layout_node->is_generated_for_pseudo_element())
-            return layout_node->pseudo_element_generator().ptr();
-        return nullptr;
-    }
-
-    if (item.kind == ItemKind::EmptyLine)
-        return item_dom_node(item);
-
-    auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.paintable);
-    return layout_node_shell ? static_cast<Layout::Node const*>(layout_node_shell)->dom_node() : nullptr;
+    bool allow_pseudo_fallback = false;
+    auto* shell = Layout::RustFFI::layout_arena_hit_test_item_dispatch_shell(m_arena->handle(), item_index, &allow_pseudo_fallback);
+    return dom_node_for_dispatch_shell(shell, allow_pseudo_fallback);
 }
 
-bool HitTestDisplayList::item_is_direct_caret_target(Item const& item) const
+bool HitTestDisplayList::item_is_direct_caret_target(size_t item_index) const
 {
-    auto const* dom_node = item_dom_node(item);
-    return dom_node && dom_node == event_dispatch_dom_node_for_item(item);
+    auto const* dom_node = item_dom_node(item_index);
+    return dom_node && dom_node == event_dispatch_dom_node_for_item(item_index);
 }
 
 // https://html.spec.whatwg.org/multipage/image-maps.html#image-map-processing-model
@@ -457,10 +361,10 @@ static GC::Ptr<DOM::Node> image_map_area_for_point(Layout::Node const& layout_no
     return map_element->area_for_point(local_point - image_rect.location(), image_rect.size());
 }
 
-HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSSPixelPoint local_point) const
+HitTestResult HitTestDisplayList::hit_test_result_for_item(Item item, CSSPixelPoint local_point) const
 {
     auto const* paintable_layout_node = layout_node_for_item(item);
-    auto hit_node = item.hit_node;
+    auto hit_node = item.hit_node();
 
     auto const* named_layout_node = layout_node_for_committed_slot(*m_arena, hit_node);
     VERIFY(named_layout_node && as<Layout::NodeWithStyle>(*named_layout_node).pointer_events() != CSS::PointerEvents::None);
@@ -482,278 +386,109 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
         }
     }
 
-    switch (item.kind) {
-    case ItemKind::Box: {
-        GC::Ptr<DOM::Node> node = root_element;
-        if (!node && paintable_layout_node)
-            node = image_map_area_for_point(*paintable_layout_node, local_point);
-        if (!node)
-            node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item));
-        return HitTestResult {
-            .node = node,
-            .hit_node = hit_node,
-            .arena = *m_arena,
-        };
-    }
-    case ItemKind::SvgPath:
-        return HitTestResult {
-            .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .hit_node = hit_node,
-            .arena = *m_arena,
-        };
-    case ItemKind::TextFragment: {
-        VERIFY(item.text_fragment_index.has_value());
-        GC::Ptr<DOM::Node> node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item));
-        if (!node) {
-            auto* layout_node_shell = Layout::RustFFI::layout_arena_paintable_event_dispatch_node_shell(m_arena->handle(), item.paintable);
-            node = layout_node_shell ? static_cast<Layout::Node*>(layout_node_shell)->dom_node() : nullptr;
-        }
-        return HitTestResult {
-            .node = node,
-            .hit_node = hit_node,
-            .arena = *m_arena,
-            .index_in_node = Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
-                m_arena->handle(), item.paintable, *item.text_fragment_index,
-                local_point.x(), local_point.y()),
-            .is_text_fragment = true,
-        };
-    }
-    case ItemKind::EmptyLine:
-        // NB: Not reachable through regular hit testing; see item_contains().
-        return HitTestResult {
-            .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .hit_node = hit_node,
-            .arena = *m_arena,
-        };
-    case ItemKind::EmptyEditable:
-        return HitTestResult {
-            .node = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .hit_node = hit_node,
-            .arena = *m_arena,
-            .index_in_node = 0,
-        };
-    case ItemKind::ChromeWidget:
-        return HitTestResult {
-            .node = root_element ? root_element : const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
-            .hit_node = hit_node,
-            .arena = *m_arena,
-            .chrome_widget = chrome_widget_for_item(item),
-        };
-    }
-    VERIFY_NOT_REACHED();
+    auto resolved = Layout::RustFFI::layout_arena_hit_test_resolve_hit(m_arena->handle(), item.index(), local_point);
+    GC::Ptr<DOM::Node> node = root_element;
+    if (!node && paintable_layout_node)
+        node = image_map_area_for_point(*paintable_layout_node, local_point);
+    if (!node)
+        node = const_cast<DOM::Node*>(dom_node_for_dispatch_shell(resolved.dispatch_shell, resolved.allow_pseudo_fallback));
+    if (!node)
+        node = const_cast<DOM::Node*>(dom_node_for_dispatch_shell(resolved.fallback_dispatch_shell, false));
+
+    // NB: Empty-line items are not reachable through regular hit testing; the descriptor still resolves them for
+    // callers that already hold such an item.
+    auto result = HitTestResult {
+        .node = node,
+        .hit_node = hit_node,
+        .arena = *m_arena,
+        .chrome_widget = chrome_widget_for_item(item),
+        .is_text_fragment = resolved.is_text_fragment,
+    };
+    if (resolved.has_index_in_node)
+        result.index_in_node = resolved.index_in_node;
+    return result;
 }
 
-Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item const& item, CSSPixelPoint local_point, CaretPositionType type) const
+Optional<CaretPosition> HitTestDisplayList::caret_position_for_item(Item item, CSSPixelPoint local_point, CaretPositionType type) const
 {
-    switch (item.kind) {
-    case ItemKind::TextFragment: {
-        VERIFY(item.text_fragment_index.has_value());
-        auto facts = fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index);
-        auto const* fragment_layout = fragment_layout_node(facts);
-        auto const* fragment_dom_node = fragment_layout ? fragment_layout->dom_node() : nullptr;
-        if (!fragment_dom_node)
-            return {};
+    auto resolved = Layout::RustFFI::layout_arena_hit_test_resolve_caret(m_arena->handle(), item.index(), local_point, to_underlying(type));
+    if (!resolved.has_position || !resolved.node_shell)
+        return {};
+    auto* dom_node = static_cast<Layout::Node*>(resolved.node_shell)->dom_node();
+    if (!dom_node)
+        return {};
 
-        auto index_in_node = [&]() -> size_t {
-            switch (type) {
-            case CaretPositionType::Before:
-                return facts.dom_start_offset_in_node;
-            case CaretPositionType::After:
-                return facts.dom_end_offset_with_trailing_whitespace;
-            case CaretPositionType::Closest:
-                return Layout::RustFFI::layout_arena_paintable_fragment_index_in_node_for_point(
-                    m_arena->handle(), item.paintable, *item.text_fragment_index,
-                    local_point.x(), local_point.y());
-            }
-            VERIFY_NOT_REACHED();
-        }();
+    Optional<CSSPixelRect> debug_rect;
+    if (resolved.has_debug_rect)
+        debug_rect = resolved.debug_rect;
 
-        // A position at the fragment's whitespace-extended end may coincide with the start of the next fragment;
-        // Upstream affinity keeps it rendering on this fragment's line.
-        auto affinity = index_in_node >= facts.dom_end_offset_in_node && index_in_node == facts.dom_end_offset_with_trailing_whitespace
-            ? TextAffinity::Upstream
-            : TextAffinity::Downstream;
-
-        auto debug_rect = Layout::RustFFI::layout_arena_paintable_fragment_caret_range_rect(
-            m_arena->handle(), item.paintable, *item.text_fragment_index, index_in_node);
+    switch (resolved.boundary) {
+    case Layout::RustFFI::FfiCaretBoundaryKind::Offset:
         return CaretPosition {
-            .paintable = item.paintable,
+            .paintable = item.paintable(),
             .arena = *m_arena,
-            .boundary = { const_cast<DOM::Node&>(*fragment_dom_node), static_cast<WebIDL::UnsignedLong>(index_in_node) },
-            .affinity = affinity,
+            .boundary = { *dom_node, static_cast<WebIDL::UnsignedLong>(resolved.offset) },
+            .affinity = resolved.affinity_is_upstream ? TextAffinity::Upstream : TextAffinity::Downstream,
             .debug_rect = debug_rect,
         };
+    case Layout::RustFFI::FfiCaretBoundaryKind::BeforeNode:
+    case Layout::RustFFI::FfiCaretBoundaryKind::AfterNode:
+        break;
     }
-    case ItemKind::EmptyLine: {
-        auto const* dom_node = item_dom_node(item);
-        if (!dom_node)
-            return {};
-        // An empty line has a single caret position regardless of where on the line the point is.
-        return CaretPosition {
-            .paintable = item.paintable,
-            .arena = *m_arena,
-            .boundary = { const_cast<DOM::Node&>(*dom_node), static_cast<WebIDL::UnsignedLong>(item.caret_offset) },
-            .debug_rect = item.caret_rect,
-        };
-    }
-    case ItemKind::EmptyEditable: {
-        auto const* layout_node = layout_node_for_item(item);
-        auto* dom_node = const_cast<DOM::Node*>(layout_node ? layout_node->dom_node() : nullptr);
-        if (!dom_node)
-            return {};
-        return CaretPosition {
-            .paintable = item.paintable,
-            .arena = *m_arena,
-            .boundary = { *dom_node, 0 },
-            .debug_rect = item.caret_rect,
-        };
-    }
-    case ItemKind::Box: {
-        auto const* layout_node = layout_node_for_item(item);
-        auto const* layout_node_with_style = layout_node ? as_if<Layout::NodeWithStyle>(*layout_node) : nullptr;
-        auto* dom_node = const_cast<DOM::Node*>(layout_node ? layout_node->dom_node() : nullptr);
-        if (!layout_node_with_style || !dom_node || !dom_node->parent())
-            return {};
 
-        auto before_boundary = DOM::BoundaryPoint { *dom_node->parent(), static_cast<WebIDL::UnsignedLong>(dom_node->index()) };
-        auto after_boundary = DOM::BoundaryPoint { *dom_node->parent(), static_cast<WebIDL::UnsignedLong>(dom_node->index() + 1) };
-        auto point_is_before_box = [&] {
-            switch (type) {
-            case CaretPositionType::Before:
-                return true;
-            case CaretPositionType::After:
-                return false;
-            case CaretPositionType::Closest:
-                return local_point_is_before_box(*layout_node_with_style, item.rect, local_point);
-            }
-            VERIFY_NOT_REACHED();
-        }();
-        return CaretPosition {
-            .paintable = item.paintable,
-            .arena = *m_arena,
-            .boundary = point_is_before_box ? before_boundary : after_boundary,
-            .secondary_boundary = point_is_before_box ? after_boundary : before_boundary,
-            .debug_rect = item.caret_rect,
-        };
-    }
-    case ItemKind::SvgPath:
-    case ItemKind::ChromeWidget:
+    auto* parent = dom_node->parent();
+    if (!parent)
         return {};
-    }
-    VERIFY_NOT_REACHED();
+    auto before_boundary = DOM::BoundaryPoint { *parent, static_cast<WebIDL::UnsignedLong>(dom_node->index()) };
+    auto after_boundary = DOM::BoundaryPoint { *parent, static_cast<WebIDL::UnsignedLong>(dom_node->index() + 1) };
+    auto is_before = resolved.boundary == Layout::RustFFI::FfiCaretBoundaryKind::BeforeNode;
+    return CaretPosition {
+        .paintable = item.paintable(),
+        .arena = *m_arena,
+        .boundary = is_before ? before_boundary : after_boundary,
+        .secondary_boundary = is_before ? after_boundary : before_boundary,
+        .debug_rect = debug_rect,
+    };
 }
 
-Optional<CaretPosition> HitTestDisplayList::caret_position_for_hit_container(Item const& item) const
+Optional<CaretPosition> HitTestDisplayList::caret_position_for_hit_container(Item item) const
 {
-    auto dom_node = item_dom_node(item);
+    auto dom_node = item_dom_node(item.index());
     if (!dom_node)
         return {};
 
     return CaretPosition {
-        .paintable = item.paintable,
+        .paintable = item.paintable(),
         .arena = *m_arena,
         .boundary = { const_cast<DOM::Node&>(*dom_node), 0 },
-        .debug_rect = item.caret_rect,
+        .debug_rect = item.caret_rect(),
     };
-}
-
-bool HitTestDisplayList::item_contains_caret_position(Item const& item, DOM::Node const& node, size_t offset, TextAffinity affinity) const
-{
-    switch (item.kind) {
-    case ItemKind::TextFragment: {
-        VERIFY(item.text_fragment_index.has_value());
-        auto facts = fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index);
-        auto const* fragment_layout = fragment_layout_node(facts);
-        auto const* fragment_dom_node = fragment_layout ? fragment_layout->dom_node() : nullptr;
-        if (!fragment_dom_node)
-            return false;
-        if (fragment_dom_node == &node) {
-            return Layout::RustFFI::layout_arena_paintable_fragment_caret_match(
-                       m_arena->handle(), item.paintable, *item.text_fragment_index,
-                       offset, affinity == TextAffinity::Downstream)
-                != Layout::RustFFI::FfiCaretMatch::None;
-        }
-
-        auto* node_after_boundary = node.child_at_index(offset);
-        while (node_after_boundary && node_after_boundary != fragment_dom_node)
-            node_after_boundary = node_after_boundary->first_child();
-        if (node_after_boundary == fragment_dom_node && facts.dom_start_offset_in_node == 0)
-            return true;
-        return offset > 0
-            && node.child_at_index(offset - 1) == fragment_dom_node
-            && facts.dom_end_offset_with_trailing_whitespace == fragment_dom_node->length();
-    }
-    case ItemKind::EmptyLine:
-        return item_dom_node(item) == &node && item.caret_offset == offset;
-    case ItemKind::EmptyEditable: {
-        auto const* layout_node = layout_node_for_item(item);
-        return layout_node && layout_node->dom_node() == &node && offset == 0;
-    }
-    case ItemKind::Box: {
-        auto const* layout_node = layout_node_for_item(item);
-        auto dom_node = layout_node ? layout_node->dom_node() : nullptr;
-        return dom_node && dom_node->parent() == &node && (offset == dom_node->index() || offset == dom_node->index() + 1);
-    }
-    case ItemKind::SvgPath:
-    case ItemKind::ChromeWidget:
-        return false;
-    }
-    VERIFY_NOT_REACHED();
 }
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_at_line_edge(DOM::Node const& node, size_t offset, TextAffinity affinity, CaretLineEdge edge) const
 {
     if (!is_current())
         return {};
-    ensure_caret_lines();
-
-    auto line_index = caret_line_index_for_position(node, offset, affinity);
-    if (!line_index.has_value())
+    CaretPositionQueryContext context { node, offset };
+    auto line = Layout::RustFFI::layout_arena_hit_test_caret_line_for_position(m_arena->handle(), context.callbacks(), offset, affinity == TextAffinity::Downstream);
+    if (!line.has_line)
         return {};
     auto type = edge == CaretLineEdge::Start ? CaretPositionType::Before : CaretPositionType::After;
-    return caret_position_for_item(m_items[item_index_at_line_edge(*line_index, type)], {}, type);
-}
-
-Optional<size_t> HitTestDisplayList::caret_line_index_for_position(DOM::Node const& node, size_t offset, TextAffinity affinity) const
-{
-    // At a soft wrap, prefer the fragment whose line directly owns the position. Only use the preceding fragment's
-    // fallback match when no direct match exists.
-    for (bool allow_soft_wrap_fallback : { false, true }) {
-        for (size_t line_index = 0; line_index < m_caret_lines.size(); ++line_index) {
-            auto const& line = m_caret_lines[line_index];
-            for (auto caret_item_index = line.first_caret_item_index; caret_item_index <= line.last_caret_item_index; ++caret_item_index) {
-                auto const& item = caret_item(caret_item_index);
-                if (!item_contains_caret_position(item, node, offset, affinity))
-                    continue;
-                if (!allow_soft_wrap_fallback && item.kind == ItemKind::TextFragment && item.text_fragment_index.has_value()) {
-                    auto const* fragment_layout = fragment_layout_node(fragment_text_facts(m_arena->handle(), item.paintable, item.text_fragment_index));
-                    if (fragment_layout && fragment_layout->dom_node() == &node
-                        && Layout::RustFFI::layout_arena_paintable_fragment_caret_match(
-                               m_arena->handle(), item.paintable, *item.text_fragment_index,
-                               offset, affinity == TextAffinity::Downstream)
-                            == Layout::RustFFI::FfiCaretMatch::SoftWrapFallback)
-                        continue;
-                }
-                return line_index;
-            }
-        }
-    }
-    return {};
+    return caret_position_for_item(item(item_index_at_line_edge(line.line_index, type)), {}, type);
 }
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_on_adjacent_line(DOM::Node const& node, size_t offset, TextAffinity affinity, CaretLineDirection direction, CSSPixels inline_coordinate, DOM::Node const& scope) const
 {
     if (!is_current())
         return {};
-    ensure_caret_lines();
-
-    auto current_line_index = caret_line_index_for_position(node, offset, affinity);
-    if (!current_line_index.has_value())
+    CaretPositionQueryContext position_context { node, offset };
+    auto current_line = Layout::RustFFI::layout_arena_hit_test_caret_line_for_position(m_arena->handle(), position_context.callbacks(), offset, affinity == TextAffinity::Downstream);
+    if (!current_line.has_line)
         return {};
 
     // INTEROP: Vertical caret movement in Chromium, WebKit, and Gecko follows rendered line geometry rather than DOM
     QueryContext context { *this, nullptr, 1, nullptr, &scope };
-    auto adjacent = Layout::RustFFI::layout_arena_hit_test_adjacent_line(m_arena->handle(), context.callbacks(), *current_line_index, direction == CaretLineDirection::Next ? 1 : 0, inline_coordinate.raw_value());
+    auto adjacent = Layout::RustFFI::layout_arena_hit_test_adjacent_line(m_arena->handle(), context.callbacks(), current_line.line_index, direction == CaretLineDirection::Next ? 1 : 0, inline_coordinate.raw_value());
     if (!adjacent.has_line)
         return {};
     // Reuse point-to-caret resolution after choosing the line so text, atomic boxes, and empty lines share one rule for
@@ -765,12 +500,11 @@ Optional<CSSPixels> HitTestDisplayList::caret_line_block_coordinate(DOM::Node co
 {
     if (!is_current())
         return {};
-    ensure_caret_lines();
-
-    auto line_index = caret_line_index_for_position(node, offset, affinity);
-    if (!line_index.has_value())
+    CaretPositionQueryContext context { node, offset };
+    auto line = Layout::RustFFI::layout_arena_hit_test_caret_line_for_position(m_arena->handle(), context.callbacks(), offset, affinity == TextAffinity::Downstream);
+    if (!line.has_line)
         return {};
-    return CSSPixels::from_raw(Layout::RustFFI::layout_arena_hit_test_line_block_coordinate(m_arena->handle(), *line_index));
+    return CSSPixels::from_raw(Layout::RustFFI::layout_arena_hit_test_line_block_coordinate(m_arena->handle(), line.line_index));
 }
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(size_t line_index, CSSPixelPoint local_point, CaretPositionMode mode) const
@@ -778,24 +512,13 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(size_t line_
     auto caret_item = caret_item_for_line(line_index, local_point, mode);
     if (!caret_item.has_value())
         return {};
-    return caret_position_for_item(m_items[caret_item->item_index], local_point, caret_item->type);
-}
-
-bool HitTestDisplayList::line_contains_descendant_of(CaretLine const& line, DOM::Node const& ancestor) const
-{
-    for (auto caret_item_index = line.first_caret_item_index; caret_item_index <= line.last_caret_item_index; ++caret_item_index) {
-        if (auto const* dom_node = item_dom_node(caret_item(caret_item_index)); dom_node && ancestor.is_inclusive_ancestor_of(*dom_node))
-            return true;
-    }
-    return false;
+    return caret_position_for_item(item(caret_item->item_index), local_point, caret_item->type);
 }
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics, CaretPositionMode mode, GC::Ptr<DOM::Node const> constraint_scope) const
 {
     if (m_visual_context_tree_version != document.visual_context_tree().version() || !is_current())
         return {};
-    ensure_caret_lines();
-
     // First find both the topmost hit-test item and the topmost item that can directly produce a caret.
     // Non-caret items are still needed to keep later line fallback scoped to the hit content.
     // FIXME: Caret placement compares items by record order alone, ignoring the depth-sorted paint order of
@@ -804,9 +527,13 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
     Optional<TopmostItem> topmost_hit_item;
     find_topmost_items_for_caret(point, document, device_pixels_per_css_pixel, chrome_metrics, topmost_item, topmost_hit_item);
 
+    Optional<Item> topmost_hit_facts;
+    if (topmost_hit_item.has_value())
+        topmost_hit_facts = item(topmost_hit_item->index);
+
     // A constrained search only accepts direct hits inside the constraint scope.
     if (constraint_scope && topmost_item.has_value()) {
-        auto const* item_node = item_dom_node(m_items[topmost_item->index]);
+        auto const* item_node = item_dom_node(topmost_item->index);
         if (!item_node || !constraint_scope->is_inclusive_ancestor_of(*item_node))
             topmost_item = {};
     }
@@ -815,13 +542,13 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
     auto topmost_caret_item_matches_hit_item = [&] {
         return topmost_hit_item.has_value()
             && topmost_item->index == topmost_hit_item->index
-            && item_is_direct_caret_target(m_items[topmost_item->index]);
+            && item_is_direct_caret_target(topmost_item->index);
     };
     if (topmost_item.has_value() && (constraint_scope || !topmost_hit_item.has_value() || topmost_caret_item_matches_hit_item())) {
-        auto const& item = m_items[topmost_item->index];
-        if (auto caret_position = caret_position_for_item(item, topmost_item->local_point); caret_position.has_value()) {
+        auto item_facts = item(topmost_item->index);
+        if (auto caret_position = caret_position_for_item(item_facts, topmost_item->local_point); caret_position.has_value()) {
             if (caret_position->debug_rect.has_value())
-                caret_position->debug_rect = viewport_rect_for_context(item.context.spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
+                caret_position->debug_rect = viewport_rect_for_context(item_facts.context().spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
             return caret_position;
         }
     }
@@ -832,9 +559,8 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
     if (constraint_scope) {
         line_scope_dom_node = constraint_scope.ptr();
     } else if (topmost_hit_item.has_value()) {
-        auto const& topmost_hit_item_value = m_items[topmost_hit_item->index];
-        if (!item_can_produce_caret_position(topmost_hit_item_value) || !item_is_direct_caret_target(topmost_hit_item_value))
-            line_scope_dom_node = event_dispatch_dom_node_for_item(topmost_hit_item_value);
+        if (!topmost_hit_facts->can_produce_caret_position() || !item_is_direct_caret_target(topmost_hit_item->index))
+            line_scope_dom_node = event_dispatch_dom_node_for_item(topmost_hit_item->index);
     }
 
     // A constrained search must find a line even when the point is outside the scope's clipped area (e.g. dragging
@@ -854,10 +580,9 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
 
     if (!closest_line.index.has_value()) {
         if (!constraint_scope && topmost_hit_item.has_value()) {
-            auto const& item = m_items[topmost_hit_item->index];
-            auto caret_position = caret_position_for_hit_container(item);
+            auto caret_position = caret_position_for_hit_container(*topmost_hit_facts);
             if (caret_position.has_value() && caret_position->debug_rect.has_value())
-                caret_position->debug_rect = viewport_rect_for_context(item.context.spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
+                caret_position->debug_rect = viewport_rect_for_context(topmost_hit_facts->context().spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
             return caret_position;
         }
         return {};
@@ -866,15 +591,14 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
     if (!caret_position.has_value())
         return {};
     if (caret_position->debug_rect.has_value())
-        caret_position->debug_rect = viewport_rect_for_context(m_caret_lines[*closest_line.index].context.spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
+        caret_position->debug_rect = viewport_rect_for_context(caret_line(*closest_line.index).context.spatial, *caret_position->debug_rect, document, device_pixels_per_css_pixel);
 
     if (!constraint_scope && topmost_hit_item.has_value()) {
-        auto const& topmost_hit_item_value = m_items[topmost_hit_item->index];
-        if (auto const* topmost_hit_dom_node = event_dispatch_dom_node_for_item(topmost_hit_item_value); topmost_hit_dom_node && !topmost_hit_dom_node->is_inclusive_ancestor_of(*caret_position->boundary.node)) {
-            if (item_can_produce_caret_position(topmost_hit_item_value) && item_is_direct_caret_target(topmost_hit_item_value)) {
-                auto caret_position_for_topmost_hit_item = caret_position_for_item(topmost_hit_item_value, topmost_hit_item->local_point);
+        if (auto const* topmost_hit_dom_node = event_dispatch_dom_node_for_item(topmost_hit_item->index); topmost_hit_dom_node && !topmost_hit_dom_node->is_inclusive_ancestor_of(*caret_position->boundary.node)) {
+            if (topmost_hit_facts->can_produce_caret_position() && item_is_direct_caret_target(topmost_hit_item->index)) {
+                auto caret_position_for_topmost_hit_item = caret_position_for_item(*topmost_hit_facts, topmost_hit_item->local_point);
                 if (caret_position_for_topmost_hit_item.has_value() && caret_position_for_topmost_hit_item->debug_rect.has_value())
-                    caret_position_for_topmost_hit_item->debug_rect = viewport_rect_for_context(topmost_hit_item_value.context.spatial, *caret_position_for_topmost_hit_item->debug_rect, document, device_pixels_per_css_pixel);
+                    caret_position_for_topmost_hit_item->debug_rect = viewport_rect_for_context(topmost_hit_facts->context().spatial, *caret_position_for_topmost_hit_item->debug_rect, document, device_pixels_per_css_pixel);
                 return caret_position_for_topmost_hit_item;
             }
             if (item_is_inline_adjacent_to_line(topmost_hit_item->index, *closest_line.index))
@@ -894,7 +618,7 @@ Optional<HitTestResult> HitTestDisplayList::hit_test(CSSPixelPoint point, DOM::D
     auto topmost_item = find_topmost_item(point, document, device_pixels_per_css_pixel, chrome_metrics);
     if (!topmost_item.has_value())
         return {};
-    return hit_test_result_for_item(m_items[topmost_item->index], topmost_item->local_point);
+    return hit_test_result_for_item(item(topmost_item->index), topmost_item->local_point);
 }
 
 TraversalDecision HitTestDisplayList::hit_test_all(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics, Function<TraversalDecision(HitTestResult)> const& callback) const
@@ -903,11 +627,11 @@ TraversalDecision HitTestDisplayList::hit_test_all(CSSPixelPoint point, DOM::Doc
         return TraversalDecision::Continue;
 
     for (auto item_index : hit_item_indices_topmost_first(point, document, device_pixels_per_css_pixel, chrome_metrics)) {
-        auto const& item = m_items[item_index];
-        auto local_point = local_point_for_visual_context(item.context, point, document, device_pixels_per_css_pixel);
+        auto item_facts = item(item_index);
+        auto local_point = local_point_for_visual_context(item_facts.context(), point, document, device_pixels_per_css_pixel);
         if (!local_point.has_value())
             continue;
-        if (callback(hit_test_result_for_item(item, *local_point)) == TraversalDecision::Break)
+        if (callback(hit_test_result_for_item(item_facts, *local_point)) == TraversalDecision::Break)
             return TraversalDecision::Break;
     }
 

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -44,7 +44,6 @@ class WEB_API HitTestDisplayList : public RefCounted<HitTestDisplayList> {
 public:
     static NonnullRefPtr<HitTestDisplayList> create_from_rust_recording(u64 visual_context_tree_version, Layout::NodeArena&, ChromeWidgetRegistry&);
 
-    size_t item_count() const { return m_items.size(); }
     void visit_edges(GC::Cell::Visitor&);
 
     u64 visual_context_tree_version() const { return m_visual_context_tree_version; }
@@ -65,35 +64,17 @@ public:
 private:
     HitTestDisplayList(u64 visual_context_tree_version, Layout::NodeArena&, ChromeWidgetRegistry&, u64 rust_generation);
 
-    enum class ItemKind : u8 {
-        Box,
-        SvgPath,
-        TextFragment,
-        // A line box with no fragments (e.g. a blank line in a textarea), recorded as a caret target only.
-        EmptyLine,
-        EmptyEditable,
-        ChromeWidget,
-    };
-
     struct Item {
-        ItemKind kind;
-        Layout::RustFFI::NodeSlotId paintable;
-        Layout::RustFFI::NodeSlotId hit_node;
-        ChromeWidgetKind chrome_widget_kind { ChromeWidgetKind::None };
-        Optional<u32> text_fragment_index;
-        GC::Ptr<DOM::Node const> caret_node { nullptr };
-        // For EmptyLine items: the caret offset in caret_node.
-        size_t caret_offset { 0 };
-        CSSPixelRect rect;
-        CSSPixelRect caret_rect;
-        ContextRef context;
-    };
+        size_t item_index { 0 };
+        Layout::RustFFI::FfiHitTestItemExport facts;
 
-    struct CaretLine {
-        CSSPixelRect rect;
-        ContextRef context;
-        size_t first_caret_item_index { 0 };
-        size_t last_caret_item_index { 0 };
+        size_t index() const { return item_index; }
+        bool can_produce_caret_position() const { return facts.can_produce_caret_position; }
+        Layout::RustFFI::NodeSlotId paintable() const { return facts.paintable; }
+        Layout::RustFFI::NodeSlotId hit_node() const { return facts.hit_node; }
+        ChromeWidgetKind chrome_widget_kind() const { return static_cast<ChromeWidgetKind>(facts.chrome_widget_kind); }
+        CSSPixelRect caret_rect() const { return facts.caret_rect; }
+        ContextRef context() const { return facts.context; }
     };
 
     enum class CaretPositionType : u8 {
@@ -121,8 +102,8 @@ private:
     struct QueryContext;
     static Optional<TopmostItem> topmost_item_from(Layout::RustFFI::FfiTopmostItem const&);
     SortingContexts const& ensure_sorting_contexts(DOM::Document const&) const;
-    void ensure_caret_lines() const;
-    [[nodiscard]] Item const& caret_item(size_t caret_item_index) const { return m_items[m_caret_item_indices[caret_item_index]]; }
+    [[nodiscard]] Item item(size_t index) const;
+    [[nodiscard]] Layout::RustFFI::FfiCaretLineExport caret_line(size_t line_index) const { return Layout::RustFFI::layout_arena_hit_test_caret_line(m_arena->handle(), line_index); }
 
     [[nodiscard]] Optional<TopmostItem> find_topmost_item(CSSPixelPoint, DOM::Document const&, double device_pixels_per_css_pixel, ChromeMetrics const&) const;
     void find_topmost_items_for_caret(CSSPixelPoint, DOM::Document const&, double device_pixels_per_css_pixel, ChromeMetrics const&, Optional<TopmostItem>& caret_item, Optional<TopmostItem>& hit_item) const;
@@ -134,28 +115,21 @@ private:
 
     [[nodiscard]] Optional<CSSPixelPoint> local_point_for_visual_context(ContextRef, CSSPixelPoint, DOM::Document const&, double device_pixels_per_css_pixel) const;
     [[nodiscard]] CSSPixelRect viewport_rect_for_context(SpatialNodeIndex, CSSPixelRect const&, DOM::Document const&, double device_pixels_per_css_pixel) const;
-    [[nodiscard]] Layout::Node const* layout_node_for_item(Item const&) const;
-    [[nodiscard]] RefPtr<ChromeWidget> chrome_widget_for_item(Item const&) const;
-    [[nodiscard]] DOM::Node const* item_dom_node(Item const&) const;
-    [[nodiscard]] DOM::Node const* event_dispatch_dom_node_for_item(Item const&) const;
-    [[nodiscard]] bool item_can_produce_caret_position(Item const&) const;
-    [[nodiscard]] bool item_is_direct_caret_target(Item const&) const;
-    [[nodiscard]] HitTestResult hit_test_result_for_item(Item const&, CSSPixelPoint local_point) const;
-    [[nodiscard]] Optional<CaretPosition> caret_position_for_item(Item const&, CSSPixelPoint local_point, CaretPositionType = CaretPositionType::Closest) const;
-    [[nodiscard]] Optional<CaretPosition> caret_position_for_hit_container(Item const&) const;
+    [[nodiscard]] Layout::Node const* layout_node_for_item(Item) const;
+    [[nodiscard]] RefPtr<ChromeWidget> chrome_widget_for_item(Item) const;
+    [[nodiscard]] DOM::Node const* item_dom_node(size_t item_index) const;
+    [[nodiscard]] DOM::Node const* event_dispatch_dom_node_for_item(size_t item_index) const;
+    [[nodiscard]] bool item_is_direct_caret_target(size_t item_index) const;
+    [[nodiscard]] HitTestResult hit_test_result_for_item(Item, CSSPixelPoint local_point) const;
+    [[nodiscard]] Optional<CaretPosition> caret_position_for_item(Item, CSSPixelPoint local_point, CaretPositionType = CaretPositionType::Closest) const;
+    [[nodiscard]] Optional<CaretPosition> caret_position_for_hit_container(Item) const;
     [[nodiscard]] Optional<CaretPosition> caret_position_for_line(size_t line_index, CSSPixelPoint local_point, CaretPositionMode) const;
-    [[nodiscard]] bool item_contains_caret_position(Item const&, DOM::Node const&, size_t offset, TextAffinity) const;
-    [[nodiscard]] Optional<size_t> caret_line_index_for_position(DOM::Node const&, size_t offset, TextAffinity) const;
-    [[nodiscard]] bool line_contains_descendant_of(CaretLine const&, DOM::Node const&) const;
 
     u64 m_visual_context_tree_version { 0 };
     NonnullRefPtr<Layout::NodeArena> m_arena;
     NonnullRefPtr<ChromeWidgetRegistry> m_chrome_widget_registry;
     u64 m_rust_generation { 0 };
-    Vector<Item> m_items;
-    mutable bool m_caret_lines_materialized { false };
-    mutable Vector<size_t> m_caret_item_indices;
-    mutable Vector<CaretLine> m_caret_lines;
+    Vector<GC::Ptr<DOM::Node>> m_caret_node_roots;
     mutable Optional<SortingContexts> m_sorting_contexts;
 };
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -321,17 +321,7 @@ pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
 ) -> *mut c_void {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let mut current = paintable_rows.paintable_row_is_populated(slot).then_some(slot);
-        while let Some(paintable) = current {
-            let layout_node = paintable;
-            let flags = arena.node_flags_if_live(layout_node);
-            if flags & crate::layout::node_data::NodeFlag::Anonymous as u32 == 0 {
-                return arena.shell_if_live(layout_node);
-            }
-            current = crate::painting::paint_order::paint_parent(&paintable_rows, paintable);
-        }
-        std::ptr::null_mut()
+        crate::painting::hit_test::resolve::event_dispatch_shell_for_paintable(arena, slot)
     })
 }
 
@@ -1924,150 +1914,6 @@ pub unsafe extern "C" fn layout_arena_visual_line_offset_closest_to_inline_coord
     })
 }
 
-#[repr(C)]
-pub struct FfiFragmentTextFacts {
-    pub layout_node: *mut c_void,
-    pub dom_start_offset_in_node: usize,
-    pub dom_end_offset_in_node: usize,
-    pub dom_end_offset_with_trailing_whitespace: usize,
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_fragment_text_facts(
-    arena: *mut c_void,
-    block: NodeSlotId,
-    fragment_index: u32,
-) -> FfiFragmentTextFacts {
-    abort_on_panic(|| {
-        let mut facts = FfiFragmentTextFacts {
-            layout_node: std::ptr::null_mut(),
-            dom_start_offset_in_node: 0,
-            dom_end_offset_in_node: 0,
-            dom_end_offset_with_trailing_whitespace: 0,
-        };
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
-            return facts;
-        }
-        let side_data = arena.paintable_side_data(block);
-        let Some(fragment) = side_data.fragments.get(fragment_index as usize) else {
-            return facts;
-        };
-        facts.layout_node = arena.shell_if_live(fragment.layout_node);
-        facts.dom_start_offset_in_node = fragment.dom_start_offset_in_node;
-        facts.dom_end_offset_in_node = fragment.dom_end_offset_in_node;
-        facts.dom_end_offset_with_trailing_whitespace = fragment.dom_end_offset_with_trailing_whitespace;
-        facts
-    })
-}
-
-#[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum FfiCaretMatch {
-    None,
-    Direct,
-    SoftWrapFallback,
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_fragment_caret_match(
-    arena: *mut c_void,
-    block: NodeSlotId,
-    fragment_index: u32,
-    offset: usize,
-    affinity_is_downstream: bool,
-) -> FfiCaretMatch {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(block) {
-            return FfiCaretMatch::None;
-        }
-        let side_data = arena.paintable_side_data(block);
-        let Some(fragment) = side_data.fragments.get(fragment_index as usize) else {
-            return FfiCaretMatch::None;
-        };
-        match crate::painting::text_fragment::caret_match(fragment, offset, affinity_is_downstream) {
-            crate::painting::text_fragment::CaretMatch::None => FfiCaretMatch::None,
-            crate::painting::text_fragment::CaretMatch::Direct => FfiCaretMatch::Direct,
-            crate::painting::text_fragment::CaretMatch::SoftWrapFallback => FfiCaretMatch::SoftWrapFallback,
-        }
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_fragment_index_in_node_for_point(
-    arena: *mut c_void,
-    block: NodeSlotId,
-    fragment_index: u32,
-    x: CssPixels,
-    y: CssPixels,
-) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(block) {
-            return 0;
-        }
-        let side_data = arena.paintable_side_data(block);
-        let Some(fragment) = side_data.fragments.get(fragment_index as usize) else {
-            return 0;
-        };
-        crate::painting::text_fragment::index_in_node_for_point(
-            &paintable_rows,
-            fragment,
-            crate::css::css_pixels::CssPixelPoint { x, y },
-        )
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paintable_fragment_caret_range_rect(
-    arena: *mut c_void,
-    block: NodeSlotId,
-    fragment_index: u32,
-    offset: usize,
-) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(block) {
-            return FfiCssPixelRect::default();
-        }
-        let side_data = arena.paintable_side_data(block);
-        let Some(fragment) = side_data.fragments.get(fragment_index as usize) else {
-            return FfiCssPixelRect::default();
-        };
-        let offsets = crate::painting::text_fragment::compute_selection_offsets(
-            &paintable_rows,
-            fragment,
-            SELECTION_STATE_START_AND_END,
-            offset,
-            offset,
-        );
-        match offsets {
-            Some(offsets) => {
-                crate::painting::text_fragment::rect_for_selection_offsets(&paintable_rows, fragment, offsets, || {
-                    crate::painting::text_fragment::first_available_font(&paintable_rows, fragment)
-                })
-                .into()
-            }
-            None => FfiCssPixelRect::default(),
-        }
-    })
-}
-
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document
@@ -2423,39 +2269,42 @@ pub unsafe extern "C" fn layout_arena_scroll_state_snapshot(
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread; the
+/// sink pointer must stay valid for this synchronous call.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_hit_test_item_count(arena: *mut c_void) -> usize {
+pub unsafe extern "C" fn layout_arena_hit_test_visit_caret_roots_and_chrome_widgets(
+    arena: *mut c_void,
+    sink: *mut c_void,
+    visit: unsafe extern "C" fn(*mut c_void, NodeSlotId, u8, *mut c_void),
+) {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state.hit_test_list.as_ref().map_or(0, |list| list.items.len())
-    })
+        with_hit_test_list(arena, (), |list, arena| {
+            for item in list.items.iter() {
+                let caret_node_shell = arena.shell_if_live(item.caret_node);
+                if item.chrome_widget_kind == crate::painting::hit_test::CHROME_WIDGET_NONE
+                    && caret_node_shell.is_null()
+                {
+                    continue;
+                }
+                // SAFETY: The C++ host consumes the visit synchronously.
+                unsafe { visit(sink, item.paintable, item.chrome_widget_kind, caret_node_shell) };
+            }
+        });
+    });
 }
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`; `output` must point to writable
-/// storage for exactly `output_length` items, matching the current hit-test item count.
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `index` in range.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_export_hit_test_items(
+pub unsafe extern "C" fn layout_arena_hit_test_item_facts(
     arena: *mut c_void,
-    output: *mut crate::painting::host::FfiHitTestItemExport,
-    output_length: usize,
-) {
+    index: usize,
+) -> crate::painting::host::FfiHitTestItemExport {
     abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        let items = &paint_state.hit_test_list.as_ref().expect("no hit-test list").items;
-        assert_eq!(items.len(), output_length);
-        if items.is_empty() {
-            return;
-        }
-        assert!(!output.is_null());
-        // SAFETY: The caller provides writable storage for exactly `output_length` exports.
-        let output = unsafe { std::slice::from_raw_parts_mut(output, output_length) };
-        for (output, item) in output.iter_mut().zip(items.iter()) {
-            let rect = |rect: crate::css::css_pixels::CssPixelRect| used_values::FfiCssPixelRect::from(rect);
+        with_hit_test_list(arena, None, |list, arena| {
+            let item = &list.items[index];
             assert!(
                 arena.paintable_row_is_populated(item.paintable),
                 "exporting a hit-test item for a non-live paintable"
@@ -2464,20 +2313,116 @@ pub unsafe extern "C" fn layout_arena_export_hit_test_items(
                 arena.paintable_row_is_populated(item.hit_node),
                 "exporting a hit-test item that names a non-live paintable"
             );
-            *output = crate::painting::host::FfiHitTestItemExport {
-                kind: item.kind as u8,
+            Some(crate::painting::host::FfiHitTestItemExport {
+                can_produce_caret_position: item.can_produce_caret_position,
                 paintable: item.paintable,
                 hit_node: item.hit_node,
                 chrome_widget_kind: item.chrome_widget_kind,
-                text_fragment_index: item.text_fragment_index.into(),
                 caret_node_shell: arena.shell_if_live(item.caret_node),
-                caret_offset: item.caret_offset,
-                rect: rect(item.rect),
-                caret_rect: rect(item.caret_rect),
+                caret_rect: item.caret_rect.into(),
                 context: item.context,
-            };
-        }
-    });
+            })
+        })
+        .expect("no hit-test list")
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `item_index` must be in range for the current hit-test list.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_hit_test_item_target_shell(arena: *mut c_void, item_index: usize) -> *mut c_void {
+    abort_on_panic(|| {
+        with_hit_test_list(arena, std::ptr::null_mut(), |list, arena| {
+            list.item_target_shell(arena, item_index)
+        })
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `item_index` must be in range for the current hit-test list and `out_allow_pseudo_fallback`
+/// must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_hit_test_item_dispatch_shell(
+    arena: *mut c_void,
+    item_index: usize,
+    out_allow_pseudo_fallback: *mut bool,
+) -> *mut c_void {
+    abort_on_panic(|| {
+        with_hit_test_list(arena, std::ptr::null_mut(), |list, arena| {
+            let (shell, allow_pseudo_fallback) = list.item_dispatch_shell(arena, item_index);
+            // SAFETY: The caller provides writable storage for the synchronous result.
+            unsafe { *out_allow_pseudo_fallback = allow_pseudo_fallback };
+            shell
+        })
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `item_index` must be in range for the current hit-test list.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_hit_test_resolve_hit(
+    arena: *mut c_void,
+    item_index: usize,
+    local_point: FfiCssPixelPoint,
+) -> crate::painting::host::FfiResolvedHit {
+    abort_on_panic(|| {
+        with_hit_test_list(arena, Default::default(), |list, arena| {
+            list.resolve_hit(arena, item_index, local_point.into())
+        })
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `item_index` must be in range for the current hit-test list.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_hit_test_resolve_caret(
+    arena: *mut c_void,
+    item_index: usize,
+    local_point: FfiCssPixelPoint,
+    position_type: u8,
+) -> crate::painting::host::FfiResolvedCaret {
+    abort_on_panic(|| {
+        with_hit_test_list(arena, Default::default(), |list, arena| {
+            list.resolve_caret(
+                arena,
+                item_index,
+                local_point.into(),
+                crate::painting::hit_test::caret::CaretPositionType::from_u8(position_type),
+            )
+        })
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// the callback context and function pointers must remain valid for this synchronous call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_hit_test_caret_line_for_position(
+    arena: *mut c_void,
+    callbacks: crate::painting::host::FfiCaretPositionQueryCallbacks,
+    offset: usize,
+    affinity_is_downstream: bool,
+) -> crate::painting::host::FfiCaretLineForPosition {
+    abort_on_panic(|| {
+        with_hit_test_list(arena, Default::default(), |list, arena| {
+            match list.caret_line_for_position(arena, &callbacks, offset, affinity_is_downstream) {
+                Some(line_index) => crate::painting::host::FfiCaretLineForPosition {
+                    has_line: true,
+                    line_index,
+                },
+                None => Default::default(),
+            }
+        })
+    })
 }
 
 /// # Safety
@@ -2557,14 +2502,6 @@ pub unsafe extern "C" fn layout_arena_recorded_display_list(arena: *mut c_void) 
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_hit_test_caret_line_count(arena: *mut c_void) -> usize {
-    abort_on_panic(|| with_hit_test_list(arena, 0, |list, _| list.caret_lines.len()))
-}
-
-/// # Safety
-///
 /// `arena` must be a live handle from `layout_arena_create`; `line_index` in range.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_hit_test_caret_line(
@@ -2582,22 +2519,6 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_line(
             }
         })
     })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_hit_test_caret_item_count(arena: *mut c_void) -> usize {
-    abort_on_panic(|| with_hit_test_list(arena, 0, |list, _| list.caret_item_indices.len()))
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`; `caret_item_index` in range.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_hit_test_caret_item_index(arena: *mut c_void, caret_item_index: usize) -> usize {
-    abort_on_panic(|| with_hit_test_list(arena, usize::MAX, |list, _| list.caret_item_indices[caret_item_index]))
 }
 
 fn list_generation_of(paint_state: &crate::painting::paint_state::PaintState) -> u64 {
@@ -2781,8 +2702,9 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_closest_line(
     respect_clip: bool,
 ) -> crate::painting::host::FfiClosestLine {
     abort_on_panic(|| {
-        with_hit_test_list(arena, Default::default(), |list, _| {
+        with_hit_test_list(arena, Default::default(), |list, arena| {
             let closest = list.find_closest_line(
+                arena,
                 &callbacks,
                 point.into(),
                 crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
@@ -2822,8 +2744,9 @@ pub unsafe extern "C" fn layout_arena_hit_test_adjacent_line(
         } else {
             crate::painting::hit_test::caret::CaretLineDirection::Previous
         };
-        with_hit_test_list(arena, Default::default(), |list, _| {
+        with_hit_test_list(arena, Default::default(), |list, arena| {
             match list.adjacent_line(
+                arena,
                 &callbacks,
                 current_line_index,
                 direction,

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/caret.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/caret.rs
@@ -5,7 +5,9 @@
  */
 
 use super::*;
-use crate::painting::host::FfiHitTestQueryCallbacks;
+use crate::layout::LayoutNodeArena;
+use crate::painting::host::{FfiCaretPositionQueryCallbacks, FfiHitTestQueryCallbacks};
+use crate::painting::text_fragment::CaretMatch;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -137,6 +139,110 @@ impl Default for ClosestLine {
 }
 
 impl HitTestList {
+    pub(crate) fn caret_line_for_position(
+        &self,
+        arena: &LayoutNodeArena,
+        callbacks: &FfiCaretPositionQueryCallbacks,
+        offset: usize,
+        affinity_is_downstream: bool,
+    ) -> Option<usize> {
+        // At a soft wrap, prefer the fragment whose line directly owns the position. Only use the preceding
+        // fragment's fallback match when no direct match exists.
+        for allow_soft_wrap_fallback in [false, true] {
+            for (line_index, line) in self.caret_lines.iter().enumerate() {
+                for caret_item_index in line.first_caret_item_index..=line.last_caret_item_index {
+                    let item_index = self.caret_item_indices[caret_item_index];
+                    let position_match =
+                        self.item_position_match(arena, callbacks, item_index, offset, affinity_is_downstream);
+                    match position_match {
+                        CaretMatch::None => continue,
+                        CaretMatch::SoftWrapFallback if !allow_soft_wrap_fallback => continue,
+                        CaretMatch::Direct | CaretMatch::SoftWrapFallback => return Some(line_index),
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn item_position_match(
+        &self,
+        arena: &LayoutNodeArena,
+        callbacks: &FfiCaretPositionQueryCallbacks,
+        item_index: usize,
+        offset: usize,
+        affinity_is_downstream: bool,
+    ) -> CaretMatch {
+        let item = &self.items[item_index];
+        match item.kind {
+            HitTestItemKind::TextFragment => resolve::with_item_fragment(arena, item, |fragment| {
+                let shell = arena.shell_if_live(fragment.layout_node);
+                if shell.is_null() {
+                    return CaretMatch::None;
+                }
+                if callbacks.shell_is_query_node(shell) {
+                    return crate::painting::text_fragment::caret_match(fragment, offset, affinity_is_downstream);
+                }
+                if fragment.dom_start_offset_in_node == 0 && callbacks.query_boundary_descends_to_shell(shell) {
+                    return CaretMatch::Direct;
+                }
+                if callbacks.query_boundary_follows_shell_end(shell, fragment.dom_end_offset_with_trailing_whitespace) {
+                    return CaretMatch::Direct;
+                }
+                CaretMatch::None
+            })
+            .unwrap_or(CaretMatch::None),
+            HitTestItemKind::EmptyLine => {
+                let shell = arena.shell_if_live(item.caret_node);
+                if !shell.is_null() && item.caret_offset == offset && callbacks.shell_is_query_node(shell) {
+                    CaretMatch::Direct
+                } else {
+                    CaretMatch::None
+                }
+            }
+            HitTestItemKind::EmptyEditable => {
+                let shell = arena.shell_if_live(item.paintable);
+                if !shell.is_null() && offset == 0 && callbacks.shell_is_query_node(shell) {
+                    CaretMatch::Direct
+                } else {
+                    CaretMatch::None
+                }
+            }
+            HitTestItemKind::Box => {
+                let shell = arena.shell_if_live(item.paintable);
+                if !shell.is_null() && callbacks.query_is_adjacent_to_shell(shell) {
+                    CaretMatch::Direct
+                } else {
+                    CaretMatch::None
+                }
+            }
+            HitTestItemKind::SvgPath | HitTestItemKind::ChromeWidget => CaretMatch::None,
+        }
+    }
+
+    pub fn box_point_is_before(&self, item_index: usize, local_point: CssPixelPoint) -> bool {
+        let item = &self.items[item_index];
+        debug_assert_eq!(item.kind, HitTestItemKind::Box);
+
+        let block_coordinate = block_axis_coordinate(local_point, item.writing_mode);
+        if block_coordinate < block_axis_start(item.rect, item.writing_mode) {
+            return !item.block_axis_is_reverse;
+        }
+        if block_coordinate >= block_axis_end(item.rect, item.writing_mode) {
+            return item.block_axis_is_reverse;
+        }
+
+        let inline_start = inline_axis_start(item.rect, item.writing_mode);
+        let inline_end = inline_axis_end(item.rect, item.writing_mode);
+        let inline_middle = inline_start + (inline_end - inline_start).scaled(0.5);
+        let inline_coordinate = inline_axis_coordinate(local_point, item.writing_mode);
+        if item.inline_axis_is_reverse {
+            inline_coordinate > inline_middle
+        } else {
+            inline_coordinate <= inline_middle
+        }
+    }
+
     fn first_item_of_line(&self, line: &CaretLine) -> &HitTestItem {
         &self.items[self.caret_item_indices[line.first_caret_item_index]]
     }
@@ -320,8 +426,20 @@ impl HitTestList {
             || inline_axis_end(line.rect, writing_mode) <= inline_axis_start(item.rect, writing_mode)
     }
 
-    pub fn find_closest_line(
+    fn line_in_scope(&self, arena: &LayoutNodeArena, callbacks: &FfiHitTestQueryCallbacks, line_index: usize) -> bool {
+        let line = &self.caret_lines[line_index];
+        for caret_item_index in line.first_caret_item_index..=line.last_caret_item_index {
+            let shell = self.item_target_shell(arena, self.caret_item_indices[caret_item_index]);
+            if !shell.is_null() && callbacks.shell_in_scope(shell) {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn find_closest_line(
         &self,
+        arena: &LayoutNodeArena,
         callbacks: &FfiHitTestQueryCallbacks,
         point: CssPixelPoint,
         mode: CaretPositionMode,
@@ -350,7 +468,7 @@ impl HitTestList {
         };
 
         for line_index in 0..self.caret_lines.len() {
-            if scoped && !callbacks.line_in_scope(line_index) {
+            if scoped && !self.line_in_scope(arena, callbacks, line_index) {
                 continue;
             }
             let line = self.caret_lines[line_index].clone();
@@ -472,8 +590,9 @@ impl HitTestList {
         closest_line
     }
 
-    pub fn adjacent_line(
+    pub(crate) fn adjacent_line(
         &self,
+        arena: &LayoutNodeArena,
         callbacks: &FfiHitTestQueryCallbacks,
         current_line_index: usize,
         direction: CaretLineDirection,
@@ -502,7 +621,7 @@ impl HitTestList {
             let line = &self.caret_lines[line_index];
             if line_index == current_line_index
                 || line.context != current_line.context
-                || !callbacks.line_in_scope(line_index)
+                || !self.line_in_scope(arena, callbacks, line_index)
             {
                 continue;
             }

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod caret;
 pub mod query;
+pub mod resolve;
 
 use crate::css::css_pixels::CssPixels;
 use crate::css::css_pixels::{CssPixelPoint, CssPixelRect};

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/resolve.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/resolve.rs
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::*;
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeFlag;
+use crate::painting::host::FfiCaretBoundaryKind;
+use crate::painting::host::FfiResolvedCaret;
+use crate::painting::paintable_data::SELECTION_STATE_START_AND_END;
+use std::ffi::c_void;
+
+impl HitTestList {
+    pub(crate) fn item_target_shell(&self, arena: &LayoutNodeArena, item_index: usize) -> *mut c_void {
+        let item = &self.items[item_index];
+        let slot = match item.kind {
+            HitTestItemKind::TextFragment => fragment_layout_node_slot(arena, item),
+            HitTestItemKind::EmptyLine => Some(item.caret_node),
+            _ => Some(item.paintable),
+        };
+        slot.map_or(std::ptr::null_mut(), |slot| arena.shell_if_live(slot))
+    }
+
+    pub(crate) fn item_dispatch_shell(&self, arena: &LayoutNodeArena, item_index: usize) -> (*mut c_void, bool) {
+        let item = &self.items[item_index];
+        match item.kind {
+            HitTestItemKind::TextFragment => (
+                fragment_layout_node_slot(arena, item).map_or(std::ptr::null_mut(), |slot| arena.shell_if_live(slot)),
+                true,
+            ),
+            HitTestItemKind::EmptyLine => (arena.shell_if_live(item.caret_node), false),
+            _ => (event_dispatch_shell_for_paintable(arena, item.paintable), false),
+        }
+    }
+
+    pub(crate) fn resolve_hit(
+        &self,
+        arena: &LayoutNodeArena,
+        item_index: usize,
+        local_point: CssPixelPoint,
+    ) -> crate::painting::host::FfiResolvedHit {
+        let item = &self.items[item_index];
+        let (dispatch_shell, allow_pseudo_fallback) = self.item_dispatch_shell(arena, item_index);
+        let mut result = crate::painting::host::FfiResolvedHit {
+            dispatch_shell,
+            allow_pseudo_fallback,
+            ..Default::default()
+        };
+        match item.kind {
+            HitTestItemKind::TextFragment => {
+                result.fallback_dispatch_shell = event_dispatch_shell_for_paintable(arena, item.paintable);
+                result.has_index_in_node = true;
+                result.index_in_node = fragment_index_in_node_for_point(arena, item, local_point);
+                result.is_text_fragment = true;
+            }
+            HitTestItemKind::EmptyEditable => {
+                result.has_index_in_node = true;
+            }
+            _ => {}
+        }
+        result
+    }
+
+    pub(crate) fn resolve_caret(
+        &self,
+        arena: &LayoutNodeArena,
+        item_index: usize,
+        local_point: CssPixelPoint,
+        position_type: crate::painting::hit_test::caret::CaretPositionType,
+    ) -> FfiResolvedCaret {
+        let item = &self.items[item_index];
+        match item.kind {
+            HitTestItemKind::TextFragment => with_item_fragment(arena, item, |fragment| {
+                let offset = match position_type {
+                    crate::painting::hit_test::caret::CaretPositionType::Before => fragment.dom_start_offset_in_node,
+                    crate::painting::hit_test::caret::CaretPositionType::After => {
+                        fragment.dom_end_offset_with_trailing_whitespace
+                    }
+                    crate::painting::hit_test::caret::CaretPositionType::Closest => {
+                        let paintable_rows = arena.paintable_rows();
+                        crate::painting::text_fragment::index_in_node_for_point(&paintable_rows, fragment, local_point)
+                    }
+                };
+                let node_shell = arena.shell_if_live(fragment.layout_node);
+                let affinity_is_upstream = offset >= fragment.dom_end_offset_in_node
+                    && offset == fragment.dom_end_offset_with_trailing_whitespace;
+                let debug_rect = fragment_caret_range_rect(arena, fragment, offset);
+                FfiResolvedCaret {
+                    has_position: true,
+                    node_shell,
+                    boundary: FfiCaretBoundaryKind::Offset,
+                    offset,
+                    affinity_is_upstream,
+                    has_debug_rect: true,
+                    debug_rect: debug_rect.into(),
+                }
+            })
+            .unwrap_or_default(),
+            HitTestItemKind::EmptyLine => FfiResolvedCaret {
+                has_position: true,
+                node_shell: arena.shell_if_live(item.caret_node),
+                boundary: FfiCaretBoundaryKind::Offset,
+                offset: item.caret_offset,
+                has_debug_rect: true,
+                debug_rect: item.caret_rect.into(),
+                ..Default::default()
+            },
+            HitTestItemKind::EmptyEditable => FfiResolvedCaret {
+                has_position: true,
+                node_shell: arena.shell_if_live(item.paintable),
+                boundary: FfiCaretBoundaryKind::Offset,
+                has_debug_rect: true,
+                debug_rect: item.caret_rect.into(),
+                ..Default::default()
+            },
+            HitTestItemKind::Box => {
+                let is_before = match position_type {
+                    crate::painting::hit_test::caret::CaretPositionType::Before => true,
+                    crate::painting::hit_test::caret::CaretPositionType::After => false,
+                    crate::painting::hit_test::caret::CaretPositionType::Closest => {
+                        self.box_point_is_before(item_index, local_point)
+                    }
+                };
+                FfiResolvedCaret {
+                    has_position: true,
+                    node_shell: arena.shell_if_live(item.paintable),
+                    boundary: if is_before {
+                        FfiCaretBoundaryKind::BeforeNode
+                    } else {
+                        FfiCaretBoundaryKind::AfterNode
+                    },
+                    has_debug_rect: true,
+                    debug_rect: item.caret_rect.into(),
+                    ..Default::default()
+                }
+            }
+            HitTestItemKind::SvgPath | HitTestItemKind::ChromeWidget => Default::default(),
+        }
+    }
+}
+
+pub(crate) fn with_item_fragment<R>(
+    arena: &LayoutNodeArena,
+    item: &HitTestItem,
+    f: impl FnOnce(&crate::painting::paintable_data::FragmentRecord) -> R,
+) -> Option<R> {
+    let fragment_index = item.text_fragment_index? as usize;
+    arena
+        .paintable_side_data(item.paintable)
+        .fragments
+        .get(fragment_index)
+        .map(f)
+}
+
+pub(crate) fn fragment_layout_node_slot(arena: &LayoutNodeArena, item: &HitTestItem) -> Option<NodeSlotId> {
+    with_item_fragment(arena, item, |fragment| fragment.layout_node)
+}
+
+pub(crate) fn event_dispatch_shell_for_paintable(arena: &LayoutNodeArena, slot: NodeSlotId) -> *mut c_void {
+    let paintable_rows = arena.paintable_rows();
+    let mut current = paintable_rows.paintable_row_is_populated(slot).then_some(slot);
+    while let Some(paintable) = current {
+        if arena.node_flags_if_live(paintable) & NodeFlag::Anonymous as u32 == 0 {
+            return arena.shell_if_live(paintable);
+        }
+        current = crate::painting::paint_order::paint_parent(&paintable_rows, paintable);
+    }
+    std::ptr::null_mut()
+}
+
+pub(crate) fn fragment_index_in_node_for_point(
+    arena: &LayoutNodeArena,
+    item: &HitTestItem,
+    local_point: CssPixelPoint,
+) -> usize {
+    with_item_fragment(arena, item, |fragment| {
+        let paintable_rows = arena.paintable_rows();
+        crate::painting::text_fragment::index_in_node_for_point(&paintable_rows, fragment, local_point)
+    })
+    .unwrap_or(0)
+}
+
+fn fragment_caret_range_rect(
+    arena: &LayoutNodeArena,
+    fragment: &crate::painting::paintable_data::FragmentRecord,
+    offset: usize,
+) -> CssPixelRect {
+    let paintable_rows = arena.paintable_rows();
+    let Some(offsets) = crate::painting::text_fragment::compute_selection_offsets(
+        &paintable_rows,
+        fragment,
+        SELECTION_STATE_START_AND_END,
+        offset,
+        offset,
+    ) else {
+        return CssPixelRect::default();
+    };
+    crate::painting::text_fragment::rect_for_selection_offsets(&paintable_rows, fragment, offsets, || {
+        crate::painting::text_fragment::first_available_font(&paintable_rows, fragment)
+    })
+}

--- a/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/hit_test.rs
@@ -7,7 +7,7 @@
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::used_values;
 use crate::layout::used_values::OptionalCssPixelRect;
-use crate::painting::display_list::commands::{ContextRef, OptionalU32, SpatialNodeIndex};
+use crate::painting::display_list::commands::{ContextRef, SpatialNodeIndex};
 use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -75,7 +75,7 @@ pub struct FfiHitTestQueryCallbacks {
         bool,
         *mut libgfx_rust::FloatPoint,
     ) -> bool,
-    pub line_in_scope: unsafe extern "C" fn(*mut c_void, usize) -> bool,
+    pub shell_in_scope: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub sorting_context_group: unsafe extern "C" fn(*mut c_void, SpatialNodeIndex, *mut usize) -> bool,
     pub plane_depth_key:
         unsafe extern "C" fn(*mut c_void, SpatialNodeIndex, used_values::FfiCssPixelPoint, *mut i64) -> bool,
@@ -95,9 +95,9 @@ impl FfiHitTestQueryCallbacks {
         };
         has_local.then_some((local.x, local.y))
     }
-    pub(crate) fn line_in_scope(&self, line_index: usize) -> bool {
+    pub(crate) fn shell_in_scope(&self, shell: *mut c_void) -> bool {
         // SAFETY: The C++ host answers synchronously.
-        unsafe { (self.line_in_scope)(self.context, line_index) }
+        unsafe { (self.shell_in_scope)(self.context, shell) }
     }
     // The outermost 3D rendering context sorting the plane the visual context node renders into.
     pub(crate) fn sorting_context_group(&self, spatial: SpatialNodeIndex) -> Option<usize> {
@@ -116,6 +116,38 @@ impl FfiHitTestQueryCallbacks {
         // SAFETY: The C++ host writes the depth synchronously when it returns true.
         let has_depth = unsafe { (self.plane_depth_key)(self.context, spatial, point.into(), &raw mut depth) };
         has_depth.then_some(depth)
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiCaretPositionQueryCallbacks {
+    pub context: *mut c_void,
+    pub shell_is_query_node: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
+    pub query_boundary_descends_to_shell: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
+    pub query_boundary_follows_shell_end: unsafe extern "C" fn(*mut c_void, *mut c_void, usize) -> bool,
+    pub query_is_adjacent_to_shell: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
+}
+
+impl FfiCaretPositionQueryCallbacks {
+    pub(crate) fn shell_is_query_node(&self, shell: *mut c_void) -> bool {
+        // SAFETY: The C++ host compares the shell's DOM node synchronously.
+        unsafe { (self.shell_is_query_node)(self.context, shell) }
+    }
+
+    pub(crate) fn query_boundary_descends_to_shell(&self, shell: *mut c_void) -> bool {
+        // SAFETY: The C++ host walks the query boundary synchronously.
+        unsafe { (self.query_boundary_descends_to_shell)(self.context, shell) }
+    }
+
+    pub(crate) fn query_boundary_follows_shell_end(&self, shell: *mut c_void, end_offset: usize) -> bool {
+        // SAFETY: The C++ host compares the query boundary synchronously.
+        unsafe { (self.query_boundary_follows_shell_end)(self.context, shell, end_offset) }
+    }
+
+    pub(crate) fn query_is_adjacent_to_shell(&self, shell: *mut c_void) -> bool {
+        // SAFETY: The C++ host compares the query boundary synchronously.
+        unsafe { (self.query_is_adjacent_to_shell)(self.context, shell) }
     }
 }
 
@@ -166,17 +198,53 @@ pub struct FfiAdjacentLine {
     pub point_y: i32,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiCaretLineForPosition {
+    pub has_line: bool,
+    pub line_index: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiResolvedHit {
+    pub dispatch_shell: *mut c_void,
+    pub allow_pseudo_fallback: bool,
+    pub fallback_dispatch_shell: *mut c_void,
+    pub has_index_in_node: bool,
+    pub index_in_node: usize,
+    pub is_text_fragment: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiCaretBoundaryKind {
+    #[default]
+    Offset = 0,
+    BeforeNode = 1,
+    AfterNode = 2,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiResolvedCaret {
+    pub has_position: bool,
+    pub node_shell: *mut c_void,
+    pub boundary: FfiCaretBoundaryKind,
+    pub offset: usize,
+    pub affinity_is_upstream: bool,
+    pub has_debug_rect: bool,
+    pub debug_rect: used_values::FfiCssPixelRect,
+}
+
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiHitTestItemExport {
-    pub kind: u8,
+    pub can_produce_caret_position: bool,
     pub paintable: NodeSlotId,
     pub hit_node: NodeSlotId,
     pub chrome_widget_kind: u8,
-    pub text_fragment_index: OptionalU32,
     pub caret_node_shell: *mut c_void,
-    pub caret_offset: usize,
-    pub rect: used_values::FfiCssPixelRect,
     pub caret_rect: used_values::FfiCssPixelRect,
     pub context: ContextRef,
 }


### PR DESCRIPTION
The C++ HitTestDisplayList used to keep a full mirror of the Rust hit-test list (items, caret lines, caret item indices) plus duplicated logic over it: a re-derived caret-capability predicate, box caret-side selection, and the axis helpers, with per-kind switches spread across every resolution and result-construction path.

C++ now treats the list as an opaque token (arena + generation) and asks Rust everything through per-index view functions and kind-free descriptors:

- Item facts and caret lines are read on demand through FFI views; the only per-item state kept in C++ is a GC rooting sidecar for empty-line caret nodes, which must stay alive across the window between a DOM mutation and the next recording.
- The recorded can_produce_caret_position bit replaces the re-derived C++ predicate, so selection and resolution consult one source.
- Target and event-dispatch node resolution, resolved hit facts (index_in_node, text-fragment flag, dispatch fallback), and caret boundaries (Offset/BeforeNode/AfterNode vocabulary) come from Rust; C++ translates shells and boundaries into GC/DOM types uniformly, with no item-kind knowledge left.
- The position-to-line reverse lookup, including the soft-wrap fallback pass, moved into Rust behind four DOM-predicate callbacks; caret-line scope filtering asks C++ per shell, so Rust evaluates it lazily for only the lines a query actually considers.