### PR TITLE
LibWeb: Stop sampling unobservable animations in steady state

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1177,10 +1177,17 @@ void Animation::update()
     if (!m_is_finished || !m_timeline->is_monotonically_increasing()) {
         bool was_finished = m_is_finished;
         update_finished_state(DidSeek::No, SynchronouslyNotify::Yes, ShouldInvalidate::No);
-        if (play_state() == AnimationPlayState::Running && !pending())
+        if (play_state() == AnimationPlayState::Running && m_effect && is<KeyframeEffect>(*m_effect)) {
+            auto& effect = static_cast<KeyframeEffect&>(*m_effect);
+            if (effect.can_skip_per_frame_style_update()) {
+                if (auto target = effect.target())
+                    target->document().note_throttled_animation_style_update();
+            } else if (!pending()) {
+                invalidate_effect();
+            }
+        } else if (m_is_finished != was_finished) {
             invalidate_effect();
-        else if (m_is_finished != was_finished)
-            invalidate_effect();
+        }
     }
 
     // Act on the pending play or pause task

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1208,10 +1208,15 @@ void Animation::update()
         update_finished_state(DidSeek::No, SynchronouslyNotify::Yes, ShouldInvalidate::No);
         if (play_state() == AnimationPlayState::Running && m_effect && is<KeyframeEffect>(*m_effect)) {
             auto& effect = static_cast<KeyframeEffect&>(*m_effect);
+            bool output_is_constant_before_active_start = !pending()
+                && effect.is_in_the_before_phase()
+                && m_timeline
+                && m_timeline->is_monotonically_increasing()
+                && playback_rate() > 0;
             if (effect.can_skip_per_frame_style_update()) {
                 if (auto target = effect.target())
                     target->document().note_throttled_animation_style_update();
-            } else if (!pending()) {
+            } else if (!pending() && !output_is_constant_before_active_start) {
                 invalidate_effect();
             }
         } else if (m_is_finished != was_finished) {
@@ -1228,6 +1233,23 @@ void Animation::update()
     if (m_pending_pause_task == TaskState::Scheduled && is_ready_to_run_pending_pause_task()) {
         m_pending_pause_task = TaskState::None;
         run_pending_pause_task();
+    }
+
+    if (play_state() == AnimationPlayState::Running && !pending() && m_effect && is<KeyframeEffect>(*m_effect)) {
+        auto& effect = static_cast<KeyframeEffect&>(*m_effect);
+        if (effect.is_in_the_before_phase()
+            && m_timeline && m_timeline->is_monotonically_increasing()
+            && playback_rate() > 0
+            && effect.start_delay().type == TimeValue::Type::Milliseconds) {
+            auto animation_current_time = current_time();
+            if (animation_current_time.has_value() && animation_current_time->type == TimeValue::Type::Milliseconds) {
+                auto delay = (effect.start_delay().value - animation_current_time->value) / playback_rate();
+                if (delay > 0) {
+                    if (auto target = effect.target())
+                        target->document().schedule_animation_wakeup(delay);
+                }
+            }
+        }
     }
 }
 

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Animations/AnimationPlaybackEvent.h>
 #include <LibWeb/Animations/BindingsGlue.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
 #include <LibWeb/CSS/CSSAnimation.h>
@@ -1173,8 +1174,14 @@ void Animation::update()
 
     // Prevent unnecessary work if the animation is already finished and can't exit the finished state due to timeline
     // changes
-    if (!m_is_finished || !m_timeline->is_monotonically_increasing())
-        update_finished_state(DidSeek::No, SynchronouslyNotify::Yes);
+    if (!m_is_finished || !m_timeline->is_monotonically_increasing()) {
+        bool was_finished = m_is_finished;
+        update_finished_state(DidSeek::No, SynchronouslyNotify::Yes, ShouldInvalidate::No);
+        if (play_state() == AnimationPlayState::Running && !pending())
+            invalidate_effect();
+        else if (m_is_finished != was_finished)
+            invalidate_effect();
+    }
 
     // Act on the pending play or pause task
     if (m_pending_play_task == TaskState::Scheduled && is_ready()) {
@@ -1628,8 +1635,12 @@ void Animation::invalidate_effect()
     if (!m_effect)
         return;
 
-    if (auto target = m_effect->target())
-        target->document().set_needs_animated_style_update();
+    if (!is<KeyframeEffect>(*m_effect))
+        return;
+
+    auto& effect = static_cast<KeyframeEffect&>(*m_effect);
+    if (auto target = effect.target())
+        target->document().set_needs_animated_style_update(effect);
 }
 
 Animation::Animation(HTML::EnvironmentSettingsObject& environment)

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -384,6 +384,16 @@ void Animation::calculate_auto_aligned_start_time()
 // https://www.w3.org/TR/web-animations-1/#animation-current-time
 Optional<TimeValue> Animation::current_time() const
 {
+    return current_time_at(m_timeline ? m_timeline->current_time() : Optional<TimeValue> {});
+}
+
+Optional<TimeValue> Animation::current_time_for_observation() const
+{
+    return current_time_at(m_timeline ? m_timeline->current_time_for_observation() : Optional<TimeValue> {});
+}
+
+Optional<TimeValue> Animation::current_time_at(Optional<TimeValue> timeline_time) const
+{
     // The current time is calculated from the first matching condition from below:
 
     // -> If the animation’s hold time is resolved,
@@ -396,7 +406,7 @@ Optional<TimeValue> Animation::current_time() const
     //    - the animation has no associated timeline, or
     //    - the associated timeline is inactive, or
     //    - the animation’s start time is unresolved.
-    if (!m_timeline || m_timeline->is_inactive() || !m_start_time.has_value()) {
+    if (!m_timeline || !timeline_time.has_value() || !m_start_time.has_value()) {
         // The current time is an unresolved time value.
         return {};
     }
@@ -405,7 +415,13 @@ Optional<TimeValue> Animation::current_time() const
     //    current time = (timeline time - start time) × playback rate
     //    Where timeline time is the current time value of the associated timeline. The playback rate value is defined
     //    in §4.4.15 Speed control.
-    return (m_timeline->current_time().value() - m_start_time.value()) * playback_rate();
+    return (timeline_time.value() - m_start_time.value()) * playback_rate();
+}
+
+NullableCSSNumberish Animation::current_time_for_bindings() const
+{
+    update_style_if_needed();
+    return NullableCSSNumberish::from_optional_css_numberish_time(current_time_for_observation());
 }
 
 // https://www.w3.org/TR/web-animations-1/#animation-set-the-current-time
@@ -489,6 +505,11 @@ void Animation::update_style_if_needed() const
 
 AnimationPlayState Animation::play_state() const
 {
+    return play_state_at(current_time());
+}
+
+AnimationPlayState Animation::play_state_at(Optional<TimeValue> current_time) const
+{
     // The play state of animation, animation, at a given moment is the state corresponding to the first matching
     // condition from the following:
 
@@ -496,7 +517,6 @@ AnimationPlayState Animation::play_state() const
     //    - The current time of animation is unresolved, and
     //    - the start time of animation is unresolved, and
     //    - animation does not have either a pending play task or a pending pause task,
-    auto current_time = this->current_time();
     if (!current_time.has_value() && !m_start_time.has_value() && !pending()) {
         // → idle
         return AnimationPlayState::Idle;
@@ -529,7 +549,7 @@ AnimationPlayState Animation::play_state_for_bindings()
     if (auto owning_element = this->owning_element(); owning_element.has_value())
         owning_element->document().update_style();
 
-    return play_state();
+    return play_state_at(current_time_for_observation());
 }
 
 bool Animation::pending_for_bindings() const
@@ -544,9 +564,18 @@ GC::Ref<WebIDL::Promise> Animation::ready_for_bindings() const
     return ready();
 }
 
-GC::Ref<WebIDL::Promise> Animation::finished_for_bindings() const
+GC::Ref<WebIDL::Promise> Animation::finished_for_bindings()
 {
     update_style_if_needed();
+    auto observed_timeline_time = m_timeline ? m_timeline->current_time_for_observation() : Optional<TimeValue> {};
+    auto observed_current_time = current_time_at(observed_timeline_time);
+    if (m_timeline
+        && !m_is_finished
+        && play_state_at(current_time()) != AnimationPlayState::Finished
+        && play_state_at(observed_current_time) == AnimationPlayState::Finished) {
+        AnimationTimeline::CurrentTimeOverrideScope current_time_override_scope { *m_timeline, observed_timeline_time };
+        update_finished_state(DidSeek::No, SynchronouslyNotify::Yes, ShouldInvalidate::No, observed_current_time);
+    }
     return finished();
 }
 
@@ -1291,7 +1320,7 @@ WebIDL::ExceptionOr<void> Animation::silently_set_current_time(Optional<TimeValu
 }
 
 // https://www.w3.org/TR/web-animations-1/#update-an-animations-finished-state
-void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify synchronously_notify, ShouldInvalidate should_invalidate)
+void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify synchronously_notify, ShouldInvalidate should_invalidate, Optional<TimeValue> observed_current_time)
 {
     auto& realm = HTML::relevant_realm(relevant_global_object());
 
@@ -1301,11 +1330,11 @@ void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify sync
     //
     // Note: This is required to accommodate timelines that may change direction. Without this definition, a once-
     //       finished animation would remain finished even when its timeline progresses in the opposite direction.
-    Optional<TimeValue> unconstrained_current_time;
-    if (did_seek == DidSeek::No) {
+    Optional<TimeValue> unconstrained_current_time = observed_current_time;
+    if (!unconstrained_current_time.has_value() && did_seek == DidSeek::No) {
         TemporaryChange change(m_hold_time, {});
         unconstrained_current_time = current_time();
-    } else {
+    } else if (!unconstrained_current_time.has_value()) {
         unconstrained_current_time = current_time();
     }
 

--- a/Libraries/LibWeb/Animations/Animation.h
+++ b/Libraries/LibWeb/Animations/Animation.h
@@ -68,12 +68,10 @@ public:
     void calculate_auto_aligned_start_time();
 
     // https://drafts.csswg.org/web-animations-2/#dom-animation-currenttime
-    NullableCSSNumberish current_time_for_bindings() const
-    {
-        update_style_if_needed();
-        return NullableCSSNumberish::from_optional_css_numberish_time(current_time());
-    }
+    NullableCSSNumberish current_time_for_bindings() const;
     Optional<TimeValue> current_time() const;
+    Optional<TimeValue> current_time_for_observation() const;
+    Optional<TimeValue> current_time_at(Optional<TimeValue> timeline_time) const;
     virtual WebIDL::ExceptionOr<void> set_current_time_for_bindings(NullableCSSNumberish const&);
 
     double playback_rate() const { return m_playback_rate; }
@@ -101,7 +99,7 @@ public:
     }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-finished
-    GC::Ref<WebIDL::Promise> finished_for_bindings() const;
+    GC::Ref<WebIDL::Promise> finished_for_bindings();
     GC::Ref<WebIDL::Promise> finished() const { return current_finished_promise(); }
     bool is_finished() const { return m_is_finished; }
 
@@ -169,6 +167,8 @@ protected:
     virtual void finalize() override;
 
 private:
+    AnimationPlayState play_state_at(Optional<TimeValue> current_time) const;
+
     virtual GC::Ptr<Bindings::Wrappable> relevant_global_impl() const override;
 
     enum class TaskState {
@@ -192,7 +192,7 @@ private:
 
     void apply_any_pending_playback_rate();
     WebIDL::ExceptionOr<void> silently_set_current_time(Optional<TimeValue>);
-    void update_finished_state(DidSeek, SynchronouslyNotify, ShouldInvalidate = ShouldInvalidate::Yes);
+    void update_finished_state(DidSeek, SynchronouslyNotify, ShouldInvalidate = ShouldInvalidate::Yes, Optional<TimeValue> observed_current_time = {});
     void reset_an_animations_pending_tasks();
 
     bool is_ready() const;

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/Bindings/AnimationEffect.h>
 #include <LibWeb/CSS/CSSNumericValue.h>
 #include <LibWeb/CSS/ComputedStyleWorkingSet.h>
@@ -370,6 +371,9 @@ WebIDL::ExceptionOr<void> AnimationEffect::update_timing(Bindings::OptionalEffec
 
     // 6. Follow the procedure to normalize specified timing.
     normalize_specified_timing();
+
+    if (auto* keyframe_effect = as_if<KeyframeEffect>(*this))
+        keyframe_effect->clear_per_frame_style_update_cache();
 
     // AD-HOC: Notify the associated animation that the effect timing has changed.
     if (auto animation = m_associated_animation)

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Bitmap.h>
+#include <AK/ScopeGuard.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationEffect.h>
@@ -118,6 +119,14 @@ Bindings::EffectTiming AnimationEffect::get_timing() const
 Bindings::ComputedEffectTiming AnimationEffect::get_computed_timing() const
 {
     update_style_if_needed();
+
+    if (m_associated_animation) {
+        m_has_local_time_override_for_observation = true;
+        m_local_time_override_for_observation = m_associated_animation->current_time_for_observation();
+    }
+    ScopeGuard clear_local_time_override = [&] {
+        m_has_local_time_override_for_observation = false;
+    };
 
     // 1. Returns the calculated timing properties for this animation effect.
 
@@ -411,6 +420,9 @@ TimeValue AnimationEffect::end_time() const
 // https://www.w3.org/TR/web-animations-1/#local-time
 Optional<TimeValue> AnimationEffect::local_time() const
 {
+    if (m_has_local_time_override_for_observation)
+        return m_local_time_override_for_observation;
+
     // The local time of an animation effect at a given moment is based on the first matching condition from the
     // following:
 

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -921,6 +921,12 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 continue;
             effects_to_collect.append(effect);
         }
+        // A dirty effect may have just become irrelevant. Include it once so rebuilding the
+        // animated overlay removes its terminal contribution.
+        for (auto& dirty_effect : it.value.effects) {
+            if (!effects_to_collect.contains_slow(dirty_effect))
+                effects_to_collect.append(dirty_effect);
+        }
         if (!effects_to_collect.is_empty())
             target->document().style_computer().collect_animations_into(element, effects_to_collect.span(), *style, CSS::StyleComputer::AnimationRefresh::Yes);
         auto animated_properties_after_update = style->animated_properties_snapshot();

--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -205,6 +205,9 @@ protected:
     // https://www.w3.org/TR/web-animations-1/#time-transformations
     CSS::EasingFunction m_timing_function { CSS::EasingFunction::linear() };
 
+    mutable bool m_has_local_time_override_for_observation { false };
+    mutable Optional<TimeValue> m_local_time_override_for_observation;
+
     // Used for calculating transitions in StyleComputer
     Phase m_previous_phase { Phase::Idle };
     double m_previous_current_iteration { 0.0 };

--- a/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -6,11 +6,29 @@
 
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
 
 namespace Web::Animations {
 
 GC_DEFINE_ALLOCATOR(AnimationTimeline);
+
+AnimationTimeline::CurrentTimeOverrideScope::CurrentTimeOverrideScope(AnimationTimeline& timeline, Optional<TimeValue> current_time)
+    : m_timeline(timeline)
+    , m_previous_current_time_override(timeline.m_current_time_override_for_style_sampling)
+    , m_had_previous_current_time_override(timeline.m_has_current_time_override_for_style_sampling)
+{
+    m_timeline->set_current_time_override_for_style_sampling(move(current_time));
+}
+
+AnimationTimeline::CurrentTimeOverrideScope::~CurrentTimeOverrideScope()
+{
+    m_timeline->m_current_time_override_for_style_sampling = move(m_previous_current_time_override);
+    m_timeline->m_has_current_time_override_for_style_sampling = m_had_previous_current_time_override;
+}
 
 // https://drafts.csswg.org/web-animations-1/#dom-animationtimeline-currenttime
 Optional<TimeValue> AnimationTimeline::current_time() const
@@ -18,7 +36,47 @@ Optional<TimeValue> AnimationTimeline::current_time() const
     // Returns the current time for this timeline or null if this timeline is inactive.
     if (is_inactive())
         return {};
-    return m_current_time;
+    return effective_current_time();
+}
+
+NullableCSSNumberish AnimationTimeline::current_time_for_bindings()
+{
+    return NullableCSSNumberish::from_optional_css_numberish_time(current_time_for_observation());
+}
+
+Optional<TimeValue> AnimationTimeline::current_time_for_observation()
+{
+    if (!m_is_monotonically_increasing || !can_sample_current_time_at_timestamp())
+        return current_time();
+
+    bool has_animation_without_per_frame_tick = false;
+    for (auto const& animation : m_associated_animations) {
+        auto effect = animation.effect();
+        if (!effect || !is<KeyframeEffect>(*effect))
+            continue;
+        auto& keyframe_effect = static_cast<KeyframeEffect&>(*effect);
+        if (keyframe_effect.per_frame_animation_tick_was_skipped() || keyframe_effect.can_skip_per_frame_animation_tick()) {
+            has_animation_without_per_frame_tick = true;
+            break;
+        }
+    }
+    if (!has_animation_without_per_frame_tick)
+        return current_time();
+
+    auto& settings = associated_document()->relevant_settings_object();
+    auto task_generation = settings.responsible_event_loop().task_generation();
+    if (m_last_current_time_update_task_generation == task_generation)
+        return m_observed_current_time;
+
+    // OPTIMIZATION: An animation skipped by the per-frame sampler does not keep the rendering update loop alive.
+    //               Sample document timelines only when script observes them, and at most once per event-loop task
+    //               so all reads within a stable state agree.
+    auto timestamp = HighResolutionTime::relative_high_resolution_time(
+        HighResolutionTime::unsafe_shared_current_time(), settings.global_object());
+    m_observed_current_time = current_time_at_timestamp(timestamp);
+    m_last_current_time_update_task_generation = task_generation;
+    ++associated_document()->style_invalidation_counters().animation_timeline_synchronizations;
+    return m_observed_current_time;
 }
 
 void AnimationTimeline::set_current_time(Optional<TimeValue> value)
@@ -29,6 +87,8 @@ void AnimationTimeline::set_current_time(Optional<TimeValue> value)
     }
 
     m_current_time = value;
+    m_observed_current_time = value;
+    m_last_current_time_update_task_generation = associated_document()->relevant_settings_object().responsible_event_loop().task_generation();
 
     update_associated_animations();
 }
@@ -42,8 +102,16 @@ void AnimationTimeline::update_associated_animations()
     //   updated.
     // - Queueing animation events for any such animations.
     // NB: Since we dispatch events for all animations regardless of whether they have a timeline we handle them all together in Document::update_animations_and_send_events()
+    ++associated_document()->style_invalidation_counters().animation_timeline_associated_animation_updates;
     for (auto& animation : m_associated_animations)
         animation.update();
+}
+
+Optional<TimeValue> AnimationTimeline::effective_current_time() const
+{
+    if (m_has_current_time_override_for_style_sampling)
+        return m_current_time_override_for_style_sampling;
+    return m_current_time;
 }
 
 // https://drafts.csswg.org/web-animations-2/#timeline-duration
@@ -62,7 +130,7 @@ NullableCSSNumberish AnimationTimeline::duration_for_bindings() const
 bool AnimationTimeline::is_inactive() const
 {
     // A timeline is considered to be inactive when its time value is unresolved, and active otherwise.
-    return !m_current_time.has_value();
+    return !effective_current_time().has_value();
 }
 
 AnimationTimeline::AnimationTimeline(GC::Ref<DOM::Document> document)

--- a/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -21,11 +21,23 @@ class AnimationTimeline : public Bindings::GCAllocatedWrappable {
 public:
     static constexpr bool OVERRIDES_FINALIZE = true;
 
-    NullableCSSNumberish current_time_for_bindings() const
-    {
-        return NullableCSSNumberish::from_optional_css_numberish_time(current_time());
-    }
+    class CurrentTimeOverrideScope {
+    public:
+        CurrentTimeOverrideScope(AnimationTimeline&, Optional<TimeValue>);
+        ~CurrentTimeOverrideScope();
+
+        CurrentTimeOverrideScope(CurrentTimeOverrideScope const&) = delete;
+        CurrentTimeOverrideScope& operator=(CurrentTimeOverrideScope const&) = delete;
+
+    private:
+        GC::Ref<AnimationTimeline> m_timeline;
+        Optional<TimeValue> m_previous_current_time_override;
+        bool m_had_previous_current_time_override { false };
+    };
+
+    NullableCSSNumberish current_time_for_bindings();
     Optional<TimeValue> current_time() const;
+    Optional<TimeValue> current_time_for_observation();
 
     virtual void update_current_time(double timestamp) = 0;
 
@@ -54,6 +66,8 @@ protected:
 
     void set_current_time(Optional<TimeValue> value);
     void update_associated_animations();
+    virtual bool can_sample_current_time_at_timestamp() const { return false; }
+    virtual Optional<TimeValue> current_time_at_timestamp(double) const { return current_time(); }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animationtimeline-currenttime
     Optional<TimeValue> m_current_time {};
@@ -65,6 +79,23 @@ protected:
     GC::Ref<DOM::Document> m_associated_document;
 
     GC::WeakHashSet<Animation> m_associated_animations;
+    Optional<u64> m_last_current_time_update_task_generation;
+    Optional<TimeValue> m_observed_current_time;
+
+private:
+    friend class DOM::Document;
+
+    void set_current_time_override_for_style_sampling(Optional<TimeValue> value)
+    {
+        m_current_time_override_for_style_sampling = move(value);
+        m_has_current_time_override_for_style_sampling = true;
+    }
+    void clear_current_time_override_for_style_sampling() { m_has_current_time_override_for_style_sampling = false; }
+
+    Optional<TimeValue> effective_current_time() const;
+
+    Optional<TimeValue> m_current_time_override_for_style_sampling;
+    bool m_has_current_time_override_for_style_sampling { false };
 };
 
 }

--- a/Libraries/LibWeb/Animations/DocumentTimeline.cpp
+++ b/Libraries/LibWeb/Animations/DocumentTimeline.cpp
@@ -66,6 +66,13 @@ void DocumentTimeline::update_current_time(double timestamp)
         m_is_monotonically_increasing = true;
 }
 
+Optional<TimeValue> DocumentTimeline::current_time_at_timestamp(double timestamp) const
+{
+    if (is_inactive())
+        return {};
+    return TimeValue { TimeValue::Type::Milliseconds, timestamp - m_origin_time };
+}
+
 // https://www.w3.org/TR/web-animations-1/#document-timelines
 bool DocumentTimeline::is_inactive() const
 {

--- a/Libraries/LibWeb/Animations/DocumentTimeline.h
+++ b/Libraries/LibWeb/Animations/DocumentTimeline.h
@@ -42,6 +42,10 @@ public:
     virtual Optional<double> convert_a_timeline_time_to_an_origin_relative_time(Optional<TimeValue>) override;
     virtual bool can_convert_a_timeline_time_to_an_origin_relative_time() const override { return true; }
 
+protected:
+    virtual bool can_sample_current_time_at_timestamp() const override { return true; }
+    virtual Optional<TimeValue> current_time_at_timestamp(double) const override;
+
 private:
     DocumentTimeline(DOM::Document&, HighResolutionTime::DOMHighResTimeStamp origin_time);
     virtual ~DocumentTimeline() override = default;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1018,6 +1018,7 @@ KeyframeEffect::KeyframeEffect() = default;
 
 void KeyframeEffect::invalidate_effect()
 {
+    m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
         m_target_element->document().set_needs_animated_style_update(*this);
 }
@@ -1031,18 +1032,44 @@ void KeyframeEffect::visit_edges(GC::Cell::Visitor& visitor)
 
 bool KeyframeEffect::can_skip_per_frame_style_update() const
 {
+    auto target = this->target();
+    auto cache_result = [&](bool result) {
+        if (target && target->document().layout_is_up_to_date()) {
+            m_can_skip_per_frame_style_update_cache = CanSkipPerFrameStyleUpdateCache {
+                .target_style_generation = target->animation_style_generation(),
+                .target_subtree_style_generation = target->animation_subtree_style_generation(),
+                .target_is_connected = target->is_connected(),
+                .layout_node = target->unsafe_layout_node(),
+                .result = result,
+            };
+        }
+        return result;
+    };
+    if (target && target->document().layout_is_up_to_date()) {
+        auto const* layout_node = target->unsafe_layout_node();
+        if (m_can_skip_per_frame_style_update_cache.has_value()
+            && m_can_skip_per_frame_style_update_cache->target_style_generation == target->animation_style_generation()
+            && m_can_skip_per_frame_style_update_cache->target_subtree_style_generation == target->animation_subtree_style_generation()
+            && m_can_skip_per_frame_style_update_cache->target_is_connected == target->is_connected()
+            && m_can_skip_per_frame_style_update_cache->layout_node == layout_node) {
+            ++target->document().style_invalidation_counters().animation_style_skip_cache_hits;
+            return m_can_skip_per_frame_style_update_cache->result;
+        }
+        if (m_can_skip_per_frame_style_update_cache.has_value())
+            ++target->document().style_invalidation_counters().animation_style_skip_cache_misses;
+    }
+
     // INTEROP: Other engines suppress main-thread style sampling for invisible transform animations. Restrict this
     // optimization to the infinite transform-only case until animation overflow updates can also be throttled safely.
     if (!isinf(iteration_count()) || pseudo_element_type().has_value())
-        return false;
+        return cache_result(false);
 
-    auto target = this->target();
     if (!target)
         return false;
     if (!target->is_connected())
-        return true;
+        return cache_result(true);
     if (target->namespace_uri() == Namespace::SVG)
-        return false;
+        return cache_result(false);
 
     bool has_animated_property = false;
     auto const* key_frame_set = m_key_frame_set.ptr();
@@ -1056,17 +1083,17 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
                     CSS::PropertyID::Translate,
                     CSS::PropertyID::Rotate,
                     CSS::PropertyID::Scale))
-                return false;
+                return cache_result(false);
         }
     }
     if (!has_animated_property)
-        return false;
+        return cache_result(false);
 
     if (!target->document().layout_is_up_to_date())
         return false;
     auto const* layout_node = target->unsafe_layout_node();
     if (!layout_node || layout_node->visibility() != CSS::Visibility::Hidden)
-        return false;
+        return cache_result(false);
 
     bool has_visible_descendant = false;
     layout_node->for_each_in_inclusive_subtree_of_type<Layout::NodeWithStyle>([&](auto const& descendant) {
@@ -1076,9 +1103,9 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
         return TraversalDecision::Break;
     });
     if (has_visible_descendant)
-        return false;
+        return cache_result(false);
 
-    return true;
+    return cache_result(true);
 }
 
 bool KeyframeEffect::can_skip_per_frame_animation_tick() const

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -20,7 +20,11 @@
 #include <LibWeb/ComputedValuesRustFFI.h>
 #include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Slot.h>
+#include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -1067,6 +1071,37 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
         return TraversalDecision::Break;
     });
     if (has_visible_descendant)
+        return false;
+
+    return true;
+}
+
+bool KeyframeEffect::can_skip_per_frame_animation_tick() const
+{
+    if (!can_skip_per_frame_style_update())
+        return false;
+
+    auto has_css_animation_event_listener = [](DOM::EventTarget const& event_target) {
+        return event_target.has_event_listener(HTML::EventNames::animationcancel)
+            || event_target.has_event_listener(HTML::EventNames::animationend)
+            || event_target.has_event_listener(HTML::EventNames::animationiteration)
+            || event_target.has_event_listener(HTML::EventNames::animationstart)
+            || event_target.has_event_listener(HTML::EventNames::webkitAnimationEnd)
+            || event_target.has_event_listener(HTML::EventNames::webkitAnimationIteration)
+            || event_target.has_event_listener(HTML::EventNames::webkitAnimationStart);
+    };
+
+    auto target = this->target();
+    VERIFY(target);
+    for (auto* node = static_cast<DOM::Node*>(target.ptr()); node;) {
+        if (has_css_animation_event_listener(*node))
+            return false;
+        if (auto assigned_slot = DOM::assigned_slot_for_node(*node))
+            node = assigned_slot.ptr();
+        else
+            node = node->parent_or_shadow_host();
+    }
+    if (auto window = target->document().window(); window && has_css_animation_event_listener(*window))
         return false;
 
     return true;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1036,7 +1036,11 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
         return false;
 
     auto target = this->target();
-    if (!target || target->namespace_uri() == Namespace::SVG)
+    if (!target)
+        return false;
+    if (!target->is_connected())
+        return true;
+    if (target->namespace_uri() == Namespace::SVG)
         return false;
 
     bool has_animated_property = false;
@@ -1081,12 +1085,11 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     if (!can_skip_per_frame_style_update())
         return false;
 
-    auto has_css_animation_event_listener = [](DOM::EventTarget const& event_target) {
+    // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.
+    auto has_css_animation_event_listener_requiring_animation_tick = [](DOM::EventTarget const& event_target) {
         return event_target.has_event_listener(HTML::EventNames::animationcancel)
-            || event_target.has_event_listener(HTML::EventNames::animationend)
             || event_target.has_event_listener(HTML::EventNames::animationiteration)
             || event_target.has_event_listener(HTML::EventNames::animationstart)
-            || event_target.has_event_listener(HTML::EventNames::webkitAnimationEnd)
             || event_target.has_event_listener(HTML::EventNames::webkitAnimationIteration)
             || event_target.has_event_listener(HTML::EventNames::webkitAnimationStart);
     };
@@ -1094,14 +1097,14 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     auto target = this->target();
     VERIFY(target);
     for (auto* node = static_cast<DOM::Node*>(target.ptr()); node;) {
-        if (has_css_animation_event_listener(*node))
+        if (has_css_animation_event_listener_requiring_animation_tick(*node))
             return false;
         if (auto assigned_slot = DOM::assigned_slot_for_node(*node))
             node = assigned_slot.ptr();
         else
             node = node->parent_or_shadow_host();
     }
-    if (auto window = target->document().window(); window && has_css_animation_event_listener(*window))
+    if (auto window = target->document().window(); window && has_css_animation_event_listener_requiring_animation_tick(*window))
         return false;
 
     return true;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1014,7 +1014,7 @@ KeyframeEffect::KeyframeEffect() = default;
 void KeyframeEffect::invalidate_effect()
 {
     if (m_target_element)
-        m_target_element->document().set_needs_animated_style_update();
+        m_target_element->document().set_needs_animated_style_update(*this);
 }
 
 void KeyframeEffect::visit_edges(GC::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1110,6 +1110,15 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
     return true;
 }
 
+void KeyframeEffect::request_observation_sample()
+{
+    if (m_needs_observation_sample)
+        return;
+    m_needs_observation_sample = true;
+    if (m_target_element)
+        m_target_element->document().set_needs_animated_style_update(*this);
+}
+
 void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
 {
     auto target = this->target();

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1024,6 +1024,54 @@ void KeyframeEffect::visit_edges(GC::Cell::Visitor& visitor)
     visitor.visit(m_keyframe_objects_cache);
 }
 
+bool KeyframeEffect::can_skip_per_frame_style_update() const
+{
+    // INTEROP: Other engines suppress main-thread style sampling for invisible transform animations. Restrict this
+    // optimization to the infinite transform-only case until animation overflow updates can also be throttled safely.
+    if (!isinf(iteration_count()) || pseudo_element_type().has_value())
+        return false;
+
+    auto target = this->target();
+    if (!target || target->namespace_uri() == Namespace::SVG)
+        return false;
+
+    bool has_animated_property = false;
+    auto const* key_frame_set = m_key_frame_set.ptr();
+    if (!key_frame_set)
+        return false;
+    for (auto const& keyframe : key_frame_set->keyframes_by_key) {
+        for (auto const& property : keyframe.properties) {
+            has_animated_property = true;
+            if (!first_is_one_of(property.key,
+                    CSS::PropertyID::Transform,
+                    CSS::PropertyID::Translate,
+                    CSS::PropertyID::Rotate,
+                    CSS::PropertyID::Scale))
+                return false;
+        }
+    }
+    if (!has_animated_property)
+        return false;
+
+    if (!target->document().layout_is_up_to_date())
+        return false;
+    auto const* layout_node = target->unsafe_layout_node();
+    if (!layout_node || layout_node->visibility() != CSS::Visibility::Hidden)
+        return false;
+
+    bool has_visible_descendant = false;
+    layout_node->for_each_in_inclusive_subtree_of_type<Layout::NodeWithStyle>([&](auto const& descendant) {
+        if (descendant.visibility() != CSS::Visibility::Visible)
+            return TraversalDecision::Continue;
+        has_visible_descendant = true;
+        return TraversalDecision::Break;
+    });
+    if (has_visible_descendant)
+        return false;
+
+    return true;
+}
+
 void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
 {
     auto target = this->target();

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -9,6 +9,7 @@
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibWeb/Animations/Animation.h>
+#include <LibWeb/Animations/AnimationTimeline.h>
 #include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/Animations/PseudoElementParsing.h>
 #include <LibWeb/Bindings/KeyframeEffect.h>
@@ -1082,6 +1083,13 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
 
 bool KeyframeEffect::can_skip_per_frame_animation_tick() const
 {
+    if (auto animation = associated_animation(); animation && !animation->pending()
+        && animation->play_state() == Bindings::AnimationPlayState::Running
+        && animation->playback_rate() > 0
+        && animation->timeline() && animation->timeline()->is_monotonically_increasing()
+        && is_in_the_before_phase())
+        return true;
+
     if (!can_skip_per_frame_style_update())
         return false;
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -146,6 +146,7 @@ public:
     virtual bool is_keyframe_effect() const override { return true; }
 
     bool can_skip_per_frame_style_update() const;
+    void clear_per_frame_style_update_cache() { m_can_skip_per_frame_style_update_cache.clear(); }
     bool can_skip_per_frame_animation_tick() const;
     void request_observation_sample();
     bool request_element_scoped_observation_sample(u64 task_generation)
@@ -189,6 +190,14 @@ private:
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
     bool m_needs_observation_sample { false };
+    struct CanSkipPerFrameStyleUpdateCache {
+        u64 target_style_generation { 0 };
+        u64 target_subtree_style_generation { 0 };
+        bool target_is_connected { false };
+        Layout::Node const* layout_node { nullptr };
+        bool result { false };
+    };
+    mutable Optional<CanSkipPerFrameStyleUpdateCache> m_can_skip_per_frame_style_update_cache;
     Optional<u64> m_last_element_scoped_observation_sample_task_generation;
     bool m_per_frame_animation_tick_was_skipped { false };
 };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -145,6 +145,7 @@ public:
 
     virtual bool is_keyframe_effect() const override { return true; }
 
+    bool can_skip_per_frame_style_update() const;
     virtual void update_computed_properties(AnimationUpdateContext&) override;
     void update_computed_properties_for_style(AnimationUpdateContext&, DOM::AbstractElement);
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -146,6 +146,10 @@ public:
     virtual bool is_keyframe_effect() const override { return true; }
 
     bool can_skip_per_frame_style_update() const;
+    bool can_skip_per_frame_animation_tick() const;
+    bool per_frame_animation_tick_was_skipped() const { return m_per_frame_animation_tick_was_skipped; }
+    void note_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = true; }
+    void clear_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = false; }
     virtual void update_computed_properties(AnimationUpdateContext&) override;
     void update_computed_properties_for_style(AnimationUpdateContext&, DOM::AbstractElement);
 
@@ -173,6 +177,7 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    bool m_per_frame_animation_tick_was_skipped { false };
 };
 
 WebIDL::ExceptionOr<Vector<BaseKeyframe>> process_keyframes(JS::Realm&, GC::Ptr<JS::Object>);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -147,6 +147,17 @@ public:
 
     bool can_skip_per_frame_style_update() const;
     bool can_skip_per_frame_animation_tick() const;
+    void request_observation_sample();
+    bool request_element_scoped_observation_sample(u64 task_generation)
+    {
+        if (m_last_element_scoped_observation_sample_task_generation == task_generation)
+            return false;
+        m_last_element_scoped_observation_sample_task_generation = task_generation;
+        request_observation_sample();
+        return true;
+    }
+    bool observation_sample_requested() const { return m_needs_observation_sample; }
+    bool consume_observation_sample_request() { return exchange(m_needs_observation_sample, false); }
     bool per_frame_animation_tick_was_skipped() const { return m_per_frame_animation_tick_was_skipped; }
     void note_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = true; }
     void clear_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = false; }
@@ -177,6 +188,8 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    bool m_needs_observation_sample { false };
+    Optional<u64> m_last_element_scoped_observation_sample_task_generation;
     bool m_per_frame_animation_tick_was_skipped { false };
 };
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -741,7 +741,7 @@ static Optional<Layout::NodeWithStyle*> prepare_computed_style_and_layout_for_pr
     if (needs_layout || needs_layout_node) {
         // Properties that need layout computation or layout node for special resolution
         // always need update_layout() to ensure both style and layout tree are up to date.
-        abstract_element.document().update_layout(DOM::UpdateLayoutReason::ResolvedCSSStyleDeclarationProperty);
+        abstract_element.document().update_layout_if_needed_for_node(abstract_element.element(), DOM::UpdateLayoutReason::ResolvedCSSStyleDeclarationProperty);
         layout_node = abstract_element.layout_node();
     }
     // Ensure styles are up to date. update_layout()/update_style() skip display:none subtrees,
@@ -769,7 +769,7 @@ static Optional<Layout::NodeWithStyle*> prepare_computed_style_and_layout_for_pr
     bool const needs_layout_for_container_queries = style_or_inheritance_ancestor_depends_on_size_container_query
         && !abstract_element.document().layout_is_up_to_date();
     if (needs_layout_for_container_queries) {
-        abstract_element.document().update_layout(DOM::UpdateLayoutReason::ResolvedCSSStyleDeclarationProperty);
+        abstract_element.document().update_layout_if_needed_for_node(abstract_element.element(), DOM::UpdateLayoutReason::ResolvedCSSStyleDeclarationProperty);
         layout_node = abstract_element.layout_node();
         // A synthetic pseudo which is not rendered is not part of the layout-driven pseudo
         // recomputation above. Refresh its CSSOM-only style against the settled container size.

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -902,13 +902,13 @@ void Document::update_style()
 
 bool Document::update_style_for_element(AbstractElement const& abstract_element)
 {
-    flush_throttled_animation_style_update();
+    flush_throttled_animation_style_update_for_node(abstract_element.element());
     return CSS::update_style_for_element(*this, abstract_element, StyleUpdateMode::Normal);
 }
 
 bool Document::update_style_for_element(AbstractElement const& abstract_element, StyleUpdateMode mode)
 {
-    flush_throttled_animation_style_update();
+    flush_throttled_animation_style_update_for_node(abstract_element.element());
     return CSS::update_style_for_element(*this, abstract_element, mode);
 }
 

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -449,7 +449,7 @@ static void update_style(DOM::Document& document)
     record_non_author_stylesheets(document);
     if (document.has_completed_style_update()
         && !document.style_computer().style_engine().has_pending_transaction()) {
-        document.update_animated_style_if_needed();
+        document.sample_animation_effects_needing_style_update();
         if (!document.style_computer().style_engine().has_pending_transaction())
             return;
     }
@@ -466,7 +466,7 @@ static void update_style(DOM::Document& document)
 
     if (!style_engine_transaction.reactions.is_empty())
         document.note_style_stabilization_has_style_reactions();
-    document.update_animated_style_if_needed();
+    document.sample_animation_effects_needing_style_update();
 
     auto style_engine_reactions = move(style_engine_transaction.reactions);
     auto prefers_broad_matching_batch = style_engine_transaction.prefers_broad_matching_batch;
@@ -627,7 +627,7 @@ static void update_style(DOM::Document& document)
 
     document.set_has_completed_style_update();
     apply_document_style_invalidation_after_style_change(document, invalidation);
-    document.update_animated_style_if_needed();
+    document.sample_animation_effects_needing_style_update();
 }
 
 static void apply_targeted_style_invalidation(DOM::Element& element, RequiredInvalidationAfterStyleChange const& invalidation, bool did_change_custom_properties, bool descendant_style_recompute_needed, Optional<StyleNodeID> child_materialized_by_targeted_update)
@@ -782,7 +782,7 @@ static bool update_style_for_element(DOM::Document& document, DOM::AbstractEleme
             update_style(document);
             ran_regular_style_update = true;
         } else {
-            document.update_animated_style_if_needed();
+            document.sample_animation_effects_needing_style_update();
             if (!document.is_running_update_layout()
                 && document.style_computer().style_engine().has_pending_transaction()) {
                 update_style(document);

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -246,6 +246,10 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
         bool const was_unstyled = !previous_style_record;
         auto const* previous_box_values = element->style_group<ComputedValues::BoxValues>();
         bool const was_display_none = previous_box_values && display_from_ffi_display(previous_box_values->display).is_none();
+        auto const* previous_inherited_box_values = element->style_group<ComputedValues::InheritedBoxValues>();
+        auto const previous_visibility = previous_inherited_box_values
+            ? Optional<Visibility> { static_cast<Visibility>(previous_inherited_box_values->visibility) }
+            : Optional<Visibility> {};
         bool const needs_regular_style_recompute = reaction.reaction & (StyleEngine::PublishedStyle | StyleEngine::RecomputeStyle | StyleEngine::RecomputeDescendantStyles | StyleEngine::AncestorBecameVisible);
         bool const needs_custom_property_recompute = reaction.reaction & StyleEngine::InheritedCustomProperties;
         bool const needs_inherited_style_recompute = reaction.reaction & StyleEngine::InheritedStyle;
@@ -318,6 +322,12 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
         } else if (needs_custom_property_recompute && element->refresh_inherited_custom_property_data()) {
             did_change_custom_properties = true;
             element->invalidate_descendant_styles_depending_on_style_container_query();
+        }
+
+        auto const* current_inherited_box_values = element->style_group<ComputedValues::InheritedBoxValues>();
+        if (previous_visibility.has_value() && current_inherited_box_values
+            && *previous_visibility != static_cast<Visibility>(current_inherited_box_values->visibility)) {
+            document.throttled_animation_visibility_changed();
         }
 
         if (!invalidation.is_none() || did_change_custom_properties || ancestor_became_visible)
@@ -892,11 +902,13 @@ void Document::update_style()
 
 bool Document::update_style_for_element(AbstractElement const& abstract_element)
 {
+    flush_throttled_animation_style_update();
     return CSS::update_style_for_element(*this, abstract_element, StyleUpdateMode::Normal);
 }
 
 bool Document::update_style_for_element(AbstractElement const& abstract_element, StyleUpdateMode mode)
 {
+    flush_throttled_animation_style_update();
     return CSS::update_style_for_element(*this, abstract_element, mode);
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2637,6 +2637,12 @@ void Document::sample_animation_effects_needing_style_update()
     if (!m_needs_animated_style_update)
         return;
 
+    VERIFY(!m_is_updating_animated_style);
+    m_is_updating_animated_style = true;
+    ScopeGuard clear_is_updating_animated_style = [&] {
+        finish_animated_style_update();
+    };
+
     Animations::AnimationUpdateContext context;
 
     GC::RootVector<GC::Ref<Animations::Animation>> animations;
@@ -2661,6 +2667,11 @@ void Document::sample_animation_effects_needing_style_update()
 
 void Document::set_needs_animated_style_update(Animations::KeyframeEffect& effect)
 {
+    if (m_is_updating_animated_style) {
+        m_effects_needing_animated_style_update_after_current_update.set(effect);
+        return;
+    }
+
     m_effects_needing_animated_style_update.set(effect);
     if (m_needs_animated_style_update)
         return;
@@ -2672,6 +2683,37 @@ void Document::set_needs_animated_style_update(Animations::KeyframeEffect& effec
         return;
 
     page().client().request_frame();
+}
+
+void Document::finish_animated_style_update()
+{
+    VERIFY(m_is_updating_animated_style);
+    m_is_updating_animated_style = false;
+
+    GC::RootVector<GC::Ref<Animations::KeyframeEffect>> effects;
+    for (auto& effect : m_effects_needing_animated_style_update_after_current_update)
+        effects.append(effect);
+    m_effects_needing_animated_style_update_after_current_update.clear();
+
+    for (auto& effect : effects)
+        set_needs_animated_style_update(*effect);
+}
+
+void Document::request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const& node)
+{
+    VERIFY(!m_is_updating_animated_style);
+    m_is_updating_animated_style = true;
+    ScopeGuard clear_is_updating_animated_style = [&] {
+        finish_animated_style_update();
+    };
+    for (auto& animation : m_associated_animations) {
+        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+            continue;
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        auto target = effect.target();
+        if (target && target->is_shadow_including_inclusive_ancestor_of(node))
+            set_needs_animated_style_update(effect);
+    }
 }
 
 void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates, ReadonlySpan<Layout::Box const*> boxes_needing_eager_measurement)
@@ -7377,8 +7419,11 @@ void Document::associate_with_animation(GC::Ref<Animations::Animation> animation
 
 void Document::disassociate_with_animation(GC::Ref<Animations::Animation> animation)
 {
-    if (animation->effect() && is<Animations::KeyframeEffect>(*animation->effect()))
-        m_effects_needing_animated_style_update.remove(static_cast<Animations::KeyframeEffect&>(*animation->effect()));
+    if (animation->effect() && is<Animations::KeyframeEffect>(*animation->effect())) {
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation->effect());
+        m_effects_needing_animated_style_update.remove(effect);
+        m_effects_needing_animated_style_update_after_current_update.remove(effect);
+    }
     m_associated_animations.remove(animation);
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2683,12 +2683,18 @@ void Document::sample_animation_effects_needing_style_update()
     }
 
     m_has_throttled_animation_style_update = has_throttled_animation_style_update;
+    if (m_force_throttled_animation_style_update)
+        m_last_forced_throttled_animation_style_update_task_generation = relevant_settings_object().responsible_event_loop().task_generation();
     m_force_throttled_animation_style_update = false;
 }
 
 void Document::flush_throttled_animation_style_update()
 {
     if (!m_has_throttled_animation_style_update)
+        return;
+    auto task_generation = relevant_settings_object().responsible_event_loop().task_generation();
+    if (!m_needs_animated_style_update
+        && m_last_forced_throttled_animation_style_update_task_generation == task_generation)
         return;
     m_has_throttled_animation_style_update = false;
     m_force_throttled_animation_style_update = true;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -703,6 +703,7 @@ void Document::record_layout_tree_build(u64 rebuilt_subtree_root_count, bool esc
 
 void Document::finalize()
 {
+    stop_animation_wakeup_timer();
     if (m_layout_node_arena)
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
     CSS::ComputedValuesFFI::rust_custom_property_registry_destroy(m_rust_custom_property_registry);
@@ -2752,6 +2753,67 @@ void Document::flush_throttled_animation_style_update_for_node(Node const& node)
         else
             effect->request_element_scoped_observation_sample(task_generation);
     }
+}
+
+void Document::stop_animation_wakeup_timer()
+{
+    if (!m_animation_wakeup_timer)
+        return;
+    m_animation_wakeup_timer->stop();
+    m_animation_wakeup_deadline.clear();
+}
+
+void Document::schedule_animation_wakeup(double delay_ms)
+{
+    auto timer_delay_ms = clamp(static_cast<i64>(ceil(delay_ms)), 1, static_cast<i64>(NumericLimits<int>::max()));
+    auto deadline = MonotonicTime::now() + AK::Duration::from_milliseconds(timer_delay_ms);
+    if (m_animation_wakeup_timer && m_animation_wakeup_timer->is_active()
+        && m_animation_wakeup_deadline.has_value() && *m_animation_wakeup_deadline <= deadline)
+        return;
+
+    m_animation_wakeup_deadline = deadline;
+    if (!m_animation_wakeup_timer) {
+        m_animation_wakeup_timer = Core::Timer::create_single_shot(static_cast<int>(timer_delay_ms), GC::weak_callback(*this, [](auto& document) {
+            document.m_animation_wakeup_deadline.clear();
+            auto timestamp = HighResolutionTime::relative_high_resolution_time(
+                HighResolutionTime::unsafe_shared_current_time(), document.relevant_settings_object().global_object());
+            Optional<double> next_wakeup_delay_ms;
+            bool reached_wakeup = false;
+            for (auto& animation : document.m_associated_animations) {
+                if (!animation.effect())
+                    continue;
+                auto* effect = as_if<Animations::KeyframeEffect>(*animation.effect());
+                if (!effect)
+                    continue;
+                if (animation.play_state() != Bindings::AnimationPlayState::Running
+                    || animation.pending()
+                    || animation.playback_rate() <= 0
+                    || !animation.timeline()
+                    || !animation.timeline()->is_monotonically_increasing()
+                    || effect->start_delay().type != Animations::TimeValue::Type::Milliseconds)
+                    continue;
+                auto timeline_time = animation.timeline()->current_time_at_timestamp(timestamp);
+                auto current_time = animation.current_time_at(timeline_time);
+                if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
+                    continue;
+                if (current_time->value < effect->start_delay().value) {
+                    auto delay = (effect->start_delay().value - current_time->value) / animation.playback_rate();
+                    if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                        next_wakeup_delay_ms = delay;
+                    continue;
+                }
+                effect->request_observation_sample();
+                reached_wakeup = true;
+            }
+            if (next_wakeup_delay_ms.has_value())
+                document.schedule_animation_wakeup(*next_wakeup_delay_ms);
+            if (reached_wakeup) {
+                ++document.m_style_invalidation_counters.animation_frame_pump_requests;
+                document.page().client().request_frame();
+            }
+        }));
+    }
+    m_animation_wakeup_timer->restart(static_cast<int>(timer_delay_ms));
 }
 
 void Document::throttled_animation_visibility_changed()
@@ -5991,6 +6053,7 @@ void Document::destroy()
 
     // 2. Abort document.
     abort();
+    stop_animation_wakeup_timer();
 
     // AD-HOC: Notify document observers that this document became inactive.
     //         This handles iframe-removal destruction, which doesn't otherwise go through
@@ -6472,6 +6535,7 @@ bool Document::is_allowed_to_use_feature(PolicyControlledFeature feature) const
 
 void Document::did_stop_being_active_document_in_navigable()
 {
+    stop_animation_wakeup_timer();
     clear_layout_nodes_for_inactive_document();
     tear_down_layout_tree();
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2351,6 +2351,9 @@ void Document::update_layout(UpdateLayoutReason reason)
     if (!navigable || navigable->active_document().ptr() != this)
         return;
 
+    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate)
+        flush_throttled_animation_style_update();
+
     VERIFY(!m_is_running_update_layout);
     m_is_running_update_layout = true;
     ScopeGuard guard = [&] {
@@ -2646,11 +2649,19 @@ void Document::sample_animation_effects_needing_style_update()
     Animations::AnimationUpdateContext context;
 
     GC::RootVector<GC::Ref<Animations::Animation>> animations;
-    for (auto& effect : m_effects_needing_animated_style_update) {
-        auto animation = effect.associated_animation();
-        if (!animation || animation->is_idle())
-            continue;
-        animations.append(*animation);
+    if (m_force_throttled_animation_style_update) {
+        for (auto& animation : m_associated_animations) {
+            if (animation.is_idle() || !animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+                continue;
+            animations.append(animation);
+        }
+    } else {
+        for (auto& effect : m_effects_needing_animated_style_update) {
+            auto animation = effect.associated_animation();
+            if (!animation || animation->is_idle())
+                continue;
+            animations.append(*animation);
+        }
     }
     m_effects_needing_animated_style_update.clear();
     m_needs_animated_style_update = false;
@@ -2661,8 +2672,35 @@ void Document::sample_animation_effects_needing_style_update()
         return Animations::KeyframeEffect::composite_order(a_effect, b_effect) < 0;
     });
 
-    for (auto& animation : animations)
+    bool has_throttled_animation_style_update = m_force_throttled_animation_style_update ? false : m_has_throttled_animation_style_update;
+    for (auto& animation : animations) {
+        if (!m_force_throttled_animation_style_update
+            && static_cast<Animations::KeyframeEffect&>(*animation->effect()).can_skip_per_frame_style_update()) {
+            has_throttled_animation_style_update = true;
+            continue;
+        }
         animation->effect()->update_computed_properties(context);
+    }
+
+    m_has_throttled_animation_style_update = has_throttled_animation_style_update;
+    m_force_throttled_animation_style_update = false;
+}
+
+void Document::flush_throttled_animation_style_update()
+{
+    if (!m_has_throttled_animation_style_update)
+        return;
+    m_has_throttled_animation_style_update = false;
+    m_force_throttled_animation_style_update = true;
+    m_needs_animated_style_update = true;
+}
+
+void Document::throttled_animation_visibility_changed()
+{
+    if (!m_has_throttled_animation_style_update)
+        return;
+    flush_throttled_animation_style_update();
+    page().client().request_frame();
 }
 
 void Document::set_needs_animated_style_update(Animations::KeyframeEffect& effect)
@@ -5053,8 +5091,10 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
     event->set_bubbles(true);
     dispatch_event(event);
 
-    if (m_visibility_state == HTML::VisibilityState::Visible)
+    if (m_visibility_state == HTML::VisibilityState::Visible) {
+        flush_throttled_animation_style_update();
         page().client().request_frame();
+    }
 }
 
 // https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7486,6 +7486,34 @@ void Document::append_pending_animation_event(Web::DOM::Document::PendingAnimati
     ++m_style_invalidation_counters.committed_animation_events;
 }
 
+void Document::prepare_to_observe_css_animation_events()
+{
+    GC::RootVector<GC::Ref<Animations::KeyframeEffect>> effects_to_synchronize;
+    for (auto& animation : m_associated_animations) {
+        if (!animation.is_css_animation() || !animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+            continue;
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        if (effect.per_frame_animation_tick_was_skipped())
+            effects_to_synchronize.append(effect);
+    }
+    if (effects_to_synchronize.is_empty())
+        return;
+
+    auto timestamp = HighResolutionTime::relative_high_resolution_time(
+        HighResolutionTime::unsafe_shared_current_time(), relevant_settings_object().global_object());
+    auto timelines_to_update = GC::RootVector { m_associated_animation_timelines.values() };
+    for (auto const& timeline : timelines_to_update)
+        timeline->update_current_time(timestamp);
+
+    // OPTIMIZATION: Events which occurred while there were no listeners were intentionally not sampled. Establish
+    //               the current phase as the baseline so a newly added listener only observes future events.
+    for (auto& effect : effects_to_synchronize) {
+        effect->set_previous_phase(effect->phase());
+        effect->set_previous_current_iteration(effect->current_iteration().value_or(0.0));
+        effect->clear_per_frame_animation_tick_was_skipped();
+    }
+}
+
 // https://www.w3.org/TR/web-animations-1/#update-animations-and-send-events
 void Document::update_animations_and_send_events(double timestamp)
 {
@@ -7568,13 +7596,22 @@ void Document::update_animations_and_send_events(double timestamp)
     //         false to true, and the flag is both set and cleared within the same rendering update.
     //         Without this, animations only advance when unrelated tasks happen to schedule rendering
     //         updates. Keep the frame pump going as long as some animation attached to a monotonically
-    //         increasing timeline is running.
+    //         increasing timeline needs main-thread painting or observable animation events.
     for (auto const& animation : m_associated_animations) {
         if (animation.play_state() != Bindings::AnimationPlayState::Running)
             continue;
         auto timeline = animation.timeline();
         if (!timeline || !timeline->is_monotonically_increasing())
             continue;
+        if (animation.effect() && is<Animations::KeyframeEffect>(*animation.effect())) {
+            auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+            if (effect.can_skip_per_frame_animation_tick()) {
+                effect.note_per_frame_animation_tick_was_skipped();
+                continue;
+            }
+            effect.clear_per_frame_animation_tick_was_skipped();
+        }
+        ++m_style_invalidation_counters.animation_frame_pump_requests;
         page().client().request_frame();
         break;
     }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2062,6 +2062,9 @@ void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutRe
     if (!node.is_connected())
         return;
 
+    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate)
+        flush_throttled_animation_style_update_for_node(node);
+
     auto* document_element = this->document_element();
     auto const may_have_style_query_dependencies = document_element && document_element->is_style_query_container();
     auto const reads_layout_geometry = reason == UpdateLayoutReason::ElementGetClientRects
@@ -2115,7 +2118,7 @@ void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutRe
         }
     }
 
-    update_layout(reason);
+    update_layout(reason, ThrottledAnimationSamplingScope::Element);
 }
 
 void Document::flush_deferred_style_change_event()
@@ -2347,11 +2350,16 @@ Document::PartialRelayoutResult Document::try_partial_relayout(HashTable<WeakPtr
 
 void Document::update_layout(UpdateLayoutReason reason)
 {
+    update_layout(reason, ThrottledAnimationSamplingScope::Document);
+}
+
+void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSamplingScope animation_sampling_scope)
+{
     auto navigable = this->navigable();
     if (!navigable || navigable->active_document().ptr() != this)
         return;
 
-    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate)
+    if (reason != UpdateLayoutReason::HTMLEventLoopRenderingUpdate && animation_sampling_scope == ThrottledAnimationSamplingScope::Document)
         flush_throttled_animation_style_update();
 
     VERIFY(!m_is_running_update_layout);
@@ -2646,8 +2654,6 @@ void Document::sample_animation_effects_needing_style_update()
         finish_animated_style_update();
     };
 
-    Animations::AnimationUpdateContext context;
-
     GC::RootVector<GC::Ref<Animations::Animation>> animations;
     if (m_force_throttled_animation_style_update) {
         for (auto& animation : m_associated_animations) {
@@ -2666,6 +2672,30 @@ void Document::sample_animation_effects_needing_style_update()
     m_effects_needing_animated_style_update.clear();
     m_needs_animated_style_update = false;
 
+    if (animations.is_empty()) {
+        m_force_throttled_animation_style_update = false;
+        m_has_throttled_animation_style_update = false;
+        return;
+    }
+
+    bool has_requested_observation_sample = any_of(animations, [](auto const& animation) {
+        return as_if<Animations::KeyframeEffect>(*animation->effect())->observation_sample_requested();
+    });
+
+    GC::RootVector<GC::Ref<Animations::AnimationTimeline>> timelines_with_current_time_override;
+    if (m_force_throttled_animation_style_update || has_requested_observation_sample) {
+        for (auto& timeline : m_associated_animation_timelines)
+            timelines_with_current_time_override.append(timeline);
+        for (auto& timeline : timelines_with_current_time_override)
+            timeline->set_current_time_override_for_style_sampling(timeline->current_time_for_observation());
+    }
+    ScopeGuard clear_current_time_overrides = [&] {
+        for (auto& timeline : timelines_with_current_time_override)
+            timeline->clear_current_time_override_for_style_sampling();
+    };
+
+    Animations::AnimationUpdateContext context;
+
     quick_sort(animations, [](GC::Ref<Animations::Animation>& a, GC::Ref<Animations::Animation>& b) {
         auto& a_effect = as<Animations::KeyframeEffect>(*a->effect());
         auto& b_effect = as<Animations::KeyframeEffect>(*b->effect());
@@ -2674,10 +2704,12 @@ void Document::sample_animation_effects_needing_style_update()
 
     bool has_throttled_animation_style_update = m_force_throttled_animation_style_update ? false : m_has_throttled_animation_style_update;
     for (auto& animation : animations) {
-        if (!m_force_throttled_animation_style_update
-            && static_cast<Animations::KeyframeEffect&>(*animation->effect()).can_skip_per_frame_style_update()) {
+        auto& effect = *as_if<Animations::KeyframeEffect>(*animation->effect());
+        bool observation_sample_requested = effect.consume_observation_sample_request();
+        if (effect.can_skip_per_frame_style_update()) {
             has_throttled_animation_style_update = true;
-            continue;
+            if (!m_force_throttled_animation_style_update && !observation_sample_requested)
+                continue;
         }
         animation->effect()->update_computed_properties(context);
     }
@@ -2699,6 +2731,27 @@ void Document::flush_throttled_animation_style_update()
     m_has_throttled_animation_style_update = false;
     m_force_throttled_animation_style_update = true;
     m_needs_animated_style_update = true;
+}
+
+void Document::flush_throttled_animation_style_update_for_node(Node const& node)
+{
+    auto task_generation = relevant_settings_object().responsible_event_loop().task_generation();
+    for (auto& animation : m_associated_animations) {
+        if (!animation.effect())
+            continue;
+        auto* effect = as_if<Animations::KeyframeEffect>(*animation.effect());
+        if (!effect)
+            continue;
+        auto target = effect->target();
+        if (!target
+            || !effect->can_skip_per_frame_style_update()
+            || (!target->is_shadow_including_inclusive_ancestor_of(node) && !node.is_shadow_including_inclusive_ancestor_of(*target)))
+            continue;
+        if (m_is_updating_animated_style)
+            m_effects_needing_animated_style_update_after_current_update.set(*effect);
+        else
+            effect->request_element_scoped_observation_sample(task_generation);
+    }
 }
 
 void Document::throttled_animation_visibility_changed()
@@ -2740,7 +2793,7 @@ void Document::finish_animated_style_update()
     m_effects_needing_animated_style_update_after_current_update.clear();
 
     for (auto& effect : effects)
-        set_needs_animated_style_update(*effect);
+        effect->request_observation_sample();
 }
 
 void Document::request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const& node)
@@ -2750,14 +2803,7 @@ void Document::request_reentrant_animation_style_flush_for_testing(Badge<Interna
     ScopeGuard clear_is_updating_animated_style = [&] {
         finish_animated_style_update();
     };
-    for (auto& animation : m_associated_animations) {
-        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
-            continue;
-        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
-        auto target = effect.target();
-        if (target && target->is_shadow_including_inclusive_ancestor_of(node))
-            set_needs_animated_style_update(effect);
-    }
+    flush_throttled_animation_style_update_for_node(node);
 }
 
 void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates, ReadonlySpan<Layout::Box const*> boxes_needing_eager_measurement)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2632,7 +2632,7 @@ void Document::invalidate_style_for_viewport_change()
     });
 }
 
-void Document::update_animated_style_if_needed()
+void Document::sample_animation_effects_needing_style_update()
 {
     if (!m_needs_animated_style_update)
         return;
@@ -2640,16 +2640,14 @@ void Document::update_animated_style_if_needed()
     Animations::AnimationUpdateContext context;
 
     GC::RootVector<GC::Ref<Animations::Animation>> animations;
-
-    for (auto& animation : m_associated_animations) {
-        if (animation.is_idle())
+    for (auto& effect : m_effects_needing_animated_style_update) {
+        auto animation = effect.associated_animation();
+        if (!animation || animation->is_idle())
             continue;
-
-        if (!animation.effect())
-            continue;
-
-        animations.append(animation);
+        animations.append(*animation);
     }
+    m_effects_needing_animated_style_update.clear();
+    m_needs_animated_style_update = false;
 
     quick_sort(animations, [](GC::Ref<Animations::Animation>& a, GC::Ref<Animations::Animation>& b) {
         auto& a_effect = as<Animations::KeyframeEffect>(*a->effect());
@@ -2659,12 +2657,11 @@ void Document::update_animated_style_if_needed()
 
     for (auto& animation : animations)
         animation->effect()->update_computed_properties(context);
-
-    m_needs_animated_style_update = false;
 }
 
-void Document::set_needs_animated_style_update()
+void Document::set_needs_animated_style_update(Animations::KeyframeEffect& effect)
 {
+    m_effects_needing_animated_style_update.set(effect);
     if (m_needs_animated_style_update)
         return;
 
@@ -7380,6 +7377,8 @@ void Document::associate_with_animation(GC::Ref<Animations::Animation> animation
 
 void Document::disassociate_with_animation(GC::Ref<Animations::Animation> animation)
 {
+    if (animation->effect() && is<Animations::KeyframeEffect>(*animation->effect()))
+        m_effects_needing_animated_style_update.remove(static_cast<Animations::KeyframeEffect&>(*animation->effect()));
     m_associated_animations.remove(animation);
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1023,6 +1023,7 @@ public:
     };
     void append_pending_animation_event(PendingAnimationEvent const&);
     void update_animations_and_send_events(double timestamp);
+    void prepare_to_observe_css_animation_events();
     void dispatch_events_for_animation_if_necessary(GC::Ref<Animations::Animation>);
     void remove_replaced_animations();
 
@@ -1100,6 +1101,7 @@ public:
         u64 animated_style_reconstruction_fallbacks { 0 };
         u64 animated_style_overlay_builds { 0 };
         u64 animated_style_full_builds { 0 };
+        u64 animation_frame_pump_requests { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };
         u64 computed_longhand_evaluations { 0 };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -500,10 +500,14 @@ public:
     };
     void update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates, ReadonlySpan<Layout::Box const*> boxes_needing_eager_measurement = {});
     void update_paint_and_hit_testing_properties_if_needed();
-    void update_animated_style_if_needed();
+    void sample_animation_effects_needing_style_update();
     void update_style_computer_viewport_rect();
     bool needs_animated_style_update() const { return m_needs_animated_style_update; }
-    void clear_needs_animated_style_update() { m_needs_animated_style_update = false; }
+    void clear_needs_animated_style_update()
+    {
+        m_needs_animated_style_update = false;
+        m_effects_needing_animated_style_update.clear();
+    }
     bool is_running_update_layout() const { return m_is_running_update_layout; }
 
     void invalidate_layout_tree(InvalidateLayoutTreeReason);
@@ -1054,7 +1058,7 @@ public:
     GC::RootVector<GC::Ref<Element>> elements_from_point(double x, double y);
     GC::Ptr<Element const> scrolling_element() const;
 
-    void set_needs_animated_style_update();
+    void set_needs_animated_style_update(Animations::KeyframeEffect&);
 
     CSS::SheetSetStyleCacheRegistry& sheet_set_style_cache_registry() { return m_sheet_set_style_cache_registry; }
 
@@ -1702,6 +1706,7 @@ private:
     u64 m_full_layout_count { 0 };
 
     bool m_needs_animated_style_update { false };
+    GC::WeakHashSet<Animations::KeyframeEffect> m_effects_needing_animated_style_update;
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1102,6 +1102,8 @@ public:
         u64 animated_style_overlay_builds { 0 };
         u64 animated_style_full_builds { 0 };
         u64 animation_frame_pump_requests { 0 };
+        u64 animation_timeline_associated_animation_updates { 0 };
+        u64 animation_timeline_synchronizations { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };
         u64 computed_longhand_evaluations { 0 };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1111,6 +1111,8 @@ public:
         u64 animated_style_full_builds { 0 };
         u64 animation_frame_pump_requests { 0 };
         u64 animation_timeline_associated_animation_updates { 0 };
+        u64 animation_style_skip_cache_hits { 0 };
+        u64 animation_style_skip_cache_misses { 0 };
         u64 animation_timeline_synchronizations { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -469,6 +469,9 @@ public:
     void obtain_theme_color();
 
     void update_style();
+    void note_throttled_animation_style_update() { m_has_throttled_animation_style_update = true; }
+    void flush_throttled_animation_style_update();
+    void throttled_animation_visibility_changed();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }
     void set_suppresses_attribute_style_invalidation(bool suppresses) { m_suppresses_attribute_style_invalidation = suppresses; }
@@ -1713,6 +1716,8 @@ private:
     GC::WeakHashSet<Animations::KeyframeEffect> m_effects_needing_animated_style_update;
     GC::WeakHashSet<Animations::KeyframeEffect> m_effects_needing_animated_style_update_after_current_update;
     bool m_is_updating_animated_style { false };
+    bool m_has_throttled_animation_style_update { false };
+    bool m_force_throttled_animation_style_update { false };
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -507,6 +507,7 @@ public:
     {
         m_needs_animated_style_update = false;
         m_effects_needing_animated_style_update.clear();
+        m_effects_needing_animated_style_update_after_current_update.clear();
     }
     bool is_running_update_layout() const { return m_is_running_update_layout; }
 
@@ -1059,6 +1060,7 @@ public:
     GC::Ptr<Element const> scrolling_element() const;
 
     void set_needs_animated_style_update(Animations::KeyframeEffect&);
+    void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
 
     CSS::SheetSetStyleCacheRegistry& sheet_set_style_cache_registry() { return m_sheet_set_style_cache_registry; }
 
@@ -1450,6 +1452,8 @@ protected:
 private:
     friend struct AdoptedStyleSheetsAccess;
 
+    void finish_animated_style_update();
+
     GC::Ref<WebIDL::ObservableArray> adopted_style_sheets() const;
 
     void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
@@ -1707,6 +1711,8 @@ private:
 
     bool m_needs_animated_style_update { false };
     GC::WeakHashSet<Animations::KeyframeEffect> m_effects_needing_animated_style_update;
+    GC::WeakHashSet<Animations::KeyframeEffect> m_effects_needing_animated_style_update_after_current_update;
+    bool m_is_updating_animated_style { false };
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -472,6 +472,8 @@ public:
     void note_throttled_animation_style_update() { m_has_throttled_animation_style_update = true; }
     void flush_throttled_animation_style_update();
     void flush_throttled_animation_style_update_for_node(Node const&);
+    void schedule_animation_wakeup(double delay_ms);
+    void stop_animation_wakeup_timer();
     void throttled_animation_visibility_changed();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }
@@ -1835,6 +1837,8 @@ private:
     bool m_will_declaratively_refresh { false };
 
     RefPtr<Core::Timer> m_active_refresh_timer;
+    RefPtr<Core::Timer> m_animation_wakeup_timer;
+    Optional<MonotonicTime> m_animation_wakeup_deadline;
 
     bool m_temporary_document_for_fragment_parsing { false };
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1722,6 +1722,7 @@ private:
     bool m_is_updating_animated_style { false };
     bool m_has_throttled_animation_style_update { false };
     bool m_force_throttled_animation_style_update { false };
+    Optional<u64> m_last_forced_throttled_animation_style_update_task_generation;
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -471,6 +471,7 @@ public:
     void update_style();
     void note_throttled_animation_style_update() { m_has_throttled_animation_style_update = true; }
     void flush_throttled_animation_style_update();
+    void flush_throttled_animation_style_update_for_node(Node const&);
     void throttled_animation_visibility_changed();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }
@@ -482,7 +483,12 @@ public:
     };
     bool update_style_for_element(AbstractElement const&);
     bool update_style_for_element(AbstractElement const&, StyleUpdateMode);
+    enum class ThrottledAnimationSamplingScope : u8 {
+        Document,
+        Element,
+    };
     void update_layout(UpdateLayoutReason);
+    void update_layout(UpdateLayoutReason, ThrottledAnimationSamplingScope);
     void note_content_visibility_auto_style() { m_may_have_content_visibility_auto_style = true; }
     void note_default_scroll_shift_anchor() { m_may_have_default_scroll_shift_anchor = true; }
     [[nodiscard]] bool may_have_default_scroll_shift_anchor() const { return m_may_have_default_scroll_shift_anchor; }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4904,6 +4904,8 @@ void Element::replace_style_record(CSS::StyleRecordID style_record_identity)
 
 void Element::set_computed_style(Optional<CSS::PseudoElement> pseudo_element_type, CSS::StyleRecordID style_record_identity)
 {
+    for (auto* element = this; element; element = element->parent_or_shadow_host_element())
+        ++element->m_animation_subtree_style_generation;
     if (pseudo_element_type.has_value()) {
         VERIFY(is_synthetic_pseudo_element(*pseudo_element_type));
         if (!!style_record_identity)
@@ -4912,6 +4914,7 @@ void Element::set_computed_style(Optional<CSS::PseudoElement> pseudo_element_typ
             existing_pseudo_element->set_computed_style(0);
         return;
     }
+    ++m_animation_style_generation;
     replace_style_record(style_record_identity);
     computed_properties_changed();
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -354,6 +354,8 @@ public:
 
     [[nodiscard]] CSS::ComputedStyleRecordView computed_style(Optional<CSS::PseudoElement> = {}) const;
     [[nodiscard]] CSS::StyleRecordID style_record_identity(Optional<CSS::PseudoElement> = {}) const;
+    u64 animation_style_generation() const { return m_animation_style_generation; }
+    u64 animation_subtree_style_generation() const { return m_animation_subtree_style_generation; }
     [[nodiscard]] bool has_style(Optional<CSS::PseudoElement> pseudo_element = {}) const { return !!style_record_identity(pseudo_element); }
     [[nodiscard]] void const* style_record_payloads(Optional<CSS::PseudoElement> = {}) const;
     template<typename StyleGroup>
@@ -899,6 +901,8 @@ private:
     // borrow the record-owned computed-values view rather than retaining one complete style per
     // element.
     CSS::StyleRecordID m_style_record_identity;
+    u64 m_animation_style_generation { 0 };
+    u64 m_animation_subtree_style_generation { 0 };
     RefPtr<CSS::CustomPropertyData const> m_custom_property_data;
     OwnPtr<CSS::StyleInputRecord> m_style_input_record;
     PublishedCustomPropertyNames m_published_custom_property_names;

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -286,6 +286,46 @@ static void invalidate_compositor_wheel_event_listener_state(EventTarget& event_
     }
 }
 
+static bool is_css_animation_event_listener(DOMEventListener const& listener)
+{
+    return AK::first_is_one_of(listener.type,
+        HTML::EventNames::animationcancel,
+        HTML::EventNames::animationend,
+        HTML::EventNames::animationiteration,
+        HTML::EventNames::animationstart,
+        HTML::EventNames::webkitAnimationEnd,
+        HTML::EventNames::webkitAnimationIteration,
+        HTML::EventNames::webkitAnimationStart);
+}
+
+static void wake_animation_frame_pump_for_animation_event_listener(EventTarget& event_target, DOMEventListener const& listener)
+{
+    if (!is_css_animation_event_listener(listener))
+        return;
+
+    if (auto* window = as_if<HTML::Window>(event_target)) {
+        window->associated_document().page().client().request_frame();
+        return;
+    }
+
+    if (auto* node = as_if<Node>(event_target))
+        node->document().page().client().request_frame();
+}
+
+static void prepare_to_observe_css_animation_events(EventTarget& event_target, DOMEventListener const& listener)
+{
+    if (!is_css_animation_event_listener(listener))
+        return;
+
+    if (auto* window = as_if<HTML::Window>(event_target)) {
+        window->associated_document().prepare_to_observe_css_animation_events();
+        return;
+    }
+
+    if (auto* node = as_if<Node>(event_target))
+        node->document().prepare_to_observe_css_animation_events();
+}
+
 static void update_needs_beforeunload_check(EventTarget& event_target, DOMEventListener const& listener)
 {
     if (listener.type != HTML::EventNames::beforeunload)
@@ -369,8 +409,10 @@ void EventTarget::add_an_event_listener(DOMEventListener& listener)
             && entry->capture == listener.capture;
     });
     if (it == event_listener_list.end()) {
+        prepare_to_observe_css_animation_events(*this, listener);
         event_listener_list.append(listener);
         invalidate_compositor_wheel_event_listener_state(*this, listener);
+        wake_animation_frame_pump_for_animation_event_listener(*this, listener);
         update_needs_beforeunload_check(*this, listener);
         event_listener_list_changed();
     }

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
@@ -29,6 +29,12 @@ void InternalAnimationTimeline::set_time(Optional<double> time)
     set_current_time(time.map([](double value) -> Animations::TimeValue { return { Animations::TimeValue::Type::Milliseconds, value }; }));
 }
 
+void InternalAnimationTimeline::set_time_for_observation(double time)
+{
+    m_time_for_observation = Animations::TimeValue { Animations::TimeValue::Type::Milliseconds, time };
+    m_last_current_time_update_task_generation = {};
+}
+
 InternalAnimationTimeline::InternalAnimationTimeline(GC::Ref<DOM::Document> document)
     : AnimationTimeline(document)
 {

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.h
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.h
@@ -24,10 +24,17 @@ public:
     virtual void update_current_time(double timestamp) override;
 
     void set_time(Optional<double> time);
+    void set_time_for_observation(double time);
+
+protected:
+    virtual bool can_sample_current_time_at_timestamp() const override { return m_time_for_observation.has_value(); }
+    virtual Optional<Animations::TimeValue> current_time_at_timestamp(double) const override { return m_time_for_observation; }
 
 private:
     explicit InternalAnimationTimeline(GC::Ref<DOM::Document>);
     virtual ~InternalAnimationTimeline() override = default;
+
+    Optional<Animations::TimeValue> m_time_for_observation;
 };
 
 }

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.idl
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.idl
@@ -1,4 +1,5 @@
 [Exposed=Nobody]
 interface InternalAnimationTimeline : AnimationTimeline {
     undefined setTime(double? time);
+    undefined setTimeForObservation(double time);
 };

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1776,6 +1776,8 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
     object->define_direct_property("animationFramePumpRequests"_utf16_fly_string, JS::Value(counters.animation_frame_pump_requests), JS::default_attributes);
     object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
+    object->define_direct_property("animationStyleSkipCacheHits"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_hits), JS::default_attributes);
+    object->define_direct_property("animationStyleSkipCacheMisses"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_misses), JS::default_attributes);
     object->define_direct_property("animationTimelineSynchronizations"_utf16_fly_string, JS::Value(counters.animation_timeline_synchronizations), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1191,6 +1191,11 @@ void Internals::reset_style_invalidation_counters()
     window().associated_document().reset_style_invalidation_counters();
 }
 
+void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
+{
+    window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
+}
+
 GC::Ref<JS::Object> Internals::layout_tree_build_stats()
 {
     auto object = JS::Object::create(window().principal_realm(), nullptr);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1774,6 +1774,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("animatedStyleOverlayBuilds"_utf16_fly_string, JS::Value(counters.animated_style_overlay_builds), JS::default_attributes);
     object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
+    object->define_direct_property("animationFramePumpRequests"_utf16_fly_string, JS::Value(counters.animation_frame_pump_requests), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);
     object->define_direct_property("computedLonghandEvaluations"_utf16_fly_string, JS::Value(counters.computed_longhand_evaluations), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1775,6 +1775,8 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
     object->define_direct_property("animationFramePumpRequests"_utf16_fly_string, JS::Value(counters.animation_frame_pump_requests), JS::default_attributes);
+    object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
+    object->define_direct_property("animationTimelineSynchronizations"_utf16_fly_string, JS::Value(counters.animation_timeline_synchronizations), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);
     object->define_direct_property("computedLonghandEvaluations"_utf16_fly_string, JS::Value(counters.computed_longhand_evaluations), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -181,6 +181,7 @@ public:
     DOM::Document::StyleInvalidationCounters const& style_invalidation_counters() const;
     GC::Ref<JS::Object> style_invalidation_counters_object() const;
     void reset_style_invalidation_counters();
+    void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();
     GC::Ref<JS::Object> computed_values_stats();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -162,6 +162,7 @@ interface Internals {
     // elementStyleRecomputations, and styleEnvironmentVersion.
     [ImplementedAs=style_invalidation_counters_object] object getStyleInvalidationCounters();
     undefined resetStyleInvalidationCounters();
+    undefined requestReentrantAnimationStyleFlushForTesting(Node node);
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of
     // subtrees rebuilt in place), lastBuildEscapedRebuildRoots (whether any tree mutation

--- a/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
@@ -1,4 +1,8 @@
 completed effects stay out of animated style updates: true
+stable skip eligibility is cached: true
+unrelated style changes preserve skip eligibility: true
+timing changes invalidate skip eligibility: true
+descendant style changes invalidate skip eligibility: true
 finished sibling contribution is retained: true
 active sibling contributes to computed style: true
 paused animation builds no overlays: true

--- a/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
@@ -1,0 +1,4 @@
+completed effects stay out of animated style updates: true
+finished sibling contribution is retained: true
+active sibling contributes to computed style: true
+paused animation builds no overlays: true

--- a/Tests/LibWeb/Text/expected/css/animation-finished-observation.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-finished-observation.txt
@@ -1,0 +1,4 @@
+observed play state is finished: true
+finished getter observes the same state: true
+finish event current time is effect end: true
+finish event timeline time is observation time: true

--- a/Tests/LibWeb/Text/expected/css/animation-observation-timeline.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-observation-timeline.txt
@@ -1,0 +1,3 @@
+one synchronization in a task: 1
+getter updates associated animations: 0
+next task synchronizes again: 2

--- a/Tests/LibWeb/Text/expected/css/delayed-script-animation-start-wakeup.txt
+++ b/Tests/LibWeb/Text/expected/css/delayed-script-animation-start-wakeup.txt
@@ -1,0 +1,4 @@
+delayed script animation receives its start wake-up: true
+zero-delay animation wakes after rewind: true
+animationstart fires near the active boundary: true
+delayed script animation uses a bounded frame pump: true

--- a/Tests/LibWeb/Text/expected/css/element-scoped-animation-sampling.txt
+++ b/Tests/LibWeb/Text/expected/css/element-scoped-animation-sampling.txt
@@ -1,0 +1,4 @@
+unrelated reads do not sample animation: true
+related reads sample once per task: true
+related read samples in a later task: true
+ancestor reads sample descendant animations: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -1,0 +1,6 @@
+hidden animation overlay builds: 0
+computed style samples hidden animation: true
+visible animation builds while hidden stays throttled: 4
+computed style samples hidden animation alongside visible animation: true
+style-only visibility change samples animation: true
+visible descendant keeps animation updating: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -4,6 +4,11 @@ animation event listener keeps frame pump active: true
 animation event listener skips past events: 0
 removing animation event listener stops frame pump: 0
 computed style samples hidden animation: true
+detached animation stops frame pump: 0
+detached animation current time advances: true
+unreachable end listener leaves detached animation throttled: true
+detached animation listener keeps frame pump active: true
+detached animation dispatches iteration event: 1
 visible animation builds while hidden stays throttled: 4
 computed style samples hidden animation alongside visible animation: true
 style-only visibility change samples animation: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -9,6 +9,9 @@ detached animation current time advances: true
 unreachable end listener leaves detached animation throttled: true
 detached animation listener keeps frame pump active: true
 detached animation dispatches iteration event: 1
+computed style uses current timeline sample: true
+computed timing uses current timeline sample: true
+geometry uses current timeline sample: true
 visible animation builds while hidden stays throttled: 4
 computed style samples hidden animation alongside visible animation: true
 style-only visibility change samples animation: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -1,4 +1,8 @@
 hidden animation overlay builds: 0
+hidden animation frame pump requests: 0
+animation event listener keeps frame pump active: true
+animation event listener skips past events: 0
+removing animation event listener stops frame pump: 0
 computed style samples hidden animation: true
 visible animation builds while hidden stays throttled: 4
 computed style samples hidden animation alongside visible animation: true

--- a/Tests/LibWeb/Text/expected/css/reentrant-animation-style-flush.txt
+++ b/Tests/LibWeb/Text/expected/css/reentrant-animation-style-flush.txt
@@ -1,0 +1,1 @@
+reentrant style read queues a follow-up sample: true

--- a/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
+++ b/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
@@ -27,6 +27,14 @@
             { transform: "translateX(100px)" },
         ], { duration: 100000, iterations: Infinity });
 
+        const hiddenTarget = document.createElement("div");
+        hiddenTarget.style.visibility = "hidden";
+        document.body.append(hiddenTarget);
+        const hiddenAnimation = hiddenTarget.animate([
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100000, iterations: Infinity });
+
         for (let i = 0; i < 4; ++i)
             await nextFrame();
         internals.resetStyleInvalidationCounters();
@@ -34,6 +42,33 @@
             await nextFrame();
         const steadyCounters = internals.getStyleInvalidationCounters();
         println(`completed effects stay out of animated style updates: ${steadyCounters.animatedStyleOverlayBuilds <= 6}`);
+        println(`stable skip eligibility is cached: ${steadyCounters.animationStyleSkipCacheHits > 0}`);
+
+        const unrelatedTarget = document.createElement("div");
+        document.body.append(unrelatedTarget);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i) {
+            unrelatedTarget.style.color = `rgb(${i}, 0, 0)`;
+            await nextFrame();
+        }
+        const unrelatedStyleCounters = internals.getStyleInvalidationCounters();
+        println(`unrelated style changes preserve skip eligibility: ${unrelatedStyleCounters.animationStyleSkipCacheHits > 0 && unrelatedStyleCounters.animationStyleSkipCacheMisses === 0}`);
+
+        hiddenAnimation.effect.updateTiming({ iterations: 1 });
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`timing changes invalidate skip eligibility: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 0}`);
+        hiddenAnimation.effect.updateTiming({ iterations: Infinity });
+        await nextFrame();
+
+        const visibleChild = document.createElement("div");
+        visibleChild.style.visibility = "visible";
+        hiddenTarget.append(visibleChild);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`descendant style changes invalidate skip eligibility: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 4}`);
 
         const siblingTarget = document.createElement("div");
         siblingTarget.style.cssText = "opacity: 0; transform-origin: center center 1px";

--- a/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
+++ b/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function nextFrame() {
+        return new Promise(requestAnimationFrame);
+    }
+
+    asyncTest(async done => {
+        const completedTargets = [];
+        for (let i = 0; i < 20; ++i) {
+            const target = document.createElement("div");
+            target.style.transformOrigin = "center center 1px";
+            document.body.append(target);
+            const animation = target.animate([
+                { transform: "translateX(0px)" },
+                { transform: "translateX(10px)" },
+            ], { duration: 1, fill: "forwards" });
+            await animation.finished;
+            completedTargets.push(target);
+        }
+
+        const activeTarget = document.createElement("div");
+        activeTarget.style.transformOrigin = "center center 1px";
+        document.body.append(activeTarget);
+        activeTarget.animate([
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100000, iterations: Infinity });
+
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        const steadyCounters = internals.getStyleInvalidationCounters();
+        println(`completed effects stay out of animated style updates: ${steadyCounters.animatedStyleOverlayBuilds <= 6}`);
+
+        const siblingTarget = document.createElement("div");
+        siblingTarget.style.cssText = "opacity: 0; transform-origin: center center 1px";
+        document.body.append(siblingTarget);
+        const filledAnimation = siblingTarget.animate([
+            { opacity: 0.4 },
+            { opacity: 0.4 },
+        ], { duration: 1, fill: "forwards" });
+        await filledAnimation.finished;
+        siblingTarget.animate([
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100000, iterations: Infinity });
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`finished sibling contribution is retained: ${getComputedStyle(siblingTarget).opacity === "0.4"}`);
+
+        const mixedTarget = document.createElement("div");
+        mixedTarget.style.opacity = "1";
+        document.body.append(mixedTarget);
+        mixedTarget.animate([
+            { opacity: 0.2 },
+            { opacity: 0.8 },
+        ], { duration: 100000 });
+        mixedTarget.animate([
+            { color: "rgb(0, 0, 0)" },
+            { color: "rgb(255, 0, 0)" },
+        ], { duration: 100000 });
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`active sibling contributes to computed style: ${getComputedStyle(mixedTarget).opacity !== "1"}`);
+
+        for (const animation of document.getAnimations())
+            animation.cancel();
+        await nextFrame();
+
+        const pausedTarget = document.createElement("div");
+        document.body.append(pausedTarget);
+        const pausedAnimation = pausedTarget.animate([
+            { color: "rgb(0, 0, 0)" },
+            { color: "rgb(255, 0, 0)" },
+        ], { duration: 100000 });
+        await pausedAnimation.ready;
+        pausedAnimation.pause();
+        await pausedAnimation.ready;
+        await nextFrame();
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`paused animation builds no overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animation-finished-observation.html
+++ b/Tests/LibWeb/Text/input/css/animation-finished-observation.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target" style="visibility: hidden"></div>
+<script>
+    asyncTest(async done => {
+        const timeline = internals.createInternalAnimationTimeline();
+        const skippedTarget = document.createElement("div");
+        skippedTarget.style.visibility = "hidden";
+        document.body.append(skippedTarget);
+        const skippedAnimation = new Animation(new KeyframeEffect(skippedTarget, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 10000, iterations: Infinity }), timeline);
+        const animation = new Animation(new KeyframeEffect(target, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { delay: 100, duration: 100, fill: "forwards" }), timeline);
+        skippedAnimation.play();
+        animation.play();
+        timeline.setTime(0);
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        timeline.setTimeForObservation(250);
+        const playState = animation.playState;
+        let finishEvent;
+        animation.addEventListener("finish", event => finishEvent = event, { once: true });
+        const finishedPromise = animation.finished;
+        await finishedPromise;
+        await new Promise(requestAnimationFrame);
+
+        println(`observed play state is finished: ${playState === "finished"}`);
+        println(`finished getter observes the same state: ${animation.playState === "finished"}`);
+        println(`finish event current time is effect end: ${finishEvent.currentTime === 200}`);
+        println(`finish event timeline time is observation time: ${finishEvent.timelineTime === 250}`);
+        skippedAnimation.cancel();
+        animation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animation-observation-timeline.html
+++ b/Tests/LibWeb/Text/input/css/animation-observation-timeline.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move {
+        from { transform: translateX(0px); }
+        to { transform: translateX(100px); }
+    }
+
+    #target {
+        animation: move 100s linear infinite;
+        visibility: hidden;
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        internals.resetStyleInvalidationCounters();
+
+        const animation = document.getAnimations()[0];
+        animation.effect.getComputedTiming();
+        animation.playState;
+        animation.finished;
+        document.timeline.currentTime;
+        animation.currentTime;
+        document.timeline.currentTime;
+        println(`one synchronization in a task: ${internals.getStyleInvalidationCounters().animationTimelineSynchronizations}`);
+        println(`getter updates associated animations: ${internals.getStyleInvalidationCounters().animationTimelineAssociatedAnimationUpdates}`);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        animation.currentTime;
+        println(`next task synchronizes again: ${internals.getStyleInvalidationCounters().animationTimelineSynchronizations}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/delayed-script-animation-start-wakeup.html
+++ b/Tests/LibWeb/Text/input/css/delayed-script-animation-start-wakeup.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<style>
+    @keyframes delayed-css-start {
+        from { color: rgb(10, 0, 0); }
+        to { color: rgb(20, 0, 0); }
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const target = document.createElement("div");
+        document.body.append(target);
+
+        const cssTarget = document.createElement("div");
+        let cssAnimationStartTime;
+        cssTarget.addEventListener("animationstart", () => {
+            cssAnimationStartTime = performance.now();
+        });
+        cssTarget.style.animation = "delayed-css-start 100s 500ms";
+        document.body.append(cssTarget);
+
+        const animation = target.animate([
+            { color: "rgb(10, 0, 0)" },
+            { color: "rgb(20, 0, 0)" },
+        ], { delay: 500, duration: 100000, fill: "backwards" });
+        await animation.ready;
+
+        const rewoundTarget = document.createElement("div");
+        rewoundTarget.style.visibility = "hidden";
+        document.body.append(rewoundTarget);
+        const rewoundAnimation = rewoundTarget.animate([
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100000, fill: "backwards", iterations: Infinity });
+        await rewoundAnimation.ready;
+        rewoundAnimation.currentTime = -100;
+
+        const readyTime = performance.now();
+        internals.resetStyleInvalidationCounters();
+        await new Promise(resolve => setTimeout(resolve, 625));
+        const counters = internals.getStyleInvalidationCounters();
+
+        println(`delayed script animation receives its start wake-up: ${animation.currentTime >= 500 && counters.animationFramePumpRequests >= 1}`);
+        println(`zero-delay animation wakes after rewind: ${rewoundAnimation.currentTime >= 0 && counters.animationFramePumpRequests >= 2}`);
+        println(`animationstart fires near the active boundary: ${cssAnimationStartTime !== undefined && cssAnimationStartTime - readyTime <= 625}`);
+        println(`delayed script animation uses a bounded frame pump: ${counters.animationFramePumpRequests >= 2 && counters.animationFramePumpRequests <= 16}`);
+
+        animation.cancel();
+        rewoundAnimation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/element-scoped-animation-sampling.html
+++ b/Tests/LibWeb/Text/input/css/element-scoped-animation-sampling.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move {
+        from { transform: translateX(0px); }
+        to { transform: translateX(100px); }
+    }
+
+    #animated {
+        width: 20px;
+        height: 20px;
+        animation: move 10s linear infinite;
+        visibility: hidden;
+    }
+
+    #overflow-container {
+        width: 20px;
+        overflow: auto;
+    }
+
+    #overflow-animated {
+        width: 20px;
+        height: 20px;
+        visibility: hidden;
+    }
+</style>
+<div id="animated"><div id="descendant"></div></div>
+<div id="unrelated"></div>
+<div id="overflow-container"><div id="overflow-animated"></div></div>
+<script>
+    asyncTest(async done => {
+        const overflowAnimated = document.getElementById("overflow-animated");
+        const overflowContainer = document.getElementById("overflow-container");
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        unrelated.getBoundingClientRect();
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 100; ++i) {
+            unrelated.getBoundingClientRect();
+            getComputedStyle(unrelated).width;
+        }
+        println(`unrelated reads do not sample animation: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        descendant.getBoundingClientRect();
+        descendant.getBoundingClientRect();
+        println(`related reads sample once per task: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 1}`);
+
+        await new Promise(requestAnimationFrame);
+        descendant.getBoundingClientRect();
+        println(`related read samples in a later task: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 2}`);
+
+        const timeline = internals.createInternalAnimationTimeline();
+        const overflowAnimation = new Animation(new KeyframeEffect(overflowAnimated, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100, iterations: Infinity }), timeline);
+        overflowAnimation.play();
+        timeline.setTime(0);
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        timeline.setTimeForObservation(50);
+        internals.resetStyleInvalidationCounters();
+        const scrollWidth = overflowContainer.scrollWidth;
+        const counters = internals.getStyleInvalidationCounters();
+        println(`ancestor reads sample descendant animations: ${counters.animatedStyleOverlayBuilds > 0 && scrollWidth > 20}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -80,6 +80,32 @@
         println(`detached animation listener keeps frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
         println(`detached animation dispatches iteration event: ${detachedIterationEvents}`);
 
+        const sampled = document.createElement("div");
+        sampled.style.visibility = "hidden";
+        document.body.append(sampled);
+        const timeline = internals.createInternalAnimationTimeline();
+        const sampledAnimation = new Animation(new KeyframeEffect(sampled, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100, iterations: Infinity }), timeline);
+        sampledAnimation.play();
+        timeline.setTime(0);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+
+        timeline.setTimeForObservation(50);
+        const sampledProgress = sampledAnimation.effect.getComputedTiming().progress;
+        const initialTransform = new DOMMatrix(getComputedStyle(sampled).transform);
+        const initialRect = sampled.getBoundingClientRect();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        timeline.setTimeForObservation(75);
+        const sampledRect = sampled.getBoundingClientRect();
+        const sampledTransform = new DOMMatrix(getComputedStyle(sampled).transform);
+        println(`computed style uses current timeline sample: ${initialTransform.e === 50 && sampledTransform.e === 75}`);
+        println(`computed timing uses current timeline sample: ${sampledProgress === 0.5}`);
+        println(`geometry uses current timeline sample: ${sampledRect.x - initialRect.x === 25}`);
+        sampled.remove();
+
         const visible = document.createElement("div");
         visible.className = "animated";
         document.body.append(visible);

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -52,6 +52,34 @@
         const afterComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
         println(`computed style samples hidden animation: ${afterComputedStyle > beforeComputedStyle}`);
 
+        const detached = document.createElement("div");
+        detached.className = "animated";
+        document.body.append(detached);
+        const detachedAnimation = detached.getAnimations()[0];
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        detached.remove();
+        detachedAnimation.play();
+        await detachedAnimation.ready;
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        const detachedTimeBeforeWait = detachedAnimation.currentTime;
+        internals.resetStyleInvalidationCounters();
+        await new Promise(resolve => setTimeout(resolve, 120));
+        println(`detached animation stops frame pump: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
+        println(`detached animation current time advances: ${detachedAnimation.currentTime > detachedTimeBeforeWait}`);
+        detached.addEventListener("animationend", () => {});
+        internals.resetStyleInvalidationCounters();
+        await new Promise(resolve => setTimeout(resolve, 120));
+        println(`unreachable end listener leaves detached animation throttled: ${internals.getStyleInvalidationCounters().animationFramePumpRequests <= 1}`);
+        let detachedIterationEvents = 0;
+        detached.addEventListener("animationiteration", () => ++detachedIterationEvents);
+        detachedAnimation.currentTime = 99950;
+        internals.resetStyleInvalidationCounters();
+        await new Promise(resolve => setTimeout(resolve, 120));
+        println(`detached animation listener keeps frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        println(`detached animation dispatches iteration event: ${detachedIterationEvents}`);
+
         const visible = document.createElement("div");
         visible.className = "animated";
         document.body.append(visible);

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    .animated {
+        animation: spin 100s linear infinite;
+    }
+</style>
+<script>
+    function nextFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    async function animationOverlayBuildsOverFrames(frameCount) {
+        const before = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
+        for (let i = 0; i < frameCount; ++i)
+            await nextFrame();
+        return internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds - before;
+    }
+
+    asyncTest(async done => {
+        const hidden = document.createElement("div");
+        hidden.className = "animated";
+        hidden.style.visibility = "hidden";
+        document.body.append(hidden);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+
+        println(`hidden animation overlay builds: ${await animationOverlayBuildsOverFrames(4)}`);
+
+        const beforeComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
+        getComputedStyle(hidden).transform;
+        const afterComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
+        println(`computed style samples hidden animation: ${afterComputedStyle > beforeComputedStyle}`);
+
+        const visible = document.createElement("div");
+        visible.className = "animated";
+        document.body.append(visible);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        println(`visible animation builds while hidden stays throttled: ${await animationOverlayBuildsOverFrames(4)}`);
+
+        const beforeMixedComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
+        getComputedStyle(hidden).transform;
+        const afterMixedComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
+        println(`computed style samples hidden animation alongside visible animation: ${afterMixedComputedStyle > beforeMixedComputedStyle}`);
+        visible.remove();
+
+        const styleOnlyVisibilityChange = document.createElement("div");
+        styleOnlyVisibilityChange.className = "animated";
+        styleOnlyVisibilityChange.style.visibility = "hidden";
+        document.body.append(styleOnlyVisibilityChange);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        internals.resetStyleInvalidationCounters();
+        styleOnlyVisibilityChange.style.visibility = "visible";
+        await new Promise(resolve => setTimeout(resolve, 0));
+        println(`style-only visibility change samples animation: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 0}`);
+        styleOnlyVisibilityChange.remove();
+
+        const visibleChild = document.createElement("div");
+        visibleChild.style.visibility = "visible";
+        hidden.append(visibleChild);
+        await nextFrame();
+
+        const visibleDescendantBuilds = await animationOverlayBuildsOverFrames(4);
+        println(`visible descendant keeps animation updating: ${visibleDescendantBuilds > 0}`);
+
+        hidden.remove();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -30,7 +30,22 @@
         for (let i = 0; i < 4; ++i)
             await nextFrame();
 
+        internals.resetStyleInvalidationCounters();
         println(`hidden animation overlay builds: ${await animationOverlayBuildsOverFrames(4)}`);
+        println(`hidden animation frame pump requests: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
+
+        hidden.getAnimations()[0].currentTime = 250000;
+        let animationIterationEvents = 0;
+        const animationIterationListener = () => ++animationIterationEvents;
+        hidden.addEventListener("animationiteration", animationIterationListener);
+        internals.resetStyleInvalidationCounters();
+        await animationOverlayBuildsOverFrames(4);
+        println(`animation event listener keeps frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        println(`animation event listener skips past events: ${animationIterationEvents}`);
+        hidden.removeEventListener("animationiteration", animationIterationListener);
+        internals.resetStyleInvalidationCounters();
+        await animationOverlayBuildsOverFrames(4);
+        println(`removing animation event listener stops frame pump: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
 
         const beforeComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
         getComputedStyle(hidden).transform;

--- a/Tests/LibWeb/Text/input/css/reentrant-animation-style-flush.html
+++ b/Tests/LibWeb/Text/input/css/reentrant-animation-style-flush.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        target.animate({ opacity: [0.2, 0.8] }, 100000);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        internals.resetStyleInvalidationCounters();
+        internals.requestReentrantAnimationStyleFlushForTesting(target);
+        await new Promise(requestAnimationFrame);
+
+        println(`reentrant style read queues a follow-up sample: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 1}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Reduce steady-state CPU usage on animation-heavy sites such as YouTube by sampling only dirty effects and stopping the frame pump when animation output cannot be observed.

Hidden transform animations, detached infinite animations, and delayed animations now remain dormant until visibility changes, event listeners, timing observations, synchronous reads, or active-start timers make an update necessary. Forced samples and timeline reads are reused within an event-loop task, while skip eligibility is cached per target.

This reduces animation sampling and frame requests from every rendering opportunity to zero while the remaining animations are unobservable.