### PR TITLE
LibDevTools: Launch the DevTools client through LaunchServices on macOS

### DIFF
--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -44,5 +44,14 @@ set(SOURCES
     StorageHelpers.cpp
 )
 
+if (APPLE)
+    list(APPEND SOURCES LaunchApplicationMacOS.mm)
+    set_source_files_properties(LaunchApplicationMacOS.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+endif()
+
 ladybird_lib(LibDevTools devtools EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibDevTools PRIVATE LibCore LibFileSystem LibHTTP LibWeb LibURL)
+
+if (APPLE)
+    target_link_libraries(LibDevTools PRIVATE "-framework AppKit")
+endif()

--- a/Libraries/LibDevTools/FirefoxClient.cpp
+++ b/Libraries/LibDevTools/FirefoxClient.cpp
@@ -15,6 +15,10 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibDevTools/FirefoxClient.h>
+
+#if defined(AK_OS_MACOS)
+#    include <LibDevTools/LaunchApplicationMacOS.h>
+#endif
 #include <LibFileSystem/FileSystem.h>
 
 #if !defined(AK_OS_WINDOWS)
@@ -273,16 +277,16 @@ NonnullOwnPtr<FirefoxClient> FirefoxClient::create()
 FirefoxClient::~FirefoxClient()
 {
     if (is_running())
-        (void)Core::Process::terminate_process(m_process->pid(), Core::Process::TerminationMode::Graceful);
+        (void)Core::Process::terminate_process(*m_process_id, Core::Process::TerminationMode::Graceful);
 }
 
 bool FirefoxClient::is_running() const
 {
 #if defined(AK_OS_WINDOWS)
     // FIXME: Implement actual live-process detection for this PID on Windows.
-    return m_process.has_value();
+    return m_process_id.has_value();
 #else
-    return m_process.has_value() && !Core::System::kill(m_process->pid(), 0).is_error();
+    return m_process_id.has_value() && !Core::System::kill(*m_process_id, 0).is_error();
 #endif
 }
 
@@ -339,13 +343,23 @@ ErrorOr<void> FirefoxClient::ensure_running(u16 port, u64 tab_id)
     }
 #endif
 
-    m_process = TRY(Core::Process::spawn({
+#if defined(AK_OS_MACOS)
+    // Firefox ships as an application bundle, and it has to come up through LaunchServices: exec'd straight from its
+    // binary, its helper processes fail their startup handshakes — and it gives up before it opens a profile at all.
+    if (auto bundle = installation->executable.parent().parent().parent(); bundle.basename().ends_with(".app"sv)) {
+        m_process_id = TRY(launch_macos_application(bundle.string(), arguments));
+        return {};
+    }
+#endif
+
+    auto process = TRY(Core::Process::spawn({
         .name = "devtools-client"sv,
         .executable = move(executable),
         .search_for_executable_in_path = search_for_executable_in_path,
         .die_with_parent = true,
         .arguments = arguments,
     }));
+    m_process_id = process.pid();
 
     return {};
 }

--- a/Libraries/LibDevTools/FirefoxClient.h
+++ b/Libraries/LibDevTools/FirefoxClient.h
@@ -25,7 +25,7 @@ public:
 private:
     FirefoxClient() = default;
 
-    Optional<Core::Process> m_process;
+    Optional<pid_t> m_process_id;
 };
 
 }

--- a/Libraries/LibDevTools/LaunchApplicationMacOS.h
+++ b/Libraries/LibDevTools/LaunchApplicationMacOS.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/Error.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+
+#include <sys/types.h>
+
+namespace DevTools {
+
+// Brings up an application bundle through LaunchServices and hands back the process it came up as.
+ErrorOr<pid_t> launch_macos_application(StringView bundle_path, Vector<ByteString> const& arguments);
+
+}

--- a/Libraries/LibDevTools/LaunchApplicationMacOS.mm
+++ b/Libraries/LibDevTools/LaunchApplicationMacOS.mm
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+
+#if !defined(AK_OS_MACOS)
+static_assert(false, "This file must only be used for macOS");
+#endif
+
+#include <LibDevTools/LaunchApplicationMacOS.h>
+
+#import <AppKit/AppKit.h>
+
+namespace DevTools {
+
+ErrorOr<pid_t> launch_macos_application(StringView bundle_path, Vector<ByteString> const& arguments)
+{
+    @autoreleasepool {
+        auto* path = [[NSString alloc] initWithBytes:bundle_path.characters_without_null_termination()
+                                              length:bundle_path.length()
+                                            encoding:NSUTF8StringEncoding];
+        if (path == nil)
+            return Error::from_string_literal("Application path is not valid UTF-8");
+
+        auto* application_arguments = [NSMutableArray arrayWithCapacity:arguments.size()];
+        for (auto const& argument : arguments) {
+            auto* value = [NSString stringWithUTF8String:argument.characters()];
+            if (value == nil)
+                return Error::from_string_literal("Application argument is not valid UTF-8");
+            [application_arguments addObject:value];
+        }
+
+        auto* configuration = [NSWorkspaceOpenConfiguration configuration];
+        configuration.createsNewApplicationInstance = YES;
+        configuration.arguments = application_arguments;
+
+        __block pid_t launched_pid = -1;
+        auto* semaphore = dispatch_semaphore_create(0);
+
+        [NSWorkspace.sharedWorkspace openApplicationAtURL:[NSURL fileURLWithPath:path isDirectory:YES]
+                                            configuration:configuration
+                                        completionHandler:^(NSRunningApplication* application, NSError* error) {
+                                            if (error == nil && application != nil)
+                                                launched_pid = application.processIdentifier;
+                                            dispatch_semaphore_signal(semaphore);
+                                        }];
+
+        // The completion handler arrives on a queue of its own — so waiting here is safe. LaunchServices answers
+        // promptly; the deadline is only so that a launch which never comes back can't wedge the caller for good.
+        auto deadline = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+        if (dispatch_semaphore_wait(semaphore, deadline) != 0)
+            return Error::from_string_literal("Timed out waiting for the application to launch");
+
+        if (launched_pid <= 0)
+            return Error::from_string_literal("Unable to launch the application");
+
+        return launched_pid;
+    }
+}
+
+}


### PR DESCRIPTION
**Problem:** On macOS, the DevTools <kbd><b>Open Client</b></kbd> button never opens a client. Firefox puts up an alert reading _“Your Firefox profile cannot be loaded. It may be missing or inaccessible.”_, and quits — whether or not a Firefox is already running, and whichever profile it’s pointed at.

**Cause:** `ensure_running()` starts the client with `Core::Process::spawn()`, which execs the Firefox binary inside its app bundle. Firefox can’t be started that way: Its helper processes fail their LaunchServices and window-server handshakes, one of them is killed, and startup aborts before any profile is opened — while the same binary exec’d with `-headless` runs, and the same bundle launched through LaunchServices runs. The profile the alert names is intact and never touched; the launch is what fails.

**Fix:** Bring the bundle up through `NSWorkspace` instead — asking for an instance of its own, and keep the process id LaunchServices gives back.
