### PR TITLE
LibWeb: Expose the Permissions API by default (and un-break the Al Jazeera news site) 

### DIFF
--- a/Libraries/LibWeb/HTML/Navigator.idl
+++ b/Libraries/LibWeb/HTML/Navigator.idl
@@ -37,7 +37,7 @@ interface Navigator {
     [SecureContext, SameObject] readonly attribute XRSystem xr;
 
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
-    [SameObject, Experimental] readonly attribute Permissions permissions;
+    [SameObject] readonly attribute Permissions permissions;
 };
 
 // NOTE: As NavigatorContentUtils, NavigatorCookies, NavigatorPlugins, and NavigatorAutomationInformation

--- a/Libraries/LibWeb/HTML/WorkerNavigator.idl
+++ b/Libraries/LibWeb/HTML/WorkerNavigator.idl
@@ -11,7 +11,7 @@ interface WorkerNavigator {
     [SecureContext, SameObject] readonly attribute ServiceWorkerContainer serviceWorker;
 
     // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
-    [SameObject, Experimental] readonly attribute Permissions permissions;
+    [SameObject] readonly attribute Permissions permissions;
 };
 
 Navigator includes GlobalPrivacyControl;

--- a/Libraries/LibWeb/PermissionsAPI/PermissionStatus.idl
+++ b/Libraries/LibWeb/PermissionsAPI/PermissionStatus.idl
@@ -1,5 +1,5 @@
 // https://w3c.github.io/permissions/#permissionstatus-interface
-[Experimental, Exposed=(Window,Worker)]
+[Exposed=(Window,Worker)]
 interface PermissionStatus : EventTarget {
     readonly attribute PermissionState state;
     readonly attribute DOMString name;

--- a/Tests/LibWeb/Text/expected/PermissionsAPI/navigator-permissions-query.txt
+++ b/Tests/LibWeb/Text/expected/PermissionsAPI/navigator-permissions-query.txt
@@ -1,0 +1,5 @@
+navigator.permissions: [object Permissions]
+query is a function: true
+unsupported name rejects: TypeError
+geolocation status: [object PermissionStatus]
+state is a permission state: true

--- a/Tests/LibWeb/Text/input/PermissionsAPI/navigator-permissions-query.html
+++ b/Tests/LibWeb/Text/input/PermissionsAPI/navigator-permissions-query.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Pins the query() contract: An unsupported name rejects, and a supported one resolves to a PermissionStatus.
+    asyncTest(async done => {
+        println(`navigator.permissions: ${Object.prototype.toString.call(navigator.permissions)}`);
+        println(`query is a function: ${typeof navigator.permissions.query === "function"}`);
+
+        try {
+            await navigator.permissions.query({ name: "surely-not-a-permission" });
+            println("unsupported name: resolved (unexpected)");
+        } catch (error) {
+            println(`unsupported name rejects: ${error.name}`);
+        }
+
+        const status = await navigator.permissions.query({ name: "geolocation" });
+        println(`geolocation status: ${Object.prototype.toString.call(status)}`);
+        println(`state is a permission state: ${["granted", "denied", "prompt"].includes(status.state)}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
> [!IMPORTANT]
> Seems like the alternative in https://github.com/LadybirdBrowser/ladybird/pull/11539 might be the better way of dealing with this. But I’m still keeping this open for the time being. 

---

**Problem:** https://www.aljazeera.com/ article pages render only the page footer; the article itself never appears. The site’s browser-checking gate logs _“Incompatible browser”,_ and refuses to React-hydrate the page. (And the same feature-detect-and-refuse pattern is common on other sites, too.)

**Cause:** The gate feature-tests `navigator.permissions`, and dies on it: It tries to read `navigator.permissions.query`, and throws. We have a working Permissions API: `query()` checks the document is fully active, converts the descriptor, rejects unsupported names with a `TypeError`, and answers geolocation from the permission store. `navigator.permissions` is however marked `[Experimental]`. So unless `--expose-experimental-interfaces` is specified, none of it exists for a page. The `Permissions` interface was already exposed, but `PermissionStatus` wasn’t. So, `query()` would’ve handed out instances of an interface whose global name pages can’t see.

**Fix:** Drop `[Experimental]` from the `navigator.permissions` attribute on `Navigator` and `WorkerNavigator`, and from the `PermissionStatus` interface — so the API’s pieces appear together. That unlocks nothing powerful: `query()` only reports permission state — it resolves to “prompt” for geolocation without prompting or granting anything, rejects every other name with a `TypeError`, and activates no capability. The features which permissions describe stay behind their own machinery.