### PR TITLE
LibWebView: Run the test suite on a profile of its own

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -496,6 +496,9 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         profile_selection.name = profile_name->to_byte_string();
     if (profile_path.has_value())
         profile_selection.path = profile_path->to_byte_string();
+    // Naming a profile is an explicit choice and wins; otherwise the app decides whether it wants a throwaway one.
+    if (!temporary_profile && !profile_name.has_value() && !profile_path.has_value())
+        temporary_profile = should_use_temporary_profile_by_default();
     profile_selection.temporary = temporary_profile;
 #endif
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -324,6 +324,8 @@ protected:
     virtual void create_platform_arguments(Core::ArgsParser&) { }
     virtual void create_platform_options(BrowserOptions&, RequestServerOptions&, WebContentOptions&) { }
     virtual bool should_coordinate_browser_process() const { return true; }
+    // An application whose state must not leak between runs — or into a developer's own browsing state.
+    virtual bool should_use_temporary_profile_by_default() const { return false; }
     virtual Core::EventLoop& create_platform_event_loop();
 
     virtual Optional<ByteString> ask_user_for_download_path([[maybe_unused]] ByteString const& file) const { return {}; }

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -25,6 +25,9 @@ public:
 
     virtual void create_platform_arguments(Core::ArgsParser&) override;
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
+
+    // Tests must not read, or write, the browser settings of whoever is running them.
+    virtual bool should_use_temporary_profile_by_default() const override { return true; }
     virtual bool should_coordinate_browser_process() const override { return false; }
     virtual bool should_capture_web_content_output() const override { return true; }
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -1124,8 +1124,6 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     for (size_t i = 0; i < concurrency; ++i) {
         auto view = TestWebView::create(theme, window_size);
         view->on_load_finish = [&](auto const&) { ++loaded_web_views; };
-        // FIXME: Figure out a better way to ensure that tests use default browser settings.
-        view->reset_zoom();
 
         views.unchecked_append(move(view));
     }


### PR DESCRIPTION
**Problem:** `test-web` read profiles of whoever ran it. Every browser setting a developer had changed for their own use was live inside the suite — so an environment where one thing is set rendered tests differently from a machine where that thing isn’t, and from CI.

**Cause:** An app with no profile selector got the default profile. Nothing distinguished the test runner from a person-actually-using browser.

**Fix:** Let an app say it wants a throwaway profile, and have `test-web` say so. Naming one explicitly still wins. So `--profile` / `--profile-path` keep working for debugging against real state. The profile is created at startup and removed at exit, once per suite. So, this resolves/removes the existing FIXME about tests picking up default browser settings.
