### PR TITLE
LibHTTP: Cache permanent redirects heuristically

### DIFF
--- a/Libraries/LibHTTP/Cache/Utilities.cpp
+++ b/Libraries/LibHTTP/Cache/Utilities.cpp
@@ -431,8 +431,15 @@ AK::Duration calculate_freshness_lifetime(u32 status_code, HeaderList const& hea
         heuristics_allowed = true;
     }
 
-    if (heuristics_allowed)
+    if (heuristics_allowed) {
+        // INTEROP: Chromium treats 301 and 308 responses without explicit freshness as indefinitely fresh, while
+        //          WebKit assigns 301 responses a one-year lifetime. Use the more conservative one-year lifetime for
+        //          both permanent redirect status codes.
+        if (status_code == 301 || status_code == 308)
+            return AK::Duration::from_seconds(365 * 24 * 60 * 60);
+
         return calculate_heuristic_freshness_lifetime(headers, current_time_offset_for_testing);
+    }
 
     // No explicit expiration time, and heuristics not allowed or not applicable.
     return {};

--- a/Tests/LibHTTP/TestCacheUtilities.cpp
+++ b/Tests/LibHTTP/TestCacheUtilities.cpp
@@ -43,3 +43,19 @@ TEST_CASE(is_cacheable_must_understand_accepts_304_status)
     auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, no-store, max-age=3600" } });
     EXPECT(HTTP::is_cacheable(304, *headers));
 }
+
+TEST_CASE(permanent_redirects_have_a_long_heuristic_freshness_lifetime)
+{
+    auto headers = HTTP::HeaderList::create();
+    auto one_year = AK::Duration::from_seconds(365 * 24 * 60 * 60);
+
+    EXPECT_EQ(HTTP::calculate_freshness_lifetime(301, *headers), one_year);
+    EXPECT_EQ(HTTP::calculate_freshness_lifetime(308, *headers), one_year);
+    EXPECT_EQ(HTTP::calculate_freshness_lifetime(302, *headers), AK::Duration {});
+}
+
+TEST_CASE(explicit_freshness_overrides_permanent_redirect_heuristic)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "max-age=42" } });
+    EXPECT_EQ(HTTP::calculate_freshness_lifetime(301, *headers), AK::Duration::from_seconds(42));
+}

--- a/Tests/LibHTTP/TestMemoryCache.cpp
+++ b/Tests/LibHTTP/TestMemoryCache.cpp
@@ -117,3 +117,36 @@ TEST_CASE(javascript_bytecode_cache_can_be_added_after_memory_cache_entry_is_com
     EXPECT_EQ(entry->javascript_bytecode_cache->bytes(), bytecode.bytes());
     EXPECT_EQ(entry->javascript_bytecode_cache_vary_key, Optional<u64> { 0 });
 }
+
+TEST_CASE(permanent_redirects_without_explicit_freshness_are_reused)
+{
+    for (auto status_code : Array<u32, 2> { 301, 308 }) {
+        auto cache = HTTP::MemoryCache::create();
+        auto url = parse_url(MUST(String::formatted("https://example.com/redirect/{}", status_code)));
+        auto request_headers = create_cacheable_request_headers();
+        auto response_headers = HTTP::HeaderList::create({ { "Location"sv, "https://example.com/target"sv } });
+
+        cache->create_entry(url, "GET"sv, *request_headers, UnixDateTime::now(), status_code, "Permanent Redirect"sv, *response_headers);
+        cache->finalize_entry(url, "GET"sv, *request_headers, status_code, *response_headers, immutable_bytes({}));
+
+        auto entry = cache->open_entry(url, "GET"sv, *request_headers, HTTP::CacheMode::Default);
+        VERIFY(entry.has_value());
+        EXPECT_EQ(entry->status_code, status_code);
+    }
+}
+
+TEST_CASE(no_store_permanent_redirects_are_not_reused)
+{
+    auto cache = HTTP::MemoryCache::create();
+    auto url = parse_url("https://example.com/redirect"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = HTTP::HeaderList::create({
+        { "Cache-Control"sv, "no-store"sv },
+        { "Location"sv, "https://example.com/target"sv },
+    });
+
+    cache->create_entry(url, "GET"sv, *request_headers, UnixDateTime::now(), 301, "Moved Permanently"sv, *response_headers);
+    cache->finalize_entry(url, "GET"sv, *request_headers, 301, *response_headers, immutable_bytes({}));
+
+    EXPECT(!cache->open_entry(url, "GET"sv, *request_headers, HTTP::CacheMode::Default).has_value());
+}


### PR DESCRIPTION
Assign a one-year heuristic freshness lifetime to 301 and 308 responses when the server omits explicit expiration, while keeping explicit freshness and `no-store` directives authoritative.

This allows repeated navigations to reuse permanent redirects such as `azure.com` → `azure.microsoft.com/en-us/`. In a live trace, this avoided a redirect request that took 327 ms. Add coverage for permanent redirects, explicit `max-age`, and `no-store` behavior.