### PR TITLE
LibWeb: Match IntersectionObserver threshold state behavior

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6718,6 +6718,8 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
             // isIntersecting be false.
             bool is_intersecting = false;
 
+            bool intersection_geometry_intersects = false;
+
             // targetRect be a DOMRectReadOnly with x, y, width, and height set to 0.
             CSSPixelRect target_rect { 0, 0, 0, 0 };
 
@@ -6750,20 +6752,20 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
 
                 // 8. Let isIntersecting be true if targetRect and rootBounds intersect or are edge-adjacent, even if the
                 //    intersection has zero area (because rootBounds or targetRect have zero area).
-                is_intersecting = target_rect.edge_adjacent_intersects(root_bounds);
+                intersection_geometry_intersects = target_rect.edge_adjacent_intersects(root_bounds);
 
                 // 9. If targetArea is non-zero, let intersectionRatio be intersectionArea divided by targetArea.
                 //    Otherwise, let intersectionRatio be 1 if isIntersecting is true, or 0 if isIntersecting is false.
                 if (target_area != 0.0)
                     intersection_ratio = (intersection_area / target_area).to_double();
                 else
-                    intersection_ratio = is_intersecting ? 1.0 : 0.0;
+                    intersection_ratio = intersection_geometry_intersects ? 1.0 : 0.0;
 
                 // 10. Set thresholdIndex to the index of the first entry in observer.thresholds whose value is greater
                 //     than intersectionRatio, or the length of observer.thresholds if intersectionRatio is greater than
                 //     or equal to the last entry in observer.thresholds.
                 // NB: Thresholds are sorted in ascending order, so we use binary search.
-                {
+                if (intersection_geometry_intersects) {
                     auto const& thresholds = observer->thresholds();
                     size_t lo = 0;
                     size_t hi = thresholds.size();
@@ -6776,6 +6778,10 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
                     }
                     threshold_index = lo;
                 }
+
+                // INTEROP: All other engines report isIntersecting as false when the intersection ratio is below the
+                //          first threshold. See https://github.com/w3c/IntersectionObserver/issues/432.
+                is_intersecting = threshold_index > 0;
             }
 
             // 11. Let intersectionObserverRegistration be the IntersectionObserverRegistration record in target’s

--- a/Tests/LibWeb/Text/expected/IntersectionObserver/is-intersecting-respects-threshold.txt
+++ b/Tests/LibWeb/Text/expected/IntersectionObserver/is-intersecting-respects-threshold.txt
@@ -1,0 +1,2 @@
+isIntersecting=false ratio=0.99
+isIntersecting=true ratio=1

--- a/Tests/LibWeb/Text/input/IntersectionObserver/is-intersecting-respects-threshold.html
+++ b/Tests/LibWeb/Text/input/IntersectionObserver/is-intersecting-respects-threshold.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #root {
+        width: 200px;
+        height: 200px;
+    }
+
+    #target {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="root"><div id="target"></div></div>
+<script>
+    asyncTest(done => {
+        const root = document.getElementById("root");
+        const target = document.getElementById("target");
+        const observer = new IntersectionObserver(entries => {
+            const entry = entries[0];
+            println(`isIntersecting=${entry.isIntersecting} ratio=${entry.intersectionRatio}`);
+
+            if (entry.intersectionRatio < 1) {
+                target.style.transform = "translateY(1px)";
+                return;
+            }
+
+            done();
+        }, {
+            root,
+            rootMargin: "-1px 0px -1px 0px",
+            threshold: [1],
+        });
+        observer.observe(target);
+    });
+</script>


### PR DESCRIPTION
Report `isIntersecting` as false when the intersection ratio does not reach the observer's first threshold. This matches Blink, WebKit, and Gecko's interoperable behavior for w3c/IntersectionObserver#432 and prevents partially intersecting targets from transitioning early.

Add coverage for a target moving from a 0.99 ratio to the configured threshold.

This fixes an issue on https://azure.com/ where the nav bar ("Featured news", "Events", etc) was snapping into its fixed pill mode too early.

Before:

<img width="1119" height="983" alt="Screenshot 2026-08-30 at 16 05 00" src="https://github.com/user-attachments/assets/c7785fef-3d19-4ced-9f6d-bf21309822b5" />

After:

<img width="1119" height="983" alt="Screenshot 2026-08-30 at 16 06 52" src="https://github.com/user-attachments/assets/38dd06fa-422f-4597-9775-12b6f1178656" />
