### PR TITLE
LibWeb: Keep replaced cascade entries in winning order

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -242,24 +242,41 @@ impl CascadedPropertyStore {
         // The chain runs newest first, so this walks it exactly as scanning a property's entries in
         // reverse did.
         let head = last_entry_index.entry(property_id).or_insert(NO_ENTRY);
+        let mut previous = NO_ENTRY;
         let mut current = *head;
         while current != NO_ENTRY {
-            let entry = &mut arena[current as usize];
-            if entry.origin == origin
-                && entry.layer_name.equals(&layer_name)
-                && entry.source_shadow_root_identity == source_shadow_root_identity
-            {
-                if entry.important && !important {
+            let entry_matches = {
+                let entry = &arena[current as usize];
+                entry.origin == origin
+                    && entry.layer_name.equals(&layer_name)
+                    && entry.source_shadow_root_identity == source_shadow_root_identity
+            };
+            if entry_matches {
+                if arena[current as usize].important && !important {
                     return -1;
                 }
-                entry.value = value;
-                entry.dependencies.set(None);
-                entry.has_style_sheet_context = has_style_sheet_context;
-                entry.important = important;
-                entry.cascade_index = cascade_index;
-                return entry.source_slot as i64;
+                let previous_for_property = arena[current as usize].previous_for_property;
+                let source_slot = {
+                    let entry = &mut arena[current as usize];
+                    entry.value = value;
+                    entry.dependencies.set(None);
+                    entry.has_style_sheet_context = has_style_sheet_context;
+                    entry.important = important;
+                    entry.cascade_index = cascade_index;
+                    entry.source_slot
+                };
+                // This declaration was applied after the current head, so make it the newest entry
+                // even when it reused the same cascade origin, layer, and shadow context.
+                if previous != NO_ENTRY {
+                    arena[previous as usize].previous_for_property = previous_for_property;
+                    arena[current as usize].previous_for_property = *head;
+                    *head = current;
+                }
+                return source_slot as i64;
             }
-            current = entry.previous_for_property;
+            let next = arena[current as usize].previous_for_property;
+            previous = current;
+            current = next;
         }
 
         let source_slot = free_source_slots.pop().unwrap_or_else(|| {

--- a/Tests/LibWeb/Text/expected/css/shadow-host-cascade-context.txt
+++ b/Tests/LibWeb/Text/expected/css/shadow-host-cascade-context.txt
@@ -10,3 +10,4 @@ normal inline vs host: 1px
 important inline vs host: 2px
 revert-layer preserves shadow host context: rgb(255, 0, 0)
 revert-layer preserves slotted host context: 7px
+important slotted after normal: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/shadow-host-cascade-context.html
+++ b/Tests/LibWeb/Text/input/css/shadow-host-cascade-context.html
@@ -11,6 +11,10 @@
     .revert-layer-outer {
         color: revert-layer;
     }
+
+    #important-slotted-target {
+        color: blue;
+    }
 </style>
 <script>
     test(() => {
@@ -224,5 +228,33 @@
 
         const revertLayerSlottedStyle = getComputedStyle(revertLayerSlottedElement);
         println(`revert-layer preserves slotted host context: ${revertLayerSlottedStyle.marginLeft}`);
+
+        class ImportantSlottedCascadeContextElement extends HTMLElement {
+            constructor() {
+                super();
+                const shadowRoot = this.attachShadow({ mode: "open" });
+                shadowRoot.innerHTML = `
+                    <style>
+                        ::slotted(a) {
+                            color: red;
+                        }
+
+                        :host ::slotted(a) {
+                            color: green !important;
+                        }
+                    </style>
+                    <slot></slot>
+                `;
+            }
+        }
+        customElements.define("important-slotted-cascade-context", ImportantSlottedCascadeContextElement);
+
+        const importantSlottedHost = document.createElement("important-slotted-cascade-context");
+        const importantSlottedTarget = document.createElement("a");
+        importantSlottedTarget.id = "important-slotted-target";
+        importantSlottedHost.appendChild(importantSlottedTarget);
+        document.body.appendChild(importantSlottedHost);
+
+        println(`important slotted after normal: ${getComputedStyle(importantSlottedTarget).color}`);
     });
 </script>


### PR DESCRIPTION
Relink a reused cascaded property entry when a later declaration replaces it. Updating an older entry in place left an intervening encapsulation context at the head of the winner chain, even when the replacement was important.

Cover normal and important slotted declarations competing with an outer document declaration.

Fixes a bad banner link color on https://azure.com/

Before:

<img width="308" height="36" alt="image" src="https://github.com/user-attachments/assets/61bac95a-a2f3-4ad8-b45a-c2c85c9a956f" />

After:

<img width="308" height="38" alt="image" src="https://github.com/user-attachments/assets/79c6cb0f-8569-435b-a5aa-47a3738b6155" />
