### PR TITLE
LibWeb: Cache SkTextBlobs in DisplayListResourceStorage

### DIFF
--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -65,6 +65,7 @@ class ChromeWidgetRegistry;
 class CanvasSurfaceRegistry;
 class DisplayList;
 struct DisplayListCommandRun;
+struct DisplayListGlyph;
 class DisplayListPlayerSkia;
 class DisplayListResourceStorage;
 struct DisplayListResourceSet;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -11,7 +11,6 @@
 #include <core/SkCanvas.h>
 #include <core/SkColorFilter.h>
 #include <core/SkColorSpace.h>
-#include <core/SkFont.h>
 #include <core/SkMaskFilter.h>
 #include <core/SkPath.h>
 #include <core/SkPathEffect.h>
@@ -32,7 +31,6 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/DecodedImageFrame.h>
-#include <LibGfx/Font/Font.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibGfx/SkiaUtils.h>
@@ -190,23 +188,11 @@ void DisplayListPlayerSkia::paint_scrollbar(Gfx::PaintingSurface& surface, Paint
 
 void DisplayListPlayerSkia::play_command(DrawGlyphRun const& command)
 {
-    auto const& font = resource_storage().font(command.font_id);
     auto glyphs = inline_objects<DisplayListGlyph>(command.glyphs);
     if (glyphs.is_empty())
         return;
 
-    auto sk_font = font.skia_font(command.scale);
-    SkTextBlobBuilder builder;
-    auto const& run = builder.allocRunPos(sk_font, glyphs.size());
-
-    auto font_ascent = font.pixel_metrics().ascent;
-    for (size_t i = 0; i < glyphs.size(); ++i) {
-        run.glyphs[i] = glyphs[i].glyph_id;
-        run.pos[i * 2] = glyphs[i].position.x() * command.scale;
-        run.pos[i * 2 + 1] = (glyphs[i].position.y() + font_ascent) * command.scale;
-    }
-
-    auto blob = builder.make();
+    auto blob = resource_storage().text_blob(command.font_id, command.scale, glyphs);
     if (!blob)
         return;
 

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BitCast.h>
+#include <AK/ByteBuffer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/Filter.h>
@@ -17,7 +19,9 @@
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 #include <core/SkColorSpace.h>
+#include <core/SkFont.h>
 #include <core/SkImage.h>
+#include <core/SkTextBlob.h>
 #include <core/SkYUVAPixmaps.h>
 #include <gpu/ganesh/GrDirectContext.h>
 #include <gpu/ganesh/SkImageGanesh.h>
@@ -79,6 +83,21 @@ struct DisplayListCachedNestedRasterResource {
     // bounded set of rasters, most recently used first.
     static constexpr size_t max_rasters = 32;
     Vector<Raster> rasters;
+};
+
+struct DisplayListCachedTextBlobResource {
+    DisplayListCachedTextBlobResource(ByteBuffer glyph_bytes, sk_sp<SkTextBlob> blob, size_t byte_size, MonotonicTime last_used)
+        : glyph_bytes(move(glyph_bytes))
+        , blob(move(blob))
+        , byte_size(byte_size)
+        , last_used(last_used)
+    {
+    }
+
+    ByteBuffer glyph_bytes;
+    sk_sp<SkTextBlob> blob;
+    size_t byte_size { 0 };
+    MonotonicTime last_used;
 };
 
 struct DisplayListCachedVideoSinkImageResource {
@@ -370,6 +389,86 @@ void DisplayListResourceStorage::add_cached_nested_display_list_raster(DisplayLi
     resource.rasters.prepend({ rect_in_list_space, move(image) });
 }
 
+static u64 text_blob_glyph_hash(ReadonlySpan<DisplayListGlyph> glyphs)
+{
+    u64 hash = glyphs.size();
+    for (auto const& glyph : glyphs) {
+        u64 position = static_cast<u64>(bit_cast<u32>(glyph.position.x())) << 32 | bit_cast<u32>(glyph.position.y());
+        hash = (hash ^ position) * 0x9e3779b97f4a7c15ULL;
+        hash = (hash ^ glyph.glyph_id) * 0x9e3779b97f4a7c15ULL;
+        hash ^= hash >> 32;
+    }
+    return hash;
+}
+
+static sk_sp<SkTextBlob> make_text_blob(Gfx::Font const& font, float scale, ReadonlySpan<DisplayListGlyph> glyphs)
+{
+    auto sk_font = font.skia_font(scale);
+    SkTextBlobBuilder builder;
+    auto const& run = builder.allocRunPos(sk_font, glyphs.size());
+
+    auto font_ascent = font.pixel_metrics().ascent;
+    for (size_t i = 0; i < glyphs.size(); ++i) {
+        run.glyphs[i] = glyphs[i].glyph_id;
+        run.pos[i * 2] = glyphs[i].position.x() * scale;
+        run.pos[i * 2 + 1] = (glyphs[i].position.y() + font_ascent) * scale;
+    }
+    return builder.make();
+}
+
+sk_sp<SkTextBlob> DisplayListResourceStorage::text_blob(FontResourceId font_id, float scale, ReadonlySpan<DisplayListGlyph> glyphs) const
+{
+    constexpr size_t max_text_blob_cache_bytes = 16 * MiB;
+    constexpr auto text_blob_idle_duration = AK::Duration::from_milliseconds(250);
+
+    ReadonlyBytes glyph_bytes { reinterpret_cast<u8 const*>(glyphs.data()), glyphs.size() * sizeof(DisplayListGlyph) };
+    DisplayListTextBlobCacheKey key { font_id.value(), bit_cast<u32>(scale), text_blob_glyph_hash(glyphs) };
+    auto now = MonotonicTime::now();
+
+    if (auto cached = m_text_blobs.find(key); cached != m_text_blobs.end()) {
+        auto& resource = *cached->value;
+        if (resource.glyph_bytes.bytes() == glyph_bytes) {
+            resource.last_used = now;
+            return resource.blob;
+        }
+        m_text_blob_cache_bytes -= resource.byte_size;
+        m_text_blobs.remove(cached);
+    }
+
+    auto blob = make_text_blob(font(font_id), scale, glyphs);
+    if (!blob)
+        return nullptr;
+
+    auto byte_size = glyphs.size() * 24 + 256;
+    if (m_text_blob_cache_bytes + byte_size > max_text_blob_cache_bytes) {
+        if (now - m_text_blob_cache_sweep_time < text_blob_idle_duration)
+            return blob;
+        m_text_blob_cache_sweep_time = now;
+        m_text_blobs.remove_all_matching([&](auto const&, auto const& resource) {
+            if (now - resource->last_used < text_blob_idle_duration)
+                return false;
+            m_text_blob_cache_bytes -= resource->byte_size;
+            return true;
+        });
+        if (m_text_blob_cache_bytes + byte_size > max_text_blob_cache_bytes)
+            return blob;
+    }
+
+    m_text_blob_cache_bytes += byte_size;
+    m_text_blobs.set(key, make<DisplayListCachedTextBlobResource>(MUST(ByteBuffer::copy(glyph_bytes)), blob, byte_size, now));
+    return blob;
+}
+
+void DisplayListResourceStorage::remove_text_blobs_without_font()
+{
+    m_text_blobs.remove_all_matching([&](auto const& key, auto const& resource) {
+        if (m_fonts.contains(key.font_id))
+            return false;
+        m_text_blob_cache_bytes -= resource->byte_size;
+        return true;
+    });
+}
+
 bool DisplayListResourceStorage::should_cache_nested_display_list_raster(DisplayListResourceId id) const
 {
     // Only rasterize a list that has been painted before: content that is re-recorded for every update gets a
@@ -593,6 +692,8 @@ void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransactio
 
     for (auto id : transaction.font_ids_to_remove)
         m_fonts.remove(id.value());
+    if (!transaction.font_ids_to_remove.is_empty())
+        remove_text_blobs_without_font();
     for (auto id : transaction.image_frame_ids_to_remove)
         m_image_frames.remove(id.value());
     for (auto id : transaction.video_sink_ids_to_remove) {
@@ -612,6 +713,7 @@ void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resou
     m_fonts.remove_all_matching([&](auto id, auto const&) {
         return !resource_set.fonts.contains(FontResourceId { id });
     });
+    remove_text_blobs_without_font();
     m_image_frames.remove_all_matching([&](auto id, auto const&) {
         return !resource_set.image_frames.contains(ImageFrameResourceId { id });
     });

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -15,6 +15,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Span.h>
+#include <AK/Time.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/DecodedImageFrame.h>
@@ -28,6 +29,7 @@
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 
 class SkImage;
+class SkTextBlob;
 
 template<typename T>
 class sk_sp;
@@ -61,9 +63,18 @@ struct DisplayListVideoSinkResource {
     Media::VideoSinkHandle sink_handle;
 };
 
+struct DisplayListTextBlobCacheKey {
+    u64 font_id { 0 };
+    u32 scale_bits { 0 };
+    u64 glyph_hash { 0 };
+
+    bool operator==(DisplayListTextBlobCacheKey const&) const = default;
+};
+
 struct DisplayListStoredImageFrameResource;
 struct DisplayListCachedSkiaImageResource;
 struct DisplayListCachedNestedRasterResource;
+struct DisplayListCachedTextBlobResource;
 struct DisplayListStoredVideoSinkResource;
 
 struct DisplayListResource {
@@ -120,6 +131,7 @@ public:
     sk_sp<SkImage> cached_nested_display_list_raster(DisplayListResourceId, RefPtr<Gfx::SkiaBackendContext> const&, Gfx::IntRect visible_rect_in_list_space, Gfx::IntRect& raster_rect_in_list_space) const;
     void add_cached_nested_display_list_raster(DisplayListResourceId, RefPtr<Gfx::SkiaBackendContext> const&, Gfx::IntRect rect_in_list_space, sk_sp<SkImage>) const;
     bool should_cache_nested_display_list_raster(DisplayListResourceId) const;
+    sk_sp<SkTextBlob> text_blob(FontResourceId, float scale, ReadonlySpan<DisplayListGlyph>) const;
     RefPtr<Media::VideoSink const> video_sink(VideoSinkResourceId id) const;
     Optional<Media::VideoSinkHandle> video_sink_handle(VideoSinkResourceId id) const { return m_video_sink_handles.get(id.value()); }
     HashMap<u64, Media::VideoSinkHandle> const& video_sink_handles() const { return m_video_sink_handles; }
@@ -132,6 +144,7 @@ private:
     void collect_referenced_resources(DisplayList const&, DisplayListResourceSet&) const;
     void add_referenced_display_list(DisplayListResourceId, DisplayListResourceSet&) const;
     bool nested_display_list_requires_direct_replay(DisplayListResourceId, HashTable<u64>& visited_display_lists) const;
+    void remove_text_blobs_without_font();
 
     HashMap<u64, NonnullRefPtr<Gfx::Font const>> m_fonts;
     HashMap<u64, NonnullOwnPtr<DisplayListStoredImageFrameResource>> m_image_frames;
@@ -140,6 +153,21 @@ private:
     HashMap<u64, DisplayListResource> m_display_lists;
     mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedSkiaImageResource>> m_display_list_cached_skia_images;
     mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedNestedRasterResource>> m_display_list_cached_nested_rasters;
+    mutable HashMap<DisplayListTextBlobCacheKey, NonnullOwnPtr<DisplayListCachedTextBlobResource>> m_text_blobs;
+    mutable size_t m_text_blob_cache_bytes { 0 };
+    mutable MonotonicTime m_text_blob_cache_sweep_time { MonotonicTime::now() };
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<Web::Painting::DisplayListTextBlobCacheKey> : public DefaultTraits<Web::Painting::DisplayListTextBlobCacheKey> {
+    static unsigned hash(Web::Painting::DisplayListTextBlobCacheKey const& key)
+    {
+        return pair_int_hash(u64_hash(key.font_id ^ key.glyph_hash), key.scale_bits);
+    }
 };
 
 }


### PR DESCRIPTION
The player built a fresh SkTextBlob for every DrawGlyphRun on every replay and dropped it after drawing. The builder work is the smaller part of that cost: Ganesh caches per-blob GPU data (subruns, atlas glyph references, vertices) keyed by the blob's uniqueID and purges it when the blob is destroyed, so every frame regenerated that data for all visible text, with a strike lookup per glyph.

Blobs are now retained per context, keyed by font id, scale and glyph payload. The command carries no run identity and WebContent recreates glyph runs on every layout commit, so the content is the only stable identity; a byte comparison on lookup makes hash collisions harmless. Translation, color and orientation are applied at draw time, so text shadows share the blob with the text they shadow.

Entries die with their font, and a per-storage budget with an idle sweep bounds the rest, degrading to build-and-drop for any overflow.