### PR TITLE
LibWeb: Fetch preload=none media after explicit load

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -370,7 +370,7 @@ void HTMLMediaElement::adopted_from(DOM::Document& old_document)
             main_thread_event_loop().task_queue().remove_tasks_matching([&](auto const& task) {
                 return task.source() == media_element_event_task_source();
             });
-            select_resource();
+            select_resource_for_current_load();
         }
     }
 
@@ -499,6 +499,10 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load()
 {
     // When the load() method on a media element is invoked, the user agent must run the media element load algorithm.
     TRY(load_element());
+
+    // INTEROP: This is not specified, but matches Chromium and Firefox. An explicit load() call requests that the
+    //          pending resource selection start fetching even if preload=none.
+    promote_current_resource_selection_to_explicit();
     return {};
 }
 
@@ -1084,6 +1088,12 @@ void HTMLMediaElement::children_changed(ChildrenChangedMetadata const& metadata)
 // https://html.spec.whatwg.org/multipage/media.html#concept-media-load-algorithm
 void HTMLMediaElement::select_resource()
 {
+    m_current_resource_selection_is_explicit = false;
+    select_resource_for_current_load();
+}
+
+void HTMLMediaElement::select_resource_for_current_load()
+{
     // 1. Set the element's networkState attribute to the NETWORK_NO_SOURCE value.
     m_network_state = NetworkState::NoSource;
 
@@ -1319,6 +1329,11 @@ bool HTMLMediaElement::preload_attribute_is_in_none_state() const
 
 bool HTMLMediaElement::should_wait_for_an_implementation_defined_event_before_fetching_the_resource() const
 {
+    // INTEROP: This is not specified, but matches Chromium and Firefox. An explicit load() call requests that loading
+    //          start, so do not run the optional preload=none deferral steps.
+    if (m_current_resource_selection_is_explicit)
+        return false;
+
     if (!preload_attribute_is_in_none_state())
         return false;
 
@@ -1329,6 +1344,11 @@ bool HTMLMediaElement::should_wait_for_an_implementation_defined_event_before_fe
         return false;
 
     return true;
+}
+
+void HTMLMediaElement::promote_current_resource_selection_to_explicit()
+{
+    m_current_resource_selection_is_explicit = true;
 }
 
 void HTMLMediaElement::wait_for_an_implementation_defined_event_before_fetching_the_resource(u32 fetch_generation)

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -224,6 +224,8 @@ private:
     void set_assigned_media_provider_object(MediaProviderObject const&);
 
     WebIDL::ExceptionOr<void> load_element();
+    void select_resource_for_current_load();
+    void promote_current_resource_selection_to_explicit();
 
     void load_url_resource(URL::URL const&, ESCAPING Function<void(Utf16String)> failure_callback);
     void load_remote_resource(ByteRange const&);
@@ -419,6 +421,7 @@ private:
     OwnPtr<RemoteFetchData> m_remote_fetch_data;
     u32 m_current_fetch_generation { 0 };
     bool m_waiting_for_an_implementation_defined_event_to_fetch_the_resource { false };
+    bool m_current_resource_selection_is_explicit { false };
 
     OwnPtr<Media::PlaybackManager> m_playback_manager;
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -26,6 +26,7 @@ Text/input/HTML/media-source-mp4-reordered-frames.html
 Text/input/HTML/media-source-remove.html
 Text/input/HTML/media-source-setup.html
 Text/input/HTML/media-source-split-ignored-element.html
+Text/input/HTML/HTMLMediaElement-load-overrides-preload-none.html
 Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-load-overrides-preload-none.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-load-overrides-preload-none.txt
@@ -1,0 +1,3 @@
+source error event fired after load() call
+server saw media request after load() call: true
+server saw media request after automatic load: false

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-load-overrides-preload-none.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-load-overrides-preload-none.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const mediaPath = `/echo/HTMLMediaElement-load-overrides-preload-none-${crypto.randomUUID()}.mp3`;
+    const automaticMediaPath = `/echo/HTMLMediaElement-automatic-load-honors-preload-none-${crypto.randomUUID()}.mp3`;
+    document.write(`<audio id="audio" preload="none"><source id="source" type="audio/mpeg"></audio>`);
+
+    asyncTest(done => {
+        window.addEventListener("load", async () => {
+            source.src = mediaPath;
+
+            const sourceErrorPromise = new Promise(resolve => {
+                source.addEventListener("error", resolve, { once: true });
+            });
+            audio.load();
+            await sourceErrorPromise;
+
+            println("source error event fired after load() call");
+            const response = await fetch(`/recorded-request-headers${mediaPath}`);
+            println(`server saw media request after load() call: ${response.status === 200}`);
+
+            const suspendPromise = new Promise(resolve => {
+                audio.addEventListener("suspend", resolve, { once: true });
+            });
+            audio.src = automaticMediaPath;
+            await suspendPromise;
+
+            const automaticResponse = await fetch(`/recorded-request-headers${automaticMediaPath}`);
+            println(`server saw media request after automatic load: ${automaticResponse.status === 200}`);
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
`HTMLMediaElement.load()` restarted resource selection but still honored the optional `preload="none"` fetch deferral. Media players that wait for `canplay` before calling `play()` could therefore wait indefinitely without issuing a media request.

Treat an explicit `load()` call as the implementation-defined request that ends this deferral, and carry that intent through queued resource selection and document adoption. Automatic resource selection continues to honor `preload="none"`.

Add request-recording coverage for setting a `<source>` and explicitly calling `load()`.