### PR TITLE
LibWeb+Compositor: Compute frame damage at raster time

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -96,10 +96,10 @@ void CompositorContextHandle::viewport_size_updated(Gfx::IntSize viewport_size, 
     m_host.viewport_size_updated(m_context_id, viewport_size, window_resize_in_progress);
 }
 
-void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
+void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect)
 {
     m_host.flush_canvas_2d_stream();
-    m_host.present_frame(m_context_id, viewport_rect, damage_rect);
+    m_host.present_frame(m_context_id, viewport_rect);
 }
 
 void CompositorContextHandle::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -49,7 +49,7 @@ public:
     void cancel_smooth_scroll(AsyncScrollNodeStableID);
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
-    void present_frame(Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
+    void present_frame(Gfx::IntRect viewport_rect);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
@@ -95,7 +95,7 @@ public:
     virtual void cancel_smooth_scroll(CompositorContextId, AsyncScrollNodeStableID) = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
     virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;
-    virtual void present_frame(CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) = 0;
+    virtual void present_frame(CompositorContextId, Gfx::IntRect viewport_rect) = 0;
     virtual void request_screenshot(CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback) = 0;
 
 protected:

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -82,7 +82,6 @@
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BoxViews.h>
-#include <LibWeb/Painting/DisplayListDamage.h>
 #include <LibWeb/Painting/DocumentPaintState.h>
 #include <LibWeb/Painting/PaintableTypes.h>
 #include <LibWeb/Painting/ScrollSnap.h>
@@ -5114,9 +5113,6 @@ void LocalNavigable::repaint_after_compositor_process_reconnect()
         m_needs_repaint = true;
         m_needs_to_record_display_list = true;
         m_compositor_display_list_paint_config.clear();
-        m_compositor_display_list.clear();
-        m_compositor_visual_context_tree.clear();
-        m_compositor_scroll_state_snapshot.clear();
         m_compositor_display_list_resources = {};
     }
 
@@ -5148,7 +5144,7 @@ void LocalNavigable::set_should_show_caret_hit_test_debug_overlay(bool value)
         child_navigable->set_should_show_caret_hit_test_debug_overlay(value);
 }
 
-bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_config, Gfx::IntRect* damage_rect)
+bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 {
     if (!has_compositor_context())
         return false;
@@ -5193,32 +5189,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     document_paint_state.refresh_scroll_state(*document);
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paint_state.scroll_state_snapshot() };
-    auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-    Gfx::IntRect surface_rect { {}, viewport_rect.size() };
-    if (damage_rect)
-        *damage_rect = surface_rect;
     if (should_record_display_list) {
-        if (damage_rect
-            && m_compositor_display_list
-            && m_compositor_visual_context_tree.has_value()
-            && m_compositor_scroll_state_snapshot.has_value()
-            && m_compositor_scroll_state_snapshot->device_offsets() == scroll_state_snapshot.device_offsets()
-            && m_compositor_display_list_paint_config == paint_config) {
-            auto computed_damage = Painting::compute_display_list_damage(
-                m_compositor_display_list->command_bytes(),
-                *m_compositor_visual_context_tree,
-                *m_compositor_scroll_state_snapshot,
-                display_list->command_bytes(),
-                *visual_context_tree,
-                scroll_state_snapshot,
-                surface_rect);
-            if (computed_damage.has_value())
-                *damage_rect = *computed_damage;
-        }
-
-        m_compositor_display_list = display_list;
-        m_compositor_visual_context_tree = *visual_context_tree;
-        m_compositor_scroll_state_snapshot = scroll_state_snapshot;
         m_compositor_display_list_visual_context_tree_version = display_list->compatible_visual_context_tree_version();
         compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
         document_paint_state.did_update_visual_context_tree_in_compositor();
@@ -5259,11 +5230,10 @@ void LocalNavigable::paint_next_frame()
 
     m_needs_repaint = false;
 
-    Gfx::IntRect damage_rect;
-    if (!record_display_list_and_scroll_state(paint_config, &damage_rect))
+    if (!record_display_list_and_scroll_state(paint_config))
         return;
     viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-    compositor_context().present_frame(viewport_rect, damage_rect);
+    compositor_context().present_frame(viewport_rect);
 }
 
 void LocalNavigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintConfig paint_config, Function<void()>&& callback)

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -278,7 +278,7 @@ public:
     void clear_pending_navigations();
     void prepare_to_populate_reconstructed_history_entry(Utf16String navigation_api_key);
 
-    bool record_display_list_and_scroll_state(PaintConfig, Gfx::IntRect* damage_rect = nullptr);
+    bool record_display_list_and_scroll_state(PaintConfig);
     void paint_next_frame();
     void render_screenshot(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
     Painting::DisplayListResourceStorage& display_list_resource_storage() { return m_display_list_resource_storage; }
@@ -538,9 +538,6 @@ private:
     bool m_should_show_caret_hit_test_debug_overlay { false };
     Optional<PaintConfig> m_compositor_display_list_paint_config;
     u64 m_compositor_display_list_visual_context_tree_version { 0 };
-    RefPtr<Painting::DisplayList> m_compositor_display_list;
-    Optional<Painting::AccumulatedVisualContextTree> m_compositor_visual_context_tree;
-    Optional<Painting::ScrollStateSnapshot> m_compositor_scroll_state_snapshot;
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_compositor_display_list_resources;
     OwnPtr<Compositor::CompositorContextHandle> m_compositor_context;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -199,7 +199,7 @@ public:
 
     WEB_API Optional<Gfx::FloatPoint> transform_point_for_hit_test(ContextRef, Gfx::FloatPoint, ScrollStateSnapshot const&, ClipBehavior = ClipBehavior::Respect) const;
     Gfx::FloatPoint inverse_transform_point(SpatialNodeIndex, Gfx::FloatPoint) const;
-    Gfx::FloatRect transform_rect_to_viewport(SpatialNodeIndex, Gfx::FloatRect const&, ScrollStateSnapshot const&, IncludeVisualViewportTransform = IncludeVisualViewportTransform::Yes) const;
+    WEB_API Gfx::FloatRect transform_rect_to_viewport(SpatialNodeIndex, Gfx::FloatRect const&, ScrollStateSnapshot const&, IncludeVisualViewportTransform = IncludeVisualViewportTransform::Yes) const;
     // Sum of the snapshot entries along the scroll-parent chain from the given scroll-like node.
     Gfx::FloatPoint cumulative_scroll_chain_offset(SpatialNodeIndex, ScrollStateSnapshot const&) const;
     Gfx::FloatMatrix4x4 accumulated_matrix(SpatialNodeIndex, ScrollStateSnapshot const&, IncludeVisualViewportTransform) const;

--- a/Libraries/LibWeb/Painting/CanvasSurfaceRegistry.h
+++ b/Libraries/LibWeb/Painting/CanvasSurfaceRegistry.h
@@ -37,11 +37,13 @@ public:
     void set_canvas_surface(CanvasId id, NonnullRefPtr<Gfx::PaintingSurface> surface)
     {
         m_surfaces.set(id, move(surface));
+        m_content_generations.set(id, ++m_last_content_generation);
     }
 
     void remove_canvas_surface(CanvasId id)
     {
         m_surfaces.remove(id);
+        m_content_generations.remove(id);
     }
 
     Gfx::PaintingSurface const* canvas_surface(CanvasId id) const
@@ -49,9 +51,16 @@ public:
         return m_surfaces.get(id).value_or(nullptr);
     }
 
+    u64 canvas_content_generation(CanvasId id) const
+    {
+        return m_content_generations.get(id).value_or(0);
+    }
+
 private:
     u64 m_next_canvas_id { 1 };
+    u64 m_last_content_generation { 0 };
     HashMap<CanvasId, NonnullRefPtr<Gfx::PaintingSurface>> m_surfaces;
+    HashMap<CanvasId, u64> m_content_generations;
 };
 
 }

--- a/Libraries/LibWebView/CompositorConnection.cpp
+++ b/Libraries/LibWebView/CompositorConnection.cpp
@@ -232,11 +232,11 @@ void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorCont
     async_viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
-void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
+void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
     if (!can_send_message_to_compositor())
         return;
-    async_present_frame(context_id, viewport_rect, damage_rect);
+    async_present_frame(context_id, viewport_rect);
 }
 
 Optional<Web::Painting::CanvasId> CompositorConnection::create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias, Vector<String>& out_supported_extensions)

--- a/Libraries/LibWebView/CompositorConnection.h
+++ b/Libraries/LibWebView/CompositorConnection.h
@@ -59,7 +59,7 @@ public:
     void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
-    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect);
     void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&&);
 
     Optional<Web::Painting::CanvasId> create_webgl_context(Web::WebGL::WebGLVersion, Gfx::IntSize, bool depth, bool stencil, bool antialias, Vector<String>& out_supported_extensions);

--- a/Libraries/LibWebView/CompositorHostBase.cpp
+++ b/Libraries/LibWebView/CompositorHostBase.cpp
@@ -289,10 +289,10 @@ void CompositorHostBase::viewport_size_updated(Web::Compositor::CompositorContex
         connection->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
-void CompositorHostBase::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
+void CompositorHostBase::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
     if (auto* connection = compositor_connection())
-        connection->present_frame(context_id, viewport_rect, damage_rect);
+        connection->present_frame(context_id, viewport_rect);
 }
 
 void CompositorHostBase::request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Libraries/LibWebView/CompositorHostBase.h
+++ b/Libraries/LibWebView/CompositorHostBase.h
@@ -35,7 +35,7 @@ public:
     virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
-    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override;
+    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;
     virtual void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback) override;
 
 protected:

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -565,10 +565,7 @@ void CompositorState::resume_presentation_after_becoming_visible(Web::Compositor
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
     }
 
-    auto frame_rect_to_present = root_context.pending_present_frame_viewport_rect();
-    if (!frame_rect_to_present.has_value())
-        frame_rect_to_present = root_context.current_frame_rect_to_present();
-    if (frame_rect_to_present.has_value())
+    if (auto frame_rect_to_present = root_context.frame_rect_to_repaint(); frame_rect_to_present.has_value())
         schedule_present_frame(root_context_id, root_context, *frame_rect_to_present);
 }
 
@@ -576,15 +573,6 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    if (context->should_defer_main_thread_present_for_async_scroll()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
-        // NB: The in-flight compositor frame may have been rasterized before the
-        //     main thread installed its new display list. Preserve the present as
-        //     a full repaint so that it uses both the new list and the latest
-        //     compositor scroll state once presentation is unblocked.
-        schedule_present_frame(context_id, *context, viewport_rect);
-        return;
-    }
     damage_rect.intersect({ {}, viewport_rect.size() });
     schedule_present_frame(context_id, *context, ContextState::PendingFrame { viewport_rect, damage_rect });
 }
@@ -596,7 +584,7 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     if (!prepared_frame.has_value())
         return;
 
-    m_pending_async_presents.append(context_id, pending_frame.viewport_rect, pending_frame.damage_rect, prepared_frame->bitmap_id);
+    m_pending_async_presents.append(context_id, pending_frame.viewport_rect, prepared_frame->damage_rect, prepared_frame->bitmap_id);
     auto* pending_present = &m_pending_async_presents.last();
 
     auto& event_loop = Core::EventLoop::current();
@@ -620,7 +608,7 @@ void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextI
 {
     schedule_present_frame(context_id, context, ContextState::PendingFrame {
                                                     .viewport_rect = viewport_rect,
-                                                    .damage_rect = { {}, viewport_rect.size() },
+                                                    .forced_damage_rect = { {}, viewport_rect.size() },
                                                 });
 }
 
@@ -696,7 +684,7 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
         if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
             context.queue_present_frame({
                 .viewport_rect = *animation_frame,
-                .damage_rect = { {}, animation_frame->size() },
+                .forced_damage_rect = { {}, animation_frame->size() },
             });
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
@@ -924,10 +912,7 @@ void CompositorState::shrink_backing_stores_after_resize(Web::Compositor::Compos
 
 void CompositorState::present_current_frame(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    // A queued frame already captures the newest viewport rect and will pick up
-    // the updated resource when the outstanding bitmap is acknowledged.
-    auto frame_to_present = context.current_frame_rect_to_present();
-    if (frame_to_present.has_value())
+    if (auto frame_to_present = context.frame_rect_to_repaint(); frame_to_present.has_value())
         schedule_present_frame(context_id, context, *frame_to_present);
 }
 

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -605,10 +605,7 @@ void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextI
 
 void CompositorState::schedule_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
 {
-    schedule_present_frame(context_id, context, ContextState::PendingFrame {
-                                                    .viewport_rect = viewport_rect,
-                                                    .forced_damage_rect = { {}, viewport_rect.size() },
-                                                });
+    schedule_present_frame(context_id, context, ContextState::PendingFrame::repainting_everything(viewport_rect));
 }
 
 void CompositorState::schedule_pending_present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context)
@@ -681,10 +678,7 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
             continue;
 
         if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
-            context.queue_present_frame({
-                .viewport_rect = *animation_frame,
-                .forced_damage_rect = { {}, animation_frame->size() },
-            });
+            context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*animation_frame));
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
         if (!pending_present_frame.has_value()) {
@@ -694,7 +688,7 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
             continue;
         }
         if (context.has_active_smooth_scroll_animations())
-            schedule_present_frame(context_id, context, pending_present_frame->viewport_rect);
+            schedule_present_frame(context_id, context, ContextState::PendingFrame::repainting_changes(pending_present_frame->viewport_rect));
         present_frame(context_id, context, *pending_present_frame);
     }
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -569,12 +569,11 @@ void CompositorState::resume_presentation_after_becoming_visible(Web::Compositor
         schedule_present_frame(root_context_id, root_context, *frame_rect_to_present);
 }
 
-void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
+void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
     auto* context = context_if_present(context_id);
     VERIFY(context);
-    damage_rect.intersect({ {}, viewport_rect.size() });
-    schedule_present_frame(context_id, *context, ContextState::PendingFrame { viewport_rect, damage_rect });
+    schedule_present_frame(context_id, *context, ContextState::PendingFrame { viewport_rect, {} });
 }
 
 void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, ContextState::PendingFrame pending_frame)

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -105,7 +105,7 @@ public:
     void set_paused_debugger_overlay(Web::Compositor::CompositorContextId, bool visible, double device_pixel_ratio, Optional<String> font_family, Optional<WebView::PausedDebuggerOverlayAction> hovered_action);
     void set_display_metadata(Web::Compositor::CompositorContextId, Optional<u64> display_id, double refresh_rate);
     void set_context_visibility(Web::Compositor::CompositorContextId, Web::Compositor::ContextVisibility);
-    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
     void set_client_gpu_presentation_capability(bool supported, u64 adapter_luid);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -59,6 +59,6 @@ endpoint CompositorWebContentServer
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
-    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) =|
+    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) =|
     request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) =|
 }

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -302,11 +302,11 @@ void ConnectionFromWebContent::viewport_size_updated(Web::Compositor::Compositor
     m_compositor_state->viewport_size_updated(context_id, viewport_size, window_resize_in_progress);
 }
 
-void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect)
+void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
     if (!context_is_owned_by_this_connection(context_id))
         return;
-    m_compositor_state->present_frame(context_id, viewport_rect, damage_rect);
+    m_compositor_state->present_frame(context_id, viewport_rect);
 }
 
 void ConnectionFromWebContent::request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -69,7 +69,7 @@ private:
     virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;
-    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override;
+    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;
     virtual void request_screenshot(Web::Compositor::CompositorContextId, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) override;
 
     virtual void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&) override;

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -270,7 +270,7 @@ ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEve
         ContextUpdateResult result;
         result.accepted = true;
         if (!m_async_scrolling_viewport_rect.is_empty())
-            result.frame_to_present = m_async_scrolling_viewport_rect;
+            result.frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect);
         if (auto frame_to_present = apply_viewport_scrollbar_drag(*drag); frame_to_present.has_value()) {
             result.frame_to_present = *frame_to_present;
             result.should_request_rendering_update = true;
@@ -288,9 +288,9 @@ ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEve
         }
 
         auto hovered_scrollbar_index = m_viewport_scrollbar_controller.hit_test(m_async_scroll_tree, m_scroll_state_snapshot, position);
-        Optional<Gfx::IntRect> frame_to_present;
+        Optional<PendingFrame> frame_to_present;
         if (m_viewport_scrollbar_controller.set_hovered_scrollbar(hovered_scrollbar_index) && !m_async_scrolling_viewport_rect.is_empty())
-            frame_to_present = m_async_scrolling_viewport_rect;
+            frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect);
         return {
             .accepted = hovered_scrollbar_index.has_value(),
             .frame_to_present = frame_to_present,
@@ -314,21 +314,21 @@ ContextState::ContextUpdateResult ContextState::handle_mouse_event(Web::MouseEve
         // release scrolls nothing.
         result.should_request_rendering_update = true;
         if (!m_async_scrolling_viewport_rect.is_empty())
-            result.frame_to_present = m_async_scrolling_viewport_rect;
+            result.frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect);
         if (auto frame_to_present = apply_viewport_scrollbar_drag(*drag); frame_to_present.has_value())
             result.frame_to_present = *frame_to_present;
 
         auto hovered_scrollbar_index = m_viewport_scrollbar_controller.hit_test(m_async_scroll_tree, m_scroll_state_snapshot, position);
         if (m_viewport_scrollbar_controller.set_hovered_scrollbar(hovered_scrollbar_index) && !m_async_scrolling_viewport_rect.is_empty())
-            result.frame_to_present = m_async_scrolling_viewport_rect;
+            result.frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect);
 
         return result;
     }
     case Web::MouseEvent::Type::MouseLeave: {
         auto had_capture = m_viewport_scrollbar_controller.has_captured_scrollbar();
-        Optional<Gfx::IntRect> frame_to_present;
+        Optional<PendingFrame> frame_to_present;
         if (m_viewport_scrollbar_controller.set_hovered_scrollbar({}) && !m_async_scrolling_viewport_rect.is_empty())
-            frame_to_present = m_async_scrolling_viewport_rect;
+            frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect);
         return {
             .accepted = had_capture,
             .frame_to_present = frame_to_present,
@@ -383,7 +383,7 @@ ContextState::ContextUpdateResult ContextState::handle_pinch_event(Web::PinchEve
 
     return {
         .accepted = true,
-        .frame_to_present = m_async_scrolling_viewport_rect,
+        .frame_to_present = PendingFrame::repainting_changes(m_async_scrolling_viewport_rect),
         .should_request_rendering_update = false,
     };
 }
@@ -429,7 +429,7 @@ ContextState::AsyncScrollResult ContextState::async_scroll_by(
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(scroll_offsets, operation_id);
     m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    return { .enqueue_result = { true, operation_id }, .frame_to_present = async_scroll_viewport_rect };
+    return { .enqueue_result = { true, operation_id }, .frame_to_present = PendingFrame::repainting_changes(async_scroll_viewport_rect) };
 }
 
 ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint destination_offset, Gfx::FloatPoint main_thread_offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel, Web::Compositor::ScrollAnimationKind animation_kind)
@@ -472,7 +472,7 @@ ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::
     m_async_scrolling_viewport_rect = viewport_rect;
     return {
         .enqueue_result = { true, operation_id },
-        .frame_to_present = viewport_rect,
+        .frame_to_present = PendingFrame::repainting_changes(viewport_rect),
     };
 }
 
@@ -559,14 +559,14 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
     if (initial_scroll_target.blocked_by_main_thread_region || initial_scroll_target.blocked_by_wheel_event_region)
         return {};
 
-    Optional<Gfx::IntRect> frame_to_present;
+    Optional<PendingFrame> frame_to_present;
     auto remaining_delta = delta;
     if (auto visual_viewport_scroll_delta = apply_visual_viewport_scroll_delta(delta); visual_viewport_scroll_delta.has_value()) {
         Vector<Web::Compositor::AsyncScrollOffset> scroll_offsets;
         scroll_offsets.append(visual_viewport_scroll_delta->scroll_offset);
         store_pending_async_scroll_offsets(scroll_offsets);
         remaining_delta.translate_by(-visual_viewport_scroll_delta->consumed_delta.x(), -visual_viewport_scroll_delta->consumed_delta.y());
-        frame_to_present = m_async_scrolling_viewport_rect;
+        frame_to_present = PendingFrame::repainting_changes(m_async_scrolling_viewport_rect);
     }
 
     if (remaining_delta.is_zero())
@@ -607,7 +607,7 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
         async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     store_pending_async_scroll_offsets(scroll_offsets);
     m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    return { .accepted = true, .frame_to_present = async_scroll_viewport_rect, .should_request_rendering_update = true };
+    return { .accepted = true, .frame_to_present = PendingFrame::repainting_changes(async_scroll_viewport_rect), .should_request_rendering_update = true };
 }
 
 Web::Compositor::PendingAsyncScrollUpdates ContextState::take_pending_async_scroll_updates()
@@ -720,14 +720,12 @@ void ContextState::queue_present_frame(PendingFrame pending_frame)
         return;
     }
 
-    if (m_pending_present_frame->viewport_rect != pending_frame.viewport_rect) {
-        m_pending_present_frame = PendingFrame {
-            .viewport_rect = pending_frame.viewport_rect,
-            .forced_damage_rect = { {}, pending_frame.viewport_rect.size() },
-        };
+    if (m_pending_present_frame->viewport_rect.size() != pending_frame.viewport_rect.size()) {
+        m_pending_present_frame = PendingFrame::repainting_everything(pending_frame.viewport_rect);
         return;
     }
 
+    m_pending_present_frame->viewport_rect = pending_frame.viewport_rect;
     m_pending_present_frame->forced_damage_rect.unite(pending_frame.forced_damage_rect);
 }
 
@@ -829,12 +827,8 @@ bool ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& d
         return false;
 
     Optional<PendingFrame> pending_frame = m_pending_present_frame;
-    if (!pending_frame.has_value() && m_presented_frame.has_value()) {
-        pending_frame = PendingFrame {
-            .viewport_rect = *m_presented_frame,
-            .forced_damage_rect = { {}, m_presented_frame->size() },
-        };
-    }
+    if (!pending_frame.has_value() && m_presented_frame.has_value())
+        pending_frame = PendingFrame::repainting_everything(*m_presented_frame);
     if (!pending_frame.has_value())
         return false;
 
@@ -1010,7 +1004,7 @@ void ContextState::note_user_scroll_gesture_end_if_drag_ended(bool was_dragging_
         m_user_scroll_gesture_ended = true;
 }
 
-Optional<Gfx::IntRect> ContextState::apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const& drag)
+Optional<ContextState::PendingFrame> ContextState::apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const& drag)
 {
     auto scroll_delta = m_viewport_scrollbar_controller.scroll_delta_for_drag(m_async_scroll_tree, m_scroll_state_snapshot, drag);
     if (!scroll_delta.has_value())
@@ -1030,7 +1024,7 @@ Optional<Gfx::IntRect> ContextState::apply_viewport_scrollbar_drag(ViewportScrol
     auto async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
     async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
     m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
-    return async_scroll_viewport_rect;
+    return PendingFrame::repainting_everything(async_scroll_viewport_rect);
 }
 
 void ContextState::rebuild_wheel_hit_test_targets()

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -14,11 +14,23 @@
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SkiaUtils.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Painting/DisplayListDamage.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <core/SkCanvas.h>
 #include <core/SkImage.h>
+#include <math.h>
 
 namespace Compositor {
+
+template<typename Callback>
+static void for_each_drawn_canvas(Web::Painting::DisplayList const& display_list, Callback callback)
+{
+    display_list.for_each_command_header([&](Web::Painting::DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        if (header.command_type != Web::Painting::DisplayListCommandType::DrawCanvas)
+            return;
+        callback(header, Web::Painting::read_display_list_object<Web::Painting::DrawCanvas>(payload));
+    });
+}
 
 static void set_or_append_pending_scroll_offset(
     Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets,
@@ -598,14 +610,6 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
     return { .accepted = true, .frame_to_present = async_scroll_viewport_rect, .should_request_rendering_update = true };
 }
 
-bool ContextState::should_defer_main_thread_present_for_async_scroll() const
-{
-    if (m_pending_async_scroll_offsets.is_empty())
-        return false;
-    return m_pending_present_frame.has_value()
-        || is_present_blocked();
-}
-
 Web::Compositor::PendingAsyncScrollUpdates ContextState::take_pending_async_scroll_updates()
 {
     Web::Compositor::PendingAsyncScrollUpdates updates;
@@ -719,12 +723,12 @@ void ContextState::queue_present_frame(PendingFrame pending_frame)
     if (m_pending_present_frame->viewport_rect != pending_frame.viewport_rect) {
         m_pending_present_frame = PendingFrame {
             .viewport_rect = pending_frame.viewport_rect,
-            .damage_rect = { {}, pending_frame.viewport_rect.size() },
+            .forced_damage_rect = { {}, pending_frame.viewport_rect.size() },
         };
         return;
     }
 
-    m_pending_present_frame->damage_rect.unite(pending_frame.damage_rect);
+    m_pending_present_frame->forced_damage_rect.unite(pending_frame.forced_damage_rect);
 }
 
 void ContextState::mark_pending_present_frame_scheduled()
@@ -764,20 +768,15 @@ bool ContextState::needs_rasterization() const
         || (!m_latest_rendered_surface && m_presented_frame.has_value());
 }
 
-Optional<Gfx::IntRect> ContextState::current_frame_rect_to_present() const
+Optional<Gfx::IntRect> ContextState::frame_rect_to_repaint() const
 {
     if (m_pending_present_frame.has_value())
-        return {};
-    if (!m_presented_frame.has_value())
-        return {};
+        return m_pending_present_frame->viewport_rect;
     return m_presented_frame;
 }
 
 Optional<Gfx::IntRect> ContextState::video_present_rect() const
 {
-    // The viewport to present a hosted video frame into. Unlike current_frame_rect_to_present this is not gated on a
-    // present already being in flight: a new frame must always (re)queue a present so the latest frame lands once the
-    // outstanding one completes.
     if (m_presented_frame.has_value())
         return m_presented_frame;
     if (!m_viewport_size.is_empty())
@@ -797,19 +796,22 @@ Optional<ContextState::PreparedFrame> ContextState::prepare_frame(Web::Painting:
         return {};
     }
 
-    auto render_target = m_backing_store_manager.acquire_render_target(pending_frame.damage_rect);
+    auto damage_rect = frame_damage_for(pending_frame);
+    auto render_target = m_backing_store_manager.acquire_render_target(damage_rect);
     if (!render_target.has_value()) {
         queue_present_frame(pending_frame);
         return {};
     }
     auto& back_store = render_target->surface;
     paint_current_display_list(display_list_player, back_store, composited_context_resolver, render_target->damage_rect);
+    remember_rasterized_frame(pending_frame.viewport_rect.size());
 
     auto rendered_bitmap_id = render_target->bitmap_id;
     m_gpu_present_bitmap_id_awaiting_completion = rendered_bitmap_id;
     return PreparedFrame {
         .rendered_surface = &back_store,
         .bitmap_id = rendered_bitmap_id,
+        .damage_rect = damage_rect,
     };
 }
 
@@ -830,17 +832,18 @@ bool ContextState::present_synchronously(Web::Painting::DisplayListPlayerSkia& d
     if (!pending_frame.has_value() && m_presented_frame.has_value()) {
         pending_frame = PendingFrame {
             .viewport_rect = *m_presented_frame,
-            .damage_rect = { {}, m_presented_frame->size() },
+            .forced_damage_rect = { {}, m_presented_frame->size() },
         };
     }
     if (!pending_frame.has_value())
         return false;
 
-    auto render_target = m_backing_store_manager.acquire_render_target(pending_frame->damage_rect);
+    auto render_target = m_backing_store_manager.acquire_render_target(frame_damage_for(*pending_frame));
     if (!render_target.has_value())
         return false;
     auto& back_store = render_target->surface;
     paint_current_display_list(display_list_player, back_store, composited_context_resolver, render_target->damage_rect);
+    remember_rasterized_frame(pending_frame->viewport_rect.size());
     display_list_player.flush(back_store);
     m_backing_store_manager.complete_rendering(render_target->bitmap_id, false);
     m_latest_rendered_surface = m_backing_store_manager.latest_rendered_surface();
@@ -1058,6 +1061,88 @@ Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_
     m_visual_context_tree_for_compositing = current_visual_context_tree();
     m_visual_context_tree_for_compositing->set_visual_viewport_transform(*m_async_visual_viewport_transform);
     return *m_visual_context_tree_for_compositing;
+}
+
+Gfx::IntRect ContextState::frame_damage_for(PendingFrame const& pending_frame) const
+{
+    Gfx::IntRect viewport_rect { {}, pending_frame.viewport_rect.size() };
+    auto forced_damage_rect = pending_frame.forced_damage_rect.intersected(viewport_rect);
+    if (forced_damage_rect.contains(viewport_rect))
+        return viewport_rect;
+    auto damage_rect = damage_since_last_raster(viewport_rect.size());
+    damage_rect.unite(forced_damage_rect);
+    return damage_rect;
+}
+
+Gfx::IntRect ContextState::damage_since_last_raster(Gfx::IntSize viewport_size) const
+{
+    Gfx::IntRect viewport_rect { {}, viewport_size };
+    if (!m_last_rasterized_frame.has_value())
+        return viewport_rect;
+    auto const& last_frame = *m_last_rasterized_frame;
+    if (last_frame.viewport_size != viewport_size)
+        return viewport_rect;
+    if (last_frame.display_list->surface_clear_color() != m_display_list->surface_clear_color())
+        return viewport_rect;
+    if (auto viewport_scroll_node_id = m_async_scroll_tree.viewport_scroll_node_id(); viewport_scroll_node_id.has_value()) {
+        auto index = viewport_scroll_node_id->scroll_node_index;
+        if (last_frame.scroll_state_snapshot.device_offset_for_index(index) != m_scroll_state_snapshot.device_offset_for_index(index))
+            return viewport_rect;
+    }
+
+    auto const& visual_context_tree = visual_context_tree_for_compositing();
+    auto display_list_damage = Web::Painting::compute_display_list_damage(
+        last_frame.display_list->command_bytes(),
+        last_frame.visual_context_tree,
+        last_frame.scroll_state_snapshot,
+        m_display_list->command_bytes(),
+        visual_context_tree,
+        m_scroll_state_snapshot,
+        viewport_rect);
+    if (!display_list_damage.has_value())
+        return viewport_rect;
+
+    auto damage_rect = *display_list_damage;
+    for (auto const& scrollbar : m_viewport_scrollbar_controller.scrollbars()) {
+        if (last_frame.scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_node_index) == m_scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_node_index))
+            continue;
+        damage_rect.unite(scrollbar.gutter_rect.united(scrollbar.expanded_gutter_rect));
+    }
+    for_each_drawn_canvas(*m_display_list, [&](auto const& header, auto const& draw_canvas) {
+        auto last_content_generation = last_frame.canvas_content_generations.get(draw_canvas.canvas_id);
+        if (last_content_generation.has_value() && *last_content_generation == m_canvas_surface_registry.canvas_content_generation(draw_canvas.canvas_id))
+            return;
+        if (!header.has_bounding_rect) {
+            damage_rect = viewport_rect;
+            return;
+        }
+        auto canvas_rect = visual_context_tree.transform_rect_to_viewport(header.context.spatial, header.bounding_rect.template to_type<float>(), m_scroll_state_snapshot);
+        if (!isfinite(canvas_rect.x()) || !isfinite(canvas_rect.y()) || !isfinite(canvas_rect.width()) || !isfinite(canvas_rect.height())) {
+            damage_rect = viewport_rect;
+            return;
+        }
+        canvas_rect.intersect(viewport_rect.to_type<float>());
+        if (canvas_rect.is_empty())
+            return;
+        damage_rect.unite(Gfx::enclosing_int_rect(canvas_rect).inflated(1, 1, 1, 1));
+    });
+    damage_rect.intersect(viewport_rect);
+    return damage_rect;
+}
+
+void ContextState::remember_rasterized_frame(Gfx::IntSize viewport_size)
+{
+    HashMap<Web::Painting::CanvasId, u64> canvas_content_generations;
+    for_each_drawn_canvas(*m_display_list, [&](auto const&, auto const& draw_canvas) {
+        canvas_content_generations.set(draw_canvas.canvas_id, m_canvas_surface_registry.canvas_content_generation(draw_canvas.canvas_id));
+    });
+    m_last_rasterized_frame = RasterizedFrame {
+        .display_list = NonnullRefPtr { *m_display_list },
+        .visual_context_tree = visual_context_tree_for_compositing(),
+        .scroll_state_snapshot = m_scroll_state_snapshot,
+        .viewport_size = viewport_size,
+        .canvas_content_generations = move(canvas_content_generations),
+    };
 }
 
 void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect, PaintUIOverlay paint_ui_overlay)

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -61,14 +61,22 @@ class ContextState {
     AK_MAKE_NONMOVABLE(ContextState);
 
 public:
+    struct PendingFrame {
+        Gfx::IntRect viewport_rect;
+        Gfx::IntRect forced_damage_rect;
+
+        static PendingFrame repainting_everything(Gfx::IntRect viewport_rect) { return { viewport_rect, { {}, viewport_rect.size() } }; }
+        static PendingFrame repainting_changes(Gfx::IntRect viewport_rect) { return { viewport_rect, {} }; }
+    };
+
     struct AsyncScrollResult {
         Web::Compositor::AsyncScrollEnqueueResult enqueue_result;
-        Optional<Gfx::IntRect> frame_to_present;
+        Optional<PendingFrame> frame_to_present;
     };
 
     struct ContextUpdateResult {
         bool accepted { false };
-        Optional<Gfx::IntRect> frame_to_present;
+        Optional<PendingFrame> frame_to_present;
         bool should_request_rendering_update { false };
     };
 
@@ -76,11 +84,6 @@ public:
         Gfx::PaintingSurface* rendered_surface { nullptr };
         i32 bitmap_id { 0 };
         Gfx::IntRect damage_rect;
-    };
-
-    struct PendingFrame {
-        Gfx::IntRect viewport_rect;
-        Gfx::IntRect forced_damage_rect;
     };
 
     ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, Web::Painting::CanvasSurfaceRegistry const&, bool async_scrolling_enabled);
@@ -191,7 +194,7 @@ private:
     void store_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});
     void cancel_smooth_scroll_taken_over_by_user_input(Web::Compositor::AsyncScrollNodeID);
     void note_user_scroll_gesture_end_if_drag_ended(bool was_dragging_viewport_scrollbar);
-    Optional<Gfx::IntRect> apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const&);
+    Optional<PendingFrame> apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const&);
     void rebuild_wheel_hit_test_targets();
     bool is_present_blocked() const;
     bool can_render_frame() const;

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
@@ -74,11 +75,12 @@ public:
     struct PreparedFrame {
         Gfx::PaintingSurface* rendered_surface { nullptr };
         i32 bitmap_id { 0 };
+        Gfx::IntRect damage_rect;
     };
 
     struct PendingFrame {
         Gfx::IntRect viewport_rect;
-        Gfx::IntRect damage_rect;
+        Gfx::IntRect forced_damage_rect;
     };
 
     ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, Web::Painting::CanvasSurfaceRegistry const&, bool async_scrolling_enabled);
@@ -123,7 +125,6 @@ public:
     Optional<Gfx::IntRect> advance_smooth_scroll_animations(MonotonicTime now);
     bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }
     ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Web::Compositor::SnapContainerHandling);
-    bool should_defer_main_thread_present_for_async_scroll() const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
 
     void viewport_size_updated(Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
@@ -150,7 +151,7 @@ public:
     bool can_schedule_pending_present_frame_if_unblocked() const;
     Optional<PendingFrame> take_pending_present_frame_if_unblocked();
     bool needs_rasterization() const;
-    Optional<Gfx::IntRect> current_frame_rect_to_present() const;
+    Optional<Gfx::IntRect> frame_rect_to_repaint() const;
     Optional<Gfx::IntRect> video_present_rect() const;
     Optional<PreparedFrame> prepare_frame(Web::Painting::DisplayListPlayerSkia&, PendingFrame, CompositedContextResolver const*);
     void did_submit_prepared_frame(Gfx::IntRect);
@@ -173,6 +174,14 @@ private:
         Gfx::FloatPoint consumed_delta;
     };
 
+    struct RasterizedFrame {
+        NonnullRefPtr<Web::Painting::DisplayList const> display_list;
+        Web::Painting::AccumulatedVisualContextTree visual_context_tree;
+        Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
+        Gfx::IntSize viewport_size;
+        HashMap<Web::Painting::CanvasId, u64> canvas_content_generations;
+    };
+
     void stop_backing_store_shrink_timer();
     Web::Painting::AccumulatedVisualContextTree const& current_visual_context_tree() const;
     Optional<Gfx::FloatPoint> viewport_scroll_offset_from(Vector<Web::Compositor::AsyncScrollOffset> const&) const;
@@ -192,6 +201,9 @@ private:
         Yes,
     };
     void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&, CompositedContextResolver const*, Optional<Gfx::IntRect> damage_rect = {}, PaintUIOverlay = PaintUIOverlay::Yes);
+    Gfx::IntRect frame_damage_for(PendingFrame const&) const;
+    Gfx::IntRect damage_since_last_raster(Gfx::IntSize viewport_size) const;
+    void remember_rasterized_frame(Gfx::IntSize viewport_size);
 
     CompositorStateWebContentClient& m_web_content_client;
     Web::Painting::CanvasSurfaceRegistry const& m_canvas_surface_registry;
@@ -209,6 +221,7 @@ private:
     BackingStoreManager m_backing_store_manager;
     RefPtr<Gfx::PaintingSurface> m_latest_rendered_surface;
     RefPtr<Gfx::PaintingSurface> m_damage_surface;
+    Optional<RasterizedFrame> m_last_rasterized_frame;
 
     Web::Compositor::AsyncScrollTree m_async_scroll_tree;
     ViewportScrollbarController m_viewport_scrollbar_controller;

--- a/Services/Compositor/ViewportScrollbarController.h
+++ b/Services/Compositor/ViewportScrollbarController.h
@@ -44,6 +44,7 @@ public:
     void set_scrollbars(Vector<Web::Compositor::ViewportScrollbar> const&);
 
     bool is_empty() const { return m_scrollbars.is_empty(); }
+    Vector<Web::Compositor::ViewportScrollbar> const& scrollbars() const { return m_scrollbars; }
     bool has_captured_scrollbar() const { return m_captured_scrollbar_index.has_value(); }
 
     Optional<size_t> hit_test(Web::Compositor::AsyncScrollTree const&, Web::Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position) const;

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -785,3 +785,77 @@ TEST_CASE(child_context_presents_repaint_the_parent)
     fixture.compositor_state->present_frame(child_context_id, child_viewport_rect);
     EXPECT_EQ(fixture.wait_for_frame(already_presented).damage_rect, fixture.viewport_rect);
 }
+
+TEST_CASE(async_scroll_presents_report_the_damage_of_the_scrolled_content)
+{
+    PresentingContextFixture fixture { { 100, 100 }, true };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto viewport_scroll_node_index = visual_context_tree.append_spatial(Web::Painting::ScrollData {}, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto nested_scroll_node_index = visual_context_tree.append_spatial(Web::Painting::ScrollData {}, viewport_scroll_node_index);
+    Web::UniqueNodeID document_id { 1 };
+
+    ByteBuffer command_bytes;
+    append_display_list_command(
+        command_bytes,
+        Web::Painting::CompositorScrollNode {
+            .document_id = document_id,
+            .scrollable_node_id = Web::UniqueNodeID { 2 },
+            .scroll_node_index = viewport_scroll_node_index,
+            .parent_scroll_node_index = Web::Painting::VISUAL_VIEWPORT_NODE_INDEX,
+            .scrollport_rect = { 0, 0, 100, 100 },
+            .min_scroll_offset = { 0, 0 },
+            .max_scroll_offset = { 0, 100 },
+            .scroll_node_kind = Web::Painting::CompositorScrollNodeKind::Viewport,
+            .pseudo_element_type = 0,
+            .is_viewport = true,
+            .can_be_wheel_scrolled_horizontally = false,
+            .can_be_wheel_scrolled_vertically = true,
+            .snaps_scroll_position_horizontally = false,
+            .snaps_scroll_position_vertically = false,
+        });
+    append_display_list_command(
+        command_bytes,
+        Web::Painting::CompositorScrollNode {
+            .document_id = document_id,
+            .scrollable_node_id = Web::UniqueNodeID { 3 },
+            .scroll_node_index = nested_scroll_node_index,
+            .parent_scroll_node_index = viewport_scroll_node_index,
+            .scrollport_rect = { 10, 10, 40, 40 },
+            .min_scroll_offset = { 0, 0 },
+            .max_scroll_offset = { 0, 100 },
+            .scroll_node_kind = Web::Painting::CompositorScrollNodeKind::Element,
+            .pseudo_element_type = 0,
+            .is_viewport = false,
+            .can_be_wheel_scrolled_horizontally = false,
+            .can_be_wheel_scrolled_vertically = true,
+            .snaps_scroll_position_horizontally = false,
+            .snaps_scroll_position_vertically = false,
+        });
+    append_display_list_command(
+        command_bytes,
+        Web::Painting::CompositorWheelHitTestTarget {
+            .document_id = document_id,
+            .target_scroll_node_index = nested_scroll_node_index,
+            .rect = { 10, 10, 40, 40 },
+        },
+        {},
+        in_spatial_node(viewport_scroll_node_index.value()));
+    Web::Painting::FillRect nested_content { { 10, 10, 40, 10 }, Gfx::Color::Red };
+    append_display_list_command(command_bytes, nested_content, nested_content.rect, in_spatial_node(nested_scroll_node_index.value()));
+    Web::Painting::FillRect viewport_content { { 60, 60, 10, 10 }, Gfx::Color::Green };
+    append_display_list_command(command_bytes, viewport_content, viewport_content.rect, in_spatial_node(viewport_scroll_node_index.value()));
+    fixture.install(decode_display_list(visual_context_tree, move(command_bytes), {}, Web::Painting::DisplayList::AsyncScrollingMetadata { .viewport_rect = { 0, 0, 100, 100 } }), visual_context_tree);
+    fixture.present();
+
+    auto already_presented = fixture.compositor_client.presented_frames.size();
+    EXPECT(fixture.compositor_state->async_scroll_by(fixture.context_id, { 20, 20 }, { 0, 5 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor));
+    auto nested_scroll_frame = fixture.wait_for_frame(already_presented);
+    EXPECT_EQ(nested_scroll_frame.content_rect, fixture.viewport_rect);
+    EXPECT_EQ(nested_scroll_frame.damage_rect, (Gfx::IntRect { 9, 4, 42, 17 }));
+
+    already_presented = fixture.compositor_client.presented_frames.size();
+    EXPECT(fixture.compositor_state->async_scroll_by(fixture.context_id, { 80, 80 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor));
+    auto viewport_scroll_frame = fixture.wait_for_frame(already_presented);
+    EXPECT_EQ(viewport_scroll_frame.content_rect, (Gfx::IntRect { 0, 10, 100, 100 }));
+    EXPECT_EQ(viewport_scroll_frame.damage_rect, fixture.viewport_rect);
+}

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -387,3 +387,401 @@ TEST_CASE(ui_overlay_hover_changes_require_repainting)
     EXPECT(!context.set_paused_debugger_overlay(true, 1.0, {}, WebView::PausedDebuggerOverlayAction::StepOver));
     EXPECT(context.set_paused_debugger_overlay(true, 1.0, {}, {}));
 }
+
+struct Fill {
+    Gfx::IntRect rect;
+    Gfx::Color color;
+    Web::Painting::ContextRef context {};
+    bool bounded { true };
+};
+
+static NonnullRefPtr<Web::Painting::DisplayList> make_fills_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Vector<Fill> const& fills, Optional<Gfx::Color> surface_clear_color = {}, Optional<Web::Painting::DisplayList::AsyncScrollingMetadata> async_scrolling_metadata = {})
+{
+    ByteBuffer command_bytes;
+    for (auto const& fill : fills) {
+        Web::Painting::FillRect command { fill.rect, fill.color };
+        append_display_list_command(command_bytes, command, fill.bounded ? Optional<Gfx::IntRect> { fill.rect } : Optional<Gfx::IntRect> {}, fill.context);
+    }
+    return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color, async_scrolling_metadata);
+}
+
+static Web::Painting::AccumulatedVisualContextTree make_translated_visual_context_tree(Gfx::FloatPoint translation)
+{
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto matrix = Gfx::translation_matrix(Gfx::FloatVector3 { translation.x(), translation.y(), 0 });
+    visual_context_tree.append_spatial(Web::Painting::TransformData { .matrix = matrix, .origin = {} }, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    return visual_context_tree;
+}
+
+static Web::Painting::ScrollStateSnapshot scroll_state_snapshot_with_offset(Web::Painting::SpatialNodeIndex index, Gfx::FloatPoint device_offset)
+{
+    Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
+    scroll_state_snapshot.set_device_offset_for_index(index, device_offset);
+    return scroll_state_snapshot;
+}
+
+static constexpr Web::Painting::ContextRef in_spatial_node(u32 index)
+{
+    return { Web::Painting::SpatialNodeIndex { index }, Web::Painting::NO_FRAME_NODE };
+}
+
+static Gfx::IntRect const test_viewport_rect { 0, 0, 16, 16 };
+
+struct PresentingContextFixture {
+    Core::EventLoop event_loop;
+    TestCompositorClient compositor_client;
+    TestWebContentClient web_content_client;
+    NonnullRefPtr<Compositor::CompositorState> compositor_state;
+    Web::Compositor::CompositorContextId context_id;
+    Gfx::IntRect viewport_rect;
+
+    explicit PresentingContextFixture(Gfx::IntSize viewport_size = test_viewport_rect.size(), bool async_scrolling_enabled = false)
+        : compositor_state(Compositor::CompositorState::create({}, async_scrolling_enabled))
+        , context_id(Web::Compositor::compositor_context_id_for_page(1))
+        , viewport_rect({}, viewport_size)
+    {
+        compositor_state->set_client(compositor_client);
+        compositor_state->create_context(context_id, 1, web_content_client);
+        compositor_state->viewport_size_updated(context_id, viewport_size, Web::Compositor::WindowResizingInProgress::No);
+        VERIFY(!compositor_client.allocated_bitmap_ids.is_empty());
+        release_all_buffers();
+    }
+
+    void release_all_buffers()
+    {
+        for (auto bitmap_id : compositor_client.allocated_bitmap_ids)
+            compositor_state->presented_bitmap_ready_to_paint(context_id, bitmap_id);
+    }
+
+    void install(NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Web::Painting::ScrollStateSnapshot scroll_state_snapshot = {})
+    {
+        compositor_state->update_display_list(context_id, move(display_list), visual_context_tree, {}, move(scroll_state_snapshot));
+    }
+
+    TestCompositorClient::PresentedFrame wait_for_frame(size_t already_presented)
+    {
+        VERIFY(spin_event_loop_until(event_loop, 2000, [&] { return compositor_client.presented_frames.size() > already_presented; }));
+        release_all_buffers();
+        return compositor_client.presented_frames.last();
+    }
+
+    bool presents_another_frame(size_t already_presented)
+    {
+        return spin_event_loop_until(event_loop, 100, [&] { return compositor_client.presented_frames.size() > already_presented; });
+    }
+
+    TestCompositorClient::PresentedFrame present(Optional<Gfx::IntRect> rect = {})
+    {
+        auto already_presented = compositor_client.presented_frames.size();
+        compositor_state->present_frame(context_id, rect.value_or(viewport_rect), {});
+        return wait_for_frame(already_presented);
+    }
+};
+
+struct RasterizingContextFixture {
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context;
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    Gfx::IntRect viewport_rect;
+
+    explicit RasterizingContextFixture(Gfx::IntSize viewport_size = test_viewport_rect.size())
+        : context(1, client, canvas_surface_registry, false)
+        , viewport_rect({}, viewport_size)
+    {
+        context.viewport_size_updated(viewport_size, Web::Compositor::WindowResizingInProgress::No);
+        auto publication = context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed);
+        VERIFY(publication.has_value());
+        VERIFY(context.acknowledge_presented_bitmap(publication->bitmap_ids[0]));
+    }
+
+    Optional<Compositor::ContextState::PreparedFrame> prepare(Gfx::IntRect forced_damage_rect = {})
+    {
+        return context.prepare_frame(display_list_player, { viewport_rect, forced_damage_rect }, nullptr);
+    }
+
+    void finish(Compositor::ContextState::PreparedFrame const& prepared_frame)
+    {
+        display_list_player.flush(*prepared_frame.rendered_surface);
+        context.did_submit_prepared_frame(viewport_rect);
+        context.did_finish_gpu_present(prepared_frame.bitmap_id);
+        VERIFY(context.acknowledge_presented_bitmap(prepared_frame.bitmap_id));
+    }
+
+    Gfx::IntRect rasterize(Gfx::IntRect forced_damage_rect = {})
+    {
+        auto prepared_frame = prepare(forced_damage_rect);
+        VERIFY(prepared_frame.has_value());
+        finish(*prepared_frame);
+        return prepared_frame->damage_rect;
+    }
+
+    Gfx::Color pixel(int x, int y)
+    {
+        return context.latest_rendered_surface()->snapshot_bitmap()->get_pixel(x, y);
+    }
+};
+
+TEST_CASE(re_presenting_identical_state_reports_empty_damage)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+
+    auto first_frame = fixture.present();
+    EXPECT_EQ(first_frame.damage_rect, fixture.viewport_rect);
+    EXPECT_EQ(first_frame.content_rect, fixture.viewport_rect);
+
+    EXPECT(fixture.present().damage_rect.is_empty());
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    EXPECT(fixture.present().damage_rect.is_empty());
+}
+
+TEST_CASE(changed_command_reports_its_inflated_rect)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue } }), visual_context_tree);
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 6, 6 }));
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 8, 8, 4, 4 }, Gfx::Color::Blue } }), visual_context_tree);
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 12, 12 }));
+}
+
+TEST_CASE(changed_command_is_repainted_within_its_damage)
+{
+    RasterizingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }, Gfx::Color::Green), visual_context_tree, {});
+    EXPECT_EQ(fixture.rasterize(), fixture.viewport_rect);
+    EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Red);
+    EXPECT_EQ(fixture.pixel(0, 0), Gfx::Color::Green);
+
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue } }, Gfx::Color::Green), visual_context_tree, {});
+    EXPECT_EQ(fixture.rasterize(), (Gfx::IntRect { 1, 1, 6, 6 }));
+    EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Blue);
+    EXPECT_EQ(fixture.pixel(0, 0), Gfx::Color::Green);
+}
+
+TEST_CASE(scroll_state_only_update_damages_only_moved_commands)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    Web::Painting::SpatialNodeIndex scroll_node_index { 1 };
+    auto display_list = make_fills_display_list(visual_context_tree, {
+                                                                         { { 0, 0, 4, 4 }, Gfx::Color::Green },
+                                                                         { { 0, 8, 4, 2 }, Gfx::Color::Red, in_spatial_node(1) },
+                                                                     });
+    fixture.install(display_list, visual_context_tree, scroll_state_snapshot_with_offset(scroll_node_index, { 0, 0 }));
+    fixture.present();
+
+    fixture.compositor_state->update_scroll_state(fixture.context_id, scroll_state_snapshot_with_offset(scroll_node_index, { 0, -2 }));
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 0, 5, 5, 6 }));
+}
+
+TEST_CASE(tree_only_update_damages_transformed_commands)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = make_translated_visual_context_tree({ 0, 0 });
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red, in_spatial_node(1) } }), visual_context_tree);
+    fixture.present();
+
+    auto translated_tree = make_translated_visual_context_tree({ 4, 0 });
+    translated_tree.reuse_version_from(visual_context_tree);
+    fixture.compositor_state->update_visual_context_tree(fixture.context_id, translated_tree);
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 10, 6 }));
+
+    fixture.compositor_state->update_visual_context_tree(fixture.context_id, make_translated_visual_context_tree({ 8, 0 }));
+    EXPECT(fixture.present().damage_rect.is_empty());
+}
+
+TEST_CASE(surface_clear_color_change_forces_full_damage)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }, Gfx::Color::Green), visual_context_tree);
+    fixture.present();
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }, Gfx::Color::Blue), visual_context_tree);
+    EXPECT_EQ(fixture.present().damage_rect, fixture.viewport_rect);
+}
+
+TEST_CASE(surface_clear_color_change_repaints_the_background)
+{
+    RasterizingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }, Gfx::Color::Green), visual_context_tree, {});
+    fixture.rasterize();
+    EXPECT_EQ(fixture.pixel(0, 0), Gfx::Color::Green);
+
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }, Gfx::Color::Blue), visual_context_tree, {});
+    EXPECT_EQ(fixture.rasterize(), fixture.viewport_rect);
+    EXPECT_EQ(fixture.pixel(0, 0), Gfx::Color::Blue);
+    EXPECT_EQ(fixture.pixel(3, 3), Gfx::Color::Red);
+}
+
+TEST_CASE(viewport_size_change_forces_full_damage)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    Gfx::IntRect resized_viewport_rect { 0, 0, 20, 20 };
+    auto already_presented = fixture.compositor_client.presented_frames.size();
+    fixture.compositor_state->viewport_size_updated(fixture.context_id, resized_viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    fixture.compositor_state->present_frame(fixture.context_id, resized_viewport_rect, {});
+    auto frame = fixture.wait_for_frame(already_presented);
+    EXPECT_EQ(frame.content_rect, resized_viewport_rect);
+    EXPECT_EQ(frame.damage_rect, resized_viewport_rect);
+}
+
+TEST_CASE(viewport_location_change_reports_only_the_diff)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    Gfx::IntRect moved_viewport_rect { 0, 4, 16, 16 };
+    auto frame = fixture.present(moved_viewport_rect);
+    EXPECT_EQ(frame.content_rect, moved_viewport_rect);
+    EXPECT(frame.damage_rect.is_empty());
+}
+
+TEST_CASE(screenshot_between_presents_does_not_advance_the_baseline)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue } }), visual_context_tree);
+    auto bitmap = MUST(Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, fixture.viewport_rect.size()));
+    Gfx::ShareableBitmap target_bitmap { bitmap, Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
+    EXPECT(fixture.compositor_state->request_screenshot(fixture.context_id, target_bitmap));
+    EXPECT_EQ(bitmap->get_pixel(3, 3), Gfx::Color::Blue);
+
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 6, 6 }));
+}
+
+TEST_CASE(blocked_present_does_not_advance_the_baseline)
+{
+    RasterizingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree, {});
+    auto first_frame = fixture.prepare();
+    VERIFY(first_frame.has_value());
+    EXPECT_EQ(first_frame->damage_rect, fixture.viewport_rect);
+    fixture.display_list_player.flush(*first_frame->rendered_surface);
+    fixture.context.did_submit_prepared_frame(fixture.viewport_rect);
+
+    fixture.context.install_display_list_update(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue } }), visual_context_tree, {});
+    EXPECT(!fixture.prepare().has_value());
+    EXPECT(fixture.context.pending_present_frame_viewport_rect().has_value());
+
+    fixture.context.did_finish_gpu_present(first_frame->bitmap_id);
+    VERIFY(fixture.context.acknowledge_presented_bitmap(first_frame->bitmap_id));
+    EXPECT_EQ(fixture.rasterize(), (Gfx::IntRect { 1, 1, 6, 6 }));
+}
+
+TEST_CASE(updates_between_rasters_are_diffed_against_the_last_rasterized_frame)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    auto already_presented = fixture.compositor_client.presented_frames.size();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red }, { { 10, 10, 4, 4 }, Gfx::Color::Green } }), visual_context_tree);
+    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect, {});
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue }, { { 10, 10, 4, 4 }, Gfx::Color::Green } }), visual_context_tree);
+    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect, {});
+
+    auto frame = fixture.wait_for_frame(already_presented);
+    EXPECT(!fixture.presents_another_frame(already_presented + 1));
+    EXPECT_EQ(frame.damage_rect, (Gfx::IntRect { 1, 1, 14, 14 }));
+}
+
+TEST_CASE(unbounded_change_reports_full_damage)
+{
+    PresentingContextFixture fixture;
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red } }), visual_context_tree);
+    fixture.present();
+
+    fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red, {}, false } }), visual_context_tree);
+    EXPECT_EQ(fixture.present().damage_rect, fixture.viewport_rect);
+}
+
+TEST_CASE(canvas_content_changes_damage_the_canvas_rect)
+{
+    PresentingContextFixture fixture;
+    auto& canvas_surface_registry = fixture.compositor_state->canvas_surface_registry();
+    auto make_canvas_surface = [] { return Gfx::PaintingSurface::create_with_size({ 4, 4 }, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied); };
+    auto canvas_id = canvas_surface_registry.create_canvas_surface(make_canvas_surface());
+
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    ByteBuffer command_bytes;
+    Web::Painting::DrawCanvas draw_canvas {
+        .dst_rect = { 4, 4, 4, 4 },
+        .canvas_id = canvas_id,
+        .content_generation = 1,
+        .scaling_mode = Gfx::ScalingMode::NearestNeighbor,
+    };
+    append_display_list_command(command_bytes, draw_canvas, draw_canvas.dst_rect);
+    fixture.install(decode_display_list(visual_context_tree, move(command_bytes)), visual_context_tree);
+    fixture.present();
+    EXPECT(fixture.present().damage_rect.is_empty());
+
+    canvas_surface_registry.set_canvas_surface(canvas_id, make_canvas_surface());
+    EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 3, 3, 6, 6 }));
+    EXPECT(fixture.present().damage_rect.is_empty());
+}
+
+TEST_CASE(compositor_initiated_presents_request_full_damage)
+{
+    PresentingContextFixture fixture { { 100, 100 }, true };
+    auto visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    fixture.install(make_scrollable_viewport_display_list(visual_context_tree), visual_context_tree);
+    fixture.present();
+
+    auto already_presented = fixture.compositor_client.presented_frames.size();
+    EXPECT(fixture.compositor_state->handle_mouse_event(fixture.context_id, mouse_event(Web::MouseEvent::Type::MouseMove, 98, 10)));
+    EXPECT_EQ(fixture.wait_for_frame(already_presented).damage_rect, fixture.viewport_rect);
+}
+
+TEST_CASE(child_context_presents_repaint_the_parent)
+{
+    PresentingContextFixture fixture;
+    Web::Compositor::CompositorContextId child_context_id { 2 };
+    fixture.compositor_state->create_context(child_context_id, {}, fixture.web_content_client);
+    fixture.compositor_state->set_parent_context(child_context_id, fixture.context_id);
+    fixture.compositor_state->viewport_size_updated(child_context_id, { 8, 8 }, Web::Compositor::WindowResizingInProgress::No);
+
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    ByteBuffer command_bytes;
+    Web::Painting::DrawCompositedContext draw_composited_context {
+        .dst_rect = { 4, 4, 8, 8 },
+        .child_context_id = child_context_id,
+        .scaling_mode = Gfx::ScalingMode::NearestNeighbor,
+    };
+    append_display_list_command(command_bytes, draw_composited_context, draw_composited_context.dst_rect);
+    fixture.install(decode_display_list(visual_context_tree, move(command_bytes)), visual_context_tree);
+
+    auto child_visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    Gfx::IntRect child_viewport_rect { 0, 0, 8, 8 };
+    fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Red } }), child_visual_context_tree, {}, {});
+    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect, {});
+    fixture.present();
+    EXPECT(fixture.present().damage_rect.is_empty());
+
+    fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Blue } }), child_visual_context_tree, {}, {});
+    auto already_presented = fixture.compositor_client.presented_frames.size();
+    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect, {});
+    EXPECT_EQ(fixture.wait_for_frame(already_presented).damage_rect, fixture.viewport_rect);
+}

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -296,8 +296,8 @@ TEST_CASE(hidden_context_coalesces_presents_and_presents_once_when_shown)
     compositor_state->update_display_list(context_id, make_display_list(visual_context_tree, Gfx::Color::Red), visual_context_tree, {}, {});
 
     compositor_state->set_context_visibility(context_id, Web::Compositor::ContextVisibility::Hidden);
-    compositor_state->present_frame(context_id, viewport_rect, { 0, 0, 2, 2 });
-    compositor_state->present_frame(context_id, viewport_rect, { 2, 2, 2, 2 });
+    compositor_state->present_frame(context_id, viewport_rect);
+    compositor_state->present_frame(context_id, viewport_rect);
     compositor_state->presented_bitmap_ready_to_paint(context_id, compositor_client.allocated_bitmap_ids[0]);
     EXPECT(!spin_event_loop_until(event_loop, 100, [&] { return !compositor_client.presented_frames.is_empty(); }));
 
@@ -473,7 +473,7 @@ struct PresentingContextFixture {
     TestCompositorClient::PresentedFrame present(Optional<Gfx::IntRect> rect = {})
     {
         auto already_presented = compositor_client.presented_frames.size();
-        compositor_state->present_frame(context_id, rect.value_or(viewport_rect), {});
+        compositor_state->present_frame(context_id, rect.value_or(viewport_rect));
         return wait_for_frame(already_presented);
     }
 };
@@ -634,7 +634,7 @@ TEST_CASE(viewport_size_change_forces_full_damage)
     Gfx::IntRect resized_viewport_rect { 0, 0, 20, 20 };
     auto already_presented = fixture.compositor_client.presented_frames.size();
     fixture.compositor_state->viewport_size_updated(fixture.context_id, resized_viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
-    fixture.compositor_state->present_frame(fixture.context_id, resized_viewport_rect, {});
+    fixture.compositor_state->present_frame(fixture.context_id, resized_viewport_rect);
     auto frame = fixture.wait_for_frame(already_presented);
     EXPECT_EQ(frame.content_rect, resized_viewport_rect);
     EXPECT_EQ(frame.damage_rect, resized_viewport_rect);
@@ -698,9 +698,9 @@ TEST_CASE(updates_between_rasters_are_diffed_against_the_last_rasterized_frame)
 
     auto already_presented = fixture.compositor_client.presented_frames.size();
     fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red }, { { 10, 10, 4, 4 }, Gfx::Color::Green } }), visual_context_tree);
-    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect, {});
+    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect);
     fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Blue }, { { 10, 10, 4, 4 }, Gfx::Color::Green } }), visual_context_tree);
-    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect, {});
+    fixture.compositor_state->present_frame(fixture.context_id, fixture.viewport_rect);
 
     auto frame = fixture.wait_for_frame(already_presented);
     EXPECT(!fixture.presents_another_frame(already_presented + 1));
@@ -776,12 +776,12 @@ TEST_CASE(child_context_presents_repaint_the_parent)
     auto child_visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
     Gfx::IntRect child_viewport_rect { 0, 0, 8, 8 };
     fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Red } }), child_visual_context_tree, {}, {});
-    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect, {});
+    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect);
     fixture.present();
     EXPECT(fixture.present().damage_rect.is_empty());
 
     fixture.compositor_state->update_display_list(child_context_id, make_fills_display_list(child_visual_context_tree, { { child_viewport_rect, Gfx::Color::Blue } }), child_visual_context_tree, {}, {});
     auto already_presented = fixture.compositor_client.presented_frames.size();
-    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect, {});
+    fixture.compositor_state->present_frame(child_context_id, child_viewport_rect);
     EXPECT_EQ(fixture.wait_for_frame(already_presented).damage_rect, fixture.viewport_rect);
 }


### PR DESCRIPTION
Damage was computed in WebContent by diffing a new recording against copies of the last display list, visual context tree and scroll snapshot it had sent, but only the compositor knows what is actually on screen: async scrolling and pinch change the scroll offsets and the visual viewport transform after the fact, presents get coalesced, deferred or dropped, and canvas content reaches the compositor through the surface registry without any recording. Every present WebContent could not diff, which was all tree-only and scroll-only updates, canvas frames and every compositor-initiated present, repainted the whole viewport, and main-thread presents had to become full repaints whenever async scroll offsets were pending. Diffing right before rasterization against what was last rasterized makes each frame's damage exact by construction, at under a millisecond per frame on the heaviest pages, and lets WebContent stop keeping copies of what it sent.