### PR TITLE
LibWeb: Restore the gcc build of set_visual_animations

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -117,7 +117,11 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_viewport_
 
 void AccumulatedVisualContextTree::set_visual_animations(Vector<Compositor::VisualAnimation> animations)
 {
-    m_visual_animations = animations.is_empty() ? nullptr : adopt_ref(*new VisualAnimationList(move(animations)));
+    if (animations.is_empty()) {
+        m_visual_animations = nullptr;
+        return;
+    }
+    m_visual_animations = adopt_ref(*new VisualAnimationList(move(animations)));
 }
 
 AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation_samples(i64 monotonic_time_ns) const

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -163,7 +163,10 @@ void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<C
         }
     }
     m_visual_animations = animations;
-    m_visual_context_tree_visual_animations = animations.is_empty() ? nullptr : adopt_ref(*new VisualAnimationList(move(animations)));
+    if (animations.is_empty())
+        m_visual_context_tree_visual_animations = nullptr;
+    else
+        m_visual_context_tree_visual_animations = adopt_ref(*new VisualAnimationList(move(animations)));
     m_visual_context_tree_needs_compositor_update = true;
     if (animation_parameters_changed)
         ++document.style_invalidation_counters().compositor_visual_animation_updates;


### PR DESCRIPTION
**Problem:** Every Linux x86_64 Release GNU CI job was failing.

**Cause:** Both `set_visual_animations` implementations — the visual context tree’s and `DocumentPaintState`’s — choose the new list with a conditional expression whose branches are `nullptr` and the `NonnullRefPtr` that `adopt_ref` returns. `NonnullRefPtr` deliberately has no constructor taking `nullptr` — and nothing converts in the other direction either. So the two branches share no common type. gcc 16.2 and clang accept the expression regardless — but the CI container’s older gcc rejects it. And gcc stops at the first failing TU — so the second site only surfaced once the first was fixed.

**Fix:** Assign the empty and non-empty cases separately — rather than selecting between them — so no common type is needed.
