### PR TITLE
LibWeb+Compositor: Harden animation and input state handling

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -151,6 +151,35 @@ WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations_inter
     return relevant_animations;
 }
 
+ReadonlySpan<GC::Ref<Animation>> Animatable::associated_animations_in_composite_order()
+{
+    if (!m_impl)
+        return {};
+
+    if (!m_impl->is_sorted_by_composite_order) {
+        quick_sort(m_impl->associated_animations, [](auto const& a, auto const& b) {
+            auto a_effect = a->effect();
+            auto b_effect = b->effect();
+            bool a_is_keyframe_effect = a_effect && is<KeyframeEffect>(*a_effect);
+            bool b_is_keyframe_effect = b_effect && is<KeyframeEffect>(*b_effect);
+            if (a_is_keyframe_effect && b_is_keyframe_effect)
+                return KeyframeEffect::composite_order(static_cast<KeyframeEffect&>(*a_effect), static_cast<KeyframeEffect&>(*b_effect)) < 0;
+            if (a_is_keyframe_effect != b_is_keyframe_effect)
+                return !a_is_keyframe_effect;
+            return a->global_animation_list_order() < b->global_animation_list_order();
+        });
+        m_impl->is_sorted_by_composite_order = true;
+    }
+
+    return m_impl->associated_animations.span();
+}
+
+void Animatable::invalidate_associated_animation_composite_order()
+{
+    if (m_impl)
+        m_impl->is_sorted_by_composite_order = false;
+}
+
 bool Animatable::has_relevant_animations() const
 {
     if (!m_impl)
@@ -177,6 +206,7 @@ void Animatable::disassociate_with_animation(GC::Ref<Animation> animation)
 {
     auto& impl = *m_impl;
     impl.associated_animations.remove_first_matching([&](auto element) { return animation == element; });
+    impl.is_sorted_by_composite_order = false;
 
     as<DOM::Element>(*this).document().disassociate_with_animation(animation);
 }

--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -196,6 +196,8 @@ bool Animatable::has_relevant_animations() const
 void Animatable::associate_with_animation(GC::Ref<Animation> animation)
 {
     auto& impl = ensure_impl();
+    if (impl.associated_animations.contains_slow(animation))
+        return;
     impl.associated_animations.append(animation);
     impl.is_sorted_by_composite_order = false;
 
@@ -219,6 +221,36 @@ void Animatable::on_document_changed(DOM::Document& old_document, DOM::Document&
     for (auto const& animation : m_impl->associated_animations) {
         old_document.disassociate_with_animation(animation);
         new_document.associate_with_animation(animation);
+    }
+}
+
+void Animatable::cancel_css_animations_and_transitions()
+{
+    if (!m_impl)
+        return;
+
+    GC::RootVector<GC::Ref<Animation>> animations_to_cancel;
+    for (auto& animations : m_impl->css_defined_animations) {
+        if (!animations)
+            continue;
+        for (auto& animation : *animations)
+            animations_to_cancel.append(animation);
+        animations->clear();
+    }
+    for (auto& transition : m_impl->transitions) {
+        if (!transition)
+            continue;
+        for (auto& animation : transition->associated_transitions)
+            animations_to_cancel.append(animation.value);
+        transition->associated_transitions.clear();
+        transition->transition_attribute_indices.clear();
+        transition->transition_attributes.clear();
+    }
+    m_impl->has_css_defined_animations = false;
+
+    for (auto& animation : animations_to_cancel) {
+        animation->cancel(Animation::ShouldInvalidate::No);
+        animation->schedule_disassociation_from_target_after_css_cancellation();
     }
 }
 
@@ -337,6 +369,19 @@ bool Animatable::has_css_defined_animations() const
         return false;
 
     return m_impl->has_css_defined_animations;
+}
+
+bool Animatable::has_css_animations_or_transitions() const
+{
+    if (!m_impl)
+        return false;
+    if (m_impl->has_css_defined_animations)
+        return true;
+    for (auto const& transition : m_impl->transitions) {
+        if (transition && !transition->associated_transitions.is_empty())
+            return true;
+    }
+    return false;
 }
 
 Vector<GC::Ref<CSS::CSSAnimation>> const* Animatable::css_defined_animations(Optional<CSS::PseudoElement> pseudo_element)

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -55,6 +55,8 @@ public:
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations(GetAnimationsOptions const& options);
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations(Bindings::GetAnimationsOptions const& options);
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations_internal(GetAnimationsSorted sorted, GetAnimationsOptions const& options);
+    ReadonlySpan<GC::Ref<Animation>> associated_animations_in_composite_order();
+    void invalidate_associated_animation_composite_order();
     bool has_relevant_animations() const;
 
     void associate_with_animation(GC::Ref<Animation>);

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -62,8 +62,10 @@ public:
     void associate_with_animation(GC::Ref<Animation>);
     void disassociate_with_animation(GC::Ref<Animation>);
     void on_document_changed(DOM::Document& old_document, DOM::Document& new_document);
+    void cancel_css_animations_and_transitions();
 
     bool has_css_defined_animations() const;
+    bool has_css_animations_or_transitions() const;
     Vector<GC::Ref<CSS::CSSAnimation>> const* css_defined_animations(Optional<CSS::PseudoElement>);
     void set_css_defined_animations(Optional<CSS::PseudoElement>, Vector<GC::Ref<CSS::CSSAnimation>>&&);
 

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -799,6 +799,13 @@ WebIDL::ExceptionOr<void> Animation::play(ShouldInvalidate should_invalidate)
 // https://drafts.csswg.org/web-animations-2/#play-an-animation
 WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind, ShouldInvalidate should_invalidate)
 {
+    m_css_cancellation_disassociation_pending = false;
+    if (m_needs_target_reassociation && m_effect) {
+        if (auto target = m_effect->target())
+            target->associate_with_animation(*this);
+        m_needs_target_reassociation = false;
+    }
+
     // 1. Let aborted pause be a boolean flag that is true if animation has a pending pause task, and false otherwise.
     auto aborted_pause = m_pending_pause_task == TaskState::Scheduled;
 
@@ -903,6 +910,15 @@ WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind, S
     update_finished_state(DidSeek::No, SynchronouslyNotify::No, should_invalidate);
 
     return {};
+}
+
+void Animation::disassociate_from_target_after_css_cancellation()
+{
+    m_css_cancellation_disassociation_pending = false;
+    if (!m_effect || !m_effect->target())
+        return;
+    m_effect->target()->disassociate_with_animation(*this);
+    m_needs_target_reassociation = true;
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-animation-pause

--- a/Libraries/LibWeb/Animations/Animation.h
+++ b/Libraries/LibWeb/Animations/Animation.h
@@ -140,6 +140,9 @@ public:
 
     Optional<DOM::AbstractElement> owning_element() const { return m_owning_element; }
     void set_owning_element(Optional<DOM::AbstractElement>&& value) { m_owning_element = move(value); }
+    void schedule_disassociation_from_target_after_css_cancellation() { m_css_cancellation_disassociation_pending = true; }
+    bool css_cancellation_disassociation_pending() const { return m_css_cancellation_disassociation_pending; }
+    void disassociate_from_target_after_css_cancellation();
     void update_style_if_needed() const;
 
     virtual AnimationClass animation_class() const { return AnimationClass::None; }
@@ -253,6 +256,8 @@ private:
 
     // https://www.w3.org/TR/css-animations-2/#owning-element-section
     Optional<DOM::AbstractElement> m_owning_element;
+    bool m_css_cancellation_disassociation_pending { false };
+    bool m_needs_target_reassociation { false };
 
     Optional<HTML::TaskID> m_pending_finish_microtask_id;
 

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -913,7 +913,14 @@ AnimationUpdateContext::~AnimationUpdateContext()
         target->document().style_computer().for_each_provisional_transition_effect(element, [&](KeyframeEffect& effect) {
             effects_to_collect.append(effect);
         });
-        effects_to_collect.extend(it.value.effects);
+        for (auto& animation : target->associated_animations_in_composite_order()) {
+            if (animation->is_idle() || !animation->effect() || !is<KeyframeEffect>(*animation->effect()))
+                continue;
+            auto& effect = static_cast<KeyframeEffect&>(*animation->effect());
+            if (effect.target() != target || effect.pseudo_element_type() != element.pseudo_element())
+                continue;
+            effects_to_collect.append(effect);
+        }
         if (!effects_to_collect.is_empty())
             target->document().style_computer().collect_animations_into(element, effects_to_collect.span(), *style, CSS::StyleComputer::AnimationRefresh::Yes);
         auto animated_properties_after_update = style->animated_properties_snapshot();

--- a/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -56,6 +56,17 @@ int CSSAnimation::class_specific_composite_order(GC::Ref<Animations::Animation> 
     return global_animation_list_order() - other->global_animation_list_order();
 }
 
+void CSSAnimation::set_animation_name_index(size_t index)
+{
+    if (m_animation_name_index == index)
+        return;
+    m_animation_name_index = index;
+    if (auto effect = this->effect(); effect && is<Animations::KeyframeEffect>(*effect)) {
+        if (auto target = static_cast<Animations::KeyframeEffect&>(*effect).target())
+            target->invalidate_associated_animation_composite_order();
+    }
+}
+
 Animations::AnimationClass CSSAnimation::animation_class() const
 {
     if (owning_element().has_value())

--- a/Libraries/LibWeb/CSS/CSSAnimation.h
+++ b/Libraries/LibWeb/CSS/CSSAnimation.h
@@ -29,7 +29,7 @@ public:
 
     void apply_css_properties(AnimationProperties const&);
 
-    void set_animation_name_index(size_t index) { m_animation_name_index = index; }
+    void set_animation_name_index(size_t index);
 
     EasingFunction const& default_easing() const { return m_default_easing; }
 

--- a/Libraries/LibWeb/CSS/EasingFunction.cpp
+++ b/Libraries/LibWeb/CSS/EasingFunction.cpp
@@ -21,10 +21,8 @@ double LinearEasingFunction::evaluate_at(double input_progress, bool before_flag
 {
     Vector<StyleValueFFI::FfiLinearEasingPoint> points;
     points.ensure_capacity(control_points.size());
-    for (auto const& point : control_points) {
-        VERIFY(point.input.has_value());
-        points.unchecked_append({ .input = *point.input, .output = point.output });
-    }
+    for (auto const& point : control_points)
+        points.unchecked_append({ .input = point.input, .output = point.output });
     StyleValueFFI::FfiEasingDescriptor descriptor {
         .kind = StyleValueFFI::FfiEasingKind::Linear,
         .linear_points = points.data(),
@@ -74,10 +72,15 @@ double StepsEasingFunction::evaluate_at(double input_progress, bool before_flag)
 }
 
 // https://drafts.csswg.org/css-easing/#linear-canonicalization
-static Vector<LinearEasingFunction::ControlPoint> canonicalize_linear_easing_function_control_points(Vector<LinearEasingFunction::ControlPoint> control_points)
+struct UnresolvedLinearEasingControlPoint {
+    Optional<double> input;
+    double output;
+};
+
+static Vector<LinearEasingFunction::ControlPoint> canonicalize_linear_easing_function_control_points(Vector<UnresolvedLinearEasingControlPoint> control_points)
 {
     // To canonicalize a linear() function’s control points, perform the following:
-    Vector<LinearEasingFunction::ControlPoint> canonicalized_control_points = control_points;
+    auto canonicalized_control_points = move(control_points);
 
     // 1. If the first control point lacks an input progress value, set its input progress value to 0.
     if (!canonicalized_control_points.first().input.has_value())
@@ -125,7 +128,11 @@ static Vector<LinearEasingFunction::ControlPoint> canonicalize_linear_easing_fun
         }
     }
 
-    return canonicalized_control_points;
+    Vector<LinearEasingFunction::ControlPoint> resolved_control_points;
+    resolved_control_points.ensure_capacity(canonicalized_control_points.size());
+    for (auto const& control_point : canonicalized_control_points)
+        resolved_control_points.unchecked_append({ control_point.input.value(), control_point.output });
+    return resolved_control_points;
 }
 
 // https://drafts.csswg.org/css-easing-2/#linear-easing-function
@@ -168,7 +175,7 @@ EasingFunction EasingFunction::from_style_value(StyleValue const& style_value)
     if (style_value.is_easing()) {
         return style_value.as_easing().function().visit(
             [&](EasingStyleValue::Linear const& linear) -> EasingFunction {
-                Vector<LinearEasingFunction::ControlPoint> resolved_control_points;
+                Vector<UnresolvedLinearEasingControlPoint> unresolved_control_points;
 
                 for (auto const& control_point : linear.stops) {
                     double output = number_from_style_value(control_point.output, {});
@@ -177,13 +184,13 @@ EasingFunction EasingFunction::from_style_value(StyleValue const& style_value)
                     if (control_point.input)
                         input = Percentage::from_style_value(*control_point.input).as_fraction();
 
-                    resolved_control_points.append({ input, output });
+                    unresolved_control_points.append({ input, output });
                 }
 
                 // https://drafts.csswg.org/css-easing-2/#funcdef-linear
                 // If an argument lacks a <percentage>, its input progress value is initially empty. This is corrected
                 // at used value time by linear() canonicalization.
-                resolved_control_points = canonicalize_linear_easing_function_control_points(resolved_control_points);
+                auto resolved_control_points = canonicalize_linear_easing_function_control_points(move(unresolved_control_points));
 
                 return LinearEasingFunction { resolved_control_points, linear.to_utf16_string(SerializationMode::ResolvedValue) };
             },
@@ -237,9 +244,7 @@ NonnullRefPtr<StyleValue const> EasingFunction::to_style_value() const
         [](LinearEasingFunction const& linear) -> NonnullRefPtr<StyleValue const> {
             Vector<EasingStyleValue::Linear::Stop> stops;
             for (auto const& point : linear.control_points) {
-                ValueComparingRefPtr<StyleValue const> input;
-                if (point.input.has_value())
-                    input = PercentageStyleValue::create(Percentage { *point.input * 100 });
+                auto input = PercentageStyleValue::create(Percentage { point.input * 100 });
                 stops.append({ NumberStyleValue::create(point.output), move(input) });
             }
             return EasingStyleValue::create(EasingStyleValue::Linear { move(stops) });

--- a/Libraries/LibWeb/CSS/EasingFunction.h
+++ b/Libraries/LibWeb/CSS/EasingFunction.h
@@ -12,7 +12,7 @@ namespace Web::CSS {
 
 struct LinearEasingFunction {
     struct ControlPoint {
-        Optional<double> input;
+        double input;
         double output;
 
         bool operator==(ControlPoint const&) const = default;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -760,10 +760,8 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         return easing.visit(
             [&](LinearEasingFunction const& linear) {
                 points.ensure_capacity(linear.control_points.size());
-                for (auto const& point : linear.control_points) {
-                    VERIFY(point.input.has_value());
-                    points.unchecked_append({ .input = *point.input, .output = point.output });
-                }
+                for (auto const& point : linear.control_points)
+                    points.unchecked_append({ .input = point.input, .output = point.output });
                 return StyleValueFFI::FfiEasingDescriptor {
                     .kind = StyleValueFFI::FfiEasingKind::Linear,
                     .linear_points = points.data(),

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -21,7 +21,7 @@ void AsyncScrollTree::set_state(AsyncScrollingState&& state)
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree = nullptr;
+    m_visual_context_tree_version.clear();
 }
 
 AsyncScrollNode const* AsyncScrollTree::scroll_node_for_id(AsyncScrollNodeID node_id) const
@@ -194,16 +194,23 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree = nullptr;
+    m_visual_context_tree_version.clear();
     m_scroll_state_snapshot = scroll_state_snapshot;
     if (!display_list || !visual_context_tree)
         return;
 
     VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
-    m_visual_context_tree = visual_context_tree;
+    m_visual_context_tree_version = visual_context_tree->version();
+
+    auto context_is_valid = [&](Painting::ContextRef context) {
+        return context.spatial.value() < visual_context_tree->spatial_nodes().size()
+            && (context.frame == Painting::NO_FRAME_NODE || context.frame.value() < visual_context_tree->frame_nodes().size());
+    };
 
     m_cached_wheel_hit_test_targets.ensure_capacity(m_wheel_hit_test_regions.size());
     for (auto const& target : m_wheel_hit_test_regions) {
+        if (!context_is_valid(target.context))
+            continue;
         m_cached_wheel_hit_test_targets.append({
             .target_node_id = target.target_node_id,
             .context = target.context,
@@ -215,6 +222,8 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
 
     m_cached_main_thread_wheel_event_targets.ensure_capacity(m_main_thread_wheel_event_regions.size());
     for (auto const& region : m_main_thread_wheel_event_regions) {
+        if (!context_is_valid(region.context))
+            continue;
         m_cached_main_thread_wheel_event_targets.append({
             .context = region.context,
             .rect = region.rect,
@@ -223,6 +232,8 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
     }
 
     for (auto const& region : m_blocking_wheel_event_regions) {
+        if (!context_is_valid(region.context))
+            continue;
         m_cached_blocking_wheel_event_targets.append({
             .context = region.context,
             .rect = region.rect,
@@ -236,7 +247,7 @@ void AsyncScrollTree::clear_wheel_hit_test_targets()
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree = nullptr;
+    m_visual_context_tree_version.clear();
 }
 
 static bool wheel_hit_test_target_contains_point(CachedWheelHitTestTarget const& target, Gfx::FloatPoint position_in_context)
@@ -271,7 +282,7 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::scroll_node_id_for_stable_id(AsyncS
     return {};
 }
 
-WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta, SnapContainerHandling snap_container_handling) const
+WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::AccumulatedVisualContextTree const& visual_context_tree, Gfx::FloatPoint position, Gfx::FloatPoint delta, SnapContainerHandling snap_container_handling) const
 {
     auto scrolled_on_the_main_thread_instead = [&](WheelHitTestResult const& result) {
         if (snap_container_handling == SnapContainerHandling::ScrollOnCompositor || !result.node_id.has_value())
@@ -289,8 +300,13 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoi
         return result;
     };
 
-    if (!m_visual_context_tree)
+    if (m_visual_context_tree_version != visual_context_tree.version())
         return {};
+
+    auto context_is_valid = [&](Painting::ContextRef context) {
+        return context.spatial.value() < visual_context_tree.spatial_nodes().size()
+            && (context.frame == Painting::NO_FRAME_NODE || context.frame.value() < visual_context_tree.frame_nodes().size());
+    };
 
     if (m_has_blocking_wheel_event_region_covering_viewport)
         return { {}, false, true };
@@ -299,7 +315,9 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoi
         if (!target.viewport_rect.contains(position))
             continue;
 
-        auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
+        if (!context_is_valid(target.context))
+            continue;
+        auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
         if (position_in_context.has_value() && target.rect.contains(*position_in_context))
             return { {}, true };
     }
@@ -308,7 +326,9 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoi
         if (!target.viewport_rect.contains(position))
             continue;
 
-        auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
+        if (!context_is_valid(target.context))
+            continue;
+        auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
         if (position_in_context.has_value() && target.rect.contains(*position_in_context))
             return { {}, false, true };
     }
@@ -317,7 +337,9 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoi
         if (!target.viewport_rect.contains(position))
             continue;
 
-        auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
+        if (!context_is_valid(target.context))
+            continue;
+        auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
         if (!position_in_context.has_value() || !wheel_hit_test_target_contains_point(target, *position_in_context))
             continue;
         if (!target.target_node_id.has_value())

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -59,7 +59,7 @@ public:
     Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&) const;
     Optional<AsyncScrollNodeID> viewport_scroll_node_id() const;
     Optional<AsyncScrollNodeID> scroll_node_id_for_stable_id(AsyncScrollNodeStableID) const;
-    WheelHitTestResult hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta, SnapContainerHandling) const;
+    WheelHitTestResult hit_test_scroll_node_for_wheel(Painting::AccumulatedVisualContextTree const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, SnapContainerHandling) const;
     bool scroll_node_is_viewport(AsyncScrollNodeID) const;
     Vector<AsyncScrollOffset> apply_scroll_delta(AsyncScrollNodeID, Gfx::FloatPoint delta, Painting::AccumulatedVisualContextTree const&, Painting::ScrollStateSnapshot&);
     Optional<Gfx::FloatPoint> set_scroll_offset(AsyncScrollNodeID, Gfx::FloatPoint, Painting::AccumulatedVisualContextTree const&, Painting::ScrollStateSnapshot&);
@@ -83,7 +83,7 @@ private:
     Vector<BlockingWheelEventRegion> m_blocking_wheel_event_regions;
     Vector<CachedMainThreadWheelEventTarget> m_cached_main_thread_wheel_event_targets;
     Vector<CachedBlockingWheelEventTarget> m_cached_blocking_wheel_event_targets;
-    Painting::AccumulatedVisualContextTree const* m_visual_context_tree { nullptr };
+    Optional<u64> m_visual_context_tree_version;
     Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     bool m_has_blocking_wheel_event_region_covering_viewport { false };
 };

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -205,6 +205,9 @@ bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_s
 
     VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
     for (auto const& region : async_scrolling_state.blocking_wheel_event_regions) {
+        if (region.context.spatial.value() >= visual_context_tree->spatial_nodes().size()
+            || (region.context.frame != Painting::NO_FRAME_NODE && region.context.frame.value() >= visual_context_tree->frame_nodes().size()))
+            return true;
         auto position_in_context = visual_context_tree->transform_point_for_hit_test(region.context, position, scroll_state_snapshot);
         if (position_in_context.has_value() && region.rect.contains(*position_in_context))
             return true;
@@ -221,7 +224,7 @@ static WheelHitTestResult hit_test_scroll_node_at_position(AsyncScrollingState c
     auto async_scrolling_state_copy = async_scrolling_state;
     scroll_tree.set_state(move(async_scrolling_state_copy));
     scroll_tree.rebuild_wheel_hit_test_targets(display_list, visual_context_tree, scroll_state_snapshot);
-    return scroll_tree.hit_test_scroll_node_for_wheel(position, delta, snap_container_handling);
+    return scroll_tree.hit_test_scroll_node_for_wheel(*visual_context_tree, position, delta, snap_container_handling);
 }
 
 WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList const> const& display_list, Painting::AccumulatedVisualContextTree const* visual_context_tree, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta, SnapContainerHandling snap_container_handling, bool blocking_wheel_event_regions_are_current)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7383,6 +7383,14 @@ void Document::disassociate_with_animation(GC::Ref<Animations::Animation> animat
     m_associated_animations.remove(animation);
 }
 
+size_t Document::associated_animation_count() const
+{
+    size_t count = 0;
+    for ([[maybe_unused]] auto& animation : m_associated_animations)
+        ++count;
+    return count;
+}
+
 void Document::append_pending_animation_event(Web::DOM::Document::PendingAnimationEvent const& event)
 {
     if (m_style_stabilization_epoch_depth > 0) {
@@ -7411,8 +7419,11 @@ void Document::update_animations_and_send_events(double timestamp)
         for (auto& animation : m_associated_animations)
             animations.append(animation);
 
-        for (auto& animation : animations)
+        for (auto& animation : animations) {
             dispatch_events_for_animation_if_necessary(animation);
+            if (animation->css_cancellation_disassociation_pending())
+                animation->disassociate_from_target_after_css_cancellation();
+        }
 
         // 2. Remove replaced animations for doc.
         remove_replaced_animations();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1005,6 +1005,7 @@ public:
     void disassociate_with_timeline(GC::Ref<Animations::AnimationTimeline>);
     void associate_with_animation(GC::Ref<Animations::Animation>);
     void disassociate_with_animation(GC::Ref<Animations::Animation>);
+    size_t associated_animation_count() const;
 
     struct PendingAnimationEvent {
         GC::Ref<DOM::Event> event;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -6263,8 +6263,8 @@ Utf16FlyString const& Element::html_uppercased_qualified_name() const
 
 void Element::play_or_cancel_animations_after_display_property_change()
 {
-    // OPTIMIZATION: We don't care about elements with no CSS defined animations
-    if (!has_css_defined_animations())
+    // OPTIMIZATION: We don't care about elements with no CSS animations or transitions.
+    if (!has_css_animations_or_transitions())
         return;
 
     // OPTIMIZATION: We don't care about animations in disconnected subtrees.
@@ -6286,21 +6286,22 @@ void Element::play_or_cancel_animations_after_display_property_change()
 
     auto has_inclusive_ancestor_with_display_none_ignoring_animations = this->has_inclusive_ancestor_with_display_none_ignoring_animations();
 
+    if (has_inclusive_ancestor_with_display_none_ignoring_animations) {
+        cancel_css_animations_and_transitions();
+        return;
+    }
+
     auto play_or_cancel_depending_on_display = [&](Vector<GC::Ref<CSS::CSSAnimation>> const& animations) {
         for (auto& animation : animations) {
-            if (has_inclusive_ancestor_with_display_none_ignoring_animations) {
-                animation->cancel();
-            } else {
-                // NOTE: It is safe to assume this has a value as it is set when creating a CSS defined animation
-                auto play_state = animation->last_css_animation_play_state().value();
+            // NOTE: It is safe to assume this has a value as it is set when creating a CSS defined animation
+            auto play_state = animation->last_css_animation_play_state().value();
 
-                if (play_state == CSS::AnimationPlayState::Running) {
-                    HTML::TemporaryExecutionContext context(document().relevant_settings_object());
-                    animation->play_from_css();
-                } else if (play_state == CSS::AnimationPlayState::Paused) {
-                    HTML::TemporaryExecutionContext context(document().relevant_settings_object());
-                    animation->pause_from_css();
-                }
+            if (play_state == CSS::AnimationPlayState::Running) {
+                HTML::TemporaryExecutionContext context(document().relevant_settings_object());
+                animation->play_from_css();
+            } else if (play_state == CSS::AnimationPlayState::Paused) {
+                HTML::TemporaryExecutionContext context(document().relevant_settings_object());
+                animation->pause_from_css();
             }
         }
     };

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1369,6 +1369,10 @@ void Node::remove(bool suppress_observers)
         removal_style_record_pins.pin_layout_style_records(*this);
 
     // 11. Run the removing steps with node, true, and parent.
+    if (was_connected) {
+        if (auto* element = as_if<Element>(*this))
+            element->cancel_css_animations_and_transitions();
+    }
     removed_from(IsSubtreeRoot::Yes, parent, parent_root);
 
     // A subtree holding the focused or hovered node takes `:focus-within` and `:hover` out of the
@@ -1389,6 +1393,11 @@ void Node::remove(bool suppress_observers)
 
     // 14. For each shadow-including descendant descendant of node, in shadow-including tree order:
     for_each_shadow_including_descendant([&](Node& descendant) {
+        if (was_connected) {
+            if (auto* element = as_if<Element>(descendant))
+                element->cancel_css_animations_and_transitions();
+        }
+
         // 1. Run the removing steps with descendant, false, and parent.
         descendant.removed_from(IsSubtreeRoot::No, parent, parent_root);
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1745,6 +1745,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
 {
     auto& realm = HTML::relevant_realm(window());
     auto const& counters = style_invalidation_counters();
+    auto& document = window().associated_document();
     auto object = JS::Object::create(realm, nullptr);
     object->define_direct_property("styleEnvironmentVersion"_utf16_fly_string, JS::Value(window().associated_document().style_environment_version()), JS::default_attributes);
     object->define_direct_property("styleEngineReactionBatchRuns"_utf16_fly_string, JS::Value(counters.style_engine_reaction_batch_runs), JS::default_attributes);
@@ -1765,6 +1766,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("elementInheritedStyleGroupSwaps"_utf16_fly_string, JS::Value(counters.element_inherited_style_group_swaps), JS::default_attributes);
     object->define_direct_property("animatedStyleReconstructionFallbacks"_utf16_fly_string, JS::Value(counters.animated_style_reconstruction_fallbacks), JS::default_attributes);
     object->define_direct_property("animatedStyleOverlayBuilds"_utf16_fly_string, JS::Value(counters.animated_style_overlay_builds), JS::default_attributes);
+    object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1663,6 +1663,7 @@ Utf16String Internals::async_scrolling_state_wheel_target_at(double x, double y,
     scroll_tree.rebuild_wheel_hit_test_targets(snapshot->display_list, &snapshot->visual_context_tree, snapshot->document->scroll_state_snapshot());
 
     auto target = scroll_tree.hit_test_scroll_node_for_wheel(
+        snapshot->visual_context_tree,
         { static_cast<float>(x), static_cast<float>(y) },
         { static_cast<float>(delta_x), static_cast<float>(delta_y) },
         Compositor::snap_container_handling_for(wheel_delta_precision_from(precise), scroll_gesture_phase_from(phase)));

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -401,7 +401,7 @@ ContextState::AsyncScrollResult ContextState::async_scroll_by(
 
     // Scroll node chaining selects a scrolling box the main thread never examined, so the snap containers among the
     // chained boxes are recognized here rather than only before the step is admitted to this path.
-    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta, snap_container_handling);
+    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(visual_context_tree_for_compositing(), position, delta, snap_container_handling);
     if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
         return {};
     if (scroll_target.node_id->document_id != expected_document_id)
@@ -555,7 +555,7 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
     if (!m_can_accept_async_wheel_events)
         return {};
 
-    auto initial_scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta, snap_container_handling);
+    auto initial_scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(visual_context_tree_for_compositing(), position, delta, snap_container_handling);
     if (initial_scroll_target.blocked_by_main_thread_region || initial_scroll_target.blocked_by_wheel_event_region)
         return {};
 
@@ -580,7 +580,7 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
     if (auto scale = visual_viewport_scale_for_compositing(); scale.has_value() && *scale > 1.0f)
         async_scroll_delta.scale_by(1.0f / *scale);
 
-    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, async_scroll_delta, snap_container_handling);
+    auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(visual_context_tree_for_compositing(), position, async_scroll_delta, snap_container_handling);
     if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value()) {
         if (frame_to_present.has_value())
             return {

--- a/Tests/Compositor/TestAsyncScrollTree.cpp
+++ b/Tests/Compositor/TestAsyncScrollTree.cpp
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <LibTest/TestCase.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 static Web::Compositor::AsyncScrollNodeID const viewport_node_id { .document_id = Web::UniqueNodeID { 1 }, .scroll_node_index = Web::Painting::SpatialNodeIndex { 1 } };
@@ -28,6 +30,64 @@ static Web::Compositor::AsyncScrollTree make_scroll_tree_with_viewport_scroll_no
     Web::Compositor::AsyncScrollTree scroll_tree;
     scroll_tree.set_state(move(state));
     return scroll_tree;
+}
+
+static NonnullRefPtr<Web::Painting::DisplayList> make_empty_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree)
+{
+    return Web::Painting::DisplayList::create_from_command_bytes(visual_context_tree, ByteBuffer {}, {});
+}
+
+TEST_CASE(wheel_hit_testing_rejects_a_different_visual_context_tree_version)
+{
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    Web::Compositor::AsyncScrollingState state;
+    state.main_thread_wheel_event_regions.append({
+        .context = { Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Web::Painting::NO_FRAME_NODE },
+        .rect = { 0, 0, 100, 100 },
+    });
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+    scroll_tree.rebuild_wheel_hit_test_targets(make_empty_display_list(visual_context_tree), &visual_context_tree, {});
+    auto current_result = scroll_tree.hit_test_scroll_node_for_wheel(
+        visual_context_tree, { 20, 20 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor);
+    EXPECT(current_result.blocked_by_main_thread_region);
+
+    auto replacement_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto replacement_result = scroll_tree.hit_test_scroll_node_for_wheel(
+        replacement_tree, { 20, 20 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor);
+    EXPECT(!replacement_result.blocked_by_main_thread_region);
+}
+
+TEST_CASE(wheel_hit_testing_ignores_invalid_visual_context_indices)
+{
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    Web::Compositor::AsyncScrollingState state;
+    state.main_thread_wheel_event_regions.append({
+        .context = { Web::Painting::SpatialNodeIndex { 100 }, Web::Painting::NO_FRAME_NODE },
+        .rect = { 0, 0, 100, 100 },
+    });
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+    scroll_tree.rebuild_wheel_hit_test_targets(make_empty_display_list(visual_context_tree), &visual_context_tree, {});
+    auto result = scroll_tree.hit_test_scroll_node_for_wheel(
+        visual_context_tree, { 20, 20 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor);
+    EXPECT(!result.blocked_by_main_thread_region);
+}
+
+TEST_CASE(blocking_wheel_event_hit_testing_fails_closed_for_invalid_visual_context_indices)
+{
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    Web::Compositor::AsyncScrollingState state;
+    state.has_blocking_wheel_event_listeners = true;
+    state.blocking_wheel_event_regions.append({
+        .context = { Web::Painting::SpatialNodeIndex { 100 }, Web::Painting::NO_FRAME_NODE },
+        .rect = { 0, 0, 100, 100 },
+    });
+
+    EXPECT(Web::Compositor::blocks_wheel_event_at_position(
+        state, make_empty_display_list(visual_context_tree), &visual_context_tree, {}, { 20, 20 }));
 }
 
 TEST_CASE(async_scrolling_resolves_sticky_offsets_from_the_visual_context_tree)

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -94,7 +94,7 @@ static Web::Painting::AccumulatedVisualContextTree make_scrollable_viewport_visu
     return visual_context_tree;
 }
 
-static NonnullRefPtr<Web::Painting::DisplayList> make_scrollable_viewport_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, bool with_viewport_scrollbar = true)
+static NonnullRefPtr<Web::Painting::DisplayList> make_scrollable_viewport_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, bool with_viewport_scrollbar = true, Optional<Web::Painting::ContextRef> wheel_hit_test_context = {})
 {
     ByteBuffer command_bytes;
     Web::UniqueNodeID document_id { 1 };
@@ -119,6 +119,18 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_scrollable_viewport_displa
             .snaps_scroll_position_horizontally = false,
             .snaps_scroll_position_vertically = false,
         });
+
+    if (wheel_hit_test_context.has_value()) {
+        append_display_list_command(
+            command_bytes,
+            Web::Painting::CompositorWheelHitTestTarget {
+                .document_id = document_id,
+                .target_scroll_node_index = scroll_node_index,
+                .rect = { 0, 0, 100, 100 },
+            },
+            {},
+            *wheel_hit_test_context);
+    }
 
     if (with_viewport_scrollbar) {
         append_display_list_command(
@@ -194,6 +206,37 @@ TEST_CASE(rasterization_clears_damaged_pixels_to_the_canvas_color_in_presentatio
     paint_frame(make_display_list(visual_context_tree, {}));
     bitmap = context.latest_rendered_surface()->snapshot_bitmap();
     EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Transparent);
+}
+
+TEST_CASE(wheel_hit_testing_ignores_targets_from_a_larger_visual_context_tree)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, true };
+    auto visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    auto removed_transform = visual_context_tree.append_spatial(
+        Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} },
+        Web::Painting::SpatialNodeIndex { 1 });
+
+    context.install_display_list_update(
+        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { removed_transform, Web::Painting::NO_FRAME_NODE }),
+        visual_context_tree,
+        {});
+
+    auto smaller_visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    context.install_display_list_update(
+        make_scrollable_viewport_display_list(smaller_visual_context_tree, false, Web::Painting::ContextRef { removed_transform, Web::Painting::NO_FRAME_NODE }),
+        smaller_visual_context_tree,
+        {});
+
+    auto result = context.async_scroll_by(
+        Web::UniqueNodeID { 1 },
+        { 20, 20 },
+        { 0, 10 },
+        { 0, 0, 100, 100 },
+        Web::Compositor::SnapContainerHandling::ScrollOnCompositor,
+        Web::Compositor::AsyncScrollOperationTracking::No);
+    EXPECT(result.enqueue_result.accepted);
 }
 
 TEST_CASE(oversized_backing_stores_are_rejected)

--- a/Tests/LibWeb/Text/expected/css/animation-transition-composite-order.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-transition-composite-order.txt
@@ -1,0 +1,2 @@
+transition started: true
+script animation wins: 0.75

--- a/Tests/LibWeb/Text/expected/css/removed-css-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/removed-css-animations.txt
@@ -1,0 +1,10 @@
+large animation-free subtree is removed: true
+animations are associated after insertion: true
+removed CSS animations are cancelled: true
+removed CSS transitions are cancelled: true
+removed CSS animations are disassociated: true
+reinsertion creates a fresh animation: true
+reinserted animation starts near the beginning: true
+reinsertion dispatches animationstart: true
+retargeted animation is associated once: true
+display none cancels transition-only elements: true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/event-dispatch.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/event-dispatch.tentative.txt
@@ -2,19 +2,19 @@ Harness status: OK
 
 Found 30 tests
 
-22 Pass
-8 Fail
+26 Pass
+4 Fail
 Pass	Idle -> Pending or Before
 Pass	Idle -> Before
 Pass	Idle or Pending -> Active
 Pass	Idle or Pending -> After
-Fail	Before -> Idle (display: none)
+Pass	Before -> Idle (display: none)
 Pass	Before -> Idle (Animation.timeline = null)
 Pass	Before -> Active
 Pass	Before -> After
-Fail	Active -> Idle, no delay (display: none)
+Pass	Active -> Idle, no delay (display: none)
 Pass	Active -> Idle, no delay (Animation.timeline = null)
-Fail	Active -> Idle, with positive delay (display: none)
+Pass	Active -> Idle, with positive delay (display: none)
 Pass	Active -> Idle, with positive delay (Animation.timeline = null)
 Fail	Active -> Idle, with negative delay (display: none)
 Pass	Active -> Idle, with negative delay (Animation.timeline = null)
@@ -24,7 +24,7 @@ Pass	After -> Before
 Pass	After -> Active
 Pass	Calculating the interval start and end time with negative start delay.
 Fail	Calculating the interval start and end time with negative end delay.
-Fail	Call Animation.cancel after canceling transition.
+Pass	Call Animation.cancel after canceling transition.
 Fail	Restart transition after canceling transition immediately
 Pass	Call Animation.cancel after restarting transition immediately
 Pass	Set timeline and play transition after clear the timeline

--- a/Tests/LibWeb/Text/input/css/animation-transition-composite-order.html
+++ b/Tests/LibWeb/Text/input/css/animation-transition-composite-order.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+    #target {
+        opacity: 0;
+        transition: opacity 100000s step-end;
+    }
+
+    #target.changed {
+        opacity: 0.25;
+    }
+</style>
+<script src="../include.js"></script>
+<div id="target"></div>
+<script>
+    promiseTest(async () => {
+        const opacityAnimation = target.animate(
+            { opacity: [0.75, 0.75] },
+            { delay: 100000, duration: 100000 },
+        );
+        target.animate({ color: ["red", "red"] }, 100000);
+        await animationFrame();
+        await animationFrame();
+
+        // The color animation populates the element's composite-order cache while the
+        // delayed opacity animation does not yet hide the underlying style change.
+        getComputedStyle(target).opacity;
+        target.classList.add("changed");
+
+        println(`transition started: ${target.getAnimations().some(animation => animation instanceof CSSTransition)}`);
+        opacityAnimation.currentTime = 100000;
+        println(`script animation wins: ${getComputedStyle(target).opacity}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/removed-css-animations.html
+++ b/Tests/LibWeb/Text/input/css/removed-css-animations.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes spin {
+        to { transform: rotate(1turn); }
+    }
+
+    .spinner {
+        width: 20px;
+        height: 20px;
+        animation: spin 10s linear infinite;
+    }
+
+    .transitioner {
+        opacity: 1;
+        transition: opacity 10s linear;
+    }
+</style>
+<script>
+    asyncTest(async done => {
+        const animationFreeContainer = document.createElement("div");
+        for (let i = 0; i < 10_000; ++i)
+            animationFreeContainer.append(document.createElement("div"));
+        document.body.append(animationFreeContainer);
+        animationFreeContainer.remove();
+        println(`large animation-free subtree is removed: ${animationFreeContainer.childElementCount === 10_000 && !animationFreeContainer.isConnected}`);
+
+        const initialCount = internals.getStyleInvalidationCounters().associatedAnimations;
+        const container = document.createElement("div");
+        for (let i = 0; i < 5; ++i) {
+            const spinner = document.createElement("div");
+            spinner.className = "spinner";
+            container.append(spinner);
+        }
+        const transitioner = document.createElement("div");
+        transitioner.className = "transitioner";
+        container.append(transitioner);
+        document.body.append(container);
+        await new Promise(requestAnimationFrame);
+        transitioner.style.opacity = "0";
+        await new Promise(requestAnimationFrame);
+
+        const spinner = container.firstElementChild;
+        const removedAnimation = spinner.getAnimations()[0];
+        const removedTransition = transitioner.getAnimations()[0];
+        println(`animations are associated after insertion: ${internals.getStyleInvalidationCounters().associatedAnimations === initialCount + 6}`);
+
+        container.remove();
+        println(`removed CSS animations are cancelled: ${removedAnimation.playState === "idle"}`);
+        println(`removed CSS transitions are cancelled: ${removedTransition.playState === "idle"}`);
+        await new Promise(requestAnimationFrame);
+        println(`removed CSS animations are disassociated: ${internals.getStyleInvalidationCounters().associatedAnimations === initialCount}`);
+
+        let starts = 0;
+        spinner.addEventListener("animationstart", () => ++starts);
+        document.body.append(spinner);
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        const reinsertedAnimation = spinner.getAnimations()[0];
+        println(`reinsertion creates a fresh animation: ${reinsertedAnimation !== removedAnimation}`);
+        println(`reinserted animation starts near the beginning: ${reinsertedAnimation.currentTime < 1000}`);
+        println(`reinsertion dispatches animationstart: ${starts === 1}`);
+
+        const retargetedElement = document.createElement("div");
+        document.body.append(retargetedElement);
+        removedAnimation.effect.target = retargetedElement;
+        removedAnimation.play();
+        println(`retargeted animation is associated once: ${retargetedElement.getAnimations().filter(animation => animation === removedAnimation).length === 1}`);
+
+        const displayNoneTransitioner = document.createElement("div");
+        displayNoneTransitioner.className = "transitioner";
+        document.body.append(displayNoneTransitioner);
+        await new Promise(requestAnimationFrame);
+        displayNoneTransitioner.style.opacity = "0";
+        await new Promise(requestAnimationFrame);
+        const displayNoneTransition = displayNoneTransitioner.getAnimations()[0];
+        displayNoneTransitioner.style.display = "none";
+        await new Promise(requestAnimationFrame);
+        println(`display none cancels transition-only elements: ${displayNoneTransition.playState === "idle"}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
- Resolve linear easing inputs during canonicalization and keep associated animations cached in composite order.
- Cancel and disassociate CSS animations and transitions when their owning subtree becomes unrendered, while allowing fresh animations to be created after reinsertion. Script-created animations remain unaffected.
- Tie wheel hit testing to the current visual context tree and reject stale versions or invalid context indices after display-list replacement.