### PR TITLE
LibWebView: Share system font knowledge with helper processes

### DIFF
--- a/Libraries/LibCore/MappedFileWindows.cpp
+++ b/Libraries/LibCore/MappedFileWindows.cpp
@@ -46,18 +46,23 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_range_and_close(int f
     if (offset < 0 || !AK::is_within_range<size_t>(offset))
         return Error::from_errno(EINVAL);
 
-    LARGE_INTEGER large_file_size = {};
-    if (!GetFileSizeEx(to_handle(fd), &large_file_size))
-        return Error::from_windows_error();
-
-    auto file_size = static_cast<size_t>(large_file_size.QuadPart);
     auto requested_offset = static_cast<size_t>(offset);
-    if (requested_offset > file_size)
-        return Error::from_errno(EINVAL);
-    if (size == to_end_of_file)
-        size = file_size - requested_offset;
-    else if (size > file_size - requested_offset)
-        return Error::from_errno(EINVAL);
+    LARGE_INTEGER large_file_size = {};
+    auto is_file_handle = GetFileSizeEx(to_handle(fd), &large_file_size);
+    if (is_file_handle) {
+        auto file_size = static_cast<size_t>(large_file_size.QuadPart);
+        if (requested_offset > file_size)
+            return Error::from_errno(EINVAL);
+        if (size == to_end_of_file)
+            size = file_size - requested_offset;
+        else if (size > file_size - requested_offset)
+            return Error::from_errno(EINVAL);
+    } else {
+        // AnonymousBuffer descriptors are file mapping handles rather than file handles on Windows. Their size cannot
+        // be queried with GetFileSizeEx, so callers must provide the mapped range explicitly.
+        if (size == to_end_of_file)
+            return Error::from_windows_error();
+    }
 
     if (size == 0)
         return adopt_own(*new MappedFile(nullptr, 0, nullptr, 0, mode));
@@ -71,12 +76,18 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_range_and_close(int f
     if (view_size.has_overflow())
         return Error::from_errno(EOVERFLOW);
 
-    // Like the POSIX backend, read-only mappings are shared and writable mappings are
-    // copy-on-write, so writes through a MappedFile never reach the underlying file.
-    HANDLE file_mapping = CreateFileMappingW(to_handle(fd), nullptr, mode == Mode::ReadOnly ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, nullptr);
-    if (!file_mapping)
-        return Error::from_windows_error();
-    ScopeGuard file_mapping_guard = [&] { CloseHandle(file_mapping); };
+    // Like the POSIX backend, read-only mappings are shared and writable mappings are copy-on-write, so writes through
+    // a MappedFile never reach the underlying file. AnonymousBuffer descriptors already refer to a file mapping object.
+    HANDLE file_mapping = to_handle(fd);
+    if (is_file_handle) {
+        file_mapping = CreateFileMappingW(to_handle(fd), nullptr, mode == Mode::ReadOnly ? PAGE_READONLY : PAGE_WRITECOPY, 0, 0, nullptr);
+        if (!file_mapping)
+            return Error::from_windows_error();
+    }
+    ScopeGuard file_mapping_guard = [&] {
+        if (is_file_handle)
+            CloseHandle(file_mapping);
+    };
 
     void* view = MapViewOfFile(file_mapping, mode == Mode::ReadOnly ? FILE_MAP_READ : FILE_MAP_COPY, static_cast<DWORD>(aligned_offset >> 32), static_cast<DWORD>(aligned_offset & 0xFFFFFFFF), view_size.value());
     if (!view)

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -13,10 +13,12 @@ set(SOURCES
     Cursor.cpp
     Filter.cpp
     Font/Font.cpp
+    Font/FontCatalog.cpp
     Font/FontDatabase.cpp
     Font/FontSupport.cpp
     Font/FontVariationSettings.cpp
     Font/PathFontProvider.cpp
+    Font/SharedFontProvider.cpp
     Font/Typeface.cpp
     Font/TypefaceSkia.cpp
     Font/WOFF/Loader.cpp

--- a/Libraries/LibGfx/Font/FontCatalog.cpp
+++ b/Libraries/LibGfx/Font/FontCatalog.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/FontCatalog.h>
+#include <LibGfx/RustFFI.h>
+
+namespace Gfx {
+
+static Optional<FontCatalogFace> convert_face(FFI::FfiFontCatalogFace const& face)
+{
+    if (face.format > to_underlying(FontFileFormat::WOFF))
+        return {};
+    return FontCatalogFace {
+        .family = StringView { face.family, face.family_length },
+        .face_id = face.face_id,
+        .ttc_index = face.ttc_index,
+        .weight = face.weight,
+        .width = face.width,
+        .slope = face.slope,
+        .format = static_cast<FontFileFormat>(face.format),
+    };
+}
+
+ErrorOr<NonnullOwnPtr<FontCatalogBuilder>> FontCatalogBuilder::create(u64 generation)
+{
+    auto* builder = FFI::font_catalog_builder_create(generation);
+    if (!builder)
+        return Error::from_string_literal("Failed to create font catalog builder");
+    return adopt_nonnull_own_or_enomem(new (nothrow) FontCatalogBuilder(*builder));
+}
+
+FontCatalogBuilder::FontCatalogBuilder(FFI::FontCatalogBuilder& builder)
+    : m_builder(&builder)
+{
+}
+
+FontCatalogBuilder::~FontCatalogBuilder()
+{
+    FFI::font_catalog_builder_destroy(m_builder);
+}
+
+ErrorOr<void> FontCatalogBuilder::add_face(FontCatalogFace const& face)
+{
+    FFI::FfiFontCatalogFaceInput input {
+        .family = reinterpret_cast<u8 const*>(face.family.characters_without_null_termination()),
+        .family_length = face.family.length(),
+        .face_id = face.face_id,
+        .ttc_index = face.ttc_index,
+        .weight = face.weight,
+        .width = face.width,
+        .slope = face.slope,
+        .format = to_underlying(face.format),
+    };
+    if (!FFI::font_catalog_builder_add_face(m_builder, input))
+        return Error::from_string_literal("Invalid or duplicate font catalog face");
+    return {};
+}
+
+ErrorOr<ByteBuffer> FontCatalogBuilder::serialize() const
+{
+    auto size = FFI::font_catalog_builder_serialize(m_builder, nullptr, 0);
+    if (size == 0)
+        return Error::from_string_literal("Failed to size serialized font catalog");
+    auto output = TRY(ByteBuffer::create_uninitialized(size));
+    if (FFI::font_catalog_builder_serialize(m_builder, output.data(), output.size()) != output.size())
+        return Error::from_string_literal("Failed to serialize font catalog");
+    return output;
+}
+
+ErrorOr<NonnullOwnPtr<FontCatalog>> FontCatalog::parse(ReadonlyBytes bytes, u64 expected_generation)
+{
+    auto* catalog = FFI::font_catalog_parse(bytes.data(), bytes.size(), expected_generation);
+    if (!catalog)
+        return Error::from_string_literal("Invalid font catalog");
+    return adopt_nonnull_own_or_enomem(new (nothrow) FontCatalog(*catalog));
+}
+
+FontCatalog::FontCatalog(FFI::FontCatalog& catalog)
+    : m_catalog(&catalog)
+{
+}
+
+FontCatalog::~FontCatalog()
+{
+    FFI::font_catalog_destroy(m_catalog);
+}
+
+u64 FontCatalog::generation() const
+{
+    return FFI::font_catalog_generation(m_catalog);
+}
+
+size_t FontCatalog::face_count() const
+{
+    return FFI::font_catalog_face_count(m_catalog);
+}
+
+Optional<FontCatalogFace> FontCatalog::face_at(size_t index) const
+{
+    FFI::FfiFontCatalogFace face {};
+    if (!FFI::font_catalog_face_at(m_catalog, index, &face))
+        return {};
+    return convert_face(face);
+}
+
+Optional<FontCatalogFace> FontCatalog::face_by_id(u64 face_id) const
+{
+    FFI::FfiFontCatalogFace face {};
+    if (!FFI::font_catalog_face_by_id(m_catalog, face_id, &face))
+        return {};
+    return convert_face(face);
+}
+
+Optional<FontCatalogFace> FontCatalog::match_style(StringView family, u16 weight, u16 width, u8 slope) const
+{
+    FFI::FfiFontCatalogFace face {};
+    if (!FFI::font_catalog_match_style(m_catalog, reinterpret_cast<u8 const*>(family.characters_without_null_termination()), family.length(), weight, width, slope, &face))
+        return {};
+    return convert_face(face);
+}
+
+size_t FontCatalog::family_face_count(StringView family) const
+{
+    return FFI::font_catalog_family_face_count(m_catalog, reinterpret_cast<u8 const*>(family.characters_without_null_termination()), family.length());
+}
+
+Optional<FontCatalogFace> FontCatalog::family_face_at(StringView family, size_t index) const
+{
+    FFI::FfiFontCatalogFace face {};
+    if (!FFI::font_catalog_family_face_at(m_catalog, reinterpret_cast<u8 const*>(family.characters_without_null_termination()), family.length(), index, &face))
+        return {};
+    return convert_face(face);
+}
+
+}

--- a/Libraries/LibGfx/Font/FontCatalog.h
+++ b/Libraries/LibGfx/Font/FontCatalog.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <AK/OwnPtr.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace Gfx {
+
+namespace FFI {
+
+struct FontCatalog;
+struct FontCatalogBuilder;
+
+}
+
+enum class FontFileFormat : u8 {
+    OpenType,
+    WOFF,
+};
+
+struct FontCatalogFace {
+    StringView family;
+    u64 face_id { 0 };
+    u32 ttc_index { 0 };
+    u16 weight { 0 };
+    u16 width { 0 };
+    u8 slope { 0 };
+    FontFileFormat format { FontFileFormat::OpenType };
+};
+
+class FontCatalogBuilder {
+    AK_MAKE_NONCOPYABLE(FontCatalogBuilder);
+    AK_MAKE_NONMOVABLE(FontCatalogBuilder);
+
+public:
+    static ErrorOr<NonnullOwnPtr<FontCatalogBuilder>> create(u64 generation);
+    ~FontCatalogBuilder();
+
+    ErrorOr<void> add_face(FontCatalogFace const&);
+    ErrorOr<ByteBuffer> serialize() const;
+
+private:
+    explicit FontCatalogBuilder(FFI::FontCatalogBuilder&);
+
+    FFI::FontCatalogBuilder* m_builder { nullptr };
+};
+
+class FontCatalog {
+    AK_MAKE_NONCOPYABLE(FontCatalog);
+    AK_MAKE_NONMOVABLE(FontCatalog);
+
+public:
+    static ErrorOr<NonnullOwnPtr<FontCatalog>> parse(ReadonlyBytes, u64 expected_generation);
+    ~FontCatalog();
+
+    u64 generation() const;
+    size_t face_count() const;
+    Optional<FontCatalogFace> face_at(size_t index) const;
+    Optional<FontCatalogFace> face_by_id(u64 face_id) const;
+    Optional<FontCatalogFace> match_style(StringView family, u16 weight, u16 width, u8 slope) const;
+    size_t family_face_count(StringView family) const;
+    Optional<FontCatalogFace> family_face_at(StringView family, size_t index) const;
+
+private:
+    explicit FontCatalog(FFI::FontCatalog&);
+
+    FFI::FontCatalog* m_catalog { nullptr };
+};
+
+}

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -24,6 +24,24 @@ namespace Gfx {
 // Key function for SystemFontProvider to emit the vtable here
 SystemFontProvider::~SystemFontProvider() = default;
 
+RefPtr<Typeface> SystemFontProvider::get_typeface_by_id(u64, u64)
+{
+    return nullptr;
+}
+
+RefPtr<Gfx::Font> SystemFontProvider::get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    auto typeface_or_error = TypefaceSkia::find_typeface_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+    if (typeface_or_error.is_error() || !typeface_or_error.value())
+        return nullptr;
+    return typeface_or_error.release_value()->font(point_size, {});
+}
+
+Optional<FlyString> SystemFontProvider::resolve_generic_family(StringView family_name, u16 weight, u8 slope)
+{
+    return TypefaceSkia::resolve_generic_family(family_name, weight, slope);
+}
+
 FontDatabase& FontDatabase::the()
 {
     static FontDatabase& database = *new FontDatabase;
@@ -52,21 +70,17 @@ RefPtr<Gfx::Font> FontDatabase::get(FlyString const& family, float point_size, u
 
 RefPtr<Gfx::Font> FontDatabase::get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
 {
-    CodePointFallbackKey key { code_point, weight, width, slope, prefer_color_emoji };
-    auto& entry = m_code_point_fallback_cache.ensure(key, [&]() -> CodePointFallbackEntry {
-        auto typeface_or_error = TypefaceSkia::find_typeface_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
-        if (typeface_or_error.is_error() || !typeface_or_error.value())
-            return { {}, nullptr };
+    return m_system_font_provider->get_font_for_code_point(code_point, point_size, weight, width, slope, prefer_color_emoji);
+}
 
-        auto typeface = typeface_or_error.release_value();
-        return { typeface->family(), typeface };
-    });
+RefPtr<Typeface> FontDatabase::get_typeface_by_id(u64 generation, u64 face_id)
+{
+    return m_system_font_provider->get_typeface_by_id(generation, face_id);
+}
 
-    // FIXME: Does it matter that we don't pass a FontVariationSettings or ShapeFeatures here?
-    if (entry.typeface)
-        return entry.typeface->font(point_size, {});
-
-    return nullptr;
+Optional<FlyString> FontDatabase::resolve_generic_family(StringView family_name, u16 weight, u8 slope)
+{
+    return m_system_font_provider->resolve_generic_family(family_name, weight, slope);
 }
 
 void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)> callback)

--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -16,23 +16,6 @@
 
 namespace Gfx {
 
-struct CodePointFallbackKey {
-    u32 code_point { 0 };
-    u16 weight { 0 };
-    u16 width { 0 };
-    u8 slope { 0 };
-    bool prefer_color_emoji { false };
-
-    bool operator==(CodePointFallbackKey const&) const = default;
-
-    unsigned hash() const
-    {
-        return pair_int_hash(
-            pair_int_hash(code_point, weight),
-            pair_int_hash(pair_int_hash(width, slope), prefer_color_emoji));
-    }
-};
-
 class SystemFontProvider {
 public:
     virtual ~SystemFontProvider();
@@ -40,6 +23,9 @@ public:
     virtual StringView name() const = 0;
     virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {}) = 0;
     virtual void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>) = 0;
+    virtual RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id);
+    virtual RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
+    virtual Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
 };
 
 class FontDatabase {
@@ -49,8 +35,11 @@ public:
 
     RefPtr<Gfx::Font> get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {});
     RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
+    RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id);
+    Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
     [[nodiscard]] StringView system_font_provider_name() const;
+    [[nodiscard]] bool has_system_font_provider() const { return m_system_font_provider; }
 
     void set_force_freetype_rasterization(bool force) { m_force_freetype_rasterization = force; }
     [[nodiscard]] bool force_freetype_rasterization() const { return m_force_freetype_rasterization; }
@@ -63,20 +52,6 @@ private:
 
     OwnPtr<SystemFontProvider> m_system_font_provider;
     bool m_force_freetype_rasterization { false };
-
-    struct CodePointFallbackEntry {
-        FlyString family_name;
-        RefPtr<Typeface const> typeface;
-    };
-    HashMap<CodePointFallbackKey, CodePointFallbackEntry> m_code_point_fallback_cache;
 };
 
 }
-
-template<>
-struct AK::Traits<Gfx::CodePointFallbackKey> : public AK::DefaultTraits<Gfx::CodePointFallbackKey> {
-    static unsigned hash(Gfx::CodePointFallbackKey const& key)
-    {
-        return key.hash();
-    }
-};

--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -41,6 +41,16 @@ static u32 number_of_fonts_in_ttc(ReadonlyBytes bytes)
 
 void PathFontProvider::load_all_fonts_from_uri(StringView uri)
 {
+    for_each_typeface_in_uri(uri, m_loaded_paths, [this](String const&, u32, FontFileFormat, NonnullRefPtr<Typeface> font) {
+        auto& family = m_typeface_by_family.ensure(font->family(), [] {
+            return Vector<NonnullRefPtr<Typeface>> {};
+        });
+        family.append(move(font));
+    });
+}
+
+void PathFontProvider::for_each_typeface_in_uri(StringView uri, HashTable<String>& loaded_paths, Function<void(String const&, u32, FontFileFormat, NonnullRefPtr<Typeface>)> callback)
+{
     auto root_or_error = Core::Resource::load_from_uri(uri);
     if (root_or_error.is_error()) {
         if (root_or_error.error().is_errno() && root_or_error.error().code() == ENOENT) {
@@ -51,7 +61,7 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
     }
     auto root = root_or_error.release_value();
 
-    root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
+    root->for_each_descendant_file([&](Core::Resource const& resource) -> IterationDecision {
         auto uri = resource.uri();
         auto path = LexicalPath(uri.bytes_as_string_view());
         auto is_truetype = path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv);
@@ -59,27 +69,20 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
         if (!is_truetype && !is_woff)
             return IterationDecision::Continue;
 
-        if (m_loaded_paths.set(resource.filesystem_path(), AK::HashSetExistingEntryBehavior::Keep) != AK::HashSetResult::InsertedNewEntry)
+        auto filesystem_path = resource.filesystem_path();
+        if (loaded_paths.set(filesystem_path, AK::HashSetExistingEntryBehavior::Keep) != AK::HashSetResult::InsertedNewEntry)
             return IterationDecision::Continue;
 
         if (is_truetype) {
             auto font_count = number_of_fonts_in_ttc(resource.data());
             for (u32 ttc_index = 0; ttc_index < font_count; ++ttc_index) {
                 if (auto font_or_error = Typeface::try_load_from_resource(resource, ttc_index); !font_or_error.is_error()) {
-                    auto font = font_or_error.release_value();
-                    auto& family = m_typeface_by_family.ensure(font->family(), [] {
-                        return Vector<NonnullRefPtr<Typeface>> {};
-                    });
-                    family.append(font);
+                    callback(filesystem_path, ttc_index, FontFileFormat::OpenType, font_or_error.release_value());
                 }
             }
         } else {
             if (auto font_or_error = WOFF::try_load_from_resource(resource); !font_or_error.is_error()) {
-                auto font = font_or_error.release_value();
-                auto& family = m_typeface_by_family.ensure(font->family(), [] {
-                    return Vector<NonnullRefPtr<Typeface>> {};
-                });
-                family.append(font);
+                callback(filesystem_path, 0, FontFileFormat::WOFF, font_or_error.release_value());
             }
         }
         return IterationDecision::Continue;

--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/LexicalPath.h>
 #include <LibCore/Resource.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/Font/WOFF/Loader.h>
@@ -70,6 +71,12 @@ void PathFontProvider::for_each_typeface_in_uri(StringView uri, HashTable<String
             return IterationDecision::Continue;
 
         auto filesystem_path = resource.filesystem_path();
+        auto canonical_path = FileSystem::real_path(filesystem_path.bytes_as_string_view());
+        if (canonical_path.is_error()) {
+            dbgln("PathFontProvider: Unable to canonicalize '{}': {}", filesystem_path, canonical_path.error());
+            return IterationDecision::Continue;
+        }
+        filesystem_path = MUST(String::from_byte_string(canonical_path.release_value()));
         if (loaded_paths.set(filesystem_path, AK::HashSetExistingEntryBehavior::Keep) != AK::HashSetResult::InsertedNewEntry)
             return IterationDecision::Continue;
 

--- a/Libraries/LibGfx/Font/PathFontProvider.h
+++ b/Libraries/LibGfx/Font/PathFontProvider.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
+#include <LibGfx/Font/FontCatalog.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/Typeface.h>
 
@@ -26,6 +27,7 @@ public:
     void set_name_but_fixme_should_create_custom_system_font_provider(String name) { m_name = move(name); }
 
     void load_all_fonts_from_uri(StringView);
+    static void for_each_typeface_in_uri(StringView, HashTable<String>& loaded_paths, Function<void(String const& path, u32 ttc_index, FontFileFormat, NonnullRefPtr<Typeface>)>);
 
     virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& font_variation_settings = {}, Optional<Gfx::ShapeFeatures> const& shape_features = {}) override;
     virtual void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>) override;

--- a/Libraries/LibGfx/Font/SharedFontProvider.cpp
+++ b/Libraries/LibGfx/Font/SharedFontProvider.cpp
@@ -12,7 +12,7 @@
 
 namespace Gfx {
 
-ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create(NonnullOwnPtr<Core::MappedFile> mapping, u64 generation, SharedFontProviderCallbacks callbacks)
+ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create(NonnullOwnPtr<Core::MappedFile> mapping, u64 generation, SharedFontProviderCallbacks&& callbacks)
 {
     auto catalog = TRY(FontCatalog::parse(mapping->bytes(), generation));
     return adopt_nonnull_own_or_enomem(new (nothrow) SharedFontProvider(move(mapping), move(catalog), move(callbacks)));

--- a/Libraries/LibGfx/Font/SharedFontProvider.cpp
+++ b/Libraries/LibGfx/Font/SharedFontProvider.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NumericLimits.h>
+#include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/SharedFontProvider.h>
+#include <LibGfx/Font/WOFF/Loader.h>
+
+namespace Gfx {
+
+ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create(NonnullOwnPtr<Core::MappedFile> mapping, u64 generation, SharedFontProviderCallbacks callbacks)
+{
+    auto catalog = TRY(FontCatalog::parse(mapping->bytes(), generation));
+    return adopt_nonnull_own_or_enomem(new (nothrow) SharedFontProvider(move(mapping), move(catalog), move(callbacks)));
+}
+
+ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create_from_catalog_file_or_empty(IPC::File file, u64 size, u64 generation, SharedFontProviderCallbacks&& callbacks)
+{
+    if (size == 0 || size > NumericLimits<size_t>::max()) {
+        dbgln("SharedFontProvider: Refusing invalid font catalog size {}. Using an empty catalog.", size);
+        return create_empty(generation, move(callbacks));
+    }
+
+    auto mapping = Core::MappedFile::map_from_fd_range_and_close(file.take_fd(), "font catalog"sv, 0, static_cast<size_t>(size));
+    if (mapping.is_error()) {
+        dbgln("SharedFontProvider: Unable to map font catalog: {}. Using an empty catalog.", mapping.error());
+        return create_empty(generation, move(callbacks));
+    }
+
+    auto provider = create(mapping.release_value(), generation, move(callbacks));
+    if (provider.is_error()) {
+        dbgln("SharedFontProvider: Unable to parse font catalog: {}. Using an empty catalog.", provider.error());
+        return create_empty(generation, move(callbacks));
+    }
+    return provider;
+}
+
+ErrorOr<NonnullOwnPtr<SharedFontProvider>> SharedFontProvider::create_empty(u64 generation, SharedFontProviderCallbacks&& callbacks)
+{
+    auto builder = TRY(FontCatalogBuilder::create(generation));
+    auto serialized = TRY(builder->serialize());
+    auto buffer = TRY(Core::AnonymousBuffer::create_with_size(serialized.size()));
+    serialized.bytes().copy_to({ buffer.data<u8>(), buffer.size() });
+    auto file = TRY(IPC::File::clone_fd(buffer.fd()));
+    auto mapping = TRY(Core::MappedFile::map_from_fd_range_and_close(file.take_fd(), "empty font catalog"sv, 0, serialized.size()));
+    return create(move(mapping), generation, move(callbacks));
+}
+
+SharedFontProvider::SharedFontProvider(NonnullOwnPtr<Core::MappedFile> mapping, NonnullOwnPtr<FontCatalog> catalog, SharedFontProviderCallbacks callbacks)
+    : m_catalog_mapping(move(mapping))
+    , m_catalog(move(catalog))
+    , m_callbacks(move(callbacks))
+{
+    m_resource_fonts.load_all_fonts_from_uri("resource://fonts"sv);
+}
+
+SharedFontProvider::~SharedFontProvider()
+{
+    clear_typeface_cache();
+}
+
+void SharedFontProvider::clear_typeface_cache()
+{
+    for (auto const& entry : m_typeface_cache)
+        entry.value->clear_font_cache();
+    m_typeface_cache.clear();
+}
+
+ErrorOr<void> SharedFontProvider::replace_catalog(NonnullOwnPtr<Core::MappedFile> mapping, u64 generation)
+{
+    auto catalog = TRY(FontCatalog::parse(mapping->bytes(), generation));
+    m_catalog = move(catalog);
+    m_catalog_mapping = move(mapping);
+    clear_typeface_cache();
+    m_failed_face_ids.clear();
+    m_code_point_cache.clear();
+    return {};
+}
+
+ErrorOr<void> SharedFontProvider::replace_catalog(IPC::File file, u64 size, u64 generation)
+{
+    if (size == 0 || size > NumericLimits<size_t>::max())
+        return Error::from_string_literal("Invalid font catalog size");
+    auto mapping = TRY(Core::MappedFile::map_from_fd_range_and_close(file.take_fd(), "font catalog"sv, 0, static_cast<size_t>(size)));
+    return replace_catalog(move(mapping), generation);
+}
+
+static FontVariationSettings default_variations(float point_size, unsigned weight, unsigned width)
+{
+    FontVariationSettings settings;
+    settings.set_weight(static_cast<float>(weight));
+    settings.set_optical_sizing(point_size / 0.75f);
+
+    switch (width) {
+    case FontWidth::UltraCondensed:
+        settings.set_width(50);
+        break;
+    case FontWidth::ExtraCondensed:
+        settings.set_width(62.5);
+        break;
+    case FontWidth::Condensed:
+        settings.set_width(75);
+        break;
+    case FontWidth::SemiCondensed:
+        settings.set_width(87.5);
+        break;
+    case FontWidth::Normal:
+        settings.set_width(100);
+        break;
+    case FontWidth::SemiExpanded:
+        settings.set_width(112.5);
+        break;
+    case FontWidth::Expanded:
+        settings.set_width(125);
+        break;
+    case FontWidth::ExtraExpanded:
+        settings.set_width(150);
+        break;
+    case FontWidth::UltraExpanded:
+        settings.set_width(200);
+        break;
+    default:
+        settings.set_width(100);
+        break;
+    }
+
+    return settings;
+}
+
+static ShapeFeatures default_shape_features()
+{
+    return {
+        { { 'c', 'l', 'i', 'g' }, 1 },
+        { { 'k', 'e', 'r', 'n' }, 1 },
+        { { 'l', 'i', 'g', 'a' }, 1 },
+    };
+}
+
+RefPtr<Gfx::Font> SharedFontProvider::get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& variation_settings, Optional<Gfx::ShapeFeatures> const& shape_features)
+{
+    if (auto resource_font = m_resource_fonts.get_font(family, point_size, weight, width, slope, variation_settings, shape_features))
+        return resource_font;
+
+    RefPtr<Typeface> typeface;
+    if (auto face = m_catalog->match_style(family.bytes_as_string_view(), weight, width, slope); face.has_value()) {
+        typeface = load_catalog_face(*face);
+    } else if (m_callbacks.match_font) {
+        auto family_string = family.to_string();
+        typeface = load_brokered_font(m_callbacks.match_font(family_string, weight, width, slope));
+    }
+    if (!typeface)
+        return nullptr;
+
+    return typeface->font(point_size, variation_settings.value_or_lazy_evaluated([&] { return default_variations(point_size, weight, width); }), shape_features.value_or_lazy_evaluated(default_shape_features));
+}
+
+void SharedFontProvider::for_each_typeface_with_family_name(FlyString const& family, Function<void(Typeface const&)> callback)
+{
+    m_resource_fonts.for_each_typeface_with_family_name(family, [&](Typeface const& typeface) {
+        callback(typeface);
+    });
+
+    auto family_name = family.bytes_as_string_view();
+    auto count = m_catalog->family_face_count(family_name);
+    for (size_t index = 0; index < count; ++index) {
+        auto face = m_catalog->family_face_at(family_name, index);
+        if (!face.has_value())
+            continue;
+        if (auto typeface = load_catalog_face(*face))
+            callback(*typeface);
+    }
+}
+
+RefPtr<Typeface> SharedFontProvider::get_typeface_by_id(u64 generation, u64 face_id)
+{
+    if (generation != m_catalog->generation() || face_id == 0)
+        return nullptr;
+    if (auto typeface = m_typeface_cache.get(face_id); typeface.has_value())
+        return *typeface;
+    if (auto face = m_catalog->face_by_id(face_id); face.has_value())
+        return load_catalog_face(*face);
+    if (!m_callbacks.open_font)
+        return nullptr;
+    return load_brokered_font(m_callbacks.open_font(generation, face_id));
+}
+
+RefPtr<Gfx::Font> SharedFontProvider::get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    if (!m_callbacks.match_font_for_code_point)
+        return nullptr;
+
+    CodePointCacheKey key { code_point, weight, width, slope, prefer_color_emoji };
+    if (auto cached_typeface = m_code_point_cache.get(key); cached_typeface.has_value()) {
+        if (!cached_typeface.value())
+            return nullptr;
+        return cached_typeface.value()->font(point_size, {});
+    }
+
+    auto typeface = load_brokered_font(m_callbacks.match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji));
+    m_code_point_cache.set(key, typeface);
+    if (!typeface)
+        return nullptr;
+    return typeface->font(point_size, {});
+}
+
+Optional<FlyString> SharedFontProvider::resolve_generic_family(StringView family_name, u16 weight, u8 slope)
+{
+    if (!m_callbacks.resolve_generic_family)
+        return {};
+    auto family = String::from_utf8(family_name);
+    if (family.is_error())
+        return {};
+    return m_callbacks.resolve_generic_family(family.release_value(), weight, slope);
+}
+
+RefPtr<Typeface> SharedFontProvider::load_catalog_face(FontCatalogFace const& face)
+{
+    if (auto cached = m_typeface_cache.get(face.face_id); cached.has_value())
+        return *cached;
+    if (m_failed_face_ids.contains(face.face_id) || !m_callbacks.open_font)
+        return nullptr;
+    auto brokered_font = m_callbacks.open_font(m_catalog->generation(), face.face_id);
+    if (!brokered_font.file.has_value()) {
+        m_failed_face_ids.set(face.face_id);
+        return nullptr;
+    }
+    return load_font_file(face.face_id, face.ttc_index, face.format, brokered_font.file.release_value());
+}
+
+RefPtr<Typeface> SharedFontProvider::load_brokered_font(BrokeredFont brokered_font)
+{
+    if (brokered_font.face_id == 0 || !brokered_font.file.has_value())
+        return nullptr;
+    if (auto cached = m_typeface_cache.get(brokered_font.face_id); cached.has_value())
+        return *cached;
+    return load_font_file(brokered_font.face_id, brokered_font.ttc_index, brokered_font.format, brokered_font.file.release_value());
+}
+
+RefPtr<Typeface> SharedFontProvider::load_font_file(u64 face_id, u32 ttc_index, FontFileFormat format, IPC::File file)
+{
+    if (m_failed_face_ids.contains(face_id))
+        return nullptr;
+
+    auto mapped_file = Core::MappedFile::map_from_fd_and_close(file.take_fd(), "brokered font"sv);
+    if (mapped_file.is_error()) {
+        m_failed_face_ids.set(face_id);
+        return nullptr;
+    }
+
+    ErrorOr<NonnullRefPtr<Typeface>> typeface_or_error = Error::from_string_literal("Unsupported font file format");
+    if (format == FontFileFormat::WOFF)
+        typeface_or_error = WOFF::try_load_from_bytes(mapped_file.value()->bytes(), ttc_index);
+    else
+        typeface_or_error = Typeface::try_load_from_mapped_file(mapped_file.release_value(), ttc_index);
+
+    if (typeface_or_error.is_error()) {
+        m_failed_face_ids.set(face_id);
+        return nullptr;
+    }
+
+    auto typeface = typeface_or_error.release_value();
+    typeface->set_system_font_identifier({ m_catalog->generation(), face_id });
+    m_typeface_cache.set(face_id, typeface);
+    return typeface;
+}
+
+}

--- a/Libraries/LibGfx/Font/SharedFontProvider.h
+++ b/Libraries/LibGfx/Font/SharedFontProvider.h
@@ -38,7 +38,7 @@ class SharedFontProvider final : public SystemFontProvider {
     AK_MAKE_NONMOVABLE(SharedFontProvider);
 
 public:
-    static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create(NonnullOwnPtr<Core::MappedFile>, u64 generation, SharedFontProviderCallbacks);
+    static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create(NonnullOwnPtr<Core::MappedFile>, u64 generation, SharedFontProviderCallbacks&&);
     static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create_from_catalog_file_or_empty(IPC::File, u64 size, u64 generation, SharedFontProviderCallbacks&&);
     static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create_empty(u64 generation, SharedFontProviderCallbacks&&);
     virtual ~SharedFontProvider() override;

--- a/Libraries/LibGfx/Font/SharedFontProvider.h
+++ b/Libraries/LibGfx/Font/SharedFontProvider.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/HashFunctions.h>
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/OwnPtr.h>
+#include <LibCore/MappedFile.h>
+#include <LibGfx/Font/FontCatalog.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/PathFontProvider.h>
+#include <LibIPC/File.h>
+
+namespace Gfx {
+
+struct BrokeredFont {
+    u64 face_id { 0 };
+    u32 ttc_index { 0 };
+    FontFileFormat format { FontFileFormat::OpenType };
+    Optional<IPC::File> file;
+};
+
+struct SharedFontProviderCallbacks {
+    Function<BrokeredFont(u64 generation, u64 face_id)> open_font;
+    Function<BrokeredFont(String const& family, u16 weight, u16 width, u8 slope)> match_font;
+    Function<BrokeredFont(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)> match_font_for_code_point;
+    Function<Optional<FlyString>(String const& family, u16 weight, u8 slope)> resolve_generic_family;
+};
+
+class SharedFontProvider final : public SystemFontProvider {
+    AK_MAKE_NONCOPYABLE(SharedFontProvider);
+    AK_MAKE_NONMOVABLE(SharedFontProvider);
+
+public:
+    static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create(NonnullOwnPtr<Core::MappedFile>, u64 generation, SharedFontProviderCallbacks);
+    static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create_from_catalog_file_or_empty(IPC::File, u64 size, u64 generation, SharedFontProviderCallbacks&&);
+    static ErrorOr<NonnullOwnPtr<SharedFontProvider>> create_empty(u64 generation, SharedFontProviderCallbacks&&);
+    virtual ~SharedFontProvider() override;
+
+    ErrorOr<void> replace_catalog(NonnullOwnPtr<Core::MappedFile>, u64 generation);
+    ErrorOr<void> replace_catalog(IPC::File, u64 size, u64 generation);
+
+    virtual RefPtr<Gfx::Font> get_font(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Optional<FontVariationSettings> const& = {}, Optional<Gfx::ShapeFeatures> const& = {}) override;
+    virtual void for_each_typeface_with_family_name(FlyString const&, Function<void(Typeface const&)>) override;
+    virtual RefPtr<Typeface> get_typeface_by_id(u64 generation, u64 face_id) override;
+    virtual RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
+    virtual Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope) override;
+    virtual StringView name() const LIFETIME_BOUND override { return "Shared"sv; }
+
+private:
+    struct CodePointCacheKey {
+        u32 code_point { 0 };
+        u16 weight { 0 };
+        u16 width { 0 };
+        u8 slope { 0 };
+        bool prefer_color_emoji { false };
+
+        bool operator==(CodePointCacheKey const&) const = default;
+    };
+
+    struct CodePointCacheKeyTraits : public DefaultTraits<CodePointCacheKey> {
+        static unsigned hash(CodePointCacheKey const& key)
+        {
+            auto style_hash = pair_int_hash(pair_int_hash(key.weight, key.width), pair_int_hash(key.slope, key.prefer_color_emoji));
+            return pair_int_hash(key.code_point, style_hash);
+        }
+    };
+
+    SharedFontProvider(NonnullOwnPtr<Core::MappedFile>, NonnullOwnPtr<FontCatalog>, SharedFontProviderCallbacks);
+
+    RefPtr<Typeface> load_catalog_face(FontCatalogFace const&);
+    RefPtr<Typeface> load_brokered_font(BrokeredFont);
+    RefPtr<Typeface> load_font_file(u64 face_id, u32 ttc_index, FontFileFormat, IPC::File);
+    void clear_typeface_cache();
+
+    NonnullOwnPtr<Core::MappedFile> m_catalog_mapping;
+    NonnullOwnPtr<FontCatalog> m_catalog;
+    SharedFontProviderCallbacks m_callbacks;
+    PathFontProvider m_resource_fonts;
+    HashMap<u64, NonnullRefPtr<Typeface>> m_typeface_cache;
+    HashTable<u64> m_failed_face_ids;
+    HashMap<CodePointCacheKey, RefPtr<Typeface>, CodePointCacheKeyTraits> m_code_point_cache;
+};
+
+}

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -7,6 +7,7 @@
 #include <harfbuzz/hb.h>
 
 #include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/FontVariationSettings.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/TypefaceSkia.h>
@@ -19,6 +20,14 @@ ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_resource(Core::Resource
 {
     auto typeface = TRY(try_load_from_externally_owned_memory(resource.data(), ttc_index));
     typeface->set_resource_font_data(resource);
+    return typeface;
+}
+
+ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file, u32 ttc_index)
+{
+    auto shared_mapped_file = make_ref_counted<Core::SharedMappedFile>(move(mapped_file));
+    auto typeface = TRY(try_load_from_externally_owned_memory(shared_mapped_file->operator->().bytes(), ttc_index));
+    typeface->set_mapped_font_data(move(shared_mapped_file));
     return typeface;
 }
 
@@ -50,6 +59,11 @@ Typeface::~Typeface()
         hb_face_destroy(m_harfbuzz_face);
     if (m_harfbuzz_blob)
         hb_blob_destroy(m_harfbuzz_blob);
+}
+
+void Typeface::clear_font_cache() const
+{
+    m_fonts.clear();
 }
 
 NonnullRefPtr<Font> Typeface::font(float point_size, FontVariationSettings const& variations, Gfx::ShapeFeatures const& shape_features) const
@@ -123,6 +137,13 @@ hb_face_t* Typeface::create_harfbuzz_face() const
 
 void Typeface::encode_font_data_for_ipc(IPC::Encoder& encoder) const
 {
+    if (m_system_font_identifier.has_value()) {
+        MUST(encoder.encode(FontDataFormat::SystemFontId));
+        MUST(encoder.encode(m_system_font_identifier->generation));
+        MUST(encoder.encode(m_system_font_identifier->face_id));
+        return;
+    }
+
     VERIFY(m_font_data.has_value());
 
     m_font_data->visit(
@@ -135,7 +156,15 @@ void Typeface::encode_font_data_for_ipc(IPC::Encoder& encoder) const
             MUST(encoder.encode(FontDataFormat::ResourceFontData));
             MUST(encoder.encode(resource->uri()));
             MUST(encoder.encode(ttc_index()));
+        },
+        [&](NonnullRefPtr<Core::SharedMappedFile> const&) {
+            VERIFY_NOT_REACHED();
         });
+}
+
+void Typeface::set_mapped_font_data(NonnullRefPtr<Core::SharedMappedFile> mapped_file)
+{
+    m_font_data = FontDataBacking { move(mapped_file) };
 }
 
 void Typeface::set_anonymous_font_data(Core::AnonymousBuffer anonymous_buffer)
@@ -151,6 +180,7 @@ void Typeface::set_resource_font_data(Core::Resource const& resource)
 void Typeface::copy_font_data_from(Typeface const& other)
 {
     m_font_data = other.m_font_data;
+    m_system_font_identifier = other.m_system_font_identifier;
 }
 
 }
@@ -203,6 +233,14 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface const>> decode(Decoder& decoder)
         auto width = TRY(decoder.decode<u16>());
         auto slope = TRY(decoder.decode<u8>());
         return match_system_typeface(system_ui_font_kind, move(family_name), weight, width, slope);
+    }
+    case Gfx::Typeface::FontDataFormat::SystemFontId: {
+        auto generation = TRY(decoder.decode<u64>());
+        auto face_id = TRY(decoder.decode<u64>());
+        auto matched_typeface = Gfx::FontDatabase::the().get_typeface_by_id(generation, face_id);
+        if (!matched_typeface)
+            return Error::from_string_literal("Typeface IPC data referred to an unavailable system font");
+        return matched_typeface.release_nonnull();
     }
     }
 

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -75,6 +75,9 @@ public:
     virtual u16 width() const = 0;
     virtual u8 slope() const = 0;
 
+    ReadonlyBytes font_data() const LIFETIME_BOUND { return buffer(); }
+    u32 collection_index() const { return ttc_index(); }
+
     [[nodiscard]] NonnullRefPtr<Font> font(float point_size, FontVariationSettings const& variations = {}, Gfx::ShapeFeatures const& shape_features = {}) const;
 
     void set_system_font_identifier(SystemFontIdentifier identifier) { m_system_font_identifier = identifier; }

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -30,6 +30,13 @@ namespace Gfx {
 
 class Font;
 
+struct SystemFontIdentifier {
+    u64 generation { 0 };
+    u64 face_id { 0 };
+
+    bool operator==(SystemFontIdentifier const&) const = default;
+};
+
 struct FontCacheKey {
     float point_size;
     Vector<FontVariationAxis> axes;
@@ -53,6 +60,7 @@ struct FontCacheKey {
 class Typeface : public RefCounted<Typeface> {
 public:
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_resource(Core::Resource const&, u32 ttc_index = 0);
+    static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_mapped_file(NonnullOwnPtr<Core::MappedFile>, u32 ttc_index = 0);
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_anonymous_buffer(Core::AnonymousBuffer, u32 ttc_index = 0);
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_temporary_memory(ReadonlyBytes bytes, u32 ttc_index = 0);
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes bytes, u32 ttc_index = 0);
@@ -68,6 +76,9 @@ public:
     virtual u8 slope() const = 0;
 
     [[nodiscard]] NonnullRefPtr<Font> font(float point_size, FontVariationSettings const& variations = {}, Gfx::ShapeFeatures const& shape_features = {}) const;
+
+    void set_system_font_identifier(SystemFontIdentifier identifier) { m_system_font_identifier = identifier; }
+    Optional<SystemFontIdentifier> system_font_identifier() const { return m_system_font_identifier; }
 
     hb_face_t* harfbuzz_typeface() const;
 
@@ -94,6 +105,7 @@ protected:
         RawFontData,
         ResourceFontData,
         SystemFont,
+        SystemFontId,
     };
 
     Typeface();
@@ -105,18 +117,24 @@ protected:
 
     void set_anonymous_font_data(Core::AnonymousBuffer);
     void set_resource_font_data(Core::Resource const&);
+    void set_mapped_font_data(NonnullRefPtr<Core::SharedMappedFile>);
     void copy_font_data_from(Typeface const&);
     bool has_font_data_backing() const { return m_font_data.has_value(); }
 
 private:
+    friend class SharedFontProvider;
+
     template<typename T>
     friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
 
     template<typename T>
     friend ErrorOr<T> IPC::decode(IPC::Decoder&);
 
-    using FontDataBacking = Variant<Core::AnonymousBuffer, NonnullRefPtr<Core::Resource const>>;
+    using FontDataBacking = Variant<Core::AnonymousBuffer, NonnullRefPtr<Core::Resource const>, NonnullRefPtr<Core::SharedMappedFile>>;
     Optional<FontDataBacking> m_font_data;
+    Optional<SystemFontIdentifier> m_system_font_identifier;
+
+    void clear_font_cache() const;
 
     mutable HashMap<FontCacheKey, NonnullRefPtr<Font>> m_fonts;
     mutable hb_blob_t* m_harfbuzz_blob { nullptr };

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -83,7 +83,7 @@ static SkFontMgr& font_manager()
     auto& font_manager = skia_font_manager();
     if (!font_manager) {
 #ifdef AK_OS_MACOS
-        if (Gfx::FontDatabase::the().system_font_provider_name() != "FontConfig"sv) {
+        if (!Gfx::FontDatabase::the().force_freetype_rasterization() && (!Gfx::FontDatabase::the().has_system_font_provider() || Gfx::FontDatabase::the().system_font_provider_name() != "FontConfig"sv)) {
             font_manager = SkFontMgr_New_CoreText(nullptr);
         }
 #endif

--- a/Libraries/LibGfx/Rust/src/font_catalog.rs
+++ b/Libraries/LibGfx/Rust/src/font_catalog.rs
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::collections::{HashMap, HashSet};
+
+const MAGIC: &[u8; 8] = b"LBFONTS\0";
+const VERSION: u32 = 1;
+const HEADER_SIZE: usize = 48;
+const RECORD_SIZE: usize = 32;
+
+#[repr(C)]
+pub struct FfiFontCatalogFaceInput {
+    pub family: *const u8,
+    pub family_length: usize,
+    pub face_id: u64,
+    pub ttc_index: u32,
+    pub weight: u16,
+    pub width: u16,
+    pub slope: u8,
+    pub format: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FfiFontCatalogFace {
+    pub family: *const u8,
+    pub family_length: usize,
+    pub face_id: u64,
+    pub ttc_index: u32,
+    pub weight: u16,
+    pub width: u16,
+    pub slope: u8,
+    pub format: u8,
+}
+
+struct BuilderFace {
+    family: Vec<u8>,
+    face_id: u64,
+    ttc_index: u32,
+    weight: u16,
+    width: u16,
+    slope: u8,
+    format: u8,
+}
+
+pub struct FontCatalogBuilder {
+    generation: u64,
+    faces: Vec<BuilderFace>,
+    face_ids: HashSet<u64>,
+}
+
+#[derive(Clone, Copy)]
+struct ParsedFace {
+    family_offset: usize,
+    family_length: usize,
+    face_id: u64,
+    ttc_index: u32,
+    weight: u16,
+    width: u16,
+    slope: u8,
+    format: u8,
+}
+
+pub struct FontCatalog {
+    data: *const u8,
+    data_length: usize,
+    generation: u64,
+    faces: Vec<ParsedFace>,
+    face_by_id: HashMap<u64, usize>,
+    faces_by_family: HashMap<Vec<u8>, Vec<usize>>,
+}
+
+fn valid_face(face_id: u64, family: &[u8], weight: u16, width: u16, slope: u8, format: u8) -> bool {
+    face_id != 0
+        && !family.is_empty()
+        && std::str::from_utf8(family).is_ok()
+        && (1..=1000).contains(&weight)
+        && (1..=9).contains(&width)
+        && slope <= 2
+        && format <= 1
+}
+
+fn ascii_lowercase(bytes: &[u8]) -> Vec<u8> {
+    bytes.iter().map(u8::to_ascii_lowercase).collect()
+}
+
+fn push_u16(output: &mut Vec<u8>, value: u16) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u32(output: &mut Vec<u8>, value: u32) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u64(output: &mut Vec<u8>, value: u64) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn read_u16(data: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        data.get(offset..offset.checked_add(2)?)?.try_into().ok()?,
+    ))
+}
+
+fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        data.get(offset..offset.checked_add(4)?)?.try_into().ok()?,
+    ))
+}
+
+fn read_u64(data: &[u8], offset: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(
+        data.get(offset..offset.checked_add(8)?)?.try_into().ok()?,
+    ))
+}
+
+impl FontCatalogBuilder {
+    fn serialize(&self) -> Option<Vec<u8>> {
+        let records_size = self.faces.len().checked_mul(RECORD_SIZE)?;
+        let strings_size = self
+            .faces
+            .iter()
+            .try_fold(0usize, |size, face| size.checked_add(face.family.len()))?;
+        let total_size = HEADER_SIZE.checked_add(records_size)?.checked_add(strings_size)?;
+        let face_count = u64::try_from(self.faces.len()).ok()?;
+        let total_size_u64 = u64::try_from(total_size).ok()?;
+
+        let mut output = Vec::with_capacity(total_size);
+        output.extend_from_slice(MAGIC);
+        push_u32(&mut output, VERSION);
+        push_u32(&mut output, HEADER_SIZE as u32);
+        push_u64(&mut output, total_size_u64);
+        push_u64(&mut output, self.generation);
+        push_u64(&mut output, face_count);
+        push_u64(&mut output, HEADER_SIZE as u64);
+
+        let mut family_offset = HEADER_SIZE.checked_add(records_size)?;
+        for face in &self.faces {
+            push_u64(&mut output, face.face_id);
+            push_u64(&mut output, u64::try_from(family_offset).ok()?);
+            push_u32(&mut output, u32::try_from(face.family.len()).ok()?);
+            push_u32(&mut output, face.ttc_index);
+            push_u16(&mut output, face.weight);
+            push_u16(&mut output, face.width);
+            output.push(face.slope);
+            output.push(face.format);
+            push_u16(&mut output, 0);
+            family_offset = family_offset.checked_add(face.family.len())?;
+        }
+        for face in &self.faces {
+            output.extend_from_slice(&face.family);
+        }
+
+        debug_assert_eq!(output.len(), total_size);
+        Some(output)
+    }
+}
+
+impl FontCatalog {
+    fn parse(data: &[u8], expected_generation: u64) -> Option<Self> {
+        if data.len() < HEADER_SIZE || data.get(0..8)? != MAGIC {
+            return None;
+        }
+        if read_u32(data, 8)? != VERSION || read_u32(data, 12)? as usize != HEADER_SIZE {
+            return None;
+        }
+        if usize::try_from(read_u64(data, 16)?).ok()? != data.len() {
+            return None;
+        }
+        let generation = read_u64(data, 24)?;
+        if generation == 0 || generation != expected_generation {
+            return None;
+        }
+        let face_count = usize::try_from(read_u64(data, 32)?).ok()?;
+        let records_offset = usize::try_from(read_u64(data, 40)?).ok()?;
+        if records_offset != HEADER_SIZE {
+            return None;
+        }
+        let records_size = face_count.checked_mul(RECORD_SIZE)?;
+        let strings_offset = records_offset.checked_add(records_size)?;
+        if strings_offset > data.len() {
+            return None;
+        }
+
+        let mut faces = Vec::with_capacity(face_count);
+        let mut face_by_id = HashMap::with_capacity(face_count);
+        let mut faces_by_family: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+
+        for index in 0..face_count {
+            let offset = records_offset.checked_add(index.checked_mul(RECORD_SIZE)?)?;
+            let face_id = read_u64(data, offset)?;
+            let family_offset = usize::try_from(read_u64(data, offset + 8)?).ok()?;
+            let family_length = usize::try_from(read_u32(data, offset + 16)?).ok()?;
+            let ttc_index = read_u32(data, offset + 20)?;
+            let weight = read_u16(data, offset + 24)?;
+            let width = read_u16(data, offset + 26)?;
+            let slope = *data.get(offset + 28)?;
+            let format = *data.get(offset + 29)?;
+            if read_u16(data, offset + 30)? != 0 {
+                return None;
+            }
+
+            let family_end = family_offset.checked_add(family_length)?;
+            if family_offset < strings_offset || family_end > data.len() {
+                return None;
+            }
+            let family = data.get(family_offset..family_end)?;
+            if !valid_face(face_id, family, weight, width, slope, format) || face_by_id.contains_key(&face_id) {
+                return None;
+            }
+
+            let face = ParsedFace {
+                family_offset,
+                family_length,
+                face_id,
+                ttc_index,
+                weight,
+                width,
+                slope,
+                format,
+            };
+            faces.push(face);
+            face_by_id.insert(face_id, index);
+            faces_by_family.entry(ascii_lowercase(family)).or_default().push(index);
+        }
+
+        Some(Self {
+            data: data.as_ptr(),
+            data_length: data.len(),
+            generation,
+            faces,
+            face_by_id,
+            faces_by_family,
+        })
+    }
+
+    fn face_for_ffi(&self, index: usize) -> Option<FfiFontCatalogFace> {
+        let face = *self.faces.get(index)?;
+        let family_end = face.family_offset.checked_add(face.family_length)?;
+        if family_end > self.data_length {
+            return None;
+        }
+        Some(FfiFontCatalogFace {
+            // SAFETY: parse() validated this offset and the caller keeps the snapshot alive.
+            family: unsafe { self.data.add(face.family_offset) },
+            family_length: face.family_length,
+            face_id: face.face_id,
+            ttc_index: face.ttc_index,
+            weight: face.weight,
+            width: face.width,
+            slope: face.slope,
+            format: face.format,
+        })
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn font_catalog_builder_create(generation: u64) -> *mut FontCatalogBuilder {
+    if generation == 0 {
+        return std::ptr::null_mut();
+    }
+    Box::into_raw(Box::new(FontCatalogBuilder {
+        generation,
+        faces: Vec::new(),
+        face_ids: HashSet::new(),
+    }))
+}
+
+/// # Safety
+/// `builder` must be returned by `font_catalog_builder_create`, and `input.family`
+/// must be readable for `input.family_length` bytes during this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_builder_add_face(
+    builder: *mut FontCatalogBuilder,
+    input: FfiFontCatalogFaceInput,
+) -> bool {
+    let Some(builder) = (unsafe { builder.as_mut() }) else {
+        return false;
+    };
+    if input.family.is_null() {
+        return false;
+    }
+    let family = unsafe { std::slice::from_raw_parts(input.family, input.family_length) };
+    if !valid_face(
+        input.face_id,
+        family,
+        input.weight,
+        input.width,
+        input.slope,
+        input.format,
+    ) || !builder.face_ids.insert(input.face_id)
+    {
+        return false;
+    }
+    builder.faces.push(BuilderFace {
+        family: family.to_vec(),
+        face_id: input.face_id,
+        ttc_index: input.ttc_index,
+        weight: input.weight,
+        width: input.width,
+        slope: input.slope,
+        format: input.format,
+    });
+    true
+}
+
+/// # Safety
+/// `builder` must be returned by `font_catalog_builder_create`. If `output` is
+/// non-null, it must be writable for `output_capacity` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_builder_serialize(
+    builder: *const FontCatalogBuilder,
+    output: *mut u8,
+    output_capacity: usize,
+) -> usize {
+    let Some(builder) = (unsafe { builder.as_ref() }) else {
+        return 0;
+    };
+    let Some(serialized) = builder.serialize() else {
+        return 0;
+    };
+    if output.is_null() {
+        return serialized.len();
+    }
+    if output_capacity < serialized.len() {
+        return 0;
+    }
+    unsafe { std::ptr::copy_nonoverlapping(serialized.as_ptr(), output, serialized.len()) };
+    serialized.len()
+}
+
+/// # Safety
+/// `builder` must be null or returned by `font_catalog_builder_create`, and it
+/// must not be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_builder_destroy(builder: *mut FontCatalogBuilder) {
+    if !builder.is_null() {
+        drop(unsafe { Box::from_raw(builder) });
+    }
+}
+
+/// # Safety
+/// `data` must remain readable and at the same address until the returned
+/// catalog is destroyed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_parse(
+    data: *const u8,
+    data_length: usize,
+    expected_generation: u64,
+) -> *mut FontCatalog {
+    if data.is_null() {
+        return std::ptr::null_mut();
+    }
+    let data = unsafe { std::slice::from_raw_parts(data, data_length) };
+    FontCatalog::parse(data, expected_generation)
+        .map(|catalog| Box::into_raw(Box::new(catalog)))
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// # Safety
+/// `catalog` must be null or returned by `font_catalog_parse`, and it must not
+/// be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_destroy(catalog: *mut FontCatalog) {
+    if !catalog.is_null() {
+        drop(unsafe { Box::from_raw(catalog) });
+    }
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_generation(catalog: *const FontCatalog) -> u64 {
+    unsafe { catalog.as_ref() }.map_or(0, |catalog| catalog.generation)
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_face_count(catalog: *const FontCatalog) -> usize {
+    unsafe { catalog.as_ref() }.map_or(0, |catalog| catalog.faces.len())
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog and `output` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_face_at(
+    catalog: *const FontCatalog,
+    index: usize,
+    output: *mut FfiFontCatalogFace,
+) -> bool {
+    let (Some(catalog), Some(output)) = (unsafe { catalog.as_ref() }, unsafe { output.as_mut() }) else {
+        return false;
+    };
+    let Some(face) = catalog.face_for_ffi(index) else {
+        return false;
+    };
+    *output = face;
+    true
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog. `family` must be readable for
+/// `family_length` bytes during this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_family_face_count(
+    catalog: *const FontCatalog,
+    family: *const u8,
+    family_length: usize,
+) -> usize {
+    let Some(catalog) = (unsafe { catalog.as_ref() }) else {
+        return 0;
+    };
+    if family.is_null() {
+        return 0;
+    }
+    let family = unsafe { std::slice::from_raw_parts(family, family_length) };
+    catalog
+        .faces_by_family
+        .get(&ascii_lowercase(family))
+        .map_or(0, Vec::len)
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog. `family` must be readable for
+/// `family_length` bytes during this call and `output` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_family_face_at(
+    catalog: *const FontCatalog,
+    family: *const u8,
+    family_length: usize,
+    index: usize,
+    output: *mut FfiFontCatalogFace,
+) -> bool {
+    let (Some(catalog), Some(output)) = (unsafe { catalog.as_ref() }, unsafe { output.as_mut() }) else {
+        return false;
+    };
+    if family.is_null() {
+        return false;
+    }
+    let family = unsafe { std::slice::from_raw_parts(family, family_length) };
+    let Some(face_index) = catalog
+        .faces_by_family
+        .get(&ascii_lowercase(family))
+        .and_then(|faces| faces.get(index))
+    else {
+        return false;
+    };
+    let Some(face) = catalog.face_for_ffi(*face_index) else {
+        return false;
+    };
+    *output = face;
+    true
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog and `output` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_face_by_id(
+    catalog: *const FontCatalog,
+    face_id: u64,
+    output: *mut FfiFontCatalogFace,
+) -> bool {
+    let (Some(catalog), Some(output)) = (unsafe { catalog.as_ref() }, unsafe { output.as_mut() }) else {
+        return false;
+    };
+    let Some(index) = catalog.face_by_id.get(&face_id) else {
+        return false;
+    };
+    let Some(face) = catalog.face_for_ffi(*index) else {
+        return false;
+    };
+    *output = face;
+    true
+}
+
+/// # Safety
+/// `catalog` must point to a live parsed catalog. `family` must be readable for
+/// `family_length` bytes during this call and `output` must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn font_catalog_match_style(
+    catalog: *const FontCatalog,
+    family: *const u8,
+    family_length: usize,
+    weight: u16,
+    width: u16,
+    slope: u8,
+    output: *mut FfiFontCatalogFace,
+) -> bool {
+    let (Some(catalog), Some(output)) = (unsafe { catalog.as_ref() }, unsafe { output.as_mut() }) else {
+        return false;
+    };
+    if family.is_null() {
+        return false;
+    }
+    let family = unsafe { std::slice::from_raw_parts(family, family_length) };
+    let Some(indices) = catalog.faces_by_family.get(&ascii_lowercase(family)) else {
+        return false;
+    };
+    let Some(index) = indices.iter().find(|index| {
+        let face = catalog.faces[**index];
+        face.weight == weight && face.width == width && face.slope == slope
+    }) else {
+        return false;
+    };
+    let Some(face) = catalog.face_for_ffi(*index) else {
+        return false;
+    };
+    *output = face;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn serialized_catalog() -> Vec<u8> {
+        let mut builder = FontCatalogBuilder {
+            generation: 7,
+            faces: Vec::new(),
+            face_ids: HashSet::new(),
+        };
+        builder.faces.push(BuilderFace {
+            family: b"Example Sans".to_vec(),
+            face_id: 11,
+            ttc_index: 2,
+            weight: 400,
+            width: 5,
+            slope: 0,
+            format: 0,
+        });
+        builder.face_ids.insert(11);
+        builder.serialize().unwrap()
+    }
+
+    #[test]
+    fn round_trip_and_case_insensitive_style_match() {
+        let bytes = serialized_catalog();
+        let catalog = FontCatalog::parse(&bytes, 7).unwrap();
+        let indices = catalog.faces_by_family.get(b"example sans" as &[u8]).unwrap();
+        assert_eq!(indices, &[0]);
+        assert_eq!(catalog.faces[0].face_id, 11);
+        assert_eq!(catalog.faces[0].ttc_index, 2);
+    }
+
+    #[test]
+    fn rejects_truncation_and_wrong_generation() {
+        let bytes = serialized_catalog();
+        assert!(FontCatalog::parse(&bytes[..bytes.len() - 1], 7).is_none());
+        assert!(FontCatalog::parse(&bytes, 8).is_none());
+    }
+
+    #[test]
+    fn rejects_out_of_range_strings_and_duplicate_ids() {
+        let mut bytes = serialized_catalog();
+        bytes[16..24].copy_from_slice(&(bytes.len() as u64).to_le_bytes());
+        bytes[56..64].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(FontCatalog::parse(&bytes, 7).is_none());
+
+        let mut builder = FontCatalogBuilder {
+            generation: 9,
+            faces: Vec::new(),
+            face_ids: HashSet::new(),
+        };
+        for family in [b"First" as &[u8], b"Second"] {
+            builder.faces.push(BuilderFace {
+                family: family.to_vec(),
+                face_id: 3,
+                ttc_index: 0,
+                weight: 400,
+                width: 5,
+                slope: 0,
+                format: 0,
+            });
+        }
+        let bytes = builder.serialize().unwrap();
+        assert!(FontCatalog::parse(&bytes, 9).is_none());
+    }
+}

--- a/Libraries/LibGfx/Rust/src/font_catalog.rs
+++ b/Libraries/LibGfx/Rust/src/font_catalog.rs
@@ -70,7 +70,7 @@ pub struct FontCatalog {
     generation: u64,
     faces: Vec<ParsedFace>,
     face_by_id: HashMap<u64, usize>,
-    faces_by_family: HashMap<Vec<u8>, Vec<usize>>,
+    faces_by_family: HashMap<u64, Vec<usize>>,
 }
 
 fn valid_face(face_id: u64, family: &[u8], weight: u16, width: u16, slope: u8, format: u8) -> bool {
@@ -83,8 +83,18 @@ fn valid_face(face_id: u64, family: &[u8], weight: u16, width: u16, slope: u8, f
         && format <= 1
 }
 
-fn ascii_lowercase(bytes: &[u8]) -> Vec<u8> {
-    bytes.iter().map(u8::to_ascii_lowercase).collect()
+fn family_hash(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte.to_ascii_lowercase())).wrapping_mul(0x100000001b3)
+    })
+}
+
+fn family_names_equal(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| left.eq_ignore_ascii_case(right))
 }
 
 fn push_u16(output: &mut Vec<u8>, value: u16) {
@@ -187,7 +197,7 @@ impl FontCatalog {
 
         let mut faces = Vec::with_capacity(face_count);
         let mut face_by_id = HashMap::with_capacity(face_count);
-        let mut faces_by_family: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+        let mut faces_by_family: HashMap<u64, Vec<usize>> = HashMap::new();
 
         for index in 0..face_count {
             let offset = records_offset.checked_add(index.checked_mul(RECORD_SIZE)?)?;
@@ -224,7 +234,7 @@ impl FontCatalog {
             };
             faces.push(face);
             face_by_id.insert(face_id, index);
-            faces_by_family.entry(ascii_lowercase(family)).or_default().push(index);
+            faces_by_family.entry(family_hash(family)).or_default().push(index);
         }
 
         Some(Self {
@@ -254,6 +264,55 @@ impl FontCatalog {
             slope: face.slope,
             format: face.format,
         })
+    }
+
+    fn family_bytes(&self, index: usize) -> Option<&[u8]> {
+        let face = *self.faces.get(index)?;
+        let family_end = face.family_offset.checked_add(face.family_length)?;
+        if family_end > self.data_length {
+            return None;
+        }
+        // SAFETY: parse() validated this range and the snapshot outlives the catalog.
+        Some(unsafe { std::slice::from_raw_parts(self.data.add(face.family_offset), face.family_length) })
+    }
+
+    fn family_face_count(&self, family: &[u8]) -> usize {
+        self.faces_by_family
+            .get(&family_hash(family))
+            .into_iter()
+            .flatten()
+            .filter(|index| {
+                self.family_bytes(**index)
+                    .is_some_and(|candidate| family_names_equal(candidate, family))
+            })
+            .count()
+    }
+
+    fn family_face_index_at(&self, family: &[u8], family_index: usize) -> Option<usize> {
+        self.faces_by_family
+            .get(&family_hash(family))?
+            .iter()
+            .copied()
+            .filter(|index| {
+                self.family_bytes(*index)
+                    .is_some_and(|candidate| family_names_equal(candidate, family))
+            })
+            .nth(family_index)
+    }
+
+    fn match_style_index(&self, family: &[u8], weight: u16, width: u16, slope: u8) -> Option<usize> {
+        self.faces_by_family
+            .get(&family_hash(family))?
+            .iter()
+            .copied()
+            .find(|index| {
+                let face = self.faces[*index];
+                self.family_bytes(*index)
+                    .is_some_and(|candidate| family_names_equal(candidate, family))
+                    && face.weight == weight
+                    && face.width == width
+                    && face.slope == slope
+            })
     }
 }
 
@@ -418,10 +477,7 @@ pub unsafe extern "C" fn font_catalog_family_face_count(
         return 0;
     }
     let family = unsafe { std::slice::from_raw_parts(family, family_length) };
-    catalog
-        .faces_by_family
-        .get(&ascii_lowercase(family))
-        .map_or(0, Vec::len)
+    catalog.family_face_count(family)
 }
 
 /// # Safety
@@ -442,14 +498,10 @@ pub unsafe extern "C" fn font_catalog_family_face_at(
         return false;
     }
     let family = unsafe { std::slice::from_raw_parts(family, family_length) };
-    let Some(face_index) = catalog
-        .faces_by_family
-        .get(&ascii_lowercase(family))
-        .and_then(|faces| faces.get(index))
-    else {
+    let Some(face_index) = catalog.family_face_index_at(family, index) else {
         return false;
     };
-    let Some(face) = catalog.face_for_ffi(*face_index) else {
+    let Some(face) = catalog.face_for_ffi(face_index) else {
         return false;
     };
     *output = face;
@@ -497,16 +549,10 @@ pub unsafe extern "C" fn font_catalog_match_style(
         return false;
     }
     let family = unsafe { std::slice::from_raw_parts(family, family_length) };
-    let Some(indices) = catalog.faces_by_family.get(&ascii_lowercase(family)) else {
+    let Some(index) = catalog.match_style_index(family, weight, width, slope) else {
         return false;
     };
-    let Some(index) = indices.iter().find(|index| {
-        let face = catalog.faces[**index];
-        face.weight == weight && face.width == width && face.slope == slope
-    }) else {
-        return false;
-    };
-    let Some(face) = catalog.face_for_ffi(*index) else {
+    let Some(face) = catalog.face_for_ffi(index) else {
         return false;
     };
     *output = face;
@@ -540,8 +586,8 @@ mod tests {
     fn round_trip_and_case_insensitive_style_match() {
         let bytes = serialized_catalog();
         let catalog = FontCatalog::parse(&bytes, 7).unwrap();
-        let indices = catalog.faces_by_family.get(b"example sans" as &[u8]).unwrap();
-        assert_eq!(indices, &[0]);
+        assert_eq!(catalog.family_face_count(b"example sans"), 1);
+        assert_eq!(catalog.match_style_index(b"EXAMPLE SANS", 400, 5, 0), Some(0));
         assert_eq!(catalog.faces[0].face_id, 11);
         assert_eq!(catalog.faces[0].ttc_index, 2);
     }
@@ -556,7 +602,8 @@ mod tests {
     #[test]
     fn rejects_out_of_range_strings_and_duplicate_ids() {
         let mut bytes = serialized_catalog();
-        bytes[16..24].copy_from_slice(&(bytes.len() as u64).to_le_bytes());
+        let serialized_size = bytes.len() as u64;
+        bytes[16..24].copy_from_slice(&serialized_size.to_le_bytes());
         bytes[56..64].copy_from_slice(&u64::MAX.to_le_bytes());
         assert!(FontCatalog::parse(&bytes, 7).is_none());
 
@@ -578,5 +625,24 @@ mod tests {
         }
         let bytes = builder.serialize().unwrap();
         assert!(FontCatalog::parse(&bytes, 9).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_strings_and_face_fields() {
+        let original = serialized_catalog();
+
+        let mut invalid_utf8 = original.clone();
+        invalid_utf8[HEADER_SIZE + RECORD_SIZE] = 0xff;
+        assert!(FontCatalog::parse(&invalid_utf8, 7).is_none());
+
+        let mut invalid_weight = original.clone();
+        invalid_weight[72..74].copy_from_slice(&0_u16.to_le_bytes());
+        assert!(FontCatalog::parse(&invalid_weight, 7).is_none());
+
+        for (offset, value) in [(48, 0_u8), (76, 3), (77, 2), (78, 1)] {
+            let mut bytes = original.clone();
+            bytes[offset] = value;
+            assert!(FontCatalog::parse(&bytes, 7).is_none());
+        }
     }
 }

--- a/Libraries/LibGfx/Rust/src/lib.rs
+++ b/Libraries/LibGfx/Rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bsp_tree;
 pub mod color;
 pub mod corner_radii;
 pub mod font;
+pub mod font_catalog;
 pub mod geometry;
 pub mod matrix;
 pub mod paint_enums;

--- a/Libraries/LibWeb/Platform/FontPlugin.cpp
+++ b/Libraries/LibWeb/Platform/FontPlugin.cpp
@@ -170,7 +170,7 @@ FlyString FontPlugin::compute_generic_font_name(GenericFont generic_font, int we
             return m_system_font_family.value();
     }
 
-    auto name = Gfx::TypefaceSkia::resolve_generic_family(generic_family_name, weight, slope);
+    auto name = Gfx::FontDatabase::the().resolve_generic_family(generic_family_name, weight, slope);
     if (name.has_value()) {
         if (Gfx::FontDatabase::the().get(name.value(), 16, weight, Gfx::FontWidth::Normal, slope))
             return FlyString { name.release_value() };

--- a/Libraries/LibWeb/Worker/WebWorkerClient.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.ipc
@@ -1,11 +1,17 @@
 #include <LibHTTP/Cookie/Cookie.h>
 #include <LibHTTP/HSTS/ParsedHSTSPolicy.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibIPC/File.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
 
 endpoint WebWorkerClient {
+    open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
+
     did_close_worker() =|
     did_finish_loading_worker_script(bool worker_is_secure_context) =|
     did_fail_loading_worker_script() =|

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -9,6 +9,7 @@
 
 endpoint WebWorkerServer {
     init_transport(int peer_pid) => (int peer_pid)
+    set_font_catalog(IPC::File file, u64 size, u64 generation) =|
 
     connect_to_request_server(IPC::TransportHandle handle) =|
     simulate_request_server_connection_loss_and_reconnect_for_testing(IPC::TransportHandle replacement_handle) => ()

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -36,6 +36,7 @@
 #include <LibWebView/CompositorClient.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/FaviconStore.h>
+#include <LibWebView/FontService.h>
 #include <LibWebView/HSTSStore.h>
 #include <LibWebView/HeadlessWebView.h>
 #include <LibWebView/HelperProcess.h>
@@ -682,6 +683,8 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     };
 
     create_platform_options(m_browser_options, m_request_server_options, m_web_content_options);
+
+    m_font_service = FontService::create();
 
     // Test mode implies experimental interfaces and internals object are exposed and the Skia CPU backend is used.
     if (m_web_content_options.is_test_mode == IsTestMode::Yes) {

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -88,6 +88,7 @@ public:
     static BrowserOptions const& browser_options() { return the().m_browser_options; }
     static RequestServerOptions const& request_server_options() { return the().m_request_server_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
+    static FontService& font_service() { return *the().m_font_service; }
     JsonValue const& site_compatibility_data() const { return m_site_compatibility_data; }
     ErrorOr<void> reload_site_compatibility_data();
 
@@ -482,6 +483,7 @@ private:
     Vector<int> m_cpu_profiler_signal_handlers;
     RequestServerOptions m_request_server_options;
     WebContentOptions m_web_content_options;
+    OwnPtr<FontService> m_font_service;
     JsonValue m_site_compatibility_data;
     Optional<Core::AnonymousBuffer> m_content_blocker_list_buffer;
 

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     ExternalURLHandler.cpp
     FaviconStore.cpp
     FileDownloader.cpp
+    FontService.cpp
     Geolocation.cpp
     HeadlessWebView.cpp
     HelperProcess.cpp

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -7,9 +7,37 @@
 #include <LibWebView/CompositorClient.h>
 
 #include <LibCore/EventLoop.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/FontService.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
+
+Messages::CompositorControlClient::OpenSystemFontResponse CompositorClient::open_system_font(u64 generation, u64 face_id)
+{
+    auto font = Application::font_service().open_font(generation, face_id);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::CompositorControlClient::MatchSystemFontResponse CompositorClient::match_system_font(String family, u16 weight, u16 width, u8 slope)
+{
+    auto font = Application::font_service().match_font(family, weight, width, slope);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::CompositorControlClient::MatchSystemFontForCodePointResponse CompositorClient::match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    auto font = Application::font_service().match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::CompositorControlClient::ResolveGenericFontResponse CompositorClient::resolve_generic_font(String family, u16 weight, u8 slope)
+{
+    auto resolved = Application::font_service().resolve_generic_family(family, weight, slope);
+    if (!resolved.has_value())
+        return Optional<String> {};
+    return Optional<String> { resolved->to_string() };
+}
 
 CompositorClient::CompositorClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<CompositorControlClientEndpoint, CompositorControlServerEndpoint>(*this, move(transport))

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -32,6 +32,11 @@ public:
 private:
     virtual void die() override;
 
+    virtual Messages::CompositorControlClient::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override;
+    virtual Messages::CompositorControlClient::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override;
+    virtual Messages::CompositorControlClient::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
+    virtual Messages::CompositorControlClient::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override;
+
     virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) override;
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 };

--- a/Libraries/LibWebView/FontService.cpp
+++ b/Libraries/LibWebView/FontService.cpp
@@ -22,8 +22,12 @@ NonnullOwnPtr<FontService> FontService::create()
 
 FontService::FontService()
     : m_worker(Threading::Thread::construct("Font catalog"sv, [this] {
-        if (auto result = build_catalog(); result.is_error())
-            m_build_error = MUST(String::formatted("{}", result.error()));
+        if (auto result = build_catalog(); result.is_error()) {
+            dbgln("Unable to discover system fonts: {}. Using an empty catalog.", result.error());
+            m_font_sources.clear();
+            if (auto fallback_result = build_empty_catalog(); fallback_result.is_error())
+                m_build_error = MUST(String::formatted("{}", fallback_result.error()));
+        }
         return 0;
     }))
 {
@@ -95,6 +99,15 @@ ErrorOr<void> FontService::build_catalog()
             return callback_error.release_value();
     }
 
+    auto serialized = TRY(builder->serialize());
+    m_catalog_size = serialized.size();
+    m_catalog_file = TRY(create_immutable_font_data(serialized.bytes()));
+    return {};
+}
+
+ErrorOr<void> FontService::build_empty_catalog()
+{
+    auto builder = TRY(Gfx::FontCatalogBuilder::create(m_generation));
     auto serialized = TRY(builder->serialize());
     m_catalog_size = serialized.size();
     m_catalog_file = TRY(create_immutable_font_data(serialized.bytes()));

--- a/Libraries/LibWebView/FontService.cpp
+++ b/Libraries/LibWebView/FontService.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/AnonymousBuffer.h>
+#include <LibCore/File.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/Font/TypefaceSkia.h>
+#include <LibWebView/FontService.h>
+
+#include <fcntl.h>
+
+namespace WebView {
+
+NonnullOwnPtr<FontService> FontService::create()
+{
+    return adopt_own(*new FontService);
+}
+
+FontService::FontService()
+    : m_worker(Threading::Thread::construct("Font catalog"sv, [this] {
+        if (auto result = build_catalog(); result.is_error())
+            m_build_error = MUST(String::formatted("{}", result.error()));
+        return 0;
+    }))
+{
+    m_worker->start();
+}
+
+FontService::~FontService()
+{
+    if (m_worker->needs_to_be_joined())
+        (void)m_worker->join();
+}
+
+ErrorOr<void> FontService::wait_until_ready()
+{
+    if (m_worker->needs_to_be_joined()) {
+        auto result = m_worker->join();
+        if (result.is_error())
+            return Error::from_errno(result.error().value());
+    }
+    if (m_build_error.has_value())
+        return Error::from_string_view(m_build_error->bytes_as_string_view());
+    return {};
+}
+
+ErrorOr<FontCatalogDescriptor> FontService::clone_catalog()
+{
+    TRY(wait_until_ready());
+    return FontCatalogDescriptor {
+        .file = TRY(IPC::File::clone_fd(m_catalog_file.fd())),
+        .size = m_catalog_size,
+        .generation = m_generation,
+    };
+}
+
+ErrorOr<void> FontService::build_catalog()
+{
+    auto builder = TRY(Gfx::FontCatalogBuilder::create(m_generation));
+    HashTable<String> loaded_paths;
+    Optional<Error> callback_error;
+    u64 next_face_id = 1;
+
+    auto directories = TRY(Gfx::FontDatabase::font_directories());
+    for (auto const& directory : directories) {
+        auto uri = TRY(String::formatted("file://{}", directory));
+        Gfx::PathFontProvider::for_each_typeface_in_uri(uri, loaded_paths, [&](String const& path, u32 ttc_index, Gfx::FontFileFormat format, NonnullRefPtr<Gfx::Typeface> typeface) {
+            if (callback_error.has_value())
+                return;
+            auto face_id = next_face_id++;
+            auto result = builder->add_face({
+                .family = typeface->family().bytes_as_string_view(),
+                .face_id = face_id,
+                .ttc_index = ttc_index,
+                .weight = typeface->weight(),
+                .width = typeface->width(),
+                .slope = typeface->slope(),
+                .format = format,
+            });
+            if (result.is_error()) {
+                callback_error = result.release_error();
+                return;
+            }
+            m_font_sources.set(face_id, FontSource {
+                                            .path = path,
+                                            .ttc_index = ttc_index,
+                                            .format = format,
+                                        });
+        });
+        if (callback_error.has_value())
+            return callback_error.release_value();
+    }
+
+    auto serialized = TRY(builder->serialize());
+    m_catalog_size = serialized.size();
+    m_catalog_file = TRY(create_immutable_font_data(serialized.bytes()));
+    return {};
+}
+
+ErrorOr<IPC::File> FontService::create_immutable_font_data(ReadonlyBytes bytes)
+{
+    IPC::File file;
+    {
+        auto buffer = TRY(Core::AnonymousBuffer::create_with_size(bytes.size(), Core::AnonymousBuffer::Sealability::Sealable));
+        bytes.copy_to({ buffer.data<u8>(), buffer.size() });
+        file = TRY(IPC::File::clone_fd(buffer.fd()));
+    }
+
+#if defined(F_ADD_SEALS) && defined(F_SEAL_GROW) && defined(F_SEAL_SHRINK) && defined(F_SEAL_WRITE) && defined(F_SEAL_SEAL)
+    if (::fcntl(file.fd(), F_ADD_SEALS, F_SEAL_GROW | F_SEAL_SHRINK | F_SEAL_WRITE | F_SEAL_SEAL) < 0)
+        return Error::from_errno(errno);
+#endif
+
+    return file;
+}
+
+Gfx::BrokeredFont FontService::open_font(u64 generation, u64 face_id)
+{
+    if (wait_until_ready().is_error() || generation != m_generation || face_id == 0)
+        return {};
+
+    if (auto source = m_font_sources.get(face_id); source.has_value()) {
+        auto file = Core::File::open(source->path, Core::File::OpenMode::Read);
+        if (file.is_error())
+            return {};
+        return {
+            .face_id = face_id,
+            .ttc_index = source->ttc_index,
+            .format = source->format,
+            .file = IPC::File::adopt_file(file.release_value()),
+        };
+    }
+
+    if (auto source = m_memory_font_sources.get(face_id); source.has_value()) {
+        auto file = IPC::File::clone_fd(source->file.fd());
+        if (file.is_error())
+            return {};
+        return {
+            .face_id = face_id,
+            .ttc_index = source->ttc_index,
+            .format = source->format,
+            .file = file.release_value(),
+        };
+    }
+    return {};
+}
+
+Gfx::BrokeredFont FontService::materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia> typeface, String cache_key)
+{
+    if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
+        return open_font(m_generation, *face_id);
+
+    auto file = create_immutable_font_data(typeface->font_data());
+    if (file.is_error())
+        return {};
+
+    auto face_id = m_next_dynamic_face_id++;
+    auto ttc_index = typeface->collection_index();
+    m_memory_font_sources.set(face_id, MemoryFontSource {
+                                           .file = file.release_value(),
+                                           .ttc_index = ttc_index,
+                                           .format = Gfx::FontFileFormat::OpenType,
+                                       });
+    m_dynamic_match_cache.set(move(cache_key), face_id);
+    return open_font(m_generation, face_id);
+}
+
+Gfx::BrokeredFont FontService::match_font(String const& family, u16 weight, u16 width, u8 slope)
+{
+    if (wait_until_ready().is_error())
+        return {};
+    auto cache_key = MUST(String::formatted("family:{}:{}:{}:{}", family, weight, width, slope));
+    if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
+        return open_font(m_generation, *face_id);
+
+    auto typeface = Gfx::TypefaceSkia::match_family_style(family.bytes_as_string_view(), weight, width, slope);
+    if (typeface.is_error() || !typeface.value())
+        return {};
+    return materialize_typeface(typeface.release_value().release_nonnull(), move(cache_key));
+}
+
+Gfx::BrokeredFont FontService::match_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    if (wait_until_ready().is_error())
+        return {};
+    auto cache_key = MUST(String::formatted("character:{}:{}:{}:{}:{}", code_point, weight, width, slope, prefer_color_emoji));
+    if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
+        return open_font(m_generation, *face_id);
+
+    auto typeface = Gfx::TypefaceSkia::find_typeface_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+    if (typeface.is_error() || !typeface.value())
+        return {};
+    return materialize_typeface(typeface.release_value().release_nonnull(), move(cache_key));
+}
+
+Optional<FlyString> FontService::resolve_generic_family(String const& family, u16 weight, u8 slope)
+{
+    if (wait_until_ready().is_error())
+        return {};
+    return Gfx::TypefaceSkia::resolve_generic_family(family.bytes_as_string_view(), weight, slope);
+}
+
+}

--- a/Libraries/LibWebView/FontService.h
+++ b/Libraries/LibWebView/FontService.h
@@ -53,6 +53,7 @@ private:
     };
 
     ErrorOr<void> build_catalog();
+    ErrorOr<void> build_empty_catalog();
     ErrorOr<void> wait_until_ready();
     ErrorOr<IPC::File> create_immutable_font_data(ReadonlyBytes);
     Gfx::BrokeredFont materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia>, String cache_key);

--- a/Libraries/LibWebView/FontService.h
+++ b/Libraries/LibWebView/FontService.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
+#include <LibGfx/Font/FontCatalog.h>
+#include <LibGfx/Font/SharedFontProvider.h>
+#include <LibGfx/Font/TypefaceSkia.h>
+#include <LibThreading/Thread.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+struct FontCatalogDescriptor {
+    IPC::File file;
+    u64 size { 0 };
+    u64 generation { 0 };
+};
+
+class WEBVIEW_API FontService {
+    AK_MAKE_NONCOPYABLE(FontService);
+    AK_MAKE_NONMOVABLE(FontService);
+
+public:
+    static NonnullOwnPtr<FontService> create();
+    ~FontService();
+
+    ErrorOr<FontCatalogDescriptor> clone_catalog();
+    Gfx::BrokeredFont open_font(u64 generation, u64 face_id);
+    Gfx::BrokeredFont match_font(String const& family, u16 weight, u16 width, u8 slope);
+    Gfx::BrokeredFont match_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji);
+    Optional<FlyString> resolve_generic_family(String const& family, u16 weight, u8 slope);
+
+private:
+    FontService();
+
+    struct FontSource {
+        String path;
+        u32 ttc_index { 0 };
+        Gfx::FontFileFormat format { Gfx::FontFileFormat::OpenType };
+    };
+
+    struct MemoryFontSource {
+        IPC::File file;
+        u32 ttc_index { 0 };
+        Gfx::FontFileFormat format { Gfx::FontFileFormat::OpenType };
+    };
+
+    ErrorOr<void> build_catalog();
+    ErrorOr<void> wait_until_ready();
+    ErrorOr<IPC::File> create_immutable_font_data(ReadonlyBytes);
+    Gfx::BrokeredFont materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia>, String cache_key);
+
+    NonnullRefPtr<Threading::Thread> m_worker;
+    Optional<String> m_build_error;
+    IPC::File m_catalog_file;
+    u64 m_catalog_size { 0 };
+    u64 m_generation { 1 };
+    u64 m_next_dynamic_face_id { 1ull << 63 };
+    HashMap<u64, FontSource> m_font_sources;
+    HashMap<u64, MemoryFontSource> m_memory_font_sources;
+    HashMap<String, u64> m_dynamic_match_cache;
+};
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -26,6 +26,7 @@ class CookieJar;
 class DownloadStore;
 class ExternalURLHandler;
 class FaviconStore;
+class FontService;
 class HistoryStore;
 class HSTSStore;
 class Menu;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/System.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/CompositorClient.h>
+#include <LibWebView/FontService.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/Utilities.h>
 
@@ -275,6 +276,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(IsP
     }
 
     auto client = TRY(launch_server_process<WebView::WebContentClient>("WebContent"sv, move(arguments), is_private, initial_page_id, root_navigable_id));
+    auto font_catalog = TRY(WebView::Application::font_service().clone_catalog());
+    client->async_set_font_catalog(move(font_catalog.file), font_catalog.size, font_catalog.generation);
     if (auto system_font_family = WebView::Application::the().system_font_family(); system_font_family.has_value())
         client->async_set_system_font_family(system_font_family.release_value());
     return client;
@@ -338,7 +341,10 @@ ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process()
         arguments.append(server.value());
     }
 
-    return launch_server_process<WebView::CompositorClient>("Compositor"sv, move(arguments));
+    auto client = TRY(launch_server_process<WebView::CompositorClient>("Compositor"sv, move(arguments)));
+    auto font_catalog = TRY(WebView::Application::font_service().clone_catalog());
+    client->async_set_font_catalog(move(font_catalog.file), font_catalog.size, font_catalog.generation);
+    return client;
 }
 
 ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::HTML::AgentType type, IsPrivate is_private, Web::HTML::WorkerAgentId agent_id)
@@ -383,6 +389,8 @@ ErrorOr<NonnullRefPtr<WebWorkerClient>> launch_web_worker_process(Web::HTML::Age
     }
 
     auto client = TRY(launch_server_process<WebWorkerClient>("WebWorker"sv, move(arguments), is_private, agent_id));
+    auto font_catalog = TRY(WebView::Application::font_service().clone_catalog());
+    client->async_set_font_catalog(move(font_catalog.file), font_catalog.size, font_catalog.generation);
     if (auto system_font_family = WebView::Application::the().system_font_family(); system_font_family.has_value())
         client->async_set_system_font_family(system_font_family.release_value());
     return client;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -23,6 +23,7 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/CookieJar.h>
+#include <LibWebView/FontService.h>
 #include <LibWebView/HSTSStore.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/HistoryStore.h>
@@ -35,6 +36,32 @@
 #include <LibWebView/WorkerProcessManager.h>
 
 namespace WebView {
+
+Messages::WebContentClient::OpenSystemFontResponse WebContentClient::open_system_font(u64 generation, u64 face_id)
+{
+    auto font = Application::font_service().open_font(generation, face_id);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebContentClient::MatchSystemFontResponse WebContentClient::match_system_font(String family, u16 weight, u16 width, u8 slope)
+{
+    auto font = Application::font_service().match_font(family, weight, width, slope);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebContentClient::MatchSystemFontForCodePointResponse WebContentClient::match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    auto font = Application::font_service().match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebContentClient::ResolveGenericFontResponse WebContentClient::resolve_generic_font(String family, u16 weight, u8 slope)
+{
+    auto resolved = Application::font_service().resolve_generic_family(family, weight, slope);
+    if (!resolved.has_value())
+        return Optional<String> {};
+    return Optional<String> { resolved->to_string() };
+}
 
 HashTable<WebContentClient*>& WebContentClient::clients()
 {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -73,6 +73,11 @@ public:
     static size_t client_count() { return clients().size(); }
     static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
 
+    virtual Messages::WebContentClient::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override;
+    virtual Messages::WebContentClient::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override;
+    virtual Messages::WebContentClient::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
+    virtual Messages::WebContentClient::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override;
+
     WebContentClient(NonnullOwnPtr<IPC::Transport>, IsPrivate, u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id);
     ~WebContentClient();
 

--- a/Libraries/LibWebView/WebWorkerClient.cpp
+++ b/Libraries/LibWebView/WebWorkerClient.cpp
@@ -6,11 +6,38 @@
 
 #include <LibWebView/Application.h>
 #include <LibWebView/CookieJar.h>
+#include <LibWebView/FontService.h>
 #include <LibWebView/HSTSStore.h>
 #include <LibWebView/WebWorkerClient.h>
 #include <LibWebView/WorkerProcessManager.h>
 
 namespace WebView {
+
+Messages::WebWorkerClient::OpenSystemFontResponse WebWorkerClient::open_system_font(u64 generation, u64 face_id)
+{
+    auto font = Application::font_service().open_font(generation, face_id);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebWorkerClient::MatchSystemFontResponse WebWorkerClient::match_system_font(String family, u16 weight, u16 width, u8 slope)
+{
+    auto font = Application::font_service().match_font(family, weight, width, slope);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebWorkerClient::MatchSystemFontForCodePointResponse WebWorkerClient::match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
+{
+    auto font = Application::font_service().match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+}
+
+Messages::WebWorkerClient::ResolveGenericFontResponse WebWorkerClient::resolve_generic_font(String family, u16 weight, u8 slope)
+{
+    auto resolved = Application::font_service().resolve_generic_family(family, weight, slope);
+    if (!resolved.has_value())
+        return Optional<String> {};
+    return Optional<String> { resolved->to_string() };
+}
 
 WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport, IsPrivate is_private, Web::HTML::WorkerAgentId agent_id)
     : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))

--- a/Libraries/LibWebView/WebWorkerClient.h
+++ b/Libraries/LibWebView/WebWorkerClient.h
@@ -49,6 +49,10 @@ public:
     virtual void did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage) override;
     virtual Messages::WebWorkerClient::StartWorkerAgentResponse start_worker_agent(Web::HTML::WorkerAgentStartRequest request) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;
+    virtual Messages::WebWorkerClient::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override;
+    virtual Messages::WebWorkerClient::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override;
+    virtual Messages::WebWorkerClient::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
+    virtual Messages::WebWorkerClient::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override;
 
 private:
     virtual void die() override;

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -1,9 +1,15 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/SharedImage.h>
+#include <LibIPC/File.h>
 #include <LibWeb/Compositor/Types.h>
 
 endpoint CompositorControlClient
 {
+    open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
+
     did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) =|
     did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -2,12 +2,14 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Size.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibIPC/File.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Page/InputEvent.h>
 
 endpoint CompositorControlServer
 {
     init_transport(int peer_pid) => (int peer_pid)
+    set_font_catalog(IPC::File file, u64 size, u64 generation) =|
 
     connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)
 

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -10,6 +10,8 @@
 #include <Compositor/ConnectionFromWebContent.h>
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/SharedFontProvider.h>
 #include <LibIPC/Transport.h>
 #include <LibWebView/PausedDebuggerOverlay.h>
 
@@ -48,6 +50,67 @@ Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::i
     return Core::System::getpid();
 #endif
     VERIFY_NOT_REACHED();
+}
+
+void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 generation)
+{
+    if (m_font_provider) {
+        if (auto result = m_font_provider->replace_catalog(move(file), size, generation); result.is_error())
+            dbgln("Compositor: Unable to replace font catalog: {}", result.error());
+        return;
+    }
+
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [this](u64 requested_generation, u64 face_id) {
+        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::OpenSystemFont>(requested_generation, face_id);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->matched_face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font = [this](String const& family, u16 weight, u16 width, u8 slope) {
+        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::MatchSystemFont>(family, weight, width, slope);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font_for_code_point = [this](u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) {
+        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::MatchSystemFontForCodePoint>(code_point, weight, width, slope, prefer_color_emoji);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.resolve_generic_family = [this](String const& family, u16 weight, u8 slope) -> Optional<FlyString> {
+        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::ResolveGenericFont>(family, weight, slope);
+        if (!response)
+            return {};
+        auto resolved_family = response->take_resolved_family();
+        if (!resolved_family.has_value())
+            return {};
+        return FlyString { resolved_family.release_value() };
+    };
+
+    auto provider = Gfx::SharedFontProvider::create_from_catalog_file_or_empty(move(file), size, generation, move(callbacks));
+    if (provider.is_error()) {
+        dbgln("Compositor: Unable to install fallback font catalog: {}", provider.error());
+        return;
+    }
+    m_font_provider = provider.value().ptr();
+    Gfx::FontDatabase::the().install_system_font_provider(provider.release_value());
 }
 
 Messages::CompositorControlServer::ConnectWebContentResponse ConnectionFromClient::connect_web_content()

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -17,6 +17,12 @@
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 
+namespace Gfx {
+
+class SharedFontProvider;
+
+}
+
 namespace Compositor {
 
 class ConnectionFromClient final
@@ -36,6 +42,7 @@ private:
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, i32 web_content_connection_id) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
@@ -54,6 +61,7 @@ private:
 
     HashMap<i32, NonnullRefPtr<ConnectionFromWebContent>> m_web_content_connections;
     NonnullRefPtr<CompositorState> m_compositor_state;
+    Gfx::SharedFontProvider* m_font_provider { nullptr };
 };
 
 }

--- a/Services/Compositor/SandboxLinux.cpp
+++ b/Services/Compositor/SandboxLinux.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/Directory.h>
 #include <LibCore/Environment.h>
 #include <LibCore/StandardPaths.h>
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
@@ -21,8 +20,6 @@ ErrorOr<void> apply_sandbox(StringView)
     TRY(Sandbox::configure_runtime());
 
     Vector<Sandbox::LandlockPath> paths;
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, TRY(String::formatted("{}/fonts", WebView::s_ladybird_resource_root)), Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib"sv, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/lib64"sv, Sandbox::LandlockPath::Access::ReadOnly));

--- a/Services/Compositor/SandboxMacOS.cpp
+++ b/Services/Compositor/SandboxMacOS.cpp
@@ -9,7 +9,6 @@
 #include <Compositor/Sandbox.h>
 #include <LibCore/Directory.h>
 #include <LibCore/System.h>
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibWebView/Utilities.h>
 #include <limits.h>
@@ -31,8 +30,6 @@ ErrorOr<void> apply_sandbox(StringView cache_path)
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, LexicalPath::join(build_root, "lib"sv).string(), Sandbox::SeatbeltPath::Access::ReadAndExecute));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, LexicalPath::join(build_root, "vcpkg_installed"sv).string(), Sandbox::SeatbeltPath::Access::ReadAndExecute));
 
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        TRY(Sandbox::add_seatbelt_path_if_exists(paths, path, Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, TRY(String::formatted("{}/fonts", WebView::s_ladybird_resource_root)), Sandbox::SeatbeltPath::Access::ReadOnly));
 
     TRY(Core::Directory::create(cache_path, Core::Directory::CreateDirectories::Yes));

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -11,7 +11,6 @@
 #include <LibCore/Process.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
@@ -48,14 +47,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         Gfx::force_hinting_for_testing(Gfx::FontHintingStyle::Normal);
 
     WebView::platform_init();
-    auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
-    if (force_fontconfig) {
-        font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+    if (force_fontconfig)
         Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
-    }
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        font_provider.load_all_fonts_from_uri(TRY(String::formatted("file://{}", path)));
-    font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 
     if (!force_cpu_painting)
         Gfx::SkiaBackendContext::initialize_gpu_backend();

--- a/Services/RendererSandboxLinux.cpp
+++ b/Services/RendererSandboxLinux.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/Directory.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibSandbox/Seccomp.h>
 #include <LibWebView/Utilities.h>
@@ -32,9 +31,6 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     TRY(Sandbox::add_landlock_path_if_exists(paths, executable_path, Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, LexicalPath::join(build_root, "lib"sv).string(), Sandbox::LandlockPath::Access::ReadOnly));
     TRY(Sandbox::add_landlock_path_if_exists(paths, "/proc/self"sv, Sandbox::LandlockPath::Access::ReadOnly));
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        TRY(Sandbox::add_landlock_path_if_exists(paths, path, Sandbox::LandlockPath::Access::ReadOnly));
-
     auto pulse_runtime_path = LexicalPath::join(TRY(Core::StandardPaths::runtime_directory()), "pulse"sv).string();
     TRY(Core::Directory::create(pulse_runtime_path, Core::Directory::CreateDirectories::Yes, 0700));
     TRY(Sandbox::add_landlock_path_if_exists(paths, pulse_runtime_path, Sandbox::LandlockPath::Access::ReadWrite));

--- a/Services/RendererSandboxMacOS.cpp
+++ b/Services/RendererSandboxMacOS.cpp
@@ -7,7 +7,6 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/Directory.h>
 #include <LibCore/System.h>
-#include <LibGfx/Font/FontDatabase.h>
 #include <LibSandbox/Sandbox.h>
 #include <LibWebView/Utilities.h>
 #include <Services/RendererSandbox.h>
@@ -32,9 +31,6 @@ ErrorOr<void> apply_sandbox(Optional<StringView> config_path, Optional<StringVie
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, LexicalPath::join(build_root, "bin"sv).string(), Sandbox::SeatbeltPath::Access::ReadOnly));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, LexicalPath::join(build_root, "lib"sv).string(), Sandbox::SeatbeltPath::Access::ReadAndExecute));
     TRY(Sandbox::add_seatbelt_path_if_exists(paths, LexicalPath::join(build_root, "vcpkg_installed"sv).string(), Sandbox::SeatbeltPath::Access::ReadAndExecute));
-
-    for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
-        TRY(Sandbox::add_seatbelt_path_if_exists(paths, path, Sandbox::SeatbeltPath::Access::ReadOnly));
 
     if (cache_path.has_value()) {
         TRY(Core::Directory::create(*cache_path, Core::Directory::CreateDirectories::Yes));

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -24,6 +24,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/SharedFontProvider.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibIPC/Transport.h>
 #include <LibJS/Runtime/ConsoleObject.h>
@@ -94,9 +95,10 @@
 
 namespace WebContent {
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, bool enable_test_mode)
     : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport), 1)
     , m_page_host(PageHost::create(*this))
+    , m_enable_test_mode(enable_test_mode)
 {
 }
 
@@ -126,6 +128,70 @@ Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_tra
     return Core::System::getpid();
 #endif
     VERIFY_NOT_REACHED();
+}
+
+void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 generation)
+{
+    if (m_font_provider) {
+        if (auto result = m_font_provider->replace_catalog(move(file), size, generation); result.is_error())
+            dbgln("WebContent: Unable to replace font catalog: {}", result.error());
+        else
+            Web::Platform::FontPlugin::the().update_generic_fonts();
+        return;
+    }
+
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [this](u64 requested_generation, u64 face_id) {
+        auto response = send_sync_but_allow_failure<Messages::WebContentClient::OpenSystemFont>(requested_generation, face_id);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->matched_face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font = [this](String const& family, u16 weight, u16 width, u8 slope) {
+        auto response = send_sync_but_allow_failure<Messages::WebContentClient::MatchSystemFont>(family, weight, width, slope);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font_for_code_point = [this](u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) {
+        auto response = send_sync_but_allow_failure<Messages::WebContentClient::MatchSystemFontForCodePoint>(code_point, weight, width, slope, prefer_color_emoji);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.resolve_generic_family = [this](String const& family, u16 weight, u8 slope) -> Optional<FlyString> {
+        auto response = send_sync_but_allow_failure<Messages::WebContentClient::ResolveGenericFont>(family, weight, slope);
+        if (!response)
+            return {};
+        auto resolved_family = response->take_resolved_family();
+        if (!resolved_family.has_value())
+            return {};
+        return FlyString { resolved_family.release_value() };
+    };
+
+    auto provider = Gfx::SharedFontProvider::create_from_catalog_file_or_empty(move(file), size, generation, move(callbacks));
+    if (provider.is_error()) {
+        dbgln("WebContent: Unable to install fallback font catalog: {}", provider.error());
+        return;
+    }
+    m_font_provider = provider.value().ptr();
+    Gfx::FontDatabase::the().install_system_font_provider(provider.release_value());
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(m_enable_test_mode, m_font_provider));
 }
 
 void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -43,6 +43,12 @@
 #include <WebContent/WebContentConsoleClient.h>
 #include <WebContent/WebContentServerEndpoint.h>
 
+namespace Gfx {
+
+class SharedFontProvider;
+
+}
+
 namespace WebContent {
 
 class ConnectionFromClient final
@@ -71,12 +77,13 @@ public:
     void update_input_method_state(u64 page_id);
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
+    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, bool enable_test_mode);
 
     Optional<PageClient&> page(u64 index, SourceLocation = SourceLocation::current());
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
@@ -272,6 +279,8 @@ private:
     void enqueue_input_event(Web::QueuedInputEvent);
 
     Queue<Web::QueuedInputEvent> m_input_event_queue;
+    Gfx::SharedFontProvider* m_font_provider { nullptr };
+    bool m_enable_test_mode { false };
 };
 
 }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -1,6 +1,7 @@
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Color.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibIPC/File.h>
 #include <LibGfx/Cursor.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibHTTP/Cookie/Cookie.h>
@@ -58,6 +59,11 @@
 
 endpoint WebContentClient
 {
+    open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
+
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -49,6 +49,7 @@
 endpoint WebContentServer
 {
     init_transport(int peer_pid) => (int peer_pid)
+    set_font_catalog(IPC::File file, u64 size, u64 generation) =|
     initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
     close_server() =|
 

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -14,7 +14,6 @@
 #include <LibCore/TimeZone.h>
 #include <LibCrypto/OpenSSLForward.h>
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Font/PathFontProvider.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibMain/Main.h>
@@ -30,7 +29,6 @@
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Painting/BoxViews.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
-#include <LibWeb/Platform/FontPlugin.h>
 #include <LibWebView/Plugins/ImageCodecPlugin.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/Utilities.h>
@@ -203,12 +201,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     if (file_origins_are_tuple_origins)
         URL::set_file_scheme_urls_have_tuple_origins();
 
-    auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
-    if (force_fontconfig) {
-        font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+    if (force_fontconfig)
         Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
-    }
-    font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 
     WebContent::PageClient::set_is_headless(is_headless);
 
@@ -233,8 +227,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::HTML::Window::set_internals_object_exposed(expose_internals_object);
     Web::HTML::UniversalGlobalScopeMixin::set_experimental_interfaces_exposed(expose_experimental_interfaces);
 
-    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(enable_test_mode, &font_provider));
-
     Web::Bindings::initialize_main_thread_vm(Web::HTML::AgentType::SimilarOriginWindow);
 
     if (collect_garbage_on_every_allocation)
@@ -251,9 +243,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto browser_port = TRY(Core::MachPort::look_up_from_bootstrap_server(ByteString { mach_server_name }));
     auto transport_ports = TRY(IPC::bootstrap_transport_from_server_port(browser_port));
     auto webcontent_client = WebContent::ConnectionFromClient::construct(
-        make<IPC::Transport>(move(transport_ports.receive_right), move(transport_ports.send_right)));
+        make<IPC::Transport>(move(transport_ports.receive_right), move(transport_ports.send_right)), enable_test_mode);
 #else
-    auto webcontent_client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ConnectionFromClient>(mach_server_name));
+    auto webcontent_client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ConnectionFromClient>(mach_server_name, enable_test_mode));
 #endif
 
     auto& heap = Web::Bindings::main_thread_vm().heap();

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -6,6 +6,8 @@
 
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/SharedFontProvider.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
 #include <LibWeb/Platform/FontPlugin.h>
@@ -130,6 +132,70 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
 }
 
 ConnectionFromClient::~ConnectionFromClient() = default;
+
+void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 generation)
+{
+    if (m_font_provider) {
+        if (auto result = m_font_provider->replace_catalog(move(file), size, generation); result.is_error())
+            dbgln("WebWorker: Unable to replace font catalog: {}", result.error());
+        else
+            Web::Platform::FontPlugin::the().update_generic_fonts();
+        return;
+    }
+
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [this](u64 requested_generation, u64 face_id) {
+        auto response = send_sync_but_allow_failure<Messages::WebWorkerClient::OpenSystemFont>(requested_generation, face_id);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->matched_face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font = [this](String const& family, u16 weight, u16 width, u8 slope) {
+        auto response = send_sync_but_allow_failure<Messages::WebWorkerClient::MatchSystemFont>(family, weight, width, slope);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.match_font_for_code_point = [this](u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) {
+        auto response = send_sync_but_allow_failure<Messages::WebWorkerClient::MatchSystemFontForCodePoint>(code_point, weight, width, slope, prefer_color_emoji);
+        if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
+            return Gfx::BrokeredFont {};
+        return Gfx::BrokeredFont {
+            .face_id = response->face_id(),
+            .ttc_index = response->ttc_index(),
+            .format = static_cast<Gfx::FontFileFormat>(response->format()),
+            .file = response->take_file(),
+        };
+    };
+    callbacks.resolve_generic_family = [this](String const& family, u16 weight, u8 slope) -> Optional<FlyString> {
+        auto response = send_sync_but_allow_failure<Messages::WebWorkerClient::ResolveGenericFont>(family, weight, slope);
+        if (!response)
+            return {};
+        auto resolved_family = response->take_resolved_family();
+        if (!resolved_family.has_value())
+            return {};
+        return FlyString { resolved_family.release_value() };
+    };
+
+    auto provider = Gfx::SharedFontProvider::create_from_catalog_file_or_empty(move(file), size, generation, move(callbacks));
+    if (provider.is_error()) {
+        dbgln("WebWorker: Unable to install fallback font catalog: {}", provider.error());
+        return;
+    }
+    m_font_provider = provider.value().ptr();
+    Gfx::FontDatabase::the().install_system_font_provider(provider.release_value());
+    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(false, m_font_provider));
+}
 
 Web::Page& ConnectionFromClient::page()
 {

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -21,6 +21,12 @@
 #include <WebWorker/Forward.h>
 #include <WebWorker/PageHost.h>
 
+namespace Gfx {
+
+class SharedFontProvider;
+
+}
+
 namespace WebWorker {
 
 class ConnectionFromClient final
@@ -33,6 +39,7 @@ public:
     virtual void die() override;
 
     virtual Messages::WebWorkerServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual void close_worker() override;
 
     void request_file(Web::FileRequest);
@@ -81,6 +88,7 @@ private:
 
     RefPtr<WorkerHost> m_worker_host;
     Function<void()> m_request_server_died_callback_for_testing;
+    Gfx::SharedFontProvider* m_font_provider { nullptr };
 };
 
 }

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -22,7 +22,6 @@
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
-#include <LibWeb/Platform/FontPlugin.h>
 #include <LibWebView/Plugins/ImageCodecPlugin.h>
 #include <LibWebView/Utilities.h>
 #include <Services/RendererSandbox.h>
@@ -98,8 +97,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     Web::HTML::UniversalGlobalScopeMixin::set_experimental_interfaces_exposed(expose_experimental_interfaces);
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPlugin);
-
-    Web::Platform::FontPlugin::install(*new Web::Platform::FontPlugin(false));
 
     Web::Bindings::initialize_main_thread_vm(worker_type);
 

--- a/Tests/LibCore/TestLibCoreAnonymousBuffer.cpp
+++ b/Tests/LibCore/TestLibCoreAnonymousBuffer.cpp
@@ -7,6 +7,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Vector.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
 #include <LibTest/TestCase.h>
 #include <string.h>
@@ -92,6 +93,19 @@ TEST_CASE(reconstruct_from_anon_fd_shares_memory)
 
     StringView mirrored { mirror.data<char const>(), payload.length() };
     EXPECT_EQ(mirrored, payload);
+}
+
+TEST_CASE(map_from_anon_fd_as_read_only)
+{
+    auto original = MUST(Core::AnonymousBuffer::create_with_size(128));
+
+    auto const payload = "mapped read-only"sv;
+    memcpy(original.data<void>(), payload.characters_without_null_termination(), payload.length());
+
+    auto fd = MUST(Core::System::dup(original.fd()));
+    auto mapping = MUST(Core::MappedFile::map_from_fd_range_and_close(fd, "anonymous buffer"sv, 0, original.size()));
+
+    EXPECT_EQ(mapping->bytes().slice(0, payload.length()), payload.bytes());
 }
 
 TEST_CASE(snapshot_has_independent_contents)

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SOURCES
     TestImageWriter.cpp
     TestQuad.cpp
     TestRect.cpp
+    TestSharedFontProvider.cpp
     TestWOFF.cpp
     TestWOFF2.cpp
 )
@@ -20,6 +21,8 @@ target_link_libraries(BenchmarkJPEGLoader PRIVATE LibImageDecoders)
 target_link_libraries(TestImageDecoder PRIVATE LibImageDecoders)
 target_link_libraries(TestImageWriter PRIVATE LibImageDecoders)
 target_link_libraries(TestFont PRIVATE harfbuzz)
+target_link_libraries(TestSharedFontProvider PRIVATE LibIPC)
+target_compile_definitions(TestSharedFontProvider PRIVATE LADYBIRD_SOURCE_DIR="${LADYBIRD_SOURCE_DIR}")
 
 ladybird_test(TestBitmapSequence.cpp LibGfx LIBS LibGfx LibIPC)
 ladybird_test(TestShareableBitmap.cpp LibGfx LIBS LibGfx LibIPC)

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     BenchmarkJPEGLoader.cpp
     TestBitmapExport.cpp
     TestColor.cpp
+    TestFontCatalog.cpp
     TestFont.cpp
     TestImageDecoder.cpp
     TestImageWriter.cpp

--- a/Tests/LibGfx/TestFontCatalog.cpp
+++ b/Tests/LibGfx/TestFontCatalog.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/FontCatalog.h>
+#include <LibTest/TestCase.h>
+
+static ByteBuffer make_catalog()
+{
+    auto builder = MUST(Gfx::FontCatalogBuilder::create(42));
+    MUST(builder->add_face({
+        .family = "Example Sans"sv,
+        .face_id = 17,
+        .ttc_index = 2,
+        .weight = 400,
+        .width = 5,
+        .slope = 0,
+        .format = Gfx::FontFileFormat::OpenType,
+    }));
+    MUST(builder->add_face({
+        .family = "Example Sans"sv,
+        .face_id = 23,
+        .ttc_index = 2,
+        .weight = 700,
+        .width = 5,
+        .slope = 1,
+        .format = Gfx::FontFileFormat::OpenType,
+    }));
+    return MUST(builder->serialize());
+}
+
+TEST_CASE(round_trip_and_lookup)
+{
+    auto bytes = make_catalog();
+    auto catalog = MUST(Gfx::FontCatalog::parse(bytes, 42));
+
+    EXPECT_EQ(catalog->generation(), 42u);
+    EXPECT_EQ(catalog->face_count(), 2u);
+    EXPECT_EQ(catalog->family_face_count("example sans"sv), 2u);
+
+    auto face = catalog->match_style("EXAMPLE SANS"sv, 700, 5, 1);
+    EXPECT(face.has_value());
+    EXPECT_EQ(face->face_id, 23u);
+    EXPECT_EQ(face->ttc_index, 2u);
+    EXPECT(!catalog->match_style("Example Sans"sv, 500, 5, 0).has_value());
+
+    face = catalog->face_by_id(17);
+    EXPECT(face.has_value());
+    EXPECT_EQ(face->family, "Example Sans"sv);
+    EXPECT(!catalog->face_by_id(99).has_value());
+}
+
+TEST_CASE(builder_rejects_invalid_faces)
+{
+    auto builder = MUST(Gfx::FontCatalogBuilder::create(1));
+    EXPECT(builder->add_face({ .family = "Invalid ID"sv, .face_id = 0, .weight = 400, .width = 5, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = "Invalid"sv, .face_id = 1, .weight = 400, .width = 5, .slope = 3 }).is_error());
+    MUST(builder->add_face({ .family = "Valid"sv, .face_id = 1, .weight = 400, .width = 5, .slope = 0 }));
+    EXPECT(builder->add_face({ .family = "Duplicate"sv, .face_id = 1, .weight = 400, .width = 5, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = ""sv, .face_id = 2, .weight = 400, .width = 5, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = "Bad Weight"sv, .face_id = 3, .weight = 0, .width = 5, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = "Bad Weight"sv, .face_id = 3, .weight = 1001, .width = 5, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = "Bad Width"sv, .face_id = 3, .weight = 400, .width = 0, .slope = 0 }).is_error());
+    EXPECT(builder->add_face({ .family = "Bad Width"sv, .face_id = 3, .weight = 400, .width = 10, .slope = 0 }).is_error());
+}
+
+TEST_CASE(parser_rejects_malformed_snapshots)
+{
+    auto bytes = make_catalog();
+    EXPECT(Gfx::FontCatalog::parse(bytes.bytes().slice(0, bytes.size() - 1), 42).is_error());
+    EXPECT(Gfx::FontCatalog::parse(bytes, 41).is_error());
+
+    auto trailing_data = MUST(ByteBuffer::copy(bytes));
+    trailing_data.append(0);
+    EXPECT(Gfx::FontCatalog::parse(trailing_data, 42).is_error());
+
+    auto invalid_magic = MUST(ByteBuffer::copy(bytes));
+    invalid_magic[0] = 'X';
+    EXPECT(Gfx::FontCatalog::parse(invalid_magic, 42).is_error());
+
+    auto invalid_version = MUST(ByteBuffer::copy(bytes));
+    invalid_version[8] = 2;
+    EXPECT(Gfx::FontCatalog::parse(invalid_version, 42).is_error());
+
+    auto invalid_string = MUST(ByteBuffer::copy(bytes));
+    invalid_string[112] = 0xff;
+    EXPECT(Gfx::FontCatalog::parse(invalid_string, 42).is_error());
+
+    auto invalid_format = MUST(ByteBuffer::copy(bytes));
+    invalid_format[77] = 2;
+    EXPECT(Gfx::FontCatalog::parse(invalid_format, 42).is_error());
+
+    auto out_of_range_string = MUST(ByteBuffer::copy(bytes));
+    for (size_t index = 56; index < 64; ++index)
+        out_of_range_string[index] = 0xff;
+    EXPECT(Gfx::FontCatalog::parse(out_of_range_string, 42).is_error());
+
+    auto duplicate_id = MUST(ByteBuffer::copy(bytes));
+    for (size_t index = 0; index < sizeof(u64); ++index)
+        duplicate_id[80 + index] = duplicate_id[48 + index];
+    EXPECT(Gfx::FontCatalog::parse(duplicate_id, 42).is_error());
+}

--- a/Tests/LibGfx/TestSharedFontProvider.cpp
+++ b/Tests/LibGfx/TestSharedFontProvider.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Random.h>
+#include <AK/ScopeGuard.h>
+#include <LibCore/AnonymousBuffer.h>
+#include <LibCore/Directory.h>
+#include <LibCore/File.h>
+#include <LibCore/ResourceImplementation.h>
+#include <LibCore/ResourceImplementationFile.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/FontCatalog.h>
+#include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/Font/SharedFontProvider.h>
+#include <LibTest/TestCase.h>
+
+namespace {
+
+struct Global {
+    Global()
+    {
+        Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(MUST(String::formatted("{}/Base/res", LADYBIRD_SOURCE_DIR))));
+    }
+} global;
+
+static IPC::File copy_bytes_to_file(ReadonlyBytes bytes)
+{
+    auto buffer = MUST(Core::AnonymousBuffer::create_with_size(bytes.size()));
+    bytes.copy_to({ buffer.data<u8>(), buffer.size() });
+    return MUST(IPC::File::clone_fd(buffer.fd()));
+}
+
+static NonnullOwnPtr<Core::MappedFile> map_bytes(ReadonlyBytes bytes)
+{
+    auto file = copy_bytes_to_file(bytes);
+    return MUST(Core::MappedFile::map_from_fd_range_and_close(file.take_fd(), "font catalog test"sv, 0, bytes.size()));
+}
+
+static ByteBuffer make_catalog()
+{
+    auto builder = MUST(Gfx::FontCatalogBuilder::create(9));
+    MUST(builder->add_face({
+        .family = "Brokered Test"sv,
+        .face_id = 17,
+        .ttc_index = 0,
+        .weight = 400,
+        .width = Gfx::FontWidth::Normal,
+        .slope = 0,
+        .format = Gfx::FontFileFormat::OpenType,
+    }));
+    return MUST(builder->serialize());
+}
+
+static Gfx::BrokeredFont open_test_font(u64 face_id)
+{
+    auto path = MUST(String::formatted("{}/Tests/LibGfx/test-inputs/fonts/text.ttf", LADYBIRD_SOURCE_DIR));
+    auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
+    return {
+        .face_id = face_id,
+        .ttc_index = 0,
+        .format = Gfx::FontFileFormat::OpenType,
+        .file = IPC::File::adopt_file(move(file)),
+    };
+}
+
+}
+
+TEST_CASE(opens_catalog_faces_lazily_and_caches_them)
+{
+    auto catalog = make_catalog();
+    size_t open_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [&](u64 generation, u64 face_id) {
+        EXPECT_EQ(generation, 9u);
+        EXPECT_EQ(face_id, 17u);
+        ++open_count;
+        return open_test_font(face_id);
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create(map_bytes(catalog), 9, move(callbacks)));
+    EXPECT_EQ(open_count, 0u);
+
+    auto first_font = provider->get_font("Brokered Test"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0);
+    EXPECT(first_font);
+    EXPECT_EQ(open_count, 1u);
+
+    auto second_font = provider->get_font("Brokered Test"_fly_string, 16, 400, Gfx::FontWidth::Normal, 0);
+    EXPECT(second_font);
+    EXPECT_EQ(open_count, 1u);
+
+    auto identifier = first_font->typeface().system_font_identifier();
+    EXPECT(identifier.has_value());
+    EXPECT_EQ(identifier->generation, 9u);
+    EXPECT_EQ(identifier->face_id, 17u);
+}
+
+TEST_CASE(negatively_caches_failed_catalog_face_opens)
+{
+    auto catalog = make_catalog();
+    size_t open_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [&](u64, u64 face_id) {
+        ++open_count;
+        return Gfx::BrokeredFont {
+            .face_id = face_id,
+            .ttc_index = 0,
+            .format = Gfx::FontFileFormat::OpenType,
+            .file = {},
+        };
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create(map_bytes(catalog), 9, move(callbacks)));
+    EXPECT(!provider->get_font("Brokered Test"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0));
+    EXPECT(!provider->get_font("Brokered Test"_fly_string, 16, 400, Gfx::FontWidth::Normal, 0));
+    EXPECT_EQ(open_count, 1u);
+}
+
+TEST_CASE(empty_catalog_preserves_platform_broker_fallback)
+{
+    size_t match_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font = [&](String const& family, u16 weight, u16 width, u8 slope) {
+        EXPECT_EQ(family, "Platform Alias"sv);
+        EXPECT_EQ(weight, 400u);
+        EXPECT_EQ(width, Gfx::FontWidth::Normal);
+        EXPECT_EQ(slope, 0u);
+        ++match_count;
+        return open_test_font(91);
+    };
+
+    auto malformed = MUST(ByteBuffer::copy("not a font catalog"sv.bytes()));
+    auto provider = Gfx::SharedFontProvider::create(map_bytes(malformed), 9, move(callbacks));
+    EXPECT(provider.is_error());
+
+    provider = Gfx::SharedFontProvider::create_empty(9, move(callbacks));
+    EXPECT(!provider.is_error());
+    auto font = provider.value()->get_font("Platform Alias"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0);
+    EXPECT(font);
+    EXPECT_EQ(match_count, 1u);
+
+    auto identifier = font->typeface().system_font_identifier();
+    EXPECT(identifier.has_value());
+    EXPECT_EQ(identifier->generation, 9u);
+    EXPECT_EQ(identifier->face_id, 91u);
+}
+
+TEST_CASE(catalog_file_factory_preserves_callbacks_during_fallback)
+{
+    size_t match_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font = [&](String const&, u16, u16, u8) {
+        ++match_count;
+        return open_test_font(92);
+    };
+
+    auto malformed = MUST(ByteBuffer::copy("not a font catalog"sv.bytes()));
+    auto file = copy_bytes_to_file(malformed);
+    auto provider = MUST(Gfx::SharedFontProvider::create_from_catalog_file_or_empty(move(file), malformed.size(), 9, move(callbacks)));
+
+    EXPECT(provider->get_font("Platform Alias"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0));
+    EXPECT_EQ(match_count, 1u);
+}
+
+TEST_CASE(catalog_file_factory_handles_mapping_failure)
+{
+    size_t match_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font = [&](String const&, u16, u16, u8) {
+        ++match_count;
+        return open_test_font(96);
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create_from_catalog_file_or_empty({}, 1, 9, move(callbacks)));
+
+    EXPECT(provider->get_font("Platform Alias"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0));
+    EXPECT_EQ(match_count, 1u);
+}
+
+TEST_CASE(rejecting_replacement_preserves_current_catalog)
+{
+    auto catalog = make_catalog();
+    size_t open_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.open_font = [&](u64, u64 face_id) {
+        ++open_count;
+        return open_test_font(face_id);
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create(map_bytes(catalog), 9, move(callbacks)));
+    auto malformed = MUST(ByteBuffer::copy("not a font catalog"sv.bytes()));
+    auto file = copy_bytes_to_file(malformed);
+    EXPECT(provider->replace_catalog(move(file), malformed.size(), 9).is_error());
+
+    EXPECT(provider->get_font("Brokered Test"_fly_string, 12, 400, Gfx::FontWidth::Normal, 0));
+    EXPECT_EQ(open_count, 1u);
+}
+
+TEST_CASE(unknown_width_uses_normal_variation_width)
+{
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font = [](String const&, u16, u16, u8) {
+        return open_test_font(93);
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create_empty(9, move(callbacks)));
+    auto font = provider->get_font("Platform Alias"_fly_string, 12, 400, 99, 0);
+    EXPECT(font);
+
+    auto variation_width = font->variation_settings().axes.get(Gfx::FourCC("wdth"));
+    EXPECT(variation_width.has_value());
+    EXPECT_EQ(variation_width.value(), 100.0f);
+}
+
+TEST_CASE(caches_code_point_fallback_matches_and_misses)
+{
+    size_t match_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font_for_code_point = [&](u32 code_point, u16, u16, u8, bool) {
+        ++match_count;
+        if (code_point == 'A')
+            return open_test_font(94);
+        return Gfx::BrokeredFont {};
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create_empty(9, move(callbacks)));
+    EXPECT(provider->get_font_for_code_point('A', 12, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT(provider->get_font_for_code_point('A', 16, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT_EQ(match_count, 1u);
+
+    EXPECT(!provider->get_font_for_code_point('B', 12, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT(!provider->get_font_for_code_point('B', 16, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT_EQ(match_count, 2u);
+
+    EXPECT(provider->get_font_for_code_point('A', 12, 700, Gfx::FontWidth::Normal, 0, false));
+    EXPECT(provider->get_font_for_code_point('A', 12, 400, Gfx::FontWidth::Normal, 0, true));
+    EXPECT_EQ(match_count, 4u);
+}
+
+TEST_CASE(replacing_catalog_clears_code_point_fallback_cache)
+{
+    size_t match_count = 0;
+    Gfx::SharedFontProviderCallbacks callbacks;
+    callbacks.match_font_for_code_point = [&](u32, u16, u16, u8, bool) {
+        ++match_count;
+        return open_test_font(95);
+    };
+
+    auto provider = MUST(Gfx::SharedFontProvider::create_empty(9, move(callbacks)));
+    EXPECT(provider->get_font_for_code_point('A', 12, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT_EQ(match_count, 1u);
+
+    auto replacement = make_catalog();
+    MUST(provider->replace_catalog(map_bytes(replacement), 9));
+    EXPECT(provider->get_font_for_code_point('A', 12, 400, Gfx::FontWidth::Normal, 0, false));
+    EXPECT_EQ(match_count, 2u);
+}
+
+#ifndef AK_OS_WINDOWS
+TEST_CASE(path_provider_deduplicates_canonical_paths)
+{
+    auto font_directory = MUST(String::formatted("{}/Tests/LibGfx/test-inputs/fonts", LADYBIRD_SOURCE_DIR));
+    auto source_directory = MUST(FileSystem::real_path(font_directory));
+    auto temporary_directory = MUST(String::formatted("{}/ladybird-font-dedup-{:016x}", Core::StandardPaths::tempfile_directory(), get_random<u64>()));
+    MUST(Core::Directory::create(temporary_directory.to_byte_string(), Core::Directory::CreateDirectories::Yes));
+    auto symlink_path = MUST(String::formatted("{}/fonts", temporary_directory));
+    ScopeGuard cleanup = [&] {
+        (void)Core::System::unlink(symlink_path);
+        (void)Core::System::rmdir(temporary_directory);
+    };
+    MUST(Core::System::symlink(source_directory, symlink_path));
+
+    HashTable<String> loaded_paths;
+    size_t face_count = 0;
+    Gfx::PathFontProvider::for_each_typeface_in_uri(MUST(String::formatted("file://{}", source_directory)), loaded_paths, [&](String const&, u32, Gfx::FontFileFormat, NonnullRefPtr<Gfx::Typeface>) {
+        ++face_count;
+    });
+    auto original_face_count = face_count;
+    EXPECT(original_face_count > 0);
+
+    Gfx::PathFontProvider::for_each_typeface_in_uri(MUST(String::formatted("file://{}", symlink_path)), loaded_paths, [&](String const&, u32, Gfx::FontFileFormat, NonnullRefPtr<Gfx::Typeface>) {
+        ++face_count;
+    });
+    EXPECT_EQ(face_count, original_face_count);
+}
+#endif


### PR DESCRIPTION
Every WebContent, WebWorker, and Compositor process used to discover the machine's system fonts for itself. That meant walking the same directories, opening the same font files, and extracting the same metadata every time a helper process started.

This change makes the application process discover system fonts once. It shares a small, read-only catalog with every helper, then sends an individual font file only when a helper actually needs it.

```mermaid
flowchart LR
    Fonts["System font directories"] -->|"discover once"| UI["Application process<br/>FontService"]
    UI -->|"shared read-only catalog"| Helpers["WebContent<br/>WebWorker<br/>Compositor"]
    Helpers -->|"request face ID"| UI
    UI -->|"open font file descriptor"| Helpers
```

The catalog is an index, not a copy of every font. It contains family names, style information, collection indexes, file formats, and stable face IDs. Font paths stay in the application process and are never exposed to helpers.

When a helper needs a system font:

1. It looks for the requested family and style in its local catalog.
2. On first use, it asks the application process to open that face ID.
3. The application opens the font and returns its file descriptor over IPC.
4. The helper maps and caches the font, so later uses need no IPC.

Platform-specific operations such as generic-family resolution, emoji and missing-glyph fallback, and matches not present in the catalog are also brokered through the application process. System typefaces sent to the Compositor are represented by catalog generation and face ID instead of raw font data.

The catalog format and parser are implemented in Rust. The parser validates the version, generation, sizes, offsets, strings, face properties, and IDs before exposing the catalog to C++. The catalog lives in sealed shared memory, so its backing pages can be shared safely between processes.

This also tightens the sandbox. WebContent, WebWorker, and Compositor no longer need direct access to system font directories, so those directories are removed from the Linux and macOS sandbox allowlists. For system fonts, helpers only receive the specific file descriptors brokered by the application.

`test-web` uses the same application-owned FontService as the browser. One full test run therefore discovers fonts once and reuses that knowledge across all of its helper processes. On the development machine, two full release runs took 85.74 and 85.55 seconds on master, compared with 75.84 and 76.65 seconds with this change.

If discovery fails, the application distributes a valid empty catalog and keeps platform matching available through the broker. Helpers also reject malformed catalogs and safely fall back to an empty one.
