### PR TITLE
LibIPC+LibCore: Fix lost messages to new processes and lost signals

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericShorthands.h>
 #include <AK/HashMap.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/Singleton.h>
@@ -22,10 +23,16 @@
 #include <LibSync/Once.h>
 #include <LibSync/RWLock.h>
 #include <pthread.h>
+#include <signal.h>
 #include <sys/select.h>
 #include <unistd.h>
 
 namespace Core {
+
+// Signals remain bound to the first event loop that registers a handler.
+static Atomic<int> s_signal_wake_pipe_write_fd { -1 };
+static Atomic<pid_t> s_signal_wake_pipe_pid { 0 };
+static Atomic<unsigned> s_pending_signal_counts[NSIG];
 
 namespace {
 
@@ -144,9 +151,8 @@ struct ThreadData {
     ThreadData()
     {
         thread_id = pthread_self();
-        pid = getpid();
 
-        auto result = Core::System::pipe2(O_CLOEXEC);
+        auto result = Core::System::pipe2(O_CLOEXEC | O_NONBLOCK);
         if (result.is_error()) {
             warnln("\033[31;1mFailed to create event loop pipe:\033[0m {}", result.error());
             VERIFY_NOT_REACHED();
@@ -161,8 +167,11 @@ struct ThreadData {
 
     ~ThreadData()
     {
-        close(wake_pipe_fds[0]);
-        close(wake_pipe_fds[1]);
+        // Keep signal pipes open so an in-flight handler cannot write to a reused descriptor.
+        if (!wake_pipe_is_signal_target) {
+            close(wake_pipe_fds[0]);
+            close(wake_pipe_fds[1]);
+        }
 
         Sync::RWLockLocker<Sync::LockMode::Write> locker(thread_data_lock());
         thread_data().remove(thread_id);
@@ -178,10 +187,9 @@ struct ThreadData {
     Vector<pollfd, 32> poll_fds;
 
     // The wake pipe is used to notify another event loop that someone has called wake(), or a signal has been received.
-    // wake() writes 0i32 into the pipe, signals write the signal number (guaranteed non-zero).
     Array<int, 2> wake_pipe_fds { -1, -1 };
+    bool wake_pipe_is_signal_target { false };
 
-    pid_t pid { 0 };
     pthread_t thread_id { 0 };
 };
 
@@ -228,10 +236,11 @@ void EventLoopImplementationUnix::wake()
 {
     int wake_event = 0;
     auto result = Core::System::write(m_wake_pipe_write_fd, { &wake_event, sizeof(wake_event) });
-    // EBADF here just indicates that the ThreadData is destroyed, so we must be exiting the thread.
-    // Ignore it.
-    if (result.is_error() && result.error().code() == EBADF)
-        return;
+    if (result.is_error()) {
+        // EBADF means the thread data is gone. EAGAIN means a pending event already fills the pipe.
+        if (first_is_one_of(result.error().code(), EBADF, EAGAIN))
+            return;
+    }
     MUST(move(result));
 }
 
@@ -240,7 +249,6 @@ void EventLoopManagerUnix::wait_for_events(EventLoopImplementation::PumpMode mod
     auto& thread_data = ThreadData::the();
     Sync::MutexLocker locker(thread_data.mutex);
 
-retry:
     bool has_pending_events = ThreadEventQueue::current().has_pending_events();
 
     auto time_at_iteration_start = MonotonicTime::now_coarse();
@@ -293,17 +301,8 @@ try_select_again:
             VERIFY_NOT_REACHED();
         }
         VERIFY(nread > 0);
-        bool wake_requested = false;
-        int event_count = nread / sizeof(wake_events[0]);
-        for (int i = 0; i < event_count; i++) {
-            if (wake_events[i] != 0)
-                dispatch_signal(wake_events[i]);
-            else
-                wake_requested = true;
-        }
-
-        if (!wake_requested && nread == sizeof(wake_events))
-            goto retry;
+        if (thread_data.wake_pipe_fds[1] == s_signal_wake_pipe_write_fd.load(AK::MemoryOrder::memory_order_acquire))
+            dispatch_pending_signals();
     }
 
     if (error_or_marked_fd_count.value() != 0) {
@@ -406,6 +405,15 @@ void EventLoopManagerUnix::dispatch_signal(int signal_number)
     }
 }
 
+void EventLoopManagerUnix::dispatch_pending_signals()
+{
+    for (int signal_number = 1; signal_number < NSIG; ++signal_number) {
+        auto pending_count = s_pending_signal_counts[signal_number].exchange(0, AK::MemoryOrder::memory_order_acq_rel);
+        for (unsigned i = 0; i < pending_count; ++i)
+            dispatch_signal(signal_number);
+    }
+}
+
 SignalHandlers::SignalHandlers(int signal_number, void (*handle_signal)(int))
     : m_signal_number(signal_number)
     , m_original_handler(signal(signal_number, handle_signal))
@@ -470,33 +478,47 @@ bool SignalHandlers::remove(int handler_id)
 
 void EventLoopManagerUnix::handle_signal(int signal_number)
 {
-    VERIFY(signal_number != 0);
+    VERIFY(signal_number > 0 && signal_number < NSIG);
 
-    // Use the thread-local directly instead of ThreadData::the() to avoid
-    // taking a write lock on thread_data_lock(). Signal handlers must not
-    // acquire locks, as we may already be holding one on this thread.
-    if (!s_this_thread_data)
+    auto saved_errno = errno;
+
+    auto current_pid = getpid();
+    if (current_pid != s_signal_wake_pipe_pid.load(AK::MemoryOrder::memory_order_acquire)) {
+        // Do not forward a signal to the parent process's pipe between fork() and exec().
+        errno = saved_errno;
         return;
-    auto& thread_data = *s_this_thread_data;
-
-    // We MUST check if the current pid still matches, because there
-    // is a window between fork() and exec() where a signal delivered
-    // to our fork could be inadvertently routed to the parent process!
-    if (getpid() == thread_data.pid) {
-        int nwritten = write(thread_data.wake_pipe_fds[1], &signal_number, sizeof(signal_number));
-        if (nwritten < 0) {
-            perror("EventLoopImplementationUnix::register_signal: write");
-            VERIFY_NOT_REACHED();
-        }
-    } else {
-        // We're a fork who received a signal, reset thread_data.pid.
-        thread_data.pid = getpid();
     }
+
+    s_pending_signal_counts[signal_number].fetch_add(1, AK::MemoryOrder::memory_order_release);
+
+    auto wake_pipe_write_fd = s_signal_wake_pipe_write_fd.load(AK::MemoryOrder::memory_order_acquire);
+    if (wake_pipe_write_fd >= 0) {
+        int wake_event = 0;
+        while (write(wake_pipe_write_fd, &wake_event, sizeof(wake_event)) < 0 && errno == EINTR) {
+        }
+    }
+
+    errno = saved_errno;
 }
 
 int EventLoopManagerUnix::register_signal(int signal_number, Function<void(int)> handler)
 {
-    VERIFY(signal_number != 0);
+    VERIFY(signal_number > 0 && signal_number < NSIG);
+
+    auto& thread_data = ThreadData::the();
+    auto current_pid = getpid();
+    if (s_signal_wake_pipe_pid.load(AK::MemoryOrder::memory_order_acquire) != current_pid) {
+        s_signal_wake_pipe_write_fd.store(-1, AK::MemoryOrder::memory_order_release);
+        for (auto& pending_signal_count : s_pending_signal_counts)
+            pending_signal_count.store(0, AK::MemoryOrder::memory_order_relaxed);
+        thread_data.wake_pipe_is_signal_target = true;
+        s_signal_wake_pipe_write_fd.store(thread_data.wake_pipe_fds[1], AK::MemoryOrder::memory_order_release);
+        s_signal_wake_pipe_pid.store(current_pid, AK::MemoryOrder::memory_order_release);
+    } else {
+        // Signal handlers are process-wide, so they must share one event loop.
+        VERIFY(s_signal_wake_pipe_write_fd.load(AK::MemoryOrder::memory_order_acquire) == thread_data.wake_pipe_fds[1]);
+    }
+
     auto& info = *signals_info();
     auto handlers = info.signal_handlers.find(signal_number);
     if (handlers == info.signal_handlers.end()) {

--- a/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -34,6 +34,7 @@ public:
 
 private:
     void dispatch_signal(int signal_number);
+    void dispatch_pending_signals();
     static void handle_signal(int signal_number);
 };
 

--- a/Libraries/LibIPC/TransportBootstrapMach.cpp
+++ b/Libraries/LibIPC/TransportBootstrapMach.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/System.h>
 #include <LibIPC/MachBootstrapMessages.h>
 #include <LibIPC/TransportBootstrapMach.h>
+#include <LibIPC/TransportMachPort.h>
 #include <LibSync/Mutex.h>
 
 #include <mach/mach.h>
@@ -91,6 +92,10 @@ ErrorOr<TransportBootstrapMachPorts> TransportBootstrapMachServer::create_on_dem
 
     auto remote_receive_right = TRY(Core::MachPort::create_with_right(Core::MachPort::PortRight::Receive));
     auto remote_send_right = TRY(remote_receive_right.insert_right(Core::MachPort::MessageRight::MakeSend));
+
+    // Either peer may send messages before the other has constructed its transport.
+    TransportMachPort::raise_receive_queue_limit(local_receive_right);
+    TransportMachPort::raise_receive_queue_limit(remote_receive_right);
 
     send_transport_ports_to_child(move(reply_port), TransportBootstrapMachPorts {
                                                         .receive_right = move(remote_receive_right),

--- a/Libraries/LibIPC/TransportMachPort.cpp
+++ b/Libraries/LibIPC/TransportMachPort.cpp
@@ -100,10 +100,18 @@ ErrorOr<TransportMachPort::Paired> TransportMachPort::create_paired()
     auto port_b_recv = TRY(Core::MachPort::create_with_right(Core::MachPort::PortRight::Receive));
     auto port_b_send = TRY(port_b_recv.insert_right(Core::MachPort::MessageRight::MakeSend));
 
+    // The peer may receive messages before it has constructed its transport.
+    raise_receive_queue_limit(port_b_recv);
+
     return Paired {
         make<TransportMachPort>(move(port_a_recv), move(port_b_send)),
         TransportHandle { move(port_b_recv), move(port_a_send) },
     };
+}
+
+void TransportMachPort::raise_receive_queue_limit(Core::MachPort const& receive_right)
+{
+    set_mach_port_queue_limit(receive_right.port());
 }
 
 TransportMachPort::TransportMachPort(Core::MachPort receive_right, Core::MachPort send_right)

--- a/Libraries/LibIPC/TransportMachPort.h
+++ b/Libraries/LibIPC/TransportMachPort.h
@@ -40,6 +40,8 @@ public:
     };
     static ErrorOr<Paired> create_paired();
 
+    static void raise_receive_queue_limit(Core::MachPort const&);
+
     TransportMachPort(Core::MachPort receive_right, Core::MachPort send_right);
     ~TransportMachPort();
 

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -71,6 +71,9 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
     auto port_b_recv = TRY(Core::MachPort::create_with_right(Core::MachPort::PortRight::Receive));
     auto port_b_send = TRY(port_b_recv.insert_right(Core::MachPort::MessageRight::MakeSend));
 
+    // The child may receive startup messages before it has constructed its transport.
+    IPC::TransportMachPort::raise_receive_queue_limit(port_b_recv);
+
     Sync::MutexLocker child_registration_locker(Application::transport_bootstrap_server().child_registration_lock());
     auto process = TRY(Core::Process::spawn(spawn_options));
 

--- a/Tests/LibCore/TestLibCoreEventLoop.cpp
+++ b/Tests/LibCore/TestLibCoreEventLoop.cpp
@@ -12,6 +12,12 @@
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 
+#if !defined(AK_OS_WINDOWS)
+#    include <LibCore/System.h>
+#    include <pthread.h>
+#    include <signal.h>
+#endif
+
 TEST_CASE(test_poll_for_events)
 {
     Core::EventLoop event_loop;
@@ -125,3 +131,54 @@ TEST_CASE(stopped_timer_does_not_fire)
     loop.exec();
     EXPECT_EQ(stopped_count, 0);
 }
+
+#if !defined(AK_OS_WINDOWS)
+// Signals delivered to threads without event-loop state must wake the registering event loop.
+TEST_CASE(signal_delivered_on_thread_without_event_loop)
+{
+    Core::EventLoop event_loop;
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool handled = false;
+    auto handler_id = Core::EventLoop::register_signal(SIGUSR1, [&](int) { handled = true; });
+
+    auto thread = Threading::Thread::construct("SignalRaiser"sv, []() -> intptr_t {
+        VERIFY(pthread_kill(pthread_self(), SIGUSR1) == 0);
+        return 0;
+    });
+    thread->start();
+    (void)thread->join();
+
+    for (int i = 0; i < 400 && !handled; ++i) {
+        (void)event_loop.pump(Core::EventLoop::WaitMode::PollForEvents);
+        MUST(Core::System::sleep_ms(5));
+    }
+
+    EXPECT(handled);
+    Core::EventLoop::unregister_signal(handler_id);
+}
+
+TEST_CASE(repeated_signal_deliveries_are_preserved)
+{
+    Core::EventLoop event_loop;
+
+    static constexpr int signal_count = 4;
+    IGNORE_USE_IN_ESCAPING_LAMBDA int handled_count = 0;
+    auto handler_id = Core::EventLoop::register_signal(SIGUSR2, [&](int) { ++handled_count; });
+
+    auto thread = Threading::Thread::construct("SignalRaiser"sv, []() -> intptr_t {
+        for (int i = 0; i < signal_count; ++i)
+            VERIFY(pthread_kill(pthread_self(), SIGUSR2) == 0);
+        return 0;
+    });
+    thread->start();
+    MUST(thread->join());
+
+    for (int i = 0; i < 400 && handled_count < signal_count; ++i) {
+        (void)event_loop.pump(Core::EventLoop::WaitMode::PollForEvents);
+        MUST(Core::System::sleep_ms(5));
+    }
+
+    EXPECT_EQ(handled_count, signal_count);
+    Core::EventLoop::unregister_signal(handler_id);
+}
+#endif

--- a/Tests/LibIPC/CMakeLists.txt
+++ b/Tests/LibIPC/CMakeLists.txt
@@ -1,4 +1,7 @@
 if (UNIX AND NOT APPLE)
     ladybird_test("TestTransportSocket.cpp" LibIPC LIBS LibIPC LibSync)
 endif()
+if (APPLE)
+    ladybird_test("TestTransportMachPort.cpp" LibIPC LIBS LibIPC LibCore)
+endif()
 ladybird_test("TestConnection.cpp" LibIPC LIBS LibIPC LibThreading)

--- a/Tests/LibIPC/TestTransportMachPort.cpp
+++ b/Tests/LibIPC/TestTransportMachPort.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <LibIPC/Attachment.h>
+#include <LibIPC/Forward.h>
+#include <LibIPC/TransportMachPort.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(burst_to_not_yet_started_peer_is_delivered)
+{
+    constexpr size_t message_count = 32;
+
+    auto paired = TRY_OR_FAIL(IPC::TransportMachPort::create_paired());
+
+    for (size_t i = 0; i < message_count; ++i) {
+        IPC::MessageDataType payload;
+        payload.append(static_cast<u8>(i));
+        Vector<IPC::Attachment> attachments;
+        TRY_OR_FAIL(paired.local->post_message(move(payload), attachments));
+    }
+
+    paired.local->close_after_sending_all_pending_messages();
+
+    // Construct the peer only after sending the startup burst.
+    auto peer_transport = TRY_OR_FAIL(paired.remote_handle.create_transport());
+
+    size_t received = 0;
+    while (received < message_count) {
+        peer_transport->wait_until_readable();
+        (void)peer_transport->read_as_many_messages_as_possible_without_blocking([&](IPC::TransportMachPort::Message&& message) {
+            auto bytes = message.bytes.bytes();
+            EXPECT_EQ(bytes.size(), 1uz);
+            if (bytes.size() == 1)
+                EXPECT_EQ(bytes[0], static_cast<u8>(received));
+            ++received;
+        });
+    }
+
+    EXPECT_EQ(received, message_count);
+}


### PR DESCRIPTION
Two fixes for cross-process notifications that could be silently dropped.
Both were found while debugging OOP frames, where together they could
make a crashed WebContent process go completely unnoticed by the UI process.