### PR TITLE
LibWeb: Keep resolved pseudo-element content across in-place restyles

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -3842,8 +3842,8 @@ ErrorOr<Utf16String> Node::name_or_description(NameOrDescription target, Documen
             // FIXME: Do we need to update layout before checking this? If so we can avoid using the unsafe layout node
             //        getter here.
             if (auto before = element->pseudo_element_unsafe_layout_node(CSS::PseudoElement::Before)) {
-                // NB: We know that content has a value since we set it immediately when creating a ::before pseudo
-                //     element node.
+                // NB: The build that registers this box also resolves its content — and it stays put until the box is
+                //     rebuilt. So, a registered box in an up-to-date layout tree always has one.
                 auto const& content = before->content().value();
 
                 if (content.alt_text.has_value()) {
@@ -3908,8 +3908,7 @@ ErrorOr<Utf16String> Node::name_or_description(NameOrDescription target, Documen
             // FIXME: Do we need to update layout before checking this? If so we can avoid using the unsafe layout node
             //        getter here.
             if (auto after = element->pseudo_element_unsafe_layout_node(CSS::PseudoElement::After)) {
-                // NB: We know that content has a value since we set it immediately when creating an ::after pseudo
-                //     element node.
+                // NB: See the ::before case above.
                 auto const& content = after->content().value();
 
                 if (content.alt_text.has_value()) {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -639,7 +639,6 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
     m_mask_layers.clear();
     m_border_image.clear();
     m_list_style_image.clear();
-    m_content.clear();
     m_owned_computed_values = nullptr;
     m_style_record_identity = style_record_identity;
     publish_style_record_to_node_data();
@@ -945,7 +944,6 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     m_mask_layers.clear();
     m_border_image.clear();
     m_list_style_image.clear();
-    m_content.clear();
     Optional<DOM::AbstractElement> abstract_element;
     if (is_generated_for_pseudo_element())
         abstract_element = DOM::AbstractElement { *pseudo_element_generator(), generated_for_pseudo_element() };
@@ -1008,7 +1006,6 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     m_mask_layers.clear();
     m_border_image.clear();
     m_list_style_image.clear();
-    m_content.clear();
     m_owned_computed_values = nullptr;
     m_style_record_identity = style_record_identity;
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -761,6 +761,8 @@ private:
     mutable Optional<CSS::BorderImageData> m_border_image;
     mutable Optional<CSS::ListStyleType> m_list_style_type;
     mutable Optional<RefPtr<CSS::AbstractImageStyleValue const>> m_list_style_image;
+    // The generated content this box was built from, kept for the accessible-name code. Not derived from the style
+    // record: An in-place restyle must leave it alone — since only a layout-tree rebuild can re-resolve it.
     Optional<CSS::ContentData> m_content;
 };
 

--- a/Tests/LibWeb/Crash/Internals/accessible-name-after-pseudo-element-restyle.html
+++ b/Tests/LibWeb/Crash/Internals/accessible-name-after-pseudo-element-restyle.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    #target::before { content: "x"; }
+    #target.recolored::before { color: red; }
+</style>
+<a id="target" href="#">link</a>
+<script>
+    // Let the layout tree build; the ::before box gets its content resolved during that build.
+    document.body.offsetWidth;
+    // A style-only change to the pseudo element lands on the live box in place, with no tree rebuild.
+    target.classList.add("recolored");
+    document.body.offsetWidth;
+    // Computing the accessible name reads the ::before box's resolved content.
+    internals.dumpAccessibilityTree();
+</script>


### PR DESCRIPTION
**Problem:** Crash with a failed `VERIFY` whenever the accessibility tree is read on pages that restyle their `::before` or `::after` content after first layout. Opening DevTools on https://english.elpais.com/ repro’s it reliably.

**Cause:** The accessible-name code reads the resolved content stored on a pseudo-element’s layout box, and unwraps it on the strength of a note claiming the content’s set as soon as the box is created and thus always present. Half that was true at first: the tree builder resolves content in the same build that creates the box. But all three in-place style-application paths — `set_style_record_identity()`, `set_computed_values()`, and `apply_style()` — cleared `m_content` along with the style-derived caches around it, and nothing outside a layout tree rebuild can resolve it again. So a style-only pseudo-element change took the path that by its own guard promises no rebuild will follow — and left a live, attached box whose content is gone for good.

**Fix:** Stop clearing `m_content` in the style-application paths. It’s not derived from the style record — so a restyle has nothing to replace it with: It’s the generated content the box was built from, resolved in build order because `counter()` and `counters()` read the counters the box itself establishes, and its only consumer is the accessible-name code.
