### PR TITLE
LibWeb+Compositor: Run CSS animations on the compositor

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1698,6 +1698,7 @@ void Animation::invalidate_effect()
 
     auto& effect = static_cast<KeyframeEffect&>(*m_effect);
     effect.set_is_compositor_driven(false);
+    effect.set_is_compositor_replaced(false);
     if (auto target = effect.target())
         target->document().set_needs_animated_style_update(effect);
 }

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1697,6 +1697,7 @@ void Animation::invalidate_effect()
         return;
 
     auto& effect = static_cast<KeyframeEffect&>(*m_effect);
+    effect.set_is_compositor_driven(false);
     if (auto target = effect.target())
         target->document().set_needs_animated_style_update(effect);
 }

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1246,7 +1246,7 @@ void Animation::update()
                 auto delay = (effect.start_delay().value - animation_current_time->value) / playback_rate();
                 if (delay > 0) {
                     if (auto target = effect.target())
-                        target->document().schedule_animation_wakeup(delay);
+                        target->document().schedule_compositor_animation_wakeup(delay);
                 }
             }
         }

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1697,10 +1697,7 @@ void Animation::invalidate_effect()
         return;
 
     auto& effect = static_cast<KeyframeEffect&>(*m_effect);
-    effect.set_is_compositor_driven(false);
-    effect.set_is_compositor_replaced(false);
-    if (auto target = effect.target())
-        target->document().set_needs_animated_style_update(effect);
+    effect.invalidate_effect();
 }
 
 Animation::Animation(HTML::EnvironmentSettingsObject& environment)

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1026,7 +1026,7 @@ KeyframeEffect::KeyframeEffect() = default;
 void KeyframeEffect::invalidate_effect()
 {
     m_is_compositor_driven = false;
-    m_retained_compositor_animation.clear();
+    m_retained_compositor_animations.clear();
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
         m_target_element->document().set_needs_animated_style_update(*this);
@@ -1120,6 +1120,15 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
     return cache_result(true);
 }
 
+void KeyframeEffect::request_observation_sample()
+{
+    if (m_needs_observation_sample)
+        return;
+    m_needs_observation_sample = true;
+    if (m_target_element)
+        m_target_element->document().set_needs_animated_style_update(*this);
+}
+
 bool KeyframeEffect::can_skip_per_frame_animation_tick() const
 {
     if (auto animation = associated_animation(); animation && !animation->pending()
@@ -1131,6 +1140,10 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
 
     if (!m_is_compositor_driven && !can_skip_per_frame_style_update())
         return false;
+
+    // A compositor-driven one-iteration effect has a document timer that wakes the main thread at its active end.
+    if (m_is_compositor_driven && !isinf(iteration_count()))
+        return true;
 
     // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.
     auto has_css_animation_event_listener_requiring_animation_tick = [](DOM::EventTarget const& event_target) {
@@ -1155,15 +1168,6 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
         return false;
 
     return true;
-}
-
-void KeyframeEffect::request_observation_sample()
-{
-    if (m_needs_observation_sample)
-        return;
-    m_needs_observation_sample = true;
-    if (m_target_element)
-        m_target_element->document().set_needs_animated_style_update(*this);
 }
 
 void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1030,6 +1030,7 @@ void KeyframeEffect::invalidate_effect()
     m_is_compositor_driven = false;
     m_is_compositor_replaced = false;
     m_retained_compositor_animations.clear();
+    m_is_observation_relevant_compositor_animation = false;
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
         m_target_element->document().set_needs_animated_style_update(*this);
@@ -1145,7 +1146,7 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
         return false;
 
     // A compositor-handled one-iteration effect has a document timer that wakes the main thread at its active end.
-    if ((m_is_compositor_driven || m_is_compositor_replaced) && !isinf(iteration_count()))
+    if ((m_is_compositor_driven || m_is_compositor_replaced) && (!isinf(iteration_count()) || m_is_observation_relevant_compositor_animation))
         return true;
 
     // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -908,6 +908,13 @@ void KeyframeEffect::set_key_frame_set(RefPtr<KeyFrameSet const> key_frame_set)
     if (m_key_frame_set == key_frame_set)
         return;
 
+    m_target_properties.clear();
+    if (key_frame_set) {
+        for (auto const& keyframe : key_frame_set->keyframes_by_key) {
+            for (auto const& property : keyframe.properties)
+                m_target_properties.set(property.key);
+        }
+    }
     m_key_frame_set = move(key_frame_set);
     invalidate_effect();
 }
@@ -1018,6 +1025,7 @@ KeyframeEffect::KeyframeEffect() = default;
 
 void KeyframeEffect::invalidate_effect()
 {
+    m_is_compositor_driven = false;
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
         m_target_element->document().set_needs_animated_style_update(*this);
@@ -1032,6 +1040,9 @@ void KeyframeEffect::visit_edges(GC::Cell::Visitor& visitor)
 
 bool KeyframeEffect::can_skip_per_frame_style_update() const
 {
+    if (m_is_compositor_driven)
+        return true;
+
     auto target = this->target();
     auto cache_result = [&](bool result) {
         if (target && target->document().layout_is_up_to_date()) {
@@ -1117,7 +1128,7 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
         && is_in_the_before_phase())
         return true;
 
-    if (!can_skip_per_frame_style_update())
+    if (!m_is_compositor_driven && !can_skip_per_frame_style_update())
         return false;
 
     // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1028,6 +1028,7 @@ void KeyframeEffect::invalidate_effect()
     m_compositor_opacity_keyframe_value_cache.clear();
     m_compositor_transform_keyframe_value_cache.clear();
     m_is_compositor_driven = false;
+    m_is_compositor_replaced = false;
     m_retained_compositor_animations.clear();
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
@@ -1043,7 +1044,7 @@ void KeyframeEffect::visit_edges(GC::Cell::Visitor& visitor)
 
 bool KeyframeEffect::can_skip_per_frame_style_update() const
 {
-    if (m_is_compositor_driven)
+    if (m_is_compositor_driven || m_is_compositor_replaced)
         return true;
 
     auto target = this->target();
@@ -1140,11 +1141,11 @@ bool KeyframeEffect::can_skip_per_frame_animation_tick() const
         && is_in_the_before_phase())
         return true;
 
-    if (!m_is_compositor_driven && !can_skip_per_frame_style_update())
+    if (!m_is_compositor_driven && !m_is_compositor_replaced && !can_skip_per_frame_style_update())
         return false;
 
-    // A compositor-driven one-iteration effect has a document timer that wakes the main thread at its active end.
-    if (m_is_compositor_driven && !isinf(iteration_count()))
+    // A compositor-handled one-iteration effect has a document timer that wakes the main thread at its active end.
+    if ((m_is_compositor_driven || m_is_compositor_replaced) && !isinf(iteration_count()))
         return true;
 
     // An infinite effect cannot reach its natural end, so animationend listeners do not require a continuous tick.

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1025,6 +1025,8 @@ KeyframeEffect::KeyframeEffect() = default;
 
 void KeyframeEffect::invalidate_effect()
 {
+    m_compositor_opacity_keyframe_value_cache.clear();
+    m_compositor_transform_keyframe_value_cache.clear();
     m_is_compositor_driven = false;
     m_retained_compositor_animations.clear();
     m_can_skip_per_frame_style_update_cache.clear();

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1026,6 +1026,7 @@ KeyframeEffect::KeyframeEffect() = default;
 void KeyframeEffect::invalidate_effect()
 {
     m_is_compositor_driven = false;
+    m_retained_compositor_animation.clear();
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
         m_target_element->document().set_needs_animated_style_update(*this);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1030,6 +1030,7 @@ void KeyframeEffect::invalidate_effect()
     m_is_compositor_driven = false;
     m_is_compositor_replaced = false;
     m_retained_compositor_animations.clear();
+    m_is_offscreen_throttled = false;
     m_is_observation_relevant_compositor_animation = false;
     m_can_skip_per_frame_style_update_cache.clear();
     if (m_target_element)
@@ -1104,6 +1105,9 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
     }
     if (!has_animated_property)
         return cache_result(false);
+
+    if (m_is_offscreen_throttled)
+        return cache_result(true);
 
     if (!target->document().layout_is_up_to_date())
         return false;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -168,6 +168,14 @@ public:
     Vector<Compositor::VisualAnimation> const& retained_compositor_animations() const { return m_retained_compositor_animations; }
     void set_retained_compositor_animations(Vector<Compositor::VisualAnimation> animations) { m_retained_compositor_animations = move(animations); }
     void clear_retained_compositor_animations() { m_retained_compositor_animations.clear(); }
+    void set_is_offscreen_throttled(bool value)
+    {
+        if (m_is_offscreen_throttled == value)
+            return;
+        m_is_offscreen_throttled = value;
+        m_can_skip_per_frame_style_update_cache.clear();
+    }
+    bool is_offscreen_throttled() const { return m_is_offscreen_throttled; }
     void set_is_observation_relevant_compositor_animation(bool value) { m_is_observation_relevant_compositor_animation = value; }
     bool is_observation_relevant_compositor_animation() const { return m_is_observation_relevant_compositor_animation; }
     void request_observation_sample();
@@ -204,6 +212,8 @@ public:
     void update_computed_properties_for_style(AnimationUpdateContext&, DOM::AbstractElement);
 
 private:
+    friend class Animation;
+
     KeyframeEffect();
     virtual ~KeyframeEffect() override = default;
 
@@ -232,6 +242,7 @@ private:
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };
     bool m_is_compositor_replaced { false };
+    bool m_is_offscreen_throttled { false };
     bool m_is_observation_relevant_compositor_animation { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -157,6 +157,14 @@ public:
         m_is_compositor_driven = value;
         m_can_skip_per_frame_style_update_cache.clear();
     }
+    bool is_compositor_replaced() const { return m_is_compositor_replaced; }
+    void set_is_compositor_replaced(bool value)
+    {
+        if (m_is_compositor_replaced == value)
+            return;
+        m_is_compositor_replaced = value;
+        m_can_skip_per_frame_style_update_cache.clear();
+    }
     Vector<Compositor::VisualAnimation> const& retained_compositor_animations() const { return m_retained_compositor_animations; }
     void set_retained_compositor_animations(Vector<Compositor::VisualAnimation> animations) { m_retained_compositor_animations = move(animations); }
     void clear_retained_compositor_animations() { m_retained_compositor_animations.clear(); }
@@ -221,6 +229,7 @@ private:
     Optional<CompositorKeyframeValueCache> m_compositor_transform_keyframe_value_cache;
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };
+    bool m_is_compositor_replaced { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {
         u64 target_style_generation { 0 };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -174,6 +174,22 @@ public:
     bool per_frame_animation_tick_was_skipped() const { return m_per_frame_animation_tick_was_skipped; }
     void note_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = true; }
     void clear_per_frame_animation_tick_was_skipped() { m_per_frame_animation_tick_was_skipped = false; }
+    struct CompositorKeyframeValueCache {
+        KeyFrameSet const* key_frame_set { nullptr };
+        u64 target_style_generation { 0 };
+        u64 style_environment_version { 0 };
+        float reference_width { 0 };
+        float reference_height { 0 };
+        float device_pixels_per_css_pixel { 0 };
+        bool is_valid { false };
+        Vector<Optional<Compositor::VisualAnimationValue>> values;
+    };
+    Optional<CompositorKeyframeValueCache>& compositor_keyframe_value_cache(Compositor::VisualAnimation::TargetKind target_kind)
+    {
+        return target_kind == Compositor::VisualAnimation::TargetKind::Opacity
+            ? m_compositor_opacity_keyframe_value_cache
+            : m_compositor_transform_keyframe_value_cache;
+    }
     virtual void update_computed_properties(AnimationUpdateContext&) override;
     void update_computed_properties_for_style(AnimationUpdateContext&, DOM::AbstractElement);
 
@@ -201,6 +217,8 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    Optional<CompositorKeyframeValueCache> m_compositor_opacity_keyframe_value_cache;
+    Optional<CompositorKeyframeValueCache> m_compositor_transform_keyframe_value_cache;
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };
     bool m_needs_observation_sample { false };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -148,6 +148,8 @@ public:
     bool can_skip_per_frame_style_update() const;
     void clear_per_frame_style_update_cache() { m_can_skip_per_frame_style_update_cache.clear(); }
     bool can_skip_per_frame_animation_tick() const;
+    bool is_compositor_driven() const { return m_is_compositor_driven; }
+    void set_is_compositor_driven(bool value) { m_is_compositor_driven = value; }
     void request_observation_sample();
     bool request_element_scoped_observation_sample(u64 task_generation)
     {
@@ -189,6 +191,7 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    bool m_is_compositor_driven { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {
         u64 target_style_generation { 0 };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -18,6 +18,7 @@
 #include <LibWeb/Bindings/KeyframeEffect.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/Compositor/VisualAnimation.h>
 
 namespace Web::Animations {
 
@@ -150,6 +151,9 @@ public:
     bool can_skip_per_frame_animation_tick() const;
     bool is_compositor_driven() const { return m_is_compositor_driven; }
     void set_is_compositor_driven(bool value) { m_is_compositor_driven = value; }
+    Optional<Compositor::VisualAnimation> const& retained_compositor_animation() const { return m_retained_compositor_animation; }
+    void set_retained_compositor_animation(Compositor::VisualAnimation animation) { m_retained_compositor_animation = move(animation); }
+    void clear_retained_compositor_animation() { m_retained_compositor_animation.clear(); }
     void request_observation_sample();
     bool request_element_scoped_observation_sample(u64 task_generation)
     {
@@ -191,6 +195,7 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    Optional<Compositor::VisualAnimation> m_retained_compositor_animation;
     bool m_is_compositor_driven { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -150,10 +150,16 @@ public:
     void clear_per_frame_style_update_cache() { m_can_skip_per_frame_style_update_cache.clear(); }
     bool can_skip_per_frame_animation_tick() const;
     bool is_compositor_driven() const { return m_is_compositor_driven; }
-    void set_is_compositor_driven(bool value) { m_is_compositor_driven = value; }
-    Optional<Compositor::VisualAnimation> const& retained_compositor_animation() const { return m_retained_compositor_animation; }
-    void set_retained_compositor_animation(Compositor::VisualAnimation animation) { m_retained_compositor_animation = move(animation); }
-    void clear_retained_compositor_animation() { m_retained_compositor_animation.clear(); }
+    void set_is_compositor_driven(bool value)
+    {
+        if (m_is_compositor_driven == value)
+            return;
+        m_is_compositor_driven = value;
+        m_can_skip_per_frame_style_update_cache.clear();
+    }
+    Vector<Compositor::VisualAnimation> const& retained_compositor_animations() const { return m_retained_compositor_animations; }
+    void set_retained_compositor_animations(Vector<Compositor::VisualAnimation> animations) { m_retained_compositor_animations = move(animations); }
+    void clear_retained_compositor_animations() { m_retained_compositor_animations.clear(); }
     void request_observation_sample();
     bool request_element_scoped_observation_sample(u64 task_generation)
     {
@@ -195,7 +201,7 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
-    Optional<Compositor::VisualAnimation> m_retained_compositor_animation;
+    Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -168,6 +168,8 @@ public:
     Vector<Compositor::VisualAnimation> const& retained_compositor_animations() const { return m_retained_compositor_animations; }
     void set_retained_compositor_animations(Vector<Compositor::VisualAnimation> animations) { m_retained_compositor_animations = move(animations); }
     void clear_retained_compositor_animations() { m_retained_compositor_animations.clear(); }
+    void set_is_observation_relevant_compositor_animation(bool value) { m_is_observation_relevant_compositor_animation = value; }
+    bool is_observation_relevant_compositor_animation() const { return m_is_observation_relevant_compositor_animation; }
     void request_observation_sample();
     bool request_element_scoped_observation_sample(u64 task_generation)
     {
@@ -230,6 +232,7 @@ private:
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };
     bool m_is_compositor_replaced { false };
+    bool m_is_observation_relevant_compositor_animation { false };
     bool m_needs_observation_sample { false };
     struct CanSkipPerFrameStyleUpdateCache {
         u64 target_style_generation { 0 };

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     Compositor/CompositorHost.cpp
     Compositor/SmoothScrollAnimation.cpp
     Compositor/Types.cpp
+    Compositor/VisualAnimation.cpp
     Compression/CompressionStream.cpp
     Compression/DecompressionStream.cpp
     ContentSecurityPolicy/BlockingAlgorithms.cpp

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -207,6 +207,29 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
             && (context.frame == Painting::NO_FRAME_NODE || context.frame.value() < visual_context_tree->frame_nodes().size());
     };
 
+    Vector<bool> spatial_context_has_visual_animation;
+    spatial_context_has_visual_animation.ensure_capacity(visual_context_tree->spatial_nodes().size());
+    for ([[maybe_unused]] auto const& node : visual_context_tree->spatial_nodes())
+        spatial_context_has_visual_animation.unchecked_append(false);
+    for (auto const& animation : visual_context_tree->visual_animations()) {
+        if (animation.target_kind != VisualAnimation::TargetKind::Transform)
+            continue;
+        for (auto node_index : animation.visual_context_node_indices) {
+            if (node_index < spatial_context_has_visual_animation.size())
+                spatial_context_has_visual_animation[node_index] = true;
+        }
+    }
+    for (size_t i = 1; i < spatial_context_has_visual_animation.size(); ++i) {
+        auto parent = visual_context_tree->spatial_nodes()[i].parent;
+        if (spatial_context_has_visual_animation[parent.value()])
+            spatial_context_has_visual_animation[i] = true;
+    }
+    auto viewport_rect_for_context = [&](Painting::ContextRef context, Gfx::FloatRect const& rect) -> Optional<Gfx::FloatRect> {
+        if (spatial_context_has_visual_animation[context.spatial.value()])
+            return {};
+        return visual_context_tree->transform_rect_to_viewport(context.spatial, rect, scroll_state_snapshot);
+    };
+
     m_cached_wheel_hit_test_targets.ensure_capacity(m_wheel_hit_test_regions.size());
     for (auto const& target : m_wheel_hit_test_regions) {
         if (!context_is_valid(target.context))
@@ -216,7 +239,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
             .context = target.context,
             .rect = target.rect,
             .corner_radii = target.corner_radii,
-            .viewport_rect = visual_context_tree->transform_rect_to_viewport(target.context.spatial, target.rect, scroll_state_snapshot),
+            .viewport_rect = viewport_rect_for_context(target.context, target.rect),
         });
     }
 
@@ -227,7 +250,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
         m_cached_main_thread_wheel_event_targets.append({
             .context = region.context,
             .rect = region.rect,
-            .viewport_rect = visual_context_tree->transform_rect_to_viewport(region.context.spatial, region.rect, scroll_state_snapshot),
+            .viewport_rect = viewport_rect_for_context(region.context, region.rect),
         });
     }
 
@@ -237,7 +260,7 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
         m_cached_blocking_wheel_event_targets.append({
             .context = region.context,
             .rect = region.rect,
-            .viewport_rect = visual_context_tree->transform_rect_to_viewport(region.context.spatial, region.rect, scroll_state_snapshot),
+            .viewport_rect = viewport_rect_for_context(region.context, region.rect),
         });
     }
 }
@@ -312,9 +335,8 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::Acc
         return { {}, false, true };
 
     for (auto const& target : m_cached_main_thread_wheel_event_targets) {
-        if (!target.viewport_rect.contains(position))
+        if (target.viewport_rect.has_value() && !target.viewport_rect->contains(position))
             continue;
-
         if (!context_is_valid(target.context))
             continue;
         auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
@@ -323,9 +345,8 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::Acc
     }
 
     for (auto const& target : m_cached_blocking_wheel_event_targets) {
-        if (!target.viewport_rect.contains(position))
+        if (target.viewport_rect.has_value() && !target.viewport_rect->contains(position))
             continue;
-
         if (!context_is_valid(target.context))
             continue;
         auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);
@@ -334,9 +355,8 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::Acc
     }
 
     for (auto const& target : m_cached_wheel_hit_test_targets.in_reverse()) {
-        if (!target.viewport_rect.contains(position))
+        if (target.viewport_rect.has_value() && !target.viewport_rect->contains(position))
             continue;
-
         if (!context_is_valid(target.context))
             continue;
         auto position_in_context = visual_context_tree.transform_point_for_hit_test(target.context, position, m_scroll_state_snapshot);

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -31,20 +31,19 @@ struct CachedWheelHitTestTarget {
     Painting::ContextRef context;
     Gfx::FloatRect rect;
     Gfx::CornerRadii corner_radii;
-    Gfx::FloatRect viewport_rect;
+    Optional<Gfx::FloatRect> viewport_rect;
 };
 
 struct CachedMainThreadWheelEventTarget {
     Painting::ContextRef context;
     Gfx::FloatRect rect;
-    Gfx::FloatRect viewport_rect;
+    Optional<Gfx::FloatRect> viewport_rect;
 };
 
-// Viewport-space cache of regions containing non-passive wheel listeners.
 struct CachedBlockingWheelEventTarget {
     Painting::ContextRef context;
     Gfx::FloatRect rect;
-    Gfx::FloatRect viewport_rect;
+    Optional<Gfx::FloatRect> viewport_rect;
 };
 
 // Mutable compositor-side copy of AsyncScrollingState. Current scroll offsets live in ScrollStateSnapshot; this tree

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -213,6 +213,26 @@ bool VisualAnimationTransformOperation::is_valid() const
     return all_of(values, [](float value) { return isfinite(value); });
 }
 
+bool VisualAnimation::has_same_parameters_except_anchor(VisualAnimation const& other) const
+{
+    return target_kind == other.target_kind
+        && visual_context_node_indices == other.visual_context_node_indices
+        && has_same_animation_parameters(other);
+}
+
+bool VisualAnimation::has_same_animation_parameters(VisualAnimation const& other) const
+{
+    return target_kind == other.target_kind
+        && playback_rate == other.playback_rate
+        && start_delay_ms == other.start_delay_ms
+        && iteration_duration_ms == other.iteration_duration_ms
+        && iteration_count == other.iteration_count
+        && iteration_start == other.iteration_start
+        && playback_direction == other.playback_direction
+        && easing == other.easing
+        && keyframes == other.keyframes;
+}
+
 static VisualAnimationValue interpolate_value(VisualAnimationValue const& from, VisualAnimationValue const& to, double progress)
 {
     VERIFY(from.index() == to.index());
@@ -256,8 +276,17 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
     if (!isfinite(overall_progress) || overall_progress < 0)
         return {};
 
+    auto active_progress = overall_progress - iteration_start;
+    bool is_at_or_after_end = isfinite(iteration_count) && active_progress >= iteration_count;
     auto current_iteration = floor(overall_progress);
     auto simple_iteration_progress = fmod(overall_progress, 1.0);
+    if (is_at_or_after_end) {
+        auto terminal_overall_progress = iteration_start + iteration_count;
+        simple_iteration_progress = fmod(terminal_overall_progress, 1.0);
+        if (simple_iteration_progress == 0)
+            simple_iteration_progress = 1.0;
+        current_iteration = floor(terminal_overall_progress) - (simple_iteration_progress == 1.0 ? 1.0 : 0.0);
+    }
     bool going_forwards = true;
     switch (playback_direction) {
     case VisualAnimationPlaybackDirection::Normal:
@@ -334,6 +363,7 @@ bool VisualAnimation::is_valid() const
         return false;
     if (monotonic_time_at_anchor_ns < 0 || !isfinite(local_time_at_anchor_ms) || !isfinite(playback_rate) || playback_rate <= 0
         || !isfinite(start_delay_ms) || !isfinite(iteration_duration_ms) || iteration_duration_ms <= 0
+        || isnan(iteration_count) || iteration_count <= 0
         || !isfinite(iteration_start) || iteration_start < 0 || !easing.is_valid() || keyframes.size() < 2)
         return false;
     if (keyframes.first().offset != 0 || keyframes.last().offset != 1)
@@ -473,6 +503,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimation const& a
     TRY(encoder.encode(animation.playback_rate));
     TRY(encoder.encode(animation.start_delay_ms));
     TRY(encoder.encode(animation.iteration_duration_ms));
+    TRY(encoder.encode(animation.iteration_count));
     TRY(encoder.encode(animation.iteration_start));
     TRY(encoder.encode(animation.playback_direction));
     TRY(encoder.encode(animation.easing));
@@ -491,6 +522,7 @@ ErrorOr<Web::Compositor::VisualAnimation> decode(Decoder& decoder)
         .playback_rate = TRY(decoder.decode<double>()),
         .start_delay_ms = TRY(decoder.decode<double>()),
         .iteration_duration_ms = TRY(decoder.decode<double>()),
+        .iteration_count = TRY(decoder.decode<double>()),
         .iteration_start = TRY(decoder.decode<double>()),
         .playback_direction = TRY(decoder.decode<Web::Compositor::VisualAnimationPlaybackDirection>()),
         .easing = TRY(decoder.decode<Web::Compositor::VisualAnimationEasing>()),

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <LibGfx/Matrix4x4.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/Animations/AnimationEffect.h>
+#include <LibWeb/CSS/EasingFunction.h>
+#include <LibWeb/Compositor/VisualAnimation.h>
+#include <LibWeb/ComputedValuesRustFFI.h>
+
+namespace Web::Compositor {
+
+static_assert(to_underlying(VisualAnimationEasing::Kind::Linear) == to_underlying(CSS::StyleValueFFI::FfiEasingKind::Linear));
+static_assert(to_underlying(VisualAnimationEasing::Kind::CubicBezier) == to_underlying(CSS::StyleValueFFI::FfiEasingKind::CubicBezier));
+static_assert(to_underlying(VisualAnimationEasing::Kind::Steps) == to_underlying(CSS::StyleValueFFI::FfiEasingKind::Steps));
+static_assert(to_underlying(VisualAnimationPlaybackDirection::Normal) == to_underlying(Animations::PlaybackDirection::Normal));
+static_assert(to_underlying(VisualAnimationPlaybackDirection::Reverse) == to_underlying(Animations::PlaybackDirection::Reverse));
+static_assert(to_underlying(VisualAnimationPlaybackDirection::Alternate) == to_underlying(Animations::PlaybackDirection::Alternate));
+static_assert(to_underlying(VisualAnimationPlaybackDirection::AlternateReverse) == to_underlying(Animations::PlaybackDirection::AlternateReverse));
+
+VisualAnimationEasing VisualAnimationEasing::from_css(CSS::EasingFunction const& easing)
+{
+    return easing.visit(
+        [](CSS::LinearEasingFunction const& linear) {
+            VisualAnimationEasing result;
+            result.kind = Kind::Linear;
+            result.linear_points.clear();
+            result.linear_points.ensure_capacity(linear.control_points.size());
+            for (auto const& point : linear.control_points)
+                result.linear_points.unchecked_append({ point.input, point.output });
+            return result;
+        },
+        [](CSS::CubicBezierEasingFunction const& cubic_bezier) {
+            return VisualAnimationEasing {
+                .kind = Kind::CubicBezier,
+                .linear_points = {},
+                .x1 = cubic_bezier.x1,
+                .y1 = cubic_bezier.y1,
+                .x2 = cubic_bezier.x2,
+                .y2 = cubic_bezier.y2,
+            };
+        },
+        [](CSS::StepsEasingFunction const& steps) {
+            return VisualAnimationEasing {
+                .kind = Kind::Steps,
+                .linear_points = {},
+                .interval_count = steps.interval_count,
+                .step_position = to_underlying(steps.position),
+            };
+        });
+}
+
+double VisualAnimationEasing::evaluate_at(double input_progress, bool before_flag) const
+{
+    Vector<CSS::StyleValueFFI::FfiLinearEasingPoint> points;
+    if (kind == Kind::Linear) {
+        points.ensure_capacity(linear_points.size());
+        for (auto const& point : linear_points)
+            points.unchecked_append({ .input = point.input, .output = point.output });
+    }
+
+    CSS::StyleValueFFI::FfiEasingDescriptor descriptor {
+        .kind = static_cast<CSS::StyleValueFFI::FfiEasingKind>(to_underlying(kind)),
+        .linear_points = points.data(),
+        .linear_point_count = points.size(),
+        .x1 = x1,
+        .y1 = y1,
+        .x2 = x2,
+        .y2 = y2,
+        .interval_count = interval_count,
+        .step_position = step_position,
+    };
+    return CSS::StyleValueFFI::rust_evaluate_easing(&descriptor, input_progress, before_flag);
+}
+
+bool VisualAnimationEasing::is_valid() const
+{
+    if (!first_is_one_of(kind, Kind::Linear, Kind::CubicBezier, Kind::Steps))
+        return false;
+    if (!isfinite(x1) || !isfinite(y1) || !isfinite(x2) || !isfinite(y2))
+        return false;
+
+    switch (kind) {
+    case Kind::Linear: {
+        if (linear_points.size() < 2)
+            return false;
+        double previous_input = -NumericLimits<double>::max();
+        for (auto const& point : linear_points) {
+            if (!isfinite(point.input) || !isfinite(point.output) || point.input < previous_input)
+                return false;
+            previous_input = point.input;
+        }
+        return true;
+    }
+    case Kind::CubicBezier:
+        return x1 >= 0 && x1 <= 1 && x2 >= 0 && x2 <= 1;
+    case Kind::Steps:
+        return interval_count > 0 && step_position <= 5;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Gfx::FloatMatrix4x4 VisualAnimationTransformOperation::to_matrix() const
+{
+    using Kind = VisualAnimationTransformOperationKind;
+    switch (kind) {
+    case Kind::Translate:
+        VERIFY(values.size() == 1 || values.size() == 2);
+        return Gfx::translation_matrix(Gfx::FloatVector3 { values[0], values.size() == 2 ? values[1] : 0, 0 });
+    case Kind::Translate3d:
+        VERIFY(values.size() == 3);
+        return Gfx::translation_matrix(Gfx::FloatVector3 { values[0], values[1], values[2] });
+    case Kind::TranslateX:
+        VERIFY(values.size() == 1);
+        return Gfx::translation_matrix(Gfx::FloatVector3 { values[0], 0, 0 });
+    case Kind::TranslateY:
+        VERIFY(values.size() == 1);
+        return Gfx::translation_matrix(Gfx::FloatVector3 { 0, values[0], 0 });
+    case Kind::TranslateZ:
+        VERIFY(values.size() == 1);
+        return Gfx::translation_matrix(Gfx::FloatVector3 { 0, 0, values[0] });
+    case Kind::Scale: {
+        VERIFY(values.size() == 1 || values.size() == 2);
+        auto y = values.size() == 2 ? values[1] : values[0];
+        return Gfx::scale_matrix(Gfx::FloatVector3 { values[0], y, 1 });
+    }
+    case Kind::Scale3d:
+        VERIFY(values.size() == 3);
+        return Gfx::scale_matrix(Gfx::FloatVector3 { values[0], values[1], values[2] });
+    case Kind::ScaleX:
+        VERIFY(values.size() == 1);
+        return Gfx::scale_matrix(Gfx::FloatVector3 { values[0], 1, 1 });
+    case Kind::ScaleY:
+        VERIFY(values.size() == 1);
+        return Gfx::scale_matrix(Gfx::FloatVector3 { 1, values[0], 1 });
+    case Kind::ScaleZ:
+        VERIFY(values.size() == 1);
+        return Gfx::scale_matrix(Gfx::FloatVector3 { 1, 1, values[0] });
+    case Kind::Rotate:
+    case Kind::RotateZ:
+        VERIFY(values.size() == 1);
+        return Gfx::rotation_matrix(Gfx::FloatVector3 { 0, 0, 1 }, values[0]);
+    case Kind::RotateX:
+        VERIFY(values.size() == 1);
+        return Gfx::rotation_matrix(Gfx::FloatVector3 { 1, 0, 0 }, values[0]);
+    case Kind::RotateY:
+        VERIFY(values.size() == 1);
+        return Gfx::rotation_matrix(Gfx::FloatVector3 { 0, 1, 0 }, values[0]);
+    case Kind::Skew:
+        VERIFY(values.size() == 1 || values.size() == 2);
+        return Gfx::FloatMatrix4x4(
+            1, tanf(values[0]), 0, 0,
+            values.size() == 2 ? tanf(values[1]) : 0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1);
+    case Kind::SkewX:
+        VERIFY(values.size() == 1);
+        return Gfx::FloatMatrix4x4(
+            1, tanf(values[0]), 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1);
+    case Kind::SkewY:
+        VERIFY(values.size() == 1);
+        return Gfx::FloatMatrix4x4(
+            1, 0, 0, 0,
+            tanf(values[0]), 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+bool VisualAnimationTransformOperation::is_valid() const
+{
+    size_t expected_value_count = 0;
+    switch (kind) {
+    case VisualAnimationTransformOperationKind::Translate:
+    case VisualAnimationTransformOperationKind::Scale:
+    case VisualAnimationTransformOperationKind::Skew:
+        if (values.size() != 1 && values.size() != 2)
+            return false;
+        expected_value_count = values.size();
+        break;
+    case VisualAnimationTransformOperationKind::Translate3d:
+    case VisualAnimationTransformOperationKind::Scale3d:
+        expected_value_count = 3;
+        break;
+    case VisualAnimationTransformOperationKind::TranslateX:
+    case VisualAnimationTransformOperationKind::TranslateY:
+    case VisualAnimationTransformOperationKind::TranslateZ:
+    case VisualAnimationTransformOperationKind::ScaleX:
+    case VisualAnimationTransformOperationKind::ScaleY:
+    case VisualAnimationTransformOperationKind::ScaleZ:
+    case VisualAnimationTransformOperationKind::Rotate:
+    case VisualAnimationTransformOperationKind::RotateX:
+    case VisualAnimationTransformOperationKind::RotateY:
+    case VisualAnimationTransformOperationKind::RotateZ:
+    case VisualAnimationTransformOperationKind::SkewX:
+    case VisualAnimationTransformOperationKind::SkewY:
+        expected_value_count = 1;
+        break;
+    default:
+        return false;
+    }
+    if (values.size() != expected_value_count)
+        return false;
+    return all_of(values, [](float value) { return isfinite(value); });
+}
+
+static VisualAnimationValue interpolate_value(VisualAnimationValue const& from, VisualAnimationValue const& to, double progress)
+{
+    VERIFY(from.index() == to.index());
+    return from.visit(
+        [&](float from_opacity) -> VisualAnimationValue {
+            auto to_opacity = to.get<float>();
+            return static_cast<float>(from_opacity + (to_opacity - from_opacity) * progress);
+        },
+        [&](VisualAnimationTransformList const& from_transforms) -> VisualAnimationValue {
+            auto const& to_transforms = to.get<VisualAnimationTransformList>();
+            VERIFY(from_transforms.size() == to_transforms.size());
+            VisualAnimationTransformList transforms;
+            transforms.ensure_capacity(from_transforms.size());
+            for (size_t operation_index = 0; operation_index < from_transforms.size(); ++operation_index) {
+                auto const& from_operation = from_transforms[operation_index];
+                auto const& to_operation = to_transforms[operation_index];
+                VERIFY(from_operation.kind == to_operation.kind);
+                VERIFY(from_operation.values.size() == to_operation.values.size());
+                Vector<float> values;
+                values.ensure_capacity(from_operation.values.size());
+                for (size_t value_index = 0; value_index < from_operation.values.size(); ++value_index) {
+                    auto from_value = from_operation.values[value_index];
+                    auto to_value = to_operation.values[value_index];
+                    values.unchecked_append(static_cast<float>(from_value + (to_value - from_value) * progress));
+                }
+                transforms.unchecked_append({ from_operation.kind, move(values) });
+            }
+            return transforms;
+        });
+}
+
+Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_since_anchor) const
+{
+    if (iteration_duration_ms <= 0 || playback_rate <= 0 || keyframes.size() < 2)
+        return {};
+
+    auto local_time = local_time_at_anchor_ms + elapsed_since_anchor.to_seconds_f64() * 1000.0 * playback_rate;
+    if (!isfinite(local_time))
+        return {};
+    auto overall_progress = (local_time - start_delay_ms) / iteration_duration_ms + iteration_start;
+    if (!isfinite(overall_progress) || overall_progress < 0)
+        return {};
+
+    auto current_iteration = floor(overall_progress);
+    auto simple_iteration_progress = fmod(overall_progress, 1.0);
+    bool going_forwards = true;
+    switch (playback_direction) {
+    case VisualAnimationPlaybackDirection::Normal:
+        break;
+    case VisualAnimationPlaybackDirection::Reverse:
+        going_forwards = false;
+        break;
+    case VisualAnimationPlaybackDirection::Alternate:
+        going_forwards = fmod(current_iteration, 2.0) == 0;
+        break;
+    case VisualAnimationPlaybackDirection::AlternateReverse:
+        going_forwards = fmod(current_iteration + 1.0, 2.0) == 0;
+        break;
+    }
+
+    auto directed_progress = going_forwards ? simple_iteration_progress : 1.0 - simple_iteration_progress;
+    auto transformed_progress = easing.evaluate_at(directed_progress, false);
+    if (!isfinite(transformed_progress))
+        return {};
+
+    auto const* from_keyframe = &keyframes.first();
+    auto const* to_keyframe = &keyframes[1];
+    for (size_t index = 1; index < keyframes.size(); ++index) {
+        if (transformed_progress < keyframes[index].offset) {
+            from_keyframe = &keyframes[index - 1];
+            to_keyframe = &keyframes[index];
+            break;
+        }
+        from_keyframe = &keyframes[index - 1];
+        to_keyframe = &keyframes[index];
+    }
+
+    auto interval_width = to_keyframe->offset - from_keyframe->offset;
+    VERIFY(interval_width > 0);
+    auto interval_progress = (transformed_progress - from_keyframe->offset) / interval_width;
+    auto eased_interval_progress = from_keyframe->easing.evaluate_at(interval_progress, false);
+    if (!isfinite(eased_interval_progress))
+        return {};
+    auto value = interpolate_value(from_keyframe->value, to_keyframe->value, eased_interval_progress);
+
+    Sample sample;
+    value.visit(
+        [&](float opacity) { sample.opacity = opacity; },
+        [&](VisualAnimationTransformList const& transforms) {
+            for (auto const& transform : transforms)
+                sample.transform = sample.transform * transform.to_matrix();
+        });
+    if (target_kind == TargetKind::Opacity) {
+        if (!isfinite(sample.opacity))
+            return {};
+        sample.opacity = clamp(sample.opacity, 0.0f, 1.0f);
+        return sample;
+    }
+    for (size_t row = 0; row < 4; ++row) {
+        for (size_t column = 0; column < 4; ++column) {
+            if (!isfinite(sample.transform[row, column]))
+                return {};
+        }
+    }
+    return sample;
+}
+
+bool VisualAnimation::is_valid() const
+{
+    if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::Transform))
+        return false;
+    if (visual_context_node_indices.is_empty())
+        return false;
+    if (!first_is_one_of(playback_direction,
+            VisualAnimationPlaybackDirection::Normal,
+            VisualAnimationPlaybackDirection::Reverse,
+            VisualAnimationPlaybackDirection::Alternate,
+            VisualAnimationPlaybackDirection::AlternateReverse))
+        return false;
+    if (monotonic_time_at_anchor_ns < 0 || !isfinite(local_time_at_anchor_ms) || !isfinite(playback_rate) || playback_rate <= 0
+        || !isfinite(start_delay_ms) || !isfinite(iteration_duration_ms) || iteration_duration_ms <= 0
+        || !isfinite(iteration_start) || iteration_start < 0 || !easing.is_valid() || keyframes.size() < 2)
+        return false;
+    if (keyframes.first().offset != 0 || keyframes.last().offset != 1)
+        return false;
+
+    Optional<size_t> transform_operation_count;
+    for (size_t keyframe_index = 0; keyframe_index < keyframes.size(); ++keyframe_index) {
+        auto const& keyframe = keyframes[keyframe_index];
+        if (!isfinite(keyframe.offset) || keyframe.offset < 0 || keyframe.offset > 1 || !keyframe.easing.is_valid())
+            return false;
+        if (keyframe_index > 0 && keyframe.offset <= keyframes[keyframe_index - 1].offset)
+            return false;
+
+        if (target_kind == TargetKind::Opacity) {
+            if (!keyframe.value.has<float>() || !isfinite(keyframe.value.get<float>())
+                || keyframe.value.get<float>() < 0 || keyframe.value.get<float>() > 1)
+                return false;
+            continue;
+        }
+
+        if (!keyframe.value.has<VisualAnimationTransformList>())
+            return false;
+        auto const& transforms = keyframe.value.get<VisualAnimationTransformList>();
+        if (transforms.is_empty())
+            return false;
+        if (!transform_operation_count.has_value())
+            transform_operation_count = transforms.size();
+        if (transforms.size() != *transform_operation_count)
+            return false;
+        for (size_t operation_index = 0; operation_index < transforms.size(); ++operation_index) {
+            auto const& operation = transforms[operation_index];
+            if (!operation.is_valid())
+                return false;
+            if (keyframe_index > 0) {
+                auto const& previous_operation = keyframes[keyframe_index - 1].value.get<VisualAnimationTransformList>()[operation_index];
+                if (operation.kind != previous_operation.kind || operation.values.size() != previous_operation.values.size())
+                    return false;
+            }
+        }
+    }
+    return true;
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimationEasing::LinearPoint const& point)
+{
+    TRY(encoder.encode(point.input));
+    TRY(encoder.encode(point.output));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimationEasing::LinearPoint> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimationEasing::LinearPoint {
+        .input = TRY(decoder.decode<double>()),
+        .output = TRY(decoder.decode<double>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimationEasing const& easing)
+{
+    TRY(encoder.encode(easing.kind));
+    TRY(encoder.encode(easing.linear_points));
+    TRY(encoder.encode(easing.x1));
+    TRY(encoder.encode(easing.y1));
+    TRY(encoder.encode(easing.x2));
+    TRY(encoder.encode(easing.y2));
+    TRY(encoder.encode(easing.interval_count));
+    TRY(encoder.encode(easing.step_position));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimationEasing> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimationEasing {
+        .kind = TRY(decoder.decode<Web::Compositor::VisualAnimationEasing::Kind>()),
+        .linear_points = TRY(decoder.decode<Vector<Web::Compositor::VisualAnimationEasing::LinearPoint>>()),
+        .x1 = TRY(decoder.decode<double>()),
+        .y1 = TRY(decoder.decode<double>()),
+        .x2 = TRY(decoder.decode<double>()),
+        .y2 = TRY(decoder.decode<double>()),
+        .interval_count = TRY(decoder.decode<i32>()),
+        .step_position = TRY(decoder.decode<u8>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimationTransformOperation const& operation)
+{
+    TRY(encoder.encode(operation.kind));
+    TRY(encoder.encode(operation.values));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimationTransformOperation> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimationTransformOperation {
+        .kind = TRY(decoder.decode<Web::Compositor::VisualAnimationTransformOperationKind>()),
+        .values = TRY(decoder.decode<Vector<float>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimationKeyframe const& keyframe)
+{
+    TRY(encoder.encode(keyframe.offset));
+    TRY(encoder.encode(keyframe.easing));
+    TRY(encoder.encode(keyframe.value));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimationKeyframe> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimationKeyframe {
+        .offset = TRY(decoder.decode<double>()),
+        .easing = TRY(decoder.decode<Web::Compositor::VisualAnimationEasing>()),
+        .value = TRY(decoder.decode<Web::Compositor::VisualAnimationValue>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimation const& animation)
+{
+    TRY(encoder.encode(animation.target_kind));
+    TRY(encoder.encode(animation.visual_context_node_indices));
+    TRY(encoder.encode(animation.monotonic_time_at_anchor_ns));
+    TRY(encoder.encode(animation.local_time_at_anchor_ms));
+    TRY(encoder.encode(animation.playback_rate));
+    TRY(encoder.encode(animation.start_delay_ms));
+    TRY(encoder.encode(animation.iteration_duration_ms));
+    TRY(encoder.encode(animation.iteration_start));
+    TRY(encoder.encode(animation.playback_direction));
+    TRY(encoder.encode(animation.easing));
+    TRY(encoder.encode(animation.keyframes));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::VisualAnimation> decode(Decoder& decoder)
+{
+    return Web::Compositor::VisualAnimation {
+        .target_kind = TRY(decoder.decode<Web::Compositor::VisualAnimation::TargetKind>()),
+        .visual_context_node_indices = TRY(decoder.decode<Vector<u32>>()),
+        .monotonic_time_at_anchor_ns = TRY(decoder.decode<i64>()),
+        .local_time_at_anchor_ms = TRY(decoder.decode<double>()),
+        .playback_rate = TRY(decoder.decode<double>()),
+        .start_delay_ms = TRY(decoder.decode<double>()),
+        .iteration_duration_ms = TRY(decoder.decode<double>()),
+        .iteration_start = TRY(decoder.decode<double>()),
+        .playback_direction = TRY(decoder.decode<Web::Compositor::VisualAnimationPlaybackDirection>()),
+        .easing = TRY(decoder.decode<Web::Compositor::VisualAnimationEasing>()),
+        .keyframes = TRY(decoder.decode<Vector<Web::Compositor::VisualAnimationKeyframe>>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Time.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibGfx/Matrix4x4.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
+
+namespace Web::CSS {
+
+struct EasingFunction;
+
+}
+
+namespace Web::Compositor {
+
+struct VisualAnimationEasing {
+    enum class Kind : u8 {
+        Linear,
+        CubicBezier,
+        Steps,
+    };
+
+    struct LinearPoint {
+        double input { 0 };
+        double output { 0 };
+    };
+
+    static WEB_API VisualAnimationEasing from_css(CSS::EasingFunction const&);
+
+    WEB_API double evaluate_at(double input_progress, bool before_flag) const;
+    WEB_API bool is_valid() const;
+
+    Kind kind { Kind::Linear };
+    Vector<LinearPoint> linear_points { { 0, 0 }, { 1, 1 } };
+    double x1 { 0 };
+    double y1 { 0 };
+    double x2 { 1 };
+    double y2 { 1 };
+    i32 interval_count { 1 };
+    u8 step_position { 0 };
+};
+
+enum class VisualAnimationPlaybackDirection : u8 {
+    Normal,
+    Reverse,
+    Alternate,
+    AlternateReverse,
+};
+
+enum class VisualAnimationTransformOperationKind : u8 {
+    Translate,
+    Translate3d,
+    TranslateX,
+    TranslateY,
+    TranslateZ,
+    Scale,
+    Scale3d,
+    ScaleX,
+    ScaleY,
+    ScaleZ,
+    Rotate,
+    RotateX,
+    RotateY,
+    RotateZ,
+    Skew,
+    SkewX,
+    SkewY,
+};
+
+struct VisualAnimationTransformOperation {
+    WEB_API Gfx::FloatMatrix4x4 to_matrix() const;
+    WEB_API bool is_valid() const;
+
+    VisualAnimationTransformOperationKind kind { VisualAnimationTransformOperationKind::Translate };
+    // Translation lengths are expressed in device pixels, matching TransformData matrices.
+    Vector<float> values;
+};
+
+using VisualAnimationTransformList = Vector<VisualAnimationTransformOperation>;
+using VisualAnimationValue = Variant<float, VisualAnimationTransformList>;
+
+struct VisualAnimationKeyframe {
+    double offset { 0 };
+    VisualAnimationEasing easing;
+    VisualAnimationValue value;
+};
+
+struct VisualAnimation {
+    struct Sample {
+        float opacity { 1 };
+        Gfx::FloatMatrix4x4 transform { Gfx::FloatMatrix4x4::identity() };
+    };
+
+    enum class TargetKind : u8 {
+        Opacity,
+        Transform,
+    };
+
+    WEB_API Optional<Sample> sample(AK::Duration elapsed_since_anchor) const;
+    WEB_API bool is_valid() const;
+
+    TargetKind target_kind { TargetKind::Opacity };
+    Vector<u32> visual_context_node_indices;
+    i64 monotonic_time_at_anchor_ns { 0 };
+    double local_time_at_anchor_ms { 0 };
+    double playback_rate { 1 };
+    double start_delay_ms { 0 };
+    double iteration_duration_ms { 0 };
+    double iteration_start { 0 };
+    VisualAnimationPlaybackDirection playback_direction { VisualAnimationPlaybackDirection::Normal };
+    VisualAnimationEasing easing;
+    Vector<VisualAnimationKeyframe> keyframes;
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationEasing::LinearPoint const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimationEasing::LinearPoint> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationEasing const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimationEasing> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationTransformOperation const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimationTransformOperation> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimationKeyframe const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimationKeyframe> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::VisualAnimation const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::VisualAnimation> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -31,6 +31,8 @@ struct VisualAnimationEasing {
     struct LinearPoint {
         double input { 0 };
         double output { 0 };
+
+        bool operator==(LinearPoint const&) const = default;
     };
 
     static WEB_API VisualAnimationEasing from_css(CSS::EasingFunction const&);
@@ -46,6 +48,8 @@ struct VisualAnimationEasing {
     double y2 { 1 };
     i32 interval_count { 1 };
     u8 step_position { 0 };
+
+    bool operator==(VisualAnimationEasing const&) const = default;
 };
 
 enum class VisualAnimationPlaybackDirection : u8 {
@@ -82,6 +86,8 @@ struct VisualAnimationTransformOperation {
     VisualAnimationTransformOperationKind kind { VisualAnimationTransformOperationKind::Translate };
     // Translation lengths are expressed in device pixels, matching TransformData matrices.
     Vector<float> values;
+
+    bool operator==(VisualAnimationTransformOperation const&) const = default;
 };
 
 using VisualAnimationTransformList = Vector<VisualAnimationTransformOperation>;
@@ -91,6 +97,8 @@ struct VisualAnimationKeyframe {
     double offset { 0 };
     VisualAnimationEasing easing;
     VisualAnimationValue value;
+
+    bool operator==(VisualAnimationKeyframe const&) const = default;
 };
 
 struct VisualAnimation {
@@ -106,6 +114,8 @@ struct VisualAnimation {
 
     WEB_API Optional<Sample> sample(AK::Duration elapsed_since_anchor) const;
     WEB_API bool is_valid() const;
+    WEB_API bool has_same_animation_parameters(VisualAnimation const&) const;
+    WEB_API bool has_same_parameters_except_anchor(VisualAnimation const&) const;
 
     TargetKind target_kind { TargetKind::Opacity };
     Vector<u32> visual_context_node_indices;
@@ -114,10 +124,13 @@ struct VisualAnimation {
     double playback_rate { 1 };
     double start_delay_ms { 0 };
     double iteration_duration_ms { 0 };
+    double iteration_count { AK::Infinity<double> };
     double iteration_start { 0 };
     VisualAnimationPlaybackDirection playback_direction { VisualAnimationPlaybackDirection::Normal };
     VisualAnimationEasing easing;
     Vector<VisualAnimationKeyframe> keyframes;
+
+    bool operator==(VisualAnimation const&) const = default;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8122,6 +8122,7 @@ void Document::update_compositor_animations()
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_driven_effects;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_replaced_effects;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
+    GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_offscreen_throttled_effects;
     HashMap<DOM::AbstractElement, CompetingEffects> competing_effects;
     HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> only_translates_horizontally_cache;
     HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> animated_transform_preserves_axes_cache;
@@ -8252,9 +8253,11 @@ void Document::update_compositor_animations()
 
             bool has_content_clip = ancestor_box->overflow_x() != CSS::Overflow::Visible
                 || ancestor_box->overflow_y() != CSS::Overflow::Visible;
-            auto clip_rect = Painting::transform_rect_to_viewport(*ancestor_box, Painting::absolute_padding_box_rect(*ancestor_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
-            if (has_content_clip && !clip_rect.edge_adjacent_intersects(root_bounds))
-                has_disjoint_clip = true;
+            if (has_content_clip) {
+                auto clip_rect = Painting::transform_rect_to_viewport(*ancestor_box, Painting::absolute_padding_box_rect(*ancestor_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+                if (!clip_rect.edge_adjacent_intersects(root_bounds))
+                    has_disjoint_clip = true;
+            }
 
             // A transform outside the disjoint clip could move the clip into the observation root without updating
             // its main-thread geometry. Transforms inside the clip can only move content within the clipped region.
@@ -8327,12 +8330,15 @@ void Document::update_compositor_animations()
             previously_compositor_replaced_effects.set(effect);
         if (!effect.retained_compositor_animations().is_empty())
             previously_published_effects.set(effect);
+        if (effect.is_offscreen_throttled())
+            previously_offscreen_throttled_effects.set(effect);
         if (auto target = effect.target_abstract_element(); target.has_value()) {
             if (auto* layout_node = target->unsafe_layout_node())
                 layout_node->set_retains_compositor_animated_content(false);
         }
         effect.set_is_compositor_driven(false);
         effect.set_is_compositor_replaced(false);
+        effect.set_is_offscreen_throttled(false);
         effect.set_is_observation_relevant_compositor_animation(false);
 
         if (animation.is_idle() || !effect.is_in_effect())
@@ -8402,8 +8408,9 @@ void Document::update_compositor_animations()
             if (effect.is_observation_relevant_compositor_animation())
                 has_observation_relevant_compositor_animation = true;
             bool was_throttled = previously_compositor_driven_effects.contains(GC::Ref { effect })
-                || previously_compositor_replaced_effects.contains(GC::Ref { effect });
-            if (was_throttled && !effect.is_compositor_driven() && !effect.is_compositor_replaced()) {
+                || previously_compositor_replaced_effects.contains(GC::Ref { effect })
+                || previously_offscreen_throttled_effects.contains(GC::Ref { effect });
+            if (was_throttled && !effect.is_compositor_driven() && !effect.is_compositor_replaced() && !effect.is_offscreen_throttled()) {
                 effect.request_observation_sample();
                 requested_withdrawn_effect_sample = true;
             }
@@ -8489,6 +8496,9 @@ void Document::update_compositor_animations()
         }
 
         if (effect_visual_animations.is_empty()) {
+            auto viewport_bounds = CSSPixelRect { { 0, 0 }, viewport_rect().size() };
+            if (selected_for_transform && !transform_affects_observation && transform_subtree_is_clipped_outside(target, viewport_bounds))
+                effect.set_is_offscreen_throttled(true);
             continue;
         }
         // OPTIMIZATION: Ordinary rendering updates advance the WebContent timeline without changing compositor

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -712,6 +712,7 @@ void Document::record_layout_tree_build(u64 rebuilt_subtree_root_count, bool esc
 
 void Document::finalize()
 {
+    stop_compositor_animation_timers();
     if (m_layout_node_arena)
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
     CSS::ComputedValuesFFI::rust_custom_property_registry_destroy(m_rust_custom_property_registry);
@@ -2780,6 +2781,34 @@ bool Document::run_empty_animation_style_update_for_testing(Badge<Internals::Int
     m_effects_needing_animated_style_update.clear();
     sample_animation_effects_needing_style_update();
     return m_has_throttled_animation_style_update;
+}
+
+void Document::stop_compositor_animation_timers()
+{
+    if (m_compositor_animation_wakeup_timer) {
+        m_compositor_animation_wakeup_timer->stop();
+        m_compositor_animation_wakeup_deadline.clear();
+    }
+    if (m_compositor_animation_observation_timer)
+        m_compositor_animation_observation_timer->stop();
+}
+
+void Document::arm_compositor_animation_timers_for_testing(Badge<Internals::Internals>)
+{
+    stop_compositor_animation_timers();
+    schedule_compositor_animation_wakeup(NumericLimits<int>::max());
+    m_compositor_animation_observation_timer = Core::Timer::create_single_shot(NumericLimits<int>::max(), GC::weak_callback(*this, [](auto&) { }));
+    m_compositor_animation_observation_timer->start();
+}
+
+bool Document::compositor_animation_wakeup_timer_is_active() const
+{
+    return m_compositor_animation_wakeup_timer && m_compositor_animation_wakeup_timer->is_active();
+}
+
+bool Document::compositor_animation_observation_timer_is_active() const
+{
+    return m_compositor_animation_observation_timer && m_compositor_animation_observation_timer->is_active();
 }
 
 void Document::throttled_animation_visibility_changed()
@@ -6004,6 +6033,7 @@ void Document::destroy()
 
     // 2. Abort document.
     abort();
+    stop_compositor_animation_timers();
 
     // AD-HOC: Notify document observers that this document became inactive.
     //         This handles iframe-removal destruction, which doesn't otherwise go through
@@ -6485,6 +6515,7 @@ bool Document::is_allowed_to_use_feature(PolicyControlledFeature feature) const
 
 void Document::did_stop_being_active_document_in_navigable()
 {
+    stop_compositor_animation_timers();
     clear_layout_nodes_for_inactive_document();
     tear_down_layout_tree();
 
@@ -8053,6 +8084,8 @@ void Document::schedule_compositor_animation_wakeup(double delay_ms)
     m_compositor_animation_wakeup_deadline = deadline;
     if (!m_compositor_animation_wakeup_timer) {
         m_compositor_animation_wakeup_timer = Core::Timer::create_single_shot(static_cast<int>(timer_delay_ms), GC::weak_callback(*this, [](auto& document) {
+            // Cancelling a finite effect can leave this deadline armed. The single wake-up is harmless: it finds
+            // nothing due and leaves the timer idle unless another effect supplies a deadline.
             document.m_compositor_animation_wakeup_deadline.clear();
             auto timestamp = HighResolutionTime::relative_high_resolution_time(
                 HighResolutionTime::unsafe_shared_current_time(), document.relevant_settings_object().global_object());
@@ -8421,6 +8454,7 @@ void Document::update_compositor_animations()
         if (animation.is_idle() || !effect.is_in_effect())
             continue;
         auto& target = abstract_target->element();
+
         bool targets_opacity = effect.target_properties().contains(CSS::PropertyID::Opacity);
         bool targets_transform = any_of(effect.target_properties(), is_transform_family_property);
         bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); });

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8125,8 +8125,30 @@ void Document::update_compositor_animations()
     HashMap<DOM::AbstractElement, CompetingEffects> competing_effects;
     HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> only_translates_horizontally_cache;
     HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> animated_transform_preserves_axes_cache;
+    HashMap<Element const*, Vector<GC::Ptr<Animations::KeyframeEffect>>> in_effect_transform_effects_by_target;
     HashMap<GC::Ptr<Element>, CSSPixelRect> observation_target_rect_cache;
+    GC::RootHashTable<GC::Ref<Element>> elements_with_intersection_observation_descendants;
+    GC::RootHashTable<GC::Ref<Element>> elements_with_visibility_observation_descendants;
     Optional<double> compositor_animation_wakeup_delay_ms;
+
+    auto index_shadow_including_element_ancestors = [](Node& node, GC::RootHashTable<GC::Ref<Element>>& index) {
+        for (auto* ancestor = &node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+            if (auto* element = as_if<Element>(*ancestor))
+                index.set(*element);
+        }
+    };
+    for (auto const& observer : m_intersection_observers) {
+        if (observer.observation_targets().is_empty())
+            continue;
+        auto root = observer.intersection_root_node();
+        if (root->is_element())
+            index_shadow_including_element_ancestors(*root, elements_with_intersection_observation_descendants);
+        for (auto const& observation : observer.observation_targets()) {
+            index_shadow_including_element_ancestors(observation.target, elements_with_intersection_observation_descendants);
+            if (observer.track_visibility())
+                index_shadow_including_element_ancestors(observation.target, elements_with_visibility_observation_descendants);
+        }
+    }
 
     auto transform_preserves_horizontal_axis = [](Layout::NodeWithStyle const& layout_node) {
         if (layout_node.perspective().has_value())
@@ -8198,15 +8220,11 @@ void Document::update_compositor_animations()
             if (ancestor->has_css_transform() && !transform_preserves_horizontal_axis(*ancestor))
                 return true;
             if (auto* ancestor_element = as_if<Element>(ancestor->dom_node())) {
-                for (auto& animation : m_associated_animations) {
-                    if (animation.is_idle() || !animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
-                        continue;
-                    auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
-                    auto effect_target = effect.target();
-                    if (!effect_target || effect_target.ptr() != ancestor_element || !effect.is_in_effect())
-                        continue;
-                    if (!animated_transform_preserves_axes(effect, *effect_target, *ancestor))
-                        return true;
+                if (auto effects = in_effect_transform_effects_by_target.find(ancestor_element); effects != in_effect_transform_effects_by_target.end()) {
+                    for (auto effect : effects->value) {
+                        if (!animated_transform_preserves_axes(*effect, const_cast<Element&>(*ancestor_element), *ancestor))
+                            return true;
+                    }
                 }
             }
             if (ancestor->dom_node() == &observation_root)
@@ -8263,7 +8281,9 @@ void Document::update_compositor_animations()
         return false;
     };
 
-    auto transform_affects_intersection_observation = [&](Element const& animated_target, Animations::KeyframeEffect const& effect, bool only_translates_horizontally, bool& requires_main_thread_sampling) {
+    auto transform_affects_intersection_observation = [&](Element& animated_target, Animations::KeyframeEffect const& effect, bool only_translates_horizontally, bool& requires_main_thread_sampling) {
+        if (!elements_with_intersection_observation_descendants.contains(animated_target))
+            return false;
         for (auto const& observer : m_intersection_observers) {
             if (observer.observation_targets().is_empty())
                 continue;
@@ -8293,16 +8313,8 @@ void Document::update_compositor_animations()
         return false;
     };
 
-    auto opacity_affects_visibility_observation = [&](Element const& animated_target) {
-        for (auto const& observer : m_intersection_observers) {
-            if (!observer.track_visibility())
-                continue;
-            for (auto const& observation : observer.observation_targets()) {
-                if (animated_target.is_shadow_including_inclusive_ancestor_of(*observation.target))
-                    return true;
-            }
-        }
-        return false;
+    auto opacity_affects_visibility_observation = [&](Element& animated_target) {
+        return elements_with_visibility_observation_descendants.contains(animated_target);
     };
 
     for (auto& animation : m_associated_animations) {
@@ -8337,8 +8349,10 @@ void Document::update_compositor_animations()
         };
         if (effect.target_properties().contains(CSS::PropertyID::Opacity))
             add_competing_effect(effects.opacity);
-        if (any_of(effect.target_properties(), is_transform_family_property))
+        if (any_of(effect.target_properties(), is_transform_family_property)) {
             add_competing_effect(effects.transform);
+            in_effect_transform_effects_by_target.ensure(&target->element()).append(effect);
+        }
     }
 
     auto winner_uses_replace_keyframes = [](Animations::KeyframeEffect& effect) {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8015,6 +8015,21 @@ void Document::update_compositor_animations()
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
     HashMap<DOM::AbstractElement, CompetingEffects> competing_effects;
     Optional<double> compositor_animation_wakeup_delay_ms;
+    auto transform_affects_intersection_observation = [&](Element const& animated_target) {
+        for (auto const& observer : m_intersection_observers) {
+            if (observer.observation_targets().is_empty())
+                continue;
+            auto root = observer.intersection_root_node();
+            if (root->is_element() && animated_target.is_shadow_including_inclusive_ancestor_of(*root))
+                return true;
+            for (auto const& observation : observer.observation_targets()) {
+                if (animated_target.is_shadow_including_inclusive_ancestor_of(*observation.target))
+                    return true;
+            }
+        }
+        return false;
+    };
+
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
@@ -8105,6 +8120,7 @@ void Document::update_compositor_animations()
             continue;
         if (animation.is_idle() || !effect.is_in_effect())
             continue;
+        auto& target = abstract_target->element();
         bool targets_opacity = effect.target_properties().contains(CSS::PropertyID::Opacity);
         bool targets_transform = any_of(effect.target_properties(), is_transform_family_property);
         bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); });
@@ -8133,6 +8149,9 @@ void Document::update_compositor_animations()
             }
             continue;
         }
+
+        if (selected_for_transform && transform_affects_intersection_observation(target))
+            continue;
 
         Vector<Compositor::VisualAnimation> effect_visual_animations;
         bool opacity_was_handed_off = !selected_for_opacity;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8267,6 +8267,18 @@ void Document::update_compositor_animations()
         return false;
     };
 
+    auto opacity_affects_visibility_observation = [&](Element const& animated_target) {
+        for (auto const& observer : m_intersection_observers) {
+            if (!observer.track_visibility())
+                continue;
+            for (auto const& observation : observer.observation_targets()) {
+                if (animated_target.is_shadow_including_inclusive_ancestor_of(*observation.target))
+                    return true;
+            }
+        }
+        return false;
+    };
+
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
@@ -8407,6 +8419,13 @@ void Document::update_compositor_animations()
         }
         if (only_translates_horizontally.has_value())
             only_translates_horizontally_cache.set(effect, *only_translates_horizontally);
+
+        if (selected_for_opacity && opacity_affects_visibility_observation(target)) {
+            effect_visual_animations.remove_all_matching([](auto const& animation) {
+                return animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity;
+            });
+            opacity_was_handed_off = false;
+        }
 
         bool transform_affects_observation = false;
         bool requires_main_thread_observation_sampling = false;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7637,6 +7637,8 @@ static Optional<Compositor::VisualAnimationTransformOperation> compositor_transf
             return {};
         values.unchecked_append(value);
     }
+    if (*kind == Compositor::VisualAnimationTransformOperationKind::Translate && values.size() == 1)
+        kind = Compositor::VisualAnimationTransformOperationKind::TranslateX;
     Compositor::VisualAnimationTransformOperation operation { *kind, move(values) };
     if (!operation.is_valid())
         return {};
@@ -7718,7 +7720,68 @@ static Optional<float> compositor_opacity_animation_value(CSS::StyleValue const&
     return opacity;
 }
 
-static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind)
+static bool transform_keyframes_only_translate_horizontally(ReadonlySpan<Compositor::VisualAnimationKeyframe> keyframes)
+{
+    Vector<float> translate_y_values;
+    Vector<Compositor::VisualAnimationTransformOperationKind> operation_kinds;
+    for (size_t keyframe_index = 0; keyframe_index < keyframes.size(); ++keyframe_index) {
+        auto const& operations = keyframes[keyframe_index].value.get<Compositor::VisualAnimationTransformList>();
+        if (keyframe_index != 0 && operations.size() != operation_kinds.size())
+            return false;
+        for (size_t operation_index = 0; operation_index < operations.size(); ++operation_index) {
+            auto const& operation = operations[operation_index];
+            if (keyframe_index == 0)
+                operation_kinds.append(operation.kind);
+            else if (operation.kind != operation_kinds[operation_index])
+                return false;
+            if (operation.kind == Compositor::VisualAnimationTransformOperationKind::TranslateX) {
+                if (keyframe_index == 0)
+                    translate_y_values.append(0);
+                continue;
+            }
+            if (operation.kind != Compositor::VisualAnimationTransformOperationKind::Translate)
+                return false;
+            float translate_y = operation.values.size() == 2 ? operation.values[1] : 0;
+            if (keyframe_index == 0)
+                translate_y_values.append(translate_y);
+            else if (operation_index >= translate_y_values.size() || translate_y_values[operation_index] != translate_y)
+                return false;
+        }
+    }
+    return keyframes.size() >= 2;
+}
+
+static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEffect& effect, DOM::AbstractElement target, Layout::Node const& layout_node, float device_pixels_per_css_pixel)
+{
+    if (effect.target_properties().size() != 1 || !effect.target_properties().contains(CSS::PropertyID::Transform))
+        return false;
+    auto const* key_frame_set = effect.key_frame_set();
+    if (!key_frame_set)
+        return false;
+
+    Vector<Compositor::VisualAnimationKeyframe> keyframes;
+    for (auto const& entry : key_frame_set->keyframes_by_key) {
+        auto property = entry.properties.get(CSS::PropertyID::Transform);
+        if (!property.has_value())
+            continue;
+        if (!property->has<CSS::RustStyleValueHandle>())
+            return false;
+        auto style_value = resolved_compositor_animation_style_value(CSS::PropertyID::Transform, property->get<CSS::RustStyleValueHandle>(), target);
+        if (!style_value)
+            return false;
+        auto operations = compositor_transform_animation_value(CSS::PropertyID::Transform, *style_value, layout_node, device_pixels_per_css_pixel);
+        if (!operations.has_value())
+            return false;
+        keyframes.append({
+            .offset = 0,
+            .easing = {},
+            .value = operations.release_value(),
+        });
+    }
+    return transform_keyframes_only_translate_horizontally(keyframes);
+}
+
+static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind, Optional<bool>& only_translates_horizontally)
 {
     auto animation = effect.associated_animation();
     if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running || animation->pending())
@@ -7799,6 +7862,11 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             .values = {},
         };
         new_cache.values.ensure_capacity(key_frame_set->keyframes_by_key.size());
+        size_t transform_property_count = 0;
+        for (auto property_id : effect.target_properties()) {
+            if (is_transform_family_property(property_id))
+                ++transform_property_count;
+        }
         for (auto const& entry : key_frame_set->keyframes_by_key) {
             Optional<Compositor::VisualAnimationValue> value;
             if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
@@ -7815,11 +7883,16 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 }
             } else {
                 Compositor::VisualAnimationTransformList operations;
+                bool skip_keyframe = false;
                 for (auto property_id : { CSS::PropertyID::Translate, CSS::PropertyID::Rotate, CSS::PropertyID::Scale, CSS::PropertyID::Transform }) {
                     if (!effect.target_properties().contains(property_id))
                         continue;
                     auto property = entry.properties.get(property_id);
                     if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                        if (transform_property_count == 1) {
+                            skip_keyframe = true;
+                            break;
+                        }
                         new_cache.is_valid = false;
                         break;
                     }
@@ -7837,6 +7910,10 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 }
                 if (!new_cache.is_valid)
                     break;
+                if (skip_keyframe) {
+                    new_cache.values.append({});
+                    continue;
+                }
                 value = Compositor::VisualAnimationValue { move(operations) };
             }
             if (!value.has_value()) {
@@ -7909,6 +7986,12 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 .easing = keyframe_easings[keyframe_index],
                 .value = *value,
             });
+        }
+
+        if (target_kind == Compositor::VisualAnimation::TargetKind::Transform) {
+            only_translates_horizontally = effect.target_properties().size() == 1
+                && effect.target_properties().contains(CSS::PropertyID::Transform)
+                && transform_keyframes_only_translate_horizontally(keyframes);
         }
 
         Compositor::VisualAnimation visual_animation {
@@ -8014,17 +8097,171 @@ void Document::update_compositor_animations()
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_replaced_effects;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
     HashMap<DOM::AbstractElement, CompetingEffects> competing_effects;
+    HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> only_translates_horizontally_cache;
+    HashMap<GC::Ptr<Animations::KeyframeEffect>, bool> animated_transform_preserves_axes_cache;
+    HashMap<GC::Ptr<Element>, CSSPixelRect> observation_target_rect_cache;
     Optional<double> compositor_animation_wakeup_delay_ms;
-    auto transform_affects_intersection_observation = [&](Element const& animated_target) {
+
+    auto transform_preserves_horizontal_axis = [](Layout::NodeWithStyle const& layout_node) {
+        if (layout_node.perspective().has_value())
+            return false;
+
+        auto matrix = Gfx::FloatMatrix4x4::identity();
+        if (auto translate = layout_node.translate())
+            matrix = matrix * translate->to_matrix(&layout_node);
+        if (auto rotate = layout_node.rotate())
+            matrix = matrix * rotate->to_matrix(&layout_node);
+        if (auto scale = layout_node.scale())
+            matrix = matrix * scale->to_matrix(&layout_node);
+        layout_node.for_each_transformation([&](auto const& transformation) {
+            matrix = matrix * transformation.to_matrix(&layout_node);
+        });
+
+        constexpr auto epsilon = AK::NumericLimits<float>::epsilon();
+        return abs(matrix[1, 0]) <= epsilon
+            && abs(matrix[2, 0]) <= epsilon
+            && abs(matrix[3, 0]) <= epsilon;
+    };
+
+    auto animated_transform_preserves_axes = [&](Animations::KeyframeEffect& effect, Element& target, Layout::Node const& layout_node) {
+        return animated_transform_preserves_axes_cache.ensure(effect, [&] {
+            if (effect.target_properties().contains(CSS::PropertyID::Rotate))
+                return false;
+            if (!effect.target_properties().contains(CSS::PropertyID::Transform))
+                return true;
+            auto const* key_frame_set = effect.key_frame_set();
+            if (!key_frame_set)
+                return false;
+            auto device_pixels_per_css_pixel = static_cast<float>(page().client().device_pixels_per_css_pixel());
+            for (auto const& entry : key_frame_set->keyframes_by_key) {
+                auto property = entry.properties.get(CSS::PropertyID::Transform);
+                if (!property.has_value())
+                    continue;
+                if (!property->has<CSS::RustStyleValueHandle>())
+                    return false;
+                auto style_value = resolved_compositor_animation_style_value(CSS::PropertyID::Transform, property->get<CSS::RustStyleValueHandle>(), target);
+                if (!style_value)
+                    return false;
+                auto operations = compositor_transform_animation_value(CSS::PropertyID::Transform, *style_value, layout_node, device_pixels_per_css_pixel);
+                if (!operations.has_value())
+                    return false;
+                if (any_of(*operations, [](auto const& operation) {
+                        return !first_is_one_of(operation.kind,
+                            Compositor::VisualAnimationTransformOperationKind::Translate,
+                            Compositor::VisualAnimationTransformOperationKind::Translate3d,
+                            Compositor::VisualAnimationTransformOperationKind::TranslateX,
+                            Compositor::VisualAnimationTransformOperationKind::TranslateY,
+                            Compositor::VisualAnimationTransformOperationKind::TranslateZ,
+                            Compositor::VisualAnimationTransformOperationKind::Scale,
+                            Compositor::VisualAnimationTransformOperationKind::Scale3d,
+                            Compositor::VisualAnimationTransformOperationKind::ScaleX,
+                            Compositor::VisualAnimationTransformOperationKind::ScaleY,
+                            Compositor::VisualAnimationTransformOperationKind::ScaleZ);
+                    }))
+                    return false;
+            }
+            return true;
+        });
+    };
+
+    auto ancestor_transform_can_map_horizontal_motion_to_vertical = [&](Element const& animated_target, Node const& observation_root) {
+        auto const* layout_node = animated_target.unsafe_layout_node();
+        if (!layout_node)
+            return true;
+        for (auto const* ancestor = layout_node->parent(); ancestor; ancestor = ancestor->parent()) {
+            if (ancestor->has_css_transform() && !transform_preserves_horizontal_axis(*ancestor))
+                return true;
+            if (auto* ancestor_element = as_if<Element>(ancestor->dom_node())) {
+                for (auto& animation : m_associated_animations) {
+                    if (animation.is_idle() || !animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+                        continue;
+                    auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+                    auto effect_target = effect.target();
+                    if (!effect_target || effect_target.ptr() != ancestor_element || !effect.is_in_effect())
+                        continue;
+                    if (!animated_transform_preserves_axes(effect, *effect_target, *ancestor))
+                        return true;
+                }
+            }
+            if (ancestor->dom_node() == &observation_root)
+                break;
+        }
+        return false;
+    };
+
+    auto transform_subtree_is_clipped_outside = [](Element const& animated_target, CSSPixelRect const& root_bounds) {
+        auto const* layout_node = animated_target.unsafe_layout_node();
+        if (!layout_node || !Painting::has_committed_box(*layout_node) || root_bounds.is_empty())
+            return false;
+        if (auto const* target_box = as_if<Layout::Box>(*layout_node)) {
+            if (Painting::is_fixed_position(*target_box) || target_box->abspos_descendant_escapes())
+                return false;
+        }
+
+        bool has_disjoint_clip = false;
+        for (auto const* ancestor = layout_node->parent(); ancestor; ancestor = ancestor->parent()) {
+            auto const* ancestor_box = as_if<Layout::Box>(*ancestor);
+            if (!ancestor_box)
+                continue;
+            if (!Painting::has_committed_box(*ancestor_box) || Painting::is_fixed_position(*ancestor_box))
+                return false;
+
+            bool has_content_clip = ancestor_box->overflow_x() != CSS::Overflow::Visible
+                || ancestor_box->overflow_y() != CSS::Overflow::Visible;
+            auto clip_rect = Painting::transform_rect_to_viewport(*ancestor_box, Painting::absolute_padding_box_rect(*ancestor_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+            if (has_content_clip && !clip_rect.edge_adjacent_intersects(root_bounds))
+                has_disjoint_clip = true;
+
+            // A transform outside the disjoint clip could move the clip into the observation root without updating
+            // its main-thread geometry. Transforms inside the clip can only move content within the clipped region.
+            if (has_disjoint_clip && (ancestor_box->has_css_transform() || ancestor_box->is_sticky_position()))
+                return false;
+        }
+        return has_disjoint_clip;
+    };
+
+    auto observation_has_another_transform_animation = [&](Element const& animated_target, Element const& observation_target, Animations::KeyframeEffect const& current_effect) {
+        for (auto& animation : m_associated_animations) {
+            if (animation.is_idle() || !animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+                continue;
+            auto const& effect = static_cast<Animations::KeyframeEffect const&>(*animation.effect());
+            if (&effect == &current_effect || !effect.is_in_effect())
+                continue;
+            auto effect_target = effect.target();
+            if (!effect_target || !animated_target.is_shadow_including_inclusive_ancestor_of(*effect_target)
+                || !effect_target->is_shadow_including_inclusive_ancestor_of(observation_target))
+                continue;
+            if (any_of(effect.target_properties(), is_transform_family_property))
+                return true;
+        }
+        return false;
+    };
+
+    auto transform_affects_intersection_observation = [&](Element const& animated_target, Animations::KeyframeEffect const& effect, bool only_translates_horizontally, bool& requires_main_thread_sampling) {
         for (auto const& observer : m_intersection_observers) {
             if (observer.observation_targets().is_empty())
                 continue;
             auto root = observer.intersection_root_node();
             if (root->is_element() && animated_target.is_shadow_including_inclusive_ancestor_of(*root))
                 return true;
+            bool subtree_is_clipped_outside_root = transform_subtree_is_clipped_outside(animated_target, observer.root_intersection_rectangle());
             for (auto const& observation : observer.observation_targets()) {
-                if (animated_target.is_shadow_including_inclusive_ancestor_of(*observation.target))
+                if (!animated_target.is_shadow_including_inclusive_ancestor_of(*observation.target) || subtree_is_clipped_outside_root)
+                    continue;
+                if (only_translates_horizontally && ancestor_transform_can_map_horizontal_motion_to_vertical(animated_target, *root)) {
+                    requires_main_thread_sampling = true;
                     return true;
+                }
+                if (only_translates_horizontally && !observation_has_another_transform_animation(animated_target, *observation.target, effect)) {
+                    auto const& target_rect = observation_target_rect_cache.ensure(observation.target, [&] {
+                        return observation.target->bounding_client_rect_assuming_layout_clean();
+                    });
+                    auto root_rect = observer.root_intersection_rectangle();
+                    bool vertical_bands_are_disjoint = target_rect.bottom() < root_rect.top() || target_rect.top() > root_rect.bottom();
+                    if (vertical_bands_are_disjoint)
+                        continue;
+                }
+                return true;
             }
         }
         return false;
@@ -8150,13 +8387,11 @@ void Document::update_compositor_animations()
             continue;
         }
 
-        if (selected_for_transform && transform_affects_intersection_observation(target))
-            continue;
-
+        Optional<bool> only_translates_horizontally;
         Vector<Compositor::VisualAnimation> effect_visual_animations;
         bool opacity_was_handed_off = !selected_for_opacity;
         if (selected_for_opacity) {
-            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Opacity);
+            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Opacity, only_translates_horizontally);
             if (visual_animation.has_value()) {
                 effect_visual_animations.append(visual_animation.release_value());
                 opacity_was_handed_off = true;
@@ -8164,15 +8399,37 @@ void Document::update_compositor_animations()
         }
         bool transform_was_handed_off = !selected_for_transform;
         if (selected_for_transform) {
-            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Transform);
+            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Transform, only_translates_horizontally);
             if (visual_animation.has_value()) {
                 effect_visual_animations.append(visual_animation.release_value());
                 transform_was_handed_off = true;
             }
         }
+        if (only_translates_horizontally.has_value())
+            only_translates_horizontally_cache.set(effect, *only_translates_horizontally);
+
+        bool transform_affects_observation = false;
+        bool requires_main_thread_observation_sampling = false;
+        if (selected_for_transform) {
+            auto only_translates_horizontally = only_translates_horizontally_cache.ensure(effect, [&] {
+                auto const* layout_node = abstract_target->unsafe_layout_node();
+                auto device_pixels_per_css_pixel = static_cast<float>(page().client().device_pixels_per_css_pixel());
+                return layout_node && keyframe_effect_only_translates_horizontally(effect, *abstract_target, *layout_node, device_pixels_per_css_pixel);
+            });
+            transform_affects_observation = transform_affects_intersection_observation(target, effect, only_translates_horizontally, requires_main_thread_observation_sampling);
+        }
+        if (requires_main_thread_observation_sampling) {
+            effect_visual_animations.remove_all_matching([](auto const& animation) {
+                return animation.target_kind == Compositor::VisualAnimation::TargetKind::Transform;
+            });
+            transform_was_handed_off = false;
+        }
+
         if (effect_visual_animations.is_empty()) {
             continue;
         }
+        if (transform_affects_observation)
+            continue;
         // OPTIMIZATION: Ordinary rendering updates advance the WebContent timeline without changing compositor
         //               playback. Retain the existing descriptor and its anchor unless the effect was invalidated or
         //               one of its non-anchor parameters changed.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7675,6 +7675,15 @@ static RefPtr<CSS::StyleValue const> resolved_compositor_animation_style_value(C
     return style_value->absolutized(computation_context);
 }
 
+static bool is_transform_family_property(CSS::PropertyID property_id)
+{
+    return first_is_one_of(property_id,
+        CSS::PropertyID::Translate,
+        CSS::PropertyID::Rotate,
+        CSS::PropertyID::Scale,
+        CSS::PropertyID::Transform);
+}
+
 static Optional<Compositor::VisualAnimationTransformList> compositor_transform_animation_value(CSS::PropertyID property_id, CSS::StyleValue const& style_value, Layout::Node const& layout_node, float device_pixels_per_css_pixel)
 {
     Vector<NonnullRefPtr<CSS::TransformationStyleValue const>> transformations;
@@ -7728,13 +7737,14 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto current_time = animation->current_time();
     if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
         return {};
-    if (effect.target_properties().size() != 1)
+    if (effect.target_properties().is_empty())
         return {};
 
-    auto property_id = *effect.target_properties().begin();
-    bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && property_id == CSS::PropertyID::Opacity;
-    bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && property_id == CSS::PropertyID::Transform;
+    bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && effect.target_properties().contains(CSS::PropertyID::Opacity);
+    bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && any_of(effect.target_properties(), is_transform_family_property);
     if (!targets_opacity && !targets_transform)
+        return {};
+    if (any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); }))
         return {};
     auto target = effect.target_abstract_element();
     if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
@@ -7747,9 +7757,10 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (!layout_node)
         return {};
     if (targets_transform) {
-        if (layout_node->has_translate()
-            || layout_node->has_rotate()
-            || layout_node->has_scale()
+        if ((!effect.target_properties().contains(CSS::PropertyID::Translate) && layout_node->has_translate())
+            || (!effect.target_properties().contains(CSS::PropertyID::Rotate) && layout_node->has_rotate())
+            || (!effect.target_properties().contains(CSS::PropertyID::Scale) && layout_node->has_scale())
+            || (!effect.target_properties().contains(CSS::PropertyID::Transform) && layout_node->has_transformations())
             || layout_node->transform_origin().z.to_px(CSSPixels { 0 }) != CSSPixels { 0 })
             return {};
     }
@@ -7998,6 +8009,7 @@ void Document::update_compositor_animations()
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_driven_effects;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
     HashMap<DOM::AbstractElement, HashMap<CSS::PropertyID, size_t>> competing_effect_counts;
+    HashMap<DOM::AbstractElement, size_t> transform_family_effect_counts;
     Optional<double> compositor_animation_wakeup_delay_ms;
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
@@ -8015,9 +8027,14 @@ void Document::update_compositor_animations()
         if (!target.has_value())
             continue;
         auto& property_counts = competing_effect_counts.ensure(*target);
+        bool targets_transform_family = false;
         for (auto property_id : effect.target_properties()) {
             ++property_counts.ensure(property_id, [] { return 0; });
+            if (is_transform_family_property(property_id))
+                targets_transform_family = true;
         }
+        if (targets_transform_family)
+            ++transform_family_effect_counts.ensure(*target, [] { return 0; });
     }
 
     bool requested_withdrawn_effect_sample = false;
@@ -8053,23 +8070,18 @@ void Document::update_compositor_animations()
             continue;
         if (animation.is_idle() || !effect.is_in_effect())
             continue;
-        if (effect.target_properties().size() != 1)
-            continue;
-        auto property_id = *effect.target_properties().begin();
-        bool targets_opacity = property_id == CSS::PropertyID::Opacity;
-        bool targets_transform = property_id == CSS::PropertyID::Transform;
-        if (!targets_opacity && !targets_transform)
+        bool targets_opacity = effect.target_properties().contains(CSS::PropertyID::Opacity);
+        bool targets_transform = any_of(effect.target_properties(), is_transform_family_property);
+        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); });
+        if (targets_unsupported_property)
             continue;
         if (targets_opacity) {
             auto property_counts = competing_effect_counts.get(*abstract_target);
             if (!property_counts.has_value() || property_counts->get(CSS::PropertyID::Opacity).value_or(0) != 1)
                 continue;
         }
-        if (targets_transform) {
-            auto property_counts = competing_effect_counts.get(*abstract_target);
-            if (!property_counts.has_value() || property_counts->get(CSS::PropertyID::Transform).value_or(0) != 1)
-                continue;
-        }
+        if (targets_transform && transform_family_effect_counts.get(*abstract_target).value_or(0) != 1)
+            continue;
 
         Vector<Compositor::VisualAnimation> effect_visual_animations;
         bool opacity_was_handed_off = !targets_opacity;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -58,6 +58,7 @@
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFaceSet.h>
+#include <LibWeb/CSS/HypotheticalElement.h>
 #include <LibWeb/CSS/Invalidation/AdoptedStyleSheetInvalidator.h>
 #include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/ElementStateInvalidator.h>
@@ -69,12 +70,14 @@
 #include <LibWeb/CSS/MediaQueryListEvent.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/SelectorMatching.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleEngineInput.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ComputationContext.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpacityValueStyleValue.h>
@@ -7585,10 +7588,27 @@ static Optional<Compositor::VisualAnimationTransformOperationKind> compositor_tr
     VERIFY_NOT_REACHED();
 }
 
-static Optional<Compositor::VisualAnimationTransformOperation> compositor_transform_operation(CSS::TransformationStyleValue const& transformation, float device_pixels_per_css_pixel)
+static Optional<CSS::Length> compositor_transform_percentage_basis(CSS::TransformFunction function, size_t argument_index, CSSPixelSize reference_size)
 {
-    if (!transformation.can_be_converted_to_matrix_without_reference_box())
+    switch (function) {
+    case CSS::TransformFunction::Translate:
+    case CSS::TransformFunction::Translate3d:
+        if (argument_index == 0)
+            return CSS::Length::make_px(reference_size.width());
+        if (argument_index == 1)
+            return CSS::Length::make_px(reference_size.height());
         return {};
+    case CSS::TransformFunction::TranslateX:
+        return CSS::Length::make_px(reference_size.width());
+    case CSS::TransformFunction::TranslateY:
+        return CSS::Length::make_px(reference_size.height());
+    default:
+        return {};
+    }
+}
+
+static Optional<Compositor::VisualAnimationTransformOperation> compositor_transform_operation(CSS::TransformationStyleValue const& transformation, CSSPixelSize reference_size, float device_pixels_per_css_pixel)
+{
     auto kind = compositor_transform_operation_kind(transformation.transform_function());
     if (!kind.has_value())
         return {};
@@ -7606,7 +7626,7 @@ static Optional<Compositor::VisualAnimationTransformOperation> compositor_transf
             case CSS::TransformFunctionParameterType::Length:
             case CSS::TransformFunctionParameterType::LengthNone:
             case CSS::TransformFunctionParameterType::LengthPercentage:
-                return CSS::Length::from_style_value(style_value, {}).absolute_length_to_px().to_float() * device_pixels_per_css_pixel;
+                return CSS::Length::from_style_value(style_value, compositor_transform_percentage_basis(transformation.transform_function(), index, reference_size)).absolute_length_to_px().to_float() * device_pixels_per_css_pixel;
             case CSS::TransformFunctionParameterType::Number:
             case CSS::TransformFunctionParameterType::NumberPercentage:
                 return CSS::number_from_style_value(style_value, 1);
@@ -7640,32 +7660,53 @@ static Optional<Compositor::VisualAnimationEasing> compositor_animation_easing(A
         });
 }
 
-static Optional<Compositor::VisualAnimationValue> compositor_animation_value(CSS::PropertyID property_id, CSS::RustStyleValueHandle const& value, float device_pixels_per_css_pixel)
+static RefPtr<CSS::StyleValue const> resolved_compositor_animation_style_value(CSS::PropertyID property_id, CSS::RustStyleValueHandle const& value, DOM::AbstractElement target)
 {
+    ++target.document().style_invalidation_counters().compositor_keyframe_value_resolutions;
     auto style_value = CSS::StyleValue::adopt_rust_style_value_data(CSS::StyleValueFFI::rust_style_value_retain(value.data()));
-    if (property_id == CSS::PropertyID::Opacity) {
-        if (!style_value->is_opacity_value())
-            return {};
-        auto opacity = style_value->as_opacity_value().resolved();
-        if (!isfinite(opacity))
-            return {};
-        return opacity;
-    }
+    if (style_value->is_unresolved())
+        style_value = target.document().style_computer().resolve_unresolved_style_value(target, CSS::PropertyNameAndID::from_id(property_id), style_value->as_unresolved());
+    if (style_value->is_guaranteed_invalid() || style_value->is_unresolved() || style_value->is_pending_substitution())
+        return nullptr;
+    CSS::ComputationContext computation_context {
+        .length_resolution_context = CSS::Length::ResolutionContext::for_element(target),
+        .abstract_element = target,
+    };
+    return style_value->absolutized(computation_context);
+}
 
-    VERIFY(property_id == CSS::PropertyID::Transform);
-    auto transformations = CSS::transformations_for_style_value(*style_value);
+static Optional<Compositor::VisualAnimationTransformList> compositor_transform_animation_value(CSS::PropertyID property_id, CSS::StyleValue const& style_value, Layout::Node const& layout_node, float device_pixels_per_css_pixel)
+{
+    Vector<NonnullRefPtr<CSS::TransformationStyleValue const>> transformations;
+    if (property_id == CSS::PropertyID::Transform) {
+        transformations = CSS::transformations_for_style_value(style_value);
+    } else {
+        if (!style_value.is_transformation())
+            return {};
+        transformations.append(style_value.as_transformation());
+    }
     if (transformations.is_empty())
         return {};
 
     Compositor::VisualAnimationTransformList operations;
     operations.ensure_capacity(transformations.size());
     for (auto const& transformation : transformations) {
-        auto operation = compositor_transform_operation(*transformation, device_pixels_per_css_pixel);
+        auto operation = compositor_transform_operation(*transformation, Painting::transform_reference_box(layout_node).size(), device_pixels_per_css_pixel);
         if (!operation.has_value())
             return {};
         operations.unchecked_append(operation.release_value());
     }
     return operations;
+}
+
+static Optional<float> compositor_opacity_animation_value(CSS::StyleValue const& style_value)
+{
+    if (!style_value.is_opacity_value())
+        return {};
+    auto opacity = style_value.as_opacity_value().resolved();
+    if (!isfinite(opacity))
+        return {};
+    return opacity;
 }
 
 static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind)
@@ -7720,6 +7761,82 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (!key_frame_set || key_frame_set->keyframes_by_key.size() < 2)
         return {};
     auto device_pixels_per_css_pixel = static_cast<float>(target->document().page().client().device_pixels_per_css_pixel());
+    auto reference_box_size = Painting::transform_reference_box(*layout_node).size();
+    auto resolved_values_for_target = [&](Compositor::VisualAnimation::TargetKind target_kind) -> Animations::KeyframeEffect::CompositorKeyframeValueCache const& {
+        auto& cached_values = effect.compositor_keyframe_value_cache(target_kind);
+        auto reference_width = target_kind == Compositor::VisualAnimation::TargetKind::Transform ? reference_box_size.width().to_float() : 0;
+        auto reference_height = target_kind == Compositor::VisualAnimation::TargetKind::Transform ? reference_box_size.height().to_float() : 0;
+        auto target_style_generation = target->element().animation_style_generation();
+        auto style_environment_version = target->document().style_environment_version();
+        if (cached_values.has_value()
+            && cached_values->key_frame_set == key_frame_set
+            && cached_values->target_style_generation == target_style_generation
+            && cached_values->style_environment_version == style_environment_version
+            && cached_values->reference_width == reference_width
+            && cached_values->reference_height == reference_height
+            && cached_values->device_pixels_per_css_pixel == device_pixels_per_css_pixel)
+            return *cached_values;
+
+        Animations::KeyframeEffect::CompositorKeyframeValueCache new_cache {
+            .key_frame_set = key_frame_set,
+            .target_style_generation = target_style_generation,
+            .style_environment_version = style_environment_version,
+            .reference_width = reference_width,
+            .reference_height = reference_height,
+            .device_pixels_per_css_pixel = device_pixels_per_css_pixel,
+            .is_valid = true,
+            .values = {},
+        };
+        new_cache.values.ensure_capacity(key_frame_set->keyframes_by_key.size());
+        for (auto const& entry : key_frame_set->keyframes_by_key) {
+            Optional<Compositor::VisualAnimationValue> value;
+            if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
+                auto property = entry.properties.get(CSS::PropertyID::Opacity);
+                if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                    new_cache.values.append({});
+                    continue;
+                }
+                auto style_value = resolved_compositor_animation_style_value(CSS::PropertyID::Opacity, property->get<CSS::RustStyleValueHandle>(), *target);
+                if (style_value) {
+                    auto opacity = compositor_opacity_animation_value(*style_value);
+                    if (opacity.has_value())
+                        value = Compositor::VisualAnimationValue { opacity.release_value() };
+                }
+            } else {
+                Compositor::VisualAnimationTransformList operations;
+                for (auto property_id : { CSS::PropertyID::Translate, CSS::PropertyID::Rotate, CSS::PropertyID::Scale, CSS::PropertyID::Transform }) {
+                    if (!effect.target_properties().contains(property_id))
+                        continue;
+                    auto property = entry.properties.get(property_id);
+                    if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                        new_cache.is_valid = false;
+                        break;
+                    }
+                    auto style_value = resolved_compositor_animation_style_value(property_id, property->get<CSS::RustStyleValueHandle>(), *target);
+                    if (!style_value) {
+                        new_cache.is_valid = false;
+                        break;
+                    }
+                    auto property_operations = compositor_transform_animation_value(property_id, *style_value, *layout_node, device_pixels_per_css_pixel);
+                    if (!property_operations.has_value()) {
+                        new_cache.is_valid = false;
+                        break;
+                    }
+                    operations.extend(property_operations.release_value());
+                }
+                if (!new_cache.is_valid)
+                    break;
+                value = Compositor::VisualAnimationValue { move(operations) };
+            }
+            if (!value.has_value()) {
+                new_cache.is_valid = false;
+                break;
+            }
+            new_cache.values.append(value.release_value());
+        }
+        cached_values = move(new_cache);
+        return *cached_values;
+    };
     auto build_animation_for_target = [&](Compositor::VisualAnimation::TargetKind target_kind) -> Optional<Compositor::VisualAnimation> {
         Vector<u32> visual_context_node_indices;
         if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
@@ -7748,7 +7865,8 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
         if (visual_context_node_indices.is_empty())
             return {};
 
-        Vector<Compositor::VisualAnimationKeyframe> keyframes;
+        Vector<Compositor::VisualAnimationEasing> keyframe_easings;
+        keyframe_easings.ensure_capacity(key_frame_set->keyframes_by_key.size());
         for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it) {
             auto const& entry = *it;
             auto composite = [&] {
@@ -7767,17 +7885,26 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             if (composite != Bindings::CompositeOperation::Replace)
                 return {};
             auto easing = compositor_animation_easing(entry, *animation);
-            auto property_id = target_kind == Compositor::VisualAnimation::TargetKind::Opacity ? CSS::PropertyID::Opacity : CSS::PropertyID::Transform;
-            auto property = entry.properties.get(property_id);
-            if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>())
-                continue;
-            auto value = compositor_animation_value(property_id, property->get<CSS::RustStyleValueHandle>(), device_pixels_per_css_pixel);
-            if (!easing.has_value() || !value.has_value())
+            if (!easing.has_value())
                 return {};
+            keyframe_easings.append(easing.release_value());
+        }
+
+        auto const& cached_values = resolved_values_for_target(target_kind);
+        if (!cached_values.is_valid)
+            return {};
+        VERIFY(cached_values.values.size() == key_frame_set->keyframes_by_key.size());
+
+        Vector<Compositor::VisualAnimationKeyframe> keyframes;
+        size_t keyframe_index = 0;
+        for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it, ++keyframe_index) {
+            auto const& value = cached_values.values[keyframe_index];
+            if (!value.has_value())
+                continue;
             keyframes.append({
                 .offset = static_cast<double>(it.key()) / (100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor),
-                .easing = easing.release_value(),
-                .value = value.release_value(),
+                .easing = keyframe_easings[keyframe_index],
+                .value = *value,
             });
         }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -27,6 +27,7 @@
 #include <LibCore/Timer.h>
 #include <LibGC/ConservativeVector.h>
 #include <LibGC/Heap.h>
+#include <LibGC/RootHashTable.h>
 #include <LibGC/RootVector.h>
 #include <LibGC/Timer.h>
 #include <LibHTTP/Cookie/Cookie.h>
@@ -708,7 +709,6 @@ void Document::record_layout_tree_build(u64 rebuilt_subtree_root_count, bool esc
 
 void Document::finalize()
 {
-    stop_animation_wakeup_timer();
     if (m_layout_node_arena)
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
     CSS::ComputedValuesFFI::rust_custom_property_registry_destroy(m_rust_custom_property_registry);
@@ -2680,12 +2680,13 @@ void Document::sample_animation_effects_needing_style_update()
 
     if (animations.is_empty()) {
         m_force_throttled_animation_style_update = false;
-        m_has_throttled_animation_style_update = false;
+        // A compositor-driven effect can remain throttled when every dirty effect was cancelled before this sample.
+        // Preserve the flag so a later style or geometry read can still request a current main-thread sample.
         return;
     }
 
     bool has_requested_observation_sample = any_of(animations, [](auto const& animation) {
-        return as_if<Animations::KeyframeEffect>(*animation->effect())->observation_sample_requested();
+        return static_cast<Animations::KeyframeEffect&>(*animation->effect()).observation_sample_requested();
     });
 
     GC::RootVector<GC::Ref<Animations::AnimationTimeline>> timelines_with_current_time_override;
@@ -2710,7 +2711,7 @@ void Document::sample_animation_effects_needing_style_update()
 
     bool has_throttled_animation_style_update = m_force_throttled_animation_style_update ? false : m_has_throttled_animation_style_update;
     for (auto& animation : animations) {
-        auto& effect = *as_if<Animations::KeyframeEffect>(*animation->effect());
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation->effect());
         bool observation_sample_requested = effect.consume_observation_sample_request();
         if (effect.can_skip_per_frame_style_update()) {
             has_throttled_animation_style_update = true;
@@ -2743,82 +2744,39 @@ void Document::flush_throttled_animation_style_update_for_node(Node const& node)
 {
     auto task_generation = relevant_settings_object().responsible_event_loop().task_generation();
     for (auto& animation : m_associated_animations) {
-        if (!animation.effect())
+        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
-        auto* effect = as_if<Animations::KeyframeEffect>(*animation.effect());
-        if (!effect)
-            continue;
-        auto target = effect->target();
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        auto target = effect.target();
         if (!target
-            || !effect->can_skip_per_frame_style_update()
-            || (!target->is_shadow_including_inclusive_ancestor_of(node) && !node.is_shadow_including_inclusive_ancestor_of(*target)))
+            || (!target->is_shadow_including_inclusive_ancestor_of(node) && !node.is_shadow_including_inclusive_ancestor_of(*target))
+            || !effect.can_skip_per_frame_style_update())
             continue;
-        if (m_is_updating_animated_style)
-            m_effects_needing_animated_style_update_after_current_update.set(*effect);
-        else
-            effect->request_element_scoped_observation_sample(task_generation);
+        if (m_is_updating_animated_style) {
+            m_effects_needing_animated_style_update_after_current_update.set(effect);
+        } else {
+            effect.request_element_scoped_observation_sample(task_generation);
+        }
     }
 }
 
-void Document::stop_animation_wakeup_timer()
+void Document::request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const& node)
 {
-    if (!m_animation_wakeup_timer)
-        return;
-    m_animation_wakeup_timer->stop();
-    m_animation_wakeup_deadline.clear();
+    VERIFY(!m_is_updating_animated_style);
+    m_is_updating_animated_style = true;
+    ScopeGuard clear_is_updating_animated_style = [&] {
+        finish_animated_style_update();
+    };
+    flush_throttled_animation_style_update_for_node(node);
 }
 
-void Document::schedule_animation_wakeup(double delay_ms)
+bool Document::run_empty_animation_style_update_for_testing(Badge<Internals::Internals>)
 {
-    auto timer_delay_ms = clamp(static_cast<i64>(ceil(delay_ms)), 1, static_cast<i64>(NumericLimits<int>::max()));
-    auto deadline = MonotonicTime::now() + AK::Duration::from_milliseconds(timer_delay_ms);
-    if (m_animation_wakeup_timer && m_animation_wakeup_timer->is_active()
-        && m_animation_wakeup_deadline.has_value() && *m_animation_wakeup_deadline <= deadline)
-        return;
-
-    m_animation_wakeup_deadline = deadline;
-    if (!m_animation_wakeup_timer) {
-        m_animation_wakeup_timer = Core::Timer::create_single_shot(static_cast<int>(timer_delay_ms), GC::weak_callback(*this, [](auto& document) {
-            document.m_animation_wakeup_deadline.clear();
-            auto timestamp = HighResolutionTime::relative_high_resolution_time(
-                HighResolutionTime::unsafe_shared_current_time(), document.relevant_settings_object().global_object());
-            Optional<double> next_wakeup_delay_ms;
-            bool reached_wakeup = false;
-            for (auto& animation : document.m_associated_animations) {
-                if (!animation.effect())
-                    continue;
-                auto* effect = as_if<Animations::KeyframeEffect>(*animation.effect());
-                if (!effect)
-                    continue;
-                if (animation.play_state() != Bindings::AnimationPlayState::Running
-                    || animation.pending()
-                    || animation.playback_rate() <= 0
-                    || !animation.timeline()
-                    || !animation.timeline()->is_monotonically_increasing()
-                    || effect->start_delay().type != Animations::TimeValue::Type::Milliseconds)
-                    continue;
-                auto timeline_time = animation.timeline()->current_time_at_timestamp(timestamp);
-                auto current_time = animation.current_time_at(timeline_time);
-                if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
-                    continue;
-                if (current_time->value < effect->start_delay().value) {
-                    auto delay = (effect->start_delay().value - current_time->value) / animation.playback_rate();
-                    if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
-                        next_wakeup_delay_ms = delay;
-                    continue;
-                }
-                effect->request_observation_sample();
-                reached_wakeup = true;
-            }
-            if (next_wakeup_delay_ms.has_value())
-                document.schedule_animation_wakeup(*next_wakeup_delay_ms);
-            if (reached_wakeup) {
-                ++document.m_style_invalidation_counters.animation_frame_pump_requests;
-                document.page().client().request_frame();
-            }
-        }));
-    }
-    m_animation_wakeup_timer->restart(static_cast<int>(timer_delay_ms));
+    VERIFY(!m_is_updating_animated_style);
+    m_needs_animated_style_update = true;
+    m_effects_needing_animated_style_update.clear();
+    sample_animation_effects_needing_style_update();
+    return m_has_throttled_animation_style_update;
 }
 
 void Document::throttled_animation_visibility_changed()
@@ -2831,11 +2789,6 @@ void Document::throttled_animation_visibility_changed()
 
 void Document::set_needs_animated_style_update(Animations::KeyframeEffect& effect)
 {
-    if (m_is_updating_animated_style) {
-        m_effects_needing_animated_style_update_after_current_update.set(effect);
-        return;
-    }
-
     m_effects_needing_animated_style_update.set(effect);
     if (m_needs_animated_style_update)
         return;
@@ -2861,16 +2814,6 @@ void Document::finish_animated_style_update()
 
     for (auto& effect : effects)
         effect->request_observation_sample();
-}
-
-void Document::request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const& node)
-{
-    VERIFY(!m_is_updating_animated_style);
-    m_is_updating_animated_style = true;
-    ScopeGuard clear_is_updating_animated_style = [&] {
-        finish_animated_style_update();
-    };
-    flush_throttled_animation_style_update_for_node(node);
 }
 
 void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates, ReadonlySpan<Layout::Box const*> boxes_needing_eager_measurement)
@@ -6058,7 +6001,6 @@ void Document::destroy()
 
     // 2. Abort document.
     abort();
-    stop_animation_wakeup_timer();
 
     // AD-HOC: Notify document observers that this document became inactive.
     //         This handles iframe-removal destruction, which doesn't otherwise go through
@@ -6540,7 +6482,6 @@ bool Document::is_allowed_to_use_feature(PolicyControlledFeature feature) const
 
 void Document::did_stop_being_active_document_in_navigable()
 {
-    stop_animation_wakeup_timer();
     clear_layout_nodes_for_inactive_document();
     tear_down_layout_tree();
 
@@ -7588,6 +7529,14 @@ void Document::disassociate_with_animation(GC::Ref<Animations::Animation> animat
     m_associated_animations.remove(animation);
 }
 
+size_t Document::associated_animation_count() const
+{
+    size_t count = 0;
+    for ([[maybe_unused]] auto& animation : m_associated_animations)
+        ++count;
+    return count;
+}
+
 static Optional<Compositor::VisualAnimationTransformOperationKind> compositor_transform_operation_kind(CSS::TransformFunction function)
 {
     using CSS::TransformFunction;
@@ -7707,6 +7656,7 @@ static Optional<Compositor::VisualAnimationValue> compositor_animation_value(CSS
     auto transformations = CSS::transformations_for_style_value(*style_value);
     if (transformations.is_empty())
         return {};
+
     Compositor::VisualAnimationTransformList operations;
     operations.ensure_capacity(transformations.size());
     for (auto const& transformation : transformations) {
@@ -7718,7 +7668,7 @@ static Optional<Compositor::VisualAnimationValue> compositor_animation_value(CSS
     return operations;
 }
 
-static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree)
+static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind)
 {
     auto animation = effect.associated_animation();
     if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running || animation->pending())
@@ -7726,7 +7676,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto timeline = animation->timeline();
     if (!timeline || !timeline->is_monotonically_increasing() || !effect.is_in_the_active_phase())
         return {};
-    if (!isinf(effect.iteration_count()) || effect.composite() != Bindings::CompositeOperation::Replace)
+    if ((!isinf(effect.iteration_count()) && effect.iteration_count() != 1) || effect.composite() != Bindings::CompositeOperation::Replace)
         return {};
     if (animation->playback_rate() <= 0 || !isfinite(animation->playback_rate()))
         return {};
@@ -7737,14 +7687,16 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto current_time = animation->current_time();
     if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
         return {};
-    if (effect.pseudo_element_type().has_value() || effect.target_properties().size() != 1)
+    if (effect.target_properties().size() != 1)
         return {};
 
     auto property_id = *effect.target_properties().begin();
-    if (!first_is_one_of(property_id, CSS::PropertyID::Opacity, CSS::PropertyID::Transform))
+    bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && property_id == CSS::PropertyID::Opacity;
+    bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && property_id == CSS::PropertyID::Transform;
+    if (!targets_opacity && !targets_transform)
         return {};
-    auto target = effect.target();
-    if (!target || target->namespace_uri() == Namespace::SVG)
+    auto target = effect.target_abstract_element();
+    if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
         return {};
     auto frame_timestamp = target->document().last_animation_frame_timestamp();
     if (!frame_timestamp.has_value())
@@ -7753,88 +7705,163 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto const* layout_node = target->unsafe_layout_node();
     if (!layout_node)
         return {};
-    if (property_id == CSS::PropertyID::Transform
-        && (layout_node->has_translate() || layout_node->has_rotate() || layout_node->has_scale()
-            || layout_node->transform_origin().z.to_px(CSSPixels { 0 }) != CSSPixels { 0 }))
-        return {};
+    if (targets_transform) {
+        if (layout_node->has_translate()
+            || layout_node->has_rotate()
+            || layout_node->has_scale()
+            || layout_node->transform_origin().z.to_px(CSSPixels { 0 }) != CSSPixels { 0 })
+            return {};
+    }
     auto const* row = Painting::committed_row(*layout_node);
     if (!row)
-        return {};
-
-    Vector<u32> visual_context_node_indices;
-    if (property_id == CSS::PropertyID::Opacity) {
-        for (auto index = row->frame_nodes_begin; index < row->frame_nodes_end; ++index) {
-            if (!visual_context_tree.frame_node_at(Painting::FrameNodeIndex { index }).data.has<Painting::EffectsData>())
-                continue;
-            visual_context_node_indices.append(index);
-        }
-    } else {
-        for (auto index = row->spatial_nodes_begin; index < row->spatial_nodes_end; ++index) {
-            auto const* transform = visual_context_tree.spatial_node_at(Painting::SpatialNodeIndex { index }).data.get_pointer<Painting::TransformData>();
-            if (!transform || transform->role != Painting::TransformDataRole::CssTransform || transform->synthetic_plane)
-                continue;
-            visual_context_node_indices.append(index);
-        }
-    }
-    if (visual_context_node_indices.is_empty())
         return {};
 
     auto const* key_frame_set = effect.key_frame_set();
     if (!key_frame_set || key_frame_set->keyframes_by_key.size() < 2)
         return {};
-    Vector<Compositor::VisualAnimationKeyframe> keyframes;
     auto device_pixels_per_css_pixel = static_cast<float>(target->document().page().client().device_pixels_per_css_pixel());
-    for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it) {
-        auto const& entry = *it;
-        auto composite = [&] {
-            switch (entry.composite) {
-            case Bindings::CompositeOperationOrAuto::Replace:
-                return Bindings::CompositeOperation::Replace;
-            case Bindings::CompositeOperationOrAuto::Add:
-                return Bindings::CompositeOperation::Add;
-            case Bindings::CompositeOperationOrAuto::Accumulate:
-                return Bindings::CompositeOperation::Accumulate;
-            case Bindings::CompositeOperationOrAuto::Auto:
-                return effect.composite();
+    auto build_animation_for_target = [&](Compositor::VisualAnimation::TargetKind target_kind) -> Optional<Compositor::VisualAnimation> {
+        Vector<u32> visual_context_node_indices;
+        if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
+            for (auto index = row->frame_nodes_begin; index < row->frame_nodes_end; ++index) {
+                auto const* effects = visual_context_tree.frame_node_at(Painting::FrameNodeIndex { index }).data.get_pointer<Painting::EffectsData>();
+                if (!effects)
+                    continue;
+                // OPTIMIZATION: The display-list recorder omits content whose current opacity is zero. Keep sampling the
+                //               animation in WebContent until a paintable sample has been retained for the compositor.
+                if (effects->opacity == 0)
+                    return {};
+                visual_context_node_indices.append(index);
             }
-            VERIFY_NOT_REACHED();
-        }();
-        if (composite != Bindings::CompositeOperation::Replace)
-            return {};
-        auto property = entry.properties.get(property_id);
-        if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
-            continue;
+        } else {
+            for (auto index = row->spatial_nodes_begin; index < row->spatial_nodes_end; ++index) {
+                auto const* transform = visual_context_tree.spatial_node_at(Painting::SpatialNodeIndex { index }).data.get_pointer<Painting::TransformData>();
+                if (!transform || transform->role != Painting::TransformDataRole::CssTransform || transform->synthetic_plane)
+                    continue;
+                // OPTIMIZATION: A stacking context with a non-invertible CSS transform is omitted from the display list.
+                //               Wait for an invertible sample before handing the animation to the compositor.
+                if (!transform->matrix.is_invertible())
+                    return {};
+                visual_context_node_indices.append(index);
+            }
         }
-        auto easing = compositor_animation_easing(entry, *animation);
-        auto value = compositor_animation_value(property_id, property->get<CSS::RustStyleValueHandle>(), device_pixels_per_css_pixel);
-        if (!easing.has_value() || !value.has_value()) {
+        if (visual_context_node_indices.is_empty())
             return {};
-        }
-        keyframes.append({
-            .offset = static_cast<double>(it.key()) / (100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor),
-            .easing = easing.release_value(),
-            .value = value.release_value(),
-        });
-    }
 
-    Compositor::VisualAnimation visual_animation {
-        .target_kind = property_id == CSS::PropertyID::Opacity
-            ? Compositor::VisualAnimation::TargetKind::Opacity
-            : Compositor::VisualAnimation::TargetKind::Transform,
-        .visual_context_node_indices = move(visual_context_node_indices),
-        .monotonic_time_at_anchor_ns = static_cast<i64>(monotonic_time_at_anchor_ms * 1'000'000.0),
-        .local_time_at_anchor_ms = current_time->value,
-        .playback_rate = animation->playback_rate(),
-        .start_delay_ms = effect.start_delay().value,
-        .iteration_duration_ms = effect.iteration_duration().value,
-        .iteration_start = effect.iteration_start(),
-        .playback_direction = static_cast<Compositor::VisualAnimationPlaybackDirection>(to_underlying(effect.playback_direction())),
-        .easing = Compositor::VisualAnimationEasing::from_css(effect.timing_function()),
-        .keyframes = move(keyframes),
+        Vector<Compositor::VisualAnimationKeyframe> keyframes;
+        for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it) {
+            auto const& entry = *it;
+            auto composite = [&] {
+                switch (entry.composite) {
+                case Bindings::CompositeOperationOrAuto::Replace:
+                    return Bindings::CompositeOperation::Replace;
+                case Bindings::CompositeOperationOrAuto::Add:
+                    return Bindings::CompositeOperation::Add;
+                case Bindings::CompositeOperationOrAuto::Accumulate:
+                    return Bindings::CompositeOperation::Accumulate;
+                case Bindings::CompositeOperationOrAuto::Auto:
+                    return effect.composite();
+                }
+                VERIFY_NOT_REACHED();
+            }();
+            if (composite != Bindings::CompositeOperation::Replace)
+                return {};
+            auto easing = compositor_animation_easing(entry, *animation);
+            auto property_id = target_kind == Compositor::VisualAnimation::TargetKind::Opacity ? CSS::PropertyID::Opacity : CSS::PropertyID::Transform;
+            auto property = entry.properties.get(property_id);
+            if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>())
+                continue;
+            auto value = compositor_animation_value(property_id, property->get<CSS::RustStyleValueHandle>(), device_pixels_per_css_pixel);
+            if (!easing.has_value() || !value.has_value())
+                return {};
+            keyframes.append({
+                .offset = static_cast<double>(it.key()) / (100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor),
+                .easing = easing.release_value(),
+                .value = value.release_value(),
+            });
+        }
+
+        Compositor::VisualAnimation visual_animation {
+            .target_kind = target_kind,
+            .visual_context_node_indices = move(visual_context_node_indices),
+            .monotonic_time_at_anchor_ns = static_cast<i64>(monotonic_time_at_anchor_ms * 1'000'000.0),
+            .local_time_at_anchor_ms = current_time->value,
+            .playback_rate = animation->playback_rate(),
+            .start_delay_ms = effect.start_delay().value,
+            .iteration_duration_ms = effect.iteration_duration().value,
+            .iteration_count = effect.iteration_count(),
+            .iteration_start = effect.iteration_start(),
+            .playback_direction = static_cast<Compositor::VisualAnimationPlaybackDirection>(to_underlying(effect.playback_direction())),
+            .easing = Compositor::VisualAnimationEasing::from_css(effect.timing_function()),
+            .keyframes = move(keyframes),
+        };
+        if (!visual_animation.is_valid())
+            return {};
+        return visual_animation;
     };
-    if (!visual_animation.is_valid())
-        return {};
-    return visual_animation;
+
+    return build_animation_for_target(target_kind);
+}
+
+void Document::schedule_compositor_animation_wakeup(double delay_ms)
+{
+    auto timer_delay_ms = clamp(static_cast<i64>(ceil(delay_ms)), 1, static_cast<i64>(NumericLimits<int>::max()));
+    auto deadline = MonotonicTime::now() + AK::Duration::from_milliseconds(timer_delay_ms);
+    if (m_compositor_animation_wakeup_timer && m_compositor_animation_wakeup_timer->is_active()
+        && m_compositor_animation_wakeup_deadline.has_value() && *m_compositor_animation_wakeup_deadline <= deadline)
+        return;
+
+    m_compositor_animation_wakeup_deadline = deadline;
+    if (!m_compositor_animation_wakeup_timer) {
+        m_compositor_animation_wakeup_timer = Core::Timer::create_single_shot(static_cast<int>(timer_delay_ms), GC::weak_callback(*this, [](auto& document) {
+            document.m_compositor_animation_wakeup_deadline.clear();
+            auto timestamp = HighResolutionTime::relative_high_resolution_time(
+                HighResolutionTime::unsafe_shared_current_time(), document.relevant_settings_object().global_object());
+            Optional<double> next_wakeup_delay_ms;
+            bool reached_wakeup = false;
+            for (auto& animation : document.m_associated_animations) {
+                if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+                    continue;
+                auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+                auto timeline_time = animation.timeline() ? animation.timeline()->current_time_at_timestamp(timestamp) : Optional<Animations::TimeValue> {};
+                auto current_time = animation.current_time_at(timeline_time);
+                if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
+                    continue;
+                if (!effect.is_compositor_driven()
+                    && !animation.pending()
+                    && animation.playback_rate() > 0
+                    && effect.start_delay().type == Animations::TimeValue::Type::Milliseconds) {
+                    if (current_time->value < effect.start_delay().value) {
+                        auto delay = (effect.start_delay().value - current_time->value) / animation.playback_rate();
+                        if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                            next_wakeup_delay_ms = delay;
+                        continue;
+                    }
+                    effect.request_observation_sample();
+                    reached_wakeup = true;
+                    continue;
+                }
+                if ((!effect.is_compositor_driven() && effect.retained_compositor_animations().is_empty()) || isinf(effect.iteration_count()))
+                    continue;
+                auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
+                if (current_time->value < active_end) {
+                    auto delay = (active_end - current_time->value) / animation.playback_rate();
+                    if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                        next_wakeup_delay_ms = delay;
+                    continue;
+                }
+                effect.request_observation_sample();
+                reached_wakeup = true;
+            }
+            if (next_wakeup_delay_ms.has_value())
+                document.schedule_compositor_animation_wakeup(*next_wakeup_delay_ms);
+            if (reached_wakeup) {
+                ++document.m_style_invalidation_counters.animation_frame_pump_requests;
+                document.page().client().request_frame();
+            }
+        }));
+    }
+    m_compositor_animation_wakeup_timer->restart(static_cast<int>(timer_delay_ms));
 }
 
 void Document::update_compositor_animations()
@@ -7842,64 +7869,132 @@ void Document::update_compositor_animations()
     auto& visual_context_tree = paint_state().visual_context_tree(*this);
     Vector<Compositor::VisualAnimation> visual_animations;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_driven_effects;
-
+    GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
+    HashMap<DOM::AbstractElement, HashMap<CSS::PropertyID, size_t>> competing_effect_counts;
+    Optional<double> compositor_animation_wakeup_delay_ms;
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
         auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
         if (effect.is_compositor_driven())
             previously_compositor_driven_effects.set(effect);
-        else
-            effect.clear_retained_compositor_animation();
+        if (!effect.retained_compositor_animations().is_empty())
+            previously_published_effects.set(effect);
         effect.set_is_compositor_driven(false);
+
+        if (animation.is_idle() || !effect.is_in_effect())
+            continue;
+        auto target = effect.target_abstract_element();
+        if (!target.has_value())
+            continue;
+        auto& property_counts = competing_effect_counts.ensure(*target);
+        for (auto property_id : effect.target_properties()) {
+            ++property_counts.ensure(property_id, [] { return 0; });
+        }
     }
 
+    bool requested_withdrawn_effect_sample = false;
+    auto schedule_active_end_wakeup = [&](Animations::KeyframeEffect const& effect, Animations::Animation const& animation) {
+        if (isinf(effect.iteration_count())
+            || effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
+            || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
+            || !animation.current_time().has_value()
+            || animation.current_time()->type != Animations::TimeValue::Type::Milliseconds
+            || animation.playback_rate() <= 0)
+            return;
+        auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
+        auto delay = (active_end - animation.current_time()->value) / animation.playback_rate();
+        if (delay > 0 && (!compositor_animation_wakeup_delay_ms.has_value() || delay < *compositor_animation_wakeup_delay_ms))
+            compositor_animation_wakeup_delay_ms = delay;
+    };
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
         auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
-        auto target = effect.target();
-        if (!target || effect.target_properties().size() != 1)
+        bool published_compositor_animation = false;
+        ScopeGuard collect_effect_bookkeeping = [&] {
+            if (!published_compositor_animation)
+                effect.clear_retained_compositor_animations();
+            bool was_throttled = previously_compositor_driven_effects.contains(GC::Ref { effect });
+            if (was_throttled && !effect.is_compositor_driven()) {
+                effect.request_observation_sample();
+                requested_withdrawn_effect_sample = true;
+            }
+        };
+        auto abstract_target = effect.target_abstract_element();
+        if (!abstract_target.has_value() || effect.target_properties().is_empty())
+            continue;
+        if (animation.is_idle() || !effect.is_in_effect())
+            continue;
+        if (effect.target_properties().size() != 1)
             continue;
         auto property_id = *effect.target_properties().begin();
-
-        size_t competing_effect_count = 0;
-        for (auto& other_animation : m_associated_animations) {
-            if (other_animation.is_idle() || !other_animation.effect() || !is<Animations::KeyframeEffect>(*other_animation.effect()))
+        bool targets_opacity = property_id == CSS::PropertyID::Opacity;
+        bool targets_transform = property_id == CSS::PropertyID::Transform;
+        if (!targets_opacity && !targets_transform)
+            continue;
+        if (targets_opacity) {
+            auto property_counts = competing_effect_counts.get(*abstract_target);
+            if (!property_counts.has_value() || property_counts->get(CSS::PropertyID::Opacity).value_or(0) != 1)
                 continue;
-            auto& other_effect = static_cast<Animations::KeyframeEffect&>(*other_animation.effect());
-            if (other_effect.target() == target
-                && other_effect.pseudo_element_type() == effect.pseudo_element_type()
-                && other_effect.is_in_effect()
-                && other_effect.target_properties().contains(property_id))
-                ++competing_effect_count;
         }
-        if (competing_effect_count != 1)
-            continue;
+        if (targets_transform) {
+            auto property_counts = competing_effect_counts.get(*abstract_target);
+            if (!property_counts.has_value() || property_counts->get(CSS::PropertyID::Transform).value_or(0) != 1)
+                continue;
+        }
 
-        auto visual_animation = build_compositor_animation(effect, visual_context_tree);
-        if (!visual_animation.has_value())
-            continue;
-        if (previously_compositor_driven_effects.contains(GC::Ref { effect })) {
-            if (auto const& retained_animation = effect.retained_compositor_animation(); retained_animation.has_value() && visual_animation->has_same_animation_parameters(*retained_animation)) {
-                visual_animation->monotonic_time_at_anchor_ns = retained_animation->monotonic_time_at_anchor_ns;
-                visual_animation->local_time_at_anchor_ms = retained_animation->local_time_at_anchor_ms;
+        Vector<Compositor::VisualAnimation> effect_visual_animations;
+        bool opacity_was_handed_off = !targets_opacity;
+        if (targets_opacity) {
+            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Opacity);
+            if (visual_animation.has_value()) {
+                effect_visual_animations.append(visual_animation.release_value());
+                opacity_was_handed_off = true;
             }
         }
-        effect.set_is_compositor_driven(true);
-        effect.set_retained_compositor_animation(*visual_animation);
-        visual_animations.append(visual_animation.release_value());
+        bool transform_was_handed_off = !targets_transform;
+        if (targets_transform) {
+            auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Transform);
+            if (visual_animation.has_value()) {
+                effect_visual_animations.append(visual_animation.release_value());
+                transform_was_handed_off = true;
+            }
+        }
+        if (effect_visual_animations.is_empty()) {
+            continue;
+        }
+        // OPTIMIZATION: Ordinary rendering updates advance the WebContent timeline without changing compositor
+        //               playback. Retain the existing descriptor and its anchor unless the effect was invalidated or
+        //               one of its non-anchor parameters changed.
+        if (previously_published_effects.contains(GC::Ref { effect })) {
+            for (auto& visual_animation : effect_visual_animations) {
+                for (auto const& retained_animation : effect.retained_compositor_animations()) {
+                    if (!visual_animation.has_same_animation_parameters(retained_animation))
+                        continue;
+                    visual_animation.monotonic_time_at_anchor_ns = retained_animation.monotonic_time_at_anchor_ns;
+                    visual_animation.local_time_at_anchor_ms = retained_animation.local_time_at_anchor_ms;
+                    break;
+                }
+            }
+        }
+        if (opacity_was_handed_off && transform_was_handed_off)
+            effect.set_is_compositor_driven(true);
+        schedule_active_end_wakeup(effect, animation);
+        for (auto const& visual_animation : effect_visual_animations)
+            visual_animations.append(visual_animation);
+        effect.set_retained_compositor_animations(move(effect_visual_animations));
+        published_compositor_animation = true;
     }
 
     paint_state().set_visual_animations(*this, move(visual_animations));
-}
 
-size_t Document::associated_animation_count() const
-{
-    size_t count = 0;
-    for ([[maybe_unused]] auto& animation : m_associated_animations)
-        ++count;
-    return count;
+    if (compositor_animation_wakeup_delay_ms.has_value())
+        schedule_compositor_animation_wakeup(*compositor_animation_wakeup_delay_ms);
+
+    if (requested_withdrawn_effect_sample) {
+        ++m_style_invalidation_counters.animation_frame_pump_requests;
+    }
 }
 
 void Document::append_pending_animation_event(Web::DOM::Document::PendingAnimationEvent const& event)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7855,10 +7855,6 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 auto const* effects = visual_context_tree.frame_node_at(Painting::FrameNodeIndex { index }).data.get_pointer<Painting::EffectsData>();
                 if (!effects)
                     continue;
-                // OPTIMIZATION: The display-list recorder omits content whose current opacity is zero. Keep sampling the
-                //               animation in WebContent until a paintable sample has been retained for the compositor.
-                if (effects->opacity == 0)
-                    return {};
                 visual_context_node_indices.append(index);
             }
         } else {
@@ -7866,10 +7862,6 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 auto const* transform = visual_context_tree.spatial_node_at(Painting::SpatialNodeIndex { index }).data.get_pointer<Painting::TransformData>();
                 if (!transform || transform->role != Painting::TransformDataRole::CssTransform || transform->synthetic_plane)
                     continue;
-                // OPTIMIZATION: A stacking context with a non-invertible CSS transform is omitted from the display list.
-                //               Wait for an invertible sample before handing the animation to the compositor.
-                if (!transform->matrix.is_invertible())
-                    return {};
                 visual_context_node_indices.append(index);
             }
         }
@@ -8033,6 +8025,10 @@ void Document::update_compositor_animations()
             previously_compositor_replaced_effects.set(effect);
         if (!effect.retained_compositor_animations().is_empty())
             previously_published_effects.set(effect);
+        if (auto target = effect.target_abstract_element(); target.has_value()) {
+            if (auto* layout_node = target->unsafe_layout_node())
+                layout_node->set_retains_compositor_animated_content(false);
+        }
         effect.set_is_compositor_driven(false);
         effect.set_is_compositor_replaced(false);
 
@@ -8178,6 +8174,8 @@ void Document::update_compositor_animations()
         for (auto const& visual_animation : effect_visual_animations)
             visual_animations.append(visual_animation);
         effect.set_retained_compositor_animations(move(effect_visual_animations));
+        if (auto* layout_node = abstract_target->unsafe_layout_node())
+            layout_node->set_retains_compositor_animated_content(true);
         published_compositor_animation = true;
     }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7746,6 +7746,10 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto target = effect.target();
     if (!target || target->namespace_uri() == Namespace::SVG)
         return {};
+    auto frame_timestamp = target->document().last_animation_frame_timestamp();
+    if (!frame_timestamp.has_value())
+        return {};
+    auto monotonic_time_at_anchor_ms = *frame_timestamp + target->document().relevant_settings_object().time_origin();
     auto const* layout_node = target->unsafe_layout_node();
     if (!layout_node)
         return {};
@@ -7818,7 +7822,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             ? Compositor::VisualAnimation::TargetKind::Opacity
             : Compositor::VisualAnimation::TargetKind::Transform,
         .visual_context_node_indices = move(visual_context_node_indices),
-        .monotonic_time_at_anchor_ns = MonotonicTime::now().nanoseconds(),
+        .monotonic_time_at_anchor_ns = static_cast<i64>(monotonic_time_at_anchor_ms * 1'000'000.0),
         .local_time_at_anchor_ms = current_time->value,
         .playback_rate = animation->playback_rate(),
         .start_delay_ms = effect.start_delay().value,
@@ -7837,11 +7841,17 @@ void Document::update_compositor_animations()
 {
     auto& visual_context_tree = paint_state().visual_context_tree(*this);
     Vector<Compositor::VisualAnimation> visual_animations;
+    GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_driven_effects;
 
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
             continue;
-        static_cast<Animations::KeyframeEffect&>(*animation.effect()).set_is_compositor_driven(false);
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        if (effect.is_compositor_driven())
+            previously_compositor_driven_effects.set(effect);
+        else
+            effect.clear_retained_compositor_animation();
+        effect.set_is_compositor_driven(false);
     }
 
     for (auto& animation : m_associated_animations) {
@@ -7870,7 +7880,14 @@ void Document::update_compositor_animations()
         auto visual_animation = build_compositor_animation(effect, visual_context_tree);
         if (!visual_animation.has_value())
             continue;
+        if (previously_compositor_driven_effects.contains(GC::Ref { effect })) {
+            if (auto const& retained_animation = effect.retained_compositor_animation(); retained_animation.has_value() && visual_animation->has_same_animation_parameters(*retained_animation)) {
+                visual_animation->monotonic_time_at_anchor_ns = retained_animation->monotonic_time_at_anchor_ns;
+                visual_animation->local_time_at_anchor_ms = retained_animation->local_time_at_anchor_ms;
+            }
+        }
         effect.set_is_compositor_driven(true);
+        effect.set_retained_compositor_animation(*visual_animation);
         visual_animations.append(visual_animation.release_value());
     }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/Bindings/Document.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
+#include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/CSS/CSSImportRule.h>
@@ -62,6 +63,7 @@
 #include <LibWeb/CSS/Invalidation/LinkInvalidator.h>
 #include <LibWeb/CSS/Invalidation/MediaQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/PseudoClassInvalidator.h>
+#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>
 #include <LibWeb/CSS/Parser/Parser.h>
@@ -74,10 +76,13 @@
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/OpacityValueStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RandomValueSharingStyleValue.h>
+#include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/Compositor/VisualAnimation.h>
 #include <LibWeb/ComputedValuesRustFFI.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/ContentSecurityPolicy/Policy.h>
@@ -7581,6 +7586,295 @@ void Document::disassociate_with_animation(GC::Ref<Animations::Animation> animat
         m_effects_needing_animated_style_update_after_current_update.remove(effect);
     }
     m_associated_animations.remove(animation);
+}
+
+static Optional<Compositor::VisualAnimationTransformOperationKind> compositor_transform_operation_kind(CSS::TransformFunction function)
+{
+    using CSS::TransformFunction;
+    using Kind = Compositor::VisualAnimationTransformOperationKind;
+    switch (function) {
+    case TransformFunction::Translate:
+        return Kind::Translate;
+    case TransformFunction::Translate3d:
+        return Kind::Translate3d;
+    case TransformFunction::TranslateX:
+        return Kind::TranslateX;
+    case TransformFunction::TranslateY:
+        return Kind::TranslateY;
+    case TransformFunction::TranslateZ:
+        return Kind::TranslateZ;
+    case TransformFunction::Scale:
+        return Kind::Scale;
+    case TransformFunction::Scale3d:
+        return Kind::Scale3d;
+    case TransformFunction::ScaleX:
+        return Kind::ScaleX;
+    case TransformFunction::ScaleY:
+        return Kind::ScaleY;
+    case TransformFunction::ScaleZ:
+        return Kind::ScaleZ;
+    case TransformFunction::Rotate:
+        return Kind::Rotate;
+    case TransformFunction::RotateX:
+        return Kind::RotateX;
+    case TransformFunction::RotateY:
+        return Kind::RotateY;
+    case TransformFunction::RotateZ:
+        return Kind::RotateZ;
+    case TransformFunction::Skew:
+        return Kind::Skew;
+    case TransformFunction::SkewX:
+        return Kind::SkewX;
+    case TransformFunction::SkewY:
+        return Kind::SkewY;
+    case TransformFunction::Matrix:
+    case TransformFunction::Matrix3d:
+    case TransformFunction::Perspective:
+    case TransformFunction::Rotate3d:
+        return {};
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static Optional<Compositor::VisualAnimationTransformOperation> compositor_transform_operation(CSS::TransformationStyleValue const& transformation, float device_pixels_per_css_pixel)
+{
+    if (!transformation.can_be_converted_to_matrix_without_reference_box())
+        return {};
+    auto kind = compositor_transform_operation_kind(transformation.transform_function());
+    if (!kind.has_value())
+        return {};
+
+    auto metadata = CSS::transform_function_metadata(transformation.transform_function());
+    auto style_values = transformation.values();
+    Vector<float> values;
+    values.ensure_capacity(style_values.size());
+    for (size_t index = 0; index < style_values.size(); ++index) {
+        auto const& style_value = style_values[index];
+        auto value = [&]() -> float {
+            switch (metadata.parameters[index].type) {
+            case CSS::TransformFunctionParameterType::Angle:
+                return CSS::Angle::from_style_value(style_value, {}).to_radians();
+            case CSS::TransformFunctionParameterType::Length:
+            case CSS::TransformFunctionParameterType::LengthNone:
+            case CSS::TransformFunctionParameterType::LengthPercentage:
+                return CSS::Length::from_style_value(style_value, {}).absolute_length_to_px().to_float() * device_pixels_per_css_pixel;
+            case CSS::TransformFunctionParameterType::Number:
+            case CSS::TransformFunctionParameterType::NumberPercentage:
+                return CSS::number_from_style_value(style_value, 1);
+            }
+            VERIFY_NOT_REACHED();
+        }();
+        if (!isfinite(value))
+            return {};
+        values.unchecked_append(value);
+    }
+    Compositor::VisualAnimationTransformOperation operation { *kind, move(values) };
+    if (!operation.is_valid())
+        return {};
+    return operation;
+}
+
+static Optional<Compositor::VisualAnimationEasing> compositor_animation_easing(Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame const& keyframe, Animations::Animation const& animation)
+{
+    return keyframe.easing.visit(
+        [&](Empty) -> Optional<Compositor::VisualAnimationEasing> {
+            auto easing = animation.is_css_animation()
+                ? static_cast<CSS::CSSAnimation const&>(animation).default_easing()
+                : CSS::EasingFunction::linear();
+            return Compositor::VisualAnimationEasing::from_css(easing);
+        },
+        [](CSS::EasingFunction const& easing) -> Optional<Compositor::VisualAnimationEasing> {
+            return Compositor::VisualAnimationEasing::from_css(easing);
+        },
+        [](CSS::RustStyleValueHandle const&) -> Optional<Compositor::VisualAnimationEasing> {
+            return {};
+        });
+}
+
+static Optional<Compositor::VisualAnimationValue> compositor_animation_value(CSS::PropertyID property_id, CSS::RustStyleValueHandle const& value, float device_pixels_per_css_pixel)
+{
+    auto style_value = CSS::StyleValue::adopt_rust_style_value_data(CSS::StyleValueFFI::rust_style_value_retain(value.data()));
+    if (property_id == CSS::PropertyID::Opacity) {
+        if (!style_value->is_opacity_value())
+            return {};
+        auto opacity = style_value->as_opacity_value().resolved();
+        if (!isfinite(opacity))
+            return {};
+        return opacity;
+    }
+
+    VERIFY(property_id == CSS::PropertyID::Transform);
+    auto transformations = CSS::transformations_for_style_value(*style_value);
+    if (transformations.is_empty())
+        return {};
+    Compositor::VisualAnimationTransformList operations;
+    operations.ensure_capacity(transformations.size());
+    for (auto const& transformation : transformations) {
+        auto operation = compositor_transform_operation(*transformation, device_pixels_per_css_pixel);
+        if (!operation.has_value())
+            return {};
+        operations.unchecked_append(operation.release_value());
+    }
+    return operations;
+}
+
+static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree)
+{
+    auto animation = effect.associated_animation();
+    if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running || animation->pending())
+        return {};
+    auto timeline = animation->timeline();
+    if (!timeline || !timeline->is_monotonically_increasing() || !effect.is_in_the_active_phase())
+        return {};
+    if (!isinf(effect.iteration_count()) || effect.composite() != Bindings::CompositeOperation::Replace)
+        return {};
+    if (animation->playback_rate() <= 0 || !isfinite(animation->playback_rate()))
+        return {};
+    if (effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
+        || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
+        || effect.iteration_duration().value <= 0)
+        return {};
+    auto current_time = animation->current_time();
+    if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
+        return {};
+    if (effect.pseudo_element_type().has_value() || effect.target_properties().size() != 1)
+        return {};
+
+    auto property_id = *effect.target_properties().begin();
+    if (!first_is_one_of(property_id, CSS::PropertyID::Opacity, CSS::PropertyID::Transform))
+        return {};
+    auto target = effect.target();
+    if (!target || target->namespace_uri() == Namespace::SVG)
+        return {};
+    auto const* layout_node = target->unsafe_layout_node();
+    if (!layout_node)
+        return {};
+    if (property_id == CSS::PropertyID::Transform
+        && (layout_node->has_translate() || layout_node->has_rotate() || layout_node->has_scale()
+            || layout_node->transform_origin().z.to_px(CSSPixels { 0 }) != CSSPixels { 0 }))
+        return {};
+    auto const* row = Painting::committed_row(*layout_node);
+    if (!row)
+        return {};
+
+    Vector<u32> visual_context_node_indices;
+    if (property_id == CSS::PropertyID::Opacity) {
+        for (auto index = row->frame_nodes_begin; index < row->frame_nodes_end; ++index) {
+            if (!visual_context_tree.frame_node_at(Painting::FrameNodeIndex { index }).data.has<Painting::EffectsData>())
+                continue;
+            visual_context_node_indices.append(index);
+        }
+    } else {
+        for (auto index = row->spatial_nodes_begin; index < row->spatial_nodes_end; ++index) {
+            auto const* transform = visual_context_tree.spatial_node_at(Painting::SpatialNodeIndex { index }).data.get_pointer<Painting::TransformData>();
+            if (!transform || transform->role != Painting::TransformDataRole::CssTransform || transform->synthetic_plane)
+                continue;
+            visual_context_node_indices.append(index);
+        }
+    }
+    if (visual_context_node_indices.is_empty())
+        return {};
+
+    auto const* key_frame_set = effect.key_frame_set();
+    if (!key_frame_set || key_frame_set->keyframes_by_key.size() < 2)
+        return {};
+    Vector<Compositor::VisualAnimationKeyframe> keyframes;
+    auto device_pixels_per_css_pixel = static_cast<float>(target->document().page().client().device_pixels_per_css_pixel());
+    for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it) {
+        auto const& entry = *it;
+        auto composite = [&] {
+            switch (entry.composite) {
+            case Bindings::CompositeOperationOrAuto::Replace:
+                return Bindings::CompositeOperation::Replace;
+            case Bindings::CompositeOperationOrAuto::Add:
+                return Bindings::CompositeOperation::Add;
+            case Bindings::CompositeOperationOrAuto::Accumulate:
+                return Bindings::CompositeOperation::Accumulate;
+            case Bindings::CompositeOperationOrAuto::Auto:
+                return effect.composite();
+            }
+            VERIFY_NOT_REACHED();
+        }();
+        if (composite != Bindings::CompositeOperation::Replace)
+            return {};
+        auto property = entry.properties.get(property_id);
+        if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+            continue;
+        }
+        auto easing = compositor_animation_easing(entry, *animation);
+        auto value = compositor_animation_value(property_id, property->get<CSS::RustStyleValueHandle>(), device_pixels_per_css_pixel);
+        if (!easing.has_value() || !value.has_value()) {
+            return {};
+        }
+        keyframes.append({
+            .offset = static_cast<double>(it.key()) / (100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor),
+            .easing = easing.release_value(),
+            .value = value.release_value(),
+        });
+    }
+
+    Compositor::VisualAnimation visual_animation {
+        .target_kind = property_id == CSS::PropertyID::Opacity
+            ? Compositor::VisualAnimation::TargetKind::Opacity
+            : Compositor::VisualAnimation::TargetKind::Transform,
+        .visual_context_node_indices = move(visual_context_node_indices),
+        .monotonic_time_at_anchor_ns = MonotonicTime::now().nanoseconds(),
+        .local_time_at_anchor_ms = current_time->value,
+        .playback_rate = animation->playback_rate(),
+        .start_delay_ms = effect.start_delay().value,
+        .iteration_duration_ms = effect.iteration_duration().value,
+        .iteration_start = effect.iteration_start(),
+        .playback_direction = static_cast<Compositor::VisualAnimationPlaybackDirection>(to_underlying(effect.playback_direction())),
+        .easing = Compositor::VisualAnimationEasing::from_css(effect.timing_function()),
+        .keyframes = move(keyframes),
+    };
+    if (!visual_animation.is_valid())
+        return {};
+    return visual_animation;
+}
+
+void Document::update_compositor_animations()
+{
+    auto& visual_context_tree = paint_state().visual_context_tree(*this);
+    Vector<Compositor::VisualAnimation> visual_animations;
+
+    for (auto& animation : m_associated_animations) {
+        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+            continue;
+        static_cast<Animations::KeyframeEffect&>(*animation.effect()).set_is_compositor_driven(false);
+    }
+
+    for (auto& animation : m_associated_animations) {
+        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+            continue;
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        auto target = effect.target();
+        if (!target || effect.target_properties().size() != 1)
+            continue;
+        auto property_id = *effect.target_properties().begin();
+
+        size_t competing_effect_count = 0;
+        for (auto& other_animation : m_associated_animations) {
+            if (other_animation.is_idle() || !other_animation.effect() || !is<Animations::KeyframeEffect>(*other_animation.effect()))
+                continue;
+            auto& other_effect = static_cast<Animations::KeyframeEffect&>(*other_animation.effect());
+            if (other_effect.target() == target
+                && other_effect.pseudo_element_type() == effect.pseudo_element_type()
+                && other_effect.is_in_effect()
+                && other_effect.target_properties().contains(property_id))
+                ++competing_effect_count;
+        }
+        if (competing_effect_count != 1)
+            continue;
+
+        auto visual_animation = build_compositor_animation(effect, visual_context_tree);
+        if (!visual_animation.has_value())
+            continue;
+        effect.set_is_compositor_driven(true);
+        visual_animations.append(visual_animation.release_value());
+    }
+
+    paint_state().set_visual_animations(*this, move(visual_animations));
 }
 
 size_t Document::associated_animation_count() const

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6764,7 +6764,7 @@ void Document::queue_an_intersection_observer_entry(IntersectionObserver::Inters
 }
 
 // https://www.w3.org/TR/intersection-observer/#compute-the-intersection
-static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect target_rect, IntersectionObserver::IntersectionObserver const& observer, Layout::Box const* root_layout_box, CSSPixelRect const& root_bounds)
+static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect target_rect, IntersectionObserver::IntersectionObserver const& observer, Layout::Box const* root_layout_box, CSSPixelRect const& root_bounds, Painting::AccumulatedVisualContextTree const& visual_context_tree)
 {
     // 1. Let intersectionRect be the result of getting the bounding box for target.
     auto intersection_rect = target_rect;
@@ -6797,7 +6797,7 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect t
             auto overflow_y = container_box->overflow_y();
             bool has_content_clip = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
             if (has_content_clip) {
-                auto clip_rect = Painting::transform_rect_to_viewport(*container_box, Painting::absolute_padding_box_rect(*container_box), Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
+                auto clip_rect = Painting::transform_rect_to_viewport(*container_box, Painting::absolute_padding_box_rect(*container_box), visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No);
 
                 // Apply scroll margin to expand the scrollport for scroll containers.
                 auto& scroll_margin = observer.scroll_margin_values();
@@ -6839,9 +6839,31 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
 
     update_paint_and_hit_testing_properties_if_needed();
 
+    HashMap<Document*, Painting::AccumulatedVisualContextTree::VisualAnimationOriginalValues> observation_visual_animation_original_values;
+    ScopeGuard restore_observation_visual_context_trees = [&] {
+        for (auto& entry : observation_visual_animation_original_values)
+            entry.key->paint_state().visual_context_tree(*entry.key).restore_visual_animation_original_values(entry.value);
+    };
+    auto sample_time_ns = MonotonicTime::now().nanoseconds();
+    auto sampled_visual_context_tree = [&](Document& document) -> Optional<Painting::AccumulatedVisualContextTree const&> {
+        if (!document.m_paint_state)
+            return {};
+        auto& committed_tree = document.paint_state().visual_context_tree(document);
+        if (committed_tree.visual_animations().is_empty())
+            return committed_tree;
+        if (!observation_visual_animation_original_values.contains(&document)) {
+            auto& original_values = observation_visual_animation_original_values.ensure(&document);
+            committed_tree.sample_visual_animations(sample_time_ns, original_values);
+        }
+        return committed_tree;
+    };
+
     for (auto& observer : intersection_observers) {
         // 1. Let rootBounds be observer’s root intersection rectangle.
-        auto root_bounds = observer->root_intersection_rectangle();
+        auto root_visual_context_tree = sampled_visual_context_tree(observer->intersection_root_node()->document());
+        if (!root_visual_context_tree.has_value())
+            continue;
+        auto root_bounds = observer->root_intersection_rectangle(&*root_visual_context_tree);
 
         // Pre-compute per-observer values to avoid repeated work in the per-target loop.
         auto intersection_root_node = observer->intersection_root_node();
@@ -6881,12 +6903,16 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
             // AD-HOC: A target whose document was excluded from this rendering update has stale layout; treat it as
             //         not intersecting like other engines instead of reading its geometry.
             if (target->document().layout_is_up_to_date() && target->layout_node() && (is_implicit_root || &target->document() == &intersection_root_node->document()) && !(root_is_element && !target->is_descendant_of(*intersection_root_node))) {
+                auto target_visual_context_tree = sampled_visual_context_tree(target->document());
+                if (!target_visual_context_tree.has_value())
+                    continue;
+
                 // 4. Set targetRect to the DOMRectReadOnly obtained by getting the bounding box for target.
-                target_rect = target->bounding_client_rect_assuming_layout_clean();
+                target_rect = target->bounding_client_rect_assuming_layout_clean(*target_visual_context_tree);
 
                 // 5. Let intersectionRect be the result of running the compute the intersection algorithm on target and
                 //    observer’s intersection root.
-                intersection_rect = compute_intersection(target, target_rect, *observer, root_layout_box, root_bounds);
+                intersection_rect = compute_intersection(target, target_rect, *observer, root_layout_box, root_bounds, *target_visual_context_tree);
 
                 // 6. Let targetArea be targetRect’s area.
                 auto target_area = target_rect.width() * target_rect.height();
@@ -8295,6 +8321,7 @@ void Document::update_compositor_animations()
         }
         effect.set_is_compositor_driven(false);
         effect.set_is_compositor_replaced(false);
+        effect.set_is_observation_relevant_compositor_animation(false);
 
         if (animation.is_idle() || !effect.is_in_effect())
             continue;
@@ -8335,6 +8362,7 @@ void Document::update_compositor_animations()
         validate_winner(effects.transform);
     }
 
+    bool has_observation_relevant_compositor_animation = false;
     bool requested_withdrawn_effect_sample = false;
     auto schedule_active_end_wakeup = [&](Animations::KeyframeEffect const& effect, Animations::Animation const& animation) {
         if (isinf(effect.iteration_count())
@@ -8357,6 +8385,8 @@ void Document::update_compositor_animations()
         ScopeGuard collect_effect_bookkeeping = [&] {
             if (!published_compositor_animation)
                 effect.clear_retained_compositor_animations();
+            if (effect.is_observation_relevant_compositor_animation())
+                has_observation_relevant_compositor_animation = true;
             bool was_throttled = previously_compositor_driven_effects.contains(GC::Ref { effect })
                 || previously_compositor_replaced_effects.contains(GC::Ref { effect });
             if (was_throttled && !effect.is_compositor_driven() && !effect.is_compositor_replaced()) {
@@ -8447,8 +8477,6 @@ void Document::update_compositor_animations()
         if (effect_visual_animations.is_empty()) {
             continue;
         }
-        if (transform_affects_observation)
-            continue;
         // OPTIMIZATION: Ordinary rendering updates advance the WebContent timeline without changing compositor
         //               playback. Retain the existing descriptor and its anchor unless the effect was invalidated or
         //               one of its non-anchor parameters changed.
@@ -8465,6 +8493,7 @@ void Document::update_compositor_animations()
         }
         if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && transform_was_handed_off)
             effect.set_is_compositor_driven(true);
+        effect.set_is_observation_relevant_compositor_animation(transform_affects_observation);
         schedule_active_end_wakeup(effect, animation);
         for (auto const& visual_animation : effect_visual_animations)
             visual_animations.append(visual_animation);
@@ -8478,6 +8507,22 @@ void Document::update_compositor_animations()
 
     if (compositor_animation_wakeup_delay_ms.has_value())
         schedule_compositor_animation_wakeup(*compositor_animation_wakeup_delay_ms);
+
+    if (!has_observation_relevant_compositor_animation) {
+        if (m_compositor_animation_observation_timer)
+            m_compositor_animation_observation_timer->stop();
+    } else {
+        if (!m_compositor_animation_observation_timer) {
+            m_compositor_animation_observation_timer = Core::Timer::create_single_shot(100, GC::weak_callback(*this, [](auto& document) {
+                ++document.m_style_invalidation_counters.animation_frame_pump_requests;
+                document.page().client().request_frame();
+                document.m_compositor_animation_observation_timer->start();
+            }));
+        }
+        if (!m_compositor_animation_observation_timer->is_active()) {
+            m_compositor_animation_observation_timer->start();
+        }
+    }
 
     if (requested_withdrawn_effect_sample) {
         ++m_style_invalidation_counters.animation_frame_pump_requests;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7979,7 +7979,10 @@ void Document::schedule_compositor_animation_wakeup(double delay_ms)
                     reached_wakeup = true;
                     continue;
                 }
-                if ((!effect.is_compositor_driven() && effect.retained_compositor_animations().is_empty()) || isinf(effect.iteration_count()))
+                bool is_compositor_handled = effect.is_compositor_driven()
+                    || effect.is_compositor_replaced()
+                    || !effect.retained_compositor_animations().is_empty();
+                if (!is_compositor_handled || isinf(effect.iteration_count()))
                     continue;
                 auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
                 if (current_time->value < active_end) {
@@ -8004,12 +8007,21 @@ void Document::schedule_compositor_animation_wakeup(double delay_ms)
 
 void Document::update_compositor_animations()
 {
+    struct CompetingPropertyEffects {
+        GC::Ptr<Animations::KeyframeEffect> winner;
+        bool all_effects_use_replace { true };
+    };
+    struct CompetingEffects {
+        CompetingPropertyEffects opacity;
+        CompetingPropertyEffects transform;
+    };
+
     auto& visual_context_tree = paint_state().visual_context_tree(*this);
     Vector<Compositor::VisualAnimation> visual_animations;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_driven_effects;
+    GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_compositor_replaced_effects;
     GC::RootHashTable<GC::Ref<Animations::KeyframeEffect>> previously_published_effects;
-    HashMap<DOM::AbstractElement, HashMap<CSS::PropertyID, size_t>> competing_effect_counts;
-    HashMap<DOM::AbstractElement, size_t> transform_family_effect_counts;
+    HashMap<DOM::AbstractElement, CompetingEffects> competing_effects;
     Optional<double> compositor_animation_wakeup_delay_ms;
     for (auto& animation : m_associated_animations) {
         if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
@@ -8017,24 +8029,50 @@ void Document::update_compositor_animations()
         auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
         if (effect.is_compositor_driven())
             previously_compositor_driven_effects.set(effect);
+        if (effect.is_compositor_replaced())
+            previously_compositor_replaced_effects.set(effect);
         if (!effect.retained_compositor_animations().is_empty())
             previously_published_effects.set(effect);
         effect.set_is_compositor_driven(false);
+        effect.set_is_compositor_replaced(false);
 
         if (animation.is_idle() || !effect.is_in_effect())
             continue;
         auto target = effect.target_abstract_element();
         if (!target.has_value())
             continue;
-        auto& property_counts = competing_effect_counts.ensure(*target);
-        bool targets_transform_family = false;
-        for (auto property_id : effect.target_properties()) {
-            ++property_counts.ensure(property_id, [] { return 0; });
-            if (is_transform_family_property(property_id))
-                targets_transform_family = true;
-        }
-        if (targets_transform_family)
-            ++transform_family_effect_counts.ensure(*target, [] { return 0; });
+        auto& effects = competing_effects.ensure(*target);
+        auto add_competing_effect = [&](CompetingPropertyEffects& property_effects) {
+            if (effect.composite() != Bindings::CompositeOperation::Replace)
+                property_effects.all_effects_use_replace = false;
+            if (!property_effects.winner || Animations::KeyframeEffect::composite_order(*property_effects.winner, effect) < 0)
+                property_effects.winner = effect;
+        };
+        if (effect.target_properties().contains(CSS::PropertyID::Opacity))
+            add_competing_effect(effects.opacity);
+        if (any_of(effect.target_properties(), is_transform_family_property))
+            add_competing_effect(effects.transform);
+    }
+
+    auto winner_uses_replace_keyframes = [](Animations::KeyframeEffect& effect) {
+        auto const* key_frame_set = effect.key_frame_set();
+        if (!key_frame_set)
+            return false;
+        return all_of(key_frame_set->keyframes_by_key, [](auto const& entry) {
+            return first_is_one_of(entry.composite,
+                Bindings::CompositeOperationOrAuto::Auto,
+                Bindings::CompositeOperationOrAuto::Replace);
+        });
+    };
+    for (auto& [target, effects] : competing_effects) {
+        (void)target;
+        auto validate_winner = [&](CompetingPropertyEffects& property_effects) {
+            if (!property_effects.all_effects_use_replace
+                || (property_effects.winner && !winner_uses_replace_keyframes(*property_effects.winner)))
+                property_effects.winner = nullptr;
+        };
+        validate_winner(effects.opacity);
+        validate_winner(effects.transform);
     }
 
     bool requested_withdrawn_effect_sample = false;
@@ -8059,8 +8097,9 @@ void Document::update_compositor_animations()
         ScopeGuard collect_effect_bookkeeping = [&] {
             if (!published_compositor_animation)
                 effect.clear_retained_compositor_animations();
-            bool was_throttled = previously_compositor_driven_effects.contains(GC::Ref { effect });
-            if (was_throttled && !effect.is_compositor_driven()) {
+            bool was_throttled = previously_compositor_driven_effects.contains(GC::Ref { effect })
+                || previously_compositor_replaced_effects.contains(GC::Ref { effect });
+            if (was_throttled && !effect.is_compositor_driven() && !effect.is_compositor_replaced()) {
                 effect.request_observation_sample();
                 requested_withdrawn_effect_sample = true;
             }
@@ -8075,25 +8114,41 @@ void Document::update_compositor_animations()
         bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); });
         if (targets_unsupported_property)
             continue;
-        if (targets_opacity) {
-            auto property_counts = competing_effect_counts.get(*abstract_target);
-            if (!property_counts.has_value() || property_counts->get(CSS::PropertyID::Opacity).value_or(0) != 1)
-                continue;
-        }
-        if (targets_transform && transform_family_effect_counts.get(*abstract_target).value_or(0) != 1)
+        auto target_effects = competing_effects.get(*abstract_target);
+        VERIFY(target_effects.has_value());
+        bool opacity_has_replace_winner = !targets_opacity || target_effects->opacity.winner;
+        bool transform_has_replace_winner = !targets_transform || target_effects->transform.winner;
+        bool selected_for_opacity = targets_opacity && target_effects->opacity.winner.ptr() == &effect;
+        bool selected_for_transform = targets_transform && target_effects->transform.winner.ptr() == &effect;
+        bool all_targeted_properties_have_replace_winners = opacity_has_replace_winner && transform_has_replace_winner;
+
+        if (!selected_for_opacity && !selected_for_transform) {
+            bool can_throttle_replaced_effect = animation.play_state() == Bindings::AnimationPlayState::Running
+                && !animation.pending()
+                && animation.playback_rate() > 0
+                && animation.timeline() && animation.timeline()->is_monotonically_increasing()
+                && effect.is_in_the_active_phase()
+                && (isinf(effect.iteration_count()) || effect.iteration_count() == 1)
+                && effect.start_delay().type == Animations::TimeValue::Type::Milliseconds
+                && effect.iteration_duration().type == Animations::TimeValue::Type::Milliseconds;
+            if (all_targeted_properties_have_replace_winners && can_throttle_replaced_effect) {
+                effect.set_is_compositor_replaced(true);
+                schedule_active_end_wakeup(effect, animation);
+            }
             continue;
+        }
 
         Vector<Compositor::VisualAnimation> effect_visual_animations;
-        bool opacity_was_handed_off = !targets_opacity;
-        if (targets_opacity) {
+        bool opacity_was_handed_off = !selected_for_opacity;
+        if (selected_for_opacity) {
             auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Opacity);
             if (visual_animation.has_value()) {
                 effect_visual_animations.append(visual_animation.release_value());
                 opacity_was_handed_off = true;
             }
         }
-        bool transform_was_handed_off = !targets_transform;
-        if (targets_transform) {
+        bool transform_was_handed_off = !selected_for_transform;
+        if (selected_for_transform) {
             auto visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Transform);
             if (visual_animation.has_value()) {
                 effect_visual_animations.append(visual_animation.release_value());
@@ -8117,7 +8172,7 @@ void Document::update_compositor_animations()
                 }
             }
         }
-        if (opacity_was_handed_off && transform_was_handed_off)
+        if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && transform_was_handed_off)
             effect.set_is_compositor_driven(true);
         schedule_active_end_wakeup(effect, animation);
         for (auto const& visual_animation : effect_visual_animations)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1844,6 +1844,7 @@ private:
     RefPtr<Core::Timer> m_active_refresh_timer;
     RefPtr<Core::Timer> m_compositor_animation_wakeup_timer;
     Optional<MonotonicTime> m_compositor_animation_wakeup_deadline;
+    RefPtr<Core::Timer> m_compositor_animation_observation_timer;
 
     bool m_temporary_document_for_fragment_parsing { false };
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -472,8 +472,9 @@ public:
     void note_throttled_animation_style_update() { m_has_throttled_animation_style_update = true; }
     void flush_throttled_animation_style_update();
     void flush_throttled_animation_style_update_for_node(Node const&);
-    void schedule_animation_wakeup(double delay_ms);
-    void stop_animation_wakeup_timer();
+    void schedule_compositor_animation_wakeup(double delay_ms);
+    void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
+    bool run_empty_animation_style_update_for_testing(Badge<Internals::Internals>);
     void throttled_animation_visibility_changed();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }
@@ -1073,7 +1074,6 @@ public:
     GC::Ptr<Element const> scrolling_element() const;
 
     void set_needs_animated_style_update(Animations::KeyframeEffect&);
-    void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
 
     CSS::SheetSetStyleCacheRegistry& sheet_set_style_cache_registry() { return m_sheet_set_style_cache_registry; }
 
@@ -1111,11 +1111,11 @@ public:
         u64 animated_style_overlay_builds { 0 };
         u64 animated_style_full_builds { 0 };
         u64 animation_frame_pump_requests { 0 };
-        u64 animation_timeline_associated_animation_updates { 0 };
-        u64 compositor_visual_animation_updates { 0 };
         u64 animation_style_skip_cache_hits { 0 };
         u64 animation_style_skip_cache_misses { 0 };
         u64 animation_timeline_synchronizations { 0 };
+        u64 animation_timeline_associated_animation_updates { 0 };
+        u64 compositor_visual_animation_updates { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };
         u64 computed_longhand_evaluations { 0 };
@@ -1841,8 +1841,8 @@ private:
     bool m_will_declaratively_refresh { false };
 
     RefPtr<Core::Timer> m_active_refresh_timer;
-    RefPtr<Core::Timer> m_animation_wakeup_timer;
-    Optional<MonotonicTime> m_animation_wakeup_deadline;
+    RefPtr<Core::Timer> m_compositor_animation_wakeup_timer;
+    Optional<MonotonicTime> m_compositor_animation_wakeup_deadline;
 
     bool m_temporary_document_for_fragment_parsing { false };
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1112,6 +1112,7 @@ public:
         u64 animated_style_full_builds { 0 };
         u64 animation_frame_pump_requests { 0 };
         u64 animation_timeline_associated_animation_updates { 0 };
+        u64 compositor_visual_animation_updates { 0 };
         u64 animation_style_skip_cache_hits { 0 };
         u64 animation_style_skip_cache_misses { 0 };
         u64 animation_timeline_synchronizations { 0 };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1116,6 +1116,7 @@ public:
         u64 animation_timeline_synchronizations { 0 };
         u64 animation_timeline_associated_animation_updates { 0 };
         u64 compositor_visual_animation_updates { 0 };
+        u64 compositor_keyframe_value_resolutions { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };
         u64 computed_longhand_evaluations { 0 };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1032,6 +1032,7 @@ public:
     void append_pending_animation_event(PendingAnimationEvent const&);
     void update_animations_and_send_events(double timestamp);
     void prepare_to_observe_css_animation_events();
+    void update_compositor_animations();
     void dispatch_events_for_animation_if_necessary(GC::Ref<Animations::Animation>);
     void remove_replaced_animations();
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -473,8 +473,12 @@ public:
     void flush_throttled_animation_style_update();
     void flush_throttled_animation_style_update_for_node(Node const&);
     void schedule_compositor_animation_wakeup(double delay_ms);
+    void stop_compositor_animation_timers();
+    void arm_compositor_animation_timers_for_testing(Badge<Internals::Internals>);
     void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
     bool run_empty_animation_style_update_for_testing(Badge<Internals::Internals>);
+    bool compositor_animation_wakeup_timer_is_active() const;
+    bool compositor_animation_observation_timer_is_active() const;
     void throttled_animation_visibility_changed();
     void invalidate_style_for_viewport_change();
     bool suppresses_attribute_style_invalidation() const { return m_suppresses_attribute_style_invalidation; }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2758,16 +2758,18 @@ enum class VisualContextTransform {
     Identity,
 };
 
-static void append_border_box_rect(Vector<CSSPixelRect>& rects, Layout::Node const& layout_node, VisualContextTransform visual_context_transform)
+static void append_border_box_rect(Vector<CSSPixelRect>& rects, Layout::Node const& layout_node, VisualContextTransform visual_context_transform, Painting::AccumulatedVisualContextTree const* visual_context_tree = nullptr)
 {
     auto absolute_rect = Painting::absolute_border_box_rect(layout_node);
     if (visual_context_transform == VisualContextTransform::Identity)
         rects.append(absolute_rect);
+    else if (visual_context_tree)
+        rects.append(Painting::transform_rect_to_viewport(layout_node, absolute_rect, *visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
     else
         rects.append(Painting::transform_rect_to_viewport(layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
 }
 
-static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element, VisualContextTransform visual_context_transform = VisualContextTransform::Apply)
+static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element const& element, VisualContextTransform visual_context_transform = VisualContextTransform::Apply, Painting::AccumulatedVisualContextTree const* visual_context_tree = nullptr)
 {
     // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList
     //    object and stop this algorithm.
@@ -2794,18 +2796,20 @@ static Vector<CSSPixelRect> compute_client_rects_assuming_layout_clean(Element c
         for (auto const& absolute_rect : piece_border_box_rects) {
             if (visual_context_transform == VisualContextTransform::Identity)
                 rects.append(absolute_rect);
+            else if (visual_context_tree)
+                rects.append(Painting::transform_rect_to_viewport(*layout_node, absolute_rect, *visual_context_tree, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
             else
                 rects.append(Painting::transform_rect_to_viewport(*layout_node, absolute_rect, Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::No));
         }
         // An inline element whose content is only interrupting blocks generates no line fragments, but per CSSOM
         // we still report its (zero-sized) border area instead of an empty list.
         if (rects.is_empty())
-            append_border_box_rect(rects, *layout_node, visual_context_transform);
+            append_border_box_rect(rects, *layout_node, visual_context_transform, visual_context_tree);
         return rects;
     }
 
     if (Painting::has_committed_box(*layout_node))
-        append_border_box_rect(rects, *layout_node, visual_context_transform);
+        append_border_box_rect(rects, *layout_node, visual_context_transform, visual_context_tree);
 
     return rects;
 }
@@ -2842,6 +2846,11 @@ Vector<CSSPixelRect> Element::client_rects_assuming_layout_clean() const
 CSSPixelRect Element::bounding_client_rect_assuming_layout_clean() const
 {
     return bounding_rect_from_client_rects(client_rects_assuming_layout_clean());
+}
+
+CSSPixelRect Element::bounding_client_rect_assuming_layout_clean(Painting::AccumulatedVisualContextTree const& visual_context_tree) const
+{
+    return bounding_rect_from_client_rects(compute_client_rects_assuming_layout_clean(*this, VisualContextTransform::Apply, &visual_context_tree));
 }
 
 int Element::client_top() const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -575,6 +575,7 @@ public:
 
     [[nodiscard]] Vector<CSSPixelRect> client_rects_assuming_layout_clean() const;
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean() const;
+    [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean(Painting::AccumulatedVisualContextTree const&) const;
 
     virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle);
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -5155,6 +5155,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
 
     adopt_pending_async_scroll_offsets();
     document->update_paint_and_hit_testing_properties_if_needed();
+    document->update_compositor_animations();
 
     auto should_record_display_list = m_needs_to_record_display_list
         || !m_compositor_display_list_paint_config.has_value()

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1785,6 +1785,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
     object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("compositorVisualAnimationUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_updates), JS::default_attributes);
+    object->define_direct_property("compositorKeyframeValueResolutions"_utf16_fly_string, JS::Value(counters.compositor_keyframe_value_resolutions), JS::default_attributes);
     auto compositor_visual_animation_count = document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()
         ? document.paint_state().visual_context_tree(document).visual_animations().size()
         : 0;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1775,6 +1775,10 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
     object->define_direct_property("animationFramePumpRequests"_utf16_fly_string, JS::Value(counters.animation_frame_pump_requests), JS::default_attributes);
+    auto compositor_visual_animation_count = document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()
+        ? document.paint_state().visual_context_tree(document).visual_animations().size()
+        : 0;
+    object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
     object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
     object->define_direct_property("animationStyleSkipCacheHits"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_hits), JS::default_attributes);
     object->define_direct_property("animationStyleSkipCacheMisses"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_misses), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1196,9 +1196,9 @@ void Internals::update_compositor_animations()
     window().associated_document().update_compositor_animations();
 }
 
-void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
+bool Internals::run_empty_animation_style_update_for_testing()
 {
-    window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
+    return window().associated_document().run_empty_animation_style_update_for_testing({});
 }
 
 GC::Ref<JS::Object> Internals::layout_tree_build_stats()
@@ -1777,18 +1777,18 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("elementInheritedStyleGroupSwaps"_utf16_fly_string, JS::Value(counters.element_inherited_style_group_swaps), JS::default_attributes);
     object->define_direct_property("animatedStyleReconstructionFallbacks"_utf16_fly_string, JS::Value(counters.animated_style_reconstruction_fallbacks), JS::default_attributes);
     object->define_direct_property("animatedStyleOverlayBuilds"_utf16_fly_string, JS::Value(counters.animated_style_overlay_builds), JS::default_attributes);
-    object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("animatedStyleFullBuilds"_utf16_fly_string, JS::Value(counters.animated_style_full_builds), JS::default_attributes);
     object->define_direct_property("animationFramePumpRequests"_utf16_fly_string, JS::Value(counters.animation_frame_pump_requests), JS::default_attributes);
+    object->define_direct_property("animationStyleSkipCacheHits"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_hits), JS::default_attributes);
+    object->define_direct_property("animationStyleSkipCacheMisses"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_misses), JS::default_attributes);
+    object->define_direct_property("animationTimelineSynchronizations"_utf16_fly_string, JS::Value(counters.animation_timeline_synchronizations), JS::default_attributes);
+    object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
+    object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_updates), JS::default_attributes);
     auto compositor_visual_animation_count = document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()
         ? document.paint_state().visual_context_tree(document).visual_animations().size()
         : 0;
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
-    object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
-    object->define_direct_property("compositorVisualAnimationUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_updates), JS::default_attributes);
-    object->define_direct_property("animationStyleSkipCacheHits"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_hits), JS::default_attributes);
-    object->define_direct_property("animationStyleSkipCacheMisses"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_misses), JS::default_attributes);
-    object->define_direct_property("animationTimelineSynchronizations"_utf16_fly_string, JS::Value(counters.animation_timeline_synchronizations), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);
     object->define_direct_property("computedLonghandEvaluations"_utf16_fly_string, JS::Value(counters.computed_longhand_evaluations), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1191,6 +1191,11 @@ void Internals::reset_style_invalidation_counters()
     window().associated_document().reset_style_invalidation_counters();
 }
 
+void Internals::update_compositor_animations()
+{
+    window().associated_document().update_compositor_animations();
+}
+
 void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
 {
     window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
@@ -1780,6 +1785,7 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
         : 0;
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
     object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_updates), JS::default_attributes);
     object->define_direct_property("animationStyleSkipCacheHits"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_hits), JS::default_attributes);
     object->define_direct_property("animationStyleSkipCacheMisses"_utf16_fly_string, JS::Value(counters.animation_style_skip_cache_misses), JS::default_attributes);
     object->define_direct_property("animationTimelineSynchronizations"_utf16_fly_string, JS::Value(counters.animation_timeline_synchronizations), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1201,6 +1201,16 @@ bool Internals::run_empty_animation_style_update_for_testing()
     return window().associated_document().run_empty_animation_style_update_for_testing({});
 }
 
+void Internals::arm_compositor_animation_timers_for_testing()
+{
+    window().associated_document().arm_compositor_animation_timers_for_testing({});
+}
+
+void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
+{
+    window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
+}
+
 GC::Ref<JS::Object> Internals::layout_tree_build_stats()
 {
     auto object = JS::Object::create(window().principal_realm(), nullptr);
@@ -1790,6 +1800,8 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
         ? document.paint_state().visual_context_tree(document).visual_animations().size()
         : 0;
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
+    object->define_direct_property("compositorAnimationWakeupTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_wakeup_timer_is_active()), JS::default_attributes);
+    object->define_direct_property("compositorAnimationObservationTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_observation_timer_is_active()), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);
     object->define_direct_property("baseStyleFullBuilds"_utf16_fly_string, JS::Value(counters.base_style_full_builds), JS::default_attributes);
     object->define_direct_property("computedLonghandEvaluations"_utf16_fly_string, JS::Value(counters.computed_longhand_evaluations), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -181,6 +181,7 @@ public:
     DOM::Document::StyleInvalidationCounters const& style_invalidation_counters() const;
     GC::Ref<JS::Object> style_invalidation_counters_object() const;
     void reset_style_invalidation_counters();
+    void update_compositor_animations();
     void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -182,7 +182,7 @@ public:
     GC::Ref<JS::Object> style_invalidation_counters_object() const;
     void reset_style_invalidation_counters();
     void update_compositor_animations();
-    void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
+    bool run_empty_animation_style_update_for_testing();
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();
     GC::Ref<JS::Object> computed_values_stats();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -183,6 +183,8 @@ public:
     void reset_style_invalidation_counters();
     void update_compositor_animations();
     bool run_empty_animation_style_update_for_testing();
+    void arm_compositor_animation_timers_for_testing();
+    void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();
     GC::Ref<JS::Object> computed_values_stats();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -163,7 +163,7 @@ interface Internals {
     [ImplementedAs=style_invalidation_counters_object] object getStyleInvalidationCounters();
     undefined resetStyleInvalidationCounters();
     undefined updateCompositorAnimations();
-    undefined requestReentrantAnimationStyleFlushForTesting(Node node);
+    boolean runEmptyAnimationStyleUpdateForTesting();
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of
     // subtrees rebuilt in place), lastBuildEscapedRebuildRoots (whether any tree mutation

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -164,6 +164,8 @@ interface Internals {
     undefined resetStyleInvalidationCounters();
     undefined updateCompositorAnimations();
     boolean runEmptyAnimationStyleUpdateForTesting();
+    undefined armCompositorAnimationTimersForTesting();
+    undefined requestReentrantAnimationStyleFlushForTesting(Node node);
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of
     // subtrees rebuilt in place), lastBuildEscapedRebuildRoots (whether any tree mutation

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -162,6 +162,7 @@ interface Internals {
     // elementStyleRecomputations, and styleEnvironmentVersion.
     [ImplementedAs=style_invalidation_counters_object] object getStyleInvalidationCounters();
     undefined resetStyleInvalidationCounters();
+    undefined updateCompositorAnimations();
     undefined requestReentrantAnimationStyleFlushForTesting(Node node);
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -209,8 +209,8 @@ void IntersectionObserver::observe(DOM::Element& target)
         .previous_is_intersecting = false,
     });
 
-    // AD-HOC: Intersection geometry is computed from WebContent's visual-context tree. Ensure an animation that was
-    //         sampled only by the compositor catches up before the rendering update requested below.
+    // AD-HOC: Registering an observation changes whether transforms can remain compositor driven. Bring any pending
+    //         throttled animation state to a point where compositor eligibility can be updated by the requested frame.
     target.document().flush_throttled_animation_style_update();
     m_document->page().client().request_frame();
 }
@@ -332,7 +332,7 @@ GC::Ref<DOM::Node> IntersectionObserver::intersection_root_node() const
 }
 
 // https://www.w3.org/TR/intersection-observer/#intersectionobserver-root-intersection-rectangle
-CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
+CSSPixelRect IntersectionObserver::root_intersection_rectangle(Painting::AccumulatedVisualContextTree const* visual_context_tree) const
 {
     // If the IntersectionObserver is an implicit root observer,
     //    it’s treated as if the root were the top-level browsing context’s document, according to the following rule for document.
@@ -365,7 +365,9 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
 
         // Otherwise,
         //    it’s the result of getting the bounding box for the intersection root.
-        rect = element->bounding_client_rect_assuming_layout_clean();
+        rect = visual_context_tree
+            ? element->bounding_client_rect_assuming_layout_clean(*visual_context_tree)
+            : element->bounding_client_rect_assuming_layout_clean();
         if (auto const* layout_node = element->layout_node(); layout_node && Painting::has_committed_box(*layout_node))
             intersection_root_is_scrollable = layout_node->is_scroll_container();
     }

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -211,7 +211,7 @@ void IntersectionObserver::observe(DOM::Element& target)
 
     // AD-HOC: Registering an observation changes whether transforms can remain compositor driven. Bring any pending
     //         throttled animation state to a point where compositor eligibility can be updated by the requested frame.
-    target.document().flush_throttled_animation_style_update();
+    target.document().flush_throttled_animation_style_update_for_node(target);
     m_document->page().client().request_frame();
 }
 

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -209,6 +209,9 @@ void IntersectionObserver::observe(DOM::Element& target)
         .previous_is_intersecting = false,
     });
 
+    // AD-HOC: Intersection geometry is computed from WebContent's visual-context tree. Ensure an animation that was
+    //         sampled only by the compositor catches up before the rendering update requested below.
+    target.document().flush_throttled_animation_style_update();
     m_document->page().client().request_frame();
 }
 

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -11,6 +11,7 @@
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/IntersectionObserver.h>
 #include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserverEntry.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -60,7 +61,7 @@ public:
     Variant<GC::Ref<DOM::Element>, GC::Ref<DOM::Document>> intersection_root() const;
     GC::Ref<DOM::Node> intersection_root_node() const;
     bool is_implicit_root() const { return !m_root; }
-    CSSPixelRect root_intersection_rectangle() const;
+    CSSPixelRect root_intersection_rectangle(Painting::AccumulatedVisualContextTree const* = nullptr) const;
 
     void queue_entry(Badge<DOM::Document>, GC::Ref<IntersectionObserverEntry>);
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Demangle.h>
+#include <LibWeb/CSS/ComputedStyleWorkingSet.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CursorStyleValue.h>
@@ -520,6 +521,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     }
     set_flag(RustFFI::NodeFlag::HasAnchorNames, has_anchor_names);
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, insets_use_anchor_functions);
+    set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     synchronize_table_span_data();
@@ -646,6 +648,7 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
     VERIFY(record_view);
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !record_view->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, record_view->inset_properties_contain_anchor_functions());
+    set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     // A style change can introduce the properties that make a node carry replaced-content facts,
     // such as size containment arriving on a kept layout node.
@@ -965,6 +968,7 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     }
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !computed_values->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, computed_values->inset_properties_contain_anchor_functions());
+    set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     enroll_for_arena_replaced_content_facts_sync_if_eligible();
@@ -1010,6 +1014,7 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     m_style_record_identity = style_record_identity;
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, new_record_view->inset_properties_contain_anchor_functions());
+    set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     enroll_for_arena_replaced_content_facts_sync_if_eligible();

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -219,6 +219,7 @@ public:
     GC::Ptr<DOM::Element> pseudo_element_generator();
 
     bool needs_layout_update() const { return has_flag(RustFFI::NodeFlag::NeedsLayoutUpdate); }
+    void set_retains_compositor_animated_content(bool value) { set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, value); }
 
     // The formatting-context run cache (LADYBIRD_FC_RUN_CACHE) validates its entries against
     // these epochs; with the cache disabled nothing reads them, so the walks no-op.

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -1010,6 +1010,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::AccumulatedVisualContextTr
     TRY(encoder.encode(tree.m_frame_nodes));
     TRY(encoder.encode(tree.m_root_is_visual_viewport));
     TRY(encoder.encode(tree.m_root_isolation_frame));
+    TRY(encoder.encode(tree.m_visual_animations));
     return {};
 }
 
@@ -1022,6 +1023,7 @@ ErrorOr<Web::Painting::AccumulatedVisualContextTree> decode(Decoder& decoder)
     auto frame_nodes = TRY(decoder.decode<Vector<FrameNode>>());
     auto root_is_visual_viewport = TRY(decoder.decode<bool>());
     auto root_isolation_frame = TRY(decoder.decode<Optional<FrameNodeIndex>>());
+    auto visual_animations = TRY(decoder.decode<Vector<Web::Compositor::VisualAnimation>>());
     if (spatial_nodes.is_empty())
         return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree missing visual viewport node");
     if (!spatial_nodes[VISUAL_VIEWPORT_NODE_INDEX.value()].data.has<TransformData>())
@@ -1055,9 +1057,26 @@ ErrorOr<Web::Painting::AccumulatedVisualContextTree> decode(Decoder& decoder)
     }
     if (root_isolation_frame.has_value() && (root_isolation_frame->value() >= frame_nodes.size() || !frame_nodes[root_isolation_frame->value()].data.has<EffectsData>()))
         return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree root isolation frame is not an effects frame");
+    for (auto const& animation : visual_animations) {
+        if (!animation.is_valid())
+            return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree has an invalid visual animation");
+        for (auto node_index : animation.visual_context_node_indices) {
+            if (animation.target_kind == Web::Compositor::VisualAnimation::TargetKind::Opacity) {
+                if (node_index >= frame_nodes.size() || !frame_nodes[node_index].data.has<EffectsData>())
+                    return Error::from_string_literal("IPC decode: Opacity animation target is not an effects frame");
+            } else {
+                if (node_index >= spatial_nodes.size())
+                    return Error::from_string_literal("IPC decode: Transform animation target is not a transform node");
+                auto const* transform = spatial_nodes[node_index].data.get_pointer<TransformData>();
+                if (!transform || transform->role != TransformDataRole::CssTransform || transform->synthetic_plane)
+                    return Error::from_string_literal("IPC decode: Transform animation target is not a CSS transform node");
+            }
+        }
+    }
     AccumulatedVisualContextTree tree { version, move(spatial_nodes), move(frame_nodes), root_is_visual_viewport };
     if (root_isolation_frame.has_value())
         tree.set_root_isolation_frame(*root_isolation_frame);
+    tree.set_visual_animations(move(visual_animations));
     return tree;
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -506,6 +506,43 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(SpatialN
     return rect;
 }
 
+void AccumulatedVisualContextTree::sample_visual_animations(i64 monotonic_time_ns, VisualAnimationOriginalValues& original_values)
+{
+    VERIFY(original_values.is_empty());
+    for (auto const& animation : m_visual_animations) {
+        auto elapsed_nanoseconds = monotonic_time_ns > animation.monotonic_time_at_anchor_ns
+            ? monotonic_time_ns - animation.monotonic_time_at_anchor_ns
+            : 0;
+        auto sample = animation.sample(AK::Duration::from_nanoseconds(elapsed_nanoseconds));
+        if (!sample.has_value())
+            continue;
+        for (auto node_index : animation.visual_context_node_indices) {
+            if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
+                auto frame_node_index = FrameNodeIndex { node_index };
+                auto& frame = frame_node_at(frame_node_index);
+                if (!any_of(original_values.opacities, [&](auto const& original) { return original.node_index == frame_node_index; }))
+                    original_values.opacities.append({ frame_node_index, frame.data.get<EffectsData>().opacity });
+                frame.data.get<EffectsData>().opacity = sample->opacity;
+            } else {
+                auto spatial_node_index = SpatialNodeIndex { node_index };
+                auto& spatial = spatial_node_at(spatial_node_index);
+                if (!any_of(original_values.transforms, [&](auto const& original) { return original.node_index == spatial_node_index; }))
+                    original_values.transforms.append({ spatial_node_index, spatial.data.get<TransformData>().matrix });
+                spatial.data.get<TransformData>().matrix = sample->transform;
+            }
+        }
+    }
+}
+
+void AccumulatedVisualContextTree::restore_visual_animation_original_values(VisualAnimationOriginalValues& original_values)
+{
+    for (auto const& original : original_values.opacities)
+        frame_node_at(original.node_index).data.get<EffectsData>().opacity = original.value;
+    for (auto const& original : original_values.transforms)
+        spatial_node_at(original.node_index).data.get<TransformData>().matrix = original.value;
+    original_values.clear();
+}
+
 Gfx::FloatMatrix4x4 TransformData::matrix_including_origin() const
 {
     auto origin_translation = Gfx::translation_matrix(Gfx::Vector3<float> { origin.x(), origin.y(), 0 });

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -19,6 +19,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/WindingRule.h>
 #include <LibIPC/Forward.h>
+#include <LibWeb/Compositor/VisualAnimation.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Painting/ScrollState.h>
 #include <LibWeb/PixelUnits.h>
@@ -185,11 +186,14 @@ public:
     SpatialNode const& spatial_node_at(SpatialNodeIndex index) const { return m_spatial_nodes[index.value()]; }
     SpatialNode& spatial_node_at(SpatialNodeIndex index) { return m_spatial_nodes[index.value()]; }
     FrameNode const& frame_node_at(FrameNodeIndex index) const { return m_frame_nodes[index.value()]; }
+    FrameNode& frame_node_at(FrameNodeIndex index) { return m_frame_nodes[index.value()]; }
     WEB_API void set_frame_data(FrameNodeIndex, FrameData);
     ReadonlySpan<SpatialNode> spatial_nodes() const { return m_spatial_nodes.span(); }
     ReadonlySpan<FrameNode> frame_nodes() const { return m_frame_nodes.span(); }
     bool root_is_visual_viewport() const { return m_root_is_visual_viewport; }
     Optional<FrameNodeIndex> root_isolation_frame() const { return m_root_isolation_frame; }
+    ReadonlySpan<Compositor::VisualAnimation> visual_animations() const { return m_visual_animations; }
+    void set_visual_animations(Vector<Compositor::VisualAnimation> animations) { m_visual_animations = move(animations); }
     void set_root_isolation_frame(FrameNodeIndex frame)
     {
         VERIFY(frame.value() < m_frame_nodes.size());
@@ -220,6 +224,7 @@ private:
     Vector<FrameNode> m_frame_nodes;
     bool m_root_is_visual_viewport { true };
     Optional<FrameNodeIndex> m_root_isolation_frame;
+    Vector<Compositor::VisualAnimation> m_visual_animations;
 
     template<typename T>
     friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -150,6 +150,28 @@ struct FrameNode {
 
 class AccumulatedVisualContextTree {
 public:
+    struct VisualAnimationOriginalValues {
+        struct Opacity {
+            FrameNodeIndex node_index;
+            float value { 1 };
+        };
+
+        struct Transform {
+            SpatialNodeIndex node_index;
+            Gfx::FloatMatrix4x4 value;
+        };
+
+        bool is_empty() const { return opacities.is_empty() && transforms.is_empty(); }
+        void clear()
+        {
+            opacities.clear();
+            transforms.clear();
+        }
+
+        Vector<Opacity> opacities;
+        Vector<Transform> transforms;
+    };
+
     enum class IncludeVisualViewportTransform {
         No,
         Yes,
@@ -194,6 +216,8 @@ public:
     Optional<FrameNodeIndex> root_isolation_frame() const { return m_root_isolation_frame; }
     ReadonlySpan<Compositor::VisualAnimation> visual_animations() const { return m_visual_animations; }
     void set_visual_animations(Vector<Compositor::VisualAnimation> animations) { m_visual_animations = move(animations); }
+    WEB_API void sample_visual_animations(i64 monotonic_time_ns, VisualAnimationOriginalValues&);
+    WEB_API void restore_visual_animation_original_values(VisualAnimationOriginalValues&);
     void set_root_isolation_frame(FrameNodeIndex frame)
     {
         VERIFY(frame.value() < m_frame_nodes.size());

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -763,6 +763,11 @@ CSSPixelRect apply_css_transform_to_rect(Layout::Node const& box, CSSPixelRect c
 
 CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
 {
+    return transform_rect_to_viewport(node, rect, node.document().visual_context_tree(), include_visual_viewport_transform);
+}
+
+CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect const& rect, AccumulatedVisualContextTree const& visual_context_tree, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform)
+{
     auto const* row = committed_row(node);
     if (!row)
         return {};
@@ -770,7 +775,7 @@ CSSPixelRect transform_rect_to_viewport(Layout::Node const& node, CSSPixelRect c
     if (!document.layout_node() || !has_committed_box(*document.layout_node()))
         return rect;
     auto pixel_ratio = static_cast<float>(document.page().client().device_pixels_per_css_pixel());
-    auto result = document.visual_context_tree().transform_rect_to_viewport(
+    auto result = visual_context_tree.transform_rect_to_viewport(
         row->accumulated_visual_context.spatial, rect.to_type<float>() * pixel_ratio,
         document.scroll_state_snapshot(), include_visual_viewport_transform);
     return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -78,6 +78,7 @@ WEB_API bool is_svg_path_paintable(Layout::Node const&);
 
 WEB_API CSSPixelRect apply_css_transform_to_rect(Layout::Node const&, CSSPixelRect const&);
 WEB_API CSSPixelRect transform_rect_to_viewport(Layout::Node const&, CSSPixelRect const&, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
+WEB_API CSSPixelRect transform_rect_to_viewport(Layout::Node const&, CSSPixelRect const&, AccumulatedVisualContextTree const&, AccumulatedVisualContextTree::IncludeVisualViewportTransform = AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes);
 WEB_API Optional<CSSPixelPoint> transform_point_to_local(Layout::Node const&, CSSPixelPoint);
 WEB_API CSSPixelPoint inverse_transform_point(Layout::Node const&, CSSPixelPoint);
 WEB_API CSSPixelPoint transform_to_local_coordinates(Layout::Node const&, CSSPixelPoint);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -152,8 +152,22 @@ void DocumentPaintState::update_visual_viewport_accumulated_visual_context(DOM::
 void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<Compositor::VisualAnimation> animations)
 {
     ensure_visual_context_tree(document);
+    if (m_visual_context_tree->visual_animations() == animations.span())
+        return;
+    bool animation_parameters_changed = m_visual_animations.size() != animations.size();
+    if (!animation_parameters_changed) {
+        for (size_t index = 0; index < animations.size(); ++index) {
+            if (!m_visual_animations[index].has_same_animation_parameters(animations[index])) {
+                animation_parameters_changed = true;
+                break;
+            }
+        }
+    }
+    m_visual_animations = animations;
     m_visual_context_tree->set_visual_animations(move(animations));
     m_visual_context_tree_needs_compositor_update = true;
+    if (animation_parameters_changed)
+        ++document.style_invalidation_counters().compositor_visual_animation_updates;
 }
 
 void DocumentPaintState::append_paint_command_cache_source_resources(DisplayListResourceSet& retained_resources) const

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -149,6 +149,13 @@ void DocumentPaintState::update_visual_viewport_accumulated_visual_context(DOM::
     m_visual_context_tree_needs_compositor_update = true;
 }
 
+void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<Compositor::VisualAnimation> animations)
+{
+    ensure_visual_context_tree(document);
+    m_visual_context_tree->set_visual_animations(move(animations));
+    m_visual_context_tree_needs_compositor_update = true;
+}
+
 void DocumentPaintState::append_paint_command_cache_source_resources(DisplayListResourceSet& retained_resources) const
 {
     retained_resources.include(m_paint_command_cache_source_referenced_resources);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -39,6 +39,7 @@ public:
     void assign_accumulated_visual_contexts(DOM::Document&);
     bool update_accumulated_visual_context_values(DOM::Document&, Layout::RustFFI::NodeSlotId);
     void update_visual_viewport_accumulated_visual_context(DOM::Document&);
+    void set_visual_animations(DOM::Document&, Vector<Compositor::VisualAnimation>);
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -87,6 +87,7 @@ private:
     DisplayListResourceSet m_paint_command_cache_source_referenced_resources;
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
+    Vector<Compositor::VisualAnimation> m_visual_animations;
     u64 m_accumulated_visual_context_tree_build_count { 0 };
     bool m_visual_context_tree_needs_compositor_update { false };
     bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -164,6 +164,7 @@ pub enum NodeFlag {
     HasCommittedFragmentLink = 1 << 26,
     HasPreserve3dTransformStyle = 1 << 27,
     IsMissingTableCell = 1 << 28,
+    HasAnimatedOpacityOrTransform = 1 << 29,
 }
 
 #[repr(C)]

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -12,8 +12,8 @@ pub mod paint;
 pub mod traversal;
 
 use crate::css::css_enums;
-use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_data::{NodeFlag, NodeKind};
 use crate::layout::used_values;
 use crate::painting::border_radii::BorderRadii;
 use crate::painting::display_list::builder::RecordedDisplayList;
@@ -271,7 +271,10 @@ impl<'a> PaintRecorder<'a> {
             return facts;
         };
         let effects = style.effects();
-        let is_visible = style.visibility() == crate::css::css_enums::visibility::VISIBLE && effects.opacity != 0.0;
+        let retains_animated_content =
+            self.layout_arena.node_flags_if_live(paintable) & NodeFlag::HasAnimatedOpacityOrTransform as u32 != 0;
+        let is_visible = style.visibility() == crate::css::css_enums::visibility::VISIBLE
+            && (effects.opacity != 0.0 || retains_animated_content);
         let empty_cells_property_applies = self.display(paintable).is_internal_table()
             && style.empty_cells() == crate::css::css_enums::empty_cells::HIDE
             && crate::painting::paint_order::first_paint_child(self.layout_arena, paintable).is_none();

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::css::css_pixels::{CssPixelRect, CssPixels};
-use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_data::{NodeFlag, NodeSlotId};
 use crate::layout::node_facts;
 use crate::painting::display_list::commands::{DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
@@ -98,8 +98,10 @@ fn compute_render_spans(
         let Some(parent_style) = arena.node_style_if_live(parent) else {
             continue;
         };
+        let parent_retains_animated_content =
+            arena.node_flags_if_live(parent) & NodeFlag::HasAnimatedOpacityOrTransform as u32 != 0;
         if parent_style.visibility() != crate::css::css_enums::visibility::VISIBLE
-            || parent_style.effects().opacity == 0.0
+            || (parent_style.effects().opacity == 0.0 && !parent_retains_animated_content)
         {
             continue;
         }

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -6,8 +6,8 @@
 
 use super::{PaintPhase, PaintRecorder};
 use crate::layout::LayoutNodeArena;
-use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
+use crate::layout::node_data::{NodeFlag, NodeKind};
 use crate::layout::{node_facts, used_values};
 use crate::painting::display_list::builder::CommandRange;
 use crate::painting::display_list::commands::ContextRef;
@@ -18,7 +18,6 @@ use crate::painting::host::{
     FfiHitTestHostCallbacks, FfiPaintHostCallbacks, FfiRecordingInputs, FfiVisualContextHostCallbacks,
 };
 use crate::painting::node_painting;
-use crate::painting::paintable_data::*;
 use crate::painting::record::RecordingOutput;
 use crate::painting::record::masks::MaskLayerSet;
 use crate::painting::stacking_context::NO_STACKING_CONTEXT;
@@ -191,10 +190,12 @@ impl PaintRecorder<'_> {
         let paintable = self.stacking_contexts.nodes[index as usize].paintable;
         // https://drafts.csswg.org/css-transforms-1/#transform-function-lists
         // If a transform function causes the current transformation matrix of an object to be
-        // non-invertible, the object and its content do not get displayed.
+        // non-invertible, the object and its content do not get displayed. Retain content whose
+        // transform is animated so the compositor can reveal it without a main-thread repaint.
         if self
             .data(paintable)
-            .has_flag(PaintableFlag::HasNonInvertibleCssTransform)
+            .has_flag(crate::painting::paintable_data::PaintableFlag::HasNonInvertibleCssTransform)
+            && self.layout_arena.node_flags_if_live(paintable) & NodeFlag::HasAnimatedOpacityOrTransform as u32 == 0
         {
             return;
         }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -679,7 +679,10 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
 
         if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
             context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*animation_frame));
-        if (context.advance_visual_animations(now)) {
+        if (context.has_active_visual_animations()) {
+            context.advance_visual_animations(now);
+            // Visual animation damage deliberately covers the full viewport until we track the animated nodes' bounds
+            // before and after sampling.
             if (auto viewport_rect = context.viewport_rect_for_ui_overlay(); viewport_rect.has_value())
                 context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*viewport_rect));
         }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -561,7 +561,7 @@ void CompositorState::resume_presentation_after_becoming_visible(Web::Compositor
         auto& context = *context_entry.value;
         if (root_context_of(context) != &root_context)
             continue;
-        if (context.has_active_smooth_scroll_animations())
+        if (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations())
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
     }
 
@@ -616,8 +616,8 @@ void CompositorState::schedule_pending_present_frame(Web::Compositor::Compositor
         // own async animations still need a vsync source. The containing frame
         // may already be up to date (and therefore not schedule a new present),
         // so explicitly keep the effective display's scheduler ticking while
-        // a nested smooth scroll is active.
-        if (context.has_active_smooth_scroll_animations() && context_is_effectively_visible(context))
+        // a nested animation is active.
+        if ((context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && context_is_effectively_visible(context))
             vsync_scheduler_for_display(display_id_for_context(context)).schedule(display_refresh_rate_for_context(context));
         return;
     }
@@ -673,21 +673,25 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
             context.unschedule_pending_present_frame();
             continue;
         }
-        auto has_active_smooth_scroll_animation_on_display = context.has_active_smooth_scroll_animations() && display_id_for_context(context) == display_id;
-        if (!context.has_pending_present_frame_scheduled_on(display_id) && !has_active_smooth_scroll_animation_on_display)
+        auto has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && display_id_for_context(context) == display_id;
+        if (!context.has_pending_present_frame_scheduled_on(display_id) && !has_active_animation_on_display)
             continue;
 
         if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
             context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*animation_frame));
+        if (context.advance_visual_animations(now)) {
+            if (auto viewport_rect = context.viewport_rect_for_ui_overlay(); viewport_rect.has_value())
+                context.queue_present_frame(ContextState::PendingFrame::repainting_changes(*viewport_rect));
+        }
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
         if (!pending_present_frame.has_value()) {
-            has_active_smooth_scroll_animation_on_display = context.has_active_smooth_scroll_animations() && display_id_for_context(context) == display_id;
-            if (context.has_pending_present_frame_scheduled_on(display_id) || has_active_smooth_scroll_animation_on_display)
+            has_active_animation_on_display = (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations()) && display_id_for_context(context) == display_id;
+            if (context.has_pending_present_frame_scheduled_on(display_id) || has_active_animation_on_display)
                 vsync_scheduler_for_display(display_id).schedule(display_refresh_rate_for_context(context));
             continue;
         }
-        if (context.has_active_smooth_scroll_animations())
+        if (context.has_active_smooth_scroll_animations() || context.has_active_visual_animations())
             schedule_present_frame(context_id, context, ContextState::PendingFrame::repainting_changes(pending_present_frame->viewport_rect));
         present_frame(context_id, context, *pending_present_frame);
     }

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -106,6 +106,7 @@ ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClien
 
 ContextState::~ContextState()
 {
+    restore_visual_animation_original_values();
     stop_backing_store_shrink_timer();
 }
 
@@ -160,10 +161,11 @@ void ContextState::install_display_list_update(
     Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
+    invalidate_visual_context_tree_for_compositing();
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
-    m_visual_context_tree_for_compositing.clear();
     m_visual_animation_sample_time_ns.clear();
+    m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(visual_viewport_transform(*m_visual_context_tree), *m_async_visual_viewport_transform))
         m_async_visual_viewport_transform.clear();
@@ -184,8 +186,8 @@ void ContextState::install_display_list_update(
     m_can_accept_async_wheel_events = wheel_routing_admission == Web::Compositor::WheelRoutingAdmission::Accepted;
     m_has_blocking_wheel_event_listeners = async_scrolling_state.has_blocking_wheel_event_listeners;
     if (m_async_visual_viewport_transform.has_value() && (!m_can_accept_async_wheel_events || m_has_blocking_wheel_event_listeners)) {
+        invalidate_visual_context_tree_for_compositing();
         m_async_visual_viewport_transform.clear();
-        m_visual_context_tree_for_compositing.clear();
     }
 
     auto was_dragging_viewport_scrollbar = m_viewport_scrollbar_controller.has_captured_scrollbar();
@@ -209,9 +211,10 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
             m_display_list ? m_display_list->compatible_visual_context_tree_version() : 0);
         return;
     }
+    invalidate_visual_context_tree_for_compositing();
     m_visual_context_tree = move(visual_context_tree);
-    m_visual_context_tree_for_compositing.clear();
     m_visual_animation_sample_time_ns.clear();
+    m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
     // A constraints refresh changes sticky payloads without a new snapshot, and the snapshot that
     // pairs with this tree arrives in a separate message.
     Web::Painting::resolve_sticky_offsets(*m_visual_context_tree, m_scroll_state_snapshot);
@@ -379,8 +382,8 @@ ContextState::ContextUpdateResult ContextState::handle_pinch_event(Web::PinchEve
 
     transform.matrix = gesture_transform * transform.matrix;
     clamp_visual_viewport_transform_to_viewport(transform, m_async_scrolling_viewport_rect);
+    invalidate_visual_context_tree_for_compositing();
     m_async_visual_viewport_transform = transform;
-    m_visual_context_tree_for_compositing.clear();
     rebuild_wheel_hit_test_targets();
 
     return {
@@ -946,8 +949,8 @@ Optional<ContextState::VisualViewportScrollDelta> ContextState::apply_visual_vie
 
     transform.matrix[0, 3] = new_x;
     transform.matrix[1, 3] = new_y;
+    invalidate_visual_context_tree_for_compositing();
     m_async_visual_viewport_transform = transform;
-    m_visual_context_tree_for_compositing.clear();
     rebuild_wheel_hit_test_targets();
 
     return VisualViewportScrollDelta {
@@ -1049,37 +1052,43 @@ bool ContextState::can_render_frame() const
     return m_display_list && m_backing_store_manager.is_valid();
 }
 
-Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_tree_for_compositing() const
+void ContextState::restore_visual_animation_original_values()
 {
-    if (!m_async_visual_viewport_transform.has_value() && !m_visual_animation_sample_time_ns.has_value())
-        return current_visual_context_tree();
-
-    m_visual_context_tree_for_compositing = current_visual_context_tree();
-    if (m_async_visual_viewport_transform.has_value())
-        m_visual_context_tree_for_compositing->set_visual_viewport_transform(*m_async_visual_viewport_transform);
-    if (m_visual_animation_sample_time_ns.has_value()) {
-        for (auto const& animation : m_visual_context_tree_for_compositing->visual_animations()) {
-            auto elapsed_nanoseconds = *m_visual_animation_sample_time_ns > animation.monotonic_time_at_anchor_ns
-                ? *m_visual_animation_sample_time_ns - animation.monotonic_time_at_anchor_ns
-                : 0;
-            auto sample = animation.sample(AK::Duration::from_nanoseconds(elapsed_nanoseconds));
-            if (!sample.has_value())
-                continue;
-            for (auto node_index : animation.visual_context_node_indices) {
-                if (animation.target_kind == Web::Compositor::VisualAnimation::TargetKind::Opacity) {
-                    auto& frame = m_visual_context_tree_for_compositing->frame_node_at(Web::Painting::FrameNodeIndex { node_index });
-                    frame.data.get<Web::Painting::EffectsData>().opacity = sample->opacity;
-                } else {
-                    auto& spatial = m_visual_context_tree_for_compositing->spatial_node_at(Web::Painting::SpatialNodeIndex { node_index });
-                    spatial.data.get<Web::Painting::TransformData>().matrix = sample->transform;
-                }
-            }
-        }
-    }
-    return *m_visual_context_tree_for_compositing;
+    if (!m_visual_animation_sample_is_current)
+        return;
+    auto& sampled_tree = m_visual_context_tree_for_compositing.has_value()
+        ? *m_visual_context_tree_for_compositing
+        : *m_visual_context_tree;
+    sampled_tree.restore_visual_animation_original_values(m_visual_animation_original_values);
+    m_visual_animation_sample_is_current = false;
 }
 
-Gfx::IntRect ContextState::frame_damage_for(PendingFrame const& pending_frame) const
+void ContextState::invalidate_visual_context_tree_for_compositing()
+{
+    restore_visual_animation_original_values();
+    m_visual_context_tree_for_compositing.clear();
+}
+
+Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_tree_for_compositing()
+{
+    if (m_async_visual_viewport_transform.has_value() && !m_visual_context_tree_for_compositing.has_value()) {
+        restore_visual_animation_original_values();
+        m_visual_context_tree_for_compositing = current_visual_context_tree();
+        ++m_visual_context_tree_copy_count;
+        m_visual_context_tree_for_compositing->set_visual_viewport_transform(*m_async_visual_viewport_transform);
+    }
+
+    auto& tree = m_visual_context_tree_for_compositing.has_value()
+        ? *m_visual_context_tree_for_compositing
+        : *m_visual_context_tree;
+    if (m_visual_animation_sample_time_ns.has_value() && !m_visual_animation_sample_is_current) {
+        tree.sample_visual_animations(*m_visual_animation_sample_time_ns, m_visual_animation_original_values);
+        m_visual_animation_sample_is_current = true;
+    }
+    return tree;
+}
+
+Gfx::IntRect ContextState::frame_damage_for(PendingFrame const& pending_frame)
 {
     Gfx::IntRect viewport_rect { {}, pending_frame.viewport_rect.size() };
     auto forced_damage_rect = pending_frame.forced_damage_rect.intersected(viewport_rect);
@@ -1090,7 +1099,7 @@ Gfx::IntRect ContextState::frame_damage_for(PendingFrame const& pending_frame) c
     return damage_rect;
 }
 
-Gfx::IntRect ContextState::damage_since_last_raster(Gfx::IntSize viewport_size) const
+Gfx::IntRect ContextState::damage_since_last_raster(Gfx::IntSize viewport_size)
 {
     Gfx::IntRect viewport_rect { {}, viewport_size };
     if (!m_last_rasterized_frame.has_value())
@@ -1165,9 +1174,27 @@ bool ContextState::advance_visual_animations(MonotonicTime now)
 {
     if (!has_active_visual_animations())
         return false;
+    restore_visual_animation_original_values();
     m_visual_animation_sample_time_ns = now.nanoseconds();
-    m_visual_context_tree_for_compositing.clear();
-    return true;
+    visual_context_tree_for_compositing();
+
+    m_has_active_visual_animations = false;
+    for (auto const& animation : m_visual_context_tree->visual_animations()) {
+        if (!isfinite(animation.iteration_count)) {
+            m_has_active_visual_animations = true;
+            break;
+        }
+        auto elapsed_nanoseconds = now.nanoseconds() > animation.monotonic_time_at_anchor_ns
+            ? now.nanoseconds() - animation.monotonic_time_at_anchor_ns
+            : 0;
+        auto local_time = animation.local_time_at_anchor_ms + AK::Duration::from_nanoseconds(elapsed_nanoseconds).to_seconds_f64() * 1000.0 * animation.playback_rate;
+        auto active_end = animation.start_delay_ms + animation.iteration_duration_ms * animation.iteration_count;
+        if (!isfinite(local_time) || local_time < active_end) {
+            m_has_active_visual_animations = true;
+            break;
+        }
+    }
+    return m_has_active_visual_animations;
 }
 
 void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect, PaintUIOverlay paint_ui_overlay)

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -163,6 +163,7 @@ void ContextState::install_display_list_update(
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_for_compositing.clear();
+    m_visual_animation_sample_time_ns.clear();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(visual_viewport_transform(*m_visual_context_tree), *m_async_visual_viewport_transform))
         m_async_visual_viewport_transform.clear();
@@ -210,6 +211,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
     }
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_for_compositing.clear();
+    m_visual_animation_sample_time_ns.clear();
     // A constraints refresh changes sticky payloads without a new snapshot, and the snapshot that
     // pairs with this tree arrives in a separate message.
     Web::Painting::resolve_sticky_offsets(*m_visual_context_tree, m_scroll_state_snapshot);
@@ -1049,11 +1051,31 @@ bool ContextState::can_render_frame() const
 
 Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_tree_for_compositing() const
 {
-    if (!m_async_visual_viewport_transform.has_value())
+    if (!m_async_visual_viewport_transform.has_value() && !m_visual_animation_sample_time_ns.has_value())
         return current_visual_context_tree();
 
     m_visual_context_tree_for_compositing = current_visual_context_tree();
-    m_visual_context_tree_for_compositing->set_visual_viewport_transform(*m_async_visual_viewport_transform);
+    if (m_async_visual_viewport_transform.has_value())
+        m_visual_context_tree_for_compositing->set_visual_viewport_transform(*m_async_visual_viewport_transform);
+    if (m_visual_animation_sample_time_ns.has_value()) {
+        for (auto const& animation : m_visual_context_tree_for_compositing->visual_animations()) {
+            auto elapsed_nanoseconds = *m_visual_animation_sample_time_ns > animation.monotonic_time_at_anchor_ns
+                ? *m_visual_animation_sample_time_ns - animation.monotonic_time_at_anchor_ns
+                : 0;
+            auto sample = animation.sample(AK::Duration::from_nanoseconds(elapsed_nanoseconds));
+            if (!sample.has_value())
+                continue;
+            for (auto node_index : animation.visual_context_node_indices) {
+                if (animation.target_kind == Web::Compositor::VisualAnimation::TargetKind::Opacity) {
+                    auto& frame = m_visual_context_tree_for_compositing->frame_node_at(Web::Painting::FrameNodeIndex { node_index });
+                    frame.data.get<Web::Painting::EffectsData>().opacity = sample->opacity;
+                } else {
+                    auto& spatial = m_visual_context_tree_for_compositing->spatial_node_at(Web::Painting::SpatialNodeIndex { node_index });
+                    spatial.data.get<Web::Painting::TransformData>().matrix = sample->transform;
+                }
+            }
+        }
+    }
     return *m_visual_context_tree_for_compositing;
 }
 
@@ -1137,6 +1159,15 @@ void ContextState::remember_rasterized_frame(Gfx::IntSize viewport_size)
         .viewport_size = viewport_size,
         .canvas_content_generations = move(canvas_content_generations),
     };
+}
+
+bool ContextState::advance_visual_animations(MonotonicTime now)
+{
+    if (!has_active_visual_animations())
+        return false;
+    m_visual_animation_sample_time_ns = now.nanoseconds();
+    m_visual_context_tree_for_compositing.clear();
+    return true;
 }
 
 void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect, PaintUIOverlay paint_ui_overlay)

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -127,6 +127,8 @@ public:
     void cancel_smooth_scroll(Web::Compositor::AsyncScrollNodeStableID);
     Optional<Gfx::IntRect> advance_smooth_scroll_animations(MonotonicTime now);
     bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }
+    bool advance_visual_animations(MonotonicTime now);
+    bool has_active_visual_animations() const { return m_visual_context_tree.has_value() && !m_visual_context_tree->visual_animations().is_empty(); }
     ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Web::Compositor::SnapContainerHandling);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
 
@@ -242,6 +244,7 @@ private:
     u64 m_wheel_event_listener_state_generation { 0 };
     Web::Compositor::WheelRoutingAdmission m_wheel_routing_admission { Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState };
     Optional<Web::Painting::TransformData> m_async_visual_viewport_transform;
+    Optional<i64> m_visual_animation_sample_time_ns;
 
     Gfx::IntSize m_viewport_size;
     bool m_paused_debugger_overlay_visible { false };

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -128,7 +128,10 @@ public:
     Optional<Gfx::IntRect> advance_smooth_scroll_animations(MonotonicTime now);
     bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }
     bool advance_visual_animations(MonotonicTime now);
-    bool has_active_visual_animations() const { return m_visual_context_tree.has_value() && !m_visual_context_tree->visual_animations().is_empty(); }
+    bool has_active_visual_animations() const { return m_has_active_visual_animations; }
+    Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_testing() const { return current_visual_context_tree(); }
+    bool has_sampled_visual_animation_values_for_testing() const { return m_visual_animation_sample_is_current; }
+    u64 visual_context_tree_copy_count_for_testing() const { return m_visual_context_tree_copy_count; }
     ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Web::Compositor::SnapContainerHandling);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
 
@@ -198,16 +201,18 @@ private:
     void note_user_scroll_gesture_end_if_drag_ended(bool was_dragging_viewport_scrollbar);
     Optional<PendingFrame> apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const&);
     void rebuild_wheel_hit_test_targets();
+    void restore_visual_animation_original_values();
+    void invalidate_visual_context_tree_for_compositing();
     bool is_present_blocked() const;
     bool can_render_frame() const;
-    Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_compositing() const;
+    Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_compositing();
     enum class PaintUIOverlay : u8 {
         No,
         Yes,
     };
     void paint_current_display_list(Web::Painting::DisplayListPlayerSkia&, Gfx::PaintingSurface&, CompositedContextResolver const*, Optional<Gfx::IntRect> damage_rect = {}, PaintUIOverlay = PaintUIOverlay::Yes);
-    Gfx::IntRect frame_damage_for(PendingFrame const&) const;
-    Gfx::IntRect damage_since_last_raster(Gfx::IntSize viewport_size) const;
+    Gfx::IntRect frame_damage_for(PendingFrame const&);
+    Gfx::IntRect damage_since_last_raster(Gfx::IntSize viewport_size);
     void remember_rasterized_frame(Gfx::IntSize viewport_size);
 
     CompositorStateWebContentClient& m_web_content_client;
@@ -220,7 +225,11 @@ private:
 
     RefPtr<Web::Painting::DisplayList const> m_display_list;
     Optional<Web::Painting::AccumulatedVisualContextTree> m_visual_context_tree;
-    mutable Optional<Web::Painting::AccumulatedVisualContextTree> m_visual_context_tree_for_compositing;
+    Optional<Web::Painting::AccumulatedVisualContextTree> m_visual_context_tree_for_compositing;
+    Web::Painting::AccumulatedVisualContextTree::VisualAnimationOriginalValues m_visual_animation_original_values;
+    bool m_visual_animation_sample_is_current { false };
+    u64 m_visual_context_tree_copy_count { 0 };
+    bool m_has_active_visual_animations { false };
     Web::Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Web::Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     BackingStoreManager m_backing_store_manager;

--- a/Tests/Compositor/TestAsyncScrollTree.cpp
+++ b/Tests/Compositor/TestAsyncScrollTree.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/Tuple.h>
 #include <LibTest/TestCase.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
@@ -74,6 +75,60 @@ TEST_CASE(wheel_hit_testing_ignores_invalid_visual_context_indices)
     auto result = scroll_tree.hit_test_scroll_node_for_wheel(
         visual_context_tree, { 20, 20 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor);
     EXPECT(!result.blocked_by_main_thread_region);
+}
+
+TEST_CASE(wheel_hit_testing_prefilters_static_targets_but_tracks_animated_targets)
+{
+    auto make_tree_and_spatial = [] {
+        auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+        auto spatial = visual_context_tree.append_spatial(
+            Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} },
+            Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+        return Tuple { move(visual_context_tree), spatial };
+    };
+    auto make_scroll_tree = [](Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Web::Painting::SpatialNodeIndex spatial) {
+        Web::Compositor::AsyncScrollingState state;
+        state.main_thread_wheel_event_regions.append({
+            .context = { spatial, Web::Painting::NO_FRAME_NODE },
+            .rect = { 0, 0, 10, 10 },
+        });
+        Web::Compositor::AsyncScrollTree scroll_tree;
+        scroll_tree.set_state(move(state));
+        scroll_tree.rebuild_wheel_hit_test_targets(make_empty_display_list(visual_context_tree), &visual_context_tree, {});
+        return scroll_tree;
+    };
+    auto hit_test = [](Web::Compositor::AsyncScrollTree const& scroll_tree, Web::Painting::AccumulatedVisualContextTree const& visual_context_tree) {
+        return scroll_tree.hit_test_scroll_node_for_wheel(
+            visual_context_tree, { 15, 5 }, { 0, 10 }, Web::Compositor::SnapContainerHandling::ScrollOnCompositor);
+    };
+
+    auto static_tree_and_spatial = make_tree_and_spatial();
+    auto static_spatial = static_tree_and_spatial.get<1>();
+    auto static_tree = move(static_tree_and_spatial.get<0>());
+    auto static_scroll_tree = make_scroll_tree(static_tree, static_spatial);
+    static_tree.spatial_node_at(static_spatial).data.get<Web::Painting::TransformData>().matrix[0, 3] = 10;
+    EXPECT(!hit_test(static_scroll_tree, static_tree).blocked_by_main_thread_region);
+
+    auto animated_tree_and_spatial = make_tree_and_spatial();
+    auto animated_spatial = animated_tree_and_spatial.get<1>();
+    auto animated_tree = move(animated_tree_and_spatial.get<0>());
+    animated_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { animated_spatial.value() },
+            .monotonic_time_at_anchor_ns = 0,
+            .iteration_duration_ms = 100,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 20 } } } },
+            },
+        },
+    });
+    auto animated_scroll_tree = make_scroll_tree(animated_tree, animated_spatial);
+    Web::Painting::AccumulatedVisualContextTree::VisualAnimationOriginalValues original_values;
+    animated_tree.sample_visual_animations(50'000'000, original_values);
+    EXPECT(hit_test(animated_scroll_tree, animated_tree).blocked_by_main_thread_region);
 }
 
 TEST_CASE(blocking_wheel_event_hit_testing_fails_closed_for_invalid_visual_context_indices)

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -368,6 +368,78 @@ TEST_CASE(pinch_zoom_copies_the_visual_context_tree_once_per_update)
     }
 }
 
+TEST_CASE(culled_initial_animation_content_becomes_visible)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto opacity_spatial = visual_context_tree.append_spatial(Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} }, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto opacity_frame = visual_context_tree.append_frame(Web::Painting::EffectsData {
+                                                              .opacity = 0,
+                                                              .blend_mode = Gfx::CompositingAndBlendingOperator::Normal,
+                                                              .gfx_filter = {},
+                                                          },
+        Web::Painting::NO_FRAME_NODE, opacity_spatial);
+    Web::Compositor::VisualAnimationTransformOperation initial_scale {
+        Web::Compositor::VisualAnimationTransformOperationKind::Scale,
+        { 0 },
+    };
+    auto scale_spatial = visual_context_tree.append_spatial(Web::Painting::TransformData { initial_scale.to_matrix(), {} }, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
+            .visual_context_node_indices = { opacity_frame.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .iteration_count = 1,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, 0.0f },
+                { 1, {}, 1.0f },
+            },
+        },
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { scale_spatial.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .iteration_count = 1,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::Scale, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::Scale, { 1 } } } },
+            },
+        },
+    });
+
+    ByteBuffer command_bytes;
+    auto opacity_command = Web::Painting::FillRect { { 0, 0, 4, 4 }, Gfx::Color::Red };
+    append_display_list_command(command_bytes, opacity_command, opacity_command.rect, { opacity_spatial, opacity_frame });
+    auto scale_command = Web::Painting::FillRect { { 8, 0, 4, 4 }, Gfx::Color::Red };
+    append_display_list_command(command_bytes, scale_command, scale_command.rect, { scale_spatial, Web::Painting::NO_FRAME_NODE });
+
+    Gfx::IntRect viewport_rect { 0, 0, 12, 4 };
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.install_display_list_update(
+        decode_display_list(visual_context_tree, move(command_bytes), Gfx::Color::Transparent),
+        visual_context_tree,
+        {});
+
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    context.queue_present_frame({ viewport_rect, viewport_rect });
+    EXPECT(context.present_synchronously(display_list_player, nullptr));
+
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    auto opacity_pixel = bitmap->get_pixel(0, 0);
+    EXPECT_EQ(opacity_pixel.red(), 128);
+    EXPECT_EQ(opacity_pixel.alpha(), 128);
+    EXPECT_EQ(bitmap->get_pixel(4, 0), Gfx::Color::Red);
+}
+
 TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
 {
     TestWebContentClient client;

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -77,12 +77,12 @@ static NonnullRefPtr<Web::Painting::DisplayList> decode_display_list(Web::Painti
     return MUST(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>());
 }
 
-static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<Gfx::Color> color, Optional<Gfx::Color> surface_clear_color = {})
+static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<Gfx::Color> color, Optional<Gfx::Color> surface_clear_color = {}, Web::Painting::ContextRef context = {})
 {
     ByteBuffer command_bytes;
     if (color.has_value()) {
         auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color };
-        append_display_list_command(command_bytes, command, command.rect);
+        append_display_list_command(command_bytes, command, command.rect, context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color);
 }
@@ -208,6 +208,117 @@ TEST_CASE(rasterization_clears_damaged_pixels_to_the_canvas_color_in_presentatio
     EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Transparent);
 }
 
+TEST_CASE(visual_animations_advance_without_a_web_content_update)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto spatial = visual_context_tree.append_spatial(Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} }, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto frame = visual_context_tree.append_frame(Web::Painting::EffectsData {}, Web::Painting::NO_FRAME_NODE, spatial);
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { spatial.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 8 } } } },
+            },
+        },
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
+            .visual_context_node_indices = { frame.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, 1.0f },
+                { 1, {}, 0.0f },
+            },
+        },
+    });
+
+    Gfx::IntRect viewport_rect { 0, 0, 12, 4 };
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.install_display_list_update(
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, frame }),
+        visual_context_tree,
+        {});
+
+    auto const* spatial_node_storage = context.visual_context_tree_for_testing().spatial_nodes().data();
+    auto const* frame_node_storage = context.visual_context_tree_for_testing().frame_nodes().data();
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(250)));
+    EXPECT_EQ(context.visual_context_tree_for_testing().spatial_nodes().data(), spatial_node_storage);
+    EXPECT_EQ(context.visual_context_tree_for_testing().frame_nodes().data(), frame_node_storage);
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    EXPECT_EQ(context.visual_context_tree_for_testing().spatial_nodes().data(), spatial_node_storage);
+    EXPECT_EQ(context.visual_context_tree_for_testing().frame_nodes().data(), frame_node_storage);
+    EXPECT(context.has_sampled_visual_animation_values_for_testing());
+    context.queue_present_frame({ viewport_rect, viewport_rect });
+    EXPECT(context.present_synchronously(display_list_player, nullptr));
+
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Transparent);
+    auto animated_pixel = bitmap->get_pixel(4, 0);
+    EXPECT_EQ(animated_pixel.red(), 128);
+    EXPECT_EQ(animated_pixel.green(), 0);
+    EXPECT_EQ(animated_pixel.blue(), 0);
+    EXPECT_EQ(animated_pixel.alpha(), 128);
+
+    context.update_visual_context_tree(visual_context_tree);
+    EXPECT(!context.has_sampled_visual_animation_values_for_testing());
+    auto const& restored_tree = context.visual_context_tree_for_testing();
+    auto restored_translation = restored_tree.spatial_node_at(spatial).data.get<Web::Painting::TransformData>().matrix[0, 3];
+    EXPECT_EQ(restored_translation, 0.0f);
+    EXPECT_EQ(restored_tree.frame_node_at(frame).data.get<Web::Painting::EffectsData>().opacity, 1.0f);
+}
+
+TEST_CASE(wheel_hit_testing_uses_the_current_visual_animation_tree)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, true };
+    auto visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    auto animated_transform = visual_context_tree.append_spatial(
+        Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} },
+        Web::Painting::SpatialNodeIndex { 1 });
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { animated_transform.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 20 } } } },
+            },
+        },
+    });
+
+    context.install_display_list_update(
+        make_scrollable_viewport_display_list(visual_context_tree, false, Web::Painting::ContextRef { animated_transform, Web::Painting::NO_FRAME_NODE }),
+        visual_context_tree,
+        {});
+
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    auto result = context.async_scroll_by(
+        Web::UniqueNodeID { 1 },
+        { 20, 20 },
+        { 0, 10 },
+        { 0, 0, 100, 100 },
+        Web::Compositor::SnapContainerHandling::ScrollOnCompositor,
+        Web::Compositor::AsyncScrollOperationTracking::No);
+    EXPECT(result.enqueue_result.accepted);
+}
+
 TEST_CASE(wheel_hit_testing_ignores_targets_from_a_larger_visual_context_tree)
 {
     TestWebContentClient client;
@@ -237,6 +348,69 @@ TEST_CASE(wheel_hit_testing_ignores_targets_from_a_larger_visual_context_tree)
         Web::Compositor::SnapContainerHandling::ScrollOnCompositor,
         Web::Compositor::AsyncScrollOperationTracking::No);
     EXPECT(result.enqueue_result.accepted);
+}
+
+TEST_CASE(pinch_zoom_copies_the_visual_context_tree_once_per_update)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, true };
+    auto visual_context_tree = make_scrollable_viewport_visual_context_tree();
+    context.install_display_list_update(make_scrollable_viewport_display_list(visual_context_tree), visual_context_tree, {});
+
+    for (u64 update = 1; update <= 5; ++update) {
+        auto result = context.handle_pinch_event({
+            .position = { Web::DevicePixels { 50 }, Web::DevicePixels { 50 } },
+            .scale_delta = 0.1,
+        });
+        EXPECT(result.accepted);
+        EXPECT_EQ(context.visual_context_tree_copy_count_for_testing(), update);
+    }
+}
+
+TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto spatial = visual_context_tree.append_spatial(Web::Painting::TransformData { Gfx::FloatMatrix4x4::identity(), {} }, Web::Painting::VISUAL_VIEWPORT_NODE_INDEX);
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { spatial.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .iteration_count = 1,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 8 } } } },
+            },
+        },
+    });
+
+    Gfx::IntRect viewport_rect { 0, 0, 12, 4 };
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.install_display_list_update(
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, Web::Painting::NO_FRAME_NODE }),
+        visual_context_tree,
+        {});
+
+    EXPECT(context.has_active_visual_animations());
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    EXPECT(context.has_active_visual_animations());
+    EXPECT(!context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(1000)));
+    EXPECT(!context.has_active_visual_animations());
+
+    context.queue_present_frame({ viewport_rect, viewport_rect });
+    EXPECT(context.present_synchronously(display_list_player, nullptr));
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Transparent);
+    EXPECT_EQ(bitmap->get_pixel(8, 0), Gfx::Color::Red);
 }
 
 TEST_CASE(oversized_backing_stores_are_rejected)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SOURCES
     TestStyleStructRef.cpp
     TestTextureUpload.cpp
     TestTrackBufferDemuxer.cpp
+    TestVisualAnimation.cpp
     TestWebGLSpanWithStorage.cpp
     TestWebIDLBuffers.cpp
     TestWindowProxyWorld.cpp

--- a/Tests/LibWeb/Crash/HTML/display-none-iframe-detached-during-raf-sync-xhr.html
+++ b/Tests/LibWeb/Crash/HTML/display-none-iframe-detached-during-raf-sync-xhr.html
@@ -4,8 +4,7 @@
      synchronous XHR. Removing the iframe queues a deferred task that detaches the child document
      from its navigable, and the sync XHR spins the event loop from inside the rendering update,
      running that task before the update's style/layout step. That document is still in the
-     update's docs set, so the style/layout step processes a detached document with no paintable,
-     which the content-visibility step used to dereference. -->
+     update's docs set, so later rendering steps process a detached document with no paint state. -->
 <html class="test-wait">
 <body>
 <script>
@@ -14,6 +13,7 @@
             const iframe = document.createElement("iframe");
             iframe.style.display = "none";
             document.body.appendChild(iframe);
+            window.observer = new IntersectionObserver(() => {}, { root: iframe.contentDocument });
             requestAnimationFrame(() => {
                 iframe.remove();
                 try {

--- a/Tests/LibWeb/TestAccumulatedVisualContext.cpp
+++ b/Tests/LibWeb/TestAccumulatedVisualContext.cpp
@@ -83,3 +83,51 @@ TEST_CASE(a_fractional_clip_rect_contains_points_by_float_containment)
     EXPECT(!tree.transform_point_for_hit_test(context, { 10.25f, 15 }, scroll_state).has_value());
     EXPECT(tree.transform_point_for_hit_test(context, { 10.75f, 15 }, scroll_state).has_value());
 }
+
+TEST_CASE(visual_animation_samples_restore_original_node_values)
+{
+    auto tree = AccumulatedVisualContextTree::create();
+    auto spatial = tree.append_spatial(make_transform(12), VISUAL_VIEWPORT_NODE_INDEX);
+    auto frame = tree.append_frame(EffectsData {
+                                       .opacity = 0.75f,
+                                       .blend_mode = Gfx::CompositingAndBlendingOperator::Normal,
+                                       .gfx_filter = {},
+                                   },
+        NO_FRAME_NODE, spatial);
+    tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { spatial.value() },
+            .local_time_at_anchor_ms = 500,
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 8 } } } },
+            },
+        },
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Opacity,
+            .visual_context_node_indices = { frame.value() },
+            .local_time_at_anchor_ms = 500,
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, 1.0f },
+                { 1, {}, 0.0f },
+            },
+        },
+    });
+
+    AccumulatedVisualContextTree::VisualAnimationOriginalValues original_values;
+    tree.sample_visual_animations(0, original_values);
+    auto sampled_translation = tree.spatial_node_at(spatial).data.get<TransformData>().matrix[0, 3];
+    EXPECT_EQ(sampled_translation, 4.0f);
+    EXPECT_EQ(tree.frame_node_at(frame).data.get<EffectsData>().opacity, 0.5f);
+
+    tree.restore_visual_animation_original_values(original_values);
+    EXPECT(original_values.is_empty());
+    auto restored_translation = tree.spatial_node_at(spatial).data.get<TransformData>().matrix[0, 3];
+    EXPECT_EQ(restored_translation, 12.0f);
+    EXPECT_EQ(tree.frame_node_at(frame).data.get<EffectsData>().opacity, 0.75f);
+}

--- a/Tests/LibWeb/TestVisualAnimation.cpp
+++ b/Tests/LibWeb/TestVisualAnimation.cpp
@@ -79,6 +79,28 @@ TEST_CASE(applies_playback_direction_and_keyframe_easing)
     EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(1000))->opacity, 0.25f);
 }
 
+TEST_CASE(clamps_finite_animation_to_end_progress)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 900,
+        .iteration_duration_ms = 1000,
+        .iteration_count = 1,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(200))->opacity, 1.0f);
+    animation.playback_direction = VisualAnimationPlaybackDirection::Reverse;
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(200))->opacity, 0.0f);
+    animation.iteration_start = 0.5;
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(200))->opacity, 0.5f);
+}
+
 TEST_CASE(uses_following_interval_at_keyframe_boundary)
 {
     VisualAnimation animation {
@@ -135,4 +157,30 @@ TEST_CASE(rejects_invalid_timing)
 {
     VisualAnimation animation;
     EXPECT(!animation.sample(AK::Duration::zero()).has_value());
+}
+
+TEST_CASE(compares_animation_parameters_independently_of_visual_nodes_and_anchor)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 1 },
+        .monotonic_time_at_anchor_ns = 100,
+        .local_time_at_anchor_ms = 250,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+    auto retargeted_animation = animation;
+    retargeted_animation.visual_context_node_indices = { 2 };
+    retargeted_animation.monotonic_time_at_anchor_ns = 200;
+    retargeted_animation.local_time_at_anchor_ms = 500;
+
+    EXPECT(animation.has_same_animation_parameters(retargeted_animation));
+    EXPECT(!animation.has_same_parameters_except_anchor(retargeted_animation));
+
+    retargeted_animation.iteration_duration_ms = 2000;
+    EXPECT(!animation.has_same_animation_parameters(retargeted_animation));
 }

--- a/Tests/LibWeb/TestVisualAnimation.cpp
+++ b/Tests/LibWeb/TestVisualAnimation.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWeb/Compositor/VisualAnimation.h>
+
+using namespace Web::Compositor;
+
+static VisualAnimationEasing linear_easing()
+{
+    return {};
+}
+
+TEST_CASE(samples_opacity_across_iterations)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 250,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::zero())->opacity, 0.25f);
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(500))->opacity, 0.75f);
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(1000))->opacity, 0.25f);
+}
+
+TEST_CASE(clamps_overshooting_opacity_easing)
+{
+    VisualAnimationEasing overshooting_easing {
+        .kind = VisualAnimationEasing::Kind::CubicBezier,
+        .linear_points = {},
+        .x1 = 0.5,
+        .y1 = -1,
+        .x2 = 0.5,
+        .y2 = 2,
+    };
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 100,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, overshooting_easing, 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_EQ(animation.sample(AK::Duration::zero())->opacity, 0.0f);
+    animation.local_time_at_anchor_ms = 900;
+    EXPECT_EQ(animation.sample(AK::Duration::zero())->opacity, 1.0f);
+}
+
+TEST_CASE(applies_playback_direction_and_keyframe_easing)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 250,
+        .iteration_duration_ms = 1000,
+        .playback_direction = VisualAnimationPlaybackDirection::AlternateReverse,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, VisualAnimationEasing { .kind = VisualAnimationEasing::Kind::Steps, .linear_points = {}, .interval_count = 4, .step_position = 1 }, 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::zero())->opacity, 0.75f);
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(1000))->opacity, 0.25f);
+}
+
+TEST_CASE(uses_following_interval_at_keyframe_boundary)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 500,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), 0.0f },
+            { 0.5, VisualAnimationEasing { .kind = VisualAnimationEasing::Kind::Steps, .linear_points = {}, .interval_count = 4, .step_position = 0 }, 0.5f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::zero())->opacity, 0.625f);
+}
+
+TEST_CASE(interpolates_transform_operations_before_composing)
+{
+    VisualAnimationTransformList from {
+        { VisualAnimationTransformOperationKind::TranslateX, { 0 } },
+        { VisualAnimationTransformOperationKind::Rotate, { 0 } },
+    };
+    VisualAnimationTransformList to {
+        { VisualAnimationTransformOperationKind::TranslateX, { 100 } },
+        { VisualAnimationTransformOperationKind::Rotate, { AK::Pi<float> } },
+    };
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Transform,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 500,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), move(from) },
+            { 1, linear_easing(), move(to) },
+        },
+    };
+
+    auto expected = Gfx::translation_matrix(Gfx::FloatVector3 { 50, 0, 0 })
+        * Gfx::rotation_matrix(Gfx::FloatVector3 { 0, 0, 1 }, AK::Pi<float> / 2);
+    auto sampled = animation.sample(AK::Duration::zero())->transform;
+    for (size_t row = 0; row < 4; ++row) {
+        for (size_t column = 0; column < 4; ++column) {
+            auto sampled_value = sampled[row, column];
+            auto expected_value = expected[row, column];
+            EXPECT_APPROXIMATE(sampled_value, expected_value);
+        }
+    }
+}
+
+TEST_CASE(rejects_invalid_timing)
+{
+    VisualAnimation animation;
+    EXPECT(!animation.sample(AK::Duration::zero()).has_value());
+}

--- a/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-style-dirty-effects.txt
@@ -5,4 +5,5 @@ timing changes invalidate skip eligibility: true
 descendant style changes invalidate skip eligibility: true
 finished sibling contribution is retained: true
 active sibling contributes to computed style: true
+empty dirty updates preserve throttled reads: true
 paused animation builds no overlays: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
@@ -1,11 +1,15 @@
 animation initially uses compositor: 1
-observer keeps transform on main thread: 0
+observer keeps transform on compositor: 1
 initial position is intersecting: true
 animated position leaves viewport: true
 disconnect restores compositor animation: 1
 offscreen observed clip uses compositor: true
 offscreen clipped target is not intersecting: true
-scrolling observed clip restores main thread: 1
-withdrawn compositor animation requests frame: true
+scrolling observed clip retains compositor: true
+observed compositor animation requests sample frame: true
 scrolled clipped target enters viewport: true
 observed animation still updates intersection: true
+ancestor compositor motion updates descendant intersection: true
+leaving target starts inside root: true
+observed compositor motion is sampled within 250ms: true
+observation timer builds no animation overlays: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
@@ -3,3 +3,9 @@ observer keeps transform on main thread: 0
 initial position is intersecting: true
 animated position leaves viewport: true
 disconnect restores compositor animation: 1
+offscreen observed clip uses compositor: true
+offscreen clipped target is not intersecting: true
+scrolling observed clip restores main thread: 1
+withdrawn compositor animation requests frame: true
+scrolled clipped target enters viewport: true
+observed animation still updates intersection: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-intersection-observer.txt
@@ -1,0 +1,5 @@
+animation initially uses compositor: 1
+observer keeps transform on main thread: 0
+initial position is intersecting: true
+animated position leaves viewport: true
+disconnect restores compositor animation: 1

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-observe-scoped-flush.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-observe-scoped-flush.txt
@@ -1,0 +1,3 @@
+animation uses compositor: true
+unrelated observation skips animation sample: true
+descendant observation samples ancestor animation: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-retained-content.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-retained-content.txt
@@ -1,0 +1,2 @@
+culled animations stay on main thread: 0
+paintable animations move to compositor: 2

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-retained-content.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-retained-content.txt
@@ -1,2 +1,4 @@
-culled animations stay on main thread: 0
-paintable animations move to compositor: 2
+culled animations move immediately to compositor: 2
+opacity-zero animation content is retained: true
+singular-transform animation content is retained: true
+culled compositor animations build no overlays: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-rotated-observer-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-rotated-observer-ancestor.txt
@@ -1,0 +1,3 @@
+target starts outside root: true
+animation stays on main thread: true
+target enters root: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-timers-stop-for-inactive-document.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-timers-stop-for-inactive-document.txt
@@ -1,0 +1,4 @@
+timers armed before navigation: true
+timers stopped after navigation: true
+timers armed before destruction: true
+timers stopped after destruction: true

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-zero-delay-future-start.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-zero-delay-future-start.txt
@@ -1,0 +1,1 @@
+zero-delay future start reaches completion: true

--- a/Tests/LibWeb/Text/expected/css/compositor-competing-replace-effects.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-competing-replace-effects.txt
@@ -1,0 +1,20 @@
+Azure pair publishes opacity and transform: true
+Azure pair avoids main-thread overlays: true
+later duplicate fade wins opacity: true
+short winner controls the boundary sample: true
+loser is published when winner ends: true
+winner change republishes descriptors: true
+later script animation wins over CSS animation: true
+paused winner is sampled on the main thread: true
+cancelling winner republishes CSS animation: true
+add competitor stays on the main thread: true
+opacity loser still hands off transform: true
+pseudo-element pair publishes opacity and transform: true
+finite loser receives an end wake-up: true
+finite loser finishes after deterministic advance: true
+competing finite effects register an end wake-up: true
+losing finite effect finishes after deterministic advance: true
+both competing finite effects dispatch animationend: true
+losing finite effect restores base opacity: true
+losing infinite effect dispatches iteration events: true
+losing infinite listener keeps the frame pump active: true

--- a/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
@@ -1,4 +1,4 @@
-compositor visual animations: 3
+compositor visual animations: 4
 reference box resize updates compositor animation: true
 reference box resize resolves keyframes: true
 style change resolves keyframes: true

--- a/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
@@ -1,4 +1,13 @@
 compositor visual animations: 2
 main-thread animation overlay builds: 0
 main-thread animation frame pump requests: 0
+stable compositor animation updates: 0
 stable compositor animation updates with changing visual nodes: 0
+cancel removes compositor animations: 0
+cancel updates compositor animations: true
+empty compositor animation updates: 0
+finite animation uses compositor: true
+finite animation requests only end frames: true
+finite animation dispatches end event: true
+finite animation reaches end opacity: true
+finite animation reaches end style: true

--- a/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
@@ -1,3 +1,4 @@
 compositor visual animations: 2
 main-thread animation overlay builds: 0
 main-thread animation frame pump requests: 0
+stable compositor animation updates with changing visual nodes: 0

--- a/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
@@ -1,6 +1,11 @@
-compositor visual animations: 2
+compositor visual animations: 3
+reference box resize updates compositor animation: true
+reference box resize resolves keyframes: true
+style change resolves keyframes: true
+style change updates compositor animation: true
 main-thread animation overlay builds: 0
 main-thread animation frame pump requests: 0
+stable compositor animations reuse resolved keyframes: true
 stable compositor animation updates: 0
 stable compositor animation updates with changing visual nodes: 0
 cancel removes compositor animations: 0

--- a/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-driven-animations.txt
@@ -1,0 +1,3 @@
+compositor visual animations: 2
+main-thread animation overlay builds: 0
+main-thread animation frame pump requests: 0

--- a/Tests/LibWeb/Text/expected/css/compositor-opacity-track-visibility.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-opacity-track-visibility.txt
@@ -1,0 +1,3 @@
+infinite and finite opacity animations stay on main thread: true
+infinite opacity is current: true
+finite opacity is current: true

--- a/Tests/LibWeb/Text/expected/css/element-scoped-animation-sampling.txt
+++ b/Tests/LibWeb/Text/expected/css/element-scoped-animation-sampling.txt
@@ -1,4 +1,5 @@
 unrelated reads do not sample animation: true
 related reads sample once per task: true
 related read samples in a later task: true
+ancestor style reads sample descendant animations: true
 ancestor reads sample descendant animations: true

--- a/Tests/LibWeb/Text/expected/css/finished-compositor-animation-content-culling.txt
+++ b/Tests/LibWeb/Text/expected/css/finished-compositor-animation-content-culling.txt
@@ -1,0 +1,8 @@
+animations start on the compositor: true
+active animation content is retained: true
+paused opacity-zero content is culled: true
+main-thread opacity-zero content is culled: true
+finished opacity content is culled: true
+finished singular-transform content is culled: true
+opacity-zero target remains hit-testable: true
+scale-zero target is absent from hit testing: true

--- a/Tests/LibWeb/Text/expected/css/finite-compositor-animation-completion.txt
+++ b/Tests/LibWeb/Text/expected/css/finite-compositor-animation-completion.txt
@@ -1,0 +1,9 @@
+finite effects use the compositor: true
+finished promises resolve: true
+animationend events fire: true
+animationend sees terminal style: true
+finite effects request one end frame: true
+wake-up timer leaves animation updates to frames: true
+forwards fill retains opacity: true
+no fill restores transform: true
+terminal values remain stable: true

--- a/Tests/LibWeb/Text/expected/css/finite-compositor-targeted-wakeup.txt
+++ b/Tests/LibWeb/Text/expected/css/finite-compositor-targeted-wakeup.txt
@@ -1,0 +1,4 @@
+all effects use the compositor: true
+finite end samples only its target: true
+finite end requests one frame: true
+infinite effects remain on the compositor: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -12,7 +12,7 @@ detached animation dispatches iteration event: 1
 computed style uses current timeline sample: true
 computed timing uses current timeline sample: true
 geometry uses current timeline sample: true
-visible animation builds while hidden stays throttled: 4
+visible animation builds while hidden stays throttled: true
 computed style samples hidden animation alongside visible animation: true
 style-only visibility change samples animation: true
 visible descendant keeps animation updating: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -4,6 +4,10 @@ animation event listener keeps frame pump active: true
 animation event listener skips past events: 0
 removing animation event listener stops frame pump: 0
 computed style samples hidden animation: true
+offscreen clipped animation overlay builds: 0
+offscreen clipped animation frame pump requests: 0
+revealed clipped animation resumes: true
+revealed clipped animation requests frame: true
 computed style uses current timeline sample: true
 computed timing uses current timeline sample: true
 geometry uses current timeline sample: true

--- a/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
+++ b/Tests/LibWeb/Text/expected/css/invisible-animation-style-throttling.txt
@@ -4,14 +4,12 @@ animation event listener keeps frame pump active: true
 animation event listener skips past events: 0
 removing animation event listener stops frame pump: 0
 computed style samples hidden animation: true
-detached animation stops frame pump: 0
-detached animation current time advances: true
-unreachable end listener leaves detached animation throttled: true
-detached animation listener keeps frame pump active: true
-detached animation dispatches iteration event: 1
 computed style uses current timeline sample: true
 computed timing uses current timeline sample: true
 geometry uses current timeline sample: true
+becoming visible flushes throttled animations: true
+detached animation stops frame pump: 0
+detached animation current time advances: true
 visible animation builds while hidden stays throttled: true
 computed style samples hidden animation alongside visible animation: true
 style-only visibility change samples animation: true

--- a/Tests/LibWeb/Text/expected/css/offscreen-animation-fixed-descendant.txt
+++ b/Tests/LibWeb/Text/expected/css/offscreen-animation-fixed-descendant.txt
@@ -1,0 +1,3 @@
+animation stays on main thread: true
+animation is not offscreen throttled: true
+fixed descendant is intersecting: true

--- a/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
+++ b/Tests/LibWeb/Text/input/css/animated-style-dirty-effects.html
@@ -29,6 +29,7 @@
 
         const hiddenTarget = document.createElement("div");
         hiddenTarget.style.visibility = "hidden";
+        hiddenTarget.style.transformOrigin = "center center 1px";
         document.body.append(hiddenTarget);
         const hiddenAnimation = hiddenTarget.animate([
             { transform: "translateX(0px)" },
@@ -104,6 +105,26 @@
         for (const animation of document.getAnimations())
             animation.cancel();
         await nextFrame();
+
+        const retainedTarget = document.createElement("div");
+        retainedTarget.style.cssText = "visibility: hidden; transform-origin: center center 1px";
+        document.body.append(retainedTarget);
+        const retainedTimeline = internals.createInternalAnimationTimeline();
+        const retainedAnimation = new Animation(new KeyframeEffect(retainedTarget, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100, iterations: Infinity }), retainedTimeline);
+        retainedAnimation.play();
+        retainedTimeline.setTime(0);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        retainedTimeline.setTimeForObservation(50);
+        const retainedThrottledUpdate = internals.runEmptyAnimationStyleUpdateForTesting();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const retainedTransform = new DOMMatrix(getComputedStyle(retainedTarget).transform);
+        println(`empty dirty updates preserve throttled reads: ${retainedThrottledUpdate && retainedTransform.e === 50}`);
+        retainedAnimation.cancel();
+        retainedTarget.remove();
 
         const pausedTarget = document.createElement("div");
         document.body.append(pausedTarget);

--- a/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
@@ -40,7 +40,44 @@
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
         println(`disconnect restores compositor animation: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        animation.cancel();
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
 
+        const spacer = document.createElement("div");
+        spacer.style.height = "100vh";
+        const clip = document.createElement("div");
+        clip.style.cssText = "width: 100px; height: 100px; overflow: hidden";
+        const clippedTarget = document.createElement("div");
+        clippedTarget.style.cssText = "width: 20px; height: 20px; animation: move 100s linear infinite";
+        clip.append(clippedTarget);
+        document.body.append(spacer, clip);
+        const clippedAnimation = clippedTarget.getAnimations()[0];
+        clippedAnimation.currentTime = 0;
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        let resolveClippedObservation;
+        let clippedObservation = new Promise(resolve => resolveClippedObservation = resolve);
+        const clippedObserver = new IntersectionObserver(entries => resolveClippedObservation(entries.at(-1)));
+        clippedObserver.observe(clippedTarget);
+        const initialClippedObservation = await clippedObservation;
+        println(`offscreen observed clip uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+        println(`offscreen clipped target is not intersecting: ${!initialClippedObservation.isIntersecting}`);
+
+        clippedObservation = new Promise(resolve => resolveClippedObservation = resolve);
+        internals.resetStyleInvalidationCounters();
+        clip.scrollIntoView();
+        const scrolledObservation = await clippedObservation;
+        await new Promise(resolve => setTimeout(() => setTimeout(resolve, 0), 0));
+        println(`scrolling observed clip restores main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        println(`withdrawn compositor animation requests frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        println(`scrolled clipped target enters viewport: ${scrolledObservation.isIntersecting}`);
+
+        clippedObservation = new Promise(resolve => resolveClippedObservation = resolve);
+        clippedAnimation.currentTime = 75000;
+        const movedClippedObservation = await clippedObservation;
+        println(`observed animation still updates intersection: ${!movedClippedObservation.isIntersecting}`);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
@@ -6,6 +6,12 @@
         to { transform: translateX(10000px); }
     }
 
+    @keyframes leave-observation-root {
+        from { transform: translateX(0); }
+        25% { transform: translateX(0); }
+        26%, to { transform: translateX(30px); }
+    }
+
     #target {
         width: 20px;
         height: 20px;
@@ -28,7 +34,7 @@
         observer.observe(document.querySelector("#target"));
 
         const initialObservation = await nextObservation;
-        println(`observer keeps transform on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        println(`observer keeps transform on compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
         println(`initial position is intersecting: ${initialObservation.isIntersecting}`);
 
         nextObservation = new Promise(resolve => resolveNextObservation = resolve);
@@ -69,15 +75,70 @@
         internals.resetStyleInvalidationCounters();
         clip.scrollIntoView();
         const scrolledObservation = await clippedObservation;
-        await new Promise(resolve => setTimeout(() => setTimeout(resolve, 0), 0));
-        println(`scrolling observed clip restores main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
-        println(`withdrawn compositor animation requests frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        await new Promise(resolve => setTimeout(resolve, 120));
+        println(`scrolling observed clip retains compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+        println(`observed compositor animation requests sample frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
         println(`scrolled clipped target enters viewport: ${scrolledObservation.isIntersecting}`);
 
         clippedObservation = new Promise(resolve => resolveClippedObservation = resolve);
         clippedAnimation.currentTime = 75000;
         const movedClippedObservation = await clippedObservation;
         println(`observed animation still updates intersection: ${!movedClippedObservation.isIntersecting}`);
+
+        const animatedAncestor = document.createElement("div");
+        animatedAncestor.style.cssText = "width: 20px; height: 20px; animation: move 100s linear infinite";
+        const descendantTarget = document.createElement("div");
+        descendantTarget.style.cssText = "width: 20px; height: 20px";
+        animatedAncestor.append(descendantTarget);
+        document.body.append(animatedAncestor);
+        animatedAncestor.scrollIntoView();
+        const ancestorAnimation = animatedAncestor.getAnimations()[0];
+        ancestorAnimation.currentTime = 0;
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        let resolveDescendantObservation;
+        let descendantObservation = new Promise(resolve => resolveDescendantObservation = resolve);
+        const descendantObserver = new IntersectionObserver(entries => resolveDescendantObservation(entries.at(-1)));
+        descendantObserver.observe(descendantTarget);
+        await descendantObservation;
+        descendantObservation = new Promise(resolve => resolveDescendantObservation = resolve);
+        ancestorAnimation.currentTime = 75000;
+        const movedDescendantObservation = await descendantObservation;
+        println(`ancestor compositor motion updates descendant intersection: ${!movedDescendantObservation.isIntersecting}`);
+        descendantObserver.disconnect();
+
+        const observationRoot = document.createElement("div");
+        observationRoot.style.cssText = "width: 20px; height: 20px; overflow: hidden";
+        const leavingTarget = document.createElement("div");
+        leavingTarget.style.cssText = "width: 20px; height: 20px; animation: leave-observation-root 400ms linear infinite";
+        observationRoot.append(leavingTarget);
+        document.body.append(observationRoot);
+        observationRoot.scrollIntoView();
+        const leavingAnimation = leavingTarget.getAnimations()[0];
+        leavingAnimation.startTime = document.timeline.currentTime;
+        leavingTarget.getBoundingClientRect();
+
+        let resolveInitialLeavingObservation;
+        const initialLeavingObservation = new Promise(resolve => resolveInitialLeavingObservation = resolve);
+        let resolveLeftObservation;
+        const leftObservation = new Promise(resolve => resolveLeftObservation = resolve);
+        const leavingObserver = new IntersectionObserver(entries => {
+            const entry = entries.at(-1);
+            resolveInitialLeavingObservation(entry);
+            if (!entry.isIntersecting)
+                resolveLeftObservation(true);
+        }, { root: observationRoot });
+        leavingObserver.observe(leavingTarget);
+        println(`leaving target starts inside root: ${(await initialLeavingObservation).isIntersecting}`);
+        await new Promise(requestAnimationFrame);
+        internals.resetStyleInvalidationCounters();
+        const leftBeforeTimeout = await Promise.race([
+            leftObservation,
+            new Promise(resolve => setTimeout(() => resolve(false), 250)),
+        ]);
+        println(`observed compositor motion is sampled within 250ms: ${leftBeforeTimeout}`);
+        println(`observation timer builds no animation overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-intersection-observer.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move {
+        from { transform: translateX(0); }
+        to { transform: translateX(10000px); }
+    }
+
+    #target {
+        width: 20px;
+        height: 20px;
+        animation: move 100s linear infinite;
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        const animation = document.getAnimations()[0];
+        animation.currentTime = 0;
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        println(`animation initially uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+
+        let resolveNextObservation;
+        let nextObservation = new Promise(resolve => resolveNextObservation = resolve);
+        const observer = new IntersectionObserver(entries => resolveNextObservation(entries.at(-1)));
+        observer.observe(document.querySelector("#target"));
+
+        const initialObservation = await nextObservation;
+        println(`observer keeps transform on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        println(`initial position is intersecting: ${initialObservation.isIntersecting}`);
+
+        nextObservation = new Promise(resolve => resolveNextObservation = resolve);
+        animation.currentTime = 75000;
+        const movedObservation = await nextObservation;
+        println(`animated position leaves viewport: ${!movedObservation.isIntersecting}`);
+
+        observer.disconnect();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`disconnect restores compositor animation: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-observe-scoped-flush.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-observe-scoped-flush.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move {
+        from { transform: translateX(0); }
+        to { transform: translateX(100px); }
+    }
+
+    #animated {
+        width: 20px;
+        height: 20px;
+        animation: move 10s linear infinite;
+    }
+</style>
+<div id="animated"><div id="descendant"></div></div>
+<div id="unrelated"></div>
+<script>
+    asyncTest(async done => {
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`animation uses compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
+
+        internals.resetStyleInvalidationCounters();
+        const unrelatedObserver = new IntersectionObserver(() => {});
+        unrelatedObserver.observe(unrelated);
+        await new Promise(requestAnimationFrame);
+        println(`unrelated observation skips animation sample: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        internals.resetStyleInvalidationCounters();
+        const descendantObserver = new IntersectionObserver(() => {});
+        descendantObserver.observe(descendant);
+        await new Promise(requestAnimationFrame);
+        println(`descendant observation samples ancestor animation: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-retained-content.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-retained-content.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes reveal-opacity {
+        0%, 50% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+
+    @keyframes reveal-transform {
+        0%, 50% { transform: scale(0); }
+        100% { transform: scale(1); }
+    }
+
+    #opacity {
+        animation: reveal-opacity 100s linear infinite;
+    }
+
+    #transform {
+        animation: reveal-transform 100s linear infinite;
+    }
+</style>
+<div id="opacity">opacity</div>
+<div id="transform">transform</div>
+<script>
+    asyncTest(async done => {
+        const animations = document.getAnimations();
+        animations.forEach(animation => animation.currentTime = 0);
+
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        println(`culled animations stay on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+
+        animations.forEach(animation => animation.currentTime = 75000);
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        println(`paintable animations move to compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-retained-content.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-retained-content.html
@@ -12,11 +12,13 @@
     }
 
     #opacity {
-        animation: reveal-opacity 100s linear infinite;
+        background: rgb(21, 22, 23);
+        animation: reveal-opacity 100s linear;
     }
 
     #transform {
-        animation: reveal-transform 100s linear infinite;
+        background: rgb(24, 25, 26);
+        animation: reveal-transform 100s linear;
     }
 </style>
 <div id="opacity">opacity</div>
@@ -29,13 +31,16 @@
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
 
-        println(`culled animations stay on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        println(`culled animations move immediately to compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        const displayList = internals.dumpDisplayList();
+        println(`opacity-zero animation content is retained: ${displayList.includes("rgb(21, 22, 23)")}`);
+        println(`singular-transform animation content is retained: ${displayList.includes("rgb(24, 25, 26)")}`);
 
-        animations.forEach(animation => animation.currentTime = 75000);
+        internals.resetStyleInvalidationCounters();
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
 
-        println(`paintable animations move to compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        println(`culled compositor animations build no overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-rotated-observer-ancestor.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-rotated-observer-ancestor.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move-horizontally {
+        from, 25% { transform: translateX(0); }
+        26%, to { transform: translateX(30px); }
+    }
+
+    #root {
+        position: relative;
+        width: 20px;
+        height: 20px;
+        overflow: hidden;
+    }
+
+    #rotated-parent {
+        position: absolute;
+        top: -30px;
+        transform: rotate(90deg);
+        transform-origin: 0 0;
+    }
+
+    #target {
+        width: 20px;
+        height: 20px;
+        animation: move-horizontally 400ms linear infinite;
+    }
+</style>
+<div id="root"><div id="rotated-parent"><div id="target"></div></div></div>
+<script>
+    asyncTest(async done => {
+        const animation = target.getAnimations()[0];
+        animation.currentTime = 0;
+
+        let resolveObservation;
+        let nextObservation = new Promise(resolve => resolveObservation = resolve);
+        const observer = new IntersectionObserver(entries => resolveObservation(entries.at(-1)), { root });
+        observer.observe(target);
+
+        println(`target starts outside root: ${!(await nextObservation).isIntersecting}`);
+        println(`animation stays on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+
+        nextObservation = new Promise(resolve => resolveObservation = resolve);
+        animation.currentTime = 200;
+        println(`target enters root: ${(await nextObservation).isIntersecting}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-timers-stop-for-inactive-document.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-timers-stop-for-inactive-document.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    async function createFrameWithArmedTimers() {
+        const frame = document.createElement("iframe");
+        frame.srcdoc = "child document";
+        document.body.append(frame);
+        await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
+        frame.contentWindow.internals.armCompositorAnimationTimersForTesting();
+        return frame;
+    }
+
+    function timersAreArmed(frame) {
+        const counters = frame.contentWindow.internals.getStyleInvalidationCounters();
+        return counters.compositorAnimationWakeupTimerActive
+            && counters.compositorAnimationObservationTimerActive;
+    }
+
+    function timersAreStopped(oldInternals) {
+        const counters = oldInternals.getStyleInvalidationCounters();
+        return !counters.compositorAnimationWakeupTimerActive
+            && !counters.compositorAnimationObservationTimerActive;
+    }
+
+    asyncTest(async done => {
+        const navigatedFrame = await createFrameWithArmedTimers();
+        println(`timers armed before navigation: ${timersAreArmed(navigatedFrame)}`);
+        const navigatedInternals = navigatedFrame.contentWindow.internals;
+        navigatedFrame.srcdoc = "replacement";
+        await new Promise(resolve => navigatedFrame.addEventListener("load", resolve, { once: true }));
+        println(`timers stopped after navigation: ${timersAreStopped(navigatedInternals)}`);
+
+        const removedFrame = await createFrameWithArmedTimers();
+        println(`timers armed before destruction: ${timersAreArmed(removedFrame)}`);
+        const removedInternals = removedFrame.contentWindow.internals;
+        removedFrame.remove();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        println(`timers stopped after destruction: ${timersAreStopped(removedInternals)}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-animation-zero-delay-future-start.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-zero-delay-future-start.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        const animation = target.animate([
+            { opacity: 0.2 },
+            { opacity: 0.8 },
+        ], { duration: 20, fill: "forwards" });
+        animation.startTime = document.timeline.currentTime + 20;
+        await animation.finished;
+        println(`zero-delay future start reaches completion: ${getComputedStyle(target).opacity === "0.8"}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-competing-replace-effects.html
+++ b/Tests/LibWeb/Text/input/css/compositor-competing-replace-effects.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    @keyframes slide-up {
+        from { opacity: 0; transform: translateY(100px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+
+    .azure-pair {
+        animation: fade-in 100s, slide-up 100s ease-in-out;
+    }
+
+    .double-fade {
+        animation: fade-in 100s, fade-in 100s;
+    }
+
+    .split-winners {
+        animation: slide-up 100s ease-in-out, fade-in 100s;
+    }
+
+    .finite-pair {
+        opacity: 0.35;
+        animation: fade-in 100s linear, slide-up 100s linear;
+    }
+
+    .infinite-pair {
+        animation: fade-in 100s linear infinite, slide-up 100s linear infinite;
+    }
+
+    .finite-loser-infinite-winner {
+        animation: fade-in 100s linear, slide-up 100s linear infinite;
+    }
+
+    .css-fade {
+        animation: fade-in 100s;
+    }
+
+    #pseudo.enabled::before {
+        content: "";
+        display: block;
+        width: 10px;
+        height: 10px;
+        animation: fade-in 100s, slide-up 100s ease-in-out;
+    }
+</style>
+<div id="target"></div>
+<div id="pseudo"></div>
+<script>
+    asyncTest(async done => {
+        const target = document.querySelector("#target");
+        const nextFrames = async (count = 3) => {
+            for (let i = 0; i < count; ++i)
+                await new Promise(requestAnimationFrame);
+        };
+        const descriptorCount = () => internals.getStyleInvalidationCounters().compositorVisualAnimations;
+        const clearTarget = async () => {
+            for (const animation of target.getAnimations())
+                animation.cancel();
+            target.className = "";
+            target.removeAttribute("style");
+            await nextFrames(2);
+        };
+
+        target.className = "azure-pair";
+        await nextFrames();
+        internals.resetStyleInvalidationCounters();
+        await nextFrames(4);
+        println(`Azure pair publishes opacity and transform: ${descriptorCount() === 2}`);
+        println(`Azure pair avoids main-thread overlays: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds === 0}`);
+
+        await clearTarget();
+        target.className = "double-fade";
+        await nextFrames();
+        println(`later duplicate fade wins opacity: ${descriptorCount() === 1}`);
+
+        await clearTarget();
+        const loser = target.animate([{ opacity: 0.1 }, { opacity: 0.9 }], { duration: 100000 });
+        const winner = target.animate([{ opacity: 0.2 }, { opacity: 0.4 }], { duration: 1000 });
+        loser.currentTime = 500;
+        winner.currentTime = 500;
+        await nextFrames();
+        const winnerOpacity = parseFloat(getComputedStyle(target).opacity);
+        internals.resetStyleInvalidationCounters();
+        winner.currentTime = 1001;
+        await nextFrames();
+        const loserOpacity = parseFloat(getComputedStyle(target).opacity);
+        println(`short winner controls the boundary sample: ${Math.abs(winnerOpacity - 0.3) < 0.02}`);
+        println(`loser is published when winner ends: ${descriptorCount() === 1 && loserOpacity < 0.2}`);
+        println(`winner change republishes descriptors: ${internals.getStyleInvalidationCounters().compositorVisualAnimationUpdates > 0}`);
+
+        await clearTarget();
+        target.className = "css-fade";
+        await nextFrames();
+        const cssAnimationWasPublished = descriptorCount() === 1;
+        const scriptWinner = target.animate([{ opacity: 0.25 }, { opacity: 0.75 }], { duration: 100000 });
+        scriptWinner.currentTime = 50000;
+        await nextFrames();
+        println(`later script animation wins over CSS animation: ${cssAnimationWasPublished && descriptorCount() === 1 && Math.abs(parseFloat(getComputedStyle(target).opacity) - 0.5) < 0.02}`);
+        scriptWinner.pause();
+        await nextFrames();
+        println(`paused winner is sampled on the main thread: ${descriptorCount() === 0 && Math.abs(parseFloat(getComputedStyle(target).opacity) - 0.5) < 0.02}`);
+        scriptWinner.cancel();
+        await nextFrames();
+        println(`cancelling winner republishes CSS animation: ${descriptorCount() === 1}`);
+
+        await clearTarget();
+        target.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 100000 });
+        target.animate([{ opacity: 0 }, { opacity: 0.5 }], { duration: 100000, composite: "add" });
+        await nextFrames();
+        println(`add competitor stays on the main thread: ${descriptorCount() === 0}`);
+
+        await clearTarget();
+        target.className = "split-winners";
+        await nextFrames();
+        println(`opacity loser still hands off transform: ${descriptorCount() === 2}`);
+
+        await clearTarget();
+        document.querySelector("#pseudo").className = "enabled";
+        await nextFrames();
+        println(`pseudo-element pair publishes opacity and transform: ${descriptorCount() === 2}`);
+        for (const animation of document.getAnimations())
+            animation.cancel();
+
+        await clearTarget();
+        target.className = "finite-loser-infinite-winner";
+        await nextFrames(2);
+        const finiteLoser = target.getAnimations().find(animation => animation.animationName === "fade-in");
+        println(`finite loser receives an end wake-up: ${internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+        finiteLoser.currentTime = 100001;
+        await finiteLoser.finished;
+        println(`finite loser finishes after deterministic advance: ${finiteLoser.playState === "finished"}`);
+
+        await clearTarget();
+        let finiteAnimationEndEvents = 0;
+        target.addEventListener("animationend", () => ++finiteAnimationEndEvents);
+        target.className = "finite-pair";
+        await nextFrames(2);
+        const finiteAnimations = target.getAnimations();
+        const losingFiniteAnimation = finiteAnimations.find(animation => animation.animationName === "fade-in");
+        internals.resetStyleInvalidationCounters();
+        println(`competing finite effects register an end wake-up: ${internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+        for (const animation of finiteAnimations)
+            animation.currentTime = 100001;
+        await losingFiniteAnimation.finished;
+        await nextFrames(2);
+        println(`losing finite effect finishes after deterministic advance: ${losingFiniteAnimation.playState === "finished"}`);
+        println(`both competing finite effects dispatch animationend: ${finiteAnimationEndEvents === 2}`);
+        println(`losing finite effect restores base opacity: ${getComputedStyle(target).opacity === "0.35"}`);
+
+        await clearTarget();
+        let losingInfiniteIterations = 0;
+        const losingInfiniteIterationsObserved = new Promise(resolve => {
+            target.addEventListener("animationiteration", event => {
+                if (event.animationName !== "fade-in" || ++losingInfiniteIterations !== 2)
+                    return;
+                resolve(true);
+            });
+        });
+        target.className = "infinite-pair";
+        await nextFrames(2);
+        const losingInfiniteAnimation = target.getAnimations().find(animation => animation.animationName === "fade-in");
+        internals.resetStyleInvalidationCounters();
+        losingInfiniteAnimation.currentTime = 150000;
+        await nextFrames(2);
+        losingInfiniteAnimation.currentTime = 250000;
+        await losingInfiniteIterationsObserved;
+        println(`losing infinite effect dispatches iteration events: ${losingInfiniteIterations === 2}`);
+        println(`losing infinite listener keeps the frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
+        for (const animation of target.getAnimations())
+            animation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -11,6 +11,11 @@
         to { transform: translateX(100px) rotate(360deg); }
     }
 
+    @keyframes relative-move {
+        from { transform: translateX(calc(100vw + var(--distance))); }
+        to { transform: translateX(calc(100vw + 100% + var(--distance))); }
+    }
+
     @keyframes visual-node-churn {
         from { display: block; }
         to { display: none; }
@@ -38,16 +43,37 @@
         background: blue;
         animation: move 1s linear infinite;
     }
+
+    #relative-transform {
+        --distance: 10px;
+        width: 20px;
+        height: 20px;
+        animation: relative-move 1s linear infinite;
+    }
+
 </style>
 <div id="visual-node-churn"></div>
 <div id="opacity"></div>
 <div id="transform"></div>
+<div id="relative-transform"></div>
 <script>
     asyncTest(async done => {
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
 
         const initialCounters = internals.getStyleInvalidationCounters();
+
+        internals.resetStyleInvalidationCounters();
+        document.querySelector("#relative-transform").style.width = "40px";
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+        const resizeCounters = internals.getStyleInvalidationCounters();
+
+        internals.resetStyleInvalidationCounters();
+        document.querySelector("#relative-transform").style.setProperty("--distance", "20px");
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+        const styleChangeCounters = internals.getStyleInvalidationCounters();
 
         internals.resetStyleInvalidationCounters();
         for (let i = 0; i < 4; ++i)
@@ -91,8 +117,13 @@
         const finiteCounters = internals.getStyleInvalidationCounters();
 
         println(`compositor visual animations: ${initialCounters.compositorVisualAnimations}`);
+        println(`reference box resize updates compositor animation: ${resizeCounters.compositorVisualAnimationUpdates > 0}`);
+        println(`reference box resize resolves keyframes: ${resizeCounters.compositorKeyframeValueResolutions > 0}`);
+        println(`style change resolves keyframes: ${styleChangeCounters.compositorKeyframeValueResolutions > 0}`);
+        println(`style change updates compositor animation: ${styleChangeCounters.compositorVisualAnimationUpdates > 0}`);
         println(`main-thread animation overlay builds: ${counters.animatedStyleOverlayBuilds}`);
         println(`main-thread animation frame pump requests: ${counters.animationFramePumpRequests}`);
+        println(`stable compositor animations reuse resolved keyframes: ${counters.compositorKeyframeValueResolutions === 0}`);
         println(`stable compositor animation updates: ${counters.compositorVisualAnimationUpdates}`);
         println(`stable compositor animation updates with changing visual nodes: ${visualNodeCounters.compositorVisualAnimationUpdates}`);
         println(`cancel removes compositor animations: ${cancellationCounters.compositorVisualAnimations}`);

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes fade {
+        from { opacity: 0.2; }
+        to { opacity: 0.8; }
+    }
+
+    @keyframes move {
+        from { transform: translateX(0px) rotate(0deg); }
+        to { transform: translateX(100px) rotate(360deg); }
+    }
+
+    #opacity {
+        width: 20px;
+        height: 20px;
+        background: red;
+        animation: fade 1s linear infinite;
+    }
+
+    #transform {
+        width: 20px;
+        height: 20px;
+        background: blue;
+        animation: move 1s linear infinite;
+    }
+</style>
+<div id="opacity"></div>
+<div id="transform"></div>
+<script>
+    asyncTest(async done => {
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        println(`compositor visual animations: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        const counters = internals.getStyleInvalidationCounters();
+        println(`main-thread animation overlay builds: ${counters.animatedStyleOverlayBuilds}`);
+        println(`main-thread animation frame pump requests: ${counters.animationFramePumpRequests}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -11,6 +11,15 @@
         to { transform: translateX(100px) rotate(360deg); }
     }
 
+    @keyframes visual-node-churn {
+        from { display: block; }
+        to { display: none; }
+    }
+
+    #visual-node-churn {
+        animation: visual-node-churn 1s steps(1) infinite;
+    }
+
     #opacity {
         width: 20px;
         height: 20px;
@@ -25,6 +34,7 @@
         animation: move 1s linear infinite;
     }
 </style>
+<div id="visual-node-churn"></div>
 <div id="opacity"></div>
 <div id="transform"></div>
 <script>
@@ -38,8 +48,18 @@
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
         const counters = internals.getStyleInvalidationCounters();
+
+        internals.resetStyleInvalidationCounters();
+        const visualNodeAnimation = document.querySelector("#visual-node-churn").getAnimations()[0];
+        for (const currentTime of [0, 750, 0, 750]) {
+            visualNodeAnimation.currentTime = currentTime;
+            await new Promise(requestAnimationFrame);
+        }
+        const visualNodeCounters = internals.getStyleInvalidationCounters();
+
         println(`main-thread animation overlay builds: ${counters.animatedStyleOverlayBuilds}`);
         println(`main-thread animation frame pump requests: ${counters.animationFramePumpRequests}`);
+        println(`stable compositor animation updates with changing visual nodes: ${visualNodeCounters.compositorVisualAnimationUpdates}`);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -16,6 +16,11 @@
         to { display: none; }
     }
 
+    @keyframes finite-move {
+        from { opacity: 0.2; transform: translateX(0px); }
+        to { opacity: 0.8; transform: translateX(100px); }
+    }
+
     #visual-node-churn {
         animation: visual-node-churn 1s steps(1) infinite;
     }
@@ -42,11 +47,11 @@
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
 
-        println(`compositor visual animations: ${internals.getStyleInvalidationCounters().compositorVisualAnimations}`);
+        const initialCounters = internals.getStyleInvalidationCounters();
 
         internals.resetStyleInvalidationCounters();
         for (let i = 0; i < 4; ++i)
-            await new Promise(requestAnimationFrame);
+            internals.updateCompositorAnimations();
         const counters = internals.getStyleInvalidationCounters();
 
         internals.resetStyleInvalidationCounters();
@@ -57,9 +62,47 @@
         }
         const visualNodeCounters = internals.getStyleInvalidationCounters();
 
+        for (const animation of document.getAnimations())
+            animation.cancel();
+        internals.updateCompositorAnimations();
+        const cancellationCounters = internals.getStyleInvalidationCounters();
+
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            internals.updateCompositorAnimations();
+        const emptyCounters = internals.getStyleInvalidationCounters();
+
+        const finiteTarget = document.createElement("div");
+        finiteTarget.style.width = "20px";
+        finiteTarget.style.height = "20px";
+        finiteTarget.style.background = "green";
+        finiteTarget.style.animation = "finite-move 500ms linear forwards";
+        document.body.appendChild(finiteTarget);
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const finiteAnimation = finiteTarget.getAnimations()[0];
+        const finiteUsesCompositor = internals.getStyleInvalidationCounters().compositorVisualAnimations > 0;
+        let receivedAnimationEnd = false;
+        finiteTarget.addEventListener("animationend", () => receivedAnimationEnd = true);
+        internals.resetStyleInvalidationCounters();
+        await finiteAnimation.finished;
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const finiteCounters = internals.getStyleInvalidationCounters();
+
+        println(`compositor visual animations: ${initialCounters.compositorVisualAnimations}`);
         println(`main-thread animation overlay builds: ${counters.animatedStyleOverlayBuilds}`);
         println(`main-thread animation frame pump requests: ${counters.animationFramePumpRequests}`);
+        println(`stable compositor animation updates: ${counters.compositorVisualAnimationUpdates}`);
         println(`stable compositor animation updates with changing visual nodes: ${visualNodeCounters.compositorVisualAnimationUpdates}`);
+        println(`cancel removes compositor animations: ${cancellationCounters.compositorVisualAnimations}`);
+        println(`cancel updates compositor animations: ${cancellationCounters.compositorVisualAnimationUpdates > 0}`);
+        println(`empty compositor animation updates: ${emptyCounters.compositorVisualAnimationUpdates}`);
+        println(`finite animation uses compositor: ${finiteUsesCompositor}`);
+        println(`finite animation requests only end frames: ${finiteCounters.animationFramePumpRequests <= 2}`);
+        println(`finite animation dispatches end event: ${receivedAnimationEnd}`);
+        println(`finite animation reaches end opacity: ${getComputedStyle(finiteTarget).opacity === "0.8"}`);
+        println(`finite animation reaches end style: ${getComputedStyle(finiteTarget).transform.includes("100")}`);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -12,7 +12,8 @@
     }
 
     @keyframes relative-move {
-        from { transform: translateX(calc(100vw + var(--distance))); }
+        from { transform: translate(calc(-100% + 100vw + var(--distance))); }
+        50% { animation-timing-function: ease-in; }
         to { transform: translateX(calc(100vw + 100% + var(--distance))); }
     }
 

--- a/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
+++ b/Tests/LibWeb/Text/input/css/compositor-driven-animations.html
@@ -16,6 +16,21 @@
         to { transform: translateX(calc(100vw + 100% + var(--distance))); }
     }
 
+    @keyframes individual-move {
+        from { translate: 0px; rotate: 0deg; }
+        to { translate: 100px; rotate: 360deg; }
+    }
+
+    @keyframes individual-translate {
+        from { translate: 0px; }
+        to { translate: 100px; }
+    }
+
+    @keyframes individual-rotate {
+        from { rotate: 0deg; }
+        to { rotate: 360deg; }
+    }
+
     @keyframes visual-node-churn {
         from { display: block; }
         to { display: none; }
@@ -51,17 +66,35 @@
         animation: relative-move 1s linear infinite;
     }
 
+    #individual-transform {
+        width: 20px;
+        height: 20px;
+        animation: individual-move 1s linear infinite;
+    }
+
+    #competing-transform-effects {
+        width: 20px;
+        height: 20px;
+        animation: individual-translate 1s linear infinite, individual-rotate 1s linear infinite;
+    }
 </style>
 <div id="visual-node-churn"></div>
 <div id="opacity"></div>
 <div id="transform"></div>
 <div id="relative-transform"></div>
+<div id="individual-transform"></div>
+<div id="competing-transform-effects"></div>
 <script>
     asyncTest(async done => {
         for (let i = 0; i < 4; ++i)
             await new Promise(requestAnimationFrame);
 
         const initialCounters = internals.getStyleInvalidationCounters();
+
+        for (const animation of document.querySelector("#competing-transform-effects").getAnimations())
+            animation.cancel();
+        for (let i = 0; i < 2; ++i)
+            await new Promise(requestAnimationFrame);
 
         internals.resetStyleInvalidationCounters();
         document.querySelector("#relative-transform").style.width = "40px";

--- a/Tests/LibWeb/Text/input/css/compositor-opacity-track-visibility.html
+++ b/Tests/LibWeb/Text/input/css/compositor-opacity-track-visibility.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes fade {
+        from { opacity: 1; }
+        to { opacity: 0; }
+    }
+
+    .target {
+        width: 20px;
+        height: 20px;
+        animation: fade 1s linear;
+    }
+
+    #infinite {
+        animation-iteration-count: infinite;
+    }
+</style>
+<div id="infinite" class="target"></div>
+<div id="finite" class="target"></div>
+<script>
+    asyncTest(async done => {
+        let observations = 0;
+        let resolveInitialObservations;
+        const initialObservations = new Promise(resolve => resolveInitialObservations = resolve);
+        const observer = new IntersectionObserver(entries => {
+            observations += entries.length;
+            if (observations >= 2)
+                resolveInitialObservations();
+        }, { trackVisibility: true, delay: 100 });
+        observer.observe(infinite);
+        observer.observe(finite);
+        await initialObservations;
+
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        println(`infinite and finite opacity animations stay on main thread: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+
+        infinite.getAnimations()[0].currentTime = 500;
+        finite.getAnimations()[0].currentTime = 500;
+        println(`infinite opacity is current: ${getComputedStyle(infinite).opacity === "0.5"}`);
+        println(`finite opacity is current: ${getComputedStyle(finite).opacity === "0.5"}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/element-scoped-animation-sampling.html
+++ b/Tests/LibWeb/Text/input/css/element-scoped-animation-sampling.html
@@ -61,6 +61,8 @@
         await new Promise(requestAnimationFrame);
         timeline.setTimeForObservation(50);
         internals.resetStyleInvalidationCounters();
+        getComputedStyle(overflowContainer).width;
+        println(`ancestor style reads sample descendant animations: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 0}`);
         const scrollWidth = overflowContainer.scrollWidth;
         const counters = internals.getStyleInvalidationCounters();
         println(`ancestor reads sample descendant animations: ${counters.animatedStyleOverlayBuilds > 0 && scrollWidth > 20}`);

--- a/Tests/LibWeb/Text/input/css/finished-compositor-animation-content-culling.html
+++ b/Tests/LibWeb/Text/input/css/finished-compositor-animation-content-culling.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes fade-out {
+        from { opacity: 1; }
+        to { opacity: 0; }
+    }
+
+    @keyframes scale-out {
+        from { transform: scale(1); }
+        to { transform: scale(0); }
+    }
+
+    .under, .target {
+        position: absolute;
+        top: 0;
+        width: 100px;
+        height: 100px;
+    }
+
+    .under {
+        background: rgb(7, 8, 9);
+    }
+
+    .target {
+        animation-duration: 1000ms;
+        animation-fill-mode: forwards;
+        animation-timing-function: linear;
+    }
+
+    #opacity-under, #opacity {
+        left: 0;
+    }
+
+    #scale-under, #scale {
+        left: 120px;
+    }
+
+    #paused-under, #paused {
+        left: 240px;
+    }
+
+    #main-thread-under, #main-thread {
+        left: 360px;
+    }
+
+    #opacity {
+        background: rgb(1, 2, 3);
+        animation-name: fade-out;
+    }
+
+    #scale {
+        background: rgb(4, 5, 6);
+        animation-name: scale-out;
+    }
+
+    #paused {
+        background: rgb(10, 11, 12);
+    }
+
+    #main-thread {
+        background: rgb(13, 14, 15);
+    }
+</style>
+<div id="opacity-under" class="under"></div>
+<div id="opacity" class="target"></div>
+<div id="scale-under" class="under"></div>
+<div id="scale" class="target"></div>
+<div id="paused-under" class="under"></div>
+<div id="paused" class="target"></div>
+<div id="main-thread-under" class="under"></div>
+<div id="main-thread" class="target"></div>
+<script>
+    asyncTest(async done => {
+        const finiteAnimations = document.getAnimations();
+        finiteAnimations.forEach(animation => animation.currentTime = 0);
+        const pausedAnimation = paused.animate({ opacity: [0, 1] }, 1000);
+        pausedAnimation.pause();
+        pausedAnimation.currentTime = 0;
+        const mainThreadTarget = document.getElementById("main-thread");
+        const mainThreadAnimation = mainThreadTarget.animate([
+            { opacity: 0, color: "red" },
+            { opacity: 0, color: "blue" },
+        ], { duration: 1000, iterations: Infinity });
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        println(`animations start on the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 2}`);
+        const activeDisplayList = internals.dumpDisplayList();
+        println(`active animation content is retained: ${activeDisplayList.includes("rgb(1, 2, 3)") && activeDisplayList.includes("rgb(4, 5, 6)")}`);
+        println(`paused opacity-zero content is culled: ${!activeDisplayList.includes("rgb(10, 11, 12)")}`);
+        println(`main-thread opacity-zero content is culled: ${!activeDisplayList.includes("rgb(13, 14, 15)")}`);
+
+        await Promise.all(finiteAnimations.map(animation => animation.finished));
+        const displayList = internals.dumpDisplayList();
+        const opacityUnder = document.getElementById("opacity-under");
+        const scaleUnder = document.getElementById("scale-under");
+
+        println(`finished opacity content is culled: ${!displayList.includes("rgb(1, 2, 3)")}`);
+        println(`finished singular-transform content is culled: ${!displayList.includes("rgb(4, 5, 6)")}`);
+        println(`opacity-zero target remains hit-testable: ${document.elementFromPoint(50, 50) === opacity}`);
+        println(`scale-zero target is absent from hit testing: ${document.elementFromPoint(170, 50) === scaleUnder}`);
+        mainThreadAnimation.cancel();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/finite-compositor-animation-completion.html
+++ b/Tests/LibWeb/Text/input/css/finite-compositor-animation-completion.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes finite-opacity {
+        from { opacity: 0.2; }
+        to { opacity: 0.8; }
+    }
+
+    @keyframes finite-transform {
+        from { transform: translateX(0px); }
+        to { transform: translateX(100px); }
+    }
+
+    #opacity {
+        opacity: 0.3;
+        animation: finite-opacity 300ms linear forwards;
+    }
+
+    #transform {
+        transform: translateX(7px);
+        animation: finite-transform 300ms linear none;
+    }
+</style>
+<div id="opacity"></div>
+<div id="transform"></div>
+<script>
+    asyncTest(async done => {
+        let animationEndEvents = 0;
+        let eventHandlerSawTerminalStyle = false;
+        let animationUpdatesAtEndEvent = 0;
+        opacity.addEventListener("animationend", () => {
+            ++animationEndEvents;
+            animationUpdatesAtEndEvent = internals.getStyleInvalidationCounters().animationTimelineAssociatedAnimationUpdates;
+            eventHandlerSawTerminalStyle = getComputedStyle(opacity).opacity === "0.8";
+        });
+        transform.addEventListener("animationend", () => ++animationEndEvents);
+
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        const animations = [...opacity.getAnimations(), ...transform.getAnimations()];
+        println(`finite effects use the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 2}`);
+
+        internals.resetStyleInvalidationCounters();
+        let finishedPromises = 0;
+        await Promise.all(animations.map(animation => animation.finished.then(() => ++finishedPromises)));
+        await new Promise(requestAnimationFrame);
+
+        println(`finished promises resolve: ${finishedPromises === 2}`);
+        println(`animationend events fire: ${animationEndEvents === 2}`);
+        println(`animationend sees terminal style: ${eventHandlerSawTerminalStyle}`);
+        println(`finite effects request one end frame: ${internals.getStyleInvalidationCounters().animationFramePumpRequests === 1}`);
+        println(`wake-up timer leaves animation updates to frames: ${animationUpdatesAtEndEvent === 2}`);
+        println(`forwards fill retains opacity: ${getComputedStyle(opacity).opacity === "0.8"}`);
+        println(`no fill restores transform: ${getComputedStyle(transform).transform === "matrix(1, 0, 0, 1, 7, 0)"}`);
+        await Promise.resolve();
+        println(`terminal values remain stable: ${getComputedStyle(opacity).opacity === "0.8" && getComputedStyle(transform).transform === "matrix(1, 0, 0, 1, 7, 0)"}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/finite-compositor-targeted-wakeup.html
+++ b/Tests/LibWeb/Text/input/css/finite-compositor-targeted-wakeup.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes pulse {
+        from { opacity: 0.2; }
+        to { opacity: 0.8; }
+    }
+
+    .infinite {
+        width: 10px;
+        height: 10px;
+        animation: pulse 10s linear infinite;
+    }
+
+    #finite {
+        width: 10px;
+        height: 10px;
+        animation: pulse 300ms linear forwards;
+    }
+</style>
+<div class="infinite"></div>
+<div class="infinite"></div>
+<div class="infinite"></div>
+<div class="infinite"></div>
+<div class="infinite"></div>
+<div id="finite"></div>
+<script>
+    asyncTest(async done => {
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+        const ended = new Promise(resolve => finite.addEventListener("animationend", resolve, { once: true }));
+        println(`all effects use the compositor: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 6}`);
+
+        internals.resetStyleInvalidationCounters();
+        await ended;
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const counters = internals.getStyleInvalidationCounters();
+
+        println(`finite end samples only its target: ${counters.animatedStyleOverlayBuilds === 1}`);
+        println(`finite end requests one frame: ${counters.animationFramePumpRequests === 1}`);
+        println(`infinite effects remain on the compositor: ${counters.compositorVisualAnimations === 5}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -8,6 +8,7 @@
 
     .animated {
         animation: spin 100s linear infinite;
+        transform-origin: center center 1px;
     }
 </style>
 <script>
@@ -51,6 +52,28 @@
         getComputedStyle(hidden).transform;
         const afterComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
         println(`computed style samples hidden animation: ${afterComputedStyle > beforeComputedStyle}`);
+
+        const offscreenClip = document.createElement("div");
+        offscreenClip.style.cssText = "position: absolute; top: 200vh; width: 100px; height: 100px; overflow: hidden";
+        const offscreenAnimation = document.createElement("div");
+        offscreenAnimation.className = "animated";
+        offscreenClip.append(offscreenAnimation);
+        document.body.append(offscreenClip);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        internals.resetStyleInvalidationCounters();
+        println(`offscreen clipped animation overlay builds: ${await animationOverlayBuildsOverFrames(4)}`);
+        println(`offscreen clipped animation frame pump requests: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
+        internals.resetStyleInvalidationCounters();
+        offscreenClip.scrollIntoView();
+        await new Promise(resolve => setTimeout(() => setTimeout(resolve, 0), 0));
+        const revealedCounters = internals.getStyleInvalidationCounters();
+        println(`revealed clipped animation resumes: ${revealedCounters.animatedStyleOverlayBuilds > 0}`);
+        println(`revealed clipped animation requests frame: ${revealedCounters.animationFramePumpRequests > 0}`);
+        offscreenAnimation.getAnimations()[0].cancel();
+        offscreenClip.remove();
+        scrollTo(0, 0);
+        await nextFrame();
 
         const sampled = document.createElement("div");
         sampled.style.visibility = "hidden";

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -2,8 +2,8 @@
 <script src="../include.js"></script>
 <style>
     @keyframes spin {
-        from { transform: rotate(0deg); }
-        to { transform: rotate(360deg); }
+        from { transform: translateX(0%); }
+        to { transform: translateX(100%); }
     }
 
     .animated {
@@ -111,7 +111,7 @@
         document.body.append(visible);
         for (let i = 0; i < 4; ++i)
             await nextFrame();
-        println(`visible animation builds while hidden stays throttled: ${await animationOverlayBuildsOverFrames(4)}`);
+        println(`visible animation builds while hidden stays throttled: ${await animationOverlayBuildsOverFrames(4) > 0}`);
 
         const beforeMixedComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
         getComputedStyle(hidden).transform;

--- a/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
+++ b/Tests/LibWeb/Text/input/css/invisible-animation-style-throttling.html
@@ -52,34 +52,6 @@
         const afterComputedStyle = internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds;
         println(`computed style samples hidden animation: ${afterComputedStyle > beforeComputedStyle}`);
 
-        const detached = document.createElement("div");
-        detached.className = "animated";
-        document.body.append(detached);
-        const detachedAnimation = detached.getAnimations()[0];
-        for (let i = 0; i < 4; ++i)
-            await nextFrame();
-        detached.remove();
-        detachedAnimation.play();
-        await detachedAnimation.ready;
-        for (let i = 0; i < 4; ++i)
-            await nextFrame();
-        const detachedTimeBeforeWait = detachedAnimation.currentTime;
-        internals.resetStyleInvalidationCounters();
-        await new Promise(resolve => setTimeout(resolve, 120));
-        println(`detached animation stops frame pump: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
-        println(`detached animation current time advances: ${detachedAnimation.currentTime > detachedTimeBeforeWait}`);
-        detached.addEventListener("animationend", () => {});
-        internals.resetStyleInvalidationCounters();
-        await new Promise(resolve => setTimeout(resolve, 120));
-        println(`unreachable end listener leaves detached animation throttled: ${internals.getStyleInvalidationCounters().animationFramePumpRequests <= 1}`);
-        let detachedIterationEvents = 0;
-        detached.addEventListener("animationiteration", () => ++detachedIterationEvents);
-        detachedAnimation.currentTime = 99950;
-        internals.resetStyleInvalidationCounters();
-        await new Promise(resolve => setTimeout(resolve, 120));
-        println(`detached animation listener keeps frame pump active: ${internals.getStyleInvalidationCounters().animationFramePumpRequests > 0}`);
-        println(`detached animation dispatches iteration event: ${detachedIterationEvents}`);
-
         const sampled = document.createElement("div");
         sampled.style.visibility = "hidden";
         document.body.append(sampled);
@@ -105,6 +77,48 @@
         println(`computed timing uses current timeline sample: ${sampledProgress === 0.5}`);
         println(`geometry uses current timeline sample: ${sampledRect.x - initialRect.x === 25}`);
         sampled.remove();
+
+        const visibilityTarget = document.createElement("div");
+        visibilityTarget.style.cssText = "visibility: hidden; transform-origin: center center 1px";
+        document.body.append(visibilityTarget);
+        const visibilityTimeline = internals.createInternalAnimationTimeline();
+        const visibilityAnimation = new Animation(new KeyframeEffect(visibilityTarget, [
+            { transform: "translateX(0px)" },
+            { transform: "translateX(100px)" },
+        ], { duration: 100, iterations: Infinity }), visibilityTimeline);
+        visibilityAnimation.play();
+        visibilityTimeline.setTime(0);
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        getComputedStyle(visibilityTarget).transform;
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await setSystemVisibilityState("hidden");
+        visibilityTimeline.setTimeForObservation(50);
+        internals.resetStyleInvalidationCounters();
+        await setSystemVisibilityState("visible");
+        await new Promise(resolve => setTimeout(resolve, 0));
+        internals.updateStyle();
+        println(`becoming visible flushes throttled animations: ${internals.getStyleInvalidationCounters().animatedStyleOverlayBuilds > 0}`);
+        visibilityAnimation.cancel();
+        visibilityTarget.remove();
+
+        const detached = document.createElement("div");
+        detached.style.transformOrigin = "center center 1px";
+        document.body.append(detached);
+        const detachedAnimation = detached.animate([
+            { transform: "translateX(0%)" },
+            { transform: "translateX(100%)" },
+        ], { duration: 100000, iterations: Infinity });
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        detached.remove();
+        for (let i = 0; i < 4; ++i)
+            await nextFrame();
+        const detachedTimeBeforeWait = detachedAnimation.currentTime;
+        internals.resetStyleInvalidationCounters();
+        await new Promise(resolve => setTimeout(resolve, 120));
+        println(`detached animation stops frame pump: ${internals.getStyleInvalidationCounters().animationFramePumpRequests}`);
+        println(`detached animation current time advances: ${detachedAnimation.currentTime > detachedTimeBeforeWait}`);
 
         const visible = document.createElement("div");
         visible.className = "animated";

--- a/Tests/LibWeb/Text/input/css/offscreen-animation-fixed-descendant.html
+++ b/Tests/LibWeb/Text/input/css/offscreen-animation-fixed-descendant.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes move {
+        from { transform: none; }
+        to { transform: none; }
+    }
+
+    #clip {
+        position: absolute;
+        top: 200vh;
+        width: 100px;
+        height: 100px;
+        overflow: hidden;
+    }
+
+    #target {
+        animation: move 100s linear infinite;
+    }
+
+    #fixed {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 20px;
+        height: 20px;
+    }
+</style>
+<div id="clip"><div id="target"><div id="fixed"></div></div></div>
+<script>
+    asyncTest(async done => {
+        let resolveObservation;
+        const observation = new Promise(resolve => resolveObservation = resolve);
+        new IntersectionObserver(entries => resolveObservation(entries.at(-1))).observe(fixed);
+
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            await new Promise(requestAnimationFrame);
+
+        const counters = internals.getStyleInvalidationCounters();
+        println(`animation stays on main thread: ${counters.compositorVisualAnimations === 0}`);
+        println(`animation is not offscreen throttled: ${counters.animationFramePumpRequests > 0}`);
+        println(`fixed descendant is intersecting: ${(await observation).isIntersecting}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Every running CSS animation currently wakes WebContent at 60Hz to recompute style, rebuild paint state, and record a display list, even though the animation's entire future is known from its keyframes.

This PR describes eligible animations once (`VisualAnimation`: resolved keyframes, timing, easing, time anchor), ships them inside the visual context tree, and lets the Compositor advance them on its own vsync. Values are sampled with the same deterministic sampler in both processes and written into the tree in place (originals saved and restored, no per-frame tree copy).

```mermaid
sequenceDiagram
    participant W as WebContent
    participant C as Compositor
    W->>C: visual context tree + descriptors (once)
    loop every vsync
        C->>C: sample(keyframes, now - anchor)
        C->>C: write values into animated nodes, present
    end
    Note over W: wakes only for finite ends<br/>and script observation
```

Handed off: opacity and transform-family animations with replace composition on a monotonic timeline, infinite or single-iteration. `var()`/`calc()`/percentages are resolved to device pixels at handoff and cached. Stacked animations on one property hand off the composite-order winner; losers are throttled until it ends. Everything else stays on the main thread.

The main thread's stale state is never observable:

- Script reads (`getComputedStyle`, geometry, `currentTime`, `playState`, `getComputedTiming`, `finished`) sample on demand, once per task, scoped to the queried element.
- Finite animations get one wake-up timer at their active end for `animationend`, the finished promise and fill styles.
- IntersectionObserver keeps animations on the main thread unless the motion provably cannot change an intersection (subtree sealed behind an unreachable clip, or horizontal-only motion with the target in a disjoint vertical band); observers watching handed-off content get geometry from the shared sampler on a 100ms cadence, no style rebuilds.
- Content starting at `opacity: 0` or `scale(0)` stays in the display list while a descriptor targets it, so the Compositor has something to reveal.
- Animations behind offscreen clips run nowhere until scrolled into reach; all timers stop with the document.

This substantially improves responsiveness and fluidity of CSS animations across the web. :^)