### PR TITLE
LibWeb: Implement animation of custom properties

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -15,6 +15,7 @@
 #include <LibWeb/Bindings/AnimationEffect.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/CSS/EasingFunction.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 
 namespace Web::CSS {
 
@@ -143,7 +144,7 @@ public:
 
     void normalize_specified_timing();
 
-    HashTable<CSS::PropertyID> const& target_properties() const { return m_target_properties; }
+    HashTable<CSS::PropertyNameAndID> const& target_properties() const { return m_target_properties; }
 
     virtual GC::Ptr<DOM::Element> target() const { return {}; }
     virtual bool is_keyframe_effect() const { return false; }
@@ -214,7 +215,7 @@ protected:
 
     // https://www.w3.org/TR/web-animations-1/#target-property
     // Note: Only modified by child classes
-    HashTable<CSS::PropertyID> m_target_properties;
+    HashTable<CSS::PropertyNameAndID> m_target_properties;
 };
 
 }

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -172,6 +172,8 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
             animation_properties.append(name);
         } else if (name == "float"sv || name == "offset"sv) {
             // Ignore these property names
+        } else if (CSS::is_a_custom_property_name_string(name)) {
+            animation_properties.append(name);
         } else if (auto property = CSS::property_id_from_camel_case_string(name); property.has_value()) {
             if (CSS::is_animatable_property(property.value()))
                 animation_properties.append(name);
@@ -543,27 +545,29 @@ static WebIDL::ExceptionOr<Vector<BaseKeyframe>> process_a_keyframes_argument(JS
         //    highlight
         BaseKeyframe::ParsedProperties parsed_properties;
         for (auto& [property_string, value_string] : keyframe.unparsed_properties()) {
-            Optional<CSS::PropertyID> property_id;
+            Optional<CSS::PropertyNameAndID> property;
 
             // Handle some special cases
             if (property_string == "cssFloat"sv) {
-                property_id = CSS::PropertyID::Float;
+                property = CSS::PropertyNameAndID::from_id(CSS::PropertyID::Float);
             } else if (property_string == "cssOffset"sv) {
                 // FIXME: Support CSS offset property
             } else if (property_string == "float"sv || property_string == "offset"sv) {
                 // Ignore these properties
-            } else if (auto property = CSS::property_id_from_camel_case_string(property_string); property.has_value()) {
-                property_id = *property;
+            } else if (CSS::is_a_custom_property_name_string(property_string)) {
+                property = CSS::PropertyNameAndID::from_name(property_string);
+            } else if (auto property_id = CSS::property_id_from_camel_case_string(property_string); property_id.has_value()) {
+                property = CSS::PropertyNameAndID::from_id(*property_id);
             }
 
-            if (!property_id.has_value())
+            if (!property.has_value())
                 continue;
 
-            if (auto style_value = parse_css_value(CSS::Parser::ParsingParams(), value_string, *property_id)) {
+            if (auto style_value = parse_css_value(CSS::Parser::ParsingParams(), value_string, property->id())) {
                 // Handle 'initial' here so we don't have to get the default value of the property every frame in StyleComputer
-                if (style_value->is_initial())
-                    style_value = CSS::property_initial_value(*property_id);
-                parsed_properties.set(*property_id, CSS::RustStyleValueHandle::retained(style_value->rust_style_value_data()));
+                if (style_value->is_initial() && !property->is_custom_property())
+                    style_value = CSS::property_initial_value(property->id());
+                parsed_properties.set(*property, CSS::RustStyleValueHandle::retained(style_value->rust_style_value_data()));
             }
         }
         keyframe.properties.set(move(parsed_properties));
@@ -955,8 +959,8 @@ WebIDL::ExceptionOr<GC::RootVector<GC::Ref<JS::Object>>> KeyframeEffect::get_key
                 TRY(object->set(vm.names.composite, JS::PrimitiveString::create(vm, "auto"sv), JS::Object::ShouldThrowExceptions::Yes));
             }
 
-            for (auto const& [id, value] : keyframe.parsed_properties()) {
-                auto key = CSS::camel_case_string_from_property_id(id);
+            for (auto const& [property, value] : keyframe.parsed_properties()) {
+                auto key = property.is_custom_property() ? property.name() : CSS::camel_case_string_from_property_id(property.id());
                 // Serialization can still fall back to C++, which needs the typed facade; reflection is cold, so
                 // wrap on demand.
                 auto style_value = CSS::StyleValue::adopt_rust_style_value_data(CSS::StyleValueFFI::rust_style_value_retain(value.data()));
@@ -1003,10 +1007,14 @@ void KeyframeEffect::set_keyframes(Vector<BaseKeyframe> keyframes)
 
         auto key = static_cast<u64>(keyframe.computed_offset.value() * 100 * AnimationKeyFrameKeyScaleFactor);
 
-        for (auto const& [property_id, property_value] : keyframe.parsed_properties()) {
-            resolved_keyframe.properties.set(CSS::PropertyNameAndID::from_id(property_id), property_value);
+        for (auto const& [property, property_value] : keyframe.parsed_properties()) {
+            resolved_keyframe.properties.set(property, property_value);
+            if (property.is_custom_property()) {
+                m_target_properties.set(property);
+                continue;
+            }
             auto expansion = CSS::ComputedValuesFFI::rust_expand_property_shorthands(
-                to_underlying(property_id), property_value.data());
+                to_underlying(property.id()), property_value.data());
             for (size_t i = 0; i < expansion.count; ++i)
                 m_target_properties.set(CSS::PropertyNameAndID::from_id(static_cast<CSS::PropertyID>(expansion.properties[i].property_id)));
             CSS::ComputedValuesFFI::rust_shorthand_expansion_destroy(expansion.storage);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -599,7 +599,7 @@ WebIDL::ExceptionOr<Vector<BaseKeyframe>> process_keyframes(JS::Realm& realm, GC
 }
 
 // https://www.w3.org/TR/css-animations-2/#keyframe-processing
-void KeyframeEffect::generate_initial_and_final_frames(RefPtr<KeyFrameSet> keyframe_set, HashTable<CSS::PropertyID> const& animated_properties)
+void KeyframeEffect::generate_initial_and_final_frames(RefPtr<KeyFrameSet> keyframe_set, HashTable<CSS::PropertyNameAndID> const& animated_properties)
 {
     // 1. Find or create the initial keyframe, a keyframe with a keyframe offset of 0%, default timing function
     //    as its keyframe timing function, and default composite as its keyframe composite.
@@ -611,13 +611,13 @@ void KeyframeEffect::generate_initial_and_final_frames(RefPtr<KeyFrameSet> keyfr
         initial_keyframe = keyframe_set->keyframes_by_key.find(0);
     }
 
-    auto expanded_properties = [&](HashMap<CSS::PropertyID, Variant<KeyFrameSet::UseInitial, CSS::RustStyleValueHandle>>& properties) {
-        HashTable<CSS::PropertyID> result;
+    auto expanded_properties = [&](HashMap<CSS::PropertyNameAndID, Variant<KeyFrameSet::UseInitial, CSS::RustStyleValueHandle>>& properties) {
+        HashTable<CSS::PropertyNameAndID> result;
 
         for (auto property : properties) {
-            if (property_is_shorthand(property.key)) {
-                for (auto longhand : expanded_longhands_for_shorthand(property.key))
-                    result.set(longhand);
+            if (!property.key.is_custom_property() && property_is_shorthand(property.key.id())) {
+                for (auto longhand : expanded_longhands_for_shorthand(property.key.id()))
+                    result.set(CSS::PropertyNameAndID::from_id(longhand));
             } else {
                 result.set(property.key);
             }
@@ -1004,11 +1004,11 @@ void KeyframeEffect::set_keyframes(Vector<BaseKeyframe> keyframes)
         auto key = static_cast<u64>(keyframe.computed_offset.value() * 100 * AnimationKeyFrameKeyScaleFactor);
 
         for (auto const& [property_id, property_value] : keyframe.parsed_properties()) {
-            resolved_keyframe.properties.set(property_id, property_value);
+            resolved_keyframe.properties.set(CSS::PropertyNameAndID::from_id(property_id), property_value);
             auto expansion = CSS::ComputedValuesFFI::rust_expand_property_shorthands(
                 to_underlying(property_id), property_value.data());
             for (size_t i = 0; i < expansion.count; ++i)
-                m_target_properties.set(static_cast<CSS::PropertyID>(expansion.properties[i].property_id));
+                m_target_properties.set(CSS::PropertyNameAndID::from_id(static_cast<CSS::PropertyID>(expansion.properties[i].property_id)));
             CSS::ComputedValuesFFI::rust_shorthand_expansion_destroy(expansion.storage);
         }
 
@@ -1095,7 +1095,7 @@ bool KeyframeEffect::can_skip_per_frame_style_update() const
     for (auto const& keyframe : key_frame_set->keyframes_by_key) {
         for (auto const& property : keyframe.properties) {
             has_animated_property = true;
-            if (!first_is_one_of(property.key,
+            if (!first_is_one_of(property.key.id(),
                     CSS::PropertyID::Transform,
                     CSS::PropertyID::Translate,
                     CSS::PropertyID::Rotate,
@@ -1189,7 +1189,7 @@ void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
     bool affects_display = false;
     if (auto const* key_frame_set = this->key_frame_set()) {
         for (auto it = key_frame_set->keyframes_by_key.begin(); !affects_display && it != key_frame_set->keyframes_by_key.end(); ++it)
-            affects_display = it->properties.contains(CSS::PropertyID::Display);
+            affects_display = it->properties.contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Display));
     }
     if (!affects_display && target->has_inclusive_ancestor_with_display_none_ignoring_animations()) {
         // FIXME: Reaching this point means we failed to cancel animation for an element that started

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -48,7 +48,7 @@ StringView composite_operation_or_auto_to_string(CompositeOperationOrAuto);
 // https://www.w3.org/TR/web-animations-1/#dictdef-basekeyframe
 struct BaseKeyframe {
     using UnparsedProperties = HashMap<Utf16FlyString, Utf16String>;
-    using ParsedProperties = HashMap<CSS::PropertyID, CSS::RustStyleValueHandle>;
+    using ParsedProperties = HashMap<CSS::PropertyNameAndID, CSS::RustStyleValueHandle>;
 
     Optional<double> offset {};
     EasingValue easing { "linear"_utf16 };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -16,6 +16,7 @@
 #include <LibJS/Runtime/Value.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Bindings/KeyframeEffect.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 #include <LibWeb/Compositor/VisualAnimation.h>
@@ -88,14 +89,14 @@ public:
         struct ResolvedKeyFrame {
             // These style values can be unresolved, as they may be generated from a @keyframes rule, well
             // before they are applied to an element
-            HashMap<CSS::PropertyID, Variant<UseInitial, CSS::RustStyleValueHandle>> properties {};
+            HashMap<CSS::PropertyNameAndID, Variant<UseInitial, CSS::RustStyleValueHandle>> properties {};
             CompositeOperationOrAuto composite { CompositeOperationOrAuto::Auto };
             Variant<Empty, CSS::EasingFunction, CSS::RustStyleValueHandle> easing {};
         };
         RedBlackTree<u64, ResolvedKeyFrame> keyframes_by_key;
         Optional<StyleSheetResourceContext> style_sheet_resource_context;
     };
-    static void generate_initial_and_final_frames(RefPtr<KeyFrameSet>, HashTable<CSS::PropertyID> const& animated_properties);
+    static void generate_initial_and_final_frames(RefPtr<KeyFrameSet>, HashTable<CSS::PropertyNameAndID> const& animated_properties);
 
     static int composite_order(GC::Ref<KeyframeEffect>, GC::Ref<KeyframeEffect>);
 

--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -136,10 +136,10 @@ CSSTransition::CSSTransition(
 
     auto key_frame_set = adopt_ref(*new Animations::KeyframeEffect::KeyFrameSet);
     Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame initial_keyframe;
-    initial_keyframe.properties.set(property_id, RustStyleValueHandle::retained(m_start_value->rust_style_value_data()));
+    initial_keyframe.properties.set(PropertyNameAndID::from_id(property_id), RustStyleValueHandle::retained(m_start_value->rust_style_value_data()));
 
     Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame final_keyframe;
-    final_keyframe.properties.set(property_id, RustStyleValueHandle::retained(m_end_value->rust_style_value_data()));
+    final_keyframe.properties.set(PropertyNameAndID::from_id(property_id), RustStyleValueHandle::retained(m_end_value->rust_style_value_data()));
 
     key_frame_set->keyframes_by_key.insert(0, initial_keyframe);
     key_frame_set->keyframes_by_key.insert(100 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor, final_keyframe);

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -448,8 +448,14 @@ void ComputedStyleWorkingSet::did_apply_style_finalization_from_rust(u16 invalid
     invalidate(ComputedValuesFFI::FINALIZED_OVERFLOW_Y, PropertyID::OverflowY);
 }
 
+void ComputedStyleWorkingSet::set_animated_custom_property(Badge<StyleComputer>, Utf16FlyString name, NonnullRefPtr<StyleValue const> value)
+{
+    m_animated_custom_properties.set(move(name), move(value));
+}
+
 void ComputedStyleWorkingSet::clear_animated_properties(Badge<StyleComputer>)
 {
+    m_animated_custom_properties.clear();
     if (!m_animated_properties)
         return;
 

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -120,7 +120,9 @@ public:
     ComputedValuesFFI::AnimatedOverlay const* animated_overlay(Badge<StyleComputer>) const;
     void finish_animated_overlay_rust_mutation(Badge<StyleComputer>);
     void did_apply_style_finalization_from_rust(u16 invalidated_longhands);
+    void set_animated_custom_property(Badge<StyleComputer>, Utf16FlyString name, NonnullRefPtr<StyleValue const> value);
     void clear_animated_properties(Badge<StyleComputer>);
+    OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> const& animated_custom_properties() const { return m_animated_custom_properties; }
     StyleValue const& property(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
     void const* effective_property_data(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
 
@@ -227,6 +229,7 @@ private:
     ComputedValuesFFI::ComputedLonghandTable* m_computed_longhand_table { nullptr };
     NonnullRefPtr<WrapperMintCache> m_mint_cache;
     RefPtr<AnimatedProperties> m_animated_properties;
+    OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> m_animated_custom_properties;
 
     mutable RefPtr<Gfx::FontCascadeList const> m_cached_computed_font_list;
     mutable RefPtr<Gfx::Font const> m_cached_first_available_computed_font;

--- a/Libraries/LibWeb/CSS/CustomPropertyData.cpp
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.cpp
@@ -92,10 +92,22 @@ NonnullRefPtr<CustomPropertyData> CustomPropertyData::create_animation_overlay(
     OrderedHashMap<Utf16FlyString, StyleProperty> animated_values,
     RefPtr<CustomPropertyData const> base)
 {
+    Vector<ComputedValuesFFI::FfiCustomPropertyStoreEntry> entries;
+    entries.ensure_capacity(animated_values.size());
+    for (auto const& [name, property] : animated_values) {
+        entries.unchecked_append({
+            .name_raw = name.to_raw_leaked(),
+            .name = ffi_utf16_view(name),
+            .important = property.important == Important::Yes,
+            .data = StyleValueFFI::rust_style_value_retain(property.value->rust_style_value_data()),
+        });
+    }
+    auto const* rust_store = ComputedValuesFFI::rust_custom_property_store_create_animation_overlay(
+        entries.data(), entries.size(), base ? base->rust_store() : nullptr);
     auto declared_count = animated_values.size();
     u8 ancestor_count = base ? base->m_ancestor_count + 1 : 0;
     auto inheritance_parent = base;
-    auto data = adopt_ref(*new CustomPropertyData(move(animated_values), move(base), move(inheritance_parent), ancestor_count, declared_count, nullptr));
+    auto data = adopt_ref(*new CustomPropertyData(move(animated_values), move(base), move(inheritance_parent), ancestor_count, declared_count, rust_store));
     data->m_is_animation_overlay = true;
     return data;
 }

--- a/Libraries/LibWeb/CSS/CustomPropertyData.cpp
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.cpp
@@ -88,6 +88,18 @@ NonnullRefPtr<CustomPropertyData> CustomPropertyData::create(
     return adopt_ref(*new CustomPropertyData(move(own_values), move(parent), move(inheritance_parent), ancestor_count, declared_count, prebuilt_rust_store));
 }
 
+NonnullRefPtr<CustomPropertyData> CustomPropertyData::create_animation_overlay(
+    OrderedHashMap<Utf16FlyString, StyleProperty> animated_values,
+    RefPtr<CustomPropertyData const> base)
+{
+    auto declared_count = animated_values.size();
+    u8 ancestor_count = base ? base->m_ancestor_count + 1 : 0;
+    auto inheritance_parent = base;
+    auto data = adopt_ref(*new CustomPropertyData(move(animated_values), move(base), move(inheritance_parent), ancestor_count, declared_count, nullptr));
+    data->m_is_animation_overlay = true;
+    return data;
+}
+
 StyleProperty const* CustomPropertyData::get(Utf16FlyString const& name) const
 {
     if (auto it = m_own_values.find(name); it != m_own_values.end())

--- a/Libraries/LibWeb/CSS/CustomPropertyData.h
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.h
@@ -30,7 +30,12 @@ public:
         RefPtr<CustomPropertyData const> parent,
         // Transfers one strong Rust store reference when non-null.
         void const* prebuilt_rust_store = nullptr);
+    static NonnullRefPtr<CustomPropertyData> create_animation_overlay(
+        OrderedHashMap<Utf16FlyString, StyleProperty> animated_values,
+        RefPtr<CustomPropertyData const> base);
     ~CustomPropertyData();
+
+    bool is_animation_overlay() const { return m_is_animation_overlay; }
 
     StyleProperty const* get(Utf16FlyString const& name) const;
     RefPtr<CustomPropertyData const> inheritable_impl(RefPtr<CustomPropertyData const> inheritable_parent, AK::Function<Optional<CustomPropertyRegistration const&>(Utf16FlyString const&)> get_custom_property_registration) const;
@@ -130,6 +135,7 @@ private:
     mutable PreferredColorScheme m_cached_resolution_color_scheme { PreferredColorScheme::Auto };
     mutable RefPtr<CustomPropertyData const> m_cached_resolution;
     mutable bool m_cached_resolution_is_self { false };
+    bool m_is_animation_overlay { false };
     void const* m_rust_store { nullptr };
 };
 

--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/HashFunctions.h>
 #include <AK/Optional.h>
+#include <AK/Traits.h>
 #include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/PropertyName.h>
 #include <LibWeb/CSS/Serialize.h>
@@ -58,6 +60,20 @@ public:
         return serialize_an_identifier_to_utf16(name());
     }
 
+    bool operator==(PropertyNameAndID const& other) const
+    {
+        if (m_property_id != other.m_property_id)
+            return false;
+        return !is_custom_property() || name() == other.name();
+    }
+
+    unsigned hash() const
+    {
+        if (is_custom_property())
+            return name().hash();
+        return u32_hash(to_underlying(m_property_id));
+    }
+
 private:
     PropertyNameAndID(Optional<Utf16FlyString> name, PropertyID id)
         : m_name(move(name))
@@ -70,3 +86,8 @@ private:
 };
 
 }
+
+template<>
+struct AK::Traits<Web::CSS::PropertyNameAndID> : public DefaultTraits<Web::CSS::PropertyNameAndID> {
+    static unsigned hash(Web::CSS::PropertyNameAndID const& property) { return property.hash(); }
+};

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -80,6 +80,7 @@
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RandomValueSharingStyleValue.h>
@@ -1212,7 +1213,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_animated_custom_property_
     return finalize_custom_property_value(&computed_properties, AbstractOrHypotheticalElement { abstract_element }, name, move(specified_value));
 }
 
-void StyleComputer::publish_animated_custom_properties(ComputedStyleWorkingSet const& computed_properties, DOM::AbstractElement abstract_element) const
+void StyleComputer::publish_animated_custom_properties(ComputedStyleWorkingSet& computed_properties, DOM::AbstractElement abstract_element) const
 {
     auto data = abstract_element.custom_property_data();
     RefPtr<CustomPropertyData const> base = data;
@@ -1221,8 +1222,10 @@ void StyleComputer::publish_animated_custom_properties(ComputedStyleWorkingSet c
 
     auto const& animated_values = computed_properties.animated_custom_properties();
     if (animated_values.is_empty()) {
-        if (base.ptr() != data.ptr())
-            abstract_element.set_custom_property_data(base);
+        if (base.ptr() != data.ptr()) {
+            abstract_element.replace_custom_property_data(Badge<StyleComputer> {}, base);
+            invalidate_animated_custom_property_readers(abstract_element, animated_values);
+        }
         return;
     }
 
@@ -1248,7 +1251,45 @@ void StyleComputer::publish_animated_custom_properties(ComputedStyleWorkingSet c
                 .value = value,
             });
     }
-    abstract_element.set_custom_property_data(CustomPropertyData::create_animation_overlay(move(overlay_values), move(base)));
+    abstract_element.replace_custom_property_data(Badge<StyleComputer> {}, CustomPropertyData::create_animation_overlay(move(overlay_values), move(base)));
+    invalidate_animated_custom_property_readers(abstract_element, animated_values);
+}
+
+void StyleComputer::invalidate_animated_custom_property_readers(DOM::AbstractElement abstract_element, OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> const& animated_values) const
+{
+    auto& element = abstract_element.element();
+    auto element_references_animated_custom_property = [&] {
+        auto const* record = element.style_input_record();
+        if (!record)
+            return true;
+        if (animated_values.is_empty())
+            return !record->custom_property_references.is_empty();
+        for (auto const& name : record->custom_property_references) {
+            if (animated_values.contains(name))
+                return true;
+        }
+        return false;
+    };
+    auto& style_engine = element.document().style_computer().style_engine();
+    if (element_references_animated_custom_property())
+        style_engine.record_element_style_input_change(element.style_node_id());
+
+    auto any_animated_custom_property_inherits = [&] {
+        if (animated_values.is_empty())
+            return true;
+        for (auto const& [name, value] : animated_values) {
+            auto registration = m_document->get_registered_custom_property(name);
+            if (!registration.has_value() || registration->inherit)
+                return true;
+        }
+        return false;
+    };
+    if (!abstract_element.pseudo_element().has_value() && any_animated_custom_property_inherits()) {
+        style_engine.record_flat_tree_descendant_style_input_changes(
+            element.style_node_id(),
+            StyleEngine::InheritedStyle,
+            RequiredInvalidationAfterStyleChange::all_inherited_style_groups);
+    }
 }
 
 void StyleComputer::process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const& cascaded_properties, DOM::AbstractElement& abstract_element, ReadonlySpan<AnimationProperties> animation_definitions) const
@@ -4538,12 +4579,16 @@ RefPtr<ComputedStyleWorkingSet> StyleComputer::compute_style_impl(DOM::AbstractE
     auto reuse_computed_style = [&]() -> bool {
         if (!style_input_is_unchanged || new_style_input_record->read_beyond_the_record || !last_style_still_stands())
             return false;
+        if (auto data = abstract_element.custom_property_data(); data && data->is_animation_overlay())
+            return false;
         reuse_last_computed_style();
         return true;
     };
 
     bool has_complete_sharing_key = false;
     auto find_shared_style = [&]() {
+        if (auto data = abstract_element.custom_property_data(); data && data->is_animation_overlay())
+            return false;
         auto key_hash = compute_style_sharing_key_hash(sharing->key);
         auto bucket = m_style_sharing_cache.get(key_hash);
         if (!bucket.has_value())
@@ -5255,7 +5300,10 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::compute_properties(DOM::Ab
                 .default_font_size_raw = style_computer.default_user_font_size().raw_value(),
             };
 
-            if (auto data = abstract_element.custom_property_data(); data && data->declared_count() > 0) {
+            auto data = abstract_element.custom_property_data();
+            if (data && data->is_animation_overlay())
+                data = data->parent();
+            if (data && data->declared_count() > 0) {
                 bool shares_parent_data = inheritance_parent.has_value() && inheritance_parent->custom_property_data().ptr() == data.ptr();
                 if (!shares_parent_data) {
                     auto parent_data = inheritance_parent.has_value() ? inheritable_custom_property_data(*inheritance_parent) : nullptr;
@@ -5613,7 +5661,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::resolve_unresolved_style_value(Ab
     return StyleValue::adopt_rust_style_value_data(static_cast<StyleValueFFI::StyleValueData const*>(output.data));
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(ComputedStyleWorkingSet const* computed_style_for_custom_property_resolution, AbstractOrHypotheticalElement const& element, Utf16FlyString const& name) const
+NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(ComputedStyleWorkingSet const* computed_style_for_custom_property_resolution, AbstractOrHypotheticalElement const& element, Utf16FlyString const& name, DeclaredValueSource declared_value_source) const
 {
     // https://drafts.csswg.org/css-variables/#propdef-
     // The computed value of a custom property is its specified value with any arbitrary-substitution functions replaced.
@@ -5623,7 +5671,18 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(
     document.style_invalidation_counters().custom_property_value_computations++;
     auto registration = element.get_registered_custom_property(name);
 
-    auto value = element.get_custom_property(name);
+    auto value = [&]() -> RefPtr<StyleValue const> {
+        if (declared_value_source == DeclaredValueSource::PublishedEnvironment)
+            return element.get_custom_property(name);
+        auto data = element.custom_property_data();
+        if (data && data->is_animation_overlay())
+            data = data->parent();
+        if (!data)
+            return nullptr;
+        if (auto const* property = data->get(name))
+            return property->value;
+        return nullptr;
+    }();
     auto resolved_value = value ? value.release_nonnull() : initial_custom_property_value(registration, document);
 
     return finalize_custom_property_value(computed_style_for_custom_property_resolution, element, name, move(resolved_value));

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -715,10 +715,12 @@ void StyleComputer::collect_animations_into(DOM::AbstractElement abstract_elemen
 {
     if (refresh == AnimationRefresh::No) {
         collect_animation_effects_into(abstract_element, effects, computed_properties);
+        publish_animated_custom_properties(computed_properties, abstract_element);
         return;
     }
     m_keyframes_inherited_non_inherited_style_groups = 0;
     collect_animation_effects_into(abstract_element, effects, computed_properties);
+    publish_animated_custom_properties(computed_properties, abstract_element);
     // An animation-only overlay update resolves keyframe values just like a full style computation does, so a
     // keyframe-borne `inherit` on a non-inherited property discovered here must leave the same invalidation
     // mark behind, or a later change to the parent's value never reaches this element's animated style.
@@ -801,6 +803,20 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                 };
             });
     };
+
+    auto base_custom_property_data = [&]() -> RefPtr<CustomPropertyData const> {
+        auto data = abstract_element.custom_property_data();
+        if (data && data->is_animation_overlay())
+            return data->parent();
+        return data;
+    }();
+    auto underlying_custom_property_value = [&](Utf16FlyString const& name) -> NonnullRefPtr<StyleValue const> {
+        if (base_custom_property_data) {
+            if (auto const* style_property = base_custom_property_data->get(name))
+                return *style_property->value;
+        }
+        return initial_custom_property_value(m_document->get_registered_custom_property(name), *m_document);
+    };
     for (auto effect : effects) {
         auto animation = effect->associated_animation();
         auto output_progress = effect->transformed_progress();
@@ -859,7 +875,11 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                 bool is_use_initial = false;
                 auto style_value = value.visit(
                     [&](Animations::KeyframeEffect::KeyFrameSet::UseInitial) -> RustStyleValueHandle {
-                        if (!property.is_custom_property() && property_is_shorthand(property.id()))
+                        if (property.is_custom_property()) {
+                            is_use_initial = true;
+                            return RustStyleValueHandle::retained(underlying_custom_property_value(property.name())->rust_style_value_data());
+                        }
+                        if (property_is_shorthand(property.id()))
                             return {};
                         is_use_initial = true;
                         return RustStyleValueHandle::retained(computed_properties.property(property.id(), ComputedStyleWorkingSet::WithAnimationsApplied::No).rust_style_value_data());
@@ -871,13 +891,15 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                     // Substitution needs the typed facade, but only var()-bearing keyframes take this path,
                     // and those re-parse the value every frame anyway.
                     auto unresolved = StyleValue::adopt_rust_style_value_data(StyleValueFFI::rust_style_value_retain(style_value.data()));
-                    auto resolved = abstract_element.document().style_computer().resolve_unresolved_style_value(abstract_element, property, unresolved->as_unresolved());
-                    style_value = RustStyleValueHandle::retained(resolved->rust_style_value_data());
+                    if (!property.is_custom_property() || unresolved->as_unresolved().contains_arbitrary_substitution_function()) {
+                        auto resolved = abstract_element.document().style_computer().resolve_unresolved_style_value(abstract_element, property, unresolved->as_unresolved());
+                        style_value = RustStyleValueHandle::retained(resolved->rust_style_value_data());
+                    }
                 }
                 // https://drafts.csswg.org/css-values-5/#invalid-at-computed-value-time
                 // When substitution results in a guaranteed-invalid value, treat it as unset
                 // (i.e. inherit for inherited properties, initial for non-inherited properties).
-                if (style_value->tag == StyleValueFFI::StyleValueData::Tag::GuaranteedInvalid)
+                if (style_value->tag == StyleValueFFI::StyleValueData::Tag::GuaranteedInvalid && !property.is_custom_property())
                     continue;
                 keyframe_declarations.append({
                     .keyframe_index = keyframe_index,
@@ -902,12 +924,58 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     if (keyframe_declarations.is_empty())
         return;
 
+    Vector<PropertyNameAndID> custom_properties_by_name_id;
+    struct CustomPropertyAnimationInfo {
+        bool is_inherited { true };
+        bool is_important { false };
+    };
+    Vector<CustomPropertyAnimationInfo> custom_property_infos;
+    HashMap<Utf16FlyString, u32> custom_property_name_ids;
+    auto element_declares_own_custom_properties = [&] {
+        if (!base_custom_property_data)
+            return false;
+        auto inherit_from = abstract_element.element_to_inherit_style_from();
+        return !(inherit_from.has_value() && inherit_from->custom_property_data().ptr() == base_custom_property_data.ptr());
+    }();
+    auto custom_name_id_for = [&](PropertyNameAndID const& property) -> u32 {
+        return custom_property_name_ids.ensure(property.name(), [&] {
+            auto registration = m_document->get_registered_custom_property(property.name());
+            bool is_important = false;
+            if (element_declares_own_custom_properties) {
+                size_t declared_index = 0;
+                for (auto const& [name, style_property] : base_custom_property_data->own_values()) {
+                    if (declared_index++ >= base_custom_property_data->declared_count())
+                        break;
+                    if (name == property.name()) {
+                        is_important = style_property.important == Important::Yes;
+                        break;
+                    }
+                }
+            }
+            custom_properties_by_name_id.append(property);
+            custom_property_infos.append({
+                .is_inherited = !registration.has_value() || registration->inherit,
+                .is_important = is_important,
+            });
+            return static_cast<u32>(custom_properties_by_name_id.size());
+        });
+    };
+
     Vector<StyleValueFFI::FfiAnimationDeclaration> ffi_declarations;
     ffi_declarations.ensure_capacity(keyframe_declarations.size());
     for (auto const& declaration : keyframe_declarations) {
+        u32 custom_name_id = 0;
+        CustomPropertyAnimationInfo custom_property_info;
+        if (declaration.property.is_custom_property()) {
+            custom_name_id = custom_name_id_for(declaration.property);
+            custom_property_info = custom_property_infos[custom_name_id - 1];
+        }
         ffi_declarations.unchecked_append({
             .keyframe_index = declaration.keyframe_index,
             .property_id = to_underlying(declaration.property.id()),
+            .custom_name_id = custom_name_id,
+            .custom_is_inherited = custom_property_info.is_inherited,
+            .custom_is_important = custom_property_info.is_important,
             .value = declaration.value.data(),
             .style_sheet_resource_context = declaration.style_sheet_resource_context,
             .use_initial = declaration.use_initial,
@@ -918,12 +986,47 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     Vector<u8> important_property_bitmap;
     important_property_bitmap.append(computed_properties.property_importance_bitmap().data(), computed_properties.property_importance_bitmap().size());
 
+    Vector<NonnullRefPtr<StyleValue const>> custom_animation_value_storage;
+    Vector<StyleValueFFI::StyleValueData const*> custom_underlying_values;
+    Vector<StyleValueFFI::StyleValueData const*> custom_initial_values;
+    Vector<StyleValueFFI::FfiAnimatedCustomProperty> custom_results;
+    size_t custom_result_count = 0;
+
     auto compute_animation_values = [&](ReadonlySpan<StyleValueFFI::FfiResolvedAnimationProperty> resolved_properties, StyleValueFFI::FfiResolvedAnimationProperties const& resolved_batch) -> StyleValueFFI::FfiComputedAnimationBatch {
         VERIFY(computation_context_cache_is_empty());
         for (auto const& property : resolved_properties) {
+            if (property.custom_name_id != 0)
+                continue;
             auto source_longhand_id = static_cast<PropertyID>(property.source_longhand_id);
             if (property.value_source == StyleValueFFI::FfiAnimationSpecifiedValueSource::Inherited && !is_inherited_property(source_longhand_id))
                 m_keyframes_inherited_non_inherited_style_groups |= ComputedValues::style_group_bit_of_property(source_longhand_id);
+        }
+
+        Vector<NonnullRefPtr<StyleValue const>> custom_keyframe_value_storage;
+        Vector<void const*> custom_keyframe_values;
+        custom_keyframe_values.resize(resolved_properties.size());
+        for (size_t index = 0; index < resolved_properties.size(); ++index) {
+            auto const& property = resolved_properties[index];
+            if (property.custom_name_id == 0)
+                continue;
+            auto const& name = custom_properties_by_name_id[property.custom_name_id - 1].name();
+            auto registration = m_document->get_registered_custom_property(name);
+            auto specified_value = [&]() -> NonnullRefPtr<StyleValue const> {
+                switch (property.value_source) {
+                case StyleValueFFI::FfiAnimationSpecifiedValueSource::Inherited:
+                    return inherited_custom_property_value(registration, AbstractOrHypotheticalElement { abstract_element }, name, &computed_properties);
+                case StyleValueFFI::FfiAnimationSpecifiedValueSource::Initial:
+                    return initial_custom_property_value(registration, *m_document);
+                case StyleValueFFI::FfiAnimationSpecifiedValueSource::Underlying:
+                    return underlying_custom_property_value(name);
+                case StyleValueFFI::FfiAnimationSpecifiedValueSource::Value:
+                    return StyleValue::adopt_rust_style_value_data(StyleValueFFI::rust_style_value_retain(property.value));
+                }
+                VERIFY_NOT_REACHED();
+            }();
+            auto computed_value = compute_animated_custom_property_value(name, move(specified_value), computed_properties, abstract_element);
+            custom_keyframe_values[index] = computed_value->rust_style_value_data();
+            custom_keyframe_value_storage.append(move(computed_value));
         }
 
         Optional<DOM::AbstractElement::TreeCountingFunctionResolutionContext> tree_counting_context;
@@ -996,6 +1099,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             .font_length_resolution_context = &font_length_resolution_context,
             .line_height_length_resolution_context = &line_height_length_resolution_context,
             .remaining_length_resolution_context = &remaining_length_resolution_context,
+            .custom_property_values = custom_keyframe_values.data(),
         };
         auto computed_keyframe_batch = ComputedValuesFFI::rust_compute_animation_keyframe_longhands(&keyframe_input);
         VERIFY(computed_keyframe_batch.value_count == resolved_properties.size());
@@ -1039,12 +1143,29 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             animation_context.transform_reference_box_width = reference_box.width().to_double();
             animation_context.transform_reference_box_height = reference_box.height().to_double();
         }
+        custom_underlying_values.ensure_capacity(custom_properties_by_name_id.size());
+        custom_initial_values.ensure_capacity(custom_properties_by_name_id.size());
+        for (auto const& property : custom_properties_by_name_id) {
+            auto underlying_value = underlying_custom_property_value(property.name());
+            auto initial_value = initial_custom_property_value(m_document->get_registered_custom_property(property.name()), *m_document);
+            custom_underlying_values.unchecked_append(underlying_value->rust_style_value_data());
+            custom_initial_values.unchecked_append(initial_value->rust_style_value_data());
+            custom_animation_value_storage.append(move(underlying_value));
+            custom_animation_value_storage.append(move(initial_value));
+        }
+        custom_results.resize(custom_properties_by_name_id.size());
+
         return StyleValueFFI::FfiComputedAnimationBatch {
             .context = animation_context,
             .resolved_animation_storage = resolved_batch.storage,
             .computed_keyframe_storage = computed_keyframe_batch.storage,
             .underlying_longhand_table = computed_properties.computed_longhand_table(),
             .overlay = computed_properties.prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer> {}),
+            .custom_underlying_values = custom_underlying_values.data(),
+            .custom_initial_values = custom_initial_values.data(),
+            .custom_value_count = custom_underlying_values.size(),
+            .custom_results = custom_results.data(),
+            .custom_result_count = &custom_result_count,
         };
     };
 
@@ -1068,9 +1189,66 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         resolved_properties);
     auto result_count = StyleValueFFI::rust_evaluate_animations(&computed_batch);
     VERIFY(result_count == resolved_properties.animation_value_count);
+    VERIFY(custom_result_count <= custom_results.size());
+    for (size_t index = 0; index < custom_result_count; ++index) {
+        auto const& result = custom_results[index];
+        VERIFY(result.custom_name_id != 0 && result.custom_name_id <= custom_properties_by_name_id.size());
+        auto const& property = custom_properties_by_name_id[result.custom_name_id - 1];
+        auto style_value = StyleValue::adopt_rust_style_value_data(result.value);
+        computed_properties.set_animated_custom_property(Badge<StyleComputer> {}, property.name(), move(style_value));
+    }
     computed_properties.finish_animated_overlay_rust_mutation(Badge<StyleComputer> {});
 
     clear_computation_context_caches();
+}
+
+// https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values
+NonnullRefPtr<StyleValue const> StyleComputer::compute_animated_custom_property_value(Utf16FlyString const& name, NonnullRefPtr<StyleValue const> specified_value, ComputedStyleWorkingSet& computed_properties, DOM::AbstractElement abstract_element) const
+{
+    auto registration = m_document->get_registered_custom_property(name);
+    if (!registration.has_value() || registration->syntax.is_universal())
+        return specified_value;
+
+    return finalize_custom_property_value(&computed_properties, AbstractOrHypotheticalElement { abstract_element }, name, move(specified_value));
+}
+
+void StyleComputer::publish_animated_custom_properties(ComputedStyleWorkingSet const& computed_properties, DOM::AbstractElement abstract_element) const
+{
+    auto data = abstract_element.custom_property_data();
+    RefPtr<CustomPropertyData const> base = data;
+    if (data && data->is_animation_overlay())
+        base = data->parent();
+
+    auto const& animated_values = computed_properties.animated_custom_properties();
+    if (animated_values.is_empty()) {
+        if (base.ptr() != data.ptr())
+            abstract_element.set_custom_property_data(base);
+        return;
+    }
+
+    if (data && data->is_animation_overlay() && data->own_values().size() == animated_values.size()) {
+        bool values_unchanged = true;
+        for (auto const& [name, value] : animated_values) {
+            auto existing = data->own_values().find(name);
+            if (existing == data->own_values().end() || !existing->value.value->equals(*value)) {
+                values_unchanged = false;
+                break;
+            }
+        }
+        if (values_unchanged)
+            return;
+    }
+
+    OrderedHashMap<Utf16FlyString, StyleProperty> overlay_values;
+    for (auto const& [name, value] : animated_values) {
+        overlay_values.set(name,
+            StyleProperty {
+                .important = Important::No,
+                .property_id = PropertyID::Custom,
+                .value = value,
+            });
+    }
+    abstract_element.set_custom_property_data(CustomPropertyData::create_animation_overlay(move(overlay_values), move(base)));
 }
 
 void StyleComputer::process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const& cascaded_properties, DOM::AbstractElement& abstract_element, ReadonlySpan<AnimationProperties> animation_definitions) const

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -734,7 +734,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
 {
     struct KeyframeDeclaration {
         size_t keyframe_index { 0 };
-        PropertyID property_id;
+        PropertyNameAndID property;
         RustStyleValueHandle value;
         StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context {};
         bool use_initial { false };
@@ -855,14 +855,14 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                 .easing = to_ffi_easing(*easing, points),
                 .composite = to_ffi_composite_operation(composite_operation),
             });
-            for (auto const& [property_id, value] : it->properties) {
+            for (auto const& [property, value] : it->properties) {
                 bool is_use_initial = false;
                 auto style_value = value.visit(
                     [&](Animations::KeyframeEffect::KeyFrameSet::UseInitial) -> RustStyleValueHandle {
-                        if (property_is_shorthand(property_id))
+                        if (!property.is_custom_property() && property_is_shorthand(property.id()))
                             return {};
                         is_use_initial = true;
-                        return RustStyleValueHandle::retained(computed_properties.property(property_id, ComputedStyleWorkingSet::WithAnimationsApplied::No).rust_style_value_data());
+                        return RustStyleValueHandle::retained(computed_properties.property(property.id(), ComputedStyleWorkingSet::WithAnimationsApplied::No).rust_style_value_data());
                     },
                     [](RustStyleValueHandle const& value) -> RustStyleValueHandle { return value; });
                 if (!style_value || style_value->tag == StyleValueFFI::StyleValueData::Tag::PendingSubstitution)
@@ -871,7 +871,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                     // Substitution needs the typed facade, but only var()-bearing keyframes take this path,
                     // and those re-parse the value every frame anyway.
                     auto unresolved = StyleValue::adopt_rust_style_value_data(StyleValueFFI::rust_style_value_retain(style_value.data()));
-                    auto resolved = abstract_element.document().style_computer().resolve_unresolved_style_value(abstract_element, PropertyNameAndID::from_id(property_id), unresolved->as_unresolved());
+                    auto resolved = abstract_element.document().style_computer().resolve_unresolved_style_value(abstract_element, property, unresolved->as_unresolved());
                     style_value = RustStyleValueHandle::retained(resolved->rust_style_value_data());
                 }
                 // https://drafts.csswg.org/css-values-5/#invalid-at-computed-value-time
@@ -881,7 +881,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                     continue;
                 keyframe_declarations.append({
                     .keyframe_index = keyframe_index,
-                    .property_id = property_id,
+                    .property = property,
                     .value = move(style_value),
                     .style_sheet_resource_context = style_sheet_resource_context,
                     .use_initial = is_use_initial,
@@ -907,7 +907,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
     for (auto const& declaration : keyframe_declarations) {
         ffi_declarations.unchecked_append({
             .keyframe_index = declaration.keyframe_index,
-            .property_id = to_underlying(declaration.property_id),
+            .property_id = to_underlying(declaration.property.id()),
             .value = declaration.value.data(),
             .style_sheet_resource_context = declaration.style_sheet_resource_context,
             .use_initial = declaration.use_initial,

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -278,6 +278,8 @@ private:
     [[nodiscard]] RefPtr<ComputedStyleWorkingSet> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&, IncludeInlineStyle, StyleEngineMatchResult* = nullptr, StyleSharingCandidate* = nullptr) const;
     [[nodiscard]] NonnullRefPtr<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, CascadeInput const&, IncludeInlineStyle, StyleSharingCandidate* sharing = nullptr, Vector<StyleProperty> const* precomputed_presentational_hints = nullptr) const;
     void collect_animation_effects_into(DOM::AbstractElement, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>>, ComputedStyleWorkingSet&) const;
+    NonnullRefPtr<StyleValue const> compute_animated_custom_property_value(Utf16FlyString const& name, NonnullRefPtr<StyleValue const> specified_value, ComputedStyleWorkingSet&, DOM::AbstractElement) const;
+    void publish_animated_custom_properties(ComputedStyleWorkingSet const&, DOM::AbstractElement) const;
     Vector<GC::Ref<Animations::KeyframeEffect>> start_needed_transitions(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
     void finalize_style(ComputedStyleWorkingSet&, DOM::AbstractElement, ComputedValuesFFI::FfiStyleFinalizationMode) const;
 

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -153,7 +153,11 @@ public:
 
     void process_animation_definitions(ComputedStyleWorkingSet const& computed_properties, CascadedProperties const&, DOM::AbstractElement& abstract_element, ReadonlySpan<AnimationProperties> animation_definitions) const;
 
-    NonnullRefPtr<StyleValue const> compute_value_of_custom_property(ComputedStyleWorkingSet const*, AbstractOrHypotheticalElement const&, Utf16FlyString const& name) const;
+    enum class DeclaredValueSource : u8 {
+        PublishedEnvironment,
+        BeneathAnimationOverlay,
+    };
+    NonnullRefPtr<StyleValue const> compute_value_of_custom_property(ComputedStyleWorkingSet const*, AbstractOrHypotheticalElement const&, Utf16FlyString const& name, DeclaredValueSource = DeclaredValueSource::PublishedEnvironment) const;
     NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(AbstractOrHypotheticalElement, PropertyNameAndID const&, UnresolvedStyleValue const&) const;
     ComputationContext fallback_computation_context_for_custom_property(AbstractOrHypotheticalElement const&) const;
 
@@ -279,7 +283,8 @@ private:
     [[nodiscard]] NonnullRefPtr<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, CascadeInput const&, IncludeInlineStyle, StyleSharingCandidate* sharing = nullptr, Vector<StyleProperty> const* precomputed_presentational_hints = nullptr) const;
     void collect_animation_effects_into(DOM::AbstractElement, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>>, ComputedStyleWorkingSet&) const;
     NonnullRefPtr<StyleValue const> compute_animated_custom_property_value(Utf16FlyString const& name, NonnullRefPtr<StyleValue const> specified_value, ComputedStyleWorkingSet&, DOM::AbstractElement) const;
-    void publish_animated_custom_properties(ComputedStyleWorkingSet const&, DOM::AbstractElement) const;
+    void publish_animated_custom_properties(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
+    void invalidate_animated_custom_property_readers(DOM::AbstractElement, OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> const& animated_values) const;
     Vector<GC::Ref<Animations::KeyframeEffect>> start_needed_transitions(ComputedStyleWorkingSet&, DOM::AbstractElement) const;
     void finalize_style(ComputedStyleWorkingSet&, DOM::AbstractElement, ComputedValuesFFI::FfiStyleFinalizationMode) const;
 

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -443,6 +443,15 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                     ComputedValuesFFI::rust_shorthand_expansion_destroy(expansion.storage);
                 }
 
+                for (auto const& [name, style_property] : keyframe_style.custom_properties()) {
+                    auto property = PropertyNameAndID::from_name(name);
+                    if (!property.has_value())
+                        continue;
+                    animated_properties.set(*property);
+                    resolved_keyframe.properties.set(*property,
+                        RustStyleValueHandle::retained(style_property.value->rust_style_value_data()));
+                }
+
                 for (auto const& key : keyframe.keys()) {
                     auto resolved_key = static_cast<u64>(key.value() * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor);
 

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -391,7 +391,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                 .base_url = base_url.has_value() ? base_url->to_string() : String {},
                 .origin_clean = sheet.is_origin_clean(),
             };
-            HashTable<PropertyID> animated_properties;
+            HashTable<PropertyNameAndID> animated_properties;
 
             // Forwards pass, resolve all the user-specified keyframe properties.
             for (auto const& keyframe_rule : *rule.css_rules()) {
@@ -435,9 +435,9 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                         to_underlying(it.property_id), it.value->rust_style_value_data());
                     for (size_t i = 0; i < expansion.count; ++i) {
                         auto const& property = expansion.properties[i];
-                        auto longhand_property_id = static_cast<PropertyID>(property.property_id);
-                        animated_properties.set(longhand_property_id);
-                        resolved_keyframe.properties.set(longhand_property_id,
+                        auto longhand_property = PropertyNameAndID::from_id(static_cast<PropertyID>(property.property_id));
+                        animated_properties.set(longhand_property);
+                        resolved_keyframe.properties.set(longhand_property,
                             RustStyleValueHandle::retained(static_cast<StyleValueFFI::StyleValueData const*>(property.data)));
                     }
                     ComputedValuesFFI::rust_shorthand_expansion_destroy(expansion.storage);
@@ -447,8 +447,8 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                     auto resolved_key = static_cast<u64>(key.value() * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor);
 
                     if (auto* existing_keyframe = keyframe_set->keyframes_by_key.find(resolved_key)) {
-                        for (auto& [property_id, value] : resolved_keyframe.properties)
-                            existing_keyframe->properties.set(property_id, value);
+                        for (auto& [property, value] : resolved_keyframe.properties)
+                            existing_keyframe->properties.set(property, value);
                         if (resolved_keyframe.composite != Bindings::CompositeOperationOrAuto::Auto)
                             existing_keyframe->composite = resolved_keyframe.composite;
                         if (!resolved_keyframe.easing.has<Empty>())

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -371,14 +371,14 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
                     //     which inherited groups changed or its masked recompute will keep stale
                     //     values for them. When the swap succeeds the parameter goes unused.
                     auto inherited_style_groups_for_closure = can_use_inherited_style_group_swap ? reaction.inherited_style_groups : 0;
+                    if (needs_regular_style_recompute)
+                        document.style_computer().style_engine().consume_recorded_element_style_input_change(reaction.style_node);
                     invalidation = element->apply_style_engine_reaction(
                         did_change_custom_properties,
                         recompute_reason,
                         inherited_style_groups_for_closure);
                     if (materializes_inherited_style_reaction && invalidation.is_none() && !did_change_custom_properties)
                         ++document.style_invalidation_counters().element_inherited_style_noop_recomputations;
-                    if (needs_regular_style_recompute)
-                        document.style_computer().style_engine().consume_recorded_element_style_input_change(reaction.style_node);
                 }
             } else if (needs_custom_property_recompute && element->refresh_inherited_custom_property_data()) {
                 did_change_custom_properties = true;
@@ -723,16 +723,14 @@ static RequiredInvalidationAfterStyleChange materialize_style_for_targeted_updat
 {
     auto& style_computer = element.document().style_computer();
 
-    if (element.parent()) {
-        auto invalidation = element.apply_style_engine_reaction(did_change_custom_properties);
-        style_computer.style_engine().consume_recorded_element_style_input_change(element.style_node_id());
-        return invalidation;
-    }
+    style_computer.style_engine().consume_recorded_element_style_input_change(element.style_node_id());
+
+    if (element.parent())
+        return element.apply_style_engine_reaction(did_change_custom_properties);
 
     StyleEngine::StyleRecordDelta style_record_delta {};
     auto new_style = element.document().style_computer().materialize_style_record({ element }, did_change_custom_properties, nullptr, style_record_delta);
     element.set_computed_style({}, style_record_delta.new_style_record);
-    style_computer.style_engine().consume_recorded_element_style_input_change(element.style_node_id());
     return {};
 }
 
@@ -917,6 +915,11 @@ static bool update_style_for_element(DOM::Document& document, DOM::AbstractEleme
         auto& element = inheritance_chain[i - 1];
         bool did_change_custom_properties = false;
         auto invalidation = materialize_style_for_targeted_update(element, did_change_custom_properties);
+        if (document.style_computer().style_engine().has_recorded_element_style_input_change(element->style_node_id())) {
+            bool changed_custom_properties_again = false;
+            invalidation |= materialize_style_for_targeted_update(element, changed_custom_properties_again);
+            did_change_custom_properties |= changed_custom_properties_again;
+        }
         auto child_materialized_by_targeted_update = i > 1
             ? Optional<StyleNodeID> { inheritance_chain[i - 2]->style_node_id() }
             : Optional<StyleNodeID> {};

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -195,6 +195,11 @@ void AbstractElement::set_custom_property_data(RefPtr<CSS::CustomPropertyData co
     m_element->set_custom_property_data(m_pseudo_element, move(data));
 }
 
+void AbstractElement::replace_custom_property_data(Badge<CSS::StyleComputer>, RefPtr<CSS::CustomPropertyData const> data)
+{
+    m_element->replace_custom_property_data(m_pseudo_element, move(data));
+}
+
 RefPtr<CSS::StyleValue const> AbstractElement::get_custom_property(Utf16FlyString const& name) const
 {
     auto data = custom_property_data();

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -64,6 +64,7 @@ public:
     GC::Ptr<CSS::CSSStyleProperties const> inline_style() const;
 
     void set_custom_property_data(RefPtr<CSS::CustomPropertyData const>);
+    void replace_custom_property_data(Badge<CSS::StyleComputer>, RefPtr<CSS::CustomPropertyData const>);
     [[nodiscard]] RefPtr<CSS::CustomPropertyData const> custom_property_data() const;
     RefPtr<CSS::StyleValue const> get_custom_property(Utf16FlyString const& name) const;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7789,7 +7789,7 @@ static bool transform_keyframes_only_translate_horizontally(ReadonlySpan<Composi
 
 static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEffect& effect, DOM::AbstractElement target, Layout::Node const& layout_node, float device_pixels_per_css_pixel)
 {
-    if (effect.target_properties().size() != 1 || !effect.target_properties().contains(CSS::PropertyID::Transform))
+    if (effect.target_properties().size() != 1 || !effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform)))
         return false;
     auto const* key_frame_set = effect.key_frame_set();
     if (!key_frame_set)
@@ -7797,7 +7797,7 @@ static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEff
 
     Vector<Compositor::VisualAnimationKeyframe> keyframes;
     for (auto const& entry : key_frame_set->keyframes_by_key) {
-        auto property = entry.properties.get(CSS::PropertyID::Transform);
+        auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform));
         if (!property.has_value())
             continue;
         if (!property->has<CSS::RustStyleValueHandle>())
@@ -7852,11 +7852,11 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (effect.target_properties().is_empty())
         return {};
 
-    bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && effect.target_properties().contains(CSS::PropertyID::Opacity);
-    bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && any_of(effect.target_properties(), is_transform_family_property);
+    bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
+    bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
     if (!targets_opacity && !targets_transform)
         return {};
-    if (any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); }))
+    if (any_of(effect.target_properties(), [&](auto const& property) { return property.id() != CSS::PropertyID::Opacity && !is_transform_family_property(property.id()); }))
         return {};
     auto target = effect.target_abstract_element();
     if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
@@ -7869,10 +7869,10 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (!layout_node)
         return {};
     if (targets_transform) {
-        if ((!effect.target_properties().contains(CSS::PropertyID::Translate) && layout_node->has_translate())
-            || (!effect.target_properties().contains(CSS::PropertyID::Rotate) && layout_node->has_rotate())
-            || (!effect.target_properties().contains(CSS::PropertyID::Scale) && layout_node->has_scale())
-            || (!effect.target_properties().contains(CSS::PropertyID::Transform) && layout_node->has_transformations())
+        if ((!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Translate)) && layout_node->has_translate())
+            || (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Rotate)) && layout_node->has_rotate())
+            || (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Scale)) && layout_node->has_scale())
+            || (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform)) && layout_node->has_transformations())
             || layout_node->transform_origin().z.to_px(CSSPixels { 0 }) != CSSPixels { 0 })
             return {};
     }
@@ -7912,14 +7912,14 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
         };
         new_cache.values.ensure_capacity(key_frame_set->keyframes_by_key.size());
         size_t transform_property_count = 0;
-        for (auto property_id : effect.target_properties()) {
-            if (is_transform_family_property(property_id))
+        for (auto const& property : effect.target_properties()) {
+            if (is_transform_family_property(property.id()))
                 ++transform_property_count;
         }
         for (auto const& entry : key_frame_set->keyframes_by_key) {
             Optional<Compositor::VisualAnimationValue> value;
             if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
-                auto property = entry.properties.get(CSS::PropertyID::Opacity);
+                auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
                 if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
                     new_cache.values.append({});
                     continue;
@@ -7934,9 +7934,9 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 Compositor::VisualAnimationTransformList operations;
                 bool skip_keyframe = false;
                 for (auto property_id : { CSS::PropertyID::Translate, CSS::PropertyID::Rotate, CSS::PropertyID::Scale, CSS::PropertyID::Transform }) {
-                    if (!effect.target_properties().contains(property_id))
+                    if (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(property_id)))
                         continue;
-                    auto property = entry.properties.get(property_id);
+                    auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(property_id));
                     if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
                         if (transform_property_count == 1) {
                             skip_keyframe = true;
@@ -8035,7 +8035,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
 
         if (target_kind == Compositor::VisualAnimation::TargetKind::Transform) {
             only_translates_horizontally = effect.target_properties().size() == 1
-                && effect.target_properties().contains(CSS::PropertyID::Transform)
+                && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform))
                 && transform_keyframes_only_translate_horizontally(keyframes);
         }
 
@@ -8195,16 +8195,16 @@ void Document::update_compositor_animations()
 
     auto animated_transform_preserves_axes = [&](Animations::KeyframeEffect& effect, Element& target, Layout::Node const& layout_node) {
         return animated_transform_preserves_axes_cache.ensure(effect, [&] {
-            if (effect.target_properties().contains(CSS::PropertyID::Rotate))
+            if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Rotate)))
                 return false;
-            if (!effect.target_properties().contains(CSS::PropertyID::Transform))
+            if (!effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform)))
                 return true;
             auto const* key_frame_set = effect.key_frame_set();
             if (!key_frame_set)
                 return false;
             auto device_pixels_per_css_pixel = static_cast<float>(page().client().device_pixels_per_css_pixel());
             for (auto const& entry : key_frame_set->keyframes_by_key) {
-                auto property = entry.properties.get(CSS::PropertyID::Transform);
+                auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Transform));
                 if (!property.has_value())
                     continue;
                 if (!property->has<CSS::RustStyleValueHandle>())
@@ -8299,7 +8299,7 @@ void Document::update_compositor_animations()
             if (!effect_target || !animated_target.is_shadow_including_inclusive_ancestor_of(*effect_target)
                 || !effect_target->is_shadow_including_inclusive_ancestor_of(observation_target))
                 continue;
-            if (any_of(effect.target_properties(), is_transform_family_property))
+            if (any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); }))
                 return true;
         }
         return false;
@@ -8374,9 +8374,9 @@ void Document::update_compositor_animations()
             if (!property_effects.winner || Animations::KeyframeEffect::composite_order(*property_effects.winner, effect) < 0)
                 property_effects.winner = effect;
         };
-        if (effect.target_properties().contains(CSS::PropertyID::Opacity))
+        if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity)))
             add_competing_effect(effects.opacity);
-        if (any_of(effect.target_properties(), is_transform_family_property)) {
+        if (any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); })) {
             add_competing_effect(effects.transform);
             in_effect_transform_effects_by_target.ensure(&target->element()).append(effect);
         }
@@ -8443,9 +8443,9 @@ void Document::update_compositor_animations()
             continue;
         auto& target = abstract_target->element();
 
-        bool targets_opacity = effect.target_properties().contains(CSS::PropertyID::Opacity);
-        bool targets_transform = any_of(effect.target_properties(), is_transform_family_property);
-        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto property_id) { return property_id != CSS::PropertyID::Opacity && !is_transform_family_property(property_id); });
+        bool targets_opacity = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
+        bool targets_transform = any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
+        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto const& property) { return property.id() != CSS::PropertyID::Opacity && !is_transform_family_property(property.id()); });
         if (targets_unsupported_property)
             continue;
         auto target_effects = competing_effects.get(*abstract_target);
@@ -8757,7 +8757,7 @@ void Document::remove_replaced_animations()
     });
 
     // Lower value = higher priority
-    HashMap<CSS::PropertyID, size_t> highest_property_composite_orders;
+    HashMap<CSS::PropertyNameAndID, size_t> highest_property_composite_orders;
     for (int i = replaceable_animations.size() - 1; i >= 0; i--) {
         auto animation = replaceable_animations[i];
         bool has_any_highest_priority_property = false;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5042,6 +5042,26 @@ SyntheticPseudoElement& Element::ensure_synthetic_pseudo_element(CSS::PseudoElem
 
 void Element::set_custom_property_data(Optional<CSS::PseudoElement> pseudo_element, RefPtr<CSS::CustomPropertyData const> data)
 {
+    if (!data || !data->is_animation_overlay()) {
+        if (auto current = custom_property_data(pseudo_element); current && current->is_animation_overlay()) {
+            if (current->parent() == data)
+                return;
+            OrderedHashMap<Utf16FlyString, CSS::StyleProperty> animated_values;
+            for (auto const& [name, property] : current->own_values())
+                animated_values.set(name, property);
+            data = CSS::CustomPropertyData::create_animation_overlay(move(animated_values), move(data));
+        }
+    }
+    install_custom_property_data(pseudo_element, move(data));
+}
+
+void Element::replace_custom_property_data(Optional<CSS::PseudoElement> pseudo_element, RefPtr<CSS::CustomPropertyData const> data)
+{
+    install_custom_property_data(pseudo_element, move(data));
+}
+
+void Element::install_custom_property_data(Optional<CSS::PseudoElement> pseudo_element, RefPtr<CSS::CustomPropertyData const> data)
+{
     if (!pseudo_element.has_value()) {
         m_custom_property_data = move(data);
         return;
@@ -5091,6 +5111,16 @@ bool Element::refresh_inherited_custom_property_data()
     if (auto inherit_from = element_to_inherit_style_from({})) {
         if (auto data = inherit_from->custom_property_data({}))
             parent_data = data->inheritable(document());
+    }
+
+    if (m_custom_property_data && m_custom_property_data->is_animation_overlay()) {
+        if (m_custom_property_data->parent() == parent_data)
+            return false;
+        OrderedHashMap<Utf16FlyString, CSS::StyleProperty> animated_values;
+        for (auto const& [name, property] : m_custom_property_data->own_values())
+            animated_values.set(name, property);
+        m_custom_property_data = CSS::CustomPropertyData::create_animation_overlay(move(animated_values), move(parent_data));
+        return true;
     }
 
     if (m_custom_property_data == parent_data)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -495,6 +495,7 @@ public:
     void set_shadow_root(GC::Ptr<ShadowRoot>);
 
     void set_custom_property_data(Optional<CSS::PseudoElement>, RefPtr<CSS::CustomPropertyData const>);
+    void replace_custom_property_data(Optional<CSS::PseudoElement>, RefPtr<CSS::CustomPropertyData const>);
     [[nodiscard]] RefPtr<CSS::CustomPropertyData const> custom_property_data(Optional<CSS::PseudoElement>) const;
 
     [[nodiscard]] bool refresh_inherited_custom_property_data();
@@ -850,6 +851,8 @@ private:
     using AttributeList = Vector<Attribute, 1>;
 
     AttributeList& ensure_attribute_list();
+
+    void install_custom_property_data(Optional<CSS::PseudoElement>, RefPtr<CSS::CustomPropertyData const>);
     void synchronize_attribute(Utf16FlyString const& qualified_name) const;
     void synchronize_attribute_ns(Optional<Utf16FlyString> const&, Utf16FlyString const& local_name) const;
     void synchronize_style_attribute() const;

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -428,6 +428,7 @@ pub struct FfiAnimationKeyframeValue {
 #[repr(C)]
 pub struct FfiAnimationValueInput {
     pub property_id: u16,
+    pub custom_name_id: u32,
     pub result_of_transition: bool,
     pub underlying: *const StyleValueData,
     pub initial: *const StyleValueData,
@@ -457,6 +458,17 @@ pub struct FfiComputedAnimationBatch {
     pub computed_keyframe_storage: *mut std::ffi::c_void,
     pub underlying_longhand_table: *const std::ffi::c_void,
     pub overlay: *mut std::ffi::c_void,
+    pub custom_underlying_values: *const *const StyleValueData,
+    pub custom_initial_values: *const *const StyleValueData,
+    pub custom_value_count: usize,
+    pub custom_results: *mut FfiAnimatedCustomProperty,
+    pub custom_result_count: *mut usize,
+}
+
+#[repr(C)]
+pub struct FfiAnimatedCustomProperty {
+    pub custom_name_id: u32,
+    pub value: *const StyleValueData,
 }
 
 #[repr(C)]
@@ -477,6 +489,7 @@ pub struct FfiAnimationKeyframe {
 #[repr(C)]
 pub struct FfiAnimatedProperty {
     pub property_id: u16,
+    pub custom_name_id: u32,
     pub value: *const StyleValueData,
     pub progress: f32,
     pub start_index: usize,
@@ -510,6 +523,9 @@ impl FfiAnimationStyleSheetResourceContext {
 pub struct FfiAnimationDeclaration {
     pub keyframe_index: usize,
     pub property_id: u16,
+    pub custom_name_id: u32,
+    pub custom_is_inherited: bool,
+    pub custom_is_important: bool,
     pub value: *const StyleValueData,
     pub style_sheet_resource_context: FfiAnimationStyleSheetResourceContext,
     pub use_initial: bool,
@@ -519,6 +535,8 @@ pub struct FfiAnimationDeclaration {
 struct AnimationPropertyConflictCandidate {
     keyframe_index: usize,
     physical_property_id: u16,
+    custom_name_id: u32,
+    custom_is_inherited: bool,
     source_property_id: u16,
     source_longhand_id: u16,
     value: RetainedStyleValueData,
@@ -551,7 +569,7 @@ pub enum FfiAnimationSpecifiedValueSource {
     Underlying,
 }
 
-fn animation_specified_value_source(value: &StyleValueData, property_id: u16) -> FfiAnimationSpecifiedValueSource {
+fn animation_specified_value_source(value: &StyleValueData, is_inherited: bool) -> FfiAnimationSpecifiedValueSource {
     let StyleValueData::Keyword { keyword } = value else {
         return FfiAnimationSpecifiedValueSource::Value;
     };
@@ -567,7 +585,7 @@ fn animation_specified_value_source(value: &StyleValueData, property_id: u16) ->
     // If the cascaded value of a property is the unset keyword, then if it is an inherited
     // property, this is treated as inherit, and if it is not, this is treated as initial.
     if *keyword == crate::css::style_compute::keyword::UNSET {
-        return if crate::css::property_metadata::property_is_inherited(property_id) {
+        return if is_inherited {
             FfiAnimationSpecifiedValueSource::Inherited
         } else {
             FfiAnimationSpecifiedValueSource::Initial
@@ -598,11 +616,20 @@ fn resolve_animation_property_conflicts(
     assert_eq!(candidates.len(), value_sources.len());
     selected.fill(false);
     for (candidate, source) in candidates.iter().zip(value_sources.iter_mut()) {
-        *source = animation_specified_value_source(candidate.value.data(), candidate.physical_property_id);
+        let is_inherited = if candidate.custom_name_id != 0 {
+            candidate.custom_is_inherited
+        } else {
+            crate::css::property_metadata::property_is_inherited(candidate.physical_property_id)
+        };
+        *source = animation_specified_value_source(candidate.value.data(), is_inherited);
     }
-    let mut winners = std::collections::HashMap::<(usize, u16), usize>::new();
+    let mut winners = std::collections::HashMap::<(usize, u16, u32), usize>::new();
     for (candidate_index, candidate) in candidates.iter().enumerate() {
-        let key = (candidate.keyframe_index, candidate.physical_property_id);
+        let key = (
+            candidate.keyframe_index,
+            candidate.physical_property_id,
+            candidate.custom_name_id,
+        );
         let Some(&winner_index) = winners.get(&key) else {
             winners.insert(key, candidate_index);
             selected[candidate_index] = true;
@@ -630,6 +657,7 @@ fn resolve_animation_property_conflicts(
 pub struct FfiResolvedAnimationProperty {
     pub keyframe_index: usize,
     pub physical_property_id: u16,
+    pub custom_name_id: u32,
     pub source_longhand_id: u16,
     pub value: *const StyleValueData,
     pub value_source: FfiAnimationSpecifiedValueSource,
@@ -671,6 +699,26 @@ fn resolve_animation_declarations(
             !declaration.value.is_null(),
             "animation declaration value must not be null"
         );
+        if declaration.custom_name_id != 0 {
+            candidates.push(AnimationPropertyConflictCandidate {
+                keyframe_index: declaration.keyframe_index,
+                physical_property_id: declaration.property_id,
+                custom_name_id: declaration.custom_name_id,
+                custom_is_inherited: declaration.custom_is_inherited,
+                source_property_id: declaration.property_id,
+                source_longhand_id: declaration.property_id,
+                value: unsafe {
+                    RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                        declaration.value.cast(),
+                    ))
+                },
+                style_sheet_resource_context: declaration.style_sheet_resource_context,
+                use_initial: declaration.use_initial,
+                is_transition: declaration.is_transition,
+                suppressed_by_important: !declaration.is_transition && declaration.custom_is_important,
+            });
+            continue;
+        }
         crate::css::style_compute::expand_shorthands_with(
             declaration.property_id,
             declaration.value.cast(),
@@ -681,6 +729,8 @@ fn resolve_animation_declarations(
                 candidates.push(AnimationPropertyConflictCandidate {
                     keyframe_index: declaration.keyframe_index,
                     physical_property_id,
+                    custom_name_id: 0,
+                    custom_is_inherited: false,
                     source_property_id: declaration.property_id,
                     source_longhand_id: longhand_id,
                     value: unsafe {
@@ -714,6 +764,7 @@ fn resolve_animation_declarations(
             properties.push(FfiResolvedAnimationProperty {
                 keyframe_index: candidate.keyframe_index,
                 physical_property_id: candidate.physical_property_id,
+                custom_name_id: candidate.custom_name_id,
                 source_longhand_id: candidate.source_longhand_id,
                 value: candidate.value.pointer(),
                 value_source,
@@ -730,26 +781,28 @@ fn resolve_animation_declarations(
             .checked_add(effect.keyframe_count)
             .expect("animation keyframe range must not overflow");
         assert!(keyframe_end <= keyframes.len());
-        let mut properties_by_id = std::collections::BTreeMap::<u16, Vec<usize>>::new();
+        let mut properties_by_id = std::collections::BTreeMap::<(u16, u32), Vec<usize>>::new();
         for (index, property) in properties.iter().enumerate() {
             if (effect.first_keyframe_index..keyframe_end).contains(&property.keyframe_index) {
                 properties_by_id
-                    .entry(property.physical_property_id)
+                    .entry((property.physical_property_id, property.custom_name_id))
                     .or_default()
                     .push(index);
             }
         }
-        for (property_id, mut property_indices) in properties_by_id {
+        for ((property_id, custom_name_id), mut property_indices) in properties_by_id {
             if property_indices.len() < 2
-                || !(crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID
-                    ..=crate::css::property_metadata::LAST_LONGHAND_PROPERTY_ID)
-                    .contains(&property_id)
+                || (custom_name_id == 0
+                    && !(crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID
+                        ..=crate::css::property_metadata::LAST_LONGHAND_PROPERTY_ID)
+                        .contains(&property_id))
             {
                 continue;
             }
             property_indices.sort_by_key(|index| properties[*index].keyframe_index);
             value_plans.push(AnimationValuePlan {
                 property_id,
+                custom_name_id,
                 result_of_transition: effect.result_of_transition,
                 current_key: effect.current_key,
                 property_indices,
@@ -763,6 +816,9 @@ fn resolve_animation_declarations(
     let mut random_sharing_sources = Vec::new();
     for property in &properties {
         if property.value_source != FfiAnimationSpecifiedValueSource::Value {
+            continue;
+        }
+        if property.custom_name_id != 0 {
             continue;
         }
         let value = unsafe { &*property.value };
@@ -824,6 +880,7 @@ struct ResolvedAnimationDeclarations {
 
 struct AnimationValuePlan {
     property_id: u16,
+    custom_name_id: u32,
     result_of_transition: bool,
     current_key: f64,
     property_indices: Vec<usize>,
@@ -891,6 +948,9 @@ pub enum FfiCompositeOperation {
 fn accepted_range(property_id: u16, value_type: u8, range_overrides: &[NumericRangeOverride]) -> Option<(f64, f64)> {
     if let Some(range) = range_overrides.iter().find(|range| range.value_type == value_type) {
         return Some((range.min, range.max));
+    }
+    if property_id == crate::css::property_metadata::property_id::CUSTOM {
+        return None;
     }
     property_numeric_ranges(property_id)
         .iter()
@@ -6587,6 +6647,15 @@ pub(crate) fn interpolate_value(
     to: &StyleValueData,
     delta: f32,
 ) -> FfiAnimationValueResult {
+    if property_id == crate::css::property_metadata::property_id::CUSTOM {
+        // https://drafts.css-houdini.org/css-properties-values-api/#animation-behavior-of-custom-properties
+        // When referenced by animations and transitions, custom property values interpolate by computed value, in accordance with the type that they parsed as.
+        let result = interpolate_scalar_value(property_id, from, to, delta, &[]);
+        if !result.handled || result.value.is_null() && context.is_some_and(|context| context.allow_discrete) {
+            return discrete_value(context, from, to, delta);
+        }
+        return result;
+    }
     let animation_type = property_animation_type(property_id);
     if animation_type == ANIMATION_TYPE_NONE {
         // https://www.w3.org/TR/web-animations-1/#not-animatable
@@ -6965,6 +7034,7 @@ fn evaluate_animation_value(
         if start_keyframe.value.is_null() {
             return FfiAnimatedProperty {
                 property_id: input.property_id,
+                custom_name_id: input.custom_name_id,
                 value: std::ptr::null(),
                 progress,
                 start_index,
@@ -6975,6 +7045,7 @@ fn evaluate_animation_value(
         }
         return FfiAnimatedProperty {
             property_id: input.property_id,
+            custom_name_id: input.custom_name_id,
             value: unsafe { crate::css::style_value::retain_style_value(start_keyframe.value) },
             progress,
             start_index,
@@ -6998,6 +7069,7 @@ fn evaluate_animation_value(
     assert!(result.handled);
     FfiAnimatedProperty {
         property_id: input.property_id,
+        custom_name_id: input.custom_name_id,
         value: result.value,
         progress,
         start_index,
@@ -7113,14 +7185,28 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
         }
         let mut inputs = Vec::with_capacity(resolved.value_plans.len());
         for (plan, keyframes) in resolved.value_plans.iter().zip(&keyframes_by_value) {
-            let underlying = underlying_longhand_table
-                .get(plan.property_id)
-                .expect("an animated longhand must have an underlying computed value");
+            let (underlying, initial) = if plan.custom_name_id != 0 {
+                let custom_index = (plan.custom_name_id - 1) as usize;
+                assert!(custom_index < computed.custom_value_count);
+                (
+                    unsafe { *computed.custom_underlying_values.add(custom_index) },
+                    unsafe { *computed.custom_initial_values.add(custom_index) },
+                )
+            } else {
+                let underlying = underlying_longhand_table
+                    .get(plan.property_id)
+                    .expect("an animated longhand must have an underlying computed value");
+                (
+                    underlying.pointer(),
+                    crate::css::style_compute::initial_value_data(plan.property_id),
+                )
+            };
             inputs.push(FfiAnimationValueInput {
                 property_id: plan.property_id,
+                custom_name_id: plan.custom_name_id,
                 result_of_transition: plan.result_of_transition,
-                underlying: underlying.pointer(),
-                initial: crate::css::style_compute::initial_value_data(plan.property_id),
+                underlying,
+                initial,
                 current_key: plan.current_key,
                 keyframes: keyframes.as_ptr(),
                 keyframe_count: keyframes.len(),
@@ -7131,20 +7217,32 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
         // https://www.w3.org/TR/web-animations-1/#effect-stacks
         // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
         //     next effect affecting the same property.
-        let mut previous_values = Vec::<(u16, *const StyleValueData)>::new();
+        let mut custom_final_values = Vec::<(u32, RetainedStyleValueData)>::new();
+        let mut previous_values = Vec::<(u16, u32, *const StyleValueData)>::new();
         for input in &inputs {
             let previous_value = previous_values
                 .iter()
                 .rev()
-                .find(|(property_id, _)| *property_id == input.property_id)
-                .map(|(_, value)| unsafe { &**value });
+                .find(|(property_id, custom_name_id, _)| {
+                    *property_id == input.property_id && *custom_name_id == input.custom_name_id
+                })
+                .map(|(_, _, value)| unsafe { &**value });
             let result = evaluate_animation_value(&computed.context, input, previous_value);
             if !result.apply {
                 assert!(result.value.is_null());
                 continue;
             }
+            if input.custom_name_id != 0 {
+                if !result.value.is_null() {
+                    previous_values.push((input.property_id, input.custom_name_id, result.value));
+                    custom_final_values.push((input.custom_name_id, unsafe {
+                        RetainedStyleValueData::from_retained_pointer(result.value)
+                    }));
+                }
+                continue;
+            }
             if !result.value.is_null() {
-                previous_values.push((input.property_id, result.value));
+                previous_values.push((input.property_id, input.custom_name_id, result.value));
                 let value = unsafe { RetainedStyleValueData::from_retained_pointer(result.value) };
                 overlay.set_owned(input.property_id, value, false, input.result_of_transition);
             } else {
@@ -7158,6 +7256,28 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
                     input.result_of_transition,
                 );
             }
+        }
+        if !custom_final_values.is_empty() {
+            assert!(!computed.custom_results.is_null());
+            assert!(!computed.custom_result_count.is_null());
+            let mut final_by_name = std::collections::BTreeMap::<u32, RetainedStyleValueData>::new();
+            for (custom_name_id, value) in custom_final_values {
+                final_by_name.insert(custom_name_id, value);
+            }
+            let mut written = 0;
+            for (custom_name_id, value) in final_by_name {
+                assert!(written < computed.custom_value_count);
+                let pointer = value.pointer();
+                std::mem::forget(value);
+                unsafe {
+                    computed.custom_results.add(written).write(FfiAnimatedCustomProperty {
+                        custom_name_id,
+                        value: pointer,
+                    });
+                }
+                written += 1;
+            }
+            unsafe { computed.custom_result_count.write(written) };
         }
         overlay.refresh_ffi_entries();
         inputs.len()
@@ -7215,6 +7335,8 @@ mod tests {
         };
         let candidates = [
             AnimationPropertyConflictCandidate {
+                custom_name_id: 0,
+                custom_is_inherited: false,
                 keyframe_index: 0,
                 physical_property_id: property_id::BORDER_TOP_COLOR,
                 source_property_id: property_id::BORDER,
@@ -7226,6 +7348,8 @@ mod tests {
                 is_transition: false,
             },
             AnimationPropertyConflictCandidate {
+                custom_name_id: 0,
+                custom_is_inherited: false,
                 keyframe_index: 0,
                 physical_property_id: property_id::BORDER_TOP_COLOR,
                 source_property_id: property_id::BORDER_TOP,
@@ -7237,6 +7361,8 @@ mod tests {
                 is_transition: false,
             },
             AnimationPropertyConflictCandidate {
+                custom_name_id: 0,
+                custom_is_inherited: false,
                 keyframe_index: 0,
                 physical_property_id: property_id::BORDER_TOP_COLOR,
                 source_property_id: property_id::BORDER_TOP_COLOR,
@@ -7248,6 +7374,8 @@ mod tests {
                 is_transition: false,
             },
             AnimationPropertyConflictCandidate {
+                custom_name_id: 0,
+                custom_is_inherited: false,
                 keyframe_index: 0,
                 physical_property_id: property_id::BORDER_TOP_COLOR,
                 source_property_id: property_id::BORDER_TOP_COLOR,
@@ -7259,6 +7387,8 @@ mod tests {
                 is_transition: false,
             },
             AnimationPropertyConflictCandidate {
+                custom_name_id: 0,
+                custom_is_inherited: false,
                 keyframe_index: 1,
                 physical_property_id: property_id::BORDER_TOP_COLOR,
                 source_property_id: property_id::BORDER,
@@ -7283,27 +7413,45 @@ mod tests {
         let keyword_value = |keyword| StyleValueData::Keyword { keyword };
 
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::INHERIT), property_id::MARGIN_LEFT),
+            animation_specified_value_source(
+                &keyword_value(keyword::INHERIT),
+                crate::css::property_metadata::property_is_inherited(property_id::MARGIN_LEFT)
+            ),
             FfiAnimationSpecifiedValueSource::Inherited
         );
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::UNSET), property_id::COLOR),
+            animation_specified_value_source(
+                &keyword_value(keyword::UNSET),
+                crate::css::property_metadata::property_is_inherited(property_id::COLOR)
+            ),
             FfiAnimationSpecifiedValueSource::Inherited
         );
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::UNSET), property_id::MARGIN_LEFT),
+            animation_specified_value_source(
+                &keyword_value(keyword::UNSET),
+                crate::css::property_metadata::property_is_inherited(property_id::MARGIN_LEFT)
+            ),
             FfiAnimationSpecifiedValueSource::Initial
         );
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::INITIAL), property_id::COLOR),
+            animation_specified_value_source(
+                &keyword_value(keyword::INITIAL),
+                crate::css::property_metadata::property_is_inherited(property_id::COLOR)
+            ),
             FfiAnimationSpecifiedValueSource::Initial
         );
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::REVERT), property_id::COLOR),
+            animation_specified_value_source(
+                &keyword_value(keyword::REVERT),
+                crate::css::property_metadata::property_is_inherited(property_id::COLOR)
+            ),
             FfiAnimationSpecifiedValueSource::Underlying
         );
         assert_eq!(
-            animation_specified_value_source(&keyword_value(keyword::REVERT_LAYER), property_id::COLOR),
+            animation_specified_value_source(
+                &keyword_value(keyword::REVERT_LAYER),
+                crate::css::property_metadata::property_is_inherited(property_id::COLOR)
+            ),
             FfiAnimationSpecifiedValueSource::Underlying
         );
     }
@@ -7319,6 +7467,9 @@ mod tests {
         ];
         let declarations = [
             FfiAnimationDeclaration {
+                custom_name_id: 0,
+                custom_is_inherited: false,
+                custom_is_important: false,
                 keyframe_index: 0,
                 property_id: property_id::OPACITY,
                 value: Arc::as_ptr(&values[0]),
@@ -7327,6 +7478,9 @@ mod tests {
                 is_transition: false,
             },
             FfiAnimationDeclaration {
+                custom_name_id: 0,
+                custom_is_inherited: false,
+                custom_is_important: false,
                 keyframe_index: 1,
                 property_id: property_id::COLOR,
                 value: Arc::as_ptr(&values[1]),
@@ -7335,6 +7489,9 @@ mod tests {
                 is_transition: false,
             },
             FfiAnimationDeclaration {
+                custom_name_id: 0,
+                custom_is_inherited: false,
+                custom_is_important: false,
                 keyframe_index: 2,
                 property_id: property_id::OPACITY,
                 value: Arc::as_ptr(&values[2]),
@@ -7384,6 +7541,9 @@ mod tests {
         let declaration = FfiAnimationDeclaration {
             keyframe_index: 0,
             property_id: crate::css::property_metadata::property_id::BORDER,
+            custom_name_id: 0,
+            custom_is_inherited: false,
+            custom_is_important: false,
             value: &raw const *pending,
             style_sheet_resource_context: FfiAnimationStyleSheetResourceContext::empty(),
             use_initial: false,
@@ -7540,6 +7700,7 @@ mod tests {
         ];
         let input = FfiAnimationValueInput {
             property_id: crate::css::property_metadata::property_id::FLEX_GROW,
+            custom_name_id: 0,
             result_of_transition: false,
             underlying: &raw const underlying,
             initial: &raw const underlying,
@@ -7591,6 +7752,7 @@ mod tests {
             ];
             let input = FfiAnimationValueInput {
                 property_id: crate::css::property_metadata::property_id::FLEX_GROW,
+                custom_name_id: 0,
                 result_of_transition: false,
                 underlying: Arc::as_ptr(&underlying),
                 initial: Arc::as_ptr(&initial),

--- a/Libraries/LibWeb/Rust/src/css/custom_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/custom_properties.rs
@@ -2852,6 +2852,69 @@ pub unsafe extern "C" fn rust_custom_property_store_create(
     })
 }
 
+/// Creates a store holding an element's animated custom property values on top of the element's
+/// own environment store. Transfers one strong reference per entry value and returns one strong
+/// store reference.
+///
+/// # Safety
+/// `entries` must point to `entry_count` valid entries whose `data` pointers are retained
+/// style value references. `base` must be null or a live store reference.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_store_create_animation_overlay(
+    entries: *const FfiCustomPropertyStoreEntry,
+    entry_count: usize,
+    base: *const c_void,
+) -> *const c_void {
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
+    abort_on_panic(|| {
+        let entries = if entry_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(entries, entry_count) }
+        };
+        let base = if base.is_null() {
+            None
+        } else {
+            let base = base.cast::<CustomPropertyStore>();
+            Some(unsafe { &*base })
+        };
+        let (mut own_values, mut own_names, parent, inheritance_parent, ancestor_count) = match base {
+            Some(base) => (
+                base.own_values.clone(),
+                base.own_names.clone(),
+                base.parent.clone(),
+                base.inheritance_parent.clone(),
+                base.ancestor_count,
+            ),
+            None => (HashMap::new(), HashMap::new(), None, None, 0),
+        };
+        let mut declared_names = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let name = unsafe { entry.name.to_utf16() }.expect("invalid custom property name");
+            declared_names.push(entry.name_raw);
+            own_names.insert(name.clone(), entry.name_raw);
+            own_values.insert(
+                entry.name_raw,
+                CustomPropertyEntry {
+                    _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
+                    name,
+                    value: unsafe { RetainedStyleValueData::from_retained_pointer(entry.data.cast()) },
+                    important: entry.important,
+                },
+            );
+        }
+        Arc::into_raw(Arc::new(CustomPropertyStore {
+            own_values,
+            declared_names,
+            own_names,
+            ancestor_count,
+            parent,
+            inheritance_parent,
+        }))
+        .cast()
+    })
+}
+
 /// Releases one store reference returned by `rust_custom_property_store_create`.
 ///
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -2758,6 +2758,7 @@ pub struct FfiAnimationKeyframeLonghandInput {
     pub font_length_resolution_context: *const FfiLengthResolutionContext,
     pub line_height_length_resolution_context: *const FfiLengthResolutionContext,
     pub remaining_length_resolution_context: *const FfiLengthResolutionContext,
+    pub custom_property_values: *const *const c_void,
 }
 
 #[repr(C)]
@@ -5272,6 +5273,9 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
         };
         let mut longhands_by_keyframe = std::collections::BTreeMap::<usize, Vec<usize>>::new();
         for (index, property) in properties.iter().enumerate() {
+            if property.custom_name_id != 0 {
+                continue;
+            }
             assert!((FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&property.physical_property_id));
             assert!(!property.value.is_null());
             longhands_by_keyframe
@@ -5284,6 +5288,19 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
         let mut values = std::iter::repeat_with(|| None)
             .take(properties.len())
             .collect::<Vec<_>>();
+        for (index, property) in properties.iter().enumerate() {
+            if property.custom_name_id == 0 {
+                continue;
+            }
+            assert!(!input.custom_property_values.is_null());
+            let value = unsafe { *input.custom_property_values.add(index) };
+            assert!(!value.is_null());
+            values[index] = Some(unsafe {
+                crate::css::style_value::RetainedStyleValueData::from_retained_pointer(
+                    crate::css::style_value::retain_style_value(value.cast()),
+                )
+            });
+        }
         let mut depends_on_viewport_metrics = false;
         let mut font_metrics_depend_on_viewport_metrics = false;
         for indices in longhands_by_keyframe.values() {

--- a/Tests/LibWeb/Text/expected/css/custom-property-keyframes-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/custom-property-keyframes-animation.txt
@@ -1,0 +1,6 @@
+registered <angle> at 50%: 180deg
+unregistered at 50%: bbb
+registered <number> at 25%: 25
+declared value as implicit keyframe at 50%: 75px
+keyframe with initial keyword at 50%: 50
+important declaration suppresses animation: 10

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/animation-important-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/animation-important-001.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 7 tests
 
-6 Pass
-1 Fail
+7 Pass
 Pass	Interpolated value is observable
 Pass	Important rules override animations
 Pass	Non-overriden interpolations are observable
 Pass	Important rules override animations (::before)
 Pass	Important rules do not override animations on :visited as seen from JS
 Pass	Standard property animations appearing via setKeyframes do not override important declarations
-Fail	Custom property animations appearing via setKeyframes do not override important declarations
+Pass	Custom property animations appearing via setKeyframes do not override important declarations

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-mixins/function-shadow-animations.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-mixins/function-shadow-animations.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 3 tests
 
-1 Pass
-2 Fail
+2 Pass
+1 Fail
 Pass	Can animate standard property in shadow
 Fail	Can animate typed custom property in shadow
-Fail	Can animate untyped custom property in shadow
+Pass	Can animate untyped custom property in shadow

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-angle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-angle.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	Animating a custom property of type <angle>
+Pass	Animating a custom property of type <angle> with a single keyframe
+Pass	Animating a custom property of type <angle> with additivity
+Fail	Animating a custom property of type <angle> with a single keyframe and additivity
+Fail	Animating a custom property of type <angle> with iterationComposite

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-color.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-color.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 6 tests
+
+4 Pass
+2 Fail
+Pass	Animating a custom property of type <color>
+Pass	Animating a custom property of type <color> with a single keyframe
+Pass	Animating a custom property of type <color> with additivity
+Fail	Animating a custom property of type <color> with a single keyframe and additivity
+Fail	Animating a custom property of type <color> with iterationComposite
+Pass	Animating a custom property of type <color> with single keyframe and initialValue contrast-color()

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-custom-ident.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-custom-ident.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Animating a custom property of type <custom-ident> is discrete
+Pass	Animating a custom property of type <custom-ident>+ is discrete
+Pass	Animating a custom property of type <custom-ident># is discrete

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-image.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-image.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Animating a custom property of type <image> is discrete
+Pass	Animating a custom property of type <image>+ is discrete
+Pass	Animating a custom property of type <image># is discrete

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-length.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-length.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	Animating a custom property of type <length>
+Pass	Animating a custom property of type <length> with a single keyframe
+Pass	Animating a custom property of type <length> with additivity
+Fail	Animating a custom property of type <length> with a single keyframe and additivity
+Fail	Animating a custom property of type <length> with iterationComposite

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Animating a custom property allowing multiple list types with two mismatching types

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-number.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-number.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	Animating a custom property of type <number>
+Pass	Animating a custom property of type <number> with a single keyframe
+Pass	Animating a custom property of type <number> with additivity
+Fail	Animating a custom property of type <number> with a single keyframe and additivity
+Fail	Animating a custom property of type <number> with iterationComposite

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-url.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-url.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Animating a custom property of type <url> is discrete
+Pass	Animating a custom property of type <url>+ is discrete
+Pass	Animating a custom property of type <url># is discrete

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Animated custom property is applied in a shorthand property.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/registered-neutral-keyframe.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/registered-neutral-keyframe.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	CSS Animations neutral keyframes on registered custom properties should produce the underlying value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/registered-var-to-registered-animating.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/animation/registered-var-to-registered-animating.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Animated registered custom properties can var() reference other animated registered custom properties across separate Animations.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.txt
@@ -2,24 +2,25 @@ Harness status: OK
 
 Found 20 tests
 
-20 Fail
-Fail	Initially, the sibling-index() is 3 for --time
-Fail	Initially, the sibling-index() is 3 for --angle
-Fail	Initially, the sibling-index() is 3 for --resolution
-Fail	Initially, the sibling-index() is 3 for --percentage
-Fail	Initially, the sibling-index() is 3 for --number
-Fail	Initially, the sibling-index() is 3 for --integer
-Fail	Initially, the sibling-index() is 3 for --length
-Fail	Initially, the sibling-index() is 3 for --length-percentage
+18 Pass
+2 Fail
+Pass	Initially, the sibling-index() is 3 for --time
+Pass	Initially, the sibling-index() is 3 for --angle
+Pass	Initially, the sibling-index() is 3 for --resolution
+Pass	Initially, the sibling-index() is 3 for --percentage
+Pass	Initially, the sibling-index() is 3 for --number
+Pass	Initially, the sibling-index() is 3 for --integer
+Pass	Initially, the sibling-index() is 3 for --length
+Pass	Initially, the sibling-index() is 3 for --length-percentage
 Fail	Initially, the sibling-index() is 3 for --color
-Fail	Initially, the sibling-index() is 3 for --list
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --time
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --angle
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --resolution
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --percentage
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --number
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --integer
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --length
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --length-percentage
+Pass	Initially, the sibling-index() is 3 for --list
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --time
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --angle
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --resolution
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --percentage
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --number
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --integer
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --length
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --length-percentage
 Fail	Removing a preceding sibling of #target reduces the sibling-index() for --color
-Fail	Removing a preceding sibling of #target reduces the sibling-index() for --list
+Pass	Removing a preceding sibling of #target reduces the sibling-index() for --list

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/Animatable/animate.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/Animatable/animate.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 153 tests
 
-139 Pass
-14 Fail
+141 Pass
+12 Fail
 Pass	Element.animate() creates an Animation object
 Pass	Element.animate() creates an Animation object in the relevant realm of the target element
 Pass	Element.animate() creates an Animation object with a KeyframeEffect
@@ -25,7 +25,7 @@ Pass	Element.animate() accepts a one property one value property-indexed keyfram
 Pass	Element.animate() accepts a one property one non-array value property-indexed keyframes specification
 Pass	Element.animate() accepts a one property two value property-indexed keyframes specification where the first value is invalid
 Pass	Element.animate() accepts a one property two value property-indexed keyframes specification where the second value is invalid
-Fail	Element.animate() accepts a property-indexed keyframes specification with a CSS variable as the property
+Pass	Element.animate() accepts a property-indexed keyframes specification with a CSS variable as the property
 Fail	Element.animate() accepts a property-indexed keyframe with a single offset
 Pass	Element.animate() accepts a property-indexed keyframe with an array of offsets
 Pass	Element.animate() accepts a property-indexed keyframe with an array of offsets that is too short
@@ -60,7 +60,7 @@ Pass	Element.animate() accepts a two property keyframe sequence where one proper
 Pass	Element.animate() accepts a one property two keyframe sequence that needs to stringify its values
 Pass	Element.animate() accepts a keyframe sequence with a CSS variable reference
 Pass	Element.animate() accepts a keyframe sequence with a CSS variable reference in a shorthand property
-Fail	Element.animate() accepts a keyframe sequence with a CSS variable as its property
+Pass	Element.animate() accepts a keyframe sequence with a CSS variable as its property
 Pass	Element.animate() accepts a keyframe sequence with duplicate values for a given interior offset
 Pass	Element.animate() accepts a keyframe sequence with duplicate values for offsets 0 and 1
 Pass	Element.animate() accepts a two property four keyframe sequence

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/KeyframeEffect/constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/KeyframeEffect/constructor.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 175 tests
 
-120 Pass
-55 Fail
+121 Pass
+54 Fail
 Pass	A KeyframeEffect can be constructed with no frames
 Pass	easing values are parsed correctly when passed to the KeyframeEffect constructor in KeyframeEffectOptions
 Pass	Invalid easing values are correctly rejected when passed to the KeyframeEffect constructor in KeyframeEffectOptions
@@ -38,8 +38,8 @@ Pass	A KeyframeEffect can be constructed with a one property two value property-
 Fail	A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the first value is invalid roundtrips
 Pass	A KeyframeEffect can be constructed with a one property two value property-indexed keyframes specification where the second value is invalid
 Fail	A KeyframeEffect constructed with a one property two value property-indexed keyframes specification where the second value is invalid roundtrips
-Fail	A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable as the property
-Pass	A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable as the property roundtrips
+Pass	A KeyframeEffect can be constructed with a property-indexed keyframes specification with a CSS variable as the property
+Fail	A KeyframeEffect constructed with a property-indexed keyframes specification with a CSS variable as the property roundtrips
 Fail	A KeyframeEffect can be constructed with a property-indexed keyframe with a single offset
 Fail	A KeyframeEffect constructed with a property-indexed keyframe with a single offset roundtrips
 Pass	A KeyframeEffect can be constructed with a property-indexed keyframe with an array of offsets
@@ -108,7 +108,7 @@ Pass	A KeyframeEffect can be constructed with a keyframe sequence with a CSS var
 Fail	A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference roundtrips
 Pass	A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable reference in a shorthand property
 Fail	A KeyframeEffect constructed with a keyframe sequence with a CSS variable reference in a shorthand property roundtrips
-Fail	A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable as its property
+Pass	A KeyframeEffect can be constructed with a keyframe sequence with a CSS variable as its property
 Fail	A KeyframeEffect constructed with a keyframe sequence with a CSS variable as its property roundtrips
 Pass	A KeyframeEffect can be constructed with a keyframe sequence with duplicate values for a given interior offset
 Pass	A KeyframeEffect constructed with a keyframe sequence with duplicate values for a given interior offset roundtrips

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/KeyframeEffect/setKeyframes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/interfaces/KeyframeEffect/setKeyframes.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 80 tests
 
-67 Pass
-13 Fail
+69 Pass
+11 Fail
 Pass	Keyframes can be replaced with an empty keyframe
 Pass	Keyframes can be replaced with a one property two value property-indexed keyframes specification
 Pass	Keyframes can be replaced with a one shorthand property two value property-indexed keyframes specification
@@ -19,7 +19,7 @@ Pass	Keyframes can be replaced with a one property one value property-indexed ke
 Pass	Keyframes can be replaced with a one property one non-array value property-indexed keyframes specification
 Pass	Keyframes can be replaced with a one property two value property-indexed keyframes specification where the first value is invalid
 Pass	Keyframes can be replaced with a one property two value property-indexed keyframes specification where the second value is invalid
-Fail	Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable as the property
+Pass	Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable as the property
 Fail	Keyframes can be replaced with a property-indexed keyframe with a single offset
 Pass	Keyframes can be replaced with a property-indexed keyframe with an array of offsets
 Pass	Keyframes can be replaced with a property-indexed keyframe with an array of offsets that is too short
@@ -54,7 +54,7 @@ Pass	Keyframes can be replaced with a two property keyframe sequence where one p
 Pass	Keyframes can be replaced with a one property two keyframe sequence that needs to stringify its values
 Pass	Keyframes can be replaced with a keyframe sequence with a CSS variable reference
 Pass	Keyframes can be replaced with a keyframe sequence with a CSS variable reference in a shorthand property
-Fail	Keyframes can be replaced with a keyframe sequence with a CSS variable as its property
+Pass	Keyframes can be replaced with a keyframe sequence with a CSS variable as its property
 Pass	Keyframes can be replaced with a keyframe sequence with duplicate values for a given interior offset
 Pass	Keyframes can be replaced with a keyframe sequence with duplicate values for offsets 0 and 1
 Pass	Keyframes can be replaced with a two property four keyframe sequence

--- a/Tests/LibWeb/Text/input/css/custom-property-keyframes-animation.html
+++ b/Tests/LibWeb/Text/input/css/custom-property-keyframes-animation.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<style>
+    @property --angle {
+        syntax: "<angle>";
+        inherits: false;
+        initial-value: 0deg;
+    }
+    @property --count {
+        syntax: "<number>";
+        inherits: true;
+        initial-value: 0;
+    }
+    @property --size {
+        syntax: "<length>";
+        inherits: false;
+        initial-value: 0px;
+    }
+    @property --reset {
+        syntax: "<number>";
+        inherits: false;
+        initial-value: 20;
+    }
+    @property --guarded {
+        syntax: "<number>";
+        inherits: false;
+        initial-value: 0;
+    }
+    @keyframes spin {
+        from { --angle: 0deg; --plain: aaa; }
+        to { --angle: 360deg; --plain: bbb; }
+    }
+    @keyframes count-up { to { --count: 100; } }
+    @keyframes grow { to { --size: 100px; } }
+    @keyframes to-initial {
+        from { --reset: 80; }
+        to { --reset: initial; }
+    }
+    @keyframes guarded-run { from { --guarded: 0; } to { --guarded: 100; } }
+    #halfway { animation: spin 10s linear -5s paused; }
+    #quarter { animation: count-up 10s linear -2.5s paused; }
+    #implicit { --size: 50px; animation: grow 10s linear -5s paused; }
+    #keyword { animation: to-initial 10s linear -5s paused; }
+    #important { --guarded: 10 !important; animation: guarded-run 10s linear -5s paused; }
+</style>
+<div id="halfway"></div>
+<div id="quarter"></div>
+<div id="implicit"></div>
+<div id="keyword"></div>
+<div id="important"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const valueAt = (id, name) => getComputedStyle(document.getElementById(id)).getPropertyValue(name);
+        println("registered <angle> at 50%: " + valueAt("halfway", "--angle"));
+        println("unregistered at 50%: " + valueAt("halfway", "--plain"));
+        println("registered <number> at 25%: " + valueAt("quarter", "--count"));
+        println("declared value as implicit keyframe at 50%: " + valueAt("implicit", "--size"));
+        println("keyframe with initial keyword at 50%: " + valueAt("keyword", "--reset"));
+        println("important declaration suppresses animation: " + valueAt("important", "--guarded"));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-angle.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-angle.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "0deg"
+}, {
+  keyframes: ["100deg", "200deg"],
+  expected: "150deg"
+}, 'Animating a custom property of type <angle>');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  keyframes: "200deg",
+  expected: "150deg"
+}, 'Animating a custom property of type <angle> with a single keyframe');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: ["200deg", "300deg"],
+  expected: "350deg"
+}, 'Animating a custom property of type <angle> with additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  composite: "add",
+  keyframes: "300deg",
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<angle>",
+  inherits: false,
+  initialValue: "100deg"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0deg", "100deg"],
+  expected: "250deg"
+}, 'Animating a custom property of type <angle> with iterationComposite');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-color.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-color.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "black"
+}, {
+  keyframes: ["rgb(100, 100, 100)", "rgb(200, 200, 200)"],
+  expected: "rgb(150, 150, 150)"
+}, 'Animating a custom property of type <color>');
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "rgb(100, 100, 100)"
+}, {
+  keyframes: "rgb(200, 200, 200)",
+  expected: "rgb(150, 150, 150)"
+}, 'Animating a custom property of type <color> with a single keyframe');
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "rgb(100, 100, 100)"
+}, {
+  composite: "add",
+  keyframes: ["rgb(50, 50, 50)", "rgb(150, 150, 150)"],
+  expected: "rgb(200, 200, 200)"
+}, 'Animating a custom property of type <color> with additivity');
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "rgb(100, 100, 100)"
+}, {
+  composite: "add",
+  keyframes: "rgb(150, 150, 150)",
+  expected: "rgb(175, 175, 175)"
+}, 'Animating a custom property of type <color> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "black"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["rgb(0, 0, 0)", "rgb(100, 100, 100)"],
+  expected: "rgb(250, 250, 250)"
+}, 'Animating a custom property of type <color> with iterationComposite');
+
+animation_test({
+  syntax: "<color>",
+  inherits: false,
+  initialValue: "contrast-color(white)"
+}, {
+  keyframes: "white",
+  expected: "rgb(128, 128, 128)"
+}, 'Animating a custom property of type <color> with single keyframe and initialValue contrast-color()');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<custom-ident>", "from", "to");
+discrete_animation_test("<custom-ident>+", "from1 from2", "to1 to2");
+discrete_animation_test("<custom-ident>#", "from1, from2", "to1, to2");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-image.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-image.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<image>", 'url("https://example.com/from")', 'url("https://example.com/to")');
+discrete_animation_test("<image>+", 'url("https://example.com/from1") url("https://example.com/from2")', 'url("https://example.com/to1") url("https://example.com/to2")');
+discrete_animation_test("<image>#", 'url("https://example.com/from1"), url("https://example.com/from2")', 'url("https://example.com/to1"), url("https://example.com/to2")');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="container">
+    <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: true,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = container.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-length.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-length.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<length>",
+  inherits: false,
+  initialValue: "0px"
+}, {
+  keyframes: ["100px", "200px"],
+  expected: "150px"
+}, 'Animating a custom property of type <length>');
+
+animation_test({
+  syntax: "<length>",
+  inherits: false,
+  initialValue: "100px"
+}, {
+  keyframes: "200px",
+  expected: "150px"
+}, 'Animating a custom property of type <length> with a single keyframe');
+
+animation_test({
+  syntax: "<length>",
+  inherits: false,
+  initialValue: "100px"
+}, {
+  composite: "add",
+  keyframes: ["200px", "300px"],
+  expected: "350px"
+}, 'Animating a custom property of type <length> with additivity');
+
+animation_test({
+  syntax: "<length>",
+  inherits: false,
+  initialValue: "100px"
+}, {
+  composite: "add",
+  keyframes: "300px",
+  expected: "250px"
+}, 'Animating a custom property of type <length> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<length>",
+  inherits: false,
+  initialValue: "100px"
+}, {
+  iterationComposite: "accumulate",
+  keyframes: ["0px", "100px"],
+  expected: "250px"
+}, 'Animating a custom property of type <length> with iterationComposite');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<number>+ | <transform-list>",
+  inherits: false,
+  initialValue: "translateX(100px)"
+}, {
+  keyframes: ["200"],
+  expected: "200"
+}, 'Animating a custom property allowing multiple list types with two mismatching types');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+test(() => {
+  CSS.registerProperty({
+    name: "--my-length",
+    syntax: "<length>",
+    inherits: false,
+    initialValue: "0px"
+  });
+
+  target.style.marginLeft = "var(--my-length)";
+
+  const duration = 1000;
+  const animation = target.animate({ "--my-length": "100px" }, duration);
+  animation.pause();
+  animation.currentTime = duration / 4;
+
+  assert_equals(getComputedStyle(target).marginLeft, "25px");
+}, "Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-number.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-number.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 0
+}, {
+  keyframes: [100, 200],
+  expected: "150"
+}, 'Animating a custom property of type <number>');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  keyframes: 200,
+  expected: "150"
+}, 'Animating a custom property of type <number> with a single keyframe');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: [200, 300],
+  expected: "350"
+}, 'Animating a custom property of type <number> with additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  composite: "add",
+  keyframes: 300,
+  expected: "250"
+}, 'Animating a custom property of type <number> with a single keyframe and additivity');
+
+animation_test({
+  syntax: "<number>",
+  inherits: false,
+  initialValue: 100
+}, {
+  iterationComposite: "accumulate",
+  keyframes: [0, 100],
+  expected: "250"
+}, 'Animating a custom property of type <number> with iterationComposite');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-url.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-url.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/utils.js"></script>
+<div id="target"></div>
+<script>
+
+discrete_animation_test("<url>", 'url("https://example.com/from")', 'url("https://example.com/to")');
+discrete_animation_test("<url>+", 'url("https://example.com/from1") url("https://example.com/from2")', 'url("https://example.com/to1") url("https://example.com/to2")');
+discrete_animation_test("<url>#", 'url("https://example.com/from1"), url("https://example.com/from2")', 'url("https://example.com/to1"), url("https://example.com/to2")');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<style>
+
+@property --angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes angle-animation {
+  from { --angle: 0deg }
+  to { --angle: 180deg }
+}
+
+#target {
+  animation: angle-animation 1000s linear -500s paused;
+  background: linear-gradient(var(--angle), black, white);
+}
+
+</style>
+
+<div id="target"></div>
+
+<script>
+
+test(() => {
+    assert_equals(getComputedStyle(target).backgroundImage, 'linear-gradient(90deg, rgb(0, 0, 0), rgb(255, 255, 255))')
+}, "Animated custom property is applied in a shorthand property.");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/registered-neutral-keyframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/registered-neutral-keyframe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+@keyframes test {
+  to { --x: to; }
+}
+#target {
+  --x: underlying;
+}
+</style>
+<div id="target"></div>
+<script>
+CSS.registerProperty({
+  name: '--x',
+  syntax: '*',
+  inherits: false,
+});
+
+test(() => {
+  target.style.animation = 'test 10s';
+  target.style.animationDelay = '-2.5s';
+  assert_equals(getComputedStyle(target).getPropertyValue('--x'), 'underlying', 'at 25%');
+
+  target.style.animationDelay = '-7.5s';
+  assert_equals(getComputedStyle(target).getPropertyValue('--x'), 'to', 'at 75%');
+}, 'CSS Animations neutral keyframes on registered custom properties should produce the underlying value');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/registered-var-to-registered-animating.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-properties-values-api/animation/registered-var-to-registered-animating.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+#target {
+  --static: 100;
+}
+</style>
+<div id="target"></div>
+<script>
+setup(() => {
+  for (let name of ['--test', '--static', '--animated']) {
+    CSS.registerProperty({
+      name,
+      syntax: '<number>',
+      initialValue: '0',
+      inherits: false,
+    });
+  }
+});
+
+test(() => {
+  // --test is animating from a static value to an animated value resulting in it changing quadratically.
+  let animation = target.animate({'--test': ['var(--static)', 'var(--animated)']}, 100);
+  let referencedAnimation = target.animate({'--animated': ['200', '300']}, 100);
+
+  referencedAnimation.currentTime = 25;
+  {
+    animation.currentTime = 25;
+    // lerp(100, lerp(200, 300, 25%), 25%) == 0.75*100 + 0.25*(0.75*200 + 0.25*300) == 131.25
+    assert_equals(getComputedStyle(target).getPropertyValue('--test'), '131.25', 'target at 25%, to at 25%');
+
+    animation.currentTime = 75;
+    // lerp(100, lerp(200, 300, 25%), 75%) == 0.25*100 + 0.75*(0.75*200 + 0.25*300) == 193.75
+    assert_equals(getComputedStyle(target).getPropertyValue('--test'), '193.75', 'target at 75%, to at 25%');
+  }
+
+  referencedAnimation.currentTime = 75;
+  {
+    animation.currentTime = 25;
+    // lerp(100, lerp(200, 300, 75%), 25%) == 0.75*100 + 0.25*(0.25*200 + 0.75*300) == 143.75
+    assert_equals(getComputedStyle(target).getPropertyValue('--test'), '143.75', 'target at 25%, to at 25%');
+
+    animation.currentTime = 75;
+    // lerp(100, lerp(200, 300, 75%), 75%) == 0.25*100 + 0.75*(0.25*200 + 0.75*300) == 231.25
+    assert_equals(getComputedStyle(target).getPropertyValue('--test'), '231.25', 'target at 75%, to at 25%');
+  }
+}, 'Animated registered custom properties can var() reference other animated registered custom properties across separate Animations.');
+</script>


### PR DESCRIPTION
This PR makes animations work for keyframes that contain custom properties. See individual commits for details.

This also makes the bobbing animation, used when the player is walking, work correctly on https://cssdoom.wtf

Also, this makes the the animated border of the "Explore Open Tech button on https://futo.tech work correctly.

Before:

https://github.com/user-attachments/assets/f75916ac-8dc2-4692-ad70-5425dc787351

After:

https://github.com/user-attachments/assets/2e8bc61e-dacd-4c84-95a2-2f9faa7a2e81