### PR TITLE
LibWeb: Report MediaSource buffered ranges accurately

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -56,6 +56,8 @@
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/MediaSourceExtensions/MediaSource.h>
+#include <LibWeb/MediaSourceExtensions/SourceBuffer.h>
+#include <LibWeb/MediaSourceExtensions/SourceBufferList.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Page/ScreenWakeLockHandle.h>
@@ -431,6 +433,58 @@ GC::Ref<TimeRanges> HTMLMediaElement::buffered() const
     // The buffered attribute must return a new static normalized TimeRanges object that represents the ranges of the
     // media resource, if any, that the user agent has buffered, at the time the attribute is evaluated.
     auto time_ranges = TimeRanges::create();
+
+    // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
+    // The HTMLMediaElement's buffered attribute returns a static normalized TimeRanges object based on the following steps.
+    if (m_attached_media_source) {
+        // Let recent intersection ranges equal an empty TimeRanges object.
+        Media::TimeRanges recent_intersection_ranges;
+
+        // If activeSourceBuffers.length does not equal 0 then run the following steps:
+        auto active_source_buffers = m_attached_media_source->active_source_buffers();
+        if (active_source_buffers->length() == 0)
+            return time_ranges;
+
+        // Let active ranges be the ranges returned by buffered for each SourceBuffer object in activeSourceBuffers.
+        Vector<Media::TimeRanges> active_ranges;
+        active_ranges.ensure_capacity(active_source_buffers->length());
+        Optional<AK::Duration> highest_end_time;
+        for (u32 i = 0; i < active_source_buffers->length(); ++i) {
+            auto ranges = active_source_buffers->item(i)->buffered_ranges();
+            if (!ranges.is_empty()) {
+                auto range_end_time = ranges.highest_end_time();
+                if (!highest_end_time.has_value() || range_end_time > highest_end_time.value())
+                    highest_end_time = range_end_time;
+            }
+            active_ranges.append(move(ranges));
+        }
+
+        // Let highest end time be the largest range end time in the active ranges.
+        // INTEROP: Chromium and WebKit return an empty TimeRanges object if every active range is empty.
+        if (!highest_end_time.has_value())
+            return time_ranges;
+
+        // Let recent intersection ranges equal a TimeRanges object containing a single range from 0 to highest end time.
+        recent_intersection_ranges.add_range(AK::Duration::zero(), highest_end_time.value());
+
+        // For each SourceBuffer object in activeSourceBuffers run the following steps:
+        for (auto& source_ranges : active_ranges) {
+            // Let source ranges equal the ranges returned by the buffered attribute on the current SourceBuffer.
+
+            // If readyState is "ended", then set the end time on the last range in source ranges to highest end time.
+            if (m_attached_media_source->ready_state() == MediaSourceExtensions::ReadyState::Ended && !source_ranges.is_empty())
+                source_ranges.add_range(source_ranges[source_ranges.size() - 1].start, highest_end_time.value());
+
+            // Let new intersection ranges equal the intersection between the recent intersection ranges and the source ranges.
+            // Replace the ranges in recent intersection ranges with the new intersection ranges.
+            recent_intersection_ranges = recent_intersection_ranges.intersection(source_ranges);
+        }
+
+        for (auto const& range : recent_intersection_ranges)
+            time_ranges->add_range(range.start.to_seconds_f64(), range.end.to_seconds_f64());
+        return time_ranges;
+    }
+
     if (m_playback_manager) {
         for (auto const& range : m_playback_manager->buffered_time_ranges())
             time_ranges->add_range(range.start.to_seconds_f64(), range.end.to_seconds_f64());

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -253,11 +253,16 @@ GC::Ref<HTML::TimeRanges> SourceBuffer::buffered()
 
     // NB: Further steps to intersect the buffered ranges of the track buffers are implemented within
     //     SourceBufferProcessor::buffered_ranges() below, since it has access to the track buffers.
-    auto ranges = m_processor->buffered_ranges();
+    auto ranges = buffered_ranges();
     for (auto const& range : ranges)
         time_ranges->add_range(range.start.to_seconds_f64(), range.end.to_seconds_f64());
 
     return time_ranges;
+}
+
+Media::TimeRanges SourceBuffer::buffered_ranges() const
+{
+    return m_processor->buffered_ranges();
 }
 
 // https://w3c.github.io/media-source/#dom-sourcebuffer-mode

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -9,6 +9,7 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <AK/Types.h>
+#include <LibMedia/TimeRanges.h>
 #include <LibWeb/Bindings/SourceBuffer.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/WebIDL/Buffers.h>
@@ -56,6 +57,7 @@ public:
 
     // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
     GC::Ref<HTML::TimeRanges> buffered();
+    Media::TimeRanges buffered_ranges() const;
 
     void set_content_type(Utf16View type);
 

--- a/Tests/LibWeb/Text/expected/HTML/media-source-buffered.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-buffered.txt
@@ -1,3 +1,4 @@
+video before append: []
 after init: []
 after cluster 1: [0.004-4.9745]
 after cluster 3: [0.004-4.9745, 9.604-12.044]

--- a/Tests/LibWeb/Text/input/HTML/media-source-buffered.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-buffered.html
@@ -36,7 +36,9 @@
 
             mediaSource.addEventListener("sourceopen", async () => {
                 try {
+                    mediaSource.duration = 20;
                     const sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+                    step(`video before append: ${formatRanges(video.buffered)}`);
 
                     const response = await fetch("../../../Assets/test-webm.webm");
                     if (!response.ok) {


### PR DESCRIPTION
Report MediaSource-backed buffered ranges from active SourceBuffers instead of using PlaybackManager. Avoid treating an element with no prepared tracks as buffered from zero through its full duration, which causes HLS clients to skip every media fragment.

Follow the MSE intersection algorithm, including its ended-state range extension. Add coverage for the pre-append state that must expose an empty TimeRanges object.