### PR TITLE
LibWeb: Update accumulated visual context trees incrementally

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -1020,16 +1020,17 @@ AnimationUpdateContext::~AnimationUpdateContext()
                 : invalidation.layout_tree_rebuild_root();
             target->set_needs_layout_tree_rebuild(DOM::SetNeedsLayoutTreeUpdateReason::KeyframeEffect, rebuild_root);
         }
-        if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::Rebuild) {
-            element.document().set_needs_accumulated_visual_contexts_update(true);
-        } else if (invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::UpdateValues) {
+        if (invalidation.accumulated_visual_contexts() != CSS::AccumulatedVisualContextInvalidation::None) {
+            auto scope = invalidation.accumulated_visual_contexts() == CSS::AccumulatedVisualContextInvalidation::Rebuild
+                ? DOM::Document::AccumulatedVisualContextUpdateScope::Structure
+                : DOM::Document::AccumulatedVisualContextUpdateScope::Values;
             // NB: Element-reference pseudo elements (e.g. ::placeholder) are not synthetic, so schedule their
             //     layout node directly instead of going through the owning element.
             if (element.pseudo_element().has_value()) {
                 if (auto pseudo_element_node = target->pseudo_element_unsafe_layout_node(element.pseudo_element().value()))
-                    element.document().schedule_accumulated_visual_context_value_update(*pseudo_element_node);
+                    element.document().schedule_accumulated_visual_context_update(*pseudo_element_node, scope);
             } else {
-                element.document().schedule_accumulated_visual_context_value_update(target);
+                element.document().schedule_accumulated_visual_context_update(target, scope);
             }
         }
         if (invalidation.needs_scrollable_overflow_recalculation()) {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1606,6 +1606,7 @@
   },
   "contain": {
     "style-group": "BoxValues",
+    "affects-accumulated-visual-contexts": true,
     "affects-stacking-context": true,
     "animation-type": "none",
     "inherited": false,
@@ -4918,6 +4919,7 @@
   },
   "transform-style": {
     "style-group": "TransformValues",
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "flat",

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -45,7 +45,9 @@ static bool update_style_for_element(DOM::Document&, DOM::AbstractElement const&
 static void apply_element_style_invalidation_after_style_change(DOM::Element& element, RequiredInvalidationAfterStyleChange const& invalidation)
 {
     if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::UpdateValues)
-        element.document().schedule_accumulated_visual_context_value_update(element);
+        element.document().schedule_accumulated_visual_context_update(element, DOM::Document::AccumulatedVisualContextUpdateScope::Values);
+    else if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::Rebuild)
+        element.document().schedule_accumulated_visual_context_update(element, DOM::Document::AccumulatedVisualContextUpdateScope::Structure);
 
     if (invalidation.needs_scrollable_overflow_recalculation())
         element.document().schedule_scrollable_overflow_recalculation(element);
@@ -83,8 +85,6 @@ static void apply_document_style_invalidation_after_style_change(DOM::Document& 
 {
     if (invalidation.needs_repaint())
         document.set_needs_to_record_display_list();
-    if (invalidation.accumulated_visual_contexts() == AccumulatedVisualContextInvalidation::Rebuild)
-        document.set_needs_accumulated_visual_contexts_update(true);
     if (invalidation.needs_stacking_context_tree_rebuild())
         document.invalidate_stacking_context_tree();
 }

--- a/Libraries/LibWeb/CSS/VisualViewport.cpp
+++ b/Libraries/LibWeb/CSS/VisualViewport.cpp
@@ -234,7 +234,7 @@ void VisualViewport::update_accumulated_visual_context()
         return;
     }
 
-    m_document->set_needs_accumulated_visual_contexts_update(true);
+    m_document->schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::FirstBuild);
 }
 
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -21,7 +21,7 @@ void AsyncScrollTree::set_state(AsyncScrollingState&& state)
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree_version.clear();
+    m_visual_context_tree_structural_epoch.clear();
 }
 
 AsyncScrollNode const* AsyncScrollTree::scroll_node_for_id(AsyncScrollNodeID node_id) const
@@ -194,13 +194,13 @@ void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayLis
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree_version.clear();
+    m_visual_context_tree_structural_epoch.clear();
     m_scroll_state_snapshot = scroll_state_snapshot;
     if (!display_list || !visual_context_tree)
         return;
 
-    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
-    m_visual_context_tree_version = visual_context_tree->version();
+    VERIFY(display_list->compatible_visual_context_tree_structural_epoch() == visual_context_tree->structural_epoch());
+    m_visual_context_tree_structural_epoch = visual_context_tree->structural_epoch();
 
     auto context_is_valid = [&](Painting::ContextRef context) {
         return context.spatial.value() < visual_context_tree->spatial_node_count()
@@ -261,7 +261,7 @@ void AsyncScrollTree::clear_wheel_hit_test_targets()
     m_cached_wheel_hit_test_targets.clear();
     m_cached_main_thread_wheel_event_targets.clear();
     m_cached_blocking_wheel_event_targets.clear();
-    m_visual_context_tree_version.clear();
+    m_visual_context_tree_structural_epoch.clear();
 }
 
 static bool wheel_hit_test_target_contains_point(CachedWheelHitTestTarget const& target, Gfx::FloatPoint position_in_context)
@@ -314,7 +314,7 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Painting::Acc
         return result;
     };
 
-    if (m_visual_context_tree_version != visual_context_tree.version())
+    if (m_visual_context_tree_structural_epoch != visual_context_tree.structural_epoch())
         return {};
 
     auto context_is_valid = [&](Painting::ContextRef context) {

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -82,7 +82,7 @@ private:
     Vector<BlockingWheelEventRegion> m_blocking_wheel_event_regions;
     Vector<CachedMainThreadWheelEventTarget> m_cached_main_thread_wheel_event_targets;
     Vector<CachedBlockingWheelEventTarget> m_cached_blocking_wheel_event_targets;
-    Optional<u64> m_visual_context_tree_version;
+    Optional<u64> m_visual_context_tree_structural_epoch;
     Painting::ScrollStateSnapshot m_scroll_state_snapshot;
     bool m_has_blocking_wheel_event_region_covering_viewport { false };
 };

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -203,7 +203,7 @@ bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_s
     if (!display_list || !visual_context_tree)
         return async_scrolling_state.has_blocking_wheel_event_listeners;
 
-    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree->version());
+    VERIFY(display_list->compatible_visual_context_tree_structural_epoch() == visual_context_tree->structural_epoch());
     for (auto const& region : async_scrolling_state.blocking_wheel_event_regions) {
         if (region.context.spatial.value() >= visual_context_tree->spatial_node_count()
             || (region.context.frame != Painting::NO_FRAME_NODE && region.context.frame.value() >= visual_context_tree->frame_node_count()))

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7260,9 +7260,9 @@ Painting::AccumulatedVisualContextTree Document::visual_context_tree() const
     return paint_state().visual_context_tree(*this);
 }
 
-u64 Document::visual_context_tree_version() const
+u64 Document::visual_context_tree_structural_epoch() const
 {
-    return paint_state().visual_context_tree_version(*this);
+    return paint_state().visual_context_tree_structural_epoch(*this);
 }
 
 Painting::ScrollStateSnapshot const& Document::scroll_state_snapshot() const
@@ -10514,7 +10514,7 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     auto display_list = Painting::record_rust_display_list(*this, *placeholder_display_list, resource_storage, cache_mode, config, overlay_inputs);
     if (!display_list)
         return nullptr;
-    m_hit_test_display_list = Painting::HitTestDisplayList::create_from_rust_recording(visual_context_tree.version(), layout_node_arena(), *m_chrome_widget_registry);
+    m_hit_test_display_list = Painting::HitTestDisplayList::create_from_rust_recording(visual_context_tree.structural_epoch(), layout_node_arena(), *m_chrome_widget_registry);
 
     if (cache_mode == Painting::PaintCommandCacheMode::ReadWrite) {
         document_paint_state.set_display_list_used_as_paint_command_cache_source(display_list, resource_storage.collect_referenced_resources(*display_list));
@@ -10553,7 +10553,7 @@ Painting::HitTestDisplayList const* Document::ensure_hit_test_display_list()
         (void)record_display_list(paint_config, throwaway_resource_storage_for_hit_test_only_recording, Painting::PaintCommandCacheMode::ReadOnly);
     };
 
-    if (!m_hit_test_display_list || !m_hit_test_display_list->is_current() || m_hit_test_display_list->visual_context_tree_version() != visual_context_tree_version())
+    if (!m_hit_test_display_list || !m_hit_test_display_list->is_current() || m_hit_test_display_list->visual_context_tree_structural_epoch() != visual_context_tree_structural_epoch())
         rebuild_hit_test_display_list();
 
     return m_hit_test_display_list.ptr();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10338,8 +10338,30 @@ void Document::set_needs_accumulated_visual_contexts_update(bool value)
         set_needs_repaint(InvalidateDisplayList::No);
 }
 
-void Document::schedule_accumulated_visual_context_value_update(Layout::Node const& layout_node)
+void Document::schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason reason)
 {
+    if (m_layout_node_arena)
+        Layout::RustFFI::layout_arena_visual_context_request_full_rebuild(m_layout_node_arena->handle(), reason);
+    set_needs_accumulated_visual_contexts_update(true);
+}
+
+void Document::schedule_accumulated_visual_context_update(Layout::Node const& layout_node, AccumulatedVisualContextUpdateScope scope)
+{
+    if (!Painting::has_committed_box(layout_node))
+        return;
+    auto slot = Painting::committed_row_slot(layout_node);
+    Layout::RustFFI::layout_arena_visual_context_note_box_dirty(
+        layout_node_arena().handle(),
+        slot,
+        scope == AccumulatedVisualContextUpdateScope::Values
+            ? Layout::RustFFI::FfiVisualContextBoxDirtyKind::StyleValueChange
+            : Layout::RustFFI::FfiVisualContextBoxDirtyKind::StyleStructuralChange);
+
+    if (scope == AccumulatedVisualContextUpdateScope::Structure) {
+        set_needs_accumulated_visual_contexts_update(true);
+        return;
+    }
+
     // NB: A full rebuild is already pending and will refresh all node values anyway.
     if (m_needs_accumulated_visual_contexts_update)
         return;
@@ -10348,24 +10370,35 @@ void Document::schedule_accumulated_visual_context_value_update(Layout::Node con
     static constexpr size_t max_pending_visual_context_value_updates = 1024;
     if (m_boxes_needing_visual_context_value_update.size() >= max_pending_visual_context_value_updates) {
         m_boxes_needing_visual_context_value_update.clear();
-        set_needs_accumulated_visual_contexts_update(true);
+        schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::DocumentWideStructuralChange);
         return;
     }
 
-    if (Painting::has_committed_box(layout_node)) {
-        m_boxes_needing_visual_context_value_update.append(Painting::committed_row_slot(layout_node));
-        set_needs_repaint(InvalidateDisplayList::No);
-    }
+    m_boxes_needing_visual_context_value_update.append(slot);
+    set_needs_repaint(InvalidateDisplayList::No);
 }
 
-void Document::schedule_accumulated_visual_context_value_update(Element& element)
+void Document::schedule_accumulated_visual_context_update(Element& element, AccumulatedVisualContextUpdateScope scope)
 {
     if (auto* layout_node = element.unsafe_layout_node())
-        schedule_accumulated_visual_context_value_update(*layout_node);
+        schedule_accumulated_visual_context_update(*layout_node, scope);
     element.for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement const& pseudo_element) {
         if (auto* pseudo_element_layout_node = pseudo_element.unsafe_layout_node())
-            schedule_accumulated_visual_context_value_update(*pseudo_element_layout_node);
+            schedule_accumulated_visual_context_update(*pseudo_element_layout_node, scope);
     });
+
+    // https://drafts.csswg.org/css-backgrounds/#root-background
+    // The root and body boxes paint each other's propagated background layers, so a structural
+    // change on either has to reach both.
+    if (scope != AccumulatedVisualContextUpdateScope::Structure)
+        return;
+    if (element.is_document_element()) {
+        if (auto* body = this->body(); body && body->unsafe_layout_node())
+            schedule_accumulated_visual_context_update(*body->unsafe_layout_node(), scope);
+    } else if (&element == body()) {
+        if (auto* document_element = this->document_element(); document_element && document_element->unsafe_layout_node())
+            schedule_accumulated_visual_context_update(*document_element->unsafe_layout_node(), scope);
+    }
 }
 
 void Document::schedule_scrollable_overflow_recalculation(Layout::Node const& layout_node)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7832,6 +7832,19 @@ static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEff
     return transform_keyframes_only_translate_horizontally(keyframes);
 }
 
+static Vector<u32> owned_visual_context_node_indices(Layout::Node const& layout_node, Layout::RustFFI::FfiVisualContextBoxNodeList list)
+{
+    Vector<u32> indices;
+    if (!Painting::has_committed_box(layout_node))
+        return indices;
+    auto* arena = layout_node.arena_handle();
+    auto slot = Painting::committed_row_slot(layout_node);
+    indices.resize(Layout::RustFFI::layout_arena_paintable_visual_context_node_count(arena, slot, list));
+    if (!indices.is_empty())
+        Layout::RustFFI::layout_arena_paintable_visual_context_copy_node_indices(arena, slot, list, indices.data(), indices.size());
+    return indices;
+}
+
 static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind, Optional<bool>& only_translates_horizontally)
 {
     auto animation = effect.associated_animation();
@@ -7979,12 +7992,12 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto build_animation_for_target = [&](Compositor::VisualAnimation::TargetKind target_kind) -> Optional<Compositor::VisualAnimation> {
         Vector<u32> visual_context_node_indices;
         if (target_kind == Compositor::VisualAnimation::TargetKind::Opacity) {
-            for (auto index = row->frame_nodes_begin; index < row->frame_nodes_end; ++index) {
+            for (auto index : owned_visual_context_node_indices(*layout_node, Layout::RustFFI::FfiVisualContextBoxNodeList::FrameNodes)) {
                 if (visual_context_tree.frame_is_effects(Painting::FrameNodeIndex { index }))
                     visual_context_node_indices.append(index);
             }
         } else {
-            for (auto index = row->spatial_nodes_begin; index < row->spatial_nodes_end; ++index) {
+            for (auto index : owned_visual_context_node_indices(*layout_node, Layout::RustFFI::FfiVisualContextBoxNodeList::SpatialNodes)) {
                 if (visual_context_tree.spatial_node_is_css_transform(Painting::SpatialNodeIndex { index }))
                     visual_context_node_indices.append(index);
             }
@@ -11007,12 +11020,9 @@ Utf16String Document::dump_display_list()
     spatial_node_owners.set(Painting::VISUAL_VIEWPORT_NODE_INDEX, m_layout_root.ptr());
     spatial_node_owners.set(Painting::own_scroll_node_index(*m_layout_root), m_layout_root.ptr());
     m_layout_root->for_each_in_inclusive_subtree([&](Layout::Node const& layout_node) {
-        auto const* row = Painting::committed_row(layout_node);
-        if (!row)
-            return TraversalDecision::Continue;
-        for (auto spatial = row->spatial_nodes_begin; spatial < row->spatial_nodes_end; ++spatial)
+        for (auto spatial : owned_visual_context_node_indices(layout_node, Layout::RustFFI::FfiVisualContextBoxNodeList::SpatialNodes))
             spatial_node_owners.set(Painting::SpatialNodeIndex { spatial }, &layout_node);
-        for (auto frame = row->frame_nodes_begin; frame < row->frame_nodes_end; ++frame)
+        for (auto frame : owned_visual_context_node_indices(layout_node, Layout::RustFFI::FfiVisualContextBoxNodeList::FrameNodes))
             frame_node_owners.set(Painting::FrameNodeIndex { frame }, &layout_node);
         return TraversalDecision::Continue;
     });

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -11008,6 +11008,9 @@ Utf16String Document::dump_display_list()
     if (!has_committed_viewport_box())
         return "No paintable"_utf16;
 
+    if (paint_state().has_visual_context_tree())
+        schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::CanonicalDumpRequested);
+
     auto& resource_storage = navigable()->display_list_resource_storage();
     auto display_list = record_display_list(HTML::PaintConfig {}, resource_storage, Painting::PaintCommandCacheMode::ReadOnly);
     if (!display_list)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3001,23 +3001,8 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
     // NB: Called during paint property resolution.
     if (m_needs_accumulated_visual_contexts_update) {
         m_needs_accumulated_visual_contexts_update = false;
-        m_boxes_needing_visual_context_value_update.clear_with_capacity();
         if (has_committed_viewport_box())
-            paint_state().assign_accumulated_visual_contexts(*this);
-    } else if (!m_boxes_needing_visual_context_value_update.is_empty()) {
-        auto boxes = move(m_boxes_needing_visual_context_value_update);
-        if (has_committed_viewport_box()) {
-            for (auto const& paintable_slot : boxes) {
-                auto* layout_node = Painting::layout_node_for_committed_slot(layout_node_arena(), paintable_slot);
-                if (!layout_node)
-                    continue;
-                if (!paint_state().update_accumulated_visual_context_values(*this, paintable_slot)) {
-                    // Structure changed after all; rebuild the whole tree.
-                    paint_state().assign_accumulated_visual_contexts(*this);
-                    break;
-                }
-            }
-        }
+            paint_state().update_accumulated_visual_contexts(*this);
     }
 
     // Scroll nodes are (re)created by the visual context tree build above, so scroll offsets and
@@ -10357,25 +10342,7 @@ void Document::schedule_accumulated_visual_context_update(Layout::Node const& la
             ? Layout::RustFFI::FfiVisualContextBoxDirtyKind::StyleValueChange
             : Layout::RustFFI::FfiVisualContextBoxDirtyKind::StyleStructuralChange);
 
-    if (scope == AccumulatedVisualContextUpdateScope::Structure) {
-        set_needs_accumulated_visual_contexts_update(true);
-        return;
-    }
-
-    // NB: A full rebuild is already pending and will refresh all node values anyway.
-    if (m_needs_accumulated_visual_contexts_update)
-        return;
-
-    // NB: Cap the queue in case it's never consumed (e.g. forced style updates in a document that never paints).
-    static constexpr size_t max_pending_visual_context_value_updates = 1024;
-    if (m_boxes_needing_visual_context_value_update.size() >= max_pending_visual_context_value_updates) {
-        m_boxes_needing_visual_context_value_update.clear();
-        schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::DocumentWideStructuralChange);
-        return;
-    }
-
-    m_boxes_needing_visual_context_value_update.append(slot);
-    set_needs_repaint(InvalidateDisplayList::No);
+    set_needs_accumulated_visual_contexts_update(true);
 }
 
 void Document::schedule_accumulated_visual_context_update(Element& element, AccumulatedVisualContextUpdateScope scope)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1905,7 +1905,6 @@ private:
     bool m_design_mode_enabled { false };
 
     bool m_needs_accumulated_visual_contexts_update { false };
-    Vector<Layout::RustFFI::NodeSlotId> m_boxes_needing_visual_context_value_update;
 
     bool m_needs_full_scrollable_overflow_recalculation { false };
     Vector<Layout::RustFFI::NodeSlotId> m_boxes_needing_scrollable_overflow_recalculation;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -544,7 +544,7 @@ public:
     Painting::DocumentPaintState& paint_state();
     Painting::DocumentPaintState const& paint_state() const;
     Painting::AccumulatedVisualContextTree visual_context_tree() const;
-    u64 visual_context_tree_version() const;
+    u64 visual_context_tree_structural_epoch() const;
     Painting::ScrollStateSnapshot const& scroll_state_snapshot() const;
 
     GC::Ref<NodeList> get_elements_by_name(Utf16View);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1176,10 +1176,15 @@ public:
     LayoutTreeBuildStats const& layout_tree_build_stats() const { return m_layout_tree_build_stats; }
     void record_layout_tree_build(u64 rebuilt_subtree_root_count, bool escaped_rebuild_roots);
 
+    enum class AccumulatedVisualContextUpdateScope : u8 {
+        Values,
+        Structure,
+    };
     void set_needs_accumulated_visual_contexts_update(bool);
+    void schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason);
     bool can_compute_client_rects_without_accumulated_visual_contexts_update(Layout::Node const&) const;
-    void schedule_accumulated_visual_context_value_update(Element&);
-    void schedule_accumulated_visual_context_value_update(Layout::Node const&);
+    void schedule_accumulated_visual_context_update(Element&, AccumulatedVisualContextUpdateScope);
+    void schedule_accumulated_visual_context_update(Layout::Node const&, AccumulatedVisualContextUpdateScope);
     void schedule_scrollable_overflow_recalculation(Element&);
     void schedule_scrollable_overflow_recalculation(Layout::Node const&);
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -5204,7 +5204,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paint_state.scroll_state_snapshot() };
     if (should_record_display_list) {
-        m_compositor_display_list_visual_context_tree_version = display_list->compatible_visual_context_tree_version();
+        m_compositor_display_list_visual_context_tree_structural_epoch = display_list->compatible_visual_context_tree_structural_epoch();
         compositor_context().update_display_list(*display_list, visual_context_tree.release_value(), move(resource_transaction), move(scroll_state_snapshot));
         document_paint_state.did_update_visual_context_tree_in_compositor();
         m_display_list_resource_storage.retain_only(display_list_resources);
@@ -5215,7 +5215,7 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     } else {
         if (visual_context_tree_needs_compositor_update) {
             auto updated_visual_context_tree = document_paint_state.visual_context_tree(*document);
-            VERIFY(updated_visual_context_tree.version() == m_compositor_display_list_visual_context_tree_version);
+            VERIFY(updated_visual_context_tree.structural_epoch() == m_compositor_display_list_visual_context_tree_structural_epoch);
             auto updated_display_list_resources = compositor_display_list_resources(m_display_list_resource_storage, document_paint_state, m_compositor_display_list_command_resources, updated_visual_context_tree);
             auto updated_resource_transaction = m_display_list_resource_storage.create_transaction(m_compositor_display_list_resources, updated_display_list_resources);
             compositor_context().update_visual_context_tree(updated_visual_context_tree, move(updated_resource_transaction));

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -537,7 +537,7 @@ private:
     bool m_should_show_line_box_borders { false };
     bool m_should_show_caret_hit_test_debug_overlay { false };
     Optional<PaintConfig> m_compositor_display_list_paint_config;
-    u64 m_compositor_display_list_visual_context_tree_version { 0 };
+    u64 m_compositor_display_list_visual_context_tree_structural_epoch { 0 };
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_compositor_display_list_resources;
     Painting::DisplayListResourceSet m_compositor_display_list_command_resources;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -161,6 +161,15 @@ u64 Internals::visual_context_tree_node_count()
     if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
         return 0;
     auto visual_context_tree = document.paint_state().visual_context_tree(document);
+    return visual_context_tree.live_spatial_node_count() + visual_context_tree.live_frame_node_count();
+}
+
+u64 Internals::visual_context_tree_node_capacity()
+{
+    auto& document = window().associated_document();
+    if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
+        return 0;
+    auto visual_context_tree = document.paint_state().visual_context_tree(document);
     return visual_context_tree.spatial_node_count() + visual_context_tree.frame_node_count();
 }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -164,6 +164,14 @@ u64 Internals::visual_context_tree_node_count()
     return visual_context_tree.live_spatial_node_count() + visual_context_tree.live_frame_node_count();
 }
 
+u64 Internals::visual_context_tree_structural_epoch()
+{
+    auto& document = window().associated_document();
+    if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
+        return 0;
+    return document.paint_state().visual_context_tree(document).structural_epoch();
+}
+
 u64 Internals::visual_context_tree_node_capacity()
 {
     auto& document = window().associated_document();
@@ -183,13 +191,13 @@ void Internals::send_mismatched_visual_context_tree_update_to_compositor()
         return;
     auto& document_paint_state = document.paint_state();
 
-    // Force a fresh, incompatible rebuild — so the tree is minted with a new version that the Compositor's installed
+    // Force a fresh, incompatible rebuild — so the tree is minted with a new structural epoch that the Compositor's installed
     // display list was never recorded against.
     document_paint_state.set_force_incompatible_visual_context_tree_rebuild_for_testing();
     document.set_needs_accumulated_visual_contexts_update(true);
     document.update_paint_and_hit_testing_properties_if_needed();
 
-    // Send a bare visual-context-tree update carrying that new version *without* re-recording the display list —
+    // Send a bare visual-context-tree update carrying that new structural epoch *without* re-recording the display list —
     // deliberately reproducing the peer inconsistency behind issue #10368.
     navigable->compositor_context().update_visual_context_tree(document_paint_state.visual_context_tree(document), {});
 }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -155,6 +155,14 @@ void Internals::force_incompatible_visual_context_tree_rebuild()
     document.schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::ForcedForTesting);
 }
 
+u64 Internals::accumulated_visual_context_incremental_update_count()
+{
+    auto& document = window().associated_document();
+    if (!document.has_committed_viewport_box())
+        return 0;
+    return document.paint_state().accumulated_visual_context_tree_incremental_update_count();
+}
+
 u64 Internals::visual_context_pending_dirty_box_count()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -152,7 +152,15 @@ void Internals::force_incompatible_visual_context_tree_rebuild()
     if (!document.has_committed_viewport_box())
         return;
     document.paint_state().set_force_incompatible_visual_context_tree_rebuild_for_testing();
-    document.set_needs_accumulated_visual_contexts_update(true);
+    document.schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::ForcedForTesting);
+}
+
+u64 Internals::visual_context_pending_dirty_box_count()
+{
+    auto& document = window().associated_document();
+    if (!document.has_committed_viewport_box())
+        return 0;
+    return Layout::RustFFI::layout_arena_visual_context_pending_dirty_box_count(document.layout_node_arena().handle());
 }
 
 u64 Internals::visual_context_tree_node_count()
@@ -194,7 +202,7 @@ void Internals::send_mismatched_visual_context_tree_update_to_compositor()
     // Force a fresh, incompatible rebuild — so the tree is minted with a new structural epoch that the Compositor's installed
     // display list was never recorded against.
     document_paint_state.set_force_incompatible_visual_context_tree_rebuild_for_testing();
-    document.set_needs_accumulated_visual_contexts_update(true);
+    document.schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::ForcedForTesting);
     document.update_paint_and_hit_testing_properties_if_needed();
 
     // Send a bare visual-context-tree update carrying that new structural epoch *without* re-recording the display list —

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -180,6 +180,15 @@ u64 Internals::visual_context_tree_node_count()
     return visual_context_tree.live_spatial_node_count() + visual_context_tree.live_frame_node_count();
 }
 
+u64 Internals::visual_context_tree_dead_node_count()
+{
+    auto& document = window().associated_document();
+    if (!document.has_committed_viewport_box() || !document.paint_state().has_visual_context_tree())
+        return 0;
+    auto visual_context_tree = document.paint_state().visual_context_tree(document);
+    return (visual_context_tree.spatial_node_count() - visual_context_tree.live_spatial_node_count()) + (visual_context_tree.frame_node_count() - visual_context_tree.live_frame_node_count());
+}
+
 u64 Internals::visual_context_tree_structural_epoch()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -49,6 +49,7 @@ public:
     void set_test_timeout(double milliseconds);
     void force_incompatible_visual_context_tree_rebuild();
     u64 visual_context_tree_node_count();
+    u64 visual_context_tree_node_capacity();
     void send_mismatched_visual_context_tree_update_to_compositor();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -52,6 +52,7 @@ public:
     u64 visual_context_pending_dirty_box_count();
     u64 accumulated_visual_context_incremental_update_count();
     u64 visual_context_tree_node_capacity();
+    u64 visual_context_tree_dead_node_count();
     u64 visual_context_tree_structural_epoch();
     void send_mismatched_visual_context_tree_update_to_compositor();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -50,6 +50,7 @@ public:
     void force_incompatible_visual_context_tree_rebuild();
     u64 visual_context_tree_node_count();
     u64 visual_context_pending_dirty_box_count();
+    u64 accumulated_visual_context_incremental_update_count();
     u64 visual_context_tree_node_capacity();
     u64 visual_context_tree_structural_epoch();
     void send_mismatched_visual_context_tree_update_to_compositor();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -49,6 +49,7 @@ public:
     void set_test_timeout(double milliseconds);
     void force_incompatible_visual_context_tree_rebuild();
     u64 visual_context_tree_node_count();
+    u64 visual_context_pending_dirty_box_count();
     u64 visual_context_tree_node_capacity();
     u64 visual_context_tree_structural_epoch();
     void send_mismatched_visual_context_tree_update_to_compositor();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -50,6 +50,7 @@ public:
     void force_incompatible_visual_context_tree_rebuild();
     u64 visual_context_tree_node_count();
     u64 visual_context_tree_node_capacity();
+    u64 visual_context_tree_structural_epoch();
     void send_mismatched_visual_context_tree_update_to_compositor();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -6,6 +6,7 @@ interface Internals {
     undefined forceIncompatibleVisualContextTreeRebuild();
     unsigned long long visualContextTreeNodeCount();
     unsigned long long visualContextTreeNodeCapacity();
+    unsigned long long visualContextTreeStructuralEpoch();
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();
     undefined loadReferenceTestMetadata();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -5,6 +5,7 @@ interface Internals {
     undefined setTestTimeout(double milliseconds);
     undefined forceIncompatibleVisualContextTreeRebuild();
     unsigned long long visualContextTreeNodeCount();
+    unsigned long long visualContextPendingDirtyBoxCount();
     unsigned long long visualContextTreeNodeCapacity();
     unsigned long long visualContextTreeStructuralEpoch();
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -5,6 +5,7 @@ interface Internals {
     undefined setTestTimeout(double milliseconds);
     undefined forceIncompatibleVisualContextTreeRebuild();
     unsigned long long visualContextTreeNodeCount();
+    unsigned long long visualContextTreeNodeCapacity();
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();
     undefined loadReferenceTestMetadata();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -6,6 +6,7 @@ interface Internals {
     undefined forceIncompatibleVisualContextTreeRebuild();
     unsigned long long visualContextTreeNodeCount();
     unsigned long long visualContextPendingDirtyBoxCount();
+    unsigned long long accumulatedVisualContextIncrementalUpdateCount();
     unsigned long long visualContextTreeNodeCapacity();
     unsigned long long visualContextTreeStructuralEpoch();
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -8,6 +8,7 @@ interface Internals {
     unsigned long long visualContextPendingDirtyBoxCount();
     unsigned long long accumulatedVisualContextIncrementalUpdateCount();
     unsigned long long visualContextTreeNodeCapacity();
+    unsigned long long visualContextTreeDeadNodeCount();
     unsigned long long visualContextTreeStructuralEpoch();
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();
     undefined loadReferenceTestMetadata();

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -79,9 +79,9 @@ void AccumulatedVisualContextTree::release_rust_handle()
     m_rust_tree = nullptr;
 }
 
-u64 AccumulatedVisualContextTree::version() const
+u64 AccumulatedVisualContextTree::structural_epoch() const
 {
-    return Layout::RustFFI::visual_context_tree_version(m_rust_tree);
+    return Layout::RustFFI::visual_context_tree_structural_epoch(m_rust_tree);
 }
 
 ByteBuffer AccumulatedVisualContextTree::serialize_to_bytes() const

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -103,6 +103,16 @@ size_t AccumulatedVisualContextTree::frame_node_count() const
     return Layout::RustFFI::visual_context_tree_frame_node_count(m_rust_tree);
 }
 
+size_t AccumulatedVisualContextTree::live_spatial_node_count() const
+{
+    return Layout::RustFFI::visual_context_tree_live_spatial_node_count(m_rust_tree);
+}
+
+size_t AccumulatedVisualContextTree::live_frame_node_count() const
+{
+    return Layout::RustFFI::visual_context_tree_live_frame_node_count(m_rust_tree);
+}
+
 TransformWithOrigin AccumulatedVisualContextTree::visual_viewport_transform() const
 {
     return Layout::RustFFI::visual_context_tree_visual_viewport_transform(m_rust_tree);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -65,7 +65,7 @@ public:
     WEB_API AccumulatedVisualContextTree& operator=(AccumulatedVisualContextTree&&);
     WEB_API ~AccumulatedVisualContextTree();
 
-    WEB_API u64 version() const;
+    WEB_API u64 structural_epoch() const;
     WEB_API ByteBuffer serialize_to_bytes() const;
     void const* rust_handle() const { return m_rust_tree; }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -76,6 +76,8 @@ public:
 
     WEB_API size_t spatial_node_count() const;
     WEB_API size_t frame_node_count() const;
+    WEB_API size_t live_spatial_node_count() const;
+    WEB_API size_t live_frame_node_count() const;
     WEB_API TransformWithOrigin visual_viewport_transform() const;
     WEB_API AccumulatedVisualContextTree with_visual_viewport_transform(TransformWithOrigin const&) const;
     WEB_API AccumulatedVisualContextTree with_visual_animation_samples(i64 monotonic_time_ns) const;

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -19,14 +19,14 @@ namespace Web::Painting {
 
 static Atomic<u64> s_next_id { 1 };
 
-DisplayList::DisplayList(u64 compatible_visual_context_tree_version)
-    : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
+DisplayList::DisplayList(u64 compatible_visual_context_tree_structural_epoch)
+    : m_compatible_visual_context_tree_structural_epoch(compatible_visual_context_tree_structural_epoch)
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
 {
 }
 
-DisplayList::DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists)
-    : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
+DisplayList::DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists)
+    : m_compatible_visual_context_tree_structural_epoch(compatible_visual_context_tree_structural_epoch)
     , m_id(id)
     , m_command_bytes(move(command_bytes))
     , m_command_runs(move(command_runs))
@@ -107,10 +107,10 @@ void DisplayListPlayer::execute(
     RefPtr<Gfx::PaintingSurface> surface,
     CanvasSurfaceRegistry const* canvas_surface_registry)
 {
-    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
-    if (m_layer_filter_cache_tree_version != visual_context_tree.version()) {
-        m_layer_filters_by_tree_version_and_frame.clear();
-        m_layer_filter_cache_tree_version = visual_context_tree.version();
+    VERIFY(display_list.compatible_visual_context_tree_structural_epoch() == visual_context_tree.structural_epoch());
+    if (m_layer_filter_cache_tree_structural_epoch != visual_context_tree.structural_epoch()) {
+        m_layer_filters_by_tree_structural_epoch_and_frame.clear();
+        m_layer_filter_cache_tree_structural_epoch = visual_context_tree.structural_epoch();
     }
     m_surface = surface;
     m_active_display_list = &display_list;
@@ -127,7 +127,7 @@ void DisplayListPlayer::execute(
 
 void DisplayListPlayer::execute_display_list_into_surface(DisplayList const& display_list, AccumulatedVisualContextTree const& visual_context_tree, Gfx::PaintingSurface& target_surface)
 {
-    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
+    VERIFY(display_list.compatible_visual_context_tree_structural_epoch() == visual_context_tree.structural_epoch());
     TemporaryChange surface_change { m_surface, RefPtr<Gfx::PaintingSurface> { target_surface } };
     TemporaryChange display_list_change { m_active_display_list, &display_list };
     TemporaryChange visual_context_tree_change { m_active_visual_context_tree, &visual_context_tree };
@@ -141,7 +141,7 @@ void DisplayListPlayer::execute_nested_display_list(
     AccumulatedVisualContextTree const& visual_context_tree,
     ScrollStateSnapshot const& scroll_state_snapshot)
 {
-    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
+    VERIFY(display_list.compatible_visual_context_tree_structural_epoch() == visual_context_tree.structural_epoch());
     TemporaryChange display_list_change { m_active_display_list, &display_list };
     TemporaryChange visual_context_tree_change { m_active_visual_context_tree, &visual_context_tree };
     VERIFY(m_resource_storage);
@@ -151,7 +151,7 @@ void DisplayListPlayer::execute_nested_display_list(
 Gfx::Filter const& DisplayListPlayer::layer_filter(ReplayLayer const& layer)
 {
     ReadonlyBytes filter_bytes { layer.filter_bytes, layer.filter_bytes_size };
-    auto& filters_by_frame = m_layer_filters_by_tree_version_and_frame.ensure(active_visual_context_tree().version());
+    auto& filters_by_frame = m_layer_filters_by_tree_structural_epoch_and_frame.ensure(active_visual_context_tree().structural_epoch());
     if (auto cached = filters_by_frame.get(layer.frame.value()); cached.has_value() && cached->filter_bytes.bytes() == filter_bytes)
         return cached->filter;
     auto filter = Gfx::deserialize_filter(filter_bytes, [&](u64 image_id) {
@@ -207,7 +207,7 @@ void DisplayListPlayer::execute_run_commands(DisplayListCommandRun const& run, S
 void DisplayListPlayer::execute_impl(DisplayList const& display_list, ScrollStateSnapshot const& scroll_state)
 {
     auto const& visual_context_tree = active_visual_context_tree();
-    VERIFY(display_list.compatible_visual_context_tree_version() == visual_context_tree.version());
+    VERIFY(display_list.compatible_visual_context_tree_structural_epoch() == visual_context_tree.structural_epoch());
     VERIFY(m_surface);
 
     struct ReplayContext {
@@ -281,7 +281,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList const& display
 {
     TRY(encoder.encode(display_list.m_id));
     TRY(encoder.encode(display_list.m_command_bytes));
-    TRY(encoder.encode(display_list.m_compatible_visual_context_tree_version));
+    TRY(encoder.encode(display_list.m_compatible_visual_context_tree_structural_epoch));
     TRY(encoder.encode(display_list.m_surface_clear_color));
     TRY(encoder.encode(display_list.m_async_scrolling_metadata));
     TRY(encoder.encode(display_list.m_mask_display_lists));
@@ -304,7 +304,7 @@ ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
 {
     auto id = TRY(decoder.decode<u64>());
     auto command_bytes = TRY(decoder.decode<ByteBuffer>());
-    auto compatible_visual_context_tree_version = TRY(decoder.decode<u64>());
+    auto compatible_visual_context_tree_structural_epoch = TRY(decoder.decode<u64>());
     auto surface_clear_color = TRY(decoder.decode<Optional<Gfx::Color>>());
     auto async_scrolling_metadata = TRY(decoder.decode<Optional<Web::Painting::DisplayList::AsyncScrollingMetadata>>());
     auto mask_display_lists = TRY(decoder.decode<HashMap<Web::Painting::FrameNodeIndex, Web::Painting::DisplayListResourceId>>());
@@ -314,7 +314,7 @@ ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
     if (!command_runs.is_empty())
         TRY(decoder.decode_into(Bytes { reinterpret_cast<u8*>(command_runs.data()), command_runs.size() * sizeof(Web::Painting::DisplayListCommandRun) }));
     TRY(Web::Painting::validate_display_list_command_runs(command_bytes, command_runs));
-    return adopt_ref(*new Web::Painting::DisplayList(compatible_visual_context_tree_version, id, move(command_bytes), move(command_runs), surface_clear_color, move(async_scrolling_metadata), move(mask_display_lists)));
+    return adopt_ref(*new Web::Painting::DisplayList(compatible_visual_context_tree_structural_epoch, id, move(command_bytes), move(command_runs), surface_clear_color, move(async_scrolling_metadata), move(mask_display_lists)));
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -70,6 +70,18 @@ Vector<DisplayListCommandRun> compute_display_list_command_runs(ReadonlyBytes co
     return runs;
 }
 
+ErrorOr<void> validate_display_list_references_live_visual_context_nodes(DisplayList const& display_list, AccumulatedVisualContextTree const& visual_context_tree)
+{
+    Vector<FrameNodeIndex> mask_frames;
+    mask_frames.ensure_capacity(display_list.mask_display_lists().size());
+    for (auto const& mask_display_list : display_list.mask_display_lists())
+        mask_frames.unchecked_append(mask_display_list.key);
+    auto command_runs = display_list.command_runs();
+    if (!Layout::RustFFI::display_list_references_only_live_visual_context_nodes(visual_context_tree.rust_handle(), command_runs.data(), command_runs.size(), mask_frames.data(), mask_frames.size()))
+        return Error::from_string_literal("Display list references a visual context node that is not live");
+    return {};
+}
+
 ErrorOr<void> validate_display_list_command_runs(ReadonlyBytes command_bytes, ReadonlySpan<DisplayListCommandRun> runs)
 {
     size_t next_offset = 0;

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -89,8 +89,8 @@ private:
         ByteBuffer filter_bytes;
         Gfx::Filter filter;
     };
-    HashMap<u64, HashMap<u32, CachedLayerFilter>> m_layer_filters_by_tree_version_and_frame;
-    u64 m_layer_filter_cache_tree_version { 0 };
+    HashMap<u64, HashMap<u32, CachedLayerFilter>> m_layer_filters_by_tree_structural_epoch_and_frame;
+    u64 m_layer_filter_cache_tree_structural_epoch { 0 };
 };
 
 class DisplayList : public AtomicRefCounted<DisplayList> {
@@ -104,12 +104,12 @@ public:
 
     static NonnullRefPtr<DisplayList> create(AccumulatedVisualContextTree const& visual_context_tree)
     {
-        return adopt_ref(*new DisplayList(visual_context_tree.version()));
+        return adopt_ref(*new DisplayList(visual_context_tree.structural_epoch()));
     }
 
     static WEB_API NonnullRefPtr<DisplayList> create_from_command_bytes(AccumulatedVisualContextTree const&, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs);
 
-    u64 compatible_visual_context_tree_version() const { return m_compatible_visual_context_tree_version; }
+    u64 compatible_visual_context_tree_structural_epoch() const { return m_compatible_visual_context_tree_structural_epoch; }
     u64 id() const { return m_id; }
 
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
@@ -147,10 +147,10 @@ public:
     }
 
 private:
-    explicit DisplayList(u64 compatible_visual_context_tree_version);
-    DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata>, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists);
+    explicit DisplayList(u64 compatible_visual_context_tree_structural_epoch);
+    DisplayList(u64 compatible_visual_context_tree_structural_epoch, u64 id, ByteBuffer&& command_bytes, Vector<DisplayListCommandRun>&& command_runs, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata>, HashMap<FrameNodeIndex, DisplayListResourceId>&& mask_display_lists);
 
-    u64 m_compatible_visual_context_tree_version { 0 };
+    u64 m_compatible_visual_context_tree_structural_epoch { 0 };
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
     Vector<DisplayListCommandRun> m_command_runs;

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -170,6 +170,7 @@ WEB_API Vector<DisplayListCommandRun> compute_display_list_command_runs(Readonly
 // Runs must start at offset zero, follow each other without gaps, stay aligned, end at the tape's
 // end, and under DISPLAY_LIST_RUNS_DEBUG match the table recomputed from the tape.
 WEB_API ErrorOr<void> validate_display_list_command_runs(ReadonlyBytes command_bytes, ReadonlySpan<DisplayListCommandRun>);
+WEB_API ErrorOr<void> validate_display_list_references_live_visual_context_nodes(DisplayList const&, AccumulatedVisualContextTree const&);
 
 }
 

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -112,35 +112,29 @@ void DocumentPaintState::clear_scroll_state(DOM::Document& document)
     mirror_rust_clear_scroll_state(document);
 }
 
-void DocumentPaintState::assign_accumulated_visual_contexts(DOM::Document& document)
+void DocumentPaintState::update_accumulated_visual_contexts(DOM::Document& document)
 {
-    clear_scroll_state(document);
-    ++m_accumulated_visual_context_tree_build_count;
-    auto forced_incompatible_rebuild = m_force_incompatible_visual_context_tree_rebuild_for_testing;
+    auto force_full_rebuild = m_force_incompatible_visual_context_tree_rebuild_for_testing;
     m_force_incompatible_visual_context_tree_rebuild_for_testing = false;
-    auto is_compatible = rust_assign_accumulated_visual_contexts(document, forced_incompatible_rebuild);
-    if (!is_compatible)
+    auto result = rust_update_accumulated_visual_contexts(document, force_full_rebuild);
+    if (result.performed_full_build) {
+        m_scroll_state_snapshot = {};
+        ++m_accumulated_visual_context_tree_build_count;
+    } else {
+        ++m_accumulated_visual_context_tree_incremental_update_count;
+    }
+    set_needs_to_refresh_scroll_state(document, true);
+    if (result.requires_display_list_recording)
         document.set_needs_to_record_display_list();
-    m_visual_context_tree_visual_animations = nullptr;
+    if (result.performed_full_build || result.structural_epoch_changed)
+        m_visual_context_tree_visual_animations = nullptr;
     m_visual_context_tree_needs_compositor_update = true;
-}
-
-bool DocumentPaintState::update_accumulated_visual_context_values(DOM::Document& document, Layout::RustFFI::NodeSlotId paintable_slot)
-{
-    if (!has_visual_context_tree())
-        return false;
-    if (m_force_incompatible_visual_context_tree_rebuild_for_testing)
-        return false;
-    if (!rust_update_accumulated_visual_context_values(document, paintable_slot))
-        return false;
-    m_visual_context_tree_needs_compositor_update = true;
-    return true;
 }
 
 void DocumentPaintState::update_visual_viewport_accumulated_visual_context(DOM::Document& document)
 {
     if (!has_visual_context_tree()) {
-        assign_accumulated_visual_contexts(document);
+        update_accumulated_visual_contexts(document);
         return;
     }
     rust_update_visual_viewport_transform(document);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -47,10 +47,10 @@ AccumulatedVisualContextTree DocumentPaintState::visual_context_tree(DOM::Docume
     return visual_context_tree_without_update(document);
 }
 
-u64 DocumentPaintState::visual_context_tree_version(DOM::Document const& document) const
+u64 DocumentPaintState::visual_context_tree_structural_epoch(DOM::Document const& document) const
 {
     ensure_visual_context_tree(document);
-    return Layout::RustFFI::layout_arena_visual_context_tree_version(m_layout_node_arena->handle());
+    return Layout::RustFFI::layout_arena_visual_context_tree_structural_epoch(m_layout_node_arena->handle());
 }
 
 BlockingWheelEventRegionState DocumentPaintState::collect_root_blocking_wheel_event_regions(DOM::Document& document)

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -36,8 +36,7 @@ public:
     void refresh_scroll_state(DOM::Document&);
     void refresh_sticky_constraints(DOM::Document&);
 
-    void assign_accumulated_visual_contexts(DOM::Document&);
-    bool update_accumulated_visual_context_values(DOM::Document&, Layout::RustFFI::NodeSlotId);
+    void update_accumulated_visual_contexts(DOM::Document&);
     void update_visual_viewport_accumulated_visual_context(DOM::Document&);
     void set_visual_animations(DOM::Document&, Vector<Compositor::VisualAnimation>);
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
@@ -45,6 +44,7 @@ public:
     void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }
     bool has_visual_context_tree() const;
     u64 accumulated_visual_context_tree_build_count() const { return m_accumulated_visual_context_tree_build_count; }
+    u64 accumulated_visual_context_tree_incremental_update_count() const { return m_accumulated_visual_context_tree_incremental_update_count; }
 
     void recompute_selection_states(DOM::Document&, DOM::Range&);
     void reset_selection_states(DOM::Document&);
@@ -90,6 +90,7 @@ private:
     Vector<Compositor::VisualAnimation> m_visual_animations;
     RefPtr<VisualAnimationList const> m_visual_context_tree_visual_animations;
     u64 m_accumulated_visual_context_tree_build_count { 0 };
+    u64 m_accumulated_visual_context_tree_incremental_update_count { 0 };
     bool m_visual_context_tree_needs_compositor_update { false };
     bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };
 };

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -59,7 +59,7 @@ public:
     Vector<Layout::RustFFI::NodeSlotId> const& boxes_with_auto_content_visibility() const { return m_boxes_with_auto_content_visibility; }
 
     AccumulatedVisualContextTree visual_context_tree(DOM::Document const&) const;
-    u64 visual_context_tree_version(DOM::Document const&) const;
+    u64 visual_context_tree_structural_epoch(DOM::Document const&) const;
 
     void set_display_list_used_as_paint_command_cache_source(RefPtr<DisplayList const> display_list, DisplayListResourceSet referenced_resources)
     {

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -22,10 +22,10 @@
 
 namespace Web::Painting {
 
-NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording(u64 visual_context_tree_version, Layout::NodeArena& arena, ChromeWidgetRegistry& chrome_widget_registry)
+NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording(u64 visual_context_tree_structural_epoch, Layout::NodeArena& arena, ChromeWidgetRegistry& chrome_widget_registry)
 {
     auto* arena_handle = arena.handle();
-    auto list = adopt_ref(*new HitTestDisplayList(visual_context_tree_version, arena, chrome_widget_registry, Layout::RustFFI::layout_arena_hit_test_list_generation(arena_handle)));
+    auto list = adopt_ref(*new HitTestDisplayList(visual_context_tree_structural_epoch, arena, chrome_widget_registry, Layout::RustFFI::layout_arena_hit_test_list_generation(arena_handle)));
     struct VisitContext {
         HitTestDisplayList& list;
         Layout::NodeArena& arena;
@@ -56,8 +56,8 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create_from_rust_recording
     return list;
 }
 
-HitTestDisplayList::HitTestDisplayList(u64 visual_context_tree_version, Layout::NodeArena& arena, ChromeWidgetRegistry& chrome_widget_registry, u64 rust_generation)
-    : m_visual_context_tree_version(visual_context_tree_version)
+HitTestDisplayList::HitTestDisplayList(u64 visual_context_tree_structural_epoch, Layout::NodeArena& arena, ChromeWidgetRegistry& chrome_widget_registry, u64 rust_generation)
+    : m_visual_context_tree_structural_epoch(visual_context_tree_structural_epoch)
     , m_arena(arena)
     , m_chrome_widget_registry(chrome_widget_registry)
     , m_rust_generation(rust_generation)
@@ -459,7 +459,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(size_t line_
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics, CaretPositionMode mode, GC::Ptr<DOM::Node const> constraint_scope) const
 {
-    if (m_visual_context_tree_version != document.visual_context_tree_version() || !is_current())
+    if (m_visual_context_tree_structural_epoch != document.visual_context_tree_structural_epoch() || !is_current())
         return {};
     // First find both the topmost hit-test item and the topmost item that can directly produce a caret.
     // Non-caret items are still needed to keep later line fallback scoped to the hit content.
@@ -554,7 +554,7 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
 
 Optional<HitTestResult> HitTestDisplayList::hit_test(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics) const
 {
-    if (m_visual_context_tree_version != document.visual_context_tree_version() || !is_current())
+    if (m_visual_context_tree_structural_epoch != document.visual_context_tree_structural_epoch() || !is_current())
         return {};
 
     auto topmost_item = find_topmost_item(point, document, device_pixels_per_css_pixel, chrome_metrics);
@@ -565,7 +565,7 @@ Optional<HitTestResult> HitTestDisplayList::hit_test(CSSPixelPoint point, DOM::D
 
 TraversalDecision HitTestDisplayList::hit_test_all(CSSPixelPoint point, DOM::Document const& document, double device_pixels_per_css_pixel, ChromeMetrics const& chrome_metrics, Function<TraversalDecision(HitTestResult)> const& callback) const
 {
-    if (m_visual_context_tree_version != document.visual_context_tree_version() || !is_current())
+    if (m_visual_context_tree_structural_epoch != document.visual_context_tree_structural_epoch() || !is_current())
         return TraversalDecision::Continue;
 
     for (auto item_index : hit_item_indices_topmost_first(point, document, device_pixels_per_css_pixel, chrome_metrics)) {

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -42,11 +42,11 @@ enum class CaretLineDirection : u8 {
 
 class WEB_API HitTestDisplayList : public RefCounted<HitTestDisplayList> {
 public:
-    static NonnullRefPtr<HitTestDisplayList> create_from_rust_recording(u64 visual_context_tree_version, Layout::NodeArena&, ChromeWidgetRegistry&);
+    static NonnullRefPtr<HitTestDisplayList> create_from_rust_recording(u64 visual_context_tree_structural_epoch, Layout::NodeArena&, ChromeWidgetRegistry&);
 
     void visit_edges(GC::Cell::Visitor&);
 
-    u64 visual_context_tree_version() const { return m_visual_context_tree_version; }
+    u64 visual_context_tree_structural_epoch() const { return m_visual_context_tree_structural_epoch; }
     [[nodiscard]] bool is_current() const;
     [[nodiscard]] Optional<HitTestResult> hit_test(CSSPixelPoint, DOM::Document const&, double device_pixels_per_css_pixel, ChromeMetrics const&) const;
     // When constraint_scope is given, the caret position is constrained to lines inside that node, and points
@@ -62,7 +62,7 @@ public:
     TraversalDecision hit_test_all(CSSPixelPoint, DOM::Document const&, double device_pixels_per_css_pixel, ChromeMetrics const&, Function<TraversalDecision(HitTestResult)> const&) const;
 
 private:
-    HitTestDisplayList(u64 visual_context_tree_version, Layout::NodeArena&, ChromeWidgetRegistry&, u64 rust_generation);
+    HitTestDisplayList(u64 visual_context_tree_structural_epoch, Layout::NodeArena&, ChromeWidgetRegistry&, u64 rust_generation);
 
     struct Item {
         size_t item_index { 0 };
@@ -124,7 +124,7 @@ private:
     [[nodiscard]] Optional<CaretPosition> caret_position_for_hit_container(Item) const;
     [[nodiscard]] Optional<CaretPosition> caret_position_for_line(size_t line_index, CSSPixelPoint local_point, CaretPositionMode) const;
 
-    u64 m_visual_context_tree_version { 0 };
+    u64 m_visual_context_tree_structural_epoch { 0 };
     NonnullRefPtr<Layout::NodeArena> m_arena;
     NonnullRefPtr<ChromeWidgetRegistry> m_chrome_widget_registry;
     u64 m_rust_generation { 0 };

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -495,9 +495,14 @@ static void* layout_arena_handle(DOM::Document const& document)
     return const_cast<DOM::Document&>(document).layout_node_arena().handle();
 }
 
-bool rust_assign_accumulated_visual_contexts(DOM::Document& document, bool forced_incompatible_rebuild)
+VisualContextTreeUpdateResult rust_update_accumulated_visual_contexts(DOM::Document& document, bool force_full_rebuild)
 {
-    return Layout::RustFFI::layout_arena_assign_accumulated_visual_contexts(layout_arena_handle(document), viewport_row_slot(document), visual_context_host_callbacks(document), forced_incompatible_rebuild);
+    auto outcome = Layout::RustFFI::layout_arena_update_accumulated_visual_contexts(layout_arena_handle(document), viewport_row_slot(document), visual_context_host_callbacks(document), force_full_rebuild);
+    return {
+        .performed_full_build = outcome.performed_full_build,
+        .structural_epoch_changed = outcome.structural_epoch_changed,
+        .requires_display_list_recording = outcome.requires_display_list_recording,
+    };
 }
 
 void const* retain_rust_main_visual_context_tree(DOM::Document const& document)
@@ -505,11 +510,6 @@ void const* retain_rust_main_visual_context_tree(DOM::Document const& document)
     auto const* tree = Layout::RustFFI::layout_arena_main_visual_context_tree_retain(layout_arena_handle(document));
     VERIFY(tree);
     return tree;
-}
-
-bool rust_update_accumulated_visual_context_values(DOM::Document& document, Layout::RustFFI::NodeSlotId paintable_slot)
-{
-    return Layout::RustFFI::layout_arena_update_visual_context_values(layout_arena_handle(document), paintable_slot, visual_context_host_callbacks(document));
 }
 
 Optional<TransformWithOrigin> rust_compute_css_transform(Layout::Node const& box, double pixel_ratio)
@@ -1268,6 +1268,7 @@ RefPtr<DisplayList> record_rust_display_list(DOM::Document& document, DisplayLis
     inputs.is_recording_async_scrolling_metadata = true;
     inputs.document_id = document.unique_id().value();
     inputs.has_blocking_wheel_event_region_covering_viewport = wheel_event_region_state.has_blocking_wheel_event_region_covering_viewport;
+    inputs.wheel_event_listener_state_generation = document.page().wheel_event_listener_state_generation();
     inputs.viewport_wheel_overflow_x = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)));
     inputs.viewport_wheel_overflow_y = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)));
     inputs.chrome_metrics = document.page().chrome_metrics();

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -497,7 +497,10 @@ static void* layout_arena_handle(DOM::Document const& document)
 
 VisualContextTreeUpdateResult rust_update_accumulated_visual_contexts(DOM::Document& document, bool force_full_rebuild)
 {
+    auto update_timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
     auto outcome = Layout::RustFFI::layout_arena_update_accumulated_visual_contexts(layout_arena_handle(document), viewport_row_slot(document), visual_context_host_callbacks(document), force_full_rebuild);
+    if (rust_painting_timing_enabled())
+        dbgln("AVC_UPDATE rust={} µs {}", update_timer.elapsed_time().to_microseconds(), outcome.performed_full_build ? "full"sv : "incremental"sv);
     return {
         .performed_full_build = outcome.performed_full_build,
         .structural_epoch_changed = outcome.structural_epoch_changed,

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -25,9 +25,13 @@ struct ImagePaint;
 WEB_API void rust_build_stacking_context_tree(DOM::Document&);
 WEB_API void dump_stacking_context_tree(StringBuilder&, DOM::Document const&);
 
-WEB_API bool rust_assign_accumulated_visual_contexts(DOM::Document&, bool forced_incompatible_rebuild);
+struct VisualContextTreeUpdateResult {
+    bool performed_full_build { false };
+    bool structural_epoch_changed { false };
+    bool requires_display_list_recording { false };
+};
+WEB_API VisualContextTreeUpdateResult rust_update_accumulated_visual_contexts(DOM::Document&, bool force_full_rebuild);
 WEB_API void const* retain_rust_main_visual_context_tree(DOM::Document const&);
-WEB_API bool rust_update_accumulated_visual_context_values(DOM::Document&, Layout::RustFFI::NodeSlotId);
 WEB_API Optional<TransformWithOrigin> rust_compute_css_transform(Layout::Node const&, double pixel_ratio);
 WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_directions(Layout::Node const&);
 WEB_API void rust_measure_scrollable_overflow(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
@@ -65,10 +65,10 @@ FrameNodeIndex VisualContextTreeTestBuilder::append_effects_frame(FrameNodeIndex
     return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_effects_frame(m_builder, parent.value(), spatial.value(), opacity, blend_mode) };
 }
 
-AccumulatedVisualContextTree VisualContextTreeTestBuilder::finish_with_version(u64 version)
+AccumulatedVisualContextTree VisualContextTreeTestBuilder::finish_with_structural_epoch(u64 structural_epoch)
 {
     VERIFY(m_builder);
-    Layout::RustFFI::visual_context_tree_test_builder_set_version(m_builder, version);
+    Layout::RustFFI::visual_context_tree_test_builder_set_structural_epoch(m_builder, structural_epoch);
     return finish();
 }
 

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
@@ -54,7 +54,7 @@ public:
     FrameNodeIndex append_effects_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal);
 
     AccumulatedVisualContextTree finish();
-    AccumulatedVisualContextTree finish_with_version(u64 version);
+    AccumulatedVisualContextTree finish_with_structural_epoch(u64 structural_epoch);
 
 private:
     void* m_builder { nullptr };

--- a/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
@@ -26,14 +26,11 @@ impl CommandRange {
 pub struct ContextRewrite {
     pub recorded_context: ContextRef,
     pub current_context: ContextRef,
-    pub recorded_local_frame_range: (u32, u32),
-    pub current_local_frame_range: (u32, u32),
 }
 
 impl ContextRewrite {
     fn is_identity(&self) -> bool {
         self.recorded_context == self.current_context
-            && self.recorded_local_frame_range.0 == self.current_local_frame_range.0
     }
 
     fn rewrite(&self, context: ContextRef) -> ContextRef {
@@ -42,15 +39,11 @@ impl ContextRewrite {
         } else {
             context.spatial
         };
-        let (recorded_begin, recorded_end) = self.recorded_local_frame_range;
-        let frame =
-            if context.frame != FrameNodeIndex::NONE && (recorded_begin..recorded_end).contains(&context.frame.0) {
-                FrameNodeIndex(context.frame.0 - recorded_begin + self.current_local_frame_range.0)
-            } else if context.frame == self.recorded_context.frame {
-                self.current_context.frame
-            } else {
-                context.frame
-            };
+        let frame = if context.frame == self.recorded_context.frame {
+            self.current_context.frame
+        } else {
+            context.frame
+        };
         ContextRef { spatial, frame }
     }
 }
@@ -271,8 +264,6 @@ mod tests {
         ContextRewrite {
             recorded_context: recorded,
             current_context: current,
-            recorded_local_frame_range: (0, 0),
-            current_local_frame_range: (0, 0),
         }
     }
 
@@ -383,48 +374,30 @@ mod tests {
     }
 
     #[test]
-    fn a_spliced_capture_rebases_the_frames_of_its_own_range() {
+    fn a_spliced_capture_leaves_frames_other_than_the_phase_frame_untouched() {
         let mut source = DisplayListBuilder::new();
         source.append(&fill_rect(0, 0, 10, 10), &[], context(2, Some(5)));
         source.append(&fill_rect(20, 20, 10, 10), &[], context(2, Some(6)));
-        source.append(&fill_rect(40, 40, 10, 10), &[], context(2, None));
+        source.append(&fill_rect(40, 40, 10, 10), &[], context(2, Some(1)));
+        source.append(&fill_rect(60, 60, 10, 10), &[], context(2, None));
 
         let mut builder = DisplayListBuilder::new();
         builder.append_command_range(
             source.bytes(),
             whole_tape(&source),
-            Some(ContextRewrite {
-                recorded_context: context(2, Some(5)),
-                current_context: context(3, Some(11)),
-                recorded_local_frame_range: (4, 8),
-                current_local_frame_range: (10, 14),
-            }),
+            Some(rewrite(context(2, Some(1)), context(3, Some(7)))),
         );
         assert_eq!(
             header_contexts(&builder),
-            vec![context(3, Some(11)), context(3, Some(12)), context(3, None)]
+            vec![
+                context(3, Some(5)),
+                context(3, Some(6)),
+                context(3, Some(7)),
+                context(3, None)
+            ]
         );
         assert_runs_cover_tape(&builder);
-        assert_eq!(builder.command_runs().len(), 3);
-    }
-
-    #[test]
-    fn a_spliced_phase_frame_outside_the_range_maps_to_the_current_phase_frame() {
-        let mut source = DisplayListBuilder::new();
-        source.append(&fill_rect(0, 0, 10, 10), &[], context(2, Some(1)));
-
-        let mut builder = DisplayListBuilder::new();
-        builder.append_command_range(
-            source.bytes(),
-            whole_tape(&source),
-            Some(ContextRewrite {
-                recorded_context: context(2, Some(1)),
-                current_context: context(2, Some(3)),
-                recorded_local_frame_range: (7, 7),
-                current_local_frame_range: (9, 9),
-            }),
-        );
-        assert_eq!(header_contexts(&builder), vec![context(2, Some(3))]);
+        assert_eq!(builder.command_runs().len(), 4);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -206,9 +206,12 @@ fn frame_data_is_equal(a: &FrameData, b: &FrameData) -> bool {
 }
 
 fn spatial_depths(tree: &VisualContextTree) -> Vec<u32> {
-    let mut depths: Vec<u32> = Vec::with_capacity(tree.spatial_nodes.len());
-    for (i, node) in tree.spatial_nodes.iter().enumerate() {
-        depths.push(if i == 0 { 0 } else { depths[node.parent.0 as usize] + 1 });
+    let mut depths: Vec<u32> = vec![0; tree.spatial_nodes.len()];
+    for index in tree.spatial_dependency_order() {
+        if index == VISUAL_VIEWPORT_NODE_INDEX.0 {
+            continue;
+        }
+        depths[index as usize] = depths[tree.spatial_nodes[index as usize].parent.0 as usize] + 1;
     }
     depths
 }
@@ -572,13 +575,15 @@ pub fn compute_display_list_damage(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::node_data::NodeSlotId;
     use crate::painting::display_list::commands::{
         CanvasId, CompositorMainThreadWheelEventRegion, DisplayListCommand, DisplayListGlyph, DrawCanvas, FillRect,
         FontResourceId, FrameNodeIndex, ImageFrameResourceId,
     };
     use crate::painting::display_list::ffi_bytes::FfiBytes;
+    use crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT;
     use crate::painting::visual_context::{
-        ClipData, ClipMode, EffectsData, FrameData, MaskData, MaskLayerOrigin, SpatialData, TransformData,
+        ClipData, ClipMode, EffectsData, FrameData, MaskData, MaskLayerOrigin, ScrollData, SpatialData, TransformData,
         TransformDataRole,
     };
     use libgfx_rust::{
@@ -728,6 +733,54 @@ mod tests {
 
     fn context_in(spatial: SpatialNodeIndex, frame: FrameNodeIndex) -> ContextRef {
         ContextRef { spatial, frame }
+    }
+
+    #[test]
+    fn a_child_stored_below_its_parent_damages_like_the_in_order_tree() {
+        let mut in_order = identity_tree();
+        let in_order_scroll = in_order.append_spatial(
+            SpatialData::Scroll(ScrollData {
+                state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let in_order_transform = in_order.append_spatial(
+            SpatialData::Transform(transform(FloatMatrix4x4::identity())),
+            in_order_scroll,
+        );
+
+        let mut permuted = identity_tree();
+        let permuted_transform = permuted.append_spatial(
+            SpatialData::Transform(transform(FloatMatrix4x4::identity())),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let permuted_scroll = permuted.append_spatial(
+            SpatialData::Scroll(ScrollData {
+                state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        permuted.spatial_nodes[permuted_transform.0 as usize].parent = permuted_scroll;
+
+        let rect = IntRect::new(10, 10, 20, 20);
+        let old_commands = command_bytes(
+            &FillRect { rect, color: RED },
+            Some(rect),
+            context_in(in_order_transform, FrameNodeIndex::NONE),
+        );
+        let new_commands = command_bytes(
+            &FillRect { rect, color: RED },
+            Some(rect),
+            context_in(permuted_transform, FrameNodeIndex::NONE),
+        );
+        assert_eq!(
+            damage(&old_commands, &in_order, &new_commands, &permuted),
+            Some(IntRect::default())
+        );
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/display_list/depth_sorted_plan.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/depth_sorted_plan.rs
@@ -448,7 +448,8 @@ mod tests {
     use crate::painting::visual_context::resolve_sorting_contexts_over_nodes;
 
     fn sorting_contexts(parents: &[u32], sorting_context_roots: &[Option<u32>]) -> SortingContexts {
-        resolve_sorting_contexts_over_nodes(parents.len(), |index| {
+        let index_order: Vec<u32> = (0..parents.len() as u32).collect();
+        resolve_sorting_contexts_over_nodes(parents.len(), &index_order, |index| {
             (
                 SpatialNodeIndex(parents[index]),
                 sorting_context_roots[index].map(SpatialNodeIndex),

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -277,6 +277,10 @@ impl DisplayListRecorder {
         self.builder.byte_size()
     }
 
+    pub fn bytes(&self) -> &[u8] {
+        self.builder.bytes()
+    }
+
     pub fn accumulated_visual_context(&self) -> ContextRef {
         self.context
     }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -299,8 +299,6 @@ impl DisplayListRecorder {
         source: &[u8],
         range: CommandRange,
         recorded_context: ContextRef,
-        recorded_local_frame_range: (u32, u32),
-        current_local_frame_range: (u32, u32),
     ) -> CommandRange {
         let offset = self.builder.append_command_range(
             source,
@@ -308,8 +306,6 @@ impl DisplayListRecorder {
             Some(ContextRewrite {
                 recorded_context,
                 current_context: self.context,
-                recorded_local_frame_range,
-                current_local_frame_range,
             }),
         );
         CommandRange {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -139,22 +139,33 @@ fn replay_mask_of(mask: &crate::painting::visual_context::MaskData) -> ReplayMas
     }
 }
 
-impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
-    fn build_transform_palette(&mut self, scroll_offsets: &[FloatPoint]) {
-        let tree = self.tree;
-        let spatial_nodes = &tree.spatial_nodes;
-        let palette = &mut self.palette;
-        palette.to_root_matrices.reserve(spatial_nodes.len());
-        palette.local_matrices.reserve(spatial_nodes.len());
-        palette.draw_spaces.reserve(spatial_nodes.len());
-        palette.backface_culled.reserve(spatial_nodes.len());
-        palette.flattens_inherited_transform.reserve(spatial_nodes.len());
-        let replay_base_matrix = self.replay_base_matrix;
-        for (i, node) in spatial_nodes.iter().enumerate() {
-            let parent = node.parent.0 as usize;
-            let append_spatial = |palette: &mut ReplayPaletteStorage,
-                                  local_matrix: FloatMatrix4x4,
-                                  flattens_inherited_transform: bool| {
+fn fill_replay_palette_in_dependency_order(
+    tree: &VisualContextTree,
+    scroll_offsets: &[FloatPoint],
+    replay_base_matrix: FloatMatrix4x4,
+    palette: &mut ReplayPaletteStorage,
+) {
+    let spatial_nodes = &tree.spatial_nodes;
+    palette.to_root_matrices.clear();
+    palette.to_root_matrices.resize(spatial_nodes.len(), replay_base_matrix);
+    palette.local_matrices.clear();
+    palette
+        .local_matrices
+        .resize(spatial_nodes.len(), FloatMatrix4x4::identity());
+    palette.draw_spaces.clear();
+    palette
+        .draw_spaces
+        .extend((0..spatial_nodes.len()).map(|index| SpatialNodeIndex(index as u32)));
+    palette.backface_culled.clear();
+    palette.backface_culled.resize(spatial_nodes.len(), false);
+    palette.flattens_inherited_transform.clear();
+    palette.flattens_inherited_transform.resize(spatial_nodes.len(), false);
+    for index in tree.spatial_dependency_order() {
+        let i = index as usize;
+        let node = &spatial_nodes[i];
+        let parent = node.parent.0 as usize;
+        let write_spatial =
+            |palette: &mut ReplayPaletteStorage, local_matrix: FloatMatrix4x4, flattens_inherited_transform: bool| {
                 let parent_matrix = if i == 0 {
                     replay_base_matrix
                 } else {
@@ -165,75 +176,67 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                 } else {
                     parent_matrix
                 };
-                palette.to_root_matrices.push(inherited.multiplied(local_matrix));
-                palette.local_matrices.push(local_matrix);
-                palette.flattens_inherited_transform.push(flattens_inherited_transform);
-                palette.draw_spaces.push(SpatialNodeIndex(i as u32));
-                palette
-                    .backface_culled
-                    .push(if i == 0 { false } else { palette.backface_culled[parent] });
+                palette.to_root_matrices[i] = inherited.multiplied(local_matrix);
+                palette.local_matrices[i] = local_matrix;
+                palette.flattens_inherited_transform[i] = flattens_inherited_transform;
+                palette.draw_spaces[i] = SpatialNodeIndex(index);
+                palette.backface_culled[i] = if i == 0 { false } else { palette.backface_culled[parent] };
             };
-            let append_spatial_translation = |palette: &mut ReplayPaletteStorage, offset: FloatPoint| {
-                // Whole device pixels, so scrolled content never lands on subpixel positions.
-                append_spatial(
+        let write_spatial_translation = |palette: &mut ReplayPaletteStorage, offset: FloatPoint| {
+            // Whole device pixels, so scrolled content never lands on subpixel positions.
+            write_spatial(
+                palette,
+                translation_matrix(offset.x as i32 as f32, offset.y as i32 as f32, 0.0),
+                false,
+            );
+        };
+        match &node.data {
+            SpatialData::Transform(transform) => {
+                write_spatial(
                     palette,
-                    translation_matrix(offset.x as i32 as f32, offset.y as i32 as f32, 0.0),
-                    false,
+                    transform.matrix_including_origin(),
+                    transform.flattens_inherited_transform,
                 );
-            };
-            match &node.data {
-                SpatialData::Transform(transform) => {
-                    append_spatial(
-                        palette,
-                        transform.matrix_including_origin(),
-                        transform.flattens_inherited_transform,
-                    );
-                    if transform.sorting_context_root_index.is_some() || transform.establishes_sorting_context {
-                        *palette
-                            .backface_culled
-                            .last_mut()
-                            .expect("the transform's own entry was just appended") = false;
-                    }
-                }
-                SpatialData::Perspective(perspective) => {
-                    append_spatial(palette, perspective.matrix, perspective.flattens_inherited_transform);
-                }
-                SpatialData::BackfaceVisibility(backface) => {
-                    let parent_matrix = palette.to_root_matrices[parent];
-                    palette.to_root_matrices.push(if backface.flattens_inherited_transform {
-                        parent_matrix.flattened()
-                    } else {
-                        parent_matrix
-                    });
-                    palette.local_matrices.push(FloatMatrix4x4::identity());
-                    palette
-                        .flattens_inherited_transform
-                        .push(backface.flattens_inherited_transform);
-                    palette.draw_spaces.push(palette.draw_spaces[parent]);
-                    let mut culled = palette.backface_culled[parent];
-                    if !culled {
-                        let plane_root_matrix = palette.to_root_matrices[backface.plane_root_index.0 as usize];
-                        culled = should_cull_back_face(
-                            *palette
-                                .to_root_matrices
-                                .last()
-                                .expect("the marker's own entry was just appended"),
-                            plane_root_matrix,
-                        );
-                    }
-                    palette.backface_culled.push(culled);
-                }
-                SpatialData::Scroll(_) | SpatialData::Sticky(_) => {
-                    append_spatial_translation(
-                        palette,
-                        device_offset_for_index(scroll_offsets, SpatialNodeIndex(i as u32)),
-                    );
-                }
-                SpatialData::AnchorScrollShift(shift) => {
-                    append_spatial_translation(palette, shift.masked_offset(scroll_offsets));
+                if transform.sorting_context_root_index.is_some() || transform.establishes_sorting_context {
+                    palette.backface_culled[i] = false;
                 }
             }
+            SpatialData::Perspective(perspective) => {
+                write_spatial(palette, perspective.matrix, perspective.flattens_inherited_transform);
+            }
+            SpatialData::BackfaceVisibility(backface) => {
+                let parent_matrix = palette.to_root_matrices[parent];
+                palette.to_root_matrices[i] = if backface.flattens_inherited_transform {
+                    parent_matrix.flattened()
+                } else {
+                    parent_matrix
+                };
+                palette.local_matrices[i] = FloatMatrix4x4::identity();
+                palette.flattens_inherited_transform[i] = backface.flattens_inherited_transform;
+                palette.draw_spaces[i] = palette.draw_spaces[parent];
+                let mut culled = palette.backface_culled[parent];
+                if !culled {
+                    let plane_root_matrix = palette.to_root_matrices[backface.plane_root_index.0 as usize];
+                    culled = should_cull_back_face(palette.to_root_matrices[i], plane_root_matrix);
+                }
+                palette.backface_culled[i] = culled;
+            }
+            SpatialData::Scroll(_) | SpatialData::Sticky(_) => {
+                write_spatial_translation(
+                    palette,
+                    device_offset_for_index(scroll_offsets, SpatialNodeIndex(index)),
+                );
+            }
+            SpatialData::AnchorScrollShift(shift) => {
+                write_spatial_translation(palette, shift.masked_offset(scroll_offsets));
+            }
         }
+    }
+}
+
+impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
+    fn build_transform_palette(&mut self, scroll_offsets: &[FloatPoint]) {
+        fill_replay_palette_in_dependency_order(self.tree, scroll_offsets, self.replay_base_matrix, &mut self.palette);
     }
 
     fn ensure_ctm_space(&mut self, spatial: SpatialNodeIndex) {
@@ -482,6 +485,94 @@ mod tests {
     use libgfx_rust::{
         CompositingAndBlendingOperator, CornerRadii, FloatRect, MaskKind, scale_matrix, translation_matrix,
     };
+
+    #[test]
+    fn a_child_stored_below_its_parent_gets_the_same_palette_entry() {
+        let root = TransformData {
+            matrix: FloatMatrix4x4::identity(),
+            origin: FloatPoint::default(),
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        };
+        let translated = |x: f32, y: f32| {
+            SpatialData::Transform(TransformData {
+                matrix: translation_matrix(x, y, 0.0),
+                ..root
+            })
+        };
+        let flipped = SpatialData::Transform(TransformData {
+            matrix: scale_matrix(-1.0, 1.0, -1.0),
+            ..root
+        });
+
+        let mut in_order = VisualContextTree::create(root);
+        let parent = in_order.append_spatial(translated(10.0, 0.0), VISUAL_VIEWPORT_NODE_INDEX);
+        let child = in_order.append_spatial(translated(0.0, 5.0), parent);
+        let plane = in_order.append_spatial(flipped.clone(), child);
+        let marker = in_order.append_spatial(
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: child,
+                flattens_inherited_transform: false,
+            }),
+            plane,
+        );
+
+        let mut permuted = VisualContextTree::create(root);
+        let permuted_marker = permuted.append_spatial(
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: SpatialNodeIndex(3),
+                flattens_inherited_transform: false,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let permuted_plane = permuted.append_spatial(flipped, VISUAL_VIEWPORT_NODE_INDEX);
+        let permuted_child = permuted.append_spatial(translated(0.0, 5.0), VISUAL_VIEWPORT_NODE_INDEX);
+        let permuted_parent = permuted.append_spatial(translated(10.0, 0.0), VISUAL_VIEWPORT_NODE_INDEX);
+        permuted.spatial_nodes[permuted_marker.0 as usize].parent = permuted_plane;
+        permuted.spatial_nodes[permuted_plane.0 as usize].parent = permuted_child;
+        permuted.spatial_nodes[permuted_child.0 as usize].parent = permuted_parent;
+
+        let base = scale_matrix(2.0, 2.0, 1.0);
+        let mut in_order_palette = ReplayPaletteStorage::default();
+        fill_replay_palette_in_dependency_order(&in_order, &[], base, &mut in_order_palette);
+        let mut permuted_palette = ReplayPaletteStorage::default();
+        fill_replay_palette_in_dependency_order(&permuted, &[], base, &mut permuted_palette);
+        let pairs = [
+            (VISUAL_VIEWPORT_NODE_INDEX, VISUAL_VIEWPORT_NODE_INDEX),
+            (parent, permuted_parent),
+            (child, permuted_child),
+            (plane, permuted_plane),
+            (marker, permuted_marker),
+        ];
+        let map = |index: SpatialNodeIndex| pairs.iter().find(|(original, _)| *original == index).unwrap().1;
+        for (original, mapped) in pairs {
+            assert_eq!(
+                permuted_palette.to_root_matrices[mapped.0 as usize],
+                in_order_palette.to_root_matrices[original.0 as usize]
+            );
+            assert_eq!(
+                permuted_palette.local_matrices[mapped.0 as usize],
+                in_order_palette.local_matrices[original.0 as usize]
+            );
+            assert_eq!(
+                permuted_palette.draw_spaces[mapped.0 as usize],
+                map(in_order_palette.draw_spaces[original.0 as usize])
+            );
+            assert_eq!(
+                permuted_palette.backface_culled[mapped.0 as usize],
+                in_order_palette.backface_culled[original.0 as usize]
+            );
+            assert_eq!(
+                permuted_palette.flattens_inherited_transform[mapped.0 as usize],
+                in_order_palette.flattens_inherited_transform[original.0 as usize]
+            );
+        }
+        assert!(in_order_palette.backface_culled[marker.0 as usize]);
+        assert_eq!(in_order_palette.draw_spaces[marker.0 as usize], plane);
+    }
 
     #[derive(Debug, PartialEq)]
     enum PainterEvent {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -230,6 +230,7 @@ fn fill_replay_palette_in_dependency_order(
             SpatialData::AnchorScrollShift(shift) => {
                 write_spatial_translation(palette, shift.masked_offset(scroll_offsets));
             }
+            SpatialData::Dead => {}
         }
     }
 }
@@ -333,6 +334,7 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                     self.painter.push_mask(&replay_mask_of(mask));
                     self.applied_mask_frame_count += 1;
                 }
+                FrameData::Dead => unreachable!("a run never records under a tombstoned frame"),
             }
             self.applied_frames.push(frame_index);
         }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -473,6 +473,7 @@ pub fn replay_display_list(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::node_data::NodeSlotId;
     use crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX;
     use crate::painting::visual_context::{
         BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, MaskData, MaskLayerOrigin, SpatialData,
@@ -729,6 +730,8 @@ mod tests {
         let scroll_node = tree.append_spatial(
             SpatialData::Scroll(crate::painting::visual_context::ScrollData {
                 state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -964,9 +964,10 @@ pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
                 .tree
                 .as_deref()
                 .is_some_and(|previous| tree.is_compatible_with(previous));
-        tree.reused_previous_version = is_compatible;
         if is_compatible {
-            tree.version = state.tree_version();
+            tree.structural_epoch = state.structural_epoch();
+        } else {
+            arena.mark_all_paint_caches_dirty();
         }
         state.tree = Some(Rc::new(tree));
         state.paintables_with_mask_nodes = paintables_with_mask_nodes;
@@ -1203,19 +1204,11 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
         let mut paint_state = arena.paint_state().borrow_mut();
         paint_state.hit_test_list_generation += 1;
         debug_assert_eq!(output.hit_test_list.generation, paint_state.hit_test_list_generation);
-        if paint_state
-            .hit_test_item_cache_source
-            .as_ref()
-            .is_some_and(|source| source.visual_context_tree_version != output.compatible_visual_context_tree_version)
-        {
-            paint_state.hit_test_item_cache_source = None;
-        }
         let list = std::mem::take(&mut output.hit_test_list);
         if inputs.paint_command_cache_read_write {
             paint_state.hit_test_item_cache_source = Some(std::rc::Rc::new(
                 crate::painting::record::cache::HitTestItemCacheSource {
                     id: list.generation,
-                    visual_context_tree_version: output.compatible_visual_context_tree_version,
                     items: list.items.clone(),
                 },
             ));
@@ -2293,11 +2286,11 @@ pub unsafe extern "C" fn layout_arena_has_visual_context_tree(arena: *mut c_void
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_visual_context_tree_version(arena: *mut c_void) -> u64 {
+pub unsafe extern "C" fn layout_arena_visual_context_tree_structural_epoch(arena: *mut c_void) -> u64 {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
         let paint_state = arena.paint_state().borrow();
-        paint_state.visual_context.tree_version()
+        paint_state.visual_context.structural_epoch()
     })
 }
 
@@ -2332,8 +2325,8 @@ pub unsafe extern "C" fn visual_context_tree_release(tree: *const c_void) {
 ///
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_version(tree: *const c_void) -> u64 {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.version)
+pub unsafe extern "C" fn visual_context_tree_structural_epoch(tree: *const c_void) -> u64 {
+    abort_on_panic(|| unsafe { tree_from_handle(tree) }.structural_epoch)
 }
 
 /// # Safety
@@ -2594,7 +2587,7 @@ pub unsafe extern "C" fn visual_context_tree_visual_viewport_transform(
 /// # Safety
 ///
 /// `tree` must be a live retained tree handle. Returns a retained handle to a copy of the tree whose
-/// visual viewport node carries the given transform; the copy keeps the version.
+/// visual viewport node carries the given transform; the copy keeps the structural epoch.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_with_visual_viewport_transform(
     tree: *const c_void,
@@ -2611,7 +2604,7 @@ pub unsafe extern "C" fn visual_context_tree_with_visual_viewport_transform(
 ///
 /// `tree` must be a live retained tree handle; `frame_opacities` must address `frame_opacity_count`
 /// samples and `spatial_matrices` `spatial_matrix_count` samples. Returns a retained handle to a copy
-/// of the tree carrying the sampled values; the copy keeps the version.
+/// of the tree carrying the sampled values; the copy keeps the structural epoch.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     tree: *const c_void,
@@ -2983,12 +2976,15 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_effects_frame(
 /// # Safety
 ///
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`. Gives the tree
-/// the version another tree carries, so a test can stage a compatible tree-only update.
+/// the structural epoch another tree carries, so a test can stage a compatible tree-only update.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn visual_context_tree_test_builder_set_version(builder: *mut c_void, version: u64) {
+pub unsafe extern "C" fn visual_context_tree_test_builder_set_structural_epoch(
+    builder: *mut c_void,
+    structural_epoch: u64,
+) {
     abort_on_panic(|| {
         let tree = unsafe { test_builder_tree(builder) };
-        tree.version = version;
+        tree.structural_epoch = structural_epoch;
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -853,6 +853,71 @@ pub unsafe extern "C" fn layout_arena_physical_overflow_directions(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_visual_context_note_box_dirty(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    kind: crate::painting::host::FfiVisualContextBoxDirtyKind,
+) {
+    abort_on_panic(|| {
+        use crate::painting::host::FfiVisualContextBoxDirtyKind;
+        use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
+        let arena = unsafe { arena_from_handle(arena) };
+        if !arena.paintable_row_is_populated(slot) {
+            return;
+        }
+        let kind = match kind {
+            FfiVisualContextBoxDirtyKind::StyleValueChange => VisualContextBoxDirtyKind::StyleValueChange,
+            FfiVisualContextBoxDirtyKind::StyleStructuralChange => VisualContextBoxDirtyKind::StyleStructuralChange,
+            FfiVisualContextBoxDirtyKind::ScrollableOverflowFlipped => {
+                VisualContextBoxDirtyKind::ScrollableOverflowFlipped
+            }
+        };
+        arena.note_visual_context_box_dirty(slot, kind);
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_visual_context_request_full_rebuild(
+    arena: *mut c_void,
+    reason: crate::painting::host::FfiVisualContextGlobalRebuildReason,
+) {
+    abort_on_panic(|| {
+        use crate::painting::host::FfiVisualContextGlobalRebuildReason;
+        use crate::painting::visual_context::dirty::VisualContextGlobalRebuildReason;
+        let arena = unsafe { arena_from_handle(arena) };
+        let reason = match reason {
+            FfiVisualContextGlobalRebuildReason::FirstBuild => VisualContextGlobalRebuildReason::FirstBuild,
+            FfiVisualContextGlobalRebuildReason::DocumentWideStructuralChange => {
+                VisualContextGlobalRebuildReason::DocumentWideStructuralChange
+            }
+            FfiVisualContextGlobalRebuildReason::FilterResourcesChanged => {
+                VisualContextGlobalRebuildReason::FilterResourcesChanged
+            }
+            FfiVisualContextGlobalRebuildReason::ForcedForTesting => VisualContextGlobalRebuildReason::ForcedForTesting,
+        };
+        arena.request_full_visual_context_rebuild(reason);
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_visual_context_pending_dirty_box_count(arena: *mut c_void) -> usize {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paint_state = arena.paint_state().borrow();
+        paint_state.visual_context.dirty_boxes.boxes.len()
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_visual_context_node_count(
     arena: *mut c_void,
     slot: NodeSlotId,
@@ -974,6 +1039,7 @@ pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
         state.scroll_state = scroll_state;
         state.scroll_state_snapshot.clear();
         state.needs_to_refresh_scroll_state = true;
+        state.dirty_boxes.clear();
         if assignments_changed {
             arena.mark_all_descendant_subtree_caches_dirty();
         }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -2386,6 +2386,47 @@ pub unsafe extern "C" fn visual_context_tree_frame_node_count(tree: *const c_voi
 
 /// # Safety
 ///
+/// `tree` must be a live retained tree handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn visual_context_tree_live_spatial_node_count(tree: *const c_void) -> usize {
+    abort_on_panic(|| unsafe { tree_from_handle(tree) }.live_spatial_node_count as usize)
+}
+
+/// # Safety
+///
+/// `tree` must be a live retained tree handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn visual_context_tree_live_frame_node_count(tree: *const c_void) -> usize {
+    abort_on_panic(|| unsafe { tree_from_handle(tree) }.live_frame_node_count as usize)
+}
+
+/// # Safety
+///
+/// `tree` must be a live retained tree handle; `command_runs` must address `command_run_count`
+/// runs and `mask_frames` `mask_frame_count` frame indices for the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn display_list_references_only_live_visual_context_nodes(
+    tree: *const c_void,
+    command_runs: *const crate::painting::display_list::commands::DisplayListCommandRun,
+    command_run_count: usize,
+    mask_frames: *const FrameNodeIndex,
+    mask_frame_count: usize,
+) -> bool {
+    abort_on_panic(|| {
+        let tree = unsafe { tree_from_handle(tree) };
+        // SAFETY: The caller guarantees the slices address the stated number of values.
+        let (command_runs, mask_frames) = unsafe {
+            (
+                ffi_slice(command_runs, command_run_count),
+                ffi_slice(mask_frames, mask_frame_count),
+            )
+        };
+        tree.display_list_references_only_live_nodes(command_runs, mask_frames)
+    })
+}
+
+/// # Safety
+///
 /// `tree` must be a live retained tree handle; `scroll_offsets` must address `scroll_offsets_len`
 /// points and `out_local_point` must be writable.
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -853,6 +853,52 @@ pub unsafe extern "C" fn layout_arena_physical_overflow_directions(
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_visual_context_node_count(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    list: crate::painting::host::FfiVisualContextBoxNodeList,
+) -> usize {
+    abort_on_panic(|| {
+        use crate::painting::host::FfiVisualContextBoxNodeList;
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.with_paintable_visual_context_node_handles(slot, |handles| match list {
+            FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.len(),
+            FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().count(),
+        })
+    })
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread; `out`
+/// must have room for `capacity` indices.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_paintable_visual_context_copy_node_indices(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    list: crate::painting::host::FfiVisualContextBoxNodeList,
+    out: *mut u32,
+    capacity: usize,
+) {
+    abort_on_panic(|| {
+        use crate::painting::host::FfiVisualContextBoxNodeList;
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.with_paintable_visual_context_node_handles(slot, |handles| {
+            let indices: Vec<u32> = match list {
+                FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.iter().map(|index| index.0).collect(),
+                FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().map(|index| index.0).collect(),
+            };
+            assert!(indices.len() <= capacity);
+            // SAFETY: the caller warrants `capacity` writable indices behind `out`.
+            unsafe { std::ptr::copy_nonoverlapping(indices.as_ptr(), out, indices.len()) };
+        });
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_build_stacking_context_tree(arena: *mut c_void, root: NodeSlotId) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle_mut(arena) };
@@ -2757,6 +2803,8 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_scroll(builder:
         tree.append_spatial(
             crate::painting::visual_context::SpatialData::Scroll(crate::painting::visual_context::ScrollData {
                 state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: SpatialNodeIndex(parent),
             }),
             SpatialNodeIndex(parent),
         )
@@ -2793,6 +2841,12 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_sticky(
                 inset_bottom: inset(constraints.inset_bottom),
                 inset_left: inset(constraints.inset_left),
                 state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: if constraints.has_parent_sticky {
+                    SpatialNodeIndex(constraints.parent_sticky)
+                } else {
+                    SpatialNodeIndex(constraints.scroller)
+                },
             }),
             SpatialNodeIndex(parent),
         )

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -981,69 +981,207 @@ pub unsafe extern "C" fn layout_arena_build_stacking_context_tree(arena: *mut c_
 
 use crate::painting::host::FfiVisualContextHostCallbacks;
 
+fn full_visual_context_build(
+    arena: *mut c_void,
+    viewport: NodeSlotId,
+    callbacks: &FfiVisualContextHostCallbacks,
+    state: &mut crate::painting::visual_context::VisualContextState,
+    force_incompatible_rebuild: bool,
+) -> crate::painting::host::FfiVisualContextUpdateOutcome {
+    let (mut tree, scroll_state, paintables_with_mask_nodes, previous_assignments, assignments) = {
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
+        let previous_assignments = paintable_rows.visual_context_assignments();
+        let (tree, scroll_state, paintables_with_mask_nodes, assignments) =
+            crate::painting::visual_context::build::build_visual_context_tree(&paintable_rows, callbacks, viewport);
+        (
+            tree,
+            scroll_state,
+            paintables_with_mask_nodes,
+            previous_assignments,
+            assignments,
+        )
+    };
+    let arena = unsafe { arena_from_handle_mut(arena) };
+    let assignments_changed = {
+        let mut paintable_rows = arena.paintable_rows_mut();
+        for assignment in assignments {
+            assignment.apply(&mut paintable_rows);
+        }
+        previous_assignments != paintable_rows.visual_context_assignments()
+    };
+    state.build_count += 1;
+    let is_compatible = !force_incompatible_rebuild
+        && state
+            .tree
+            .as_deref()
+            .is_some_and(|previous| tree.is_compatible_with(previous));
+    if is_compatible {
+        tree.structural_epoch = state.structural_epoch();
+    } else {
+        arena.mark_all_paint_caches_dirty();
+    }
+    let structural_epoch = tree.structural_epoch;
+    state.tree = Some(Rc::new(tree));
+    state.paintables_with_mask_nodes = paintables_with_mask_nodes;
+    state.scroll_state = scroll_state;
+    state.scroll_state_snapshot.clear();
+    state.needs_to_refresh_scroll_state = true;
+    state.dirty_boxes.clear();
+    state.quarantined_slots_are_releasable = false;
+    if assignments_changed {
+        arena.mark_all_descendant_subtree_caches_dirty();
+    }
+    crate::painting::host::FfiVisualContextUpdateOutcome {
+        performed_full_build: true,
+        structural_epoch_changed: !is_compatible,
+        requires_display_list_recording: !is_compatible,
+        structural_epoch,
+    }
+}
+
+fn paintables_with_mask_nodes_in_paint_order(
+    arena: &crate::layout::LayoutNodeArena,
+    viewport: NodeSlotId,
+) -> Vec<NodeSlotId> {
+    let paintable_rows = arena.paintable_rows();
+    let mut owners = Vec::new();
+    crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, viewport, |slot| {
+        if arena
+            .paintable_visual_context_record(slot)
+            .is_some_and(|record| record.has_mask_nodes)
+        {
+            owners.push(slot);
+        }
+    });
+    owners
+}
+
 /// # Safety
 ///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_assign_accumulated_visual_contexts(
+pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
     arena: *mut c_void,
     viewport: NodeSlotId,
     callbacks: FfiVisualContextHostCallbacks,
-    force_incompatible_rebuild: bool,
-) -> bool {
+    force_full_rebuild: bool,
+) -> crate::painting::host::FfiVisualContextUpdateOutcome {
     abort_on_panic(|| {
-        let (mut tree, scroll_state, paintables_with_mask_nodes, previous_assignments, assignments) = {
-            let arena = unsafe { arena_from_handle(arena) };
-            let paintable_rows = arena.paintable_rows();
-            if !paintable_rows.paintable_row_is_populated(viewport) {
-                return false;
+        use crate::painting::visual_context::dirty::{VisualContextBoxDirtyKind, VisualContextGlobalRebuildReason};
+        use crate::painting::visual_context::incremental::{
+            IncrementalUpdateResult, update_visual_context_tree_incrementally,
+        };
+        let arena_ref = unsafe { arena_from_handle(arena) };
+        if !arena_ref.paintable_row_is_populated(viewport) {
+            return crate::painting::host::FfiVisualContextUpdateOutcome::default();
+        }
+        let inputs = callbacks.tree_inputs();
+        let root_background_source = callbacks.root_background_source();
+        let mut state = std::mem::take(&mut arena_ref.paint_state().borrow_mut().visual_context);
+        state.release_quarantined_slots_while_no_handle_is_retained();
+
+        let mut reason = state.dirty_boxes.global_reason;
+        if state.tree.is_none() {
+            reason = reason.max(VisualContextGlobalRebuildReason::FirstBuild);
+        }
+        if force_full_rebuild {
+            reason = reason.max(VisualContextGlobalRebuildReason::ForcedForTesting);
+        }
+        if state.last_tree_inputs.is_some_and(|last| {
+            last.device_pixels_per_css_pixel != inputs.device_pixels_per_css_pixel
+                || last.viewport_wheel_overflow_x != inputs.viewport_wheel_overflow_x
+                || last.viewport_wheel_overflow_y != inputs.viewport_wheel_overflow_y
+        }) {
+            reason = reason.max(VisualContextGlobalRebuildReason::TreeInputsChanged);
+        }
+        if inputs.may_have_default_scroll_shift_anchor {
+            reason = reason.max(VisualContextGlobalRebuildReason::AnchorsRegistered);
+        }
+        if state.tree.as_deref().is_some_and(|tree| tree.should_compact()) {
+            reason = reason.max(VisualContextGlobalRebuildReason::Compaction);
+        }
+        if let Some(last_source) = state.last_root_background_source
+            && (last_source.use_body_background_properties != root_background_source.use_body_background_properties
+                || last_source.body_layout_node != root_background_source.body_layout_node)
+        {
+            for body in [last_source.body_layout_node, root_background_source.body_layout_node] {
+                if arena_ref.paintable_row_is_populated(body) {
+                    let pending_box_limit = arena_ref
+                        .paintable_row_count()
+                        .max(crate::painting::visual_context::dirty::MINIMUM_PENDING_DIRTY_BOX_LIMIT);
+                    state.dirty_boxes.note_box(
+                        body,
+                        VisualContextBoxDirtyKind::StyleStructuralChange,
+                        pending_box_limit,
+                    );
+                    if let Some(html) = crate::painting::paint_order::paint_parent(&arena_ref.paintable_rows(), body) {
+                        state.dirty_boxes.note_box(
+                            html,
+                            VisualContextBoxDirtyKind::StyleStructuralChange,
+                            pending_box_limit,
+                        );
+                    }
+                }
             }
-            let previous_assignments = paintable_rows.visual_context_assignments();
-            let (tree, scroll_state, paintables_with_mask_nodes, assignments) =
-                crate::painting::visual_context::build::build_visual_context_tree(
+        }
+        let allow_structural_changes = false;
+        if reason == VisualContextGlobalRebuildReason::None && !state.dirty_boxes.is_value_only() {
+            reason = VisualContextGlobalRebuildReason::StructuralDirtyBoxes;
+        }
+
+        if reason == VisualContextGlobalRebuildReason::None {
+            let result = {
+                let paintable_rows = arena_ref.paintable_rows();
+                update_visual_context_tree_incrementally(
                     &paintable_rows,
                     &callbacks,
                     viewport,
-                );
-            (
-                tree,
-                scroll_state,
-                paintables_with_mask_nodes,
-                previous_assignments,
-                assignments,
-            )
-        };
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let assignments_changed = {
-            let mut paintable_rows = arena.paintable_rows_mut();
-            for assignment in assignments {
-                assignment.apply(&mut paintable_rows);
+                    inputs,
+                    root_background_source,
+                    &mut state,
+                    allow_structural_changes,
+                )
+            };
+            match result {
+                IncrementalUpdateResult::Applied(outcome) => {
+                    let arena_mut = unsafe { arena_from_handle_mut(arena) };
+                    {
+                        let mut paintable_rows = arena_mut.paintable_rows_mut();
+                        for assignment in outcome.assignments {
+                            assignment.apply(&mut paintable_rows);
+                        }
+                    }
+                    if outcome.mask_node_owners_changed {
+                        state.paintables_with_mask_nodes =
+                            paintables_with_mask_nodes_in_paint_order(arena_mut, viewport);
+                    }
+                    let structural_epoch_changed = outcome.delta.structural_epoch_changed;
+                    let requires_display_list_recording = outcome.delta.requires_display_list_recording;
+                    state.dirty_boxes.clear();
+                    state.incremental_update_count += 1;
+                    state.last_tree_inputs = Some(inputs);
+                    state.last_root_background_source = Some(root_background_source);
+                    let structural_epoch = state.structural_epoch();
+                    arena_mut.paint_state().borrow_mut().visual_context = state;
+                    return crate::painting::host::FfiVisualContextUpdateOutcome {
+                        performed_full_build: false,
+                        structural_epoch_changed,
+                        requires_display_list_recording,
+                        structural_epoch,
+                    };
+                }
+                IncrementalUpdateResult::NeedsFullBuild(fallback_reason) => reason = fallback_reason,
             }
-            previous_assignments != paintable_rows.visual_context_assignments()
-        };
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let state = &mut paint_state.visual_context;
-        state.build_count += 1;
-        let is_compatible = !force_incompatible_rebuild
-            && state
-                .tree
-                .as_deref()
-                .is_some_and(|previous| tree.is_compatible_with(previous));
-        if is_compatible {
-            tree.structural_epoch = state.structural_epoch();
-        } else {
-            arena.mark_all_paint_caches_dirty();
         }
-        state.tree = Some(Rc::new(tree));
-        state.paintables_with_mask_nodes = paintables_with_mask_nodes;
-        state.scroll_state = scroll_state;
-        state.scroll_state_snapshot.clear();
-        state.needs_to_refresh_scroll_state = true;
-        state.dirty_boxes.clear();
-        if assignments_changed {
-            arena.mark_all_descendant_subtree_caches_dirty();
-        }
-        is_compatible
+
+        state.last_full_build_reason = reason;
+        let outcome = full_visual_context_build(arena, viewport, &callbacks, &mut state, force_full_rebuild);
+        state.last_tree_inputs = Some(inputs);
+        state.last_root_background_source = Some(root_background_source);
+        let arena_ref = unsafe { arena_from_handle(arena) };
+        arena_ref.paint_state().borrow_mut().visual_context = state;
+        outcome
     })
 }
 
@@ -1080,46 +1218,6 @@ pub unsafe extern "C" fn layout_arena_compute_css_transform(
             out_origin.add(1).write(transform.origin.y);
         }
         true
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_update_visual_context_values(
-    arena: *mut c_void,
-    paintable: NodeSlotId,
-    callbacks: FfiVisualContextHostCallbacks,
-) -> bool {
-    abort_on_panic(|| {
-        let pixel_ratio = callbacks.tree_inputs().device_pixels_per_css_pixel;
-        let (compatible, has_non_invertible_css_transform) = {
-            let arena = unsafe { arena_from_handle(arena) };
-            let paintable_rows = arena.paintable_rows();
-            if !paintable_rows.paintable_row_is_populated(paintable) {
-                return false;
-            }
-            let mut paint_state = arena.paint_state().borrow_mut();
-            let Some(tree) = paint_state.visual_context.tree.as_mut() else {
-                return false;
-            };
-            crate::painting::visual_context::build::update_visual_context_values(
-                &paintable_rows,
-                &callbacks,
-                Rc::make_mut(tree),
-                paintable,
-                pixel_ratio,
-            )
-        };
-        if let Some(value) = has_non_invertible_css_transform {
-            let arena = unsafe { arena_from_handle_mut(arena) };
-            arena.paintable_rows_mut().paintable_data_mut(paintable).set_flag(
-                crate::painting::paintable_data::PaintableFlag::HasNonInvertibleCssTransform,
-                value,
-            );
-        }
-        compatible
     })
 }
 
@@ -1244,6 +1342,16 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
 ) -> u64 {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
+        {
+            let mut paint_state = arena.paint_state().borrow_mut();
+            if paint_state.recorded_wheel_event_listener_state_generation
+                != Some(inputs.wheel_event_listener_state_generation)
+            {
+                arena.mark_all_descendant_subtree_caches_dirty();
+                paint_state.recorded_wheel_event_listener_state_generation =
+                    Some(inputs.wheel_event_listener_state_generation);
+            }
+        }
         let mut output = {
             let paint_state = arena.paint_state().borrow();
             if !arena.paintable_row_is_populated(viewport) || paint_state.stacking_context_tree.is_none() {
@@ -1285,6 +1393,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             paint_state.paint_command_cache_source = Some(output.clone());
             // Read-only recordings commit nothing and must not age dirty stamps out.
             arena.note_paint_record_completed_with_cache_writes();
+            paint_state.visual_context.quarantined_slots_are_releasable = true;
         }
         paint_state.last_recording = Some(output);
         list_generation_of(&paint_state)

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -897,6 +897,9 @@ pub unsafe extern "C" fn layout_arena_visual_context_request_full_rebuild(
                 VisualContextGlobalRebuildReason::FilterResourcesChanged
             }
             FfiVisualContextGlobalRebuildReason::ForcedForTesting => VisualContextGlobalRebuildReason::ForcedForTesting,
+            FfiVisualContextGlobalRebuildReason::CanonicalDumpRequested => {
+                VisualContextGlobalRebuildReason::CanonicalDumpRequested
+            }
         };
         arena.request_full_visual_context_rebuild(reason);
     });
@@ -1125,10 +1128,6 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
                 }
             }
         }
-        let allow_structural_changes = false;
-        if reason == VisualContextGlobalRebuildReason::None && !state.dirty_boxes.is_value_only() {
-            reason = VisualContextGlobalRebuildReason::StructuralDirtyBoxes;
-        }
 
         if reason == VisualContextGlobalRebuildReason::None {
             let result = {
@@ -1140,7 +1139,6 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
                     inputs,
                     root_background_source,
                     &mut state,
-                    allow_structural_changes,
                 )
             };
             match result {

--- a/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/hit_test/mod.rs
@@ -50,6 +50,7 @@ pub struct HitTestItem {
     pub caret_line_index: Option<usize>,
     pub caret_line_rect: Option<CssPixelRect>,
     pub block_container_margin_rect: Option<CssPixelRect>,
+    pub block_container: NodeSlotId,
     pub context: ContextRef,
     pub border_radii: BorderRadii,
     pub path: Option<Rc<libgfx_rust::path::OwnedPath>>,

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -24,6 +24,7 @@ pub struct FfiRecordingInputs {
     pub is_recording_async_scrolling_metadata: bool,
     pub document_id: i64,
     pub has_blocking_wheel_event_region_covering_viewport: bool,
+    pub wheel_event_listener_state_generation: u64,
     pub viewport_wheel_overflow_x: u8,
     pub viewport_wheel_overflow_y: u8,
     pub chrome_metrics: crate::painting::ffi::FfiChromeMetrics,

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -22,6 +22,23 @@ pub struct FfiSvgMaskFacts {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
+pub enum FfiVisualContextBoxDirtyKind {
+    StyleValueChange,
+    StyleStructuralChange,
+    ScrollableOverflowFlipped,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiVisualContextGlobalRebuildReason {
+    FirstBuild,
+    DocumentWideStructuralChange,
+    FilterResourcesChanged,
+    ForcedForTesting,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
 pub enum FfiVisualContextBoxNodeList {
     SpatialNodes,
     FrameNodes,

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -20,6 +20,13 @@ pub struct FfiSvgMaskFacts {
     pub clip_area: OptionalCssPixelRect,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiVisualContextBoxNodeList {
+    SpatialNodes,
+    FrameNodes,
+}
+
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiVisualContextTreeInputs {

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -35,6 +35,7 @@ pub enum FfiVisualContextGlobalRebuildReason {
     DocumentWideStructuralChange,
     FilterResourcesChanged,
     ForcedForTesting,
+    CanonicalDumpRequested,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -44,6 +44,15 @@ pub enum FfiVisualContextBoxNodeList {
     FrameNodes,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+pub struct FfiVisualContextUpdateOutcome {
+    pub performed_full_build: bool,
+    pub structural_epoch_changed: bool,
+    pub requires_display_list_recording: bool,
+    pub structural_epoch: u64,
+}
+
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiVisualContextTreeInputs {

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -16,6 +16,7 @@ pub struct PaintState {
     pub(crate) last_recording: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) paint_command_cache_source: Option<Rc<crate::painting::record::RecordingOutput>>,
     pub(crate) hit_test_item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
+    pub(crate) recorded_wheel_event_listener_state_generation: Option<u64>,
     pub(crate) selection: Option<crate::painting::selection::SelectionRange>,
     pub(crate) scrollable_overflow_contained_boxes: std::collections::HashMap<NodeSlotId, Vec<NodeSlotId>>,
 }

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -26,5 +26,8 @@ impl PaintState {
             needs_to_refresh_scroll_state: true,
             ..Default::default()
         };
+        self.visual_context
+            .dirty_boxes
+            .request_full_rebuild(crate::painting::visual_context::dirty::VisualContextGlobalRebuildReason::FirstBuild);
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -13,6 +13,7 @@ use crate::layout::{
 };
 use crate::painting::node_painting;
 use crate::painting::paintable_data::*;
+use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PreparedPaintable {
@@ -115,6 +116,8 @@ impl<'a> PaintableCommit<'a> {
             // their painted output changes exactly when the enclosing line root's fragment did.
             if row_existed_before_this_commit && enclosing_line_root_content_changed {
                 self.arena().paintable_rows().mark_paint_cache_self_dirty(node);
+                self.arena()
+                    .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::InlineGeometryChanged);
             }
         }
         if row_existed_before_this_commit {
@@ -136,6 +139,7 @@ impl<'a> PaintableCommit<'a> {
             if node_kind == NodeKind::Viewport {
                 arena.paint_state().borrow_mut().reset_visual_context_state();
             }
+            arena.note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::NewRow);
         }
         PreparedPaintable {
             has_paintable_row: true,
@@ -196,6 +200,13 @@ impl<'a> PaintableCommit<'a> {
             .is_some_and(|&offset_before_commit| offset_before_commit == link.committed_offset);
         if !(content_unchanged && offset_unchanged) {
             self.arena().paintable_rows().mark_paint_cache_self_dirty(node);
+        }
+        if !offset_unchanged {
+            self.arena()
+                .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::MovedWithDescendants);
+        } else if !content_unchanged {
+            self.arena()
+                .note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::RecommittedInPlace);
         }
         {
             let arena = self.arena_mut();
@@ -422,7 +433,12 @@ impl<'a> PaintableCommit<'a> {
         } else {
             NodeSlotId::INVALID
         };
-        paintable_rows.paintable_data_mut(node).containing_block = containing_block;
+        let data = paintable_rows.paintable_data_mut(node);
+        let containing_block_changed = data.containing_block != containing_block;
+        data.containing_block = containing_block;
+        if containing_block_changed {
+            paintable_rows.note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::ContainingBlockChanged);
+        }
     }
 
     pub(crate) fn assign_inline_box_geometry(&mut self, slot: NodeSlotId) {
@@ -503,10 +519,22 @@ impl<'a> PaintableCommit<'a> {
             let border_union = border_union.expect("border union set alongside content union");
             {
                 let data = paintable_rows.paintable_data_mut(piece_node);
-                data.offset = content_union.location().into();
-                data.content_size = content_union.size().into();
-                data.local_padding_box_union = padding_union.translated(-content_union.x, -content_union.y).into();
-                data.local_border_box_union = border_union.translated(-content_union.x, -content_union.y).into();
+                let new_offset = content_union.location().into();
+                let new_content_size = content_union.size().into();
+                let new_padding_box_union = padding_union.translated(-content_union.x, -content_union.y).into();
+                let new_border_box_union = border_union.translated(-content_union.x, -content_union.y).into();
+                let inline_geometry_changed = data.offset != new_offset
+                    || data.content_size != new_content_size
+                    || data.local_padding_box_union != new_padding_box_union
+                    || data.local_border_box_union != new_border_box_union;
+                data.offset = new_offset;
+                data.content_size = new_content_size;
+                data.local_padding_box_union = new_padding_box_union;
+                data.local_border_box_union = new_border_box_union;
+                if inline_geometry_changed {
+                    paintable_rows
+                        .note_visual_context_box_dirty(piece_node, VisualContextBoxDirtyKind::InlineGeometryChanged);
+                }
             }
             // This box has at most one piece per line, so its piece indices are ordered by line.
             paintable_rows.paintable_side_data_mut(piece_node).piece_indices = piece_indices;

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -63,11 +63,6 @@ pub struct PaintableData {
     pub fixed_background_visual_context: ContextRef,
     pub has_fixed_background_visual_context: bool,
     pub has_scroll_offset_dependent_background: bool,
-    /// Ranges of spatial and frame nodes this box appended during the last tree build.
-    pub spatial_nodes_begin: u32,
-    pub spatial_nodes_end: u32,
-    pub frame_nodes_begin: u32,
-    pub frame_nodes_end: u32,
 }
 
 impl Default for PaintableData {
@@ -93,19 +88,11 @@ impl Default for PaintableData {
             fixed_background_visual_context: ContextRef::default(),
             has_fixed_background_visual_context: false,
             has_scroll_offset_dependent_background: false,
-            spatial_nodes_begin: 0,
-            spatial_nodes_end: 0,
-            frame_nodes_begin: 0,
-            frame_nodes_end: 0,
         }
     }
 }
 
 impl PaintableData {
-    pub fn local_frame_range(&self) -> (u32, u32) {
-        (self.frame_nodes_begin, self.frame_nodes_end)
-    }
-
     pub fn has_flag(&self, flag: PaintableFlag) -> bool {
         self.flags & flag as u32 != 0
     }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -11,6 +11,9 @@ use crate::painting::display_list::commands::ContextRef;
 use crate::painting::node_painting;
 use crate::painting::paintable_data::*;
 use crate::painting::record::cache::PaintCache;
+use crate::painting::visual_context::dirty::{
+    RemovedBoxBlocks, VisualContextBoxDirtyKind, VisualContextGlobalRebuildReason,
+};
 use crate::painting::visual_context::{
     BoxVisualContextNodeHandles, EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES, PaintableVisualContextRecord,
 };
@@ -639,6 +642,25 @@ impl LayoutNodeArena {
             self.paintable_rows()
                 .mark_descendant_subtree_caches_dirty_along_paint_chain(id);
         }
+        if let Some(record) = self.take_paintable_visual_context_record(id) {
+            let former_paint_parent =
+                crate::painting::paint_order::paint_parent(&self.paintable_rows(), id).unwrap_or(NodeSlotId::INVALID);
+            self.paint_state()
+                .borrow_mut()
+                .visual_context
+                .dirty_boxes
+                .note_removed(RemovedBoxBlocks {
+                    slot: id,
+                    node_handles: record.node_handles,
+                    former_paint_parent,
+                });
+        } else {
+            self.paint_state()
+                .borrow_mut()
+                .visual_context
+                .dirty_boxes
+                .forget_box(id);
+        }
         self.clear_absolute_rect_memo();
         let store = &mut self.paintable_rows;
         let index = id.slot_index() as usize;
@@ -662,6 +684,17 @@ impl LayoutNodeArena {
         .ok()
     }
 
+    pub(crate) fn take_paintable_visual_context_record(&self, id: NodeSlotId) -> Option<PaintableVisualContextRecord> {
+        if !self.paintable_row_is_populated(id) {
+            return None;
+        }
+        self.paintable_rows
+            .visual_context_records
+            .borrow_mut()
+            .get_mut(id.slot_index() as usize)
+            .and_then(Option::take)
+    }
+
     pub(crate) fn set_paintable_visual_context_record(&self, id: NodeSlotId, record: PaintableVisualContextRecord) {
         debug_assert!(self.paintable_row_is_populated(id));
         self.paintable_rows.visual_context_records.borrow_mut()[id.slot_index() as usize] = Some(record);
@@ -676,6 +709,25 @@ impl LayoutNodeArena {
             Some(record) => read(&record.node_handles),
             None => read(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES),
         }
+    }
+
+    pub(crate) fn note_visual_context_box_dirty(&self, id: NodeSlotId, kind: VisualContextBoxDirtyKind) {
+        let pending_box_limit = self
+            .paintable_row_count()
+            .max(crate::painting::visual_context::dirty::MINIMUM_PENDING_DIRTY_BOX_LIMIT);
+        self.paint_state()
+            .borrow_mut()
+            .visual_context
+            .dirty_boxes
+            .note_box(id, kind, pending_box_limit);
+    }
+
+    pub(crate) fn request_full_visual_context_rebuild(&self, reason: VisualContextGlobalRebuildReason) {
+        self.paint_state()
+            .borrow_mut()
+            .visual_context
+            .dirty_boxes
+            .request_full_rebuild(reason);
     }
 
     pub(crate) fn prepare_paintable_row_freed_reset(&self, layout_slot_index: u32) -> Option<PaintableRowReset> {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -11,18 +11,20 @@ use crate::painting::display_list::commands::ContextRef;
 use crate::painting::node_painting;
 use crate::painting::paintable_data::*;
 use crate::painting::record::cache::PaintCache;
+use crate::painting::visual_context::{
+    BoxVisualContextNodeHandles, EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES, PaintableVisualContextRecord,
+};
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::ffi::c_void;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct VisualContextAssignmentSnapshot {
     pub slot_generation: u32,
     pub has_accumulated_visual_context: bool,
     pub accumulated_visual_context: ContextRef,
     pub accumulated_visual_context_for_descendants: ContextRef,
-    pub spatial_nodes: (u32, u32),
-    pub frame_nodes: (u32, u32),
+    pub node_handles: BoxVisualContextNodeHandles,
 }
 
 pub(crate) const PAINTABLE_SLOTS_PER_CHUNK: usize = 64;
@@ -77,6 +79,7 @@ pub(crate) struct PaintableRowStore {
     chunks: Vec<Box<PaintableRowChunk>>,
     side_data: RefCell<Vec<PaintableSideData>>,
     paint_caches: RefCell<Vec<PaintCache>>,
+    visual_context_records: RefCell<Vec<Option<PaintableVisualContextRecord>>>,
     absolute_rect_memo: RefCell<Vec<Option<(NodeSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
     absolute_rect_memo_epoch: Cell<u64>,
     committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
@@ -187,6 +190,7 @@ where
     }
 
     pub(crate) fn visual_context_assignments(&self) -> Vec<VisualContextAssignmentSnapshot> {
+        let records = self.arena.paintable_rows.visual_context_records.borrow();
         (0..self.arena.paintable_row_count())
             .map(|index| {
                 let chunk = &self.arena.paintable_rows.chunks[index / PAINTABLE_SLOTS_PER_CHUNK];
@@ -196,8 +200,11 @@ where
                     has_accumulated_visual_context: data.has_accumulated_visual_context,
                     accumulated_visual_context: data.accumulated_visual_context,
                     accumulated_visual_context_for_descendants: data.accumulated_visual_context_for_descendants,
-                    spatial_nodes: (data.spatial_nodes_begin, data.spatial_nodes_end),
-                    frame_nodes: (data.frame_nodes_begin, data.frame_nodes_end),
+                    node_handles: records[index]
+                        .as_ref()
+                        .map_or_else(BoxVisualContextNodeHandles::default, |record| {
+                            record.node_handles.clone()
+                        }),
                 }
             })
             .collect()
@@ -605,6 +612,7 @@ impl LayoutNodeArena {
         let mut side_data = store.side_data.borrow_mut();
         let mut paint_caches = store.paint_caches.borrow_mut();
         let mut absolute_rect_memo = store.absolute_rect_memo.borrow_mut();
+        let mut visual_context_records = store.visual_context_records.borrow_mut();
         while side_data.len() <= index {
             if side_data.len().is_multiple_of(PAINTABLE_SLOTS_PER_CHUNK) {
                 chunks.push(new_chunk());
@@ -612,6 +620,7 @@ impl LayoutNodeArena {
             side_data.push(PaintableSideData::default());
             paint_caches.push(PaintCache::default());
             absolute_rect_memo.push(None);
+            visual_context_records.push(None);
         }
 
         chunks[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK] = PaintableData {
@@ -621,6 +630,7 @@ impl LayoutNodeArena {
         side_data[index] = PaintableSideData::default();
         paint_caches[index].clear();
         absolute_rect_memo[index] = None;
+        visual_context_records[index] = None;
     }
 
     fn reset_paintable_row(&mut self, mark_caches_dirty_along_paint_chain: bool, reset: PaintableRowReset) {
@@ -636,6 +646,36 @@ impl LayoutNodeArena {
             PaintableData::default();
         store.side_data.borrow_mut()[index] = PaintableSideData::default();
         store.paint_caches.borrow()[index].clear();
+        store.visual_context_records.borrow_mut()[index] = None;
+    }
+
+    pub(crate) fn paintable_visual_context_record(
+        &self,
+        id: NodeSlotId,
+    ) -> Option<Ref<'_, PaintableVisualContextRecord>> {
+        if !self.paintable_row_is_populated(id) {
+            return None;
+        }
+        Ref::filter_map(self.paintable_rows.visual_context_records.borrow(), |records| {
+            records.get(id.slot_index() as usize).and_then(Option::as_ref)
+        })
+        .ok()
+    }
+
+    pub(crate) fn set_paintable_visual_context_record(&self, id: NodeSlotId, record: PaintableVisualContextRecord) {
+        debug_assert!(self.paintable_row_is_populated(id));
+        self.paintable_rows.visual_context_records.borrow_mut()[id.slot_index() as usize] = Some(record);
+    }
+
+    pub(crate) fn with_paintable_visual_context_node_handles<R>(
+        &self,
+        id: NodeSlotId,
+        read: impl FnOnce(&BoxVisualContextNodeHandles) -> R,
+    ) -> R {
+        match self.paintable_visual_context_record(id) {
+            Some(record) => read(&record.node_handles),
+            None => read(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES),
+        }
     }
 
     pub(crate) fn prepare_paintable_row_freed_reset(&self, layout_slot_index: u32) -> Option<PaintableRowReset> {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -684,6 +684,13 @@ impl LayoutNodeArena {
         .ok()
     }
 
+    pub(crate) fn cloned_paintable_visual_context_record(
+        &self,
+        id: NodeSlotId,
+    ) -> Option<PaintableVisualContextRecord> {
+        self.paintable_visual_context_record(id).map(|record| record.clone())
+    }
+
     pub(crate) fn take_paintable_visual_context_record(&self, id: NodeSlotId) -> Option<PaintableVisualContextRecord> {
         if !self.paintable_row_is_populated(id) {
             return None;
@@ -709,6 +716,17 @@ impl LayoutNodeArena {
             Some(record) => read(&record.node_handles),
             None => read(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES),
         }
+    }
+
+    pub(crate) fn mark_paintable_subtree_may_own_geometry_dependent_nodes(&self, id: NodeSlotId) -> Option<bool> {
+        if !self.paintable_row_is_populated(id) {
+            return None;
+        }
+        let mut records = self.paintable_rows.visual_context_records.borrow_mut();
+        let record = records.get_mut(id.slot_index() as usize)?.as_mut()?;
+        let was_flagged = record.subtree_may_own_geometry_dependent_nodes;
+        record.subtree_may_own_geometry_dependent_nodes = true;
+        Some(was_flagged)
     }
 
     pub(crate) fn note_visual_context_box_dirty(&self, id: NodeSlotId, kind: VisualContextBoxDirtyKind) {

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -153,6 +153,5 @@ impl PaintCache {
 
 pub struct HitTestItemCacheSource {
     pub id: u64,
-    pub visual_context_tree_version: u64,
     pub items: Rc<Vec<HitTestItem>>,
 }

--- a/Libraries/LibWeb/Rust/src/painting/record/cache.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/cache.rs
@@ -20,7 +20,6 @@ pub struct CachedCommands {
     pub source_display_list_id: u64,
     pub range: CommandRange,
     pub recorded_context: ContextRef,
-    pub recorded_local_frame_range: (u32, u32),
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/hit_test_items.rs
@@ -389,7 +389,7 @@ impl<'a> PaintRecorder<'a> {
         Some(parent)
     }
 
-    fn containing_block_margin_rect(&self, containing_block: NodeSlotId) -> Option<CssPixelRect> {
+    pub(super) fn containing_block_margin_rect(&self, containing_block: NodeSlotId) -> Option<CssPixelRect> {
         if containing_block.is_invalid() || !self.layout_arena.paintable_row_is_populated(containing_block) {
             return None;
         }
@@ -410,13 +410,12 @@ impl<'a> PaintRecorder<'a> {
         ))
     }
 
-    fn margin_rect_for_paintable(&self, paintable: NodeSlotId) -> Option<CssPixelRect> {
-        self.containing_block_margin_rect(self.data(paintable).containing_block)
+    fn block_container_of_paintable(&self, paintable: NodeSlotId) -> NodeSlotId {
+        self.data(paintable).containing_block
     }
 
-    fn margin_rect_for_fragment(&self, fragment: &FragmentRecord) -> Option<CssPixelRect> {
-        let block = text_fragment::containing_block_paintable(self.layout_arena, fragment)?;
-        self.containing_block_margin_rect(block)
+    fn block_container_of_fragment(&self, fragment: &FragmentRecord) -> NodeSlotId {
+        text_fragment::containing_block_paintable(self.layout_arena, fragment).unwrap_or(NodeSlotId::INVALID)
     }
 
     fn writing_mode_of(&self, paintable: NodeSlotId) -> u8 {
@@ -466,6 +465,16 @@ impl<'a> PaintRecorder<'a> {
         )
     }
 
+    pub(super) fn containing_line_of_box(&self, paintable_box: NodeSlotId) -> (Option<usize>, Option<CssPixelRect>) {
+        match paintable_geometry::committed_containing_line_box_index(self.layout_arena, paintable_box) {
+            Some(containing_line_box_index) => (
+                Some(containing_line_box_index),
+                self.absolute_containing_line_box_rect(paintable_box),
+            ),
+            None => (None, None),
+        }
+    }
+
     fn append_box(
         &mut self,
         paintable_box: NodeSlotId,
@@ -474,26 +483,21 @@ impl<'a> PaintRecorder<'a> {
         context: ContextRef,
         border_radii: BorderRadii,
     ) {
-        let (caret_line_index, caret_line_rect) =
-            match paintable_geometry::committed_containing_line_box_index(self.layout_arena, paintable_box) {
-                Some(containing_line_box_index) => (
-                    Some(containing_line_box_index),
-                    self.absolute_containing_line_box_rect(paintable_box),
-                ),
-                None => (None, None),
-            };
+        let (caret_line_index, caret_line_rect) = self.containing_line_of_box(paintable_box);
         let can_produce_caret_position = (self.is_atomic_inline(target) || self.is_replaced_box(target)) && {
             let negative_z =
                 crate::painting::style_queries::effective_z_index(self.layout_arena, target).unwrap_or(0) < 0;
             let target_node = target;
             !negative_z && self.node_has_dom_node(target_node) && self.paintable_facts(target).dom_node_has_parent
         };
+        let block_container = self.block_container_of_paintable(paintable_box);
         let item = HitTestItem {
             rect,
             caret_rect: rect,
             caret_line_index,
             caret_line_rect,
-            block_container_margin_rect: self.margin_rect_for_paintable(paintable_box),
+            block_container_margin_rect: self.containing_block_margin_rect(block_container),
+            block_container,
             border_radii,
             can_produce_caret_position,
             ..self.base_hit_test_item(HitTestItemKind::Box, target, context)
@@ -515,6 +519,7 @@ impl<'a> PaintRecorder<'a> {
             caret_line_index: None,
             caret_line_rect: None,
             block_container_margin_rect: None,
+            block_container: NodeSlotId::INVALID,
             context,
             border_radii: BorderRadii::default(),
             path: None,
@@ -551,13 +556,15 @@ impl<'a> PaintRecorder<'a> {
         };
         let layout_arena = self.layout_arena;
         let first_available_font = || text_fragment::first_available_font(layout_arena, &fragment);
+        let block_container = self.block_container_of_fragment(&fragment);
         let item = HitTestItem {
             text_fragment_index: Some(fragment_index),
             rect: text_fragment::absolute_rect(layout_arena, &fragment),
             caret_rect: text_fragment::whole_range_rect(layout_arena, &fragment, first_available_font),
             caret_line_index: Some(fragment.line_index as usize),
             caret_line_rect: Some(text_fragment::absolute_line_box_rect(layout_arena, owner, &fragment)),
-            block_container_margin_rect: self.margin_rect_for_fragment(&fragment),
+            block_container_margin_rect: self.containing_block_margin_rect(block_container),
+            block_container,
             containing_block: layout_arena
                 .node_containing_block_if_live(fragment.layout_node)
                 .unwrap_or(NodeSlotId::INVALID),
@@ -583,6 +590,7 @@ impl<'a> PaintRecorder<'a> {
         };
         // Empty lines are only reachable through caret lines, never through regular hit testing,
         // so they are recorded with the base's empty rect and stay out of the spatial index.
+        let block_container = self.block_container_of_fragment(&fragment);
         let item = HitTestItem {
             text_fragment_index: Some(sibling_fragment_index),
             caret_node: fragment.layout_node,
@@ -590,7 +598,8 @@ impl<'a> PaintRecorder<'a> {
             caret_rect: line_rect,
             caret_line_index: Some(line_box_index),
             caret_line_rect: Some(line_rect),
-            block_container_margin_rect: self.margin_rect_for_fragment(&fragment),
+            block_container_margin_rect: self.containing_block_margin_rect(block_container),
+            block_container,
             containing_block: self
                 .layout_arena
                 .node_containing_block_if_live(fragment.layout_node)
@@ -610,12 +619,14 @@ impl<'a> PaintRecorder<'a> {
         line_rect: CssPixelRect,
         context: ContextRef,
     ) {
+        let block_container = self.block_container_of_paintable(owner);
         let item = HitTestItem {
             caret_node,
             caret_offset,
             caret_rect: line_rect,
             caret_line_rect: Some(line_rect),
-            block_container_margin_rect: self.margin_rect_for_paintable(owner),
+            block_container_margin_rect: self.containing_block_margin_rect(block_container),
+            block_container,
             can_produce_caret_position: self.node_has_dom_node(caret_node),
             ..self.base_hit_test_item(HitTestItemKind::EmptyLine, owner, context)
         };
@@ -623,10 +634,12 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn append_empty_editable(&mut self, paintable: NodeSlotId, rect: CssPixelRect, context: ContextRef) {
+        let block_container = self.block_container_of_paintable(paintable);
         let item = HitTestItem {
             rect,
             caret_rect: rect,
-            block_container_margin_rect: self.margin_rect_for_paintable(paintable),
+            block_container_margin_rect: self.containing_block_margin_rect(block_container),
+            block_container,
             can_produce_caret_position: self.node_has_dom_node(paintable),
             ..self.base_hit_test_item(HitTestItemKind::EmptyEditable, paintable, context)
         };

--- a/Libraries/LibWeb/Rust/src/painting/record/masks.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/masks.rs
@@ -130,12 +130,14 @@ impl PaintRecorder<'_> {
                 }
             }
         } else if let Some(tree) = self.paint_state.visual_context.tree.as_deref() {
-            let data = self.data(paintable);
-            for index in data.frame_nodes_begin..data.frame_nodes_end {
-                if let FrameData::Mask(mask) = &tree.frame_nodes[index as usize].data {
-                    mask_frames.push((FrameNodeIndex(index), mask.origin));
-                }
-            }
+            self.layout_arena
+                .with_paintable_visual_context_node_handles(paintable, |handles| {
+                    for index in handles.frame_handles() {
+                        if let FrameData::Mask(mask) = &tree.frame_nodes[index.0 as usize].data {
+                            mask_frames.push((index, mask.origin));
+                        }
+                    }
+                });
         }
         let mut any_svg_mask_layer_area_is_empty = false;
         for layer in layers {

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -360,12 +360,15 @@ impl<'a> PaintRecorder<'a> {
         let Some(tree) = self.paint_state.visual_context.tree.as_deref() else {
             return HashMap::new();
         };
-        let (begin, end) = self.data(paintable).local_frame_range();
-        (begin..end)
-            .map(FrameNodeIndex)
-            .map(|frame| (tree.frame_nodes[frame.0 as usize].role, frame))
-            .filter(|(role, _)| *role != FrameRole::Structural)
-            .collect()
+        self.layout_arena
+            .with_paintable_visual_context_node_handles(paintable, |handles| {
+                handles
+                    .local_frame_handles()
+                    .iter()
+                    .map(|frame| (tree.frame_nodes[frame.0 as usize].role, *frame))
+                    .filter(|(role, _)| *role != FrameRole::Structural)
+                    .collect()
+            })
     }
 
     pub(crate) fn local_context(&self, paintable: NodeSlotId, role: FrameRole) -> Option<ContextRef> {

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -36,7 +36,7 @@ use std::rc::Rc;
 #[derive(Default)]
 pub struct RecordingOutput {
     pub id: u64,
-    pub compatible_visual_context_tree_version: u64,
+    pub recorded_structural_epoch: u64,
     // A default-constructed output's 0.0 never matches a real recording scale.
     pub recorded_device_pixels_per_css_pixel: f64,
     pub hit_test_list: HitTestList,

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -472,7 +472,7 @@ impl PaintRecorder<'_> {
         let Some(command_source) = self.command_cache_source.as_ref() else {
             return false;
         };
-        let Some(item_source) = self.item_cache_source.as_ref() else {
+        let Some(item_source) = self.item_cache_source.clone() else {
             return false;
         };
         let cache = self.layout_arena.paintable_paint_cache(paintable);
@@ -503,7 +503,7 @@ impl PaintRecorder<'_> {
         let source_start = cached.hit_test_start as usize;
         let source_end = source_start + cached.hit_test_count as usize;
         for item in &item_source.items[source_start..source_end] {
-            self.list.append(item.clone());
+            self.append_spliced_hit_test_item(item);
         }
         if self.inputs.paint_command_cache_read_write {
             self.set_cached_descendant_subtree(
@@ -705,8 +705,8 @@ impl PaintRecorder<'_> {
                 // Paintable rows may hold dangling fragment pointers, but only ranges whose owners kept a valid cache
                 // entry (and therefore were not relaid out) are ever passed here.
                 let destination_start = self.list.items.len();
-                for index in start..start + count {
-                    self.list.append(source[index].clone());
+                for item in &source[start..start + count] {
+                    self.append_spliced_hit_test_item(item);
                 }
                 if cache_writes_enabled {
                     self.set_cached_hit_test_items(
@@ -793,6 +793,17 @@ impl PaintRecorder<'_> {
             return None;
         }
         Some((source.clone(), entry))
+    }
+
+    fn append_spliced_hit_test_item(&mut self, spliced: &HitTestItem) {
+        let mut item = spliced.clone();
+        if !item.block_container.is_invalid() {
+            item.block_container_margin_rect = self.containing_block_margin_rect(item.block_container);
+        }
+        if item.kind == HitTestItemKind::Box {
+            (item.caret_line_index, item.caret_line_rect) = self.containing_line_of_box(item.paintable);
+        }
+        self.list.append(item);
     }
 
     fn valid_cached_hit_test_items(

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -856,7 +856,18 @@ impl PaintRecorder<'_> {
     }
 
     fn local_frame_range(&self, paintable: NodeSlotId) -> (u32, u32) {
-        self.data(paintable).local_frame_range()
+        self.layout_arena
+            .with_paintable_visual_context_node_handles(paintable, |handles| {
+                let local_frames = handles.local_frame_handles();
+                debug_assert!(
+                    local_frames.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1),
+                    "a box's local frames are appended consecutively"
+                );
+                match (local_frames.first(), local_frames.last()) {
+                    (Some(first), Some(last)) => (first.0, last.0 + 1),
+                    _ => (0, 0),
+                }
+            })
     }
 
     #[cfg(debug_assertions)]

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -10,7 +10,7 @@ use crate::layout::node_data::NodeSlotId;
 use crate::layout::node_data::{NodeFlag, NodeKind};
 use crate::layout::{node_facts, used_values};
 use crate::painting::display_list::builder::CommandRange;
-use crate::painting::display_list::commands::ContextRef;
+use crate::painting::display_list::commands::{ContextRef, VISUAL_VIEWPORT_NODE_INDEX};
 use crate::painting::display_list::device_pixels::DevicePixelConverter;
 use crate::painting::display_list::recorder::DisplayListRecorder;
 use crate::painting::hit_test::*;
@@ -689,15 +689,19 @@ impl PaintRecorder<'_> {
                 .layout_kind(paintable)
                 .is_some_and(node_painting::foreground_is_never_cached)
                 && phase == PaintPhase::Foreground);
+        let phase_records_scrollbars_with_scroll_node_indices = phase == PaintPhase::Overlay
+            && (data.own_scroll_node_index != VISUAL_VIEWPORT_NODE_INDEX
+                || self.layout_kind(paintable) == Some(NodeKind::Viewport));
         if skip_cache {
             self.prevent_descendant_subtree_caching();
         }
+        let skip_phase_capture = skip_cache || phase_records_scrollbars_with_scroll_node_indices;
         let cache_writes_enabled = self.inputs.paint_command_cache_read_write && !is_nested;
 
         if phase_can_record_hit_test_items && !is_nested {
             let own_context = self.own_context(paintable);
             let for_descendants_context = self.for_descendants_context(paintable);
-            let cached_items = if skip_cache {
+            let cached_items = if skip_phase_capture {
                 None
             } else {
                 self.valid_cached_hit_test_items(paintable, phase, own_context, for_descendants_context)
@@ -724,7 +728,7 @@ impl PaintRecorder<'_> {
             } else {
                 let items_before = self.list.items.len();
                 self.record_hit_test_items(paintable, phase);
-                if !skip_cache && cache_writes_enabled {
+                if !skip_phase_capture && cache_writes_enabled {
                     let items_after = self.list.items.len();
                     self.set_cached_hit_test_items(
                         paintable,
@@ -738,9 +742,13 @@ impl PaintRecorder<'_> {
             }
         }
 
+        if phase == PaintPhase::Background && !is_nested {
+            self.record_async_scrolling_metadata(paintable);
+        }
+
         // SVG subtrees are recorded outside per-paintable captures, so path-bearing items are never spliced.
         let phase_context = self.recorder.accumulated_visual_context();
-        let cached_commands = if skip_cache || is_nested {
+        let cached_commands = if skip_phase_capture || is_nested {
             None
         } else {
             self.valid_cached_commands(paintable, phase)
@@ -759,16 +767,13 @@ impl PaintRecorder<'_> {
             self.spliced_capture_count += 1;
         } else {
             let command_range_start = self.recorder.byte_size();
-            if phase == PaintPhase::Background && !is_nested {
-                self.record_async_scrolling_metadata(paintable);
-            }
             self.paint(paintable, phase);
             let command_range_end = self.recorder.byte_size();
             let command_range = CommandRange {
                 offset: command_range_start as u32,
                 size: (command_range_end - command_range_start) as u32,
             };
-            if !skip_cache && cache_writes_enabled {
+            if !skip_phase_capture && cache_writes_enabled {
                 self.set_cached_commands(paintable, phase, command_range, phase_context);
             }
         }
@@ -833,6 +838,10 @@ impl PaintRecorder<'_> {
         recorded_context: ContextRef,
     ) {
         let recorded_local_frame_range = self.local_frame_range(paintable);
+        debug_assert!(
+            self.captured_range_embeds_no_scroll_node_index_payload(range),
+            "a per-phase paint capture must not embed scroll node indices"
+        );
         let cache = self.layout_arena.paintable_paint_cache(paintable);
         cache.register_capture_position(self.current_absolute_position(paintable));
         cache.set_commands(
@@ -848,6 +857,29 @@ impl PaintRecorder<'_> {
 
     fn local_frame_range(&self, paintable: NodeSlotId) -> (u32, u32) {
         self.data(paintable).local_frame_range()
+    }
+
+    #[cfg(debug_assertions)]
+    fn captured_range_embeds_no_scroll_node_index_payload(&self, range: CommandRange) -> bool {
+        use crate::painting::display_list::builder::{HEADER_SIZE, read_header};
+        use crate::painting::display_list::commands::DisplayListCommandType;
+        let bytes = &self.recorder.bytes()[range.offset as usize..(range.offset + range.size) as usize];
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let header = read_header(&bytes[offset..]);
+            if header.command_type.is_compositor_metadata()
+                || header.command_type == DisplayListCommandType::PaintScrollBar
+            {
+                return false;
+            }
+            offset += HEADER_SIZE + header.payload_size as usize;
+        }
+        true
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn captured_range_embeds_no_scroll_node_index_payload(&self, _range: CommandRange) -> bool {
+        true
     }
 
     fn set_cached_hit_test_items(

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -751,8 +751,6 @@ impl PaintRecorder<'_> {
                 &source.display_list.bytes,
                 cached.range,
                 cached.recorded_context,
-                cached.recorded_local_frame_range,
-                self.local_frame_range(paintable),
             );
             if cache_writes_enabled {
                 self.set_cached_commands(paintable, phase, destination_range, phase_context);
@@ -830,10 +828,17 @@ impl PaintRecorder<'_> {
         range: CommandRange,
         recorded_context: ContextRef,
     ) {
-        let recorded_local_frame_range = self.local_frame_range(paintable);
         debug_assert!(
             self.captured_range_embeds_no_scroll_node_index_payload(range),
             "a per-phase paint capture must not embed scroll node indices"
+        );
+        debug_assert!(
+            self.captured_range_references_only_the_phase_context_and_own_local_frames(
+                paintable,
+                range,
+                recorded_context
+            ),
+            "a per-phase paint capture records under its phase context and its own local frames"
         );
         let cache = self.layout_arena.paintable_paint_cache(paintable);
         cache.register_capture_position(self.current_absolute_position(paintable));
@@ -843,24 +848,45 @@ impl PaintRecorder<'_> {
                 source_display_list_id: self.display_list_id,
                 range,
                 recorded_context,
-                recorded_local_frame_range,
             },
         );
     }
 
-    fn local_frame_range(&self, paintable: NodeSlotId) -> (u32, u32) {
+    #[cfg(debug_assertions)]
+    fn captured_range_references_only_the_phase_context_and_own_local_frames(
+        &self,
+        paintable: NodeSlotId,
+        range: CommandRange,
+        recorded_context: ContextRef,
+    ) -> bool {
+        use crate::painting::display_list::builder::{HEADER_SIZE, read_header};
+        let bytes = &self.recorder.bytes()[range.offset as usize..(range.offset + range.size) as usize];
         self.layout_arena
             .with_paintable_visual_context_node_handles(paintable, |handles| {
-                let local_frames = handles.local_frame_handles();
-                debug_assert!(
-                    local_frames.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1),
-                    "a box's local frames are appended consecutively"
-                );
-                match (local_frames.first(), local_frames.last()) {
-                    (Some(first), Some(last)) => (first.0, last.0 + 1),
-                    _ => (0, 0),
+                let mut offset = 0;
+                while offset < bytes.len() {
+                    let header = read_header(&bytes[offset..]);
+                    let frame = header.context.frame;
+                    let frame_belongs_to_the_capture = frame.is_none()
+                        || frame == recorded_context.frame
+                        || handles.local_frame_handles().contains(&frame);
+                    if header.context.spatial != recorded_context.spatial || !frame_belongs_to_the_capture {
+                        return false;
+                    }
+                    offset += HEADER_SIZE + header.payload_size as usize;
                 }
+                true
             })
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn captured_range_references_only_the_phase_context_and_own_local_frames(
+        &self,
+        _paintable: NodeSlotId,
+        _range: CommandRange,
+        _recorded_context: ContextRef,
+    ) -> bool {
+        true
     }
 
     #[cfg(debug_assertions)]

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -72,16 +72,9 @@ pub(crate) fn record_display_list(
         .stacking_context_tree
         .as_ref()
         .expect("recording needs a built stacking context tree");
-    let visual_context_tree_version = paint_state.visual_context.tree_version();
-    // NB: Some commands embed visual context indices in their payloads. Those indices can change
-    //     when the visual context tree is rebuilt, so commands from an incompatible tree must be
-    //     recorded and cached against the new tree.
-    let command_cache_source = command_cache_source.filter(|source| {
-        source.compatible_visual_context_tree_version == visual_context_tree_version
-            && source.recorded_device_pixels_per_css_pixel == inputs.device_pixels_per_css_pixel
-    });
-    let item_cache_source =
-        item_cache_source.filter(|source| source.visual_context_tree_version == visual_context_tree_version);
+    let structural_epoch = paint_state.visual_context.structural_epoch();
+    let command_cache_source = command_cache_source
+        .filter(|source| source.recorded_device_pixels_per_css_pixel == inputs.device_pixels_per_css_pixel);
     let paintable_rows = layout_arena.paintable_rows();
     let mut recorder = PaintRecorder {
         layout_arena: &paintable_rows,
@@ -151,7 +144,7 @@ pub(crate) fn record_display_list(
     hit_test_list.generation = hit_test_list_generation;
     RecordingOutput {
         id: inputs.display_list_id,
-        compatible_visual_context_tree_version: visual_context_tree_version,
+        recorded_structural_epoch: structural_epoch,
         recorded_device_pixels_per_css_pixel: inputs.device_pixels_per_css_pixel,
         hit_test_list,
         display_list: recorder.recorder.into_builder().finish(),

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -286,8 +286,11 @@ pub(crate) struct OverflowAssignment {
 
 impl OverflowAssignment {
     pub(crate) fn apply(self, layout_arena: &mut PaintableRowsMut<'_>) {
-        let scrollability_flipped = {
+        let (scroll_metadata_changed, scrollability_flipped) = {
             let data = layout_arena.paintable_data_mut(self.box_paintable);
+            let scroll_metadata_changed = self
+                .overflow_relative_to_padding_box
+                .is_some_and(|overflow| overflow != data.overflow_relative_to_padding_box);
             let scrollability_flipped = self.overflow_relative_to_padding_box.is_some_and(|overflow| {
                 overflow.has_scrollable_overflow != data.overflow_relative_to_padding_box.has_scrollable_overflow
             });
@@ -296,8 +299,11 @@ impl OverflowAssignment {
                 data.overflow_valid_across_recommits = true;
             }
             data.overflow_measured_this_commit = true;
-            scrollability_flipped
+            (scroll_metadata_changed, scrollability_flipped)
         };
+        if scroll_metadata_changed {
+            layout_arena.mark_paint_cache_self_dirty(self.box_paintable);
+        }
         if scrollability_flipped {
             layout_arena.note_visual_context_box_dirty(
                 self.box_paintable,

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -305,6 +305,7 @@ impl OverflowAssignment {
             layout_arena.mark_paint_cache_self_dirty(self.box_paintable);
         }
         if scrollability_flipped {
+            layout_arena.mark_all_descendant_subtree_caches_dirty();
             layout_arena.note_visual_context_box_dirty(
                 self.box_paintable,
                 VisualContextBoxDirtyKind::ScrollableOverflowFlipped,

--- a/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
+++ b/Libraries/LibWeb/Rust/src/painting/scrollable_overflow.rs
@@ -12,7 +12,8 @@ use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::node_facts;
 use crate::painting::host::{FfiScrollableOverflowHostCallbacks, FfiVisualContextHostCallbacks};
 use crate::painting::paintable_data::FfiOverflowData;
-use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
+use crate::painting::paintable_rows::{PaintableRowsMut, PaintableRowsRead};
+use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
 use crate::painting::visual_context::node_values;
 use crate::painting::{paintable_geometry, style_queries, text_fragment};
 use libgfx_rust::matrix::{AffineTransform, FloatMatrix4x4};
@@ -284,13 +285,25 @@ pub(crate) struct OverflowAssignment {
 }
 
 impl OverflowAssignment {
-    pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
-        let data = layout_arena.paintable_data_mut(self.box_paintable);
-        if let Some(overflow) = self.overflow_relative_to_padding_box {
-            data.overflow_relative_to_padding_box = overflow;
-            data.overflow_valid_across_recommits = true;
+    pub(crate) fn apply(self, layout_arena: &mut PaintableRowsMut<'_>) {
+        let scrollability_flipped = {
+            let data = layout_arena.paintable_data_mut(self.box_paintable);
+            let scrollability_flipped = self.overflow_relative_to_padding_box.is_some_and(|overflow| {
+                overflow.has_scrollable_overflow != data.overflow_relative_to_padding_box.has_scrollable_overflow
+            });
+            if let Some(overflow) = self.overflow_relative_to_padding_box {
+                data.overflow_relative_to_padding_box = overflow;
+                data.overflow_valid_across_recommits = true;
+            }
+            data.overflow_measured_this_commit = true;
+            scrollability_flipped
+        };
+        if scrollability_flipped {
+            layout_arena.note_visual_context_box_dirty(
+                self.box_paintable,
+                VisualContextBoxDirtyKind::ScrollableOverflowFlipped,
+            );
         }
-        data.overflow_measured_this_commit = true;
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::local_frames::LocalFrameBuilder;
+use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
+use super::*;
+use crate::layout::node_data::{NodeFlag, NodeSlotId};
+use crate::painting::host::{FfiRootBackgroundSource, FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
+use crate::painting::paintable_data::*;
+use crate::painting::paintable_geometry;
+use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
+use libgfx_rust::FloatPoint;
+
+pub(crate) struct BoxBuildEnvironment<'a, Arena> {
+    pub layout_arena: &'a Arena,
+    pub callbacks: &'a FfiVisualContextHostCallbacks,
+    pub pixel_ratio: f64,
+    pub tree_inputs: FfiVisualContextTreeInputs,
+    pub root_background_source: FfiRootBackgroundSource,
+}
+
+pub(crate) trait AnchorScrollShiftResolver {
+    fn default_scroll_shift_anchor(&self, slot: NodeSlotId) -> NodeSlotId;
+    fn enclosing_scroll_node_index(&self, slot: NodeSlotId) -> SpatialNodeIndex;
+    fn scroll_state(&self) -> &ScrollState;
+}
+
+#[derive(Clone)]
+pub(crate) struct PaintableVisualContextAssignment {
+    pub slot: NodeSlotId,
+    pub enclosing_scroll_node_index: SpatialNodeIndex,
+    pub own_scroll_node_index: SpatialNodeIndex,
+    pub has_accumulated_visual_context: bool,
+    pub accumulated_visual_context: ContextRef,
+    pub accumulated_visual_context_for_descendants: ContextRef,
+    pub fixed_background_visual_context: ContextRef,
+    pub has_fixed_background_visual_context: bool,
+    pub has_scroll_offset_dependent_background: bool,
+    pub has_non_invertible_css_transform: bool,
+    pub record: PaintableVisualContextRecord,
+}
+
+impl PaintableVisualContextAssignment {
+    pub(crate) fn from_data(slot: NodeSlotId, data: &PaintableData, record: PaintableVisualContextRecord) -> Self {
+        Self {
+            slot,
+            enclosing_scroll_node_index: data.enclosing_scroll_node_index,
+            own_scroll_node_index: data.own_scroll_node_index,
+            has_accumulated_visual_context: data.has_accumulated_visual_context,
+            accumulated_visual_context: data.accumulated_visual_context,
+            accumulated_visual_context_for_descendants: data.accumulated_visual_context_for_descendants,
+            fixed_background_visual_context: data.fixed_background_visual_context,
+            has_fixed_background_visual_context: data.has_fixed_background_visual_context,
+            has_scroll_offset_dependent_background: data.has_scroll_offset_dependent_background,
+            has_non_invertible_css_transform: data.has_flag(PaintableFlag::HasNonInvertibleCssTransform),
+            record,
+        }
+    }
+
+    pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
+        {
+            let data = layout_arena.paintable_data_mut(self.slot);
+            data.enclosing_scroll_node_index = self.enclosing_scroll_node_index;
+            data.own_scroll_node_index = self.own_scroll_node_index;
+            data.has_accumulated_visual_context = self.has_accumulated_visual_context;
+            data.accumulated_visual_context = self.accumulated_visual_context;
+            data.accumulated_visual_context_for_descendants = self.accumulated_visual_context_for_descendants;
+            data.fixed_background_visual_context = self.fixed_background_visual_context;
+            data.has_fixed_background_visual_context = self.has_fixed_background_visual_context;
+            data.has_scroll_offset_dependent_background = self.has_scroll_offset_dependent_background;
+            data.set_flag(
+                PaintableFlag::HasNonInvertibleCssTransform,
+                self.has_non_invertible_css_transform,
+            );
+        }
+        layout_arena.set_paintable_visual_context_record(self.slot, self.record);
+    }
+}
+
+pub(crate) struct BoxVisualContextBuildOutput {
+    pub assignment: PaintableVisualContextAssignment,
+    pub descendant_contexts: DescendantVisualContexts,
+}
+
+fn scroll_state_slot_for_spatial_node(sink: &impl VisualContextNodeSink, index: SpatialNodeIndex) -> ScrollStateSlot {
+    if index == VISUAL_VIEWPORT_NODE_INDEX {
+        return NO_SCROLL_STATE_SLOT;
+    }
+    match &sink.spatial_node_at(index).data {
+        SpatialData::Scroll(scroll) => scroll.state_slot,
+        SpatialData::Sticky(sticky) => sticky.state_slot,
+        _ => panic!("spatial node {} is not a scroll-like node", index.0),
+    }
+}
+
+fn common_ancestor_slot_along_scroll_parent_chain(
+    scroll_state: &ScrollState,
+    a_slot: ScrollStateSlot,
+    b_slot: ScrollStateSlot,
+) -> ScrollStateSlot {
+    let mut a_slot_and_ancestors = Vec::new();
+    let mut slot = a_slot;
+    loop {
+        a_slot_and_ancestors.push(slot);
+        if slot == NO_SCROLL_STATE_SLOT {
+            break;
+        }
+        slot = scroll_state.state_at_slot(slot).parent_slot;
+    }
+    let mut slot = b_slot;
+    loop {
+        if a_slot_and_ancestors.contains(&slot) {
+            return slot;
+        }
+        if slot == NO_SCROLL_STATE_SLOT {
+            break;
+        }
+        slot = scroll_state.state_at_slot(slot).parent_slot;
+    }
+    NO_SCROLL_STATE_SLOT
+}
+
+// https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift
+// After layout has been performed for abspos, it is additionally shifted by the default scroll shift, as if
+// affected by a transform (before any other transforms).
+// NB: The shift is the scroll movement of the frames between the box's containing block and its default
+//     anchor box. When the anchor is itself an anchor-positioned box, its layout position does not include
+//     its own paint-time shift, so each chained anchor's shift is emitted as well, masked to the axes that
+//     every link below it compensates in. The visited set and depth cap guard against malformed anchor chains.
+fn append_anchor_scroll_shift_nodes<Arena: PaintableRowsRead, Sink: VisualContextNodeSink>(
+    env: &BoxBuildEnvironment<'_, Arena>,
+    sink: &mut Sink,
+    resolver: &dyn AnchorScrollShiftResolver,
+    layout_node: NodeSlotId,
+    own_enclosing_scroll_node_index: SpatialNodeIndex,
+    first_anchor_node: NodeSlotId,
+    mut own_state: ContextRef,
+) -> ContextRef {
+    let scroll_state = resolver.scroll_state();
+    let enclosing_scroll_node_index = |node: NodeSlotId| {
+        if node == layout_node {
+            own_enclosing_scroll_node_index
+        } else {
+            resolver.enclosing_scroll_node_index(node)
+        }
+    };
+    let mut box_node = layout_node;
+    let mut compensate_horizontal_scroll = true;
+    let mut compensate_vertical_scroll = true;
+    let mut visited: Vec<NodeSlotId> = Vec::new();
+    const MAX_ANCHOR_CHAIN_DEPTH: usize = 32;
+    let mut anchor_node = first_anchor_node;
+    while !box_node.is_invalid() && !visited.contains(&box_node) && visited.len() < MAX_ANCHOR_CHAIN_DEPTH {
+        if anchor_node.is_invalid() {
+            break;
+        }
+        if !env.layout_arena.paintable_row_is_populated(box_node)
+            || !env.layout_arena.paintable_row_is_populated(anchor_node)
+        {
+            break;
+        }
+        visited.push(box_node);
+        let box_flags = env.layout_arena.node_flags_if_live(box_node);
+        compensate_horizontal_scroll =
+            compensate_horizontal_scroll && box_flags & NodeFlag::CompensatesForHorizontalScroll as u32 != 0;
+        compensate_vertical_scroll =
+            compensate_vertical_scroll && box_flags & NodeFlag::CompensatesForVerticalScroll as u32 != 0;
+        let anchor_scroll_slot = scroll_state_slot_for_spatial_node(sink, enclosing_scroll_node_index(anchor_node));
+        let base_scroll_slot = scroll_state_slot_for_spatial_node(sink, enclosing_scroll_node_index(box_node));
+        let shared_scroll_slot =
+            common_ancestor_slot_along_scroll_parent_chain(scroll_state, anchor_scroll_slot, base_scroll_slot);
+        let mut s = anchor_scroll_slot;
+        while s != NO_SCROLL_STATE_SLOT && s != shared_scroll_slot {
+            own_state = sink.append_spatial_node_under(
+                own_state,
+                SpatialData::AnchorScrollShift(AnchorScrollShift {
+                    scroll_node_index: scroll_state.node_index_for_slot(s),
+                    negate: false,
+                    compensate_horizontal_scroll,
+                    compensate_vertical_scroll,
+                }),
+            );
+            s = scroll_state.state_at_slot(s).parent_slot;
+        }
+        let mut s = base_scroll_slot;
+        while s != NO_SCROLL_STATE_SLOT && s != shared_scroll_slot {
+            own_state = sink.append_spatial_node_under(
+                own_state,
+                SpatialData::AnchorScrollShift(AnchorScrollShift {
+                    scroll_node_index: scroll_state.node_index_for_slot(s),
+                    negate: true,
+                    compensate_horizontal_scroll,
+                    compensate_vertical_scroll,
+                }),
+            );
+            s = scroll_state.state_at_slot(s).parent_slot;
+        }
+        box_node = anchor_node;
+        anchor_node = resolver.default_scroll_shift_anchor(anchor_node);
+    }
+    own_state
+}
+
+pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: VisualContextNodeSink>(
+    env: &BoxBuildEnvironment<'_, Arena>,
+    sink: &mut Sink,
+    slot: NodeSlotId,
+    inherited: DescendantVisualContexts,
+    may_be_root_element: bool,
+    anchor_scroll_shift_resolver: Option<&dyn AnchorScrollShiftResolver>,
+) -> BoxVisualContextBuildOutput {
+    let layout_arena = env.layout_arena;
+    let first_spatial_node_index = sink.next_spatial_node_index().0;
+    let first_frame_node_index = sink.next_frame_node_index().0;
+    let facts = super::build::BoxFacts::gather(
+        layout_arena,
+        env.callbacks,
+        slot,
+        env.pixel_ratio,
+        env.tree_inputs.may_have_default_scroll_shift_anchor,
+    );
+    let position = crate::painting::style_queries::position(layout_arena, slot);
+    let is_fixed = position == crate::css::css_enums::positioning::FIXED;
+    let is_absolute = position == crate::css::css_enums::positioning::ABSOLUTE;
+    let is_sticky = position == crate::css::css_enums::positioning::STICKY;
+    let layout_node = slot;
+    let mut assignment = PaintableVisualContextAssignment::from_data(
+        slot,
+        layout_arena.paintable_data(slot),
+        PaintableVisualContextRecord {
+            inherited_input: inherited,
+            output_for_descendants: inherited,
+            node_handles: BoxVisualContextNodeHandles::default(),
+            has_mask_nodes: false,
+            may_be_root_element,
+        },
+    );
+    assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
+    assignment.own_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
+    assignment.fixed_background_visual_context = ContextRef::default();
+    assignment.has_fixed_background_visual_context = false;
+    assignment.has_scroll_offset_dependent_background = false;
+
+    let mut nearest_scroll_nodes_for_descendants = if is_fixed {
+        NearestScrollNodeIndices {
+            stopping_at_fixed_position_ancestors: VISUAL_VIEWPORT_NODE_INDEX,
+            continuing_through_fixed_position_ancestors: inherited
+                .fixed_position_nearest_scroll_nodes
+                .continuing_through_fixed_position_ancestors,
+        }
+    } else if is_absolute {
+        inherited.absolute_position_nearest_scroll_nodes
+    } else {
+        inherited.normal_nearest_scroll_nodes
+    };
+    let nearest_ancestor_scroll_node_index = if is_sticky {
+        nearest_scroll_nodes_for_descendants.continuing_through_fixed_position_ancestors
+    } else {
+        nearest_scroll_nodes_for_descendants.stopping_at_fixed_position_ancestors
+    };
+    if !is_fixed && !is_sticky {
+        assignment.enclosing_scroll_node_index = nearest_ancestor_scroll_node_index;
+    }
+
+    let creates_sticky_scroll_node = is_sticky;
+
+    let inherited_state = if is_fixed {
+        inherited.fixed_position
+    } else if is_absolute {
+        inherited.absolute_position
+    } else {
+        // In-flow and relatively positioned boxes inherit the normal descendant context from
+        // their visual parent.
+        inherited.normal
+    };
+    // Build this element's own state from inherited state.
+    let mut own_state = inherited_state;
+
+    match anchor_scroll_shift_resolver {
+        Some(resolver) => {
+            own_state = append_anchor_scroll_shift_nodes(
+                env,
+                sink,
+                resolver,
+                layout_node,
+                assignment.enclosing_scroll_node_index,
+                facts.default_scroll_shift_anchor,
+                own_state,
+            );
+        }
+        None => debug_assert!(
+            facts.default_scroll_shift_anchor.is_invalid(),
+            "anchor-positioned boxes are only built with a scroll shift resolver"
+        ),
+    }
+
+    // Out-of-flow descendants can skip overflow and scroll clips from intermediate ancestors.
+    let establishes_absolute_cb = facts.establishes_absolute_containing_block;
+    let establishes_fixed_cb = facts.establishes_fixed_containing_block;
+    let mut state_for_absolute_position_descendants = inherited.absolute_position;
+    let mut state_for_fixed_position_descendants = inherited.fixed_position;
+
+    macro_rules! append_frame_to_own_and_positioned_descendant_contexts {
+        ($make:expr) => {{
+            own_state = sink.append_frame_node_under(own_state, $make);
+            if !establishes_absolute_cb {
+                state_for_absolute_position_descendants =
+                    sink.append_frame_node_under(state_for_absolute_position_descendants, $make);
+            }
+            if !establishes_fixed_cb {
+                state_for_fixed_position_descendants =
+                    sink.append_frame_node_under(state_for_fixed_position_descendants, $make);
+            }
+        }};
+    }
+
+    let mut sticky_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
+    if creates_sticky_scroll_node {
+        own_state = sink.append_spatial_node_under(
+            own_state,
+            SpatialData::Sticky(StickyData::unconstrained(
+                nearest_ancestor_scroll_node_index,
+                None,
+                NO_SCROLL_STATE_SLOT,
+                slot,
+                nearest_ancestor_scroll_node_index,
+            )),
+        );
+        sticky_scroll_node_index = own_state.spatial;
+        assignment.enclosing_scroll_node_index = sticky_scroll_node_index;
+        nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
+            stopping_at_fixed_position_ancestors: sticky_scroll_node_index,
+            continuing_through_fixed_position_ancestors: sticky_scroll_node_index,
+        };
+    }
+
+    let transform_data = facts.transform;
+
+    if facts.effects.is_some() {
+        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Effects(facts.effects_data().unwrap()));
+    }
+
+    let flattens_inherited_transform = inherited.flattens_inherited_transform;
+
+    let mut appended_transform_node = false;
+    if let Some(mut transform) = transform_data {
+        transform.flattens_inherited_transform = flattens_inherited_transform;
+        transform.sorting_context_root_index = inherited.sorting_context_root;
+        transform.establishes_sorting_context =
+            facts.establishes_or_extends_3d_rendering_context && inherited.sorting_context_root.is_none();
+        assignment.has_non_invertible_css_transform = !facts.transform_is_invertible;
+        own_state = sink.append_spatial_node_under(own_state, SpatialData::Transform(transform));
+        appended_transform_node = true;
+    } else {
+        assignment.has_non_invertible_css_transform = false;
+    }
+
+    let inherited_plane_root = if is_fixed {
+        inherited.fixed_position_plane_root
+    } else if is_absolute {
+        inherited.absolute_position_plane_root
+    } else {
+        inherited.normal_plane_root
+    };
+    let establishes_or_extends_3d_rendering_context = facts.establishes_or_extends_3d_rendering_context;
+    let node_data_flags = layout_arena.node_flags_if_live(layout_node);
+    let invisible_to_3d_rendering_contexts = node_data_flags & NodeFlag::Anonymous as u32 != 0
+        && !layout_arena.node_is_generated_for_pseudo_element(layout_node);
+
+    let mut appended_synthetic_plane = false;
+    if !invisible_to_3d_rendering_contexts && establishes_or_extends_3d_rendering_context && !appended_transform_node {
+        own_state = sink.append_spatial_node_under(
+            own_state,
+            SpatialData::Transform(TransformData {
+                matrix: libgfx_rust::FloatMatrix4x4::identity(),
+                origin: FloatPoint::default(),
+                sorting_context_root_index: inherited.sorting_context_root,
+                flattens_inherited_transform,
+                role: TransformDataRole::CssTransform,
+                synthetic_plane: true,
+                establishes_sorting_context: inherited.sorting_context_root.is_none(),
+            }),
+        );
+        appended_synthetic_plane = true;
+    }
+
+    let mut appended_backface_marker = false;
+    // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
+    // NB: Whether the element's backface is visible depends on its accumulated 3D transformation matrix, which
+    //     is only known at replay time once scroll offsets have been applied. The node recorded below marks the
+    //     content to skip and stores the plane root from which that matrix is accumulated. The plane root bounds
+    //     the accumulation to the element's 3D rendering context.
+    // AD-HOC: The spec determines visibility from the sign of m33 in the accumulated matrix. That is wrong for
+    //         matrices with a perspective component, so we test the z-component of the transformed plane normal
+    //         instead. See: https://github.com/w3c/csswg-drafts/issues/917.
+    if facts.backface_hidden {
+        own_state = sink.append_spatial_node_under(
+            own_state,
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: inherited_plane_root,
+                flattens_inherited_transform: !appended_transform_node
+                    && !appended_synthetic_plane
+                    && flattens_inherited_transform,
+            }),
+        );
+        appended_backface_marker = true;
+    }
+
+    // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
+    // An element participates in a 3D rendering context if its parent establishes or extends a 3D rendering
+    // context. The position of each element in that three-dimensional space is determined by accumulating the
+    // transformation matrices up from the given element to the element that establishes the 3D rendering context.
+    // NB: Children of an element that neither establishes nor extends a 3D rendering context start a new plane
+    //     below the element's own transform. Anonymous boxes carry no element style and are invisible to 3D
+    //     rendering contexts, so they pass the inherited plane through unchanged. Pseudo-element boxes carry
+    //     their own style and participate normally. An inherited flatten is only materialized by an appended
+    //     node, so an element that appends none keeps it pending for its descendants.
+    let plane_root_for_descendants =
+        if establishes_or_extends_3d_rendering_context || invisible_to_3d_rendering_contexts {
+            inherited_plane_root
+        } else {
+            own_state.spatial
+        };
+    let inherited_flatten_still_pending = flattens_inherited_transform
+        && !appended_transform_node
+        && !appended_synthetic_plane
+        && !appended_backface_marker;
+    let mut descendants_flatten_inherited_transform = if invisible_to_3d_rendering_contexts {
+        flattens_inherited_transform
+    } else {
+        !establishes_or_extends_3d_rendering_context || inherited_flatten_still_pending
+    };
+
+    // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
+    // A 3D rendering context is established by a transformable element whose used value for transform-style
+    // is preserve-3d and which itself is not part of a 3D rendering context. An element that establishes a
+    // 3D rendering context also participates in that context.
+    // NB: The establishing element's own state serves as the context's root; replay sorts the content
+    //     recorded under it as the context's z=0 plane alongside the planes of the participants, whose
+    //     transform nodes reference the root.
+    let mut sorting_context_root_for_descendants = inherited.sorting_context_root;
+    if !invisible_to_3d_rendering_contexts {
+        if !establishes_or_extends_3d_rendering_context {
+            sorting_context_root_for_descendants = None;
+        } else if sorting_context_root_for_descendants.is_none() {
+            sorting_context_root_for_descendants = Some(own_state.spatial);
+        }
+    }
+
+    if let Some(css_clip) = facts.css_clip {
+        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Clip(css_clip));
+    }
+
+    if facts.clip_path.is_some() {
+        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::ClipPath(facts.clip_path_data().unwrap()));
+    }
+
+    if !facts.mask_layers.is_empty() {
+        assignment.record.has_mask_nodes = true;
+    }
+    for mask_layer in &facts.mask_layers {
+        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Mask(*mask_layer));
+    }
+
+    assignment.has_accumulated_visual_context = true;
+    assignment.accumulated_visual_context = own_state;
+
+    let local_frames_begin = sink.next_frame_node_index().0;
+    LocalFrameBuilder::new(sink, layout_arena, slot, env.pixel_ratio, false)
+        .build(own_state, Some(env.root_background_source));
+    let local_frames_end = sink.next_frame_node_index().0;
+
+    if super::node_values::wants_fixed_background_visual_context(
+        layout_arena,
+        env.root_background_source,
+        slot,
+        may_be_root_element,
+    ) {
+        // Rooted above every scroll-like node on the box's root path, the background stays put
+        // under scrolling while the box's own frames keep clipping it in their scrolled spaces.
+        let mut fixed_background_spatial = own_state.spatial;
+        let mut index = own_state.spatial;
+        while index != VISUAL_VIEWPORT_NODE_INDEX {
+            let node = sink.spatial_node_at(index);
+            if node.data.is_scroll_like() {
+                fixed_background_spatial = node.parent;
+            }
+            index = node.parent;
+        }
+        assignment.fixed_background_visual_context = ContextRef {
+            spatial: fixed_background_spatial,
+            frame: own_state.frame,
+        };
+        assignment.has_fixed_background_visual_context = true;
+    }
+
+    if super::node_values::background_depends_on_live_scroll_offset(
+        layout_arena,
+        env.root_background_source,
+        slot,
+        may_be_root_element,
+    ) {
+        assignment.has_scroll_offset_dependent_background = true;
+    }
+
+    // Build state for descendants: own state + perspective + clip + scroll.
+    let mut state_for_descendants = own_state;
+
+    if let Some(mut perspective) = facts.perspective {
+        perspective.flattens_inherited_transform = descendants_flatten_inherited_transform;
+        descendants_flatten_inherited_transform = false;
+        state_for_descendants =
+            sink.append_spatial_node_under(state_for_descendants, SpatialData::Perspective(perspective));
+    }
+
+    if facts.may_have_clip
+        && let Some(overflow_clip) = facts.overflow_clip
+    {
+        state_for_descendants = sink.append_frame_node_under(state_for_descendants, FrameData::Clip(overflow_clip));
+    }
+
+    if paintable_geometry::has_scrollable_overflow(layout_arena.paintable_data(slot)) {
+        let parent_index = if creates_sticky_scroll_node {
+            sticky_scroll_node_index
+        } else {
+            nearest_ancestor_scroll_node_index
+        };
+        state_for_descendants = sink.append_spatial_node_under(
+            state_for_descendants,
+            SpatialData::Scroll(ScrollData {
+                state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: slot,
+                registry_parent_node: parent_index,
+            }),
+        );
+        let scroll_node_index = state_for_descendants.spatial;
+        assignment.own_scroll_node_index = scroll_node_index;
+        nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
+            stopping_at_fixed_position_ancestors: scroll_node_index,
+            continuing_through_fixed_position_ancestors: scroll_node_index,
+        };
+    }
+
+    // Positioned descendants that escape into a viewport-establishing containing block lay
+    // out in the box's own coordinate space, not the viewport's user units, so they hang
+    // above the viewport transform node.
+    let state_for_positioned_descendants = state_for_descendants;
+    if let Some(svg_viewport_transform) = super::build::svg_viewport_transform_of(layout_arena, slot) {
+        let mut viewport_transform_data = super::build::compute_svg_viewport_transform_data(
+            layout_arena,
+            slot,
+            svg_viewport_transform,
+            env.pixel_ratio,
+        );
+        viewport_transform_data.flattens_inherited_transform = descendants_flatten_inherited_transform;
+        descendants_flatten_inherited_transform = false;
+        state_for_descendants =
+            sink.append_spatial_node_under(state_for_descendants, SpatialData::Transform(viewport_transform_data));
+    }
+
+    assignment.accumulated_visual_context_for_descendants = state_for_descendants;
+    assignment.record.node_handles = BoxVisualContextNodeHandles {
+        spatial: (first_spatial_node_index..sink.next_spatial_node_index().0)
+            .map(SpatialNodeIndex)
+            .collect(),
+        chain_frames: (first_frame_node_index..local_frames_begin)
+            .map(FrameNodeIndex)
+            .collect(),
+        local_frames: (local_frames_begin..local_frames_end).map(FrameNodeIndex).collect(),
+        descendant_frames: (local_frames_end..sink.next_frame_node_index().0)
+            .map(FrameNodeIndex)
+            .collect(),
+    };
+    let mut absolute_position_nearest_scroll_nodes = inherited.absolute_position_nearest_scroll_nodes;
+    let mut fixed_position_nearest_scroll_nodes = inherited.fixed_position_nearest_scroll_nodes;
+    let mut absolute_position_plane_root = inherited.absolute_position_plane_root;
+    let mut fixed_position_plane_root = inherited.fixed_position_plane_root;
+    if establishes_absolute_cb {
+        state_for_absolute_position_descendants = state_for_positioned_descendants;
+        absolute_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
+        absolute_position_plane_root = plane_root_for_descendants;
+    }
+    if establishes_fixed_cb {
+        state_for_fixed_position_descendants = state_for_positioned_descendants;
+        fixed_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
+        fixed_position_plane_root = plane_root_for_descendants;
+    }
+
+    let descendant_contexts = DescendantVisualContexts {
+        normal: state_for_descendants,
+        absolute_position: state_for_absolute_position_descendants,
+        fixed_position: state_for_fixed_position_descendants,
+        normal_nearest_scroll_nodes: nearest_scroll_nodes_for_descendants,
+        absolute_position_nearest_scroll_nodes,
+        fixed_position_nearest_scroll_nodes,
+        normal_plane_root: plane_root_for_descendants,
+        absolute_position_plane_root,
+        fixed_position_plane_root,
+        flattens_inherited_transform: descendants_flatten_inherited_transform,
+        sorting_context_root: sorting_context_root_for_descendants,
+    };
+    assignment.record.output_for_descendants = descendant_contexts;
+    BoxVisualContextBuildOutput {
+        assignment,
+        descendant_contexts,
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -236,6 +236,8 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
             node_handles: BoxVisualContextNodeHandles::default(),
             has_mask_nodes: false,
             may_be_root_element,
+            owns_geometry_dependent_nodes: false,
+            subtree_may_own_geometry_dependent_nodes: false,
         },
     );
     assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
@@ -562,17 +564,15 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     }
 
     assignment.accumulated_visual_context_for_descendants = state_for_descendants;
+    let spatial_end = sink.next_spatial_node_index().0;
+    let descendant_frames_end = sink.next_frame_node_index().0;
     assignment.record.node_handles = BoxVisualContextNodeHandles {
-        spatial: (first_spatial_node_index..sink.next_spatial_node_index().0)
-            .map(SpatialNodeIndex)
-            .collect(),
+        spatial: (first_spatial_node_index..spatial_end).map(SpatialNodeIndex).collect(),
         chain_frames: (first_frame_node_index..local_frames_begin)
             .map(FrameNodeIndex)
             .collect(),
         local_frames: (local_frames_begin..local_frames_end).map(FrameNodeIndex).collect(),
-        descendant_frames: (local_frames_end..sink.next_frame_node_index().0)
-            .map(FrameNodeIndex)
-            .collect(),
+        descendant_frames: (local_frames_end..descendant_frames_end).map(FrameNodeIndex).collect(),
     };
     let mut absolute_position_nearest_scroll_nodes = inherited.absolute_position_nearest_scroll_nodes;
     let mut fixed_position_nearest_scroll_nodes = inherited.fixed_position_nearest_scroll_nodes;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -306,7 +306,28 @@ impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
         if output.assignment.record.has_mask_nodes {
             self.paintables_with_mask_nodes.push(slot);
         }
-        self.assignments[slot.slot_index() as usize] = Some(output.assignment);
+        let mut assignment = output.assignment;
+        assignment.record.owns_geometry_dependent_nodes = super::incremental::box_owns_geometry_dependent_nodes(
+            self.layout_arena,
+            &self.tree,
+            slot,
+            &assignment.record.node_handles,
+        );
+        if assignment.record.owns_geometry_dependent_nodes {
+            assignment.record.subtree_may_own_geometry_dependent_nodes = true;
+            let mut ancestor = crate::painting::paint_order::paint_parent(self.layout_arena, slot);
+            while let Some(current) = ancestor {
+                let Some(ancestor_assignment) = self.assignments[current.slot_index() as usize].as_mut() else {
+                    break;
+                };
+                if ancestor_assignment.record.subtree_may_own_geometry_dependent_nodes {
+                    break;
+                }
+                ancestor_assignment.record.subtree_may_own_geometry_dependent_nodes = true;
+                ancestor = crate::painting::paint_order::paint_parent(self.layout_arena, current);
+            }
+        }
+        self.assignments[slot.slot_index() as usize] = Some(assignment);
         output.descendant_contexts
     }
 
@@ -399,6 +420,8 @@ pub(crate) fn build_visual_context_tree(
                 node_handles: BoxVisualContextNodeHandles::default(),
                 has_mask_nodes: false,
                 may_be_root_element: false,
+                owns_geometry_dependent_nodes: false,
+                subtree_may_own_geometry_dependent_nodes: false,
             },
         );
         viewport_assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
@@ -529,112 +552,4 @@ pub(crate) fn build_visual_context_tree(
         builder.paintables_with_mask_nodes,
         builder.assignments.into_iter().flatten().collect(),
     )
-}
-
-// Patches the transform/effects/perspective values of the box's existing visual context nodes in place.
-// Returns false if the box's node structure no longer matches; the caller must then do a full rebuild.
-pub(crate) fn update_visual_context_values(
-    layout_arena: &impl PaintableRowsRead,
-    callbacks: &FfiVisualContextHostCallbacks,
-    tree: &mut VisualContextTree,
-    slot: NodeSlotId,
-    pixel_ratio: f64,
-) -> (bool, Option<bool>) {
-    let Some(node_handles) = layout_arena
-        .paintable_visual_context_record(slot)
-        .map(|record| record.node_handles.clone())
-    else {
-        return (false, None);
-    };
-    if node_handles
-        .spatial
-        .iter()
-        .any(|index| index.0 as usize >= tree.spatial_nodes.len())
-        || node_handles
-            .frame_handles()
-            .any(|index| index.0 as usize >= tree.frame_nodes.len())
-    {
-        return (false, None);
-    }
-    let transform_with_invertibility =
-        super::node_values::compute_transform(layout_arena, callbacks, slot, pixel_ratio);
-    let transform = transform_with_invertibility.map(|(transform, _)| transform);
-    let transform_is_invertible = transform_with_invertibility.is_some_and(|(_, invertible)| invertible);
-    let effects = super::node_values::compute_effects_data(layout_arena, callbacks, slot, pixel_ratio);
-    let perspective = super::node_values::compute_perspective_data(layout_arena, slot, pixel_ratio);
-    let svg_viewport_transform_data = svg_viewport_transform_of(layout_arena, slot)
-        .map(|transform| compute_svg_viewport_transform_data(layout_arena, slot, transform, pixel_ratio));
-
-    let has_non_invertible_css_transform = transform.is_some() && !transform_is_invertible;
-
-    let compatible = (|| {
-        let mut found_css_transform = false;
-        let mut found_svg_viewport_transform = false;
-        let mut found_effects = false;
-        let mut found_perspective = false;
-        for index in node_handles.spatial.iter().map(|index| index.0 as usize) {
-            match &mut tree.spatial_nodes[index].data {
-                SpatialData::Transform(transform_data) => {
-                    if transform_data.role == TransformDataRole::SvgViewportTransform {
-                        let Some(mut new_data) = svg_viewport_transform_data else {
-                            return false;
-                        };
-                        new_data.flattens_inherited_transform = transform_data.flattens_inherited_transform;
-                        *transform_data = new_data;
-                        found_svg_viewport_transform = true;
-                        continue;
-                    }
-                    // A synthetic plane node has no computed transform behind it. It stays as-is unless the element
-                    // gained a real transform, which changes the structure the node was built for.
-                    if transform_data.synthetic_plane {
-                        if transform.is_some() {
-                            return false;
-                        }
-                        continue;
-                    }
-                    let Some(mut new_data) = transform else {
-                        return false;
-                    };
-                    new_data.flattens_inherited_transform = transform_data.flattens_inherited_transform;
-                    new_data.sorting_context_root_index = transform_data.sorting_context_root_index;
-                    new_data.establishes_sorting_context = transform_data.establishes_sorting_context;
-                    *transform_data = new_data;
-                    found_css_transform = true;
-                }
-                SpatialData::Perspective(perspective_data) => {
-                    let Some(mut new_data) = perspective else {
-                        return false;
-                    };
-                    new_data.flattens_inherited_transform = perspective_data.flattens_inherited_transform;
-                    *perspective_data = new_data;
-                    found_perspective = true;
-                }
-                _ => {}
-            }
-        }
-        for index in node_handles.frame_handles().map(|index| index.0 as usize) {
-            let node = &mut tree.frame_nodes[index];
-            if node.role != FrameRole::Structural {
-                continue;
-            }
-            // The builder duplicates a box's EffectsData into the positioned-descendant chains, so every
-            // node of a kind is patched with the same recomputed payload.
-            if let FrameData::Effects(effects_data) = &mut node.data {
-                let Some(new_effects) = &effects else {
-                    return false;
-                };
-                *effects_data = EffectsData {
-                    opacity: new_effects.opacity,
-                    blend_mode: new_effects.blend_mode,
-                    filter: new_effects.filter.clone(),
-                };
-                found_effects = true;
-            }
-        }
-        transform.is_some() == found_css_transform
-            && effects.is_some() == found_effects
-            && perspective.is_some() == found_perspective
-            && svg_viewport_transform_data.is_some() == found_svg_viewport_transform
-    })();
-    (compatible, Some(has_non_invertible_css_transform))
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -4,79 +4,21 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use super::local_frames::LocalFrameBuilder;
+use super::box_build::{
+    AnchorScrollShiftResolver, BoxBuildEnvironment, PaintableVisualContextAssignment, build_box_visual_context_nodes,
+};
 use super::refresh::compute_sticky_data;
-use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
+use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState};
 use super::*;
-use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_data::{NodeKind, NodeSlotId};
 use crate::painting::host::{FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
-use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
-use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
+use crate::painting::paintable_rows::PaintableRowsRead;
 use libgfx_rust::{
     AffineTransform, CompositingAndBlendingOperator, FloatPoint, IntRect, WindingRule, affine_to_matrix,
     scale_matrix_for_device_pixels, translated_then_multiplied,
 };
 use std::collections::HashSet;
-
-#[derive(Clone, Copy)]
-pub(crate) struct PaintableVisualContextAssignment {
-    slot: NodeSlotId,
-    enclosing_scroll_node_index: SpatialNodeIndex,
-    own_scroll_node_index: SpatialNodeIndex,
-    has_accumulated_visual_context: bool,
-    accumulated_visual_context: ContextRef,
-    accumulated_visual_context_for_descendants: ContextRef,
-    fixed_background_visual_context: ContextRef,
-    has_fixed_background_visual_context: bool,
-    has_scroll_offset_dependent_background: bool,
-    spatial_nodes_begin: u32,
-    spatial_nodes_end: u32,
-    frame_nodes_begin: u32,
-    frame_nodes_end: u32,
-    has_non_invertible_css_transform: bool,
-}
-
-impl PaintableVisualContextAssignment {
-    fn from_data(slot: NodeSlotId, data: &PaintableData) -> Self {
-        Self {
-            slot,
-            enclosing_scroll_node_index: data.enclosing_scroll_node_index,
-            own_scroll_node_index: data.own_scroll_node_index,
-            has_accumulated_visual_context: data.has_accumulated_visual_context,
-            accumulated_visual_context: data.accumulated_visual_context,
-            accumulated_visual_context_for_descendants: data.accumulated_visual_context_for_descendants,
-            fixed_background_visual_context: data.fixed_background_visual_context,
-            has_fixed_background_visual_context: data.has_fixed_background_visual_context,
-            has_scroll_offset_dependent_background: data.has_scroll_offset_dependent_background,
-            spatial_nodes_begin: data.spatial_nodes_begin,
-            spatial_nodes_end: data.spatial_nodes_end,
-            frame_nodes_begin: data.frame_nodes_begin,
-            frame_nodes_end: data.frame_nodes_end,
-            has_non_invertible_css_transform: data.has_flag(PaintableFlag::HasNonInvertibleCssTransform),
-        }
-    }
-
-    pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
-        let data = layout_arena.paintable_data_mut(self.slot);
-        data.enclosing_scroll_node_index = self.enclosing_scroll_node_index;
-        data.own_scroll_node_index = self.own_scroll_node_index;
-        data.has_accumulated_visual_context = self.has_accumulated_visual_context;
-        data.accumulated_visual_context = self.accumulated_visual_context;
-        data.accumulated_visual_context_for_descendants = self.accumulated_visual_context_for_descendants;
-        data.fixed_background_visual_context = self.fixed_background_visual_context;
-        data.has_fixed_background_visual_context = self.has_fixed_background_visual_context;
-        data.has_scroll_offset_dependent_background = self.has_scroll_offset_dependent_background;
-        data.spatial_nodes_begin = self.spatial_nodes_begin;
-        data.spatial_nodes_end = self.spatial_nodes_end;
-        data.frame_nodes_begin = self.frame_nodes_begin;
-        data.frame_nodes_end = self.frame_nodes_end;
-        data.set_flag(
-            PaintableFlag::HasNonInvertibleCssTransform,
-            self.has_non_invertible_css_transform,
-        );
-    }
-}
 
 // Content below a viewport node records in the viewport's user units scaled by the device pixel
 // ratio, mirroring how ordinary content records in CSS pixels scaled by it; the node folds the
@@ -208,7 +150,7 @@ impl BoxFacts {
         facts
     }
 
-    fn clip_path_data(&self) -> Option<ClipPathData> {
+    pub(crate) fn clip_path_data(&self) -> Option<ClipPathData> {
         self.clip_path
             .as_ref()
             .map(|(path, bounding_rect, fill_rule)| ClipPathData {
@@ -219,56 +161,33 @@ impl BoxFacts {
     }
 }
 
-fn common_ancestor_slot_along_scroll_parent_chain(
-    scroll_state: &ScrollState,
-    a_slot: ScrollStateSlot,
-    b_slot: ScrollStateSlot,
-) -> ScrollStateSlot {
-    let mut a_slot_and_ancestors = Vec::new();
-    let mut slot = a_slot;
-    loop {
-        a_slot_and_ancestors.push(slot);
-        if slot == NO_SCROLL_STATE_SLOT {
-            break;
-        }
-        slot = scroll_state.state_at_slot(slot).parent_slot;
-    }
-    let mut slot = b_slot;
-    loop {
-        if a_slot_and_ancestors.contains(&slot) {
-            return slot;
-        }
-        if slot == NO_SCROLL_STATE_SLOT {
-            break;
-        }
-        slot = scroll_state.state_at_slot(slot).parent_slot;
-    }
-    NO_SCROLL_STATE_SLOT
+struct FullBuildAnchorScrollShiftResolver<'a, Arena> {
+    layout_arena: &'a Arena,
+    callbacks: &'a FfiVisualContextHostCallbacks,
+    scroll_state: &'a ScrollState,
+    assignments: &'a [Option<PaintableVisualContextAssignment>],
+    may_have_default_scroll_shift_anchor: bool,
 }
 
-// Nearest ancestor scroll node resolved along the containing block chain, drilled down alongside
-// the visual context indices. A fixed-position ancestor decouples its subtree from all outer
-// scrollers, but sticky boxes must still reference a scrollport through fixed-position ancestors
-// for their sticky offset computation, so both resolutions are carried.
-#[derive(Clone, Copy)]
-struct NearestScrollNodeIndices {
-    stopping_at_fixed_position_ancestors: SpatialNodeIndex,
-    continuing_through_fixed_position_ancestors: SpatialNodeIndex,
-}
+impl<Arena: PaintableRowsRead> AnchorScrollShiftResolver for FullBuildAnchorScrollShiftResolver<'_, Arena> {
+    fn default_scroll_shift_anchor(&self, slot: NodeSlotId) -> NodeSlotId {
+        if !self.may_have_default_scroll_shift_anchor {
+            return NodeSlotId::INVALID;
+        }
+        self.callbacks
+            .default_scroll_shift_anchor(self.layout_arena.shell_if_live(slot))
+    }
 
-#[derive(Clone, Copy)]
-struct DescendantVisualContexts {
-    normal: ContextRef,
-    absolute_position: ContextRef,
-    fixed_position: ContextRef,
-    normal_nearest_scroll_nodes: NearestScrollNodeIndices,
-    absolute_position_nearest_scroll_nodes: NearestScrollNodeIndices,
-    fixed_position_nearest_scroll_nodes: NearestScrollNodeIndices,
-    normal_plane_root: SpatialNodeIndex,
-    absolute_position_plane_root: SpatialNodeIndex,
-    fixed_position_plane_root: SpatialNodeIndex,
-    flattens_inherited_transform: bool,
-    sorting_context_root: Option<SpatialNodeIndex>,
+    fn enclosing_scroll_node_index(&self, slot: NodeSlotId) -> SpatialNodeIndex {
+        self.assignments[slot.slot_index() as usize].as_ref().map_or_else(
+            || self.layout_arena.paintable_data(slot).enclosing_scroll_node_index,
+            |assignment| assignment.enclosing_scroll_node_index,
+        )
+    }
+
+    fn scroll_state(&self) -> &ScrollState {
+        self.scroll_state
+    }
 }
 
 struct Builder<'a, Arena> {
@@ -285,22 +204,6 @@ struct Builder<'a, Arena> {
 }
 
 impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
-    fn assignment_mut(&mut self, slot: NodeSlotId) -> &mut PaintableVisualContextAssignment {
-        let index = slot.slot_index() as usize;
-        if self.assignments[index].is_none() {
-            let assignment = PaintableVisualContextAssignment::from_data(slot, self.layout_arena.paintable_data(slot));
-            self.assignments[index] = Some(assignment);
-        }
-        self.assignments[index].as_mut().unwrap()
-    }
-
-    fn enclosing_scroll_node_index(&self, slot: NodeSlotId) -> SpatialNodeIndex {
-        self.assignments[slot.slot_index() as usize].map_or_else(
-            || self.layout_arena.paintable_data(slot).enclosing_scroll_node_index,
-            |assignment| assignment.enclosing_scroll_node_index,
-        )
-    }
-
     fn default_scroll_shift_anchor(&self, slot: NodeSlotId) -> NodeSlotId {
         if !self.may_have_default_scroll_shift_anchor {
             return NodeSlotId::INVALID;
@@ -353,456 +256,58 @@ impl<Arena: PaintableRowsRead> Builder<'_, Arena> {
         ));
     }
 
+    fn register_scroll_like_nodes(&mut self, spatial_handles: &[SpatialNodeIndex]) {
+        for node_index in spatial_handles.iter().copied() {
+            match &self.tree.spatial_nodes[node_index.0 as usize].data {
+                SpatialData::Scroll(scroll) => {
+                    let (owner_paintable, registry_parent_node) = (scroll.owner_paintable, scroll.registry_parent_node);
+                    self.register_scroll_node(node_index, owner_paintable, registry_parent_node);
+                }
+                SpatialData::Sticky(sticky) => {
+                    let (owner_paintable, registry_parent_node) = (sticky.owner_paintable, sticky.registry_parent_node);
+                    self.register_sticky_node(node_index, owner_paintable, registry_parent_node);
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn build_paintable_box(
         &mut self,
         slot: NodeSlotId,
         inherited: DescendantVisualContexts,
         may_be_root_element: bool,
     ) -> DescendantVisualContexts {
-        let first_spatial_node_index = self.tree.spatial_nodes.len() as u32;
-        let first_frame_node_index = self.tree.frame_nodes.len() as u32;
-        let facts = BoxFacts::gather(
-            self.layout_arena,
-            self.callbacks,
-            slot,
-            self.pixel_ratio,
-            self.may_have_default_scroll_shift_anchor,
-        );
-        let position = crate::painting::style_queries::position(self.layout_arena, slot);
-        let is_fixed = position == crate::css::css_enums::positioning::FIXED;
-        let is_absolute = position == crate::css::css_enums::positioning::ABSOLUTE;
-        let is_sticky = position == crate::css::css_enums::positioning::STICKY;
-        let layout_node = slot;
-        {
-            let assignment = self.assignment_mut(slot);
-            assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
-            assignment.own_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
-            assignment.fixed_background_visual_context = ContextRef::default();
-            assignment.has_fixed_background_visual_context = false;
-            assignment.has_scroll_offset_dependent_background = false;
-        }
-
-        let mut nearest_scroll_nodes_for_descendants = if is_fixed {
-            NearestScrollNodeIndices {
-                stopping_at_fixed_position_ancestors: VISUAL_VIEWPORT_NODE_INDEX,
-                continuing_through_fixed_position_ancestors: inherited
-                    .fixed_position_nearest_scroll_nodes
-                    .continuing_through_fixed_position_ancestors,
-            }
-        } else if is_absolute {
-            inherited.absolute_position_nearest_scroll_nodes
-        } else {
-            inherited.normal_nearest_scroll_nodes
+        let environment = BoxBuildEnvironment {
+            layout_arena: self.layout_arena,
+            callbacks: self.callbacks,
+            pixel_ratio: self.pixel_ratio,
+            tree_inputs: self.tree_inputs,
+            root_background_source: self.root_background_source,
         };
-        let nearest_ancestor_scroll_node_index = if is_sticky {
-            nearest_scroll_nodes_for_descendants.continuing_through_fixed_position_ancestors
-        } else {
-            nearest_scroll_nodes_for_descendants.stopping_at_fixed_position_ancestors
-        };
-        if !is_fixed && !is_sticky {
-            self.assignment_mut(slot).enclosing_scroll_node_index = nearest_ancestor_scroll_node_index;
-        }
-
-        let creates_sticky_scroll_node = is_sticky;
-
-        let inherited_state = if is_fixed {
-            inherited.fixed_position
-        } else if is_absolute {
-            inherited.absolute_position
-        } else {
-            // In-flow and relatively positioned boxes inherit the normal descendant context from
-            // their visual parent.
-            inherited.normal
-        };
-        // Build this element's own state from inherited state.
-        let mut own_state = inherited_state;
-
-        {
-            // https://drafts.csswg.org/css-anchor-position-1/#default-scroll-shift
-            // After layout has been performed for abspos, it is additionally shifted by the default scroll shift, as if
-            // affected by a transform (before any other transforms).
-            // NB: The shift is the scroll movement of the frames between the box's containing block and its default
-            //     anchor box. When the anchor is itself an anchor-positioned box, its layout position does not include
-            //     its own paint-time shift, so each chained anchor's shift is emitted as well, masked to the axes that
-            //     every link below it compensates in. The visited set and depth cap guard against malformed anchor chains.
-            let mut box_node = layout_node;
-            let mut compensate_horizontal_scroll = true;
-            let mut compensate_vertical_scroll = true;
-            let mut visited: Vec<NodeSlotId> = Vec::new();
-            const MAX_ANCHOR_CHAIN_DEPTH: usize = 32;
-            let mut anchor_node = facts.default_scroll_shift_anchor;
-            while !box_node.is_invalid() && !visited.contains(&box_node) && visited.len() < MAX_ANCHOR_CHAIN_DEPTH {
-                if anchor_node.is_invalid() {
-                    break;
-                }
-                if !self.layout_arena.paintable_row_is_populated(box_node)
-                    || !self.layout_arena.paintable_row_is_populated(anchor_node)
-                {
-                    break;
-                }
-                visited.push(box_node);
-                let box_flags = self.layout_arena.node_flags_if_live(box_node);
-                compensate_horizontal_scroll =
-                    compensate_horizontal_scroll && box_flags & NodeFlag::CompensatesForHorizontalScroll as u32 != 0;
-                compensate_vertical_scroll =
-                    compensate_vertical_scroll && box_flags & NodeFlag::CompensatesForVerticalScroll as u32 != 0;
-                let anchor_scroll_slot = self
-                    .tree
-                    .scroll_state_slot_for_node(self.enclosing_scroll_node_index(anchor_node));
-                let base_scroll_slot = self
-                    .tree
-                    .scroll_state_slot_for_node(self.enclosing_scroll_node_index(box_node));
-                let shared_scroll_slot = common_ancestor_slot_along_scroll_parent_chain(
-                    &self.scroll_state,
-                    anchor_scroll_slot,
-                    base_scroll_slot,
-                );
-                let mut s = anchor_scroll_slot;
-                while s != NO_SCROLL_STATE_SLOT && s != shared_scroll_slot {
-                    own_state = self.tree.append_spatial_under(
-                        own_state,
-                        SpatialData::AnchorScrollShift(AnchorScrollShift {
-                            scroll_node_index: self.scroll_state.node_index_for_slot(s),
-                            negate: false,
-                            compensate_horizontal_scroll,
-                            compensate_vertical_scroll,
-                        }),
-                    );
-                    s = self.scroll_state.state_at_slot(s).parent_slot;
-                }
-                let mut s = base_scroll_slot;
-                while s != NO_SCROLL_STATE_SLOT && s != shared_scroll_slot {
-                    own_state = self.tree.append_spatial_under(
-                        own_state,
-                        SpatialData::AnchorScrollShift(AnchorScrollShift {
-                            scroll_node_index: self.scroll_state.node_index_for_slot(s),
-                            negate: true,
-                            compensate_horizontal_scroll,
-                            compensate_vertical_scroll,
-                        }),
-                    );
-                    s = self.scroll_state.state_at_slot(s).parent_slot;
-                }
-                box_node = anchor_node;
-                anchor_node = self.default_scroll_shift_anchor(anchor_node);
-            }
-        }
-
-        // Out-of-flow descendants can skip overflow and scroll clips from intermediate ancestors.
-        let establishes_absolute_cb = facts.establishes_absolute_containing_block;
-        let establishes_fixed_cb = facts.establishes_fixed_containing_block;
-        let mut state_for_absolute_position_descendants = inherited.absolute_position;
-        let mut state_for_fixed_position_descendants = inherited.fixed_position;
-
-        macro_rules! append_frame_to_own_and_positioned_descendant_contexts {
-            ($make:expr) => {{
-                own_state = self.tree.append_frame_under(own_state, $make);
-                if !establishes_absolute_cb {
-                    state_for_absolute_position_descendants = self
-                        .tree
-                        .append_frame_under(state_for_absolute_position_descendants, $make);
-                }
-                if !establishes_fixed_cb {
-                    state_for_fixed_position_descendants = self
-                        .tree
-                        .append_frame_under(state_for_fixed_position_descendants, $make);
-                }
-            }};
-        }
-
-        let mut sticky_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
-        if creates_sticky_scroll_node {
-            own_state = self.tree.append_spatial_under(
-                own_state,
-                SpatialData::Sticky(StickyData::unconstrained(
-                    nearest_ancestor_scroll_node_index,
-                    None,
-                    NO_SCROLL_STATE_SLOT,
-                )),
-            );
-            sticky_scroll_node_index = own_state.spatial;
-            self.register_sticky_node(sticky_scroll_node_index, slot, nearest_ancestor_scroll_node_index);
-            {
-                self.assignment_mut(slot).enclosing_scroll_node_index = sticky_scroll_node_index;
-            }
-            nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
-                stopping_at_fixed_position_ancestors: sticky_scroll_node_index,
-                continuing_through_fixed_position_ancestors: sticky_scroll_node_index,
+        let output = {
+            let resolver = FullBuildAnchorScrollShiftResolver {
+                layout_arena: self.layout_arena,
+                callbacks: self.callbacks,
+                scroll_state: &self.scroll_state,
+                assignments: &self.assignments,
+                may_have_default_scroll_shift_anchor: self.may_have_default_scroll_shift_anchor,
             };
-        }
-
-        let transform_data = facts.transform;
-
-        if facts.effects.is_some() {
-            append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Effects(facts.effects_data().unwrap()));
-        }
-
-        let flattens_inherited_transform = inherited.flattens_inherited_transform;
-
-        let mut appended_transform_node = false;
-        if let Some(mut transform) = transform_data {
-            transform.flattens_inherited_transform = flattens_inherited_transform;
-            transform.sorting_context_root_index = inherited.sorting_context_root;
-            transform.establishes_sorting_context =
-                facts.establishes_or_extends_3d_rendering_context && inherited.sorting_context_root.is_none();
-            self.assignment_mut(slot).has_non_invertible_css_transform = !facts.transform_is_invertible;
-            own_state = self
-                .tree
-                .append_spatial_under(own_state, SpatialData::Transform(transform));
-            appended_transform_node = true;
-        } else {
-            self.assignment_mut(slot).has_non_invertible_css_transform = false;
-        }
-
-        let inherited_plane_root = if is_fixed {
-            inherited.fixed_position_plane_root
-        } else if is_absolute {
-            inherited.absolute_position_plane_root
-        } else {
-            inherited.normal_plane_root
+            build_box_visual_context_nodes(
+                &environment,
+                &mut self.tree,
+                slot,
+                inherited,
+                may_be_root_element,
+                Some(&resolver),
+            )
         };
-        let establishes_or_extends_3d_rendering_context = facts.establishes_or_extends_3d_rendering_context;
-        let node_data_flags = self.layout_arena.node_flags_if_live(layout_node);
-        let invisible_to_3d_rendering_contexts = node_data_flags & NodeFlag::Anonymous as u32 != 0
-            && !self.layout_arena.node_is_generated_for_pseudo_element(layout_node);
-
-        let mut appended_synthetic_plane = false;
-        if !invisible_to_3d_rendering_contexts
-            && establishes_or_extends_3d_rendering_context
-            && !appended_transform_node
-        {
-            own_state = self.tree.append_spatial_under(
-                own_state,
-                SpatialData::Transform(TransformData {
-                    matrix: libgfx_rust::FloatMatrix4x4::identity(),
-                    origin: FloatPoint::default(),
-                    sorting_context_root_index: inherited.sorting_context_root,
-                    flattens_inherited_transform,
-                    role: TransformDataRole::CssTransform,
-                    synthetic_plane: true,
-                    establishes_sorting_context: inherited.sorting_context_root.is_none(),
-                }),
-            );
-            appended_synthetic_plane = true;
-        }
-
-        let mut appended_backface_marker = false;
-        // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
-        // NB: Whether the element's backface is visible depends on its accumulated 3D transformation matrix, which
-        //     is only known at replay time once scroll offsets have been applied. The node recorded below marks the
-        //     content to skip and stores the plane root from which that matrix is accumulated. The plane root bounds
-        //     the accumulation to the element's 3D rendering context.
-        // AD-HOC: The spec determines visibility from the sign of m33 in the accumulated matrix. That is wrong for
-        //         matrices with a perspective component, so we test the z-component of the transformed plane normal
-        //         instead. See: https://github.com/w3c/csswg-drafts/issues/917.
-        if facts.backface_hidden {
-            own_state = self.tree.append_spatial_under(
-                own_state,
-                SpatialData::BackfaceVisibility(BackfaceVisibilityData {
-                    plane_root_index: inherited_plane_root,
-                    flattens_inherited_transform: !appended_transform_node
-                        && !appended_synthetic_plane
-                        && flattens_inherited_transform,
-                }),
-            );
-            appended_backface_marker = true;
-        }
-
-        // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
-        // An element participates in a 3D rendering context if its parent establishes or extends a 3D rendering
-        // context. The position of each element in that three-dimensional space is determined by accumulating the
-        // transformation matrices up from the given element to the element that establishes the 3D rendering context.
-        // NB: Children of an element that neither establishes nor extends a 3D rendering context start a new plane
-        //     below the element's own transform. Anonymous boxes carry no element style and are invisible to 3D
-        //     rendering contexts, so they pass the inherited plane through unchanged. Pseudo-element boxes carry
-        //     their own style and participate normally. An inherited flatten is only materialized by an appended
-        //     node, so an element that appends none keeps it pending for its descendants.
-        let plane_root_for_descendants =
-            if establishes_or_extends_3d_rendering_context || invisible_to_3d_rendering_contexts {
-                inherited_plane_root
-            } else {
-                own_state.spatial
-            };
-        let inherited_flatten_still_pending = flattens_inherited_transform
-            && !appended_transform_node
-            && !appended_synthetic_plane
-            && !appended_backface_marker;
-        let mut descendants_flatten_inherited_transform = if invisible_to_3d_rendering_contexts {
-            flattens_inherited_transform
-        } else {
-            !establishes_or_extends_3d_rendering_context || inherited_flatten_still_pending
-        };
-
-        // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
-        // A 3D rendering context is established by a transformable element whose used value for transform-style
-        // is preserve-3d and which itself is not part of a 3D rendering context. An element that establishes a
-        // 3D rendering context also participates in that context.
-        // NB: The establishing element's own state serves as the context's root; replay sorts the content
-        //     recorded under it as the context's z=0 plane alongside the planes of the participants, whose
-        //     transform nodes reference the root.
-        let mut sorting_context_root_for_descendants = inherited.sorting_context_root;
-        if !invisible_to_3d_rendering_contexts {
-            if !establishes_or_extends_3d_rendering_context {
-                sorting_context_root_for_descendants = None;
-            } else if sorting_context_root_for_descendants.is_none() {
-                sorting_context_root_for_descendants = Some(own_state.spatial);
-            }
-        }
-
-        if let Some(css_clip) = facts.css_clip {
-            append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Clip(css_clip));
-        }
-
-        if facts.clip_path.is_some() {
-            append_frame_to_own_and_positioned_descendant_contexts!(FrameData::ClipPath(
-                facts.clip_path_data().unwrap()
-            ));
-        }
-
-        if !facts.mask_layers.is_empty() {
+        self.register_scroll_like_nodes(&output.assignment.record.node_handles.spatial);
+        if output.assignment.record.has_mask_nodes {
             self.paintables_with_mask_nodes.push(slot);
         }
-        for mask_layer in &facts.mask_layers {
-            append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Mask(*mask_layer));
-        }
-
-        {
-            let assignment = self.assignment_mut(slot);
-            assignment.has_accumulated_visual_context = true;
-            assignment.accumulated_visual_context = own_state;
-        }
-
-        LocalFrameBuilder::new(&mut self.tree, self.layout_arena, slot, self.pixel_ratio, false)
-            .build(own_state, Some(self.root_background_source));
-
-        if super::node_values::wants_fixed_background_visual_context(
-            self.layout_arena,
-            self.root_background_source,
-            slot,
-            may_be_root_element,
-        ) {
-            // Rooted above every scroll-like node on the box's root path, the background stays put
-            // under scrolling while the box's own frames keep clipping it in their scrolled spaces.
-            let mut fixed_background_spatial = own_state.spatial;
-            let mut index = own_state.spatial;
-            while index != VISUAL_VIEWPORT_NODE_INDEX {
-                let node = &self.tree.spatial_nodes[index.0 as usize];
-                if node.data.is_scroll_like() {
-                    fixed_background_spatial = node.parent;
-                }
-                index = node.parent;
-            }
-            {
-                let assignment = self.assignment_mut(slot);
-                assignment.fixed_background_visual_context = ContextRef {
-                    spatial: fixed_background_spatial,
-                    frame: own_state.frame,
-                };
-                assignment.has_fixed_background_visual_context = true;
-            }
-        }
-
-        if super::node_values::background_depends_on_live_scroll_offset(
-            self.layout_arena,
-            self.root_background_source,
-            slot,
-            may_be_root_element,
-        ) {
-            self.assignment_mut(slot).has_scroll_offset_dependent_background = true;
-        }
-
-        // Build state for descendants: own state + perspective + clip + scroll.
-        let mut state_for_descendants = own_state;
-
-        if let Some(mut perspective) = facts.perspective {
-            perspective.flattens_inherited_transform = descendants_flatten_inherited_transform;
-            descendants_flatten_inherited_transform = false;
-            state_for_descendants = self
-                .tree
-                .append_spatial_under(state_for_descendants, SpatialData::Perspective(perspective));
-        }
-
-        if facts.may_have_clip
-            && let Some(overflow_clip) = facts.overflow_clip
-        {
-            state_for_descendants = self
-                .tree
-                .append_frame_under(state_for_descendants, FrameData::Clip(overflow_clip));
-        }
-
-        if paintable_geometry::has_scrollable_overflow(self.layout_arena.paintable_data(slot)) {
-            let parent_index = if creates_sticky_scroll_node {
-                sticky_scroll_node_index
-            } else {
-                nearest_ancestor_scroll_node_index
-            };
-            state_for_descendants = self.tree.append_spatial_under(
-                state_for_descendants,
-                SpatialData::Scroll(ScrollData {
-                    state_slot: NO_SCROLL_STATE_SLOT,
-                }),
-            );
-            let scroll_node_index = state_for_descendants.spatial;
-            self.register_scroll_node(scroll_node_index, slot, parent_index);
-            self.assignment_mut(slot).own_scroll_node_index = scroll_node_index;
-            nearest_scroll_nodes_for_descendants = NearestScrollNodeIndices {
-                stopping_at_fixed_position_ancestors: scroll_node_index,
-                continuing_through_fixed_position_ancestors: scroll_node_index,
-            };
-        }
-
-        // Positioned descendants that escape into a viewport-establishing containing block lay
-        // out in the box's own coordinate space, not the viewport's user units, so they hang
-        // above the viewport transform node.
-        let state_for_positioned_descendants = state_for_descendants;
-        if let Some(svg_viewport_transform) = svg_viewport_transform_of(self.layout_arena, slot) {
-            let mut viewport_transform_data =
-                compute_svg_viewport_transform_data(self.layout_arena, slot, svg_viewport_transform, self.pixel_ratio);
-            viewport_transform_data.flattens_inherited_transform = descendants_flatten_inherited_transform;
-            descendants_flatten_inherited_transform = false;
-            state_for_descendants = self
-                .tree
-                .append_spatial_under(state_for_descendants, SpatialData::Transform(viewport_transform_data));
-        }
-
-        {
-            let spatial_nodes_end = self.tree.spatial_nodes.len() as u32;
-            let frame_nodes_end = self.tree.frame_nodes.len() as u32;
-            let assignment = self.assignment_mut(slot);
-            assignment.accumulated_visual_context_for_descendants = state_for_descendants;
-            assignment.spatial_nodes_begin = first_spatial_node_index;
-            assignment.spatial_nodes_end = spatial_nodes_end;
-            assignment.frame_nodes_begin = first_frame_node_index;
-            assignment.frame_nodes_end = frame_nodes_end;
-        }
-        let mut absolute_position_nearest_scroll_nodes = inherited.absolute_position_nearest_scroll_nodes;
-        let mut fixed_position_nearest_scroll_nodes = inherited.fixed_position_nearest_scroll_nodes;
-        let mut absolute_position_plane_root = inherited.absolute_position_plane_root;
-        let mut fixed_position_plane_root = inherited.fixed_position_plane_root;
-        if establishes_absolute_cb {
-            state_for_absolute_position_descendants = state_for_positioned_descendants;
-            absolute_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
-            absolute_position_plane_root = plane_root_for_descendants;
-        }
-        if establishes_fixed_cb {
-            state_for_fixed_position_descendants = state_for_positioned_descendants;
-            fixed_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
-            fixed_position_plane_root = plane_root_for_descendants;
-        }
-
-        DescendantVisualContexts {
-            normal: state_for_descendants,
-            absolute_position: state_for_absolute_position_descendants,
-            fixed_position: state_for_fixed_position_descendants,
-            normal_nearest_scroll_nodes: nearest_scroll_nodes_for_descendants,
-            absolute_position_nearest_scroll_nodes,
-            fixed_position_nearest_scroll_nodes,
-            normal_plane_root: plane_root_for_descendants,
-            absolute_position_plane_root,
-            fixed_position_plane_root,
-            flattens_inherited_transform: descendants_flatten_inherited_transform,
-            sorting_context_root: sorting_context_root_for_descendants,
-        }
+        self.assignments[slot.slot_index() as usize] = Some(output.assignment);
+        output.descendant_contexts
     }
 
     fn has_default_scroll_shift_anchor(&self, slot: NodeSlotId) -> bool {
@@ -853,10 +358,11 @@ pub(crate) fn build_visual_context_tree(
         frame: root_isolation_frame,
     };
 
-    builder.assignment_mut(viewport).enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
     let viewport_scroll_node = builder.tree.append_spatial(
         SpatialData::Scroll(ScrollData {
             state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: viewport,
+            registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
         }),
         VISUAL_VIEWPORT_NODE_INDEX,
     );
@@ -865,13 +371,6 @@ pub(crate) fn build_visual_context_tree(
         spatial: viewport_scroll_node,
         frame: root_isolation_frame,
     };
-    {
-        let assignment = builder.assignment_mut(viewport);
-        assignment.own_scroll_node_index = viewport_scroll_node;
-        assignment.has_accumulated_visual_context = true;
-        assignment.accumulated_visual_context = root_context;
-        assignment.accumulated_visual_context_for_descendants = viewport_state_for_descendants;
-    }
 
     let viewport_nearest_scroll_nodes = NearestScrollNodeIndices {
         stopping_at_fixed_position_ancestors: viewport_scroll_node,
@@ -890,6 +389,25 @@ pub(crate) fn build_visual_context_tree(
         flattens_inherited_transform: true,
         sorting_context_root: None,
     };
+    {
+        let mut viewport_assignment = PaintableVisualContextAssignment::from_data(
+            viewport,
+            layout_arena.paintable_data(viewport),
+            PaintableVisualContextRecord {
+                inherited_input: viewport_contexts,
+                output_for_descendants: viewport_contexts,
+                node_handles: BoxVisualContextNodeHandles::default(),
+                has_mask_nodes: false,
+                may_be_root_element: false,
+            },
+        );
+        viewport_assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
+        viewport_assignment.own_scroll_node_index = viewport_scroll_node;
+        viewport_assignment.has_accumulated_visual_context = true;
+        viewport_assignment.accumulated_visual_context = root_context;
+        viewport_assignment.accumulated_visual_context_for_descendants = viewport_state_for_descendants;
+        builder.assignments[viewport.slot_index() as usize] = Some(viewport_assignment);
+    }
 
     // Anchor-positioned boxes emit AnchorScrollShift nodes by reading the enclosing scroll nodes of
     // their anchors, and an acceptable anchor may come later in tree order than the positioned box.
@@ -1022,14 +540,20 @@ pub(crate) fn update_visual_context_values(
     slot: NodeSlotId,
     pixel_ratio: f64,
 ) -> (bool, Option<bool>) {
-    let (spatial_range, frame_range) = {
-        let data = layout_arena.paintable_data(slot);
-        (
-            data.spatial_nodes_begin as usize..data.spatial_nodes_end as usize,
-            data.frame_nodes_begin as usize..data.frame_nodes_end as usize,
-        )
+    let Some(node_handles) = layout_arena
+        .paintable_visual_context_record(slot)
+        .map(|record| record.node_handles.clone())
+    else {
+        return (false, None);
     };
-    if spatial_range.end > tree.spatial_nodes.len() || frame_range.end > tree.frame_nodes.len() {
+    if node_handles
+        .spatial
+        .iter()
+        .any(|index| index.0 as usize >= tree.spatial_nodes.len())
+        || node_handles
+            .frame_handles()
+            .any(|index| index.0 as usize >= tree.frame_nodes.len())
+    {
         return (false, None);
     }
     let transform_with_invertibility =
@@ -1048,7 +572,7 @@ pub(crate) fn update_visual_context_values(
         let mut found_svg_viewport_transform = false;
         let mut found_effects = false;
         let mut found_perspective = false;
-        for index in spatial_range {
+        for index in node_handles.spatial.iter().map(|index| index.0 as usize) {
             match &mut tree.spatial_nodes[index].data {
                 SpatialData::Transform(transform_data) => {
                     if transform_data.role == TransformDataRole::SvgViewportTransform {
@@ -1088,7 +612,7 @@ pub(crate) fn update_visual_context_values(
                 _ => {}
             }
         }
-        for index in frame_range {
+        for index in node_handles.frame_handles().map(|index| index.0 as usize) {
             let node = &mut tree.frame_nodes[index];
             if node.role != FrameRole::Structural {
                 continue;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/delta.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/delta.rs
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VisualContextTreeDelta {
+    pub performed_full_build: bool,
+    pub structural_epoch_changed: bool,
+    pub requires_display_list_recording: bool,
+    pub patched_spatial_node_indices: Vec<u32>,
+    pub patched_frame_node_indices: Vec<u32>,
+    pub tombstoned_spatial_node_indices: Vec<u32>,
+    pub tombstoned_frame_node_indices: Vec<u32>,
+}
+
+impl VisualContextTreeDelta {
+    pub fn for_full_build(structural_epoch_changed: bool) -> Self {
+        Self {
+            performed_full_build: true,
+            structural_epoch_changed,
+            requires_display_list_recording: structural_epoch_changed,
+            ..Default::default()
+        }
+    }
+
+    pub fn note_patched_spatial(&mut self, index: u32) {
+        self.patched_spatial_node_indices.push(index);
+    }
+
+    pub fn note_patched_frame(&mut self, index: u32) {
+        self.patched_frame_node_indices.push(index);
+    }
+
+    pub fn note_tombstoned_spatial(&mut self, index: u32) {
+        self.tombstoned_spatial_node_indices.push(index);
+        self.structural_epoch_changed = true;
+        self.requires_display_list_recording = true;
+    }
+
+    pub fn note_tombstoned_frame(&mut self, index: u32) {
+        self.tombstoned_frame_node_indices.push(index);
+        self.structural_epoch_changed = true;
+        self.requires_display_list_recording = true;
+    }
+
+    pub fn note_repurposed_in_place(&mut self) {
+        self.structural_epoch_changed = true;
+        self.requires_display_list_recording = true;
+    }
+
+    pub fn note_allocated_spatial(&mut self, index: u32, reused_freed_slot: bool) {
+        self.patched_spatial_node_indices.push(index);
+        self.requires_display_list_recording = true;
+        if reused_freed_slot {
+            self.structural_epoch_changed = true;
+        }
+    }
+
+    pub fn note_allocated_frame(&mut self, index: u32, reused_freed_slot: bool) {
+        self.patched_frame_node_indices.push(index);
+        self.requires_display_list_recording = true;
+        if reused_freed_slot {
+            self.structural_epoch_changed = true;
+        }
+    }
+
+    pub fn finish(&mut self) {
+        sort_and_deduplicate(&mut self.tombstoned_spatial_node_indices);
+        sort_and_deduplicate(&mut self.tombstoned_frame_node_indices);
+        let tombstoned_spatial = &self.tombstoned_spatial_node_indices;
+        self.patched_spatial_node_indices
+            .retain(|index| tombstoned_spatial.binary_search(index).is_err());
+        sort_and_deduplicate(&mut self.patched_spatial_node_indices);
+        let tombstoned_frames = &self.tombstoned_frame_node_indices;
+        self.patched_frame_node_indices
+            .retain(|index| tombstoned_frames.binary_search(index).is_err());
+        sort_and_deduplicate(&mut self.patched_frame_node_indices);
+    }
+}
+
+fn sort_and_deduplicate(indices: &mut Vec<u32>) {
+    indices.sort_unstable();
+    indices.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finishing_sorts_deduplicates_and_drops_patches_of_tombstoned_indices() {
+        let mut delta = VisualContextTreeDelta::default();
+        delta.note_patched_spatial(5);
+        delta.note_patched_spatial(3);
+        delta.note_patched_spatial(3);
+        delta.note_patched_spatial(9);
+        delta.note_tombstoned_spatial(5);
+        delta.note_patched_frame(12);
+        delta.note_patched_frame(2);
+        delta.finish();
+        assert_eq!(delta.patched_spatial_node_indices, vec![3, 9]);
+        assert_eq!(delta.tombstoned_spatial_node_indices, vec![5]);
+        assert_eq!(delta.patched_frame_node_indices, vec![2, 12]);
+        assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+    }
+
+    #[test]
+    fn value_patches_alone_need_no_recording() {
+        let mut delta = VisualContextTreeDelta::default();
+        delta.note_patched_frame(1);
+        delta.finish();
+        assert!(!delta.structural_epoch_changed);
+        assert!(!delta.requires_display_list_recording);
+        assert!(!delta.performed_full_build);
+    }
+
+    #[test]
+    fn allocating_a_fresh_slot_requires_recording_without_an_epoch_change() {
+        let mut delta = VisualContextTreeDelta::default();
+        delta.note_allocated_spatial(7, false);
+        delta.note_allocated_frame(9, false);
+        delta.finish();
+        assert_eq!(delta.patched_spatial_node_indices, vec![7]);
+        assert_eq!(delta.patched_frame_node_indices, vec![9]);
+        assert!(!delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+    }
+
+    #[test]
+    fn reusing_a_freed_slot_changes_the_structural_epoch() {
+        let mut delta = VisualContextTreeDelta::default();
+        delta.note_allocated_frame(4, true);
+        delta.finish();
+        assert_eq!(delta.patched_frame_node_indices, vec![4]);
+        assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::BoxVisualContextNodeHandles;
+use crate::layout::node_data::NodeSlotId;
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum VisualContextBoxDirtyKind {
+    NewRow = 0,
+    RecommittedInPlace = 1,
+    MovedWithDescendants = 2,
+    ContainingBlockChanged = 3,
+    InlineGeometryChanged = 4,
+    StyleValueChange = 5,
+    StyleStructuralChange = 6,
+    ScrollableOverflowFlipped = 7,
+}
+
+impl VisualContextBoxDirtyKind {
+    const fn bit(self) -> u8 {
+        1 << (self as u8)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BoxDirtyBits(u8);
+
+impl BoxDirtyBits {
+    pub fn insert(&mut self, kind: VisualContextBoxDirtyKind) {
+        self.0 |= kind.bit();
+    }
+
+    pub fn contains(&self, kind: VisualContextBoxDirtyKind) -> bool {
+        self.0 & kind.bit() != 0
+    }
+
+    pub fn moves_descendants(&self) -> bool {
+        self.contains(VisualContextBoxDirtyKind::MovedWithDescendants)
+            || self.contains(VisualContextBoxDirtyKind::ContainingBlockChanged)
+    }
+
+    pub fn is_value_only(&self) -> bool {
+        self.0 == VisualContextBoxDirtyKind::StyleValueChange.bit()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemovedBoxBlocks {
+    pub slot: NodeSlotId,
+    pub node_handles: BoxVisualContextNodeHandles,
+    pub former_paint_parent: NodeSlotId,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum VisualContextGlobalRebuildReason {
+    #[default]
+    None = 0,
+    FirstBuild = 1,
+    AnchorsRegistered = 2,
+    TreeInputsChanged = 3,
+    Compaction = 4,
+    DocumentWideStructuralChange = 5,
+    SvgResourceSubtreeChanged = 6,
+    FilterResourcesChanged = 7,
+    ForcedForTesting = 8,
+}
+
+#[derive(Default)]
+pub struct VisualContextDirtySet {
+    pub boxes: HashMap<NodeSlotId, BoxDirtyBits>,
+    pub removed: Vec<RemovedBoxBlocks>,
+    pub global_reason: VisualContextGlobalRebuildReason,
+}
+
+pub const MINIMUM_PENDING_DIRTY_BOX_LIMIT: usize = 1024;
+
+impl VisualContextDirtySet {
+    pub fn note_box(&mut self, slot: NodeSlotId, kind: VisualContextBoxDirtyKind, pending_box_limit: usize) {
+        if slot.is_invalid() || self.global_reason != VisualContextGlobalRebuildReason::None {
+            return;
+        }
+        if self.boxes.len() >= pending_box_limit && !self.boxes.contains_key(&slot) {
+            self.boxes.clear();
+            self.removed.clear();
+            self.request_full_rebuild(VisualContextGlobalRebuildReason::DocumentWideStructuralChange);
+            return;
+        }
+        self.boxes.entry(slot).or_default().insert(kind);
+    }
+
+    pub fn forget_box(&mut self, slot: NodeSlotId) {
+        self.boxes.remove(&slot);
+    }
+
+    pub fn note_removed(&mut self, removed: RemovedBoxBlocks) {
+        self.boxes.remove(&removed.slot);
+        if self.global_reason == VisualContextGlobalRebuildReason::None {
+            self.removed.push(removed);
+        }
+    }
+
+    pub fn request_full_rebuild(&mut self, reason: VisualContextGlobalRebuildReason) {
+        self.global_reason = self.global_reason.max(reason);
+        self.boxes.clear();
+        self.removed.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.boxes.is_empty() && self.removed.is_empty() && self.global_reason == VisualContextGlobalRebuildReason::None
+    }
+
+    pub fn is_value_only(&self) -> bool {
+        self.global_reason == VisualContextGlobalRebuildReason::None
+            && self.removed.is_empty()
+            && self.boxes.values().all(BoxDirtyBits::is_value_only)
+    }
+
+    pub fn clear(&mut self) {
+        self.boxes.clear();
+        self.removed.clear();
+        self.global_reason = VisualContextGlobalRebuildReason::None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot(index: u32, generation: u8) -> NodeSlotId {
+        NodeSlotId::new(index, generation)
+    }
+
+    #[test]
+    fn kinds_coalesce_per_box_and_generations_stay_distinct() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.note_box(slot(3, 1), VisualContextBoxDirtyKind::StyleValueChange, usize::MAX);
+        dirty.note_box(slot(3, 1), VisualContextBoxDirtyKind::MovedWithDescendants, usize::MAX);
+        dirty.note_box(slot(3, 2), VisualContextBoxDirtyKind::NewRow, usize::MAX);
+        assert_eq!(dirty.boxes.len(), 2);
+        let bits = dirty.boxes[&slot(3, 1)];
+        assert!(bits.contains(VisualContextBoxDirtyKind::StyleValueChange));
+        assert!(bits.moves_descendants());
+        assert!(!bits.is_value_only());
+        assert!(dirty.boxes[&slot(3, 2)].contains(VisualContextBoxDirtyKind::NewRow));
+        assert!(!dirty.is_value_only());
+    }
+
+    #[test]
+    fn value_only_sets_are_recognized() {
+        let mut dirty = VisualContextDirtySet::default();
+        assert!(dirty.is_empty());
+        dirty.note_box(slot(1, 1), VisualContextBoxDirtyKind::StyleValueChange, usize::MAX);
+        assert!(dirty.is_value_only());
+        dirty.note_removed(RemovedBoxBlocks {
+            slot: slot(1, 1),
+            node_handles: BoxVisualContextNodeHandles::default(),
+            former_paint_parent: NodeSlotId::INVALID,
+        });
+        assert!(!dirty.boxes.contains_key(&slot(1, 1)));
+        assert!(!dirty.is_value_only());
+    }
+
+    #[test]
+    fn global_reasons_merge_to_the_strongest() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.request_full_rebuild(VisualContextGlobalRebuildReason::FirstBuild);
+        dirty.request_full_rebuild(VisualContextGlobalRebuildReason::None);
+        assert_eq!(dirty.global_reason, VisualContextGlobalRebuildReason::FirstBuild);
+        dirty.request_full_rebuild(VisualContextGlobalRebuildReason::ForcedForTesting);
+        dirty.request_full_rebuild(VisualContextGlobalRebuildReason::Compaction);
+        assert_eq!(dirty.global_reason, VisualContextGlobalRebuildReason::ForcedForTesting);
+        dirty.clear();
+        assert!(dirty.is_empty());
+    }
+
+    #[test]
+    fn invalid_slots_are_ignored() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.note_box(NodeSlotId::INVALID, VisualContextBoxDirtyKind::NewRow, usize::MAX);
+        assert!(dirty.is_empty());
+    }
+
+    #[test]
+    fn exceeding_the_pending_box_limit_coalesces_into_a_full_rebuild() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.note_box(slot(0, 1), VisualContextBoxDirtyKind::StyleValueChange, 2);
+        dirty.note_box(slot(1, 1), VisualContextBoxDirtyKind::StyleValueChange, 2);
+        dirty.note_box(slot(0, 1), VisualContextBoxDirtyKind::NewRow, 2);
+        assert_eq!(dirty.boxes.len(), 2);
+        assert_eq!(dirty.global_reason, VisualContextGlobalRebuildReason::None);
+        dirty.note_box(slot(2, 1), VisualContextBoxDirtyKind::StyleValueChange, 2);
+        assert!(dirty.boxes.is_empty());
+        assert_eq!(
+            dirty.global_reason,
+            VisualContextGlobalRebuildReason::DocumentWideStructuralChange
+        );
+    }
+
+    #[test]
+    fn a_pending_full_rebuild_absorbs_per_box_notes() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.note_box(slot(0, 1), VisualContextBoxDirtyKind::StyleValueChange, usize::MAX);
+        dirty.request_full_rebuild(VisualContextGlobalRebuildReason::FirstBuild);
+        dirty.note_box(slot(1, 1), VisualContextBoxDirtyKind::NewRow, usize::MAX);
+        dirty.note_removed(RemovedBoxBlocks {
+            slot: slot(2, 1),
+            node_handles: BoxVisualContextNodeHandles::default(),
+            former_paint_parent: NodeSlotId::INVALID,
+        });
+        assert!(dirty.boxes.is_empty());
+        assert!(dirty.removed.is_empty());
+        assert_eq!(dirty.global_reason, VisualContextGlobalRebuildReason::FirstBuild);
+    }
+
+    #[test]
+    fn forgetting_a_box_drops_its_pending_entry() {
+        let mut dirty = VisualContextDirtySet::default();
+        dirty.note_box(slot(0, 1), VisualContextBoxDirtyKind::NewRow, usize::MAX);
+        dirty.forget_box(slot(0, 1));
+        assert!(dirty.is_empty());
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
@@ -39,6 +39,10 @@ impl BoxDirtyBits {
         self.0 & kind.bit() != 0
     }
 
+    pub fn merge(&mut self, other: BoxDirtyBits) {
+        self.0 |= other.0;
+    }
+
     pub fn moves_descendants(&self) -> bool {
         self.contains(VisualContextBoxDirtyKind::MovedWithDescendants)
             || self.contains(VisualContextBoxDirtyKind::ContainingBlockChanged)
@@ -69,6 +73,7 @@ pub enum VisualContextGlobalRebuildReason {
     SvgResourceSubtreeChanged = 6,
     FilterResourcesChanged = 7,
     ForcedForTesting = 8,
+    StructuralDirtyBoxes = 9,
 }
 
 #[derive(Default)]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
@@ -73,7 +73,7 @@ pub enum VisualContextGlobalRebuildReason {
     SvgResourceSubtreeChanged = 6,
     FilterResourcesChanged = 7,
     ForcedForTesting = 8,
-    StructuralDirtyBoxes = 9,
+    CanonicalDumpRequested = 9,
 }
 
 #[derive(Default)]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
@@ -123,6 +123,7 @@ impl VisualContextTree {
                     if shift.compensate_vertical_scroll { "" } else { ", no-y" }
                 );
             }
+            SpatialData::Dead => text.push_str("tombstone"),
         }
         text
     }
@@ -211,6 +212,7 @@ impl VisualContextTree {
                     origin
                 );
             }
+            FrameData::Dead => text.push_str("tombstone"),
         }
         text
     }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
@@ -310,6 +310,7 @@ impl VisualContextTree {
 
 #[cfg(test)]
 mod node_dump_tests {
+    use crate::layout::node_data::NodeSlotId;
     use crate::painting::visual_context::{
         AnchorScrollShift, BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, FrameNodeIndex,
         MaskData, MaskLayerOrigin, PerspectiveData, ScrollData, SpatialData, StickyData, TransformData,
@@ -369,11 +370,19 @@ mod node_dump_tests {
         let scroll_node = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
         let outer_sticky = tree.append_spatial(
-            SpatialData::Sticky(StickyData::unconstrained(scroll_node, None, NO_SCROLL_STATE_SLOT)),
+            SpatialData::Sticky(StickyData::unconstrained(
+                scroll_node,
+                None,
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                scroll_node,
+            )),
             scroll_node,
         );
         let inner_sticky = tree.append_spatial(
@@ -396,6 +405,8 @@ mod node_dump_tests {
                 inset_bottom: Some(1.5),
                 inset_left: None,
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: scroll_node,
             }),
             outer_sticky,
         );
@@ -523,6 +534,7 @@ mod node_dump_tests {
 
 #[cfg(test)]
 mod section_dump_tests {
+    use crate::layout::node_data::NodeSlotId;
     use crate::painting::display_list::commands::{
         ContextRef, DisplayListCommandRun, FrameNodeIndex, SpatialNodeIndex,
     };
@@ -557,12 +569,16 @@ mod section_dump_tests {
         let scroll_node = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
         let unreachable_node = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -274,18 +274,28 @@ pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>
         .iter()
         .any(|removed| state.paintables_with_mask_nodes.contains(&removed.slot));
     let mut stack: Vec<PendingBox> = Vec::new();
-    let push_children = |stack: &mut Vec<PendingBox>, parent: NodeSlotId, cascade: ChildCascade| {
-        let mut children = Vec::new();
-        paint_order::for_each_paint_child(layout_arena, parent, |child| children.push(child));
-        for child in children.into_iter().rev() {
-            stack.push(PendingBox {
-                slot: child,
-                parent: Some(parent),
-                cascade,
+    let push_children =
+        |stack: &mut Vec<PendingBox>, parent: NodeSlotId, cascade: ChildCascade, visit_every_child: bool| {
+            let mut children = Vec::new();
+            paint_order::for_each_paint_child(layout_arena, parent, |child| {
+                if visit_every_child || plan.work.contains_key(&child) || plan.ancestors_of_work.contains(&child) {
+                    children.push(child);
+                }
             });
-        }
-    };
-    push_children(&mut stack, viewport, ChildCascade::default());
+            for child in children.into_iter().rev() {
+                stack.push(PendingBox {
+                    slot: child,
+                    parent: Some(parent),
+                    cascade,
+                });
+            }
+        };
+    push_children(
+        &mut stack,
+        viewport,
+        ChildCascade::default(),
+        plan.revalidate_children_of.contains(&viewport),
+    );
 
     while let Some(pending) = stack.pop() {
         let slot = pending.slot;
@@ -408,11 +418,14 @@ pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>
                 geometry_walk: pending.cascade.geometry_walk && subtree_may_own_geometry_dependent_nodes,
             }
         };
-        if child_cascade.visits_every_child()
-            || plan.ancestors_of_work.contains(&slot)
-            || plan.revalidate_children_of.contains(&slot)
-        {
-            push_children(&mut stack, slot, child_cascade);
+        let revalidate_children = plan.revalidate_children_of.contains(&slot);
+        if child_cascade.visits_every_child() || revalidate_children || plan.ancestors_of_work.contains(&slot) {
+            push_children(
+                &mut stack,
+                slot,
+                child_cascade,
+                child_cascade.visits_every_child() || revalidate_children,
+            );
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -228,7 +228,6 @@ struct PendingBox {
     cascade: ChildCascade,
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>(
     layout_arena: &Arena,
     callbacks: &FfiVisualContextHostCallbacks,
@@ -236,7 +235,6 @@ pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>
     tree_inputs: FfiVisualContextTreeInputs,
     root_background_source: FfiRootBackgroundSource,
     state: &mut VisualContextState,
-    allow_structural_changes: bool,
 ) -> IncrementalUpdateResult {
     let plan = match expand_dirty_entries(layout_arena, &state.dirty_boxes, root_background_source) {
         Ok(plan) => plan,
@@ -246,9 +244,6 @@ pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>
         return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::FirstBuild);
     };
     let mut delta = VisualContextTreeDelta::default();
-    if !state.dirty_boxes.removed.is_empty() && !allow_structural_changes {
-        return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::StructuralDirtyBoxes);
-    }
     tombstone_removed_blocks(Rc::make_mut(tree), &state.dirty_boxes, &mut delta);
 
     let environment = BoxBuildEnvironment {
@@ -329,15 +324,12 @@ pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>
                 build_box_visual_context_nodes(&environment, &mut scratch, slot, input, may_be_root_element, None);
             let (scratch_spatial, scratch_frames) = scratch.into_nodes();
             let existing_handles = existing_record.as_ref().map(|record| &record.node_handles);
-            let Some(placement) = plan_box_node_placement(
+            let placement = plan_box_node_placement(
                 tree,
                 existing_handles,
                 &output.assignment.record.node_handles,
-                allow_structural_changes,
                 &mut delta,
-            ) else {
-                return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::StructuralDirtyBoxes);
-            };
+            );
             let reconcile = write_box_nodes(
                 tree,
                 scratch_spatial,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::box_build::{BoxBuildEnvironment, PaintableVisualContextAssignment, build_box_visual_context_nodes};
+use super::delta::VisualContextTreeDelta;
+use super::dirty::{BoxDirtyBits, VisualContextBoxDirtyKind, VisualContextDirtySet, VisualContextGlobalRebuildReason};
+use super::reconcile::{BoxNodeScratch, plan_box_node_placement, write_box_nodes};
+use super::refresh::compute_sticky_data;
+use super::scroll_state::ScrollState;
+use super::*;
+use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
+use crate::painting::host::{FfiRootBackgroundSource, FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
+use crate::painting::paint_order;
+use crate::painting::paintable_rows::PaintableRowsRead;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ChildCascade {
+    input_changed: bool,
+    geometry_walk: bool,
+}
+
+impl ChildCascade {
+    fn visits_every_child(self) -> bool {
+        self.input_changed || self.geometry_walk
+    }
+}
+
+pub(crate) struct IncrementalUpdateOutcome {
+    pub delta: VisualContextTreeDelta,
+    pub assignments: Vec<PaintableVisualContextAssignment>,
+    pub mask_node_owners_changed: bool,
+}
+
+pub(crate) enum IncrementalUpdateResult {
+    Applied(IncrementalUpdateOutcome),
+    NeedsFullBuild(VisualContextGlobalRebuildReason),
+}
+
+fn box_is_inside_svg_resource_subtree(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
+    let mut node = Some(slot);
+    while let Some(current) = node {
+        if matches!(
+            layout_arena.node_kind_if_live(current),
+            Some(NodeKind::SVGMaskBox | NodeKind::SVGClipBox | NodeKind::SVGPatternBox)
+        ) {
+            return true;
+        }
+        node = layout_arena.node_parent_if_live(current);
+    }
+    false
+}
+
+struct WorkPlan {
+    work: HashMap<NodeSlotId, BoxDirtyBits>,
+    revalidate_children_of: HashSet<NodeSlotId>,
+    ancestors_of_work: HashSet<NodeSlotId>,
+}
+
+fn expand_dirty_entries(
+    layout_arena: &impl PaintableRowsRead,
+    dirty: &VisualContextDirtySet,
+    root_background_source: FfiRootBackgroundSource,
+) -> Result<WorkPlan, VisualContextGlobalRebuildReason> {
+    let mut work: HashMap<NodeSlotId, BoxDirtyBits> = HashMap::new();
+    for (slot, bits) in &dirty.boxes {
+        if !layout_arena.paintable_row_is_populated(*slot) {
+            continue;
+        }
+        if box_is_inside_svg_resource_subtree(layout_arena, *slot) {
+            return Err(VisualContextGlobalRebuildReason::SvgResourceSubtreeChanged);
+        }
+        let mut bits = *bits;
+        if layout_arena.node_kind_if_live(*slot) == Some(NodeKind::SVGSVGBox) && !bits.is_value_only() {
+            bits.insert(VisualContextBoxDirtyKind::MovedWithDescendants);
+        }
+        work.entry(*slot).or_default().merge(bits);
+        if layout_arena.node_kind_if_live(*slot) == Some(NodeKind::LegendBox)
+            && let Some(fieldset) = paint_order::paint_parent(layout_arena, *slot)
+        {
+            work.entry(fieldset)
+                .or_default()
+                .insert(VisualContextBoxDirtyKind::RecommittedInPlace);
+        }
+        let is_body = layout_arena.node_flags_if_live(*slot) & NodeFlag::IsBody as u32 != 0;
+        if is_body
+            && root_background_source.use_body_background_properties
+            && let Some(html) = paint_order::paint_parent(layout_arena, *slot)
+        {
+            work.entry(html)
+                .or_default()
+                .insert(VisualContextBoxDirtyKind::StyleStructuralChange);
+        }
+        if layout_arena.node_flags_if_live(*slot) & NodeFlag::IsHtmlHtmlElement as u32 != 0
+            && root_background_source.use_body_background_properties
+            && layout_arena.paintable_row_is_populated(root_background_source.body_layout_node)
+        {
+            work.entry(root_background_source.body_layout_node)
+                .or_default()
+                .insert(VisualContextBoxDirtyKind::StyleStructuralChange);
+        }
+    }
+    let mut revalidate_children_of = HashSet::new();
+    for removed in &dirty.removed {
+        if layout_arena.paintable_row_is_populated(removed.former_paint_parent) {
+            revalidate_children_of.insert(removed.former_paint_parent);
+        }
+    }
+    let mut ancestors_of_work = HashSet::new();
+    for slot in work.keys().copied().chain(revalidate_children_of.iter().copied()) {
+        let mut ancestor = paint_order::paint_parent(layout_arena, slot);
+        while let Some(current) = ancestor {
+            if !ancestors_of_work.insert(current) {
+                break;
+            }
+            ancestor = paint_order::paint_parent(layout_arena, current);
+        }
+    }
+    Ok(WorkPlan {
+        work,
+        revalidate_children_of,
+        ancestors_of_work,
+    })
+}
+
+fn tombstone_removed_blocks(
+    tree: &mut VisualContextTree,
+    dirty: &VisualContextDirtySet,
+    delta: &mut VisualContextTreeDelta,
+) {
+    for removed in &dirty.removed {
+        for index in &removed.node_handles.spatial {
+            if tree.tombstone_spatial_slot(*index) {
+                delta.note_tombstoned_spatial(index.0);
+            }
+        }
+        for index in removed.node_handles.frame_handles() {
+            if tree.tombstone_frame_slot(index) {
+                delta.note_tombstoned_frame(index.0);
+            }
+        }
+    }
+}
+
+pub(crate) fn rebuild_scroll_state_from_tree(
+    layout_arena: &impl PaintableRowsRead,
+    tree: &mut VisualContextTree,
+    tree_inputs: &FfiVisualContextTreeInputs,
+    delta: &mut VisualContextTreeDelta,
+) -> ScrollState {
+    let mut scroll_state = ScrollState::default();
+    for node_index in tree.spatial_dependency_order() {
+        let index = node_index as usize;
+        let node_index = SpatialNodeIndex(node_index);
+        let (is_sticky, owner_paintable, registry_parent_node) = match &tree.spatial_nodes[index].data {
+            SpatialData::Scroll(scroll) => (false, scroll.owner_paintable, scroll.registry_parent_node),
+            SpatialData::Sticky(sticky) => (true, sticky.owner_paintable, sticky.registry_parent_node),
+            _ => continue,
+        };
+        let parent_slot = tree.scroll_state_slot_for_node(registry_parent_node);
+        if is_sticky {
+            let slot = scroll_state.register_sticky_node(node_index, owner_paintable, parent_slot);
+            let refreshed = SpatialData::Sticky(compute_sticky_data(layout_arena, &scroll_state, slot, tree_inputs));
+            if !super::shape::spatial_payloads_are_equal(&tree.spatial_nodes[index].data, &refreshed) {
+                delta.note_patched_spatial(node_index.0);
+            }
+            tree.spatial_nodes[index].data = refreshed;
+        } else {
+            let slot = scroll_state.register_scroll_node(node_index, owner_paintable, parent_slot);
+            if let SpatialData::Scroll(scroll) = &mut tree.spatial_nodes[index].data {
+                scroll.state_slot = slot;
+            }
+            if layout_arena.node_kind_if_live(owner_paintable) != Some(NodeKind::Viewport)
+                && let Some(style) = layout_arena.node_style_if_live(owner_paintable)
+            {
+                use crate::css::css_enums::overflow;
+                let box_values = style.box_values();
+                if matches!(box_values.overflow_x, overflow::AUTO | overflow::SCROLL)
+                    || matches!(box_values.overflow_y, overflow::AUTO | overflow::SCROLL)
+                {
+                    scroll_state.has_non_viewport_wheel_scroll_target_candidate = true;
+                }
+            }
+        }
+    }
+    scroll_state
+}
+
+pub(crate) fn box_owns_geometry_dependent_nodes(
+    layout_arena: &impl PaintableRowsRead,
+    tree: &VisualContextTree,
+    slot: NodeSlotId,
+    handles: &BoxVisualContextNodeHandles,
+) -> bool {
+    if layout_arena.paintable_side_data(slot).svg_filter_bounds.get().is_some() {
+        return true;
+    }
+    let spatial_is_geometry_dependent = handles.spatial.iter().any(|index| {
+        matches!(
+            tree.spatial_nodes[index.0 as usize].data,
+            SpatialData::Transform(_) | SpatialData::Perspective(_) | SpatialData::Sticky(_)
+        )
+    });
+    let effects_filter_is_resolved_by_the_host_against_geometry = layout_arena
+        .node_style_if_live(slot)
+        .is_some_and(|style| crate::painting::filter_bytes::contains_url(&style.effects().filter));
+    let frames_are_geometry_dependent = handles.frame_handles().any(|index| {
+        let node = &tree.frame_nodes[index.0 as usize];
+        node.role != FrameRole::Structural
+            || match &node.data {
+                FrameData::Clip(_) | FrameData::ClipPath(_) | FrameData::Mask(_) => true,
+                FrameData::Effects(effects) => {
+                    effects.filter.is_some() && effects_filter_is_resolved_by_the_host_against_geometry
+                }
+                FrameData::Dead => false,
+            }
+    });
+    spatial_is_geometry_dependent || frames_are_geometry_dependent
+}
+
+struct PendingBox {
+    slot: NodeSlotId,
+    parent: Option<NodeSlotId>,
+    cascade: ChildCascade,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn update_visual_context_tree_incrementally<Arena: PaintableRowsRead>(
+    layout_arena: &Arena,
+    callbacks: &FfiVisualContextHostCallbacks,
+    viewport: NodeSlotId,
+    tree_inputs: FfiVisualContextTreeInputs,
+    root_background_source: FfiRootBackgroundSource,
+    state: &mut VisualContextState,
+    allow_structural_changes: bool,
+) -> IncrementalUpdateResult {
+    let plan = match expand_dirty_entries(layout_arena, &state.dirty_boxes, root_background_source) {
+        Ok(plan) => plan,
+        Err(reason) => return IncrementalUpdateResult::NeedsFullBuild(reason),
+    };
+    let Some(tree) = state.tree.as_mut() else {
+        return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::FirstBuild);
+    };
+    let mut delta = VisualContextTreeDelta::default();
+    if !state.dirty_boxes.removed.is_empty() && !allow_structural_changes {
+        return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::StructuralDirtyBoxes);
+    }
+    tombstone_removed_blocks(Rc::make_mut(tree), &state.dirty_boxes, &mut delta);
+
+    let environment = BoxBuildEnvironment {
+        layout_arena,
+        callbacks,
+        pixel_ratio: tree_inputs.device_pixels_per_css_pixel,
+        tree_inputs,
+        root_background_source,
+    };
+    let viewport_output = layout_arena
+        .paintable_visual_context_record(viewport)
+        .map(|record| record.output_for_descendants);
+    let Some(viewport_output) = viewport_output else {
+        return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::FirstBuild);
+    };
+    let mut fresh_outputs: HashMap<NodeSlotId, DescendantVisualContexts> = HashMap::new();
+    fresh_outputs.insert(viewport, viewport_output);
+    let mut assignments: Vec<PaintableVisualContextAssignment> = Vec::new();
+    let mut assignment_index_by_slot: HashMap<NodeSlotId, usize> = HashMap::new();
+    let mut mask_node_owners_changed = state
+        .dirty_boxes
+        .removed
+        .iter()
+        .any(|removed| state.paintables_with_mask_nodes.contains(&removed.slot));
+    let mut stack: Vec<PendingBox> = Vec::new();
+    let push_children = |stack: &mut Vec<PendingBox>, parent: NodeSlotId, cascade: ChildCascade| {
+        let mut children = Vec::new();
+        paint_order::for_each_paint_child(layout_arena, parent, |child| children.push(child));
+        for child in children.into_iter().rev() {
+            stack.push(PendingBox {
+                slot: child,
+                parent: Some(parent),
+                cascade,
+            });
+        }
+    };
+    push_children(&mut stack, viewport, ChildCascade::default());
+
+    while let Some(pending) = stack.pop() {
+        let slot = pending.slot;
+        let parent = pending
+            .parent
+            .expect("every pending box below the viewport has a paint parent");
+        let input = fresh_outputs.get(&parent).copied().unwrap_or_else(|| {
+            layout_arena
+                .paintable_visual_context_record(parent)
+                .expect("a paint parent that was not rebuilt keeps its record")
+                .output_for_descendants
+        });
+        let work_bits = plan.work.get(&slot).copied();
+        let (rebuild, subtree_may_own_geometry_dependent_nodes) = {
+            let record = layout_arena.paintable_visual_context_record(slot);
+            let record = record.as_deref();
+            let rebuild = work_bits.is_some()
+                || record.is_none_or(|record| record.inherited_input != input)
+                || (pending.cascade.geometry_walk && record.is_some_and(|record| record.owns_geometry_dependent_nodes));
+            (
+                rebuild,
+                record.is_some_and(|record| record.subtree_may_own_geometry_dependent_nodes),
+            )
+        };
+        let child_cascade = if rebuild {
+            let existing_record = layout_arena.cloned_paintable_visual_context_record(slot);
+            let may_be_root_element = parent == viewport;
+            let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
+            let mut scratch = BoxNodeScratch::new(tree);
+            let output =
+                build_box_visual_context_nodes(&environment, &mut scratch, slot, input, may_be_root_element, None);
+            let (scratch_spatial, scratch_frames) = scratch.into_nodes();
+            let existing_handles = existing_record.as_ref().map(|record| &record.node_handles);
+            let Some(placement) = plan_box_node_placement(
+                tree,
+                existing_handles,
+                &output.assignment.record.node_handles,
+                allow_structural_changes,
+                &mut delta,
+            ) else {
+                return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::StructuralDirtyBoxes);
+            };
+            let reconcile = write_box_nodes(
+                tree,
+                scratch_spatial,
+                scratch_frames,
+                &placement,
+                existing_handles,
+                &mut delta,
+            );
+            let mut assignment = output.assignment;
+            assignment.accumulated_visual_context = placement.remap_context(assignment.accumulated_visual_context);
+            assignment.accumulated_visual_context_for_descendants =
+                placement.remap_context(assignment.accumulated_visual_context_for_descendants);
+            assignment.fixed_background_visual_context =
+                placement.remap_context(assignment.fixed_background_visual_context);
+            assignment.enclosing_scroll_node_index = placement.remap_spatial(assignment.enclosing_scroll_node_index);
+            assignment.own_scroll_node_index = placement.remap_spatial(assignment.own_scroll_node_index);
+            let new_output = remap_descendant_contexts(&placement, output.descendant_contexts);
+            assignment.record.inherited_input = input;
+            assignment.record.output_for_descendants = new_output;
+            assignment.record.node_handles = placement.into_node_handles();
+            assignment.record.owns_geometry_dependent_nodes =
+                box_owns_geometry_dependent_nodes(layout_arena, tree, slot, &assignment.record.node_handles);
+            assignment.record.subtree_may_own_geometry_dependent_nodes =
+                assignment.record.owns_geometry_dependent_nodes || subtree_may_own_geometry_dependent_nodes;
+
+            let previous_output = existing_record.as_ref().map(|record| record.output_for_descendants);
+            let previous_contexts = existing_record.as_ref().map(|_| {
+                let data = layout_arena.paintable_data(slot);
+                (
+                    data.accumulated_visual_context,
+                    data.accumulated_visual_context_for_descendants,
+                )
+            });
+            let contexts_changed = previous_contexts
+                != Some((
+                    assignment.accumulated_visual_context,
+                    assignment.accumulated_visual_context_for_descendants,
+                ));
+            if reconcile.shape_changed || existing_record.is_none() {
+                layout_arena.invalidate_paint_cache(slot);
+            } else if contexts_changed {
+                layout_arena
+                    .paintable_rows()
+                    .mark_descendant_subtree_caches_dirty_along_paint_chain(slot);
+            }
+            if existing_record.as_ref().is_some_and(|record| record.has_mask_nodes) != assignment.record.has_mask_nodes
+            {
+                mask_node_owners_changed = true;
+            }
+            if assignment.record.owns_geometry_dependent_nodes && !subtree_may_own_geometry_dependent_nodes {
+                let mut ancestor = paint_order::paint_parent(layout_arena, slot);
+                while let Some(current) = ancestor {
+                    let ancestor_was_flagged = if let Some(&index) = assignment_index_by_slot.get(&current) {
+                        let flagged = assignments[index].record.subtree_may_own_geometry_dependent_nodes;
+                        assignments[index].record.subtree_may_own_geometry_dependent_nodes = true;
+                        flagged
+                    } else {
+                        layout_arena
+                            .mark_paintable_subtree_may_own_geometry_dependent_nodes(current)
+                            .unwrap_or(true)
+                    };
+                    if ancestor_was_flagged {
+                        break;
+                    }
+                    ancestor = paint_order::paint_parent(layout_arena, current);
+                }
+            }
+            fresh_outputs.insert(slot, new_output);
+            assignment_index_by_slot.insert(slot, assignments.len());
+            assignments.push(assignment);
+            ChildCascade {
+                input_changed: previous_output != Some(new_output),
+                geometry_walk: pending.cascade.geometry_walk || work_bits.is_some_and(|bits| bits.moves_descendants()),
+            }
+        } else {
+            ChildCascade {
+                input_changed: false,
+                geometry_walk: pending.cascade.geometry_walk && subtree_may_own_geometry_dependent_nodes,
+            }
+        };
+        if child_cascade.visits_every_child()
+            || plan.ancestors_of_work.contains(&slot)
+            || plan.revalidate_children_of.contains(&slot)
+        {
+            push_children(&mut stack, slot, child_cascade);
+        }
+    }
+
+    let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
+    let scroll_state = rebuild_scroll_state_from_tree(layout_arena, tree, &tree_inputs, &mut delta);
+    delta.finish();
+    tree.debug_assert_slot_accounting();
+    if delta.structural_epoch_changed {
+        tree.structural_epoch = allocate_structural_epoch();
+    }
+    state.scroll_state = scroll_state;
+    state.scroll_state_snapshot.clear();
+    state.needs_to_refresh_scroll_state = true;
+    IncrementalUpdateResult::Applied(IncrementalUpdateOutcome {
+        delta,
+        assignments,
+        mask_node_owners_changed,
+    })
+}
+
+fn remap_descendant_contexts(
+    placement: &super::reconcile::BoxNodePlacement,
+    contexts: DescendantVisualContexts,
+) -> DescendantVisualContexts {
+    let remap_scroll_nodes = |nodes: NearestScrollNodeIndices| NearestScrollNodeIndices {
+        stopping_at_fixed_position_ancestors: placement.remap_spatial(nodes.stopping_at_fixed_position_ancestors),
+        continuing_through_fixed_position_ancestors: placement
+            .remap_spatial(nodes.continuing_through_fixed_position_ancestors),
+    };
+    DescendantVisualContexts {
+        normal: placement.remap_context(contexts.normal),
+        absolute_position: placement.remap_context(contexts.absolute_position),
+        fixed_position: placement.remap_context(contexts.fixed_position),
+        normal_nearest_scroll_nodes: remap_scroll_nodes(contexts.normal_nearest_scroll_nodes),
+        absolute_position_nearest_scroll_nodes: remap_scroll_nodes(contexts.absolute_position_nearest_scroll_nodes),
+        fixed_position_nearest_scroll_nodes: remap_scroll_nodes(contexts.fixed_position_nearest_scroll_nodes),
+        normal_plane_root: placement.remap_spatial(contexts.normal_plane_root),
+        absolute_position_plane_root: placement.remap_spatial(contexts.absolute_position_plane_root),
+        fixed_position_plane_root: placement.remap_spatial(contexts.fixed_position_plane_root),
+        flattens_inherited_transform: contexts.flattens_inherited_transform,
+        sorting_context_root: contexts
+            .sorting_context_root
+            .map(|index| placement.remap_spatial(index)),
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/local_frames.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/local_frames.rs
@@ -7,7 +7,7 @@
 use super::node_values::{border_radii_data, padding_edge_border_radii, piece_border_radii_data};
 use super::{
     ClipData, ClipMode, ClipPathData, ContextRef, FrameData, FrameNodeIndex, FrameRole, PatternedEdgeOwner, PieceKey,
-    VisualContextTree,
+    VisualContextNodeSink,
 };
 use crate::css::computed_value_views::ComputedValuesView;
 use crate::css::css_enums::{background_box, line_style, overflow};
@@ -42,8 +42,8 @@ use std::rc::Rc;
 
 pub(crate) type LocalFrames = Vec<(FrameRole, FrameNodeIndex)>;
 
-pub(crate) struct LocalFrameBuilder<'a, Arena: PaintableRowsRead> {
-    tree: &'a mut VisualContextTree,
+pub(crate) struct LocalFrameBuilder<'a, Sink: VisualContextNodeSink, Arena: PaintableRowsRead> {
+    tree: &'a mut Sink,
     layout_arena: &'a Arena,
     slot: NodeSlotId,
     kind: NodeKind,
@@ -71,9 +71,9 @@ fn root_background_source_or_no_propagation(source: Option<FfiRootBackgroundSour
     })
 }
 
-impl<'a, Arena: PaintableRowsRead> LocalFrameBuilder<'a, Arena> {
+impl<'a, Sink: VisualContextNodeSink, Arena: PaintableRowsRead> LocalFrameBuilder<'a, Sink, Arena> {
     pub(crate) fn new(
-        tree: &'a mut VisualContextTree,
+        tree: &'a mut Sink,
         layout_arena: &'a Arena,
         slot: NodeSlotId,
         pixel_ratio: f64,
@@ -157,9 +157,7 @@ impl<'a, Arena: PaintableRowsRead> LocalFrameBuilder<'a, Arena> {
     }
 
     fn append(&mut self, parent: ContextRef, data: FrameData, role: FrameRole) -> ContextRef {
-        let frame = self
-            .tree
-            .append_frame_with_role(data, parent.frame, parent.spatial, role);
+        let frame = self.tree.append_frame_node(data, parent.frame, parent.spatial, role);
         if let Some(frames) = &mut self.frames {
             frames.push((role, frame));
         }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -238,6 +238,7 @@ pub enum SpatialData {
     Perspective(PerspectiveData),
     BackfaceVisibility(BackfaceVisibilityData),
     AnchorScrollShift(AnchorScrollShift),
+    Dead,
 }
 
 #[derive(Clone)]
@@ -246,6 +247,7 @@ pub enum FrameData {
     ClipPath(ClipPathData),
     Effects(EffectsData),
     Mask(MaskData),
+    Dead,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -260,6 +262,7 @@ enum VisualContextNodeKind {
     ClipPath,
     Effects,
     Mask,
+    Dead,
 }
 
 impl SpatialData {
@@ -271,7 +274,12 @@ impl SpatialData {
             Self::Perspective(_) => VisualContextNodeKind::Perspective,
             Self::BackfaceVisibility(_) => VisualContextNodeKind::BackfaceVisibility,
             Self::AnchorScrollShift(_) => VisualContextNodeKind::AnchorScrollShift,
+            Self::Dead => VisualContextNodeKind::Dead,
         }
+    }
+
+    pub fn is_live(&self) -> bool {
+        !matches!(self, Self::Dead)
     }
 
     pub fn is_scroll_like(&self) -> bool {
@@ -287,7 +295,7 @@ impl FrameData {
                 let [_, _, width, height] = clip_path.path.bounding_box();
                 width <= 0.0 || height <= 0.0
             }
-            Self::Effects(_) => false,
+            Self::Effects(_) | Self::Dead => false,
             Self::Mask(mask) => mask.rect.is_empty(),
         }
     }
@@ -298,7 +306,12 @@ impl FrameData {
             Self::ClipPath(_) => VisualContextNodeKind::ClipPath,
             Self::Effects(_) => VisualContextNodeKind::Effects,
             Self::Mask(_) => VisualContextNodeKind::Mask,
+            Self::Dead => VisualContextNodeKind::Dead,
         }
+    }
+
+    pub fn is_live(&self) -> bool {
+        !matches!(self, Self::Dead)
     }
 }
 
@@ -553,7 +566,15 @@ pub struct VisualContextTree {
     pub root_isolation_frame: Option<FrameNodeIndex>,
     pub version: u64,
     pub reused_previous_version: bool,
+    pub live_spatial_node_count: u32,
+    pub live_frame_node_count: u32,
+    free_spatial_slots: Vec<SpatialNodeIndex>,
+    free_frame_slots: Vec<FrameNodeIndex>,
+    quarantined_spatial_slots: Vec<SpatialNodeIndex>,
+    quarantined_frame_slots: Vec<FrameNodeIndex>,
 }
+
+const COMPACTION_DEAD_NODE_THRESHOLD: usize = 512;
 
 pub(crate) struct NodeDependencyOrder {
     pub order: Vec<u32>,
@@ -585,7 +606,7 @@ fn for_each_spatial_node_reference(
         }
         SpatialData::BackfaceVisibility(backface) => visit(backface.plane_root_index),
         SpatialData::AnchorScrollShift(shift) => visit(shift.scroll_node_index),
-        SpatialData::Perspective(_) => {}
+        SpatialData::Perspective(_) | SpatialData::Dead => {}
     }
 }
 
@@ -685,12 +706,149 @@ impl VisualContextTree {
             root_isolation_frame: None,
             version: allocate_tree_version(),
             reused_previous_version: false,
+            live_spatial_node_count: 1,
+            live_frame_node_count: 0,
+            free_spatial_slots: Vec::new(),
+            free_frame_slots: Vec::new(),
+            quarantined_spatial_slots: Vec::new(),
+            quarantined_frame_slots: Vec::new(),
         }
     }
 
+    pub fn spatial_is_live(&self, index: SpatialNodeIndex) -> bool {
+        self.spatial_nodes
+            .get(index.0 as usize)
+            .is_some_and(|node| node.data.is_live())
+    }
+
+    pub fn frame_is_live(&self, index: FrameNodeIndex) -> bool {
+        self.frame_nodes
+            .get(index.0 as usize)
+            .is_some_and(|node| node.data.is_live())
+    }
+
+    pub fn dead_node_count(&self) -> usize {
+        self.spatial_nodes.len() + self.frame_nodes.len()
+            - self.live_spatial_node_count as usize
+            - self.live_frame_node_count as usize
+    }
+
+    pub fn should_compact(&self) -> bool {
+        let live = self.live_spatial_node_count as usize + self.live_frame_node_count as usize;
+        self.dead_node_count() > live.max(COMPACTION_DEAD_NODE_THRESHOLD)
+    }
+
+    pub fn allocate_spatial_slot(&mut self) -> (SpatialNodeIndex, bool) {
+        if let Some(index) = self.free_spatial_slots.pop() {
+            debug_assert!(!self.spatial_nodes[index.0 as usize].data.is_live());
+            return (index, true);
+        }
+        self.spatial_nodes.push(SpatialNode {
+            data: SpatialData::Dead,
+            parent: VISUAL_VIEWPORT_NODE_INDEX,
+        });
+        (SpatialNodeIndex((self.spatial_nodes.len() - 1) as u32), false)
+    }
+
+    pub fn allocate_frame_slot(&mut self) -> (FrameNodeIndex, bool) {
+        if let Some(index) = self.free_frame_slots.pop() {
+            debug_assert!(!self.frame_nodes[index.0 as usize].data.is_live());
+            return (index, true);
+        }
+        self.frame_nodes.push(FrameNode::new(
+            FrameData::Dead,
+            FrameNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            FrameRole::Structural,
+        ));
+        (FrameNodeIndex((self.frame_nodes.len() - 1) as u32), false)
+    }
+
+    pub fn tombstone_spatial_slot(&mut self, index: SpatialNodeIndex) -> bool {
+        assert_ne!(
+            index, VISUAL_VIEWPORT_NODE_INDEX,
+            "the visual viewport node is never tombstoned"
+        );
+        let node = &mut self.spatial_nodes[index.0 as usize];
+        if !node.data.is_live() {
+            return false;
+        }
+        node.data = SpatialData::Dead;
+        self.live_spatial_node_count -= 1;
+        self.quarantined_spatial_slots.push(index);
+        true
+    }
+
+    pub fn tombstone_frame_slot(&mut self, index: FrameNodeIndex) -> bool {
+        assert_ne!(
+            Some(index),
+            self.root_isolation_frame,
+            "the root isolation frame is never tombstoned"
+        );
+        let node = &mut self.frame_nodes[index.0 as usize];
+        if !node.data.is_live() {
+            return false;
+        }
+        node.data = FrameData::Dead;
+        node.role = FrameRole::Structural;
+        node.clips_everything = false;
+        self.live_frame_node_count -= 1;
+        self.quarantined_frame_slots.push(index);
+        true
+    }
+
+    pub fn replace_spatial_node(&mut self, index: SpatialNodeIndex, node: SpatialNode) -> bool {
+        debug_assert!(node.data.is_live(), "slots are retired through tombstone_spatial_slot");
+        let slot = &mut self.spatial_nodes[index.0 as usize];
+        let was_live = slot.data.is_live();
+        *slot = node;
+        if !was_live {
+            self.live_spatial_node_count += 1;
+        }
+        was_live
+    }
+
+    pub fn replace_frame_node(&mut self, index: FrameNodeIndex, node: FrameNode) -> bool {
+        debug_assert!(node.data.is_live(), "slots are retired through tombstone_frame_slot");
+        let slot = &mut self.frame_nodes[index.0 as usize];
+        let was_live = slot.data.is_live();
+        *slot = node;
+        if !was_live {
+            self.live_frame_node_count += 1;
+        }
+        was_live
+    }
+
+    pub fn release_quarantined_slots_after_recording(&mut self) {
+        self.free_spatial_slots.append(&mut self.quarantined_spatial_slots);
+        self.free_frame_slots.append(&mut self.quarantined_frame_slots);
+        self.debug_assert_slot_accounting();
+    }
+
+    pub fn free_slot_count(&self) -> usize {
+        self.free_spatial_slots.len() + self.free_frame_slots.len()
+    }
+
+    pub fn quarantined_slot_count(&self) -> usize {
+        self.quarantined_spatial_slots.len() + self.quarantined_frame_slots.len()
+    }
+
+    pub(crate) fn debug_assert_slot_accounting(&self) {
+        debug_assert_eq!(
+            self.dead_node_count(),
+            self.free_slot_count() + self.quarantined_slot_count(),
+            "every dead slot is either free or quarantined"
+        );
+    }
+
     pub fn append_spatial(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex {
-        assert!((parent.0 as usize) < self.spatial_nodes.len());
+        assert!(
+            self.spatial_is_live(parent),
+            "a spatial node's parent must be a live node"
+        );
+        assert!(data.is_live(), "appended spatial nodes are live");
         self.spatial_nodes.push(SpatialNode { data, parent });
+        self.live_spatial_node_count += 1;
         SpatialNodeIndex((self.spatial_nodes.len() - 1) as u32)
     }
 
@@ -724,12 +882,18 @@ impl VisualContextTree {
         spatial: SpatialNodeIndex,
         role: FrameRole,
     ) -> FrameNodeIndex {
-        assert!((spatial.0 as usize) < self.spatial_nodes.len());
+        assert!(
+            self.spatial_is_live(spatial),
+            "a frame node's spatial node must be a live node"
+        );
+        assert!(data.is_live(), "appended frame nodes are live");
         if !parent.is_none() {
+            assert!(self.frame_is_live(parent), "a frame node's parent must be a live node");
             let parent_node = &self.frame_nodes[parent.0 as usize];
             debug_assert!(self.spatial_is_ancestor_or_self(parent_node.spatial, spatial));
         }
         self.frame_nodes.push(FrameNode::new(data, parent, spatial, role));
+        self.live_frame_node_count += 1;
         FrameNodeIndex((self.frame_nodes.len() - 1) as u32)
     }
 
@@ -822,6 +986,10 @@ impl VisualContextTree {
                 matrix: FloatMatrix4x4::identity(),
                 flattens_inherited_transform: backface.flattens_inherited_transform,
             },
+            SpatialData::Dead => LocalSpatialMatrix {
+                matrix: FloatMatrix4x4::identity(),
+                flattens_inherited_transform: false,
+            },
         }
     }
 
@@ -883,7 +1051,7 @@ impl VisualContextTree {
     pub(crate) fn spatial_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
         dependency_order(
             self.spatial_nodes.len(),
-            |_| true,
+            |index| self.spatial_nodes[index].data.is_live(),
             |index, references| {
                 for_each_spatial_node_reference(
                     SpatialNodeIndex(index as u32),
@@ -899,7 +1067,7 @@ impl VisualContextTree {
     pub(crate) fn frame_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
         dependency_order(
             self.frame_nodes.len(),
-            |_| true,
+            |index| self.frame_nodes[index].data.is_live(),
             |index, references| {
                 let parent = self.frame_nodes[index].parent;
                 if !parent.is_none() {
@@ -1439,6 +1607,136 @@ mod tests {
             contexts.outermost_context_of(permuted_context_root),
             permuted_context_root
         );
+    }
+
+    #[test]
+    fn tombstones_keep_their_links_and_leave_the_live_counts() {
+        let mut tree = tree();
+        let transform = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let empty_clip = tree.append_frame(
+            clip(FloatRect::new(0.0, 0.0, 0.0, 0.0), ClipMode::Intersect),
+            FrameNodeIndex::NONE,
+            transform,
+        );
+        assert_eq!(tree.live_spatial_node_count, 2);
+        assert_eq!(tree.live_frame_node_count, 1);
+        assert!(tree.frame_nodes[empty_clip.0 as usize].clips_everything);
+        assert!(tree.tombstone_frame_slot(empty_clip));
+        assert!(tree.tombstone_spatial_slot(transform));
+        assert!(!tree.tombstone_spatial_slot(transform));
+        assert!(!tree.spatial_is_live(transform));
+        assert!(!tree.frame_is_live(empty_clip));
+        assert_eq!(
+            tree.spatial_nodes[transform.0 as usize].parent,
+            VISUAL_VIEWPORT_NODE_INDEX
+        );
+        assert!(!tree.frame_nodes[empty_clip.0 as usize].clips_everything);
+        assert_eq!(tree.live_spatial_node_count, 1);
+        assert_eq!(tree.live_frame_node_count, 0);
+        assert_eq!(tree.dead_node_count(), 2);
+        assert!(!tree.should_compact());
+        assert!(tree.is_compatible_with(&tree.clone()));
+    }
+
+    #[test]
+    fn tombstoned_slots_stay_quarantined_until_a_recording_completes() {
+        let mut tree = tree();
+        let tombstoned = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        assert!(tree.tombstone_spatial_slot(tombstoned));
+        assert_eq!(tree.quarantined_slot_count(), 1);
+        assert_eq!(tree.free_slot_count(), 0);
+        let (fresh, reused) = tree.allocate_spatial_slot();
+        assert!(!reused);
+        assert_eq!(fresh, SpatialNodeIndex(2));
+        assert!(!tree.replace_spatial_node(
+            fresh,
+            SpatialNode {
+                data: SpatialData::Transform(transform(0.0)),
+                parent: VISUAL_VIEWPORT_NODE_INDEX,
+            },
+        ));
+        tree.release_quarantined_slots_after_recording();
+        assert_eq!(tree.quarantined_slot_count(), 0);
+        assert_eq!(tree.free_slot_count(), 1);
+        let (recycled, reused) = tree.allocate_spatial_slot();
+        assert!(reused);
+        assert_eq!(recycled, tombstoned);
+    }
+
+    #[test]
+    fn released_slots_are_reused_before_the_arrays_grow() {
+        let mut tree = tree();
+        let first = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let second = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        assert!(tree.tombstone_frame_slot(first));
+        assert!(tree.tombstone_frame_slot(second));
+        tree.release_quarantined_slots_after_recording();
+        let frame_count = tree.frame_nodes.len();
+        assert_eq!(tree.allocate_frame_slot(), (second, true));
+        assert_eq!(tree.allocate_frame_slot(), (first, true));
+        assert_eq!(tree.frame_nodes.len(), frame_count);
+        assert_eq!(tree.allocate_frame_slot(), (FrameNodeIndex(frame_count as u32), false));
+    }
+
+    #[test]
+    fn dead_node_count_counts_free_and_quarantined_slots() {
+        let mut tree = tree();
+        let transform_node = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let clip_frame = tree.append_frame(
+            clip(FloatRect::new(0.0, 0.0, 1.0, 1.0), ClipMode::Intersect),
+            FrameNodeIndex::NONE,
+            transform_node,
+        );
+        assert!(tree.tombstone_frame_slot(clip_frame));
+        tree.release_quarantined_slots_after_recording();
+        assert!(tree.tombstone_spatial_slot(transform_node));
+        assert_eq!(tree.dead_node_count(), 2);
+        assert_eq!(tree.free_slot_count(), 1);
+        assert_eq!(tree.quarantined_slot_count(), 1);
+        let (slot, reused) = tree.allocate_frame_slot();
+        assert!(reused);
+        assert!(!tree.replace_frame_node(
+            slot,
+            FrameNode::new(
+                effects(),
+                FrameNodeIndex::NONE,
+                VISUAL_VIEWPORT_NODE_INDEX,
+                FrameRole::Structural
+            )
+        ));
+        assert_eq!(tree.dead_node_count(), 1);
+        tree.debug_assert_slot_accounting();
+    }
+
+    #[test]
+    fn dependency_orders_leave_tombstones_out() {
+        let mut tree = tree();
+        let stale = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let other = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let frame = tree.append_frame(effects(), FrameNodeIndex::NONE, other);
+        assert!(tree.tombstone_spatial_slot(stale));
+        assert!(tree.tombstone_frame_slot(frame));
+        let order = tree.spatial_dependency_order_with_back_edges();
+        assert_eq!(order.order, vec![VISUAL_VIEWPORT_NODE_INDEX.0, other.0]);
+        assert!(order.back_edges.is_empty());
+        assert!(order.dangling_references.is_empty());
+        assert!(tree.frame_dependency_order().is_empty());
+    }
+
+    #[test]
+    fn a_live_node_referencing_a_tombstone_dangles() {
+        let mut tree = tree();
+        let plane_root = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let marker = tree.append_spatial(
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: plane_root,
+                flattens_inherited_transform: false,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        assert!(tree.tombstone_spatial_slot(plane_root));
+        let order = tree.spatial_dependency_order_with_back_edges();
+        assert_eq!(order.dangling_references, vec![(marker.0, plane_root.0)]);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -7,15 +7,19 @@
 pub mod basic_shapes;
 pub mod box_build;
 pub mod build;
+pub mod delta;
 pub mod dirty;
 pub mod dump;
+pub mod incremental;
 pub mod local_frames;
 pub mod nested;
 pub mod node_values;
 pub mod queries;
+pub mod reconcile;
 pub mod refresh;
 pub mod scroll_state;
 pub mod serialize;
+pub mod shape;
 
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -552,11 +556,26 @@ pub struct VisualContextState {
     pub needs_to_refresh_scroll_state: bool,
     pub build_count: u64,
     pub dirty_boxes: dirty::VisualContextDirtySet,
+    pub incremental_update_count: u64,
+    pub last_tree_inputs: Option<crate::painting::host::FfiVisualContextTreeInputs>,
+    pub last_root_background_source: Option<crate::painting::host::FfiRootBackgroundSource>,
+    pub last_full_build_reason: dirty::VisualContextGlobalRebuildReason,
+    pub quarantined_slots_are_releasable: bool,
 }
 
 impl VisualContextState {
     pub fn structural_epoch(&self) -> u64 {
         self.tree.as_ref().map_or(0, |tree| tree.structural_epoch)
+    }
+
+    pub fn release_quarantined_slots_while_no_handle_is_retained(&mut self) {
+        if !self.quarantined_slots_are_releasable {
+            return;
+        }
+        self.quarantined_slots_are_releasable = false;
+        if let Some(tree) = self.tree.as_mut() {
+            Rc::make_mut(tree).release_quarantined_slots_after_recording();
+        }
     }
 }
 
@@ -1244,6 +1263,8 @@ pub(crate) struct PaintableVisualContextRecord {
     pub node_handles: BoxVisualContextNodeHandles,
     pub has_mask_nodes: bool,
     pub may_be_root_element: bool,
+    pub owns_geometry_dependent_nodes: bool,
+    pub subtree_may_own_geometry_dependent_nodes: bool,
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -428,12 +428,13 @@ impl SortingContexts {
 
 pub fn resolve_sorting_contexts_over_nodes(
     node_count: usize,
+    nodes_in_dependency_order: &[u32],
     parent_and_sorting_context_root_of_node: impl Fn(usize) -> (SpatialNodeIndex, Option<SpatialNodeIndex>),
 ) -> SortingContexts {
     let mut is_sorting_context_root = vec![false; node_count];
     let mut has_sorting_context_roots = false;
-    for index in 0..node_count {
-        let (_, sorting_context_root) = parent_and_sorting_context_root_of_node(index);
+    for &index in nodes_in_dependency_order {
+        let (_, sorting_context_root) = parent_and_sorting_context_root_of_node(index as usize);
         if let Some(root) = sorting_context_root {
             is_sorting_context_root[root.0 as usize] = true;
             has_sorting_context_roots = true;
@@ -443,14 +444,16 @@ pub fn resolve_sorting_contexts_over_nodes(
         return SortingContexts::default();
     }
 
-    // Roots always precede their contexts' nodes, so a single forward walk resolves every node.
+    // The dependency order lists a node after its parent and its sorting context root, so a single
+    // walk along it resolves every node from entries already written.
     let mut contexts = SortingContexts {
         links: HashMap::new(),
-        leaf_by_node: Vec::with_capacity(node_count),
-        context_by_node: Vec::with_capacity(node_count),
+        leaf_by_node: vec![NO_SORTING_CONTEXT; node_count],
+        context_by_node: vec![NO_SORTING_CONTEXT; node_count],
     };
-    for (index, is_sorting_context_root) in is_sorting_context_root.iter().copied().enumerate() {
-        let spatial_index = SpatialNodeIndex(index as u32);
+    for &index in nodes_in_dependency_order {
+        let spatial_index = SpatialNodeIndex(index);
+        let index = index as usize;
         let (parent, sorting_context_root) = parent_and_sorting_context_root_of_node(index);
         let inherited_leaf = if index == 0 {
             NO_SORTING_CONTEXT
@@ -463,9 +466,9 @@ pub fn resolve_sorting_contexts_over_nodes(
             contexts.context_by_node[parent.0 as usize]
         };
         if let Some(root) = sorting_context_root {
-            contexts.leaf_by_node.push(spatial_index);
-            contexts.context_by_node.push(root);
-        } else if is_sorting_context_root {
+            contexts.leaf_by_node[index] = spatial_index;
+            contexts.context_by_node[index] = root;
+        } else if is_sorting_context_root[index] {
             contexts.links.insert(
                 spatial_index.0,
                 SortingContextLink {
@@ -473,11 +476,11 @@ pub fn resolve_sorting_contexts_over_nodes(
                     parent_leaf: inherited_leaf,
                 },
             );
-            contexts.leaf_by_node.push(spatial_index);
-            contexts.context_by_node.push(spatial_index);
+            contexts.leaf_by_node[index] = spatial_index;
+            contexts.context_by_node[index] = spatial_index;
         } else {
-            contexts.leaf_by_node.push(inherited_leaf);
-            contexts.context_by_node.push(inherited_context);
+            contexts.leaf_by_node[index] = inherited_leaf;
+            contexts.context_by_node[index] = inherited_context;
         }
     }
     contexts
@@ -550,6 +553,104 @@ pub struct VisualContextTree {
     pub root_isolation_frame: Option<FrameNodeIndex>,
     pub version: u64,
     pub reused_previous_version: bool,
+}
+
+pub(crate) struct NodeDependencyOrder {
+    pub order: Vec<u32>,
+    pub back_edges: Vec<(u32, u32)>,
+    pub dangling_references: Vec<(u32, u32)>,
+}
+
+fn for_each_spatial_node_reference(
+    index: SpatialNodeIndex,
+    node: &SpatialNode,
+    mut visit: impl FnMut(SpatialNodeIndex),
+) {
+    if index != VISUAL_VIEWPORT_NODE_INDEX {
+        visit(node.parent);
+    }
+    match &node.data {
+        SpatialData::Scroll(scroll) => visit(scroll.registry_parent_node),
+        SpatialData::Sticky(sticky) => {
+            visit(sticky.scroller);
+            if let Some(parent_sticky) = sticky.parent_sticky {
+                visit(parent_sticky);
+            }
+            visit(sticky.registry_parent_node);
+        }
+        SpatialData::Transform(transform) => {
+            if let Some(root) = transform.sorting_context_root_index {
+                visit(root);
+            }
+        }
+        SpatialData::BackfaceVisibility(backface) => visit(backface.plane_root_index),
+        SpatialData::AnchorScrollShift(shift) => visit(shift.scroll_node_index),
+        SpatialData::Perspective(_) => {}
+    }
+}
+
+fn dependency_order(
+    node_count: usize,
+    is_live: impl Fn(usize) -> bool,
+    collect_references: impl Fn(usize, &mut Vec<usize>),
+) -> NodeDependencyOrder {
+    const UNVISITED: u8 = 0;
+    const ON_STACK: u8 = 1;
+    const DONE: u8 = 2;
+    struct PendingNode {
+        node: usize,
+        references_begin: usize,
+        references_end: usize,
+        next_reference: usize,
+    }
+    let mut marks = vec![UNVISITED; node_count];
+    let mut order = Vec::with_capacity(node_count);
+    let mut back_edges = Vec::new();
+    let mut dangling_references = Vec::new();
+    let mut references: Vec<usize> = Vec::new();
+    let mut stack: Vec<PendingNode> = Vec::new();
+    let push = |node: usize, references: &mut Vec<usize>, stack: &mut Vec<PendingNode>, marks: &mut Vec<u8>| {
+        marks[node] = ON_STACK;
+        let references_begin = references.len();
+        collect_references(node, references);
+        stack.push(PendingNode {
+            node,
+            references_begin,
+            references_end: references.len(),
+            next_reference: references_begin,
+        });
+    };
+    for root in 0..node_count {
+        if marks[root] != UNVISITED || !is_live(root) {
+            continue;
+        }
+        push(root, &mut references, &mut stack, &mut marks);
+        while let Some(pending) = stack.last_mut() {
+            if pending.next_reference == pending.references_end {
+                marks[pending.node] = DONE;
+                order.push(pending.node as u32);
+                references.truncate(pending.references_begin);
+                stack.pop();
+                continue;
+            }
+            let referenced = references[pending.next_reference];
+            pending.next_reference += 1;
+            if referenced >= node_count || !is_live(referenced) {
+                dangling_references.push((pending.node as u32, referenced as u32));
+                continue;
+            }
+            match marks[referenced] {
+                ON_STACK => back_edges.push((pending.node as u32, referenced as u32)),
+                UNVISITED => push(referenced, &mut references, &mut stack, &mut marks),
+                _ => {}
+            }
+        }
+    }
+    NodeDependencyOrder {
+        order,
+        back_edges,
+        dangling_references,
+    }
 }
 
 impl VisualContextTree {
@@ -779,8 +880,59 @@ impl VisualContextTree {
         depth.is_finite().then_some(depth)
     }
 
+    pub(crate) fn spatial_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
+        dependency_order(
+            self.spatial_nodes.len(),
+            |_| true,
+            |index, references| {
+                for_each_spatial_node_reference(
+                    SpatialNodeIndex(index as u32),
+                    &self.spatial_nodes[index],
+                    |referenced| {
+                        references.push(referenced.0 as usize);
+                    },
+                );
+            },
+        )
+    }
+
+    pub(crate) fn frame_dependency_order_with_back_edges(&self) -> NodeDependencyOrder {
+        dependency_order(
+            self.frame_nodes.len(),
+            |_| true,
+            |index, references| {
+                let parent = self.frame_nodes[index].parent;
+                if !parent.is_none() {
+                    references.push(parent.0 as usize);
+                }
+            },
+        )
+    }
+
+    pub fn spatial_dependency_order(&self) -> Vec<u32> {
+        let dependency_order = self.spatial_dependency_order_with_back_edges();
+        debug_assert!(
+            dependency_order.back_edges.is_empty() && dependency_order.dangling_references.is_empty(),
+            "spatial node references form a cycle or dangle: {:?} {:?}",
+            dependency_order.back_edges,
+            dependency_order.dangling_references
+        );
+        dependency_order.order
+    }
+
+    pub fn frame_dependency_order(&self) -> Vec<u32> {
+        let dependency_order = self.frame_dependency_order_with_back_edges();
+        debug_assert!(
+            dependency_order.back_edges.is_empty() && dependency_order.dangling_references.is_empty(),
+            "frame node parents form a cycle or dangle: {:?} {:?}",
+            dependency_order.back_edges,
+            dependency_order.dangling_references
+        );
+        dependency_order.order
+    }
+
     pub fn resolve_sorting_contexts(&self) -> SortingContexts {
-        resolve_sorting_contexts_over_nodes(self.spatial_nodes.len(), |index| {
+        resolve_sorting_contexts_over_nodes(self.spatial_nodes.len(), &self.spatial_dependency_order(), |index| {
             let node = &self.spatial_nodes[index];
             let sorting_context_root = if let SpatialData::Transform(transform) = &node.data {
                 transform.sorting_context_root_index
@@ -929,6 +1081,7 @@ pub(crate) struct PaintableVisualContextRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::node_data::NodeSlotId;
     use libgfx_rust::translation_matrix;
 
     fn transform(translation: f32) -> TransformData {
@@ -1150,6 +1303,144 @@ mod tests {
             }
         );
     }
+
+    fn viewport_scroll() -> SpatialData {
+        SpatialData::Scroll(ScrollData {
+            state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
+        })
+    }
+
+    #[test]
+    fn spatial_dependency_order_puts_every_reference_before_its_referrer() {
+        let mut tree = tree();
+        let scroll = tree.append_spatial(viewport_scroll(), VISUAL_VIEWPORT_NODE_INDEX);
+        let child = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let parent = tree.append_spatial(SpatialData::Transform(transform(0.0)), scroll);
+        tree.spatial_nodes[child.0 as usize].parent = parent;
+        let sticky = tree.append_spatial(
+            SpatialData::Sticky(StickyData::unconstrained(
+                scroll,
+                None,
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                scroll,
+            )),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let order = tree.spatial_dependency_order();
+        let position = |index: SpatialNodeIndex| order.iter().position(|entry| *entry == index.0).unwrap();
+        assert_eq!(order.len(), 5);
+        assert!(position(parent) < position(child));
+        assert!(position(scroll) < position(parent));
+        assert!(position(scroll) < position(sticky));
+        assert_eq!(order[0], VISUAL_VIEWPORT_NODE_INDEX.0);
+    }
+
+    #[test]
+    fn frame_dependency_order_follows_parents_only() {
+        let mut tree = tree();
+        let root_isolation_frame = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        let child = tree.append_frame(effects(), root_isolation_frame, VISUAL_VIEWPORT_NODE_INDEX);
+        let parent = tree.append_frame(effects(), root_isolation_frame, VISUAL_VIEWPORT_NODE_INDEX);
+        tree.frame_nodes[child.0 as usize].parent = parent;
+        assert_eq!(
+            tree.frame_dependency_order(),
+            vec![root_isolation_frame.0, parent.0, child.0]
+        );
+    }
+
+    #[test]
+    fn a_reference_cycle_and_a_self_reference_are_reported_as_back_edges() {
+        let mut tree = tree();
+        let first = tree.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let second = tree.append_spatial(SpatialData::Transform(transform(0.0)), first);
+        tree.spatial_nodes[first.0 as usize].parent = second;
+        let order = tree.spatial_dependency_order_with_back_edges();
+        assert_eq!(order.back_edges, vec![(second.0, first.0)]);
+        assert!(order.dangling_references.is_empty());
+        assert_eq!(order.order.len(), 3);
+
+        let mut self_referencing = self::tree();
+        let anchored = self_referencing.append_spatial(
+            SpatialData::AnchorScrollShift(AnchorScrollShift {
+                scroll_node_index: SpatialNodeIndex(1),
+                negate: false,
+                compensate_horizontal_scroll: true,
+                compensate_vertical_scroll: true,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let order = self_referencing.spatial_dependency_order_with_back_edges();
+        assert_eq!(order.back_edges, vec![(anchored.0, anchored.0)]);
+    }
+
+    #[test]
+    fn a_reference_out_of_range_is_reported_as_dangling() {
+        let mut tree = tree();
+        let marker = tree.append_spatial(
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: SpatialNodeIndex(9),
+                flattens_inherited_transform: false,
+            }),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let order = tree.spatial_dependency_order_with_back_edges();
+        assert_eq!(order.dangling_references, vec![(marker.0, 9)]);
+        assert!(order.back_edges.is_empty());
+    }
+
+    #[test]
+    fn sorting_contexts_resolve_the_same_for_a_child_stored_below_its_parent() {
+        let mut in_order = tree();
+        let context_root = in_order.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let participant =
+            in_order.append_spatial(SpatialData::Transform(sorting_transform(context_root)), context_root);
+        let descendant = in_order.append_spatial(SpatialData::Transform(transform(0.0)), participant);
+
+        let mut permuted = tree();
+        let permuted_descendant =
+            permuted.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let permuted_participant =
+            permuted.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        let permuted_context_root =
+            permuted.append_spatial(SpatialData::Transform(transform(0.0)), VISUAL_VIEWPORT_NODE_INDEX);
+        permuted.spatial_nodes[permuted_participant.0 as usize] = SpatialNode {
+            data: SpatialData::Transform(sorting_transform(permuted_context_root)),
+            parent: permuted_context_root,
+        };
+        permuted.spatial_nodes[permuted_descendant.0 as usize].parent = permuted_participant;
+
+        let expected = in_order.resolve_sorting_contexts();
+        let contexts = permuted.resolve_sorting_contexts();
+        let pairs = [
+            (context_root, permuted_context_root),
+            (participant, permuted_participant),
+            (descendant, permuted_descendant),
+        ];
+        let map = |index: SpatialNodeIndex| {
+            pairs
+                .iter()
+                .find(|(original, _)| *original == index)
+                .map_or(index, |(_, mapped)| *mapped)
+        };
+        for (original, mapped) in pairs {
+            assert_eq!(
+                contexts.leaf_by_node[mapped.0 as usize],
+                map(expected.leaf_by_node[original.0 as usize])
+            );
+            assert_eq!(
+                contexts.context_by_node[mapped.0 as usize],
+                map(expected.context_by_node[original.0 as usize])
+            );
+        }
+        assert_eq!(
+            contexts.outermost_context_of(permuted_context_root),
+            permuted_context_root
+        );
+    }
+
     #[test]
     fn a_tree_without_sorting_context_roots_resolves_to_empty_contexts() {
         assert!(tree().resolve_sorting_contexts().is_empty());
@@ -1269,7 +1560,8 @@ mod tests {
     }
 
     fn resolve_matrices(parents: &[u32], roots: &[Option<u32>], locals: &[FloatMatrix4x4]) -> Vec<FloatMatrix4x4> {
-        let contexts = resolve_sorting_contexts_over_nodes(parents.len(), |index| {
+        let dependency_order: Vec<u32> = (0..parents.len() as u32).collect();
+        let contexts = resolve_sorting_contexts_over_nodes(parents.len(), &dependency_order, |index| {
             (SpatialNodeIndex(parents[index]), roots[index].map(SpatialNodeIndex))
         });
         let parent_by_node: Vec<SpatialNodeIndex> = parents.iter().map(|parent| SpatialNodeIndex(*parent)).collect();

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -5,6 +5,7 @@
  */
 
 pub mod basic_shapes;
+pub mod box_build;
 pub mod build;
 pub mod dump;
 pub mod local_frames;
@@ -19,6 +20,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::layout::node_data::NodeSlotId;
 use crate::painting::paintable_data::BorderEdge;
 use libgfx_rust::{
     CompositingAndBlendingOperator, CornerRadii, FloatMatrix4x4, FloatPoint, FloatRect, FloatSize, IntPoint, IntRect,
@@ -132,6 +134,8 @@ pub struct MaskData {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ScrollData {
     pub state_slot: ScrollStateSlot,
+    pub owner_paintable: NodeSlotId,
+    pub registry_parent_node: SpatialNodeIndex,
 }
 
 // A sticky box's shift is derived when the scroll state snapshot is resolved, from the scroller's
@@ -152,6 +156,8 @@ pub struct StickyData {
     pub inset_bottom: Option<f32>,
     pub inset_left: Option<f32>,
     pub state_slot: ScrollStateSlot,
+    pub owner_paintable: NodeSlotId,
+    pub registry_parent_node: SpatialNodeIndex,
 }
 
 impl StickyData {
@@ -159,6 +165,8 @@ impl StickyData {
         scroller: SpatialNodeIndex,
         parent_sticky: Option<SpatialNodeIndex>,
         state_slot: ScrollStateSlot,
+        owner_paintable: NodeSlotId,
+        registry_parent_node: SpatialNodeIndex,
     ) -> Self {
         Self {
             scroller,
@@ -173,6 +181,8 @@ impl StickyData {
             inset_bottom: None,
             inset_left: None,
             state_slot,
+            owner_paintable,
+            registry_parent_node,
         }
     }
 }
@@ -793,6 +803,129 @@ impl VisualContextTree {
     }
 }
 
+pub trait VisualContextNodeSink {
+    fn append_spatial_node(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex;
+    fn append_frame_node(
+        &mut self,
+        data: FrameData,
+        parent: FrameNodeIndex,
+        spatial: SpatialNodeIndex,
+        role: FrameRole,
+    ) -> FrameNodeIndex;
+    fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode;
+    fn next_spatial_node_index(&self) -> SpatialNodeIndex;
+    fn next_frame_node_index(&self) -> FrameNodeIndex;
+
+    fn append_spatial_node_under(&mut self, context: ContextRef, data: SpatialData) -> ContextRef {
+        ContextRef {
+            spatial: self.append_spatial_node(data, context.spatial),
+            ..context
+        }
+    }
+
+    fn append_frame_node_under(&mut self, context: ContextRef, data: FrameData) -> ContextRef {
+        ContextRef {
+            frame: self.append_frame_node(data, context.frame, context.spatial, FrameRole::Structural),
+            ..context
+        }
+    }
+}
+
+impl VisualContextNodeSink for VisualContextTree {
+    fn append_spatial_node(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex {
+        self.append_spatial(data, parent)
+    }
+
+    fn append_frame_node(
+        &mut self,
+        data: FrameData,
+        parent: FrameNodeIndex,
+        spatial: SpatialNodeIndex,
+        role: FrameRole,
+    ) -> FrameNodeIndex {
+        self.append_frame_with_role(data, parent, spatial, role)
+    }
+
+    fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode {
+        &self.spatial_nodes[index.0 as usize]
+    }
+
+    fn next_spatial_node_index(&self) -> SpatialNodeIndex {
+        SpatialNodeIndex(self.spatial_nodes.len() as u32)
+    }
+
+    fn next_frame_node_index(&self) -> FrameNodeIndex {
+        FrameNodeIndex(self.frame_nodes.len() as u32)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BoxVisualContextNodeHandles {
+    pub spatial: Vec<SpatialNodeIndex>,
+    pub chain_frames: Vec<FrameNodeIndex>,
+    pub local_frames: Vec<FrameNodeIndex>,
+    pub descendant_frames: Vec<FrameNodeIndex>,
+}
+
+pub static EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES: BoxVisualContextNodeHandles = BoxVisualContextNodeHandles {
+    spatial: Vec::new(),
+    chain_frames: Vec::new(),
+    local_frames: Vec::new(),
+    descendant_frames: Vec::new(),
+};
+
+impl BoxVisualContextNodeHandles {
+    pub fn frame_handles(&self) -> impl Iterator<Item = FrameNodeIndex> + '_ {
+        self.chain_frames
+            .iter()
+            .chain(&self.local_frames)
+            .chain(&self.descendant_frames)
+            .copied()
+    }
+
+    pub fn contains_frame(&self, frame: FrameNodeIndex) -> bool {
+        self.frame_handles().any(|handle| handle == frame)
+    }
+
+    pub fn local_frame_handles(&self) -> &[FrameNodeIndex] {
+        &self.local_frames
+    }
+}
+
+// Nearest ancestor scroll node resolved along the containing block chain, drilled down alongside
+// the visual context indices. A fixed-position ancestor decouples its subtree from all outer
+// scrollers, but sticky boxes must still reference a scrollport through fixed-position ancestors
+// for their sticky offset computation, so both resolutions are carried.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NearestScrollNodeIndices {
+    pub stopping_at_fixed_position_ancestors: SpatialNodeIndex,
+    pub continuing_through_fixed_position_ancestors: SpatialNodeIndex,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DescendantVisualContexts {
+    pub normal: ContextRef,
+    pub absolute_position: ContextRef,
+    pub fixed_position: ContextRef,
+    pub normal_nearest_scroll_nodes: NearestScrollNodeIndices,
+    pub absolute_position_nearest_scroll_nodes: NearestScrollNodeIndices,
+    pub fixed_position_nearest_scroll_nodes: NearestScrollNodeIndices,
+    pub normal_plane_root: SpatialNodeIndex,
+    pub absolute_position_plane_root: SpatialNodeIndex,
+    pub fixed_position_plane_root: SpatialNodeIndex,
+    pub flattens_inherited_transform: bool,
+    pub sorting_context_root: Option<SpatialNodeIndex>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PaintableVisualContextRecord {
+    pub inherited_input: DescendantVisualContexts,
+    pub output_for_descendants: DescendantVisualContexts,
+    pub node_handles: BoxVisualContextNodeHandles,
+    pub has_mask_nodes: bool,
+    pub may_be_root_element: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -948,6 +1081,8 @@ mod tests {
         let scroll = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -7,6 +7,7 @@
 pub mod basic_shapes;
 pub mod box_build;
 pub mod build;
+pub mod dirty;
 pub mod dump;
 pub mod local_frames;
 pub mod nested;
@@ -550,6 +551,7 @@ pub struct VisualContextState {
     pub scroll_state_snapshot: Vec<FloatPoint>,
     pub needs_to_refresh_scroll_state: bool,
     pub build_count: u64,
+    pub dirty_boxes: dirty::VisualContextDirtySet,
 }
 
 impl VisualContextState {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -499,10 +499,10 @@ pub fn resolve_sorting_contexts_over_nodes(
     contexts
 }
 
-static NEXT_TREE_VERSION: AtomicU64 = AtomicU64::new(1);
+static NEXT_STRUCTURAL_EPOCH: AtomicU64 = AtomicU64::new(1);
 
-pub fn allocate_tree_version() -> u64 {
-    NEXT_TREE_VERSION.fetch_add(1, Ordering::Relaxed)
+pub fn allocate_structural_epoch() -> u64 {
+    NEXT_STRUCTURAL_EPOCH.fetch_add(1, Ordering::Relaxed)
 }
 
 pub fn resolve_leaf_to_context_matrices(
@@ -553,8 +553,8 @@ pub struct VisualContextState {
 }
 
 impl VisualContextState {
-    pub fn tree_version(&self) -> u64 {
-        self.tree.as_ref().map_or(0, |tree| tree.version)
+    pub fn structural_epoch(&self) -> u64 {
+        self.tree.as_ref().map_or(0, |tree| tree.structural_epoch)
     }
 }
 
@@ -564,8 +564,7 @@ pub struct VisualContextTree {
     pub frame_nodes: Vec<FrameNode>,
     pub root_is_visual_viewport: bool,
     pub root_isolation_frame: Option<FrameNodeIndex>,
-    pub version: u64,
-    pub reused_previous_version: bool,
+    pub structural_epoch: u64,
     pub live_spatial_node_count: u32,
     pub live_frame_node_count: u32,
     free_spatial_slots: Vec<SpatialNodeIndex>,
@@ -704,8 +703,7 @@ impl VisualContextTree {
             frame_nodes: Vec::new(),
             root_is_visual_viewport,
             root_isolation_frame: None,
-            version: allocate_tree_version(),
-            reused_previous_version: false,
+            structural_epoch: allocate_structural_epoch(),
             live_spatial_node_count: 1,
             live_frame_node_count: 0,
             free_spatial_slots: Vec::new(),

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -697,6 +697,7 @@ impl VisualContextTree {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::node_data::NodeSlotId;
     use crate::painting::visual_context::{
         BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, PerspectiveData, ScrollData, SpatialData,
         StickyData, TransformData, TransformDataRole, scroll_state::NO_SCROLL_STATE_SLOT,
@@ -722,6 +723,8 @@ mod tests {
     fn scroll() -> SpatialData {
         SpatialData::Scroll(ScrollData {
             state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
         })
     }
 
@@ -1106,7 +1109,13 @@ mod tests {
         );
         let inner_scroll = tree.append_spatial(scroll(), transformed);
         let sticky = tree.append_spatial(
-            SpatialData::Sticky(StickyData::unconstrained(inner_scroll, None, NO_SCROLL_STATE_SLOT)),
+            SpatialData::Sticky(StickyData::unconstrained(
+                inner_scroll,
+                None,
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                inner_scroll,
+            )),
             inner_scroll,
         );
         let mut scroll_offsets = vec![FloatPoint::default(); 5];
@@ -1153,6 +1162,8 @@ mod tests {
                 inset_bottom: None,
                 inset_left: None,
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: viewport_scroll_node,
             }),
             viewport_scroll_node,
         );
@@ -1177,6 +1188,8 @@ mod tests {
                 inset_bottom: None,
                 inset_left: None,
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: viewport_scroll_node,
             }),
             header_node,
         );
@@ -1212,6 +1225,8 @@ mod tests {
                 VISUAL_VIEWPORT_NODE_INDEX,
                 None,
                 NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                VISUAL_VIEWPORT_NODE_INDEX,
             )),
             VISUAL_VIEWPORT_NODE_INDEX,
         );

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -75,10 +75,11 @@ struct SpatialChainWalk {
 impl VisualContextTree {
     pub fn fill_frames_with_empty_effective_clip(&self, empty: &mut Vec<bool>) {
         empty.clear();
-        empty.reserve(self.frame_nodes.len());
-        for node in &self.frame_nodes {
+        empty.resize(self.frame_nodes.len(), false);
+        for index in self.frame_dependency_order() {
+            let node = &self.frame_nodes[index as usize];
             let parent_is_empty = !node.parent.is_none() && empty[node.parent.0 as usize];
-            empty.push(node.clips_everything || parent_is_empty);
+            empty[index as usize] = node.clips_everything || parent_is_empty;
         }
     }
 
@@ -526,23 +527,22 @@ impl VisualContextTree {
                 resolved_offsets[slot] = offset;
                 resolved_sticky_entries.push((node_index, offset));
             };
-        for (i, node) in self.spatial_nodes.iter().enumerate() {
+        for index in self.spatial_dependency_order() {
+            let node = &self.spatial_nodes[index as usize];
             let SpatialData::Sticky(sticky) = &node.data else {
                 continue;
             };
-            let node_index = SpatialNodeIndex(i as u32);
+            let node_index = SpatialNodeIndex(index);
             if sticky.scroller == VISUAL_VIEWPORT_NODE_INDEX {
                 record_entry(&mut resolved_offsets, node_index, FloatPoint::default());
                 continue;
             }
-            assert!((sticky.scroller.0 as usize) < i);
 
-            // Sticky ancestors along the containing block chain precede this node, so their entries are
-            // already resolved in this pass.
+            // The dependency order lists a sticky node after its scroller and its parent sticky, so
+            // their entries are already resolved in this pass.
             let mut parent_sticky_offset = FloatPoint::default();
             let mut ancestor = sticky.parent_sticky;
             while let Some(ancestor_index) = ancestor {
-                assert!((ancestor_index.0 as usize) < i);
                 let entry = device_offset_for_index(&resolved_offsets, ancestor_index);
                 parent_sticky_offset = FloatPoint {
                     x: parent_sticky_offset.x + entry.x,
@@ -685,9 +685,12 @@ impl VisualContextTree {
                 *flag = true;
             }
         }
-        for index in 1..self.spatial_nodes.len() {
-            if in_subtree[self.spatial_nodes[index].parent.0 as usize] {
-                in_subtree[index] = true;
+        for index in self.spatial_dependency_order() {
+            if index == VISUAL_VIEWPORT_NODE_INDEX.0 {
+                continue;
+            }
+            if in_subtree[self.spatial_nodes[index as usize].parent.0 as usize] {
+                in_subtree[index as usize] = true;
             }
         }
         in_subtree
@@ -700,7 +703,7 @@ mod tests {
     use crate::layout::node_data::NodeSlotId;
     use crate::painting::visual_context::{
         BackfaceVisibilityData, ClipData, ClipMode, EffectsData, FrameData, PerspectiveData, ScrollData, SpatialData,
-        StickyData, TransformData, TransformDataRole, scroll_state::NO_SCROLL_STATE_SLOT,
+        SpatialNode, StickyData, TransformData, TransformDataRole, scroll_state::NO_SCROLL_STATE_SLOT,
     };
     use libgfx_rust::{CornerRadii, FloatMatrix4x4, FloatSize, perspective_matrix, scale_matrix, translation_matrix};
 
@@ -1215,6 +1218,161 @@ mod tests {
             resolve(50.0),
             vec![(header_node, point(0.0, 0.0)), (bar_node, point(0.0, 0.0))]
         );
+    }
+
+    fn sticky(scroller: SpatialNodeIndex, parent_sticky: Option<SpatialNodeIndex>, top: f32) -> SpatialData {
+        SpatialData::Sticky(StickyData {
+            scroller,
+            parent_sticky,
+            position_relative_to_scroller: point(0.0, top),
+            border_box_size: FloatSize {
+                width: 10.0,
+                height: 10.0,
+            },
+            scrollport_size: FloatSize {
+                width: 100.0,
+                height: 100.0,
+            },
+            containing_block_region: FloatRect::new(0.0, 0.0, 100.0, 1000.0),
+            needs_parent_offset_adjustment: false,
+            inset_top: Some(0.0),
+            inset_right: None,
+            inset_bottom: None,
+            inset_left: None,
+            state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: parent_sticky.unwrap_or(scroller),
+        })
+    }
+
+    fn remap_spatial_data(data: &SpatialData, map: &dyn Fn(SpatialNodeIndex) -> SpatialNodeIndex) -> SpatialData {
+        match data {
+            SpatialData::Transform(transform) => SpatialData::Transform(TransformData {
+                sorting_context_root_index: transform.sorting_context_root_index.map(map),
+                ..*transform
+            }),
+            SpatialData::BackfaceVisibility(backface) => SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: map(backface.plane_root_index),
+                ..*backface
+            }),
+            SpatialData::Sticky(sticky) => SpatialData::Sticky(StickyData {
+                scroller: map(sticky.scroller),
+                parent_sticky: sticky.parent_sticky.map(map),
+                registry_parent_node: map(sticky.registry_parent_node),
+                ..*sticky
+            }),
+            SpatialData::Scroll(scroll) => SpatialData::Scroll(ScrollData {
+                registry_parent_node: map(scroll.registry_parent_node),
+                ..*scroll
+            }),
+            other => other.clone(),
+        }
+    }
+
+    fn permuted_tree(tree: &VisualContextTree, permutation: &[u32]) -> VisualContextTree {
+        let map = |index: SpatialNodeIndex| SpatialNodeIndex(permutation[index.0 as usize]);
+        let mut permuted = tree.clone();
+        for (index, node) in tree.spatial_nodes.iter().enumerate() {
+            permuted.spatial_nodes[permutation[index] as usize] = SpatialNode {
+                data: remap_spatial_data(&node.data, &map),
+                parent: map(node.parent),
+            };
+        }
+        for (index, node) in tree.frame_nodes.iter().enumerate() {
+            permuted.frame_nodes[index].spatial = map(node.spatial);
+        }
+        permuted
+    }
+
+    #[test]
+    fn a_child_stored_below_its_parent_resolves_like_the_in_order_tree() {
+        let mut in_order = identity_tree();
+        let scroll_node = in_order.append_spatial(scroll(), VISUAL_VIEWPORT_NODE_INDEX);
+        let context_root = in_order.append_spatial(
+            SpatialData::Transform(transform_data(translation_matrix(2.0, 2.0, 0.0), FloatPoint::default())),
+            scroll_node,
+        );
+        let sorted_transform = in_order.append_spatial(
+            SpatialData::Transform(TransformData {
+                sorting_context_root_index: Some(context_root),
+                ..transform_data(translation_matrix(3.0, 3.0, 0.0), FloatPoint::default())
+            }),
+            context_root,
+        );
+        let backface = in_order.append_spatial(
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: context_root,
+                flattens_inherited_transform: false,
+            }),
+            sorted_transform,
+        );
+        let outer_sticky = in_order.append_spatial(sticky(scroll_node, None, 100.0), scroll_node);
+        let inner_sticky = in_order.append_spatial(sticky(scroll_node, Some(outer_sticky), 120.0), outer_sticky);
+        let outer_clip = in_order.append_frame(
+            clip(FloatRect::new(0.0, 0.0, 0.0, 0.0), ClipMode::Intersect),
+            FrameNodeIndex::NONE,
+            sorted_transform,
+        );
+        in_order.append_frame(
+            clip(FloatRect::new(0.0, 0.0, 50.0, 50.0), ClipMode::Intersect),
+            outer_clip,
+            sorted_transform,
+        );
+        in_order.frame_nodes.swap(0, 1);
+        in_order.frame_nodes[0].parent = FrameNodeIndex(1);
+        in_order.frame_nodes[1].parent = FrameNodeIndex::NONE;
+
+        let permutation = [0, 6, 5, 4, 3, 2, 1];
+        let permuted = permuted_tree(&in_order, &permutation);
+        let mapped = |index: SpatialNodeIndex| SpatialNodeIndex(permutation[index.0 as usize]);
+
+        let order = permuted.spatial_dependency_order();
+        let position = |index: SpatialNodeIndex| order.iter().position(|entry| *entry == index.0).unwrap();
+        assert_eq!(order.len(), in_order.spatial_nodes.len());
+        assert!(position(mapped(context_root)) < position(mapped(sorted_transform)));
+        assert!(position(mapped(sorted_transform)) < position(mapped(backface)));
+        assert!(position(mapped(scroll_node)) < position(mapped(outer_sticky)));
+        assert!(position(mapped(outer_sticky)) < position(mapped(inner_sticky)));
+
+        let mut in_order_offsets = vec![FloatPoint::default(); in_order.spatial_nodes.len()];
+        in_order_offsets[scroll_node.0 as usize] = point(0.0, -150.0);
+        let mut permuted_offsets = vec![FloatPoint::default(); permuted.spatial_nodes.len()];
+        permuted_offsets[mapped(scroll_node).0 as usize] = point(0.0, -150.0);
+        let in_order_sticky_entries = in_order.resolve_sticky_offsets(&in_order_offsets);
+        let permuted_sticky_entries = permuted.resolve_sticky_offsets(&permuted_offsets);
+        for (node, offset) in &in_order_sticky_entries {
+            assert!(permuted_sticky_entries.contains(&(mapped(*node), *offset)));
+        }
+        assert_eq!(in_order_sticky_entries.len(), permuted_sticky_entries.len());
+        for (node, offset) in in_order_sticky_entries {
+            in_order_offsets[node.0 as usize] = offset;
+            permuted_offsets[mapped(node).0 as usize] = offset;
+        }
+
+        let rect = FloatRect::new(0.0, 0.0, 10.0, 10.0);
+        for node in [backface, inner_sticky, sorted_transform] {
+            assert_eq!(
+                permuted.transform_rect_to_viewport(
+                    mapped(node),
+                    rect,
+                    &permuted_offsets,
+                    IncludeVisualViewportTransform::Yes
+                ),
+                in_order.transform_rect_to_viewport(node, rect, &in_order_offsets, IncludeVisualViewportTransform::Yes)
+            );
+        }
+
+        let in_order_subtree = in_order.spatial_nodes_in_subtrees_of(&[context_root]);
+        let permuted_subtree = permuted.spatial_nodes_in_subtrees_of(&[mapped(context_root)]);
+        for index in 0..in_order.spatial_nodes.len() {
+            assert_eq!(permuted_subtree[permutation[index] as usize], in_order_subtree[index]);
+        }
+
+        assert_eq!(
+            permuted.frames_with_empty_effective_clip(),
+            in_order.frames_with_empty_effective_clip()
+        );
+        assert_eq!(in_order.frames_with_empty_effective_clip(), vec![true, true]);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -245,6 +245,7 @@ impl VisualContextTree {
                 };
                 true
             }
+            SpatialData::Dead => true,
         }
     }
 
@@ -297,7 +298,7 @@ impl VisualContextTree {
                 }
                 clip_path.path.contains(point.x, point.y, clip_path.fill_rule as i32)
             }
-            FrameData::Effects(_) | FrameData::Mask(_) => true,
+            FrameData::Effects(_) | FrameData::Mask(_) | FrameData::Dead => true,
         }
     }
 
@@ -463,7 +464,7 @@ impl VisualContextTree {
                         let offset = shift.masked_offset(scroll_offsets);
                         rect = rect.translated(offset.x, offset.y);
                     }
-                    SpatialData::BackfaceVisibility(_) => {}
+                    SpatialData::BackfaceVisibility(_) | SpatialData::Dead => {}
                 }
             }
             if current == VISUAL_VIEWPORT_NODE_INDEX {
@@ -676,6 +677,20 @@ impl VisualContextTree {
             Some(FrameData::Effects(effects)) => Some(effects.opacity),
             _ => None,
         }
+    }
+
+    pub fn display_list_references_only_live_nodes(
+        &self,
+        command_runs: &[crate::painting::display_list::commands::DisplayListCommandRun],
+        mask_frames: &[FrameNodeIndex],
+    ) -> bool {
+        let context_is_live = |context: ContextRef| {
+            self.spatial_is_live(context.spatial) && (context.frame.is_none() || self.frame_is_live(context.frame))
+        };
+        command_runs.iter().all(|run| context_is_live(run.context))
+            && mask_frames.iter().all(|frame| {
+                self.frame_is_live(*frame) && matches!(self.frame_nodes[frame.0 as usize].data, FrameData::Mask(_))
+            })
     }
 
     pub fn spatial_nodes_in_subtrees_of(&self, roots: &[SpatialNodeIndex]) -> Vec<bool> {
@@ -1373,6 +1388,77 @@ mod tests {
             in_order.frames_with_empty_effective_clip()
         );
         assert_eq!(in_order.frames_with_empty_effective_clip(), vec![true, true]);
+    }
+
+    #[test]
+    fn a_display_list_naming_a_dead_node_is_rejected() {
+        use crate::painting::display_list::commands::DisplayListCommandRun;
+        let mut tree = identity_tree();
+        let live_spatial = tree.append_spatial(
+            SpatialData::Transform(transform_data(FloatMatrix4x4::identity(), FloatPoint::default())),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let dead_spatial = tree.append_spatial(
+            SpatialData::Transform(transform_data(FloatMatrix4x4::identity(), FloatPoint::default())),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        let live_frame = tree.append_frame(
+            effects(1.0, CompositingAndBlendingOperator::Normal),
+            FrameNodeIndex::NONE,
+            live_spatial,
+        );
+        let dead_frame = tree.append_frame(
+            effects(1.0, CompositingAndBlendingOperator::Normal),
+            FrameNodeIndex::NONE,
+            live_spatial,
+        );
+        let mask_frame = tree.append_frame(
+            FrameData::Mask(crate::painting::visual_context::MaskData {
+                rect: IntRect::new(0, 0, 4, 4),
+                kind: libgfx_rust::MaskKind::Alpha,
+                origin: crate::painting::visual_context::MaskLayerOrigin::CssMaskLayers,
+            }),
+            FrameNodeIndex::NONE,
+            live_spatial,
+        );
+        assert!(tree.tombstone_spatial_slot(dead_spatial));
+        assert!(tree.tombstone_frame_slot(dead_frame));
+        let run = |context: ContextRef| DisplayListCommandRun {
+            context,
+            ..DisplayListCommandRun::default()
+        };
+        assert!(tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, live_frame))], &[]));
+        assert!(
+            !tree.display_list_references_only_live_nodes(&[run(context_of(dead_spatial, FrameNodeIndex::NONE))], &[])
+        );
+        assert!(!tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, dead_frame))], &[]));
+        assert!(
+            tree.display_list_references_only_live_nodes(&[run(context_of(live_spatial, live_frame))], &[mask_frame])
+        );
+        assert!(!tree.display_list_references_only_live_nodes(&[], &[dead_frame]));
+        assert!(!tree.display_list_references_only_live_nodes(&[], &[live_frame]));
+    }
+
+    #[test]
+    fn sticky_resolution_and_subtree_marks_leave_tombstones_out() {
+        let mut tree = identity_tree();
+        let scroll_node = tree.append_spatial(scroll(), VISUAL_VIEWPORT_NODE_INDEX);
+        let stale = tree.append_spatial(
+            SpatialData::Transform(transform_data(FloatMatrix4x4::identity(), FloatPoint::default())),
+            scroll_node,
+        );
+        let sticky_node = tree.append_spatial(sticky(scroll_node, None, 100.0), scroll_node);
+        assert!(tree.tombstone_spatial_slot(stale));
+        let mut scroll_offsets = vec![FloatPoint::default(); 4];
+        scroll_offsets[scroll_node.0 as usize] = point(0.0, -150.0);
+        assert_eq!(
+            tree.resolve_sticky_offsets(&scroll_offsets),
+            vec![(sticky_node, point(0.0, 50.0))]
+        );
+        assert_eq!(
+            tree.spatial_nodes_in_subtrees_of(&[scroll_node]),
+            vec![false, true, false, true]
+        );
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
@@ -156,18 +156,9 @@ pub(crate) fn plan_box_node_placement(
     tree: &mut VisualContextTree,
     existing: Option<&BoxVisualContextNodeHandles>,
     provisional: &BoxVisualContextNodeHandles,
-    allow_structural_changes: bool,
     delta: &mut VisualContextTreeDelta,
-) -> Option<BoxNodePlacement> {
+) -> BoxNodePlacement {
     let existing = existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES);
-    if !allow_structural_changes
-        && (existing.spatial.len() != provisional.spatial.len()
-            || existing.chain_frames.len() != provisional.chain_frames.len()
-            || existing.local_frames.len() != provisional.local_frames.len()
-            || existing.descendant_frames.len() != provisional.descendant_frames.len())
-    {
-        return None;
-    }
     let provisional_frames: Vec<FrameNodeIndex> = provisional.frame_handles().collect();
     debug_assert!(
         provisional.spatial.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1)
@@ -191,14 +182,14 @@ pub(crate) fn plan_box_node_placement(
     let chain_frames = place_frames(&existing.chain_frames, provisional.chain_frames.len());
     let local_frames = place_frames(&existing.local_frames, provisional.local_frames.len());
     let descendant_frames = place_frames(&existing.descendant_frames, provisional.descendant_frames.len());
-    Some(BoxNodePlacement {
+    BoxNodePlacement {
         provisional_spatial_begin: provisional_begin(&provisional.spatial, |index| index.0),
         provisional_frames_begin: provisional_begin(&provisional_frames, |index| index.0),
         spatial,
         chain_frames,
         local_frames,
         descendant_frames,
-    })
+    }
 }
 
 fn remap_spatial_payload(placement: &BoxNodePlacement, data: SpatialData) -> SpatialData {
@@ -497,7 +488,7 @@ mod tests {
     }
 
     struct Planned {
-        placement: Option<BoxNodePlacement>,
+        placement: BoxNodePlacement,
         spatial: Vec<SpatialNode>,
         frames: Vec<FrameNode>,
         delta: VisualContextTreeDelta,
@@ -507,13 +498,12 @@ mod tests {
         tree: &mut VisualContextTree,
         existing: Option<&BoxVisualContextNodeHandles>,
         description: &ScratchBox,
-        allow_structural_changes: bool,
     ) -> Planned {
         let mut scratch = BoxNodeScratch::new(tree);
         let provisional = fill_scratch(&mut scratch, description);
         let (spatial, frames) = scratch.into_nodes();
         let mut delta = VisualContextTreeDelta::default();
-        let placement = plan_box_node_placement(tree, existing, &provisional, allow_structural_changes, &mut delta);
+        let placement = plan_box_node_placement(tree, existing, &provisional, &mut delta);
         Planned {
             placement,
             spatial,
@@ -527,8 +517,8 @@ mod tests {
         existing: Option<&BoxVisualContextNodeHandles>,
         description: &ScratchBox,
     ) -> (BoxNodePlacement, ReconcileOutcome, VisualContextTreeDelta) {
-        let planned = plan(tree, existing, description, true);
-        let placement = planned.placement.expect("structural changes are allowed");
+        let planned = plan(tree, existing, description);
+        let placement = planned.placement;
         let mut delta = planned.delta;
         let outcome = write_box_nodes(tree, planned.spatial, planned.frames, &placement, existing, &mut delta);
         (placement, outcome, delta)
@@ -538,8 +528,8 @@ mod tests {
     fn matching_units_keep_their_handles() {
         let mut tree = tree_with_box_a_followed_by_box_b();
         let existing = box_a_handles();
-        let planned = plan(&mut tree, Some(&existing), &ScratchBox::default(), false);
-        let placement = planned.placement.expect("nothing changes shape");
+        let planned = plan(&mut tree, Some(&existing), &ScratchBox::default());
+        let placement = planned.placement;
         assert_eq!(placement.clone().into_node_handles(), existing);
         assert_eq!(placement.remap_spatial(SpatialNodeIndex(4)), BOX_A_SPATIAL);
         assert_eq!(placement.remap_frame(FrameNodeIndex(5)), BOX_A_CHAIN_FRAME);
@@ -600,21 +590,6 @@ mod tests {
         assert!(delta.tombstoned_spatial_node_indices.is_empty());
         assert!(delta.structural_epoch_changed);
         assert_eq!(tree.spatial_nodes.len(), 4);
-    }
-
-    #[test]
-    fn restricted_placement_refuses_to_change_a_unit_length() {
-        let mut tree = tree_with_box_a_followed_by_box_b();
-        let existing = box_a_handles();
-        let description = ScratchBox {
-            spatial_count: 2,
-            ..ScratchBox::default()
-        };
-        let planned = plan(&mut tree, Some(&existing), &description, false);
-        assert!(planned.placement.is_none());
-        assert_eq!(planned.delta, VisualContextTreeDelta::default());
-        assert_eq!(tree.spatial_nodes.len(), 4);
-        assert_eq!(tree.frame_nodes.len(), 5);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/reconcile.rs
@@ -1,0 +1,728 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::delta::VisualContextTreeDelta;
+use super::shape::{frame_node_shape, frame_payloads_are_equal, spatial_node_shape, spatial_payloads_are_equal};
+use super::*;
+
+pub(crate) struct BoxNodeScratch<'a> {
+    live: &'a VisualContextTree,
+    provisional_spatial_begin: u32,
+    provisional_frames_begin: u32,
+    spatial: Vec<SpatialNode>,
+    frames: Vec<FrameNode>,
+}
+
+impl<'a> BoxNodeScratch<'a> {
+    pub(crate) fn new(live: &'a VisualContextTree) -> Self {
+        Self {
+            live,
+            provisional_spatial_begin: live.spatial_nodes.len() as u32,
+            provisional_frames_begin: live.frame_nodes.len() as u32,
+            spatial: Vec::new(),
+            frames: Vec::new(),
+        }
+    }
+
+    pub(crate) fn into_nodes(self) -> (Vec<SpatialNode>, Vec<FrameNode>) {
+        (self.spatial, self.frames)
+    }
+
+    fn frame_node_at(&self, index: FrameNodeIndex) -> &FrameNode {
+        if index.0 >= self.provisional_frames_begin {
+            &self.frames[(index.0 - self.provisional_frames_begin) as usize]
+        } else {
+            &self.live.frame_nodes[index.0 as usize]
+        }
+    }
+}
+
+impl VisualContextNodeSink for BoxNodeScratch<'_> {
+    fn append_spatial_node(&mut self, data: SpatialData, parent: SpatialNodeIndex) -> SpatialNodeIndex {
+        debug_assert!(self.spatial_node_at(parent).data.is_live());
+        self.spatial.push(SpatialNode { data, parent });
+        SpatialNodeIndex(self.provisional_spatial_begin + self.spatial.len() as u32 - 1)
+    }
+
+    fn append_frame_node(
+        &mut self,
+        data: FrameData,
+        parent: FrameNodeIndex,
+        spatial: SpatialNodeIndex,
+        role: FrameRole,
+    ) -> FrameNodeIndex {
+        debug_assert!(self.spatial_node_at(spatial).data.is_live());
+        debug_assert!(parent.is_none() || self.frame_node_at(parent).data.is_live());
+        self.frames.push(FrameNode::new(data, parent, spatial, role));
+        FrameNodeIndex(self.provisional_frames_begin + self.frames.len() as u32 - 1)
+    }
+
+    fn spatial_node_at(&self, index: SpatialNodeIndex) -> &SpatialNode {
+        if index.0 >= self.provisional_spatial_begin {
+            &self.spatial[(index.0 - self.provisional_spatial_begin) as usize]
+        } else {
+            &self.live.spatial_nodes[index.0 as usize]
+        }
+    }
+
+    fn next_spatial_node_index(&self) -> SpatialNodeIndex {
+        SpatialNodeIndex(self.provisional_spatial_begin + self.spatial.len() as u32)
+    }
+
+    fn next_frame_node_index(&self) -> FrameNodeIndex {
+        FrameNodeIndex(self.provisional_frames_begin + self.frames.len() as u32)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BoxNodePlacement {
+    provisional_spatial_begin: u32,
+    provisional_frames_begin: u32,
+    pub spatial: Vec<SpatialNodeIndex>,
+    pub chain_frames: Vec<FrameNodeIndex>,
+    pub local_frames: Vec<FrameNodeIndex>,
+    pub descendant_frames: Vec<FrameNodeIndex>,
+}
+
+impl BoxNodePlacement {
+    pub(crate) fn remap_spatial(&self, index: SpatialNodeIndex) -> SpatialNodeIndex {
+        if index.0 >= self.provisional_spatial_begin {
+            self.spatial[(index.0 - self.provisional_spatial_begin) as usize]
+        } else {
+            index
+        }
+    }
+
+    pub(crate) fn remap_frame(&self, index: FrameNodeIndex) -> FrameNodeIndex {
+        if index.is_none() || index.0 < self.provisional_frames_begin {
+            return index;
+        }
+        let mut offset = (index.0 - self.provisional_frames_begin) as usize;
+        for unit in [&self.chain_frames, &self.local_frames, &self.descendant_frames] {
+            if offset < unit.len() {
+                return unit[offset];
+            }
+            offset -= unit.len();
+        }
+        panic!("provisional frame {} lies outside the box's units", index.0)
+    }
+
+    pub(crate) fn remap_context(&self, context: ContextRef) -> ContextRef {
+        ContextRef {
+            spatial: self.remap_spatial(context.spatial),
+            frame: self.remap_frame(context.frame),
+        }
+    }
+
+    pub(crate) fn into_node_handles(self) -> BoxVisualContextNodeHandles {
+        BoxVisualContextNodeHandles {
+            spatial: self.spatial,
+            chain_frames: self.chain_frames,
+            local_frames: self.local_frames,
+            descendant_frames: self.descendant_frames,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReconcileOutcome {
+    pub shape_changed: bool,
+    pub any_payload_changed: bool,
+}
+
+fn provisional_begin<Handle: Copy>(handles: &[Handle], index_of: impl Fn(Handle) -> u32) -> u32 {
+    handles.first().map_or(u32::MAX, |first| index_of(*first))
+}
+
+fn place_unit<Handle: Copy>(
+    existing: &[Handle],
+    new_len: usize,
+    mut allocate: impl FnMut() -> (Handle, bool),
+    mut note_allocated: impl FnMut(Handle, bool),
+) -> Vec<Handle> {
+    let mut handles: Vec<Handle> = existing.iter().take(new_len).copied().collect();
+    while handles.len() < new_len {
+        let (handle, reused) = allocate();
+        note_allocated(handle, reused);
+        handles.push(handle);
+    }
+    handles
+}
+
+pub(crate) fn plan_box_node_placement(
+    tree: &mut VisualContextTree,
+    existing: Option<&BoxVisualContextNodeHandles>,
+    provisional: &BoxVisualContextNodeHandles,
+    allow_structural_changes: bool,
+    delta: &mut VisualContextTreeDelta,
+) -> Option<BoxNodePlacement> {
+    let existing = existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES);
+    if !allow_structural_changes
+        && (existing.spatial.len() != provisional.spatial.len()
+            || existing.chain_frames.len() != provisional.chain_frames.len()
+            || existing.local_frames.len() != provisional.local_frames.len()
+            || existing.descendant_frames.len() != provisional.descendant_frames.len())
+    {
+        return None;
+    }
+    let provisional_frames: Vec<FrameNodeIndex> = provisional.frame_handles().collect();
+    debug_assert!(
+        provisional.spatial.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1)
+            && provisional_frames.windows(2).all(|pair| pair[1].0 == pair[0].0 + 1),
+        "a scratch build hands out consecutive provisional indices"
+    );
+    let spatial = place_unit(
+        &existing.spatial,
+        provisional.spatial.len(),
+        || tree.allocate_spatial_slot(),
+        |handle, reused| delta.note_allocated_spatial(handle.0, reused),
+    );
+    let mut place_frames = |existing: &[FrameNodeIndex], new_len: usize| {
+        place_unit(
+            existing,
+            new_len,
+            || tree.allocate_frame_slot(),
+            |handle, reused| delta.note_allocated_frame(handle.0, reused),
+        )
+    };
+    let chain_frames = place_frames(&existing.chain_frames, provisional.chain_frames.len());
+    let local_frames = place_frames(&existing.local_frames, provisional.local_frames.len());
+    let descendant_frames = place_frames(&existing.descendant_frames, provisional.descendant_frames.len());
+    Some(BoxNodePlacement {
+        provisional_spatial_begin: provisional_begin(&provisional.spatial, |index| index.0),
+        provisional_frames_begin: provisional_begin(&provisional_frames, |index| index.0),
+        spatial,
+        chain_frames,
+        local_frames,
+        descendant_frames,
+    })
+}
+
+fn remap_spatial_payload(placement: &BoxNodePlacement, data: SpatialData) -> SpatialData {
+    match data {
+        SpatialData::Scroll(mut scroll) => {
+            scroll.registry_parent_node = placement.remap_spatial(scroll.registry_parent_node);
+            SpatialData::Scroll(scroll)
+        }
+        SpatialData::Sticky(mut sticky) => {
+            sticky.scroller = placement.remap_spatial(sticky.scroller);
+            sticky.parent_sticky = sticky.parent_sticky.map(|index| placement.remap_spatial(index));
+            sticky.registry_parent_node = placement.remap_spatial(sticky.registry_parent_node);
+            SpatialData::Sticky(sticky)
+        }
+        SpatialData::Transform(mut transform) => {
+            transform.sorting_context_root_index = transform
+                .sorting_context_root_index
+                .map(|index| placement.remap_spatial(index));
+            SpatialData::Transform(transform)
+        }
+        SpatialData::BackfaceVisibility(mut backface) => {
+            backface.plane_root_index = placement.remap_spatial(backface.plane_root_index);
+            SpatialData::BackfaceVisibility(backface)
+        }
+        SpatialData::AnchorScrollShift(mut shift) => {
+            shift.scroll_node_index = placement.remap_spatial(shift.scroll_node_index);
+            SpatialData::AnchorScrollShift(shift)
+        }
+        other => other,
+    }
+}
+
+fn write_spatial_unit(
+    tree: &mut VisualContextTree,
+    handles: &[SpatialNodeIndex],
+    existing: &[SpatialNodeIndex],
+    nodes: Vec<SpatialNode>,
+    delta: &mut VisualContextTreeDelta,
+    outcome: &mut ReconcileOutcome,
+) {
+    debug_assert_eq!(handles.len(), nodes.len());
+    if handles.len() != existing.len() {
+        outcome.shape_changed = true;
+    }
+    for (handle, node) in handles.iter().zip(nodes) {
+        let current = &tree.spatial_nodes[handle.0 as usize];
+        let was_live = current.data.is_live();
+        let shape_matches = was_live && spatial_node_shape(current) == spatial_node_shape(&node);
+        let payload_matches = shape_matches && spatial_payloads_are_equal(&current.data, &node.data);
+        if !shape_matches {
+            outcome.shape_changed = true;
+            if was_live {
+                delta.note_repurposed_in_place();
+            }
+        }
+        if payload_matches {
+            continue;
+        }
+        outcome.any_payload_changed = true;
+        tree.replace_spatial_node(*handle, node);
+        delta.note_patched_spatial(handle.0);
+    }
+    for surplus in existing.get(handles.len()..).unwrap_or(&[]) {
+        if tree.tombstone_spatial_slot(*surplus) {
+            delta.note_tombstoned_spatial(surplus.0);
+        }
+    }
+}
+
+fn write_frame_unit(
+    tree: &mut VisualContextTree,
+    handles: &[FrameNodeIndex],
+    existing: &[FrameNodeIndex],
+    nodes: Vec<FrameNode>,
+    delta: &mut VisualContextTreeDelta,
+    outcome: &mut ReconcileOutcome,
+) {
+    debug_assert_eq!(handles.len(), nodes.len());
+    if handles.len() != existing.len() {
+        outcome.shape_changed = true;
+    }
+    for (handle, node) in handles.iter().zip(nodes) {
+        let current = &tree.frame_nodes[handle.0 as usize];
+        let was_live = current.data.is_live();
+        let shape_matches = was_live && frame_node_shape(current) == frame_node_shape(&node);
+        let payload_matches = shape_matches && frame_payloads_are_equal(&current.data, &node.data);
+        if !shape_matches {
+            outcome.shape_changed = true;
+            if was_live {
+                delta.note_repurposed_in_place();
+            }
+        }
+        if payload_matches {
+            continue;
+        }
+        outcome.any_payload_changed = true;
+        if matches!(node.data, FrameData::Mask(_)) {
+            delta.requires_display_list_recording = true;
+        }
+        tree.replace_frame_node(*handle, node);
+        delta.note_patched_frame(handle.0);
+    }
+    for surplus in existing.get(handles.len()..).unwrap_or(&[]) {
+        if tree.tombstone_frame_slot(*surplus) {
+            delta.note_tombstoned_frame(surplus.0);
+        }
+    }
+}
+
+pub(crate) fn write_box_nodes(
+    tree: &mut VisualContextTree,
+    spatial: Vec<SpatialNode>,
+    frames: Vec<FrameNode>,
+    placement: &BoxNodePlacement,
+    existing: Option<&BoxVisualContextNodeHandles>,
+    delta: &mut VisualContextTreeDelta,
+) -> ReconcileOutcome {
+    let existing = existing.unwrap_or(&EMPTY_BOX_VISUAL_CONTEXT_NODE_HANDLES);
+    let mut outcome = ReconcileOutcome::default();
+    let spatial_nodes: Vec<SpatialNode> = spatial
+        .into_iter()
+        .map(|node| SpatialNode {
+            data: remap_spatial_payload(placement, node.data),
+            parent: placement.remap_spatial(node.parent),
+        })
+        .collect();
+    let mut frames = frames.into_iter().map(|node| {
+        FrameNode::new(
+            node.data,
+            placement.remap_frame(node.parent),
+            placement.remap_spatial(node.spatial),
+            node.role,
+        )
+    });
+    let chain: Vec<FrameNode> = frames.by_ref().take(placement.chain_frames.len()).collect();
+    let local: Vec<FrameNode> = frames.by_ref().take(placement.local_frames.len()).collect();
+    let descendant: Vec<FrameNode> = frames.collect();
+    debug_assert_eq!(descendant.len(), placement.descendant_frames.len());
+
+    write_spatial_unit(
+        tree,
+        &placement.spatial,
+        &existing.spatial,
+        spatial_nodes,
+        delta,
+        &mut outcome,
+    );
+    write_frame_unit(
+        tree,
+        &placement.chain_frames,
+        &existing.chain_frames,
+        chain,
+        delta,
+        &mut outcome,
+    );
+    write_frame_unit(
+        tree,
+        &placement.local_frames,
+        &existing.local_frames,
+        local,
+        delta,
+        &mut outcome,
+    );
+    write_frame_unit(
+        tree,
+        &placement.descendant_frames,
+        &existing.descendant_frames,
+        descendant,
+        delta,
+        &mut outcome,
+    );
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libgfx_rust::FloatMatrix4x4;
+
+    fn transform_data() -> TransformData {
+        TransformData {
+            matrix: FloatMatrix4x4::identity(),
+            origin: FloatPoint::default(),
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        }
+    }
+
+    fn transform() -> SpatialData {
+        SpatialData::Transform(transform_data())
+    }
+
+    fn clip(size: f32) -> FrameData {
+        FrameData::rect_clip(FloatRect::new(0.0, 0.0, size, size))
+    }
+
+    const VIEWPORT_SCROLL: SpatialNodeIndex = SpatialNodeIndex(1);
+    const ROOT_ISOLATION_FRAME: FrameNodeIndex = FrameNodeIndex(0);
+    const BOX_A_SPATIAL: SpatialNodeIndex = SpatialNodeIndex(2);
+    const BOX_B_SPATIAL: SpatialNodeIndex = SpatialNodeIndex(3);
+    const BOX_A_CHAIN_FRAME: FrameNodeIndex = FrameNodeIndex(1);
+    const BOX_A_LOCAL_FRAME: FrameNodeIndex = FrameNodeIndex(2);
+    const BOX_A_DESCENDANT_FRAME: FrameNodeIndex = FrameNodeIndex(3);
+    const BOX_B_FRAME: FrameNodeIndex = FrameNodeIndex(4);
+
+    fn tree_with_box_a_followed_by_box_b() -> VisualContextTree {
+        let mut tree = VisualContextTree::create(transform_data());
+        let root_isolation_frame = tree.append_frame_with_role(
+            FrameData::layer_blending_with(CompositingAndBlendingOperator::Normal),
+            FrameNodeIndex::NONE,
+            VISUAL_VIEWPORT_NODE_INDEX,
+            FrameRole::RootIsolation,
+        );
+        tree.root_isolation_frame = Some(root_isolation_frame);
+        assert_eq!(root_isolation_frame, ROOT_ISOLATION_FRAME);
+        assert_eq!(
+            tree.append_spatial(transform(), VISUAL_VIEWPORT_NODE_INDEX),
+            VIEWPORT_SCROLL
+        );
+        assert_eq!(tree.append_spatial(transform(), VIEWPORT_SCROLL), BOX_A_SPATIAL);
+        assert_eq!(
+            tree.append_frame(clip(10.0), ROOT_ISOLATION_FRAME, BOX_A_SPATIAL),
+            BOX_A_CHAIN_FRAME
+        );
+        assert_eq!(
+            tree.append_frame(clip(20.0), BOX_A_CHAIN_FRAME, BOX_A_SPATIAL),
+            BOX_A_LOCAL_FRAME
+        );
+        assert_eq!(
+            tree.append_frame(clip(30.0), BOX_A_LOCAL_FRAME, BOX_A_SPATIAL),
+            BOX_A_DESCENDANT_FRAME
+        );
+        assert_eq!(tree.append_spatial(transform(), BOX_A_SPATIAL), BOX_B_SPATIAL);
+        assert_eq!(
+            tree.append_frame(clip(40.0), BOX_A_DESCENDANT_FRAME, BOX_B_SPATIAL),
+            BOX_B_FRAME
+        );
+        tree
+    }
+
+    fn box_a_handles() -> BoxVisualContextNodeHandles {
+        BoxVisualContextNodeHandles {
+            spatial: vec![BOX_A_SPATIAL],
+            chain_frames: vec![BOX_A_CHAIN_FRAME],
+            local_frames: vec![BOX_A_LOCAL_FRAME],
+            descendant_frames: vec![BOX_A_DESCENDANT_FRAME],
+        }
+    }
+
+    struct ScratchBox {
+        spatial_parent: SpatialNodeIndex,
+        spatial_count: u32,
+        chain_count: u32,
+        local_count: u32,
+        descendant_count: u32,
+        local_clip_size: f32,
+    }
+
+    impl Default for ScratchBox {
+        fn default() -> Self {
+            Self {
+                spatial_parent: VIEWPORT_SCROLL,
+                spatial_count: 1,
+                chain_count: 1,
+                local_count: 1,
+                descendant_count: 1,
+                local_clip_size: 20.0,
+            }
+        }
+    }
+
+    fn fill_scratch(scratch: &mut BoxNodeScratch<'_>, description: &ScratchBox) -> BoxVisualContextNodeHandles {
+        let mut handles = BoxVisualContextNodeHandles::default();
+        let mut spatial = description.spatial_parent;
+        for _ in 0..description.spatial_count {
+            spatial = scratch.append_spatial_node(transform(), spatial);
+            handles.spatial.push(spatial);
+        }
+        let mut frame = ROOT_ISOLATION_FRAME;
+        for _ in 0..description.chain_count {
+            frame = scratch.append_frame_node(clip(10.0), frame, spatial, FrameRole::Structural);
+            handles.chain_frames.push(frame);
+        }
+        for _ in 0..description.local_count {
+            frame = scratch.append_frame_node(clip(description.local_clip_size), frame, spatial, FrameRole::Structural);
+            handles.local_frames.push(frame);
+        }
+        for _ in 0..description.descendant_count {
+            frame = scratch.append_frame_node(clip(30.0), frame, spatial, FrameRole::Structural);
+            handles.descendant_frames.push(frame);
+        }
+        handles
+    }
+
+    struct Planned {
+        placement: Option<BoxNodePlacement>,
+        spatial: Vec<SpatialNode>,
+        frames: Vec<FrameNode>,
+        delta: VisualContextTreeDelta,
+    }
+
+    fn plan(
+        tree: &mut VisualContextTree,
+        existing: Option<&BoxVisualContextNodeHandles>,
+        description: &ScratchBox,
+        allow_structural_changes: bool,
+    ) -> Planned {
+        let mut scratch = BoxNodeScratch::new(tree);
+        let provisional = fill_scratch(&mut scratch, description);
+        let (spatial, frames) = scratch.into_nodes();
+        let mut delta = VisualContextTreeDelta::default();
+        let placement = plan_box_node_placement(tree, existing, &provisional, allow_structural_changes, &mut delta);
+        Planned {
+            placement,
+            spatial,
+            frames,
+            delta,
+        }
+    }
+
+    fn write(
+        tree: &mut VisualContextTree,
+        existing: Option<&BoxVisualContextNodeHandles>,
+        description: &ScratchBox,
+    ) -> (BoxNodePlacement, ReconcileOutcome, VisualContextTreeDelta) {
+        let planned = plan(tree, existing, description, true);
+        let placement = planned.placement.expect("structural changes are allowed");
+        let mut delta = planned.delta;
+        let outcome = write_box_nodes(tree, planned.spatial, planned.frames, &placement, existing, &mut delta);
+        (placement, outcome, delta)
+    }
+
+    #[test]
+    fn matching_units_keep_their_handles() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let planned = plan(&mut tree, Some(&existing), &ScratchBox::default(), false);
+        let placement = planned.placement.expect("nothing changes shape");
+        assert_eq!(placement.clone().into_node_handles(), existing);
+        assert_eq!(placement.remap_spatial(SpatialNodeIndex(4)), BOX_A_SPATIAL);
+        assert_eq!(placement.remap_frame(FrameNodeIndex(5)), BOX_A_CHAIN_FRAME);
+        assert_eq!(placement.remap_frame(FrameNodeIndex(6)), BOX_A_LOCAL_FRAME);
+        assert_eq!(placement.remap_frame(FrameNodeIndex(7)), BOX_A_DESCENDANT_FRAME);
+        assert_eq!(placement.remap_frame(ROOT_ISOLATION_FRAME), ROOT_ISOLATION_FRAME);
+        assert_eq!(planned.delta, VisualContextTreeDelta::default());
+        assert_eq!(tree.spatial_nodes.len(), 4);
+        assert_eq!(tree.frame_nodes.len(), 5);
+    }
+
+    #[test]
+    fn a_grown_unit_allocates_fresh_slots_at_the_end_when_nothing_is_free() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            spatial_count: 2,
+            chain_count: 2,
+            descendant_count: 0,
+            ..ScratchBox::default()
+        };
+        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(placement.spatial, vec![BOX_A_SPATIAL, SpatialNodeIndex(4)]);
+        assert_eq!(placement.chain_frames, vec![BOX_A_CHAIN_FRAME, FrameNodeIndex(5)]);
+        assert_eq!(placement.local_frames, vec![BOX_A_LOCAL_FRAME]);
+        assert!(placement.descendant_frames.is_empty());
+        assert!(outcome.shape_changed);
+        assert_eq!(tree.spatial_nodes[4].parent, BOX_A_SPATIAL);
+        assert_eq!(tree.frame_nodes[5].parent, BOX_A_CHAIN_FRAME);
+        assert_eq!(tree.frame_nodes[5].spatial, SpatialNodeIndex(4));
+        assert_eq!(tree.frame_nodes[BOX_A_LOCAL_FRAME.0 as usize].parent, FrameNodeIndex(5));
+        assert!(!tree.frame_is_live(BOX_A_DESCENDANT_FRAME));
+        assert_eq!(tree.quarantined_slot_count(), 1);
+        assert_eq!(tree.free_slot_count(), 0);
+        assert!(delta.patched_spatial_node_indices.contains(&4));
+        assert!(delta.patched_frame_node_indices.contains(&5));
+        assert_eq!(delta.tombstoned_frame_node_indices, vec![BOX_A_DESCENDANT_FRAME.0]);
+        assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+        assert_eq!(tree.live_spatial_node_count, 5);
+        assert_eq!(tree.live_frame_node_count, 5);
+        tree.debug_assert_slot_accounting();
+    }
+
+    #[test]
+    fn a_unit_may_reference_a_node_at_a_higher_index() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            spatial_parent: BOX_B_SPATIAL,
+            ..ScratchBox::default()
+        };
+        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(placement.into_node_handles(), existing);
+        assert!(outcome.shape_changed);
+        assert_eq!(tree.spatial_nodes[BOX_A_SPATIAL.0 as usize].parent, BOX_B_SPATIAL);
+        assert_eq!(delta.patched_spatial_node_indices, vec![BOX_A_SPATIAL.0]);
+        assert!(delta.tombstoned_spatial_node_indices.is_empty());
+        assert!(delta.structural_epoch_changed);
+        assert_eq!(tree.spatial_nodes.len(), 4);
+    }
+
+    #[test]
+    fn restricted_placement_refuses_to_change_a_unit_length() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            spatial_count: 2,
+            ..ScratchBox::default()
+        };
+        let planned = plan(&mut tree, Some(&existing), &description, false);
+        assert!(planned.placement.is_none());
+        assert_eq!(planned.delta, VisualContextTreeDelta::default());
+        assert_eq!(tree.spatial_nodes.len(), 4);
+        assert_eq!(tree.frame_nodes.len(), 5);
+    }
+
+    #[test]
+    fn writing_in_place_patches_only_the_changed_payloads() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            local_clip_size: 25.0,
+            ..ScratchBox::default()
+        };
+        let (_, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert!(!outcome.shape_changed);
+        assert!(outcome.any_payload_changed);
+        assert_eq!(delta.patched_spatial_node_indices, Vec::<u32>::new());
+        assert_eq!(delta.patched_frame_node_indices, vec![BOX_A_LOCAL_FRAME.0]);
+        assert!(delta.tombstoned_frame_node_indices.is_empty());
+        assert!(!delta.structural_epoch_changed);
+        assert!(!delta.requires_display_list_recording);
+        assert_eq!(tree.live_spatial_node_count, 4);
+        assert_eq!(tree.live_frame_node_count, 5);
+    }
+
+    #[test]
+    fn a_shrunken_unit_tombstones_its_surplus_handles_into_quarantine() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            descendant_count: 0,
+            ..ScratchBox::default()
+        };
+        let (placement, outcome, delta) = write(&mut tree, Some(&existing), &description);
+        assert!(placement.descendant_frames.is_empty());
+        assert!(outcome.shape_changed);
+        assert!(!tree.frame_is_live(BOX_A_DESCENDANT_FRAME));
+        assert_eq!(delta.tombstoned_frame_node_indices, vec![BOX_A_DESCENDANT_FRAME.0]);
+        assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+        assert_eq!(tree.quarantined_slot_count(), 1);
+        assert_eq!(tree.free_slot_count(), 0);
+        assert_eq!(tree.frame_nodes.len(), 5);
+        tree.debug_assert_slot_accounting();
+    }
+
+    #[test]
+    fn a_reused_slot_changes_the_structural_epoch_and_a_fresh_slot_does_not() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        assert!(tree.tombstone_frame_slot(BOX_B_FRAME));
+        tree.release_quarantined_slots_after_recording();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            descendant_count: 2,
+            ..ScratchBox::default()
+        };
+        let (placement, _, delta) = write(&mut tree, Some(&existing), &description);
+        assert_eq!(placement.descendant_frames, vec![BOX_A_DESCENDANT_FRAME, BOX_B_FRAME]);
+        assert!(delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+        assert_eq!(tree.frame_nodes.len(), 5);
+
+        let mut fresh_tree = tree_with_box_a_followed_by_box_b();
+        let (placement, _, delta) = write(&mut fresh_tree, Some(&existing), &description);
+        assert_eq!(
+            placement.descendant_frames,
+            vec![BOX_A_DESCENDANT_FRAME, FrameNodeIndex(5)]
+        );
+        assert!(!delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+        assert_eq!(fresh_tree.frame_nodes.len(), 6);
+    }
+
+    #[test]
+    fn provisional_references_between_units_resolve_to_final_handles() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let existing = box_a_handles();
+        let description = ScratchBox {
+            spatial_count: 2,
+            chain_count: 2,
+            ..ScratchBox::default()
+        };
+        let (placement, _, _) = write(&mut tree, Some(&existing), &description);
+        let local = placement.local_frames[0];
+        assert_eq!(tree.frame_nodes[local.0 as usize].parent, placement.chain_frames[1]);
+        assert_eq!(tree.frame_nodes[local.0 as usize].spatial, placement.spatial[1]);
+        let descendant = placement.descendant_frames[0];
+        assert_eq!(tree.frame_nodes[descendant.0 as usize].parent, local);
+        assert_eq!(
+            tree.spatial_nodes[placement.spatial[1].0 as usize].parent,
+            placement.spatial[0]
+        );
+    }
+
+    #[test]
+    fn a_box_without_a_record_allocates_every_unit() {
+        let mut tree = tree_with_box_a_followed_by_box_b();
+        let (placement, outcome, mut delta) = write(&mut tree, None, &ScratchBox::default());
+        delta.finish();
+        assert_eq!(placement.spatial, vec![SpatialNodeIndex(4)]);
+        assert_eq!(placement.chain_frames, vec![FrameNodeIndex(5)]);
+        assert_eq!(placement.local_frames, vec![FrameNodeIndex(6)]);
+        assert_eq!(placement.descendant_frames, vec![FrameNodeIndex(7)]);
+        assert!(outcome.shape_changed);
+        assert_eq!(delta.patched_spatial_node_indices, vec![4]);
+        assert_eq!(delta.patched_frame_node_indices, vec![5, 6, 7]);
+        assert!(!delta.structural_epoch_changed);
+        assert!(delta.requires_display_list_recording);
+        assert_eq!(tree.live_spatial_node_count, 5);
+        assert_eq!(tree.live_frame_node_count, 8);
+        assert!(tree.spatial_is_live(BOX_A_SPATIAL));
+        tree.debug_assert_slot_accounting();
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/refresh.rs
@@ -91,15 +91,17 @@ pub(crate) fn compute_sticky_data(
     let parent_sticky = (sticky_state.parent_slot != NO_SCROLL_STATE_SLOT
         && scroll_state.state_at_slot(sticky_state.parent_slot).is_sticky)
         .then(|| scroll_state.node_index_for_slot(sticky_state.parent_slot));
+    let paintable: NodeSlotId = sticky_state.paintable;
     let mut data = StickyData::unconstrained(
         scroll_state.node_index_for_slot(scroller_slot),
         parent_sticky,
         sticky_slot,
+        paintable,
+        scroll_state.node_index_for_slot(sticky_state.parent_slot),
     );
     if scroller_slot == NO_SCROLL_STATE_SLOT {
         return data;
     }
-    let paintable: NodeSlotId = sticky_state.paintable;
     let scroller = scroll_state.state_at_slot(scroller_slot).paintable;
     if !layout_arena.paintable_row_is_populated(paintable) || !layout_arena.paintable_row_is_populated(scroller) {
         return data;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -10,6 +10,7 @@ use super::{
     SpatialNodeIndex, StickyData, TransformData, TransformDataRole, VISUAL_VIEWPORT_NODE_INDEX, VisualContextTree,
     scroll_state::NO_SCROLL_STATE_SLOT,
 };
+use crate::layout::node_data::NodeSlotId;
 use libgfx_rust::path::OwnedPath;
 use libgfx_rust::{
     CompositingAndBlendingOperator, CornerRadii, CornerRadius, FloatMatrix4x4, FloatPoint, FloatRect, FloatSize,
@@ -314,21 +315,29 @@ fn read_spatial_data(reader: &mut TreeByteReader<'_>) -> Option<SpatialData> {
     Some(match reader.u8()? {
         SPATIAL_KIND_SCROLL => SpatialData::Scroll(ScrollData {
             state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
         }),
-        SPATIAL_KIND_STICKY => SpatialData::Sticky(StickyData {
-            scroller: reader.spatial_index()?,
-            parent_sticky: reader.optional_spatial_index()?,
-            position_relative_to_scroller: reader.point()?,
-            border_box_size: reader.size()?,
-            scrollport_size: reader.size()?,
-            containing_block_region: reader.float_rect()?,
-            needs_parent_offset_adjustment: reader.bool()?,
-            inset_top: reader.optional_f32()?,
-            inset_right: reader.optional_f32()?,
-            inset_bottom: reader.optional_f32()?,
-            inset_left: reader.optional_f32()?,
-            state_slot: NO_SCROLL_STATE_SLOT,
-        }),
+        SPATIAL_KIND_STICKY => {
+            let scroller = reader.spatial_index()?;
+            let parent_sticky = reader.optional_spatial_index()?;
+            SpatialData::Sticky(StickyData {
+                scroller,
+                parent_sticky,
+                position_relative_to_scroller: reader.point()?,
+                border_box_size: reader.size()?,
+                scrollport_size: reader.size()?,
+                containing_block_region: reader.float_rect()?,
+                needs_parent_offset_adjustment: reader.bool()?,
+                inset_top: reader.optional_f32()?,
+                inset_right: reader.optional_f32()?,
+                inset_bottom: reader.optional_f32()?,
+                inset_left: reader.optional_f32()?,
+                state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: parent_sticky.unwrap_or(scroller),
+            })
+        }
         SPATIAL_KIND_TRANSFORM => SpatialData::Transform(TransformData {
             matrix: reader.matrix()?,
             origin: reader.point()?,
@@ -572,6 +581,8 @@ mod tests {
         let scroll_node = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
@@ -606,6 +617,8 @@ mod tests {
                 inset_bottom: Some(2.5),
                 inset_left: None,
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: scroll_node,
             }),
             scroll_node,
         );
@@ -629,6 +642,8 @@ mod tests {
                 inset_bottom: None,
                 inset_left: Some(3.0),
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: scroll_node,
             }),
             outer_sticky,
         );
@@ -728,6 +743,8 @@ mod tests {
             (SpatialData::Sticky(a), SpatialData::Sticky(b)) => {
                 StickyData {
                     state_slot: NO_SCROLL_STATE_SLOT,
+                    owner_paintable: b.owner_paintable,
+                    registry_parent_node: b.registry_parent_node,
                     ..*a
                 } == *b
             }
@@ -831,6 +848,8 @@ mod tests {
         tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
+                owner_paintable: NodeSlotId::INVALID,
+                registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
             }),
             VISUAL_VIEWPORT_NODE_INDEX,
         );
@@ -839,6 +858,8 @@ mod tests {
                 SpatialNodeIndex(1),
                 None,
                 NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                SpatialNodeIndex(1),
             )),
             SpatialNodeIndex(1),
         );
@@ -876,6 +897,8 @@ mod tests {
         let mut root_is_not_a_transform = hostile_tree();
         root_is_not_a_transform.spatial_nodes[0].data = SpatialData::Scroll(ScrollData {
             state_slot: NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
         });
         assert!(VisualContextTree::from_bytes(&encode_tree(&root_is_not_a_transform)).is_none());
 
@@ -898,6 +921,8 @@ mod tests {
             SpatialNodeIndex(1),
             Some(SpatialNodeIndex(1)),
             NO_SCROLL_STATE_SLOT,
+            NodeSlotId::INVALID,
+            SpatialNodeIndex(1),
         ));
         assert!(VisualContextTree::from_bytes(&encode_tree(&sticky_parent_is_not_sticky)).is_none());
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -442,31 +442,57 @@ fn spatial_node_has_ancestor(nodes: &[SpatialNode], mut node: usize, ancestor: S
     false
 }
 
-fn spatial_node_references_are_consistent(nodes: &[SpatialNode], index: usize) -> bool {
-    let node = &nodes[index];
-    if node.parent.0 as usize >= index.max(1) {
-        return false;
-    }
-    match &node.data {
-        SpatialData::Transform(transform) => transform
-            .sorting_context_root_index
-            .is_none_or(|root| (root.0 as usize) < index),
-        // The hit-test walk looks the plane root up on the marker's root path, so a preceding node
-        // on another branch must be rejected here rather than fail that lookup.
-        SpatialData::BackfaceVisibility(backface) => spatial_node_has_ancestor(nodes, index, backface.plane_root_index),
-        SpatialData::Sticky(sticky) => {
-            // resolve_sticky_offsets() reads the referenced nodes by kind, so a hostile tree must not
-            // get past this point with references of the wrong kind or order.
-            let scroller_is_valid = (sticky.scroller.0 as usize) < index
-                && (sticky.scroller == VISUAL_VIEWPORT_NODE_INDEX
-                    || matches!(nodes[sticky.scroller.0 as usize].data, SpatialData::Scroll(_)));
-            let parent_sticky_is_valid = sticky.parent_sticky.is_none_or(|parent| {
-                (parent.0 as usize) < index && matches!(nodes[parent.0 as usize].data, SpatialData::Sticky(_))
-            });
-            scroller_is_valid && parent_sticky_is_valid
+impl VisualContextTree {
+    fn decoded_references_are_consistent(&self) -> bool {
+        let spatial_nodes = &self.spatial_nodes;
+        let root = &spatial_nodes[VISUAL_VIEWPORT_NODE_INDEX.0 as usize];
+        if root.parent != VISUAL_VIEWPORT_NODE_INDEX || !matches!(root.data, SpatialData::Transform(_)) {
+            return false;
         }
-        SpatialData::AnchorScrollShift(shift) => (shift.scroll_node_index.0 as usize) < index,
-        SpatialData::Scroll(_) | SpatialData::Perspective(_) => true,
+        let spatial_order = self.spatial_dependency_order_with_back_edges();
+        if !spatial_order.back_edges.is_empty() || !spatial_order.dangling_references.is_empty() {
+            return false;
+        }
+        for (index, node) in spatial_nodes.iter().enumerate() {
+            match &node.data {
+                // The hit-test walk looks the plane root up on the marker's root path, so a node on
+                // another branch must be rejected here rather than fail that lookup.
+                SpatialData::BackfaceVisibility(backface) => {
+                    if !spatial_node_has_ancestor(spatial_nodes, index, backface.plane_root_index) {
+                        return false;
+                    }
+                }
+                // resolve_sticky_offsets() reads the referenced nodes by kind, so a hostile tree must not
+                // get past this point with references of the wrong kind.
+                SpatialData::Sticky(sticky) => {
+                    let scroller_is_valid = sticky.scroller == VISUAL_VIEWPORT_NODE_INDEX
+                        || matches!(spatial_nodes[sticky.scroller.0 as usize].data, SpatialData::Scroll(_));
+                    let parent_sticky_is_valid = sticky
+                        .parent_sticky
+                        .is_none_or(|parent| matches!(spatial_nodes[parent.0 as usize].data, SpatialData::Sticky(_)));
+                    if !scroller_is_valid || !parent_sticky_is_valid {
+                        return false;
+                    }
+                }
+                _ => {}
+            }
+        }
+        for node in &self.frame_nodes {
+            if node.spatial.0 as usize >= spatial_nodes.len() {
+                return false;
+            }
+        }
+        let frame_order = self.frame_dependency_order_with_back_edges();
+        if !frame_order.back_edges.is_empty() || !frame_order.dangling_references.is_empty() {
+            return false;
+        }
+        if let Some(root_isolation_frame) = self.root_isolation_frame {
+            let index = root_isolation_frame.0 as usize;
+            if index >= self.frame_nodes.len() || !matches!(self.frame_nodes[index].data, FrameData::Effects(_)) {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -510,51 +536,33 @@ impl VisualContextTree {
         }
 
         let mut spatial_nodes = Vec::with_capacity(spatial_count);
-        for index in 0..spatial_count {
+        for _ in 0..spatial_count {
             let parent = reader.spatial_index()?;
             let data = read_spatial_data(&mut reader)?;
             spatial_nodes.push(SpatialNode { data, parent });
-            if !spatial_node_references_are_consistent(&spatial_nodes, index) {
-                return None;
-            }
-        }
-        if !matches!(spatial_nodes[0].data, SpatialData::Transform(_)) {
-            return None;
         }
 
         let mut frame_nodes = Vec::with_capacity(frame_count);
-        for index in 0..frame_count {
+        for _ in 0..frame_count {
             let parent = reader.frame_index()?;
             let spatial = reader.spatial_index()?;
             let data = read_frame_data(&mut reader)?;
-            if (!parent.is_none() && parent.0 as usize >= index) || spatial.0 as usize >= spatial_count {
-                return None;
-            }
             frame_nodes.push(FrameNode::new(data, parent, spatial, FrameRole::Structural));
         }
-
-        let root_isolation_frame = if root_isolation_frame.is_none() {
-            None
-        } else {
-            let index = root_isolation_frame.0 as usize;
-            if index >= frame_nodes.len() || !matches!(frame_nodes[index].data, FrameData::Effects(_)) {
-                return None;
-            }
-            Some(root_isolation_frame)
-        };
 
         if reader.remaining() != 0 {
             return None;
         }
 
-        Some(Self {
+        let tree = Self {
             spatial_nodes,
             frame_nodes,
             root_is_visual_viewport,
-            root_isolation_frame,
+            root_isolation_frame: (!root_isolation_frame.is_none()).then_some(root_isolation_frame),
             version,
             reused_previous_version: false,
-        })
+        };
+        tree.decoded_references_are_consistent().then_some(tree)
     }
 }
 
@@ -885,14 +893,77 @@ mod tests {
     }
 
     #[test]
-    fn references_to_nodes_that_do_not_precede_the_node_are_rejected() {
-        let mut spatial_parent_after_node = hostile_tree();
-        spatial_parent_after_node.spatial_nodes[1].parent = SpatialNodeIndex(2);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&spatial_parent_after_node)).is_none());
+    fn references_to_nodes_stored_after_the_node_are_accepted() {
+        let mut child_stored_below_its_parent = hostile_tree();
+        child_stored_below_its_parent.spatial_nodes[1].parent = SpatialNodeIndex(2);
+        child_stored_below_its_parent.spatial_nodes[2] = SpatialNode {
+            data: SpatialData::Transform(transform(translation_matrix(5.0, 5.0, 0.0))),
+            parent: VISUAL_VIEWPORT_NODE_INDEX,
+        };
+        child_stored_below_its_parent.frame_nodes[0].parent = FrameNodeIndex(1);
+        child_stored_below_its_parent.frame_nodes[1].parent = FrameNodeIndex::NONE;
+        let decoded = VisualContextTree::from_bytes(&encode_tree(&child_stored_below_its_parent))
+            .expect("acyclic forward references decode");
+        assert_eq!(decoded.spatial_dependency_order(), vec![0, 2, 1]);
+        assert_eq!(decoded.frame_dependency_order(), vec![1, 0]);
+        assert_eq!(
+            decoded.transform_rect_to_viewport(
+                SpatialNodeIndex(1),
+                FloatRect::new(0.0, 0.0, 10.0, 10.0),
+                &[],
+                super::super::IncludeVisualViewportTransform::Yes
+            ),
+            FloatRect::new(5.0, 5.0, 10.0, 10.0)
+        );
+    }
+
+    #[test]
+    fn reference_cycles_self_references_and_wrong_kinds_are_rejected() {
+        let mut parent_cycle = hostile_tree();
+        parent_cycle.spatial_nodes[1].parent = SpatialNodeIndex(2);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&parent_cycle)).is_none());
+
+        let mut self_parented = hostile_tree();
+        self_parented.spatial_nodes[1].parent = SpatialNodeIndex(1);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&self_parented)).is_none());
 
         let mut root_with_a_parent = hostile_tree();
         root_with_a_parent.spatial_nodes[0].parent = SpatialNodeIndex(1);
         assert!(VisualContextTree::from_bytes(&encode_tree(&root_with_a_parent)).is_none());
+
+        let mut sticky_parent_cycle = hostile_tree();
+        sticky_parent_cycle.spatial_nodes[1] = SpatialNode {
+            data: SpatialData::Sticky(StickyData::unconstrained(
+                VISUAL_VIEWPORT_NODE_INDEX,
+                Some(SpatialNodeIndex(2)),
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                VISUAL_VIEWPORT_NODE_INDEX,
+            )),
+            parent: VISUAL_VIEWPORT_NODE_INDEX,
+        };
+        sticky_parent_cycle.spatial_nodes[2] = SpatialNode {
+            data: SpatialData::Sticky(StickyData::unconstrained(
+                VISUAL_VIEWPORT_NODE_INDEX,
+                Some(SpatialNodeIndex(1)),
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                VISUAL_VIEWPORT_NODE_INDEX,
+            )),
+            parent: VISUAL_VIEWPORT_NODE_INDEX,
+        };
+        assert!(VisualContextTree::from_bytes(&encode_tree(&sticky_parent_cycle)).is_none());
+
+        let mut parent_out_of_range = hostile_tree();
+        parent_out_of_range.spatial_nodes[1].parent = SpatialNodeIndex(7);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&parent_out_of_range)).is_none());
+
+        let mut plane_root_out_of_range = hostile_tree();
+        plane_root_out_of_range.spatial_nodes[1].data = SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+            plane_root_index: SpatialNodeIndex(9),
+            flattens_inherited_transform: false,
+        });
+        assert!(VisualContextTree::from_bytes(&encode_tree(&plane_root_out_of_range)).is_none());
 
         let mut root_is_not_a_transform = hostile_tree();
         root_is_not_a_transform.spatial_nodes[0].data = SpatialData::Scroll(ScrollData {
@@ -902,12 +973,12 @@ mod tests {
         });
         assert!(VisualContextTree::from_bytes(&encode_tree(&root_is_not_a_transform)).is_none());
 
-        let mut sorting_root_after_node = hostile_tree();
-        sorting_root_after_node.spatial_nodes[0].data = SpatialData::Transform(TransformData {
+        let mut sorting_root_cycle = hostile_tree();
+        sorting_root_cycle.spatial_nodes[0].data = SpatialData::Transform(TransformData {
             sorting_context_root_index: Some(SpatialNodeIndex(1)),
             ..transform(FloatMatrix4x4::identity())
         });
-        assert!(VisualContextTree::from_bytes(&encode_tree(&sorting_root_after_node)).is_none());
+        assert!(VisualContextTree::from_bytes(&encode_tree(&sorting_root_cycle)).is_none());
 
         let mut sticky_scroller_is_not_a_scroll_node = hostile_tree();
         sticky_scroller_is_not_a_scroll_node.spatial_nodes[1].data = SpatialData::Perspective(PerspectiveData {
@@ -926,12 +997,12 @@ mod tests {
         ));
         assert!(VisualContextTree::from_bytes(&encode_tree(&sticky_parent_is_not_sticky)).is_none());
 
-        let mut plane_root_after_node = hostile_tree();
-        plane_root_after_node.spatial_nodes[1].data = SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+        let mut plane_root_cycle = hostile_tree();
+        plane_root_cycle.spatial_nodes[1].data = SpatialData::BackfaceVisibility(BackfaceVisibilityData {
             plane_root_index: SpatialNodeIndex(2),
             flattens_inherited_transform: false,
         });
-        assert!(VisualContextTree::from_bytes(&encode_tree(&plane_root_after_node)).is_none());
+        assert!(VisualContextTree::from_bytes(&encode_tree(&plane_root_cycle)).is_none());
 
         let mut plane_root_on_another_branch = hostile_tree();
         plane_root_on_another_branch.spatial_nodes[2].parent = VISUAL_VIEWPORT_NODE_INDEX;
@@ -948,21 +1019,25 @@ mod tests {
         });
         assert!(VisualContextTree::from_bytes(&encode_tree(&plane_root_on_the_root_path)).is_some());
 
-        let mut anchor_node_after_node = hostile_tree();
-        anchor_node_after_node.spatial_nodes[1].data = SpatialData::AnchorScrollShift(AnchorScrollShift {
+        let mut anchor_node_names_itself = hostile_tree();
+        anchor_node_names_itself.spatial_nodes[1].data = SpatialData::AnchorScrollShift(AnchorScrollShift {
             scroll_node_index: SpatialNodeIndex(1),
             negate: false,
             compensate_horizontal_scroll: true,
             compensate_vertical_scroll: true,
         });
-        assert!(VisualContextTree::from_bytes(&encode_tree(&anchor_node_after_node)).is_none());
+        assert!(VisualContextTree::from_bytes(&encode_tree(&anchor_node_names_itself)).is_none());
     }
 
     #[test]
-    fn frame_references_out_of_order_or_range_are_rejected() {
-        let mut frame_parent_after_frame = hostile_tree();
-        frame_parent_after_frame.frame_nodes[0].parent = FrameNodeIndex(1);
-        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_parent_after_frame)).is_none());
+    fn frame_reference_cycles_and_ranges_are_rejected() {
+        let mut frame_parent_cycle = hostile_tree();
+        frame_parent_cycle.frame_nodes[0].parent = FrameNodeIndex(1);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_parent_cycle)).is_none());
+
+        let mut frame_parent_out_of_range = hostile_tree();
+        frame_parent_out_of_range.frame_nodes[1].parent = FrameNodeIndex(4);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_parent_out_of_range)).is_none());
 
         let mut frame_spatial_out_of_range = hostile_tree();
         frame_spatial_out_of_range.frame_nodes[1].spatial = SpatialNodeIndex(3);

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -27,11 +27,13 @@ const SPATIAL_KIND_TRANSFORM: u8 = 2;
 const SPATIAL_KIND_PERSPECTIVE: u8 = 3;
 const SPATIAL_KIND_BACKFACE_VISIBILITY: u8 = 4;
 const SPATIAL_KIND_ANCHOR_SCROLL_SHIFT: u8 = 5;
+const SPATIAL_KIND_DEAD: u8 = 6;
 
 const FRAME_KIND_CLIP: u8 = 0;
 const FRAME_KIND_CLIP_PATH: u8 = 1;
 const FRAME_KIND_EFFECTS: u8 = 2;
 const FRAME_KIND_MASK: u8 = 3;
+const FRAME_KIND_DEAD: u8 = 4;
 
 const MINIMUM_SERIALIZED_SPATIAL_NODE_SIZE: usize = 5;
 const MINIMUM_SERIALIZED_FRAME_NODE_SIZE: usize = 9;
@@ -308,6 +310,7 @@ fn write_spatial_data(writer: &mut TreeByteWriter, data: &SpatialData) {
             writer.bool(shift.compensate_horizontal_scroll);
             writer.bool(shift.compensate_vertical_scroll);
         }
+        SpatialData::Dead => writer.u8(SPATIAL_KIND_DEAD),
     }
 }
 
@@ -361,6 +364,7 @@ fn read_spatial_data(reader: &mut TreeByteReader<'_>) -> Option<SpatialData> {
             compensate_horizontal_scroll: reader.bool()?,
             compensate_vertical_scroll: reader.bool()?,
         }),
+        SPATIAL_KIND_DEAD => SpatialData::Dead,
         _ => return None,
     })
 }
@@ -392,6 +396,7 @@ fn write_frame_data(writer: &mut TreeByteWriter, data: &FrameData) {
             writer.i32(mask.kind as i32);
             writer.u8(mask.origin as u8);
         }
+        FrameData::Dead => writer.u8(FRAME_KIND_DEAD),
     }
 }
 
@@ -428,6 +433,7 @@ fn read_frame_data(reader: &mut TreeByteReader<'_>) -> Option<FrameData> {
             kind: reader.mask_kind()?,
             origin: reader.mask_layer_origin()?,
         }),
+        FRAME_KIND_DEAD => FrameData::Dead,
         _ => return None,
     })
 }
@@ -478,7 +484,9 @@ impl VisualContextTree {
             }
         }
         for node in &self.frame_nodes {
-            if node.spatial.0 as usize >= spatial_nodes.len() {
+            let spatial_is_out_of_range = node.spatial.0 as usize >= spatial_nodes.len();
+            let live_frame_in_a_tombstone = node.data.is_live() && !self.spatial_is_live(node.spatial);
+            if spatial_is_out_of_range || live_frame_in_a_tombstone {
                 return false;
             }
         }
@@ -554,6 +562,8 @@ impl VisualContextTree {
             return None;
         }
 
+        let live_spatial_node_count = spatial_nodes.iter().filter(|node| node.data.is_live()).count() as u32;
+        let live_frame_node_count = frame_nodes.iter().filter(|node| node.data.is_live()).count() as u32;
         let tree = Self {
             spatial_nodes,
             frame_nodes,
@@ -561,6 +571,12 @@ impl VisualContextTree {
             root_isolation_frame: (!root_isolation_frame.is_none()).then_some(root_isolation_frame),
             version,
             reused_previous_version: false,
+            live_spatial_node_count,
+            live_frame_node_count,
+            free_spatial_slots: Vec::new(),
+            free_frame_slots: Vec::new(),
+            quarantined_spatial_slots: Vec::new(),
+            quarantined_frame_slots: Vec::new(),
         };
         tree.decoded_references_are_consistent().then_some(tree)
     }
@@ -760,6 +776,7 @@ mod tests {
             (SpatialData::Perspective(a), SpatialData::Perspective(b)) => a == b,
             (SpatialData::BackfaceVisibility(a), SpatialData::BackfaceVisibility(b)) => a == b,
             (SpatialData::AnchorScrollShift(a), SpatialData::AnchorScrollShift(b)) => a == b,
+            (SpatialData::Dead, SpatialData::Dead) => true,
             _ => false,
         }
     }
@@ -774,6 +791,7 @@ mod tests {
                 a.opacity == b.opacity && a.blend_mode == b.blend_mode && a.filter == b.filter
             }
             (FrameData::Mask(a), FrameData::Mask(b)) => a == b,
+            (FrameData::Dead, FrameData::Dead) => true,
             _ => false,
         }
     }
@@ -784,6 +802,8 @@ mod tests {
         assert_eq!(a.root_isolation_frame, b.root_isolation_frame);
         assert_eq!(a.spatial_nodes.len(), b.spatial_nodes.len());
         assert_eq!(a.frame_nodes.len(), b.frame_nodes.len());
+        assert_eq!(a.live_spatial_node_count, b.live_spatial_node_count);
+        assert_eq!(a.live_frame_node_count, b.live_frame_node_count);
         for (node, other) in a.spatial_nodes.iter().zip(&b.spatial_nodes) {
             assert_eq!(node.parent, other.parent);
             assert!(spatial_data_matches(&node.data, &other.data));
@@ -808,6 +828,127 @@ mod tests {
                 .all(|node| node.role == FrameRole::Structural)
         );
         assert_eq!(decoded.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn a_tree_with_tombstones_round_trips_and_keeps_its_live_counts() {
+        let mut tree = tree_with_every_node_kind();
+        let scroll_node = SpatialNodeIndex(1);
+        let stale_transform = tree.append_spatial(
+            SpatialData::Transform(transform(FloatMatrix4x4::identity())),
+            scroll_node,
+        );
+        let stale_frame = tree.append_frame(
+            FrameData::Effects(EffectsData {
+                opacity: 0.5,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+            }),
+            FrameNodeIndex::NONE,
+            scroll_node,
+        );
+        assert!(tree.tombstone_spatial_slot(stale_transform));
+        assert!(tree.tombstone_frame_slot(stale_frame));
+        let bytes = tree.to_bytes();
+        let decoded = VisualContextTree::from_bytes(&bytes).expect("a serialized tree decodes");
+        assert_trees_match(&tree, &decoded);
+        assert!(!decoded.spatial_is_live(stale_transform));
+        assert!(!decoded.frame_is_live(stale_frame));
+        assert_eq!(decoded.dead_node_count(), 2);
+        assert_eq!(decoded.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn a_live_node_referencing_a_tombstone_is_rejected() {
+        let tree_with_tombstoned_target = |make_referencing_data: &dyn Fn(SpatialNodeIndex) -> SpatialData| {
+            let mut tree = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+            let target = tree.append_spatial(
+                SpatialData::Scroll(ScrollData {
+                    state_slot: NO_SCROLL_STATE_SLOT,
+                    owner_paintable: NodeSlotId::INVALID,
+                    registry_parent_node: VISUAL_VIEWPORT_NODE_INDEX,
+                }),
+                VISUAL_VIEWPORT_NODE_INDEX,
+            );
+            tree.append_spatial(make_referencing_data(target), VISUAL_VIEWPORT_NODE_INDEX);
+            assert!(tree.tombstone_spatial_slot(target));
+            tree
+        };
+        let plane_root = tree_with_tombstoned_target(&|target| {
+            SpatialData::BackfaceVisibility(BackfaceVisibilityData {
+                plane_root_index: target,
+                flattens_inherited_transform: false,
+            })
+        });
+        assert!(VisualContextTree::from_bytes(&encode_tree(&plane_root)).is_none());
+        let sorting_root = tree_with_tombstoned_target(&|target| {
+            SpatialData::Transform(TransformData {
+                sorting_context_root_index: Some(target),
+                ..transform(FloatMatrix4x4::identity())
+            })
+        });
+        assert!(VisualContextTree::from_bytes(&encode_tree(&sorting_root)).is_none());
+        let anchor = tree_with_tombstoned_target(&|target| {
+            SpatialData::AnchorScrollShift(AnchorScrollShift {
+                scroll_node_index: target,
+                negate: false,
+                compensate_horizontal_scroll: true,
+                compensate_vertical_scroll: true,
+            })
+        });
+        assert!(VisualContextTree::from_bytes(&encode_tree(&anchor)).is_none());
+        let scroller = tree_with_tombstoned_target(&|target| {
+            SpatialData::Sticky(StickyData::unconstrained(
+                target,
+                None,
+                NO_SCROLL_STATE_SLOT,
+                NodeSlotId::INVALID,
+                target,
+            ))
+        });
+        assert!(VisualContextTree::from_bytes(&encode_tree(&scroller)).is_none());
+    }
+
+    #[test]
+    fn a_live_node_under_a_tombstone_is_rejected() {
+        let mut child_under_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+        let parent = child_under_tombstone.append_spatial(
+            SpatialData::Transform(transform(FloatMatrix4x4::identity())),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        child_under_tombstone.append_spatial(SpatialData::Transform(transform(FloatMatrix4x4::identity())), parent);
+        assert!(child_under_tombstone.tombstone_spatial_slot(parent));
+        assert!(VisualContextTree::from_bytes(&encode_tree(&child_under_tombstone)).is_none());
+
+        let effects = || {
+            FrameData::Effects(EffectsData {
+                opacity: 1.0,
+                blend_mode: CompositingAndBlendingOperator::Normal,
+                filter: None,
+            })
+        };
+        let mut frame_under_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+        let parent_frame =
+            frame_under_tombstone.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        frame_under_tombstone.append_frame(effects(), parent_frame, VISUAL_VIEWPORT_NODE_INDEX);
+        assert!(frame_under_tombstone.tombstone_frame_slot(parent_frame));
+        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_under_tombstone)).is_none());
+
+        let mut frame_in_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+        let spatial = frame_in_tombstone.append_spatial(
+            SpatialData::Transform(transform(FloatMatrix4x4::identity())),
+            VISUAL_VIEWPORT_NODE_INDEX,
+        );
+        frame_in_tombstone.append_frame(effects(), FrameNodeIndex::NONE, spatial);
+        assert!(frame_in_tombstone.tombstone_spatial_slot(spatial));
+        assert!(VisualContextTree::from_bytes(&encode_tree(&frame_in_tombstone)).is_none());
+
+        let mut tombstoned_isolation_frame = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
+        let isolation_frame =
+            tombstoned_isolation_frame.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        assert!(tombstoned_isolation_frame.tombstone_frame_slot(isolation_frame));
+        tombstoned_isolation_frame.root_isolation_frame = Some(isolation_frame);
+        assert!(VisualContextTree::from_bytes(&encode_tree(&tombstoned_isolation_frame)).is_none());
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -509,7 +509,7 @@ impl VisualContextTree {
         let mut writer = TreeByteWriter::default();
         writer.u32(SERIALIZED_TREE_MAGIC);
         writer.u32(SERIALIZED_TREE_FORMAT);
-        writer.u64(self.version);
+        writer.u64(self.structural_epoch);
         writer.bool(self.root_is_visual_viewport);
         writer.frame_index(self.root_isolation_frame.unwrap_or(FrameNodeIndex::NONE));
         writer.u32(self.spatial_nodes.len() as u32);
@@ -531,7 +531,7 @@ impl VisualContextTree {
         if reader.u32()? != SERIALIZED_TREE_MAGIC || reader.u32()? != SERIALIZED_TREE_FORMAT {
             return None;
         }
-        let version = reader.u64()?;
+        let structural_epoch = reader.u64()?;
         let root_is_visual_viewport = reader.bool()?;
         let root_isolation_frame = reader.frame_index()?;
         let spatial_count = reader.u32()? as usize;
@@ -569,8 +569,7 @@ impl VisualContextTree {
             frame_nodes,
             root_is_visual_viewport,
             root_isolation_frame: (!root_isolation_frame.is_none()).then_some(root_isolation_frame),
-            version,
-            reused_previous_version: false,
+            structural_epoch,
             live_spatial_node_count,
             live_frame_node_count,
             free_spatial_slots: Vec::new(),
@@ -601,7 +600,7 @@ mod tests {
 
     fn tree_with_every_node_kind() -> VisualContextTree {
         let mut tree = VisualContextTree::create(transform(FloatMatrix4x4::identity()));
-        tree.version = 42;
+        tree.structural_epoch = 42;
         let scroll_node = tree.append_spatial(
             SpatialData::Scroll(ScrollData {
                 state_slot: NO_SCROLL_STATE_SLOT,
@@ -797,7 +796,7 @@ mod tests {
     }
 
     fn assert_trees_match(a: &VisualContextTree, b: &VisualContextTree) {
-        assert_eq!(a.version, b.version);
+        assert_eq!(a.structural_epoch, b.structural_epoch);
         assert_eq!(a.root_is_visual_viewport, b.root_is_visual_viewport);
         assert_eq!(a.root_isolation_frame, b.root_isolation_frame);
         assert_eq!(a.spatial_nodes.len(), b.spatial_nodes.len());
@@ -954,7 +953,7 @@ mod tests {
     #[test]
     fn a_content_root_tree_round_trips() {
         let mut tree = VisualContextTree::create_with_content_root(transform(translation_matrix(-8.0, -9.0, 0.0)));
-        tree.version = 7;
+        tree.structural_epoch = 7;
         let decoded = VisualContextTree::from_bytes(&tree.to_bytes()).expect("a serialized tree decodes");
         assert_trees_match(&tree, &decoded);
     }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SpatialNodeShape {
+    Scroll {
+        parent: SpatialNodeIndex,
+        registry_parent_node: SpatialNodeIndex,
+    },
+    Sticky {
+        parent: SpatialNodeIndex,
+        registry_parent_node: SpatialNodeIndex,
+    },
+    Transform {
+        parent: SpatialNodeIndex,
+        sorting_context_root_index: Option<SpatialNodeIndex>,
+        flattens_inherited_transform: bool,
+        role: TransformDataRole,
+        synthetic_plane: bool,
+    },
+    Perspective {
+        parent: SpatialNodeIndex,
+        flattens_inherited_transform: bool,
+    },
+    BackfaceVisibility {
+        parent: SpatialNodeIndex,
+        plane_root_index: SpatialNodeIndex,
+        flattens_inherited_transform: bool,
+    },
+    AnchorScrollShift {
+        parent: SpatialNodeIndex,
+        scroll_node_index: SpatialNodeIndex,
+        negate: bool,
+        compensate_horizontal_scroll: bool,
+        compensate_vertical_scroll: bool,
+    },
+    Dead,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FrameShapeKind {
+    Clip { mode: ClipMode },
+    ClipPath,
+    Effects,
+    Mask { origin: MaskLayerOrigin },
+    Dead,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FrameNodeShape {
+    pub kind: FrameShapeKind,
+    pub parent: FrameNodeIndex,
+    pub spatial: SpatialNodeIndex,
+    pub role: FrameRole,
+}
+
+pub(crate) fn spatial_node_shape(node: &SpatialNode) -> SpatialNodeShape {
+    let parent = node.parent;
+    match &node.data {
+        SpatialData::Scroll(scroll) => SpatialNodeShape::Scroll {
+            parent,
+            registry_parent_node: scroll.registry_parent_node,
+        },
+        SpatialData::Sticky(sticky) => SpatialNodeShape::Sticky {
+            parent,
+            registry_parent_node: sticky.registry_parent_node,
+        },
+        SpatialData::Transform(transform) => SpatialNodeShape::Transform {
+            parent,
+            sorting_context_root_index: transform.sorting_context_root_index,
+            flattens_inherited_transform: transform.flattens_inherited_transform,
+            role: transform.role,
+            synthetic_plane: transform.synthetic_plane,
+        },
+        SpatialData::Perspective(perspective) => SpatialNodeShape::Perspective {
+            parent,
+            flattens_inherited_transform: perspective.flattens_inherited_transform,
+        },
+        SpatialData::BackfaceVisibility(backface) => SpatialNodeShape::BackfaceVisibility {
+            parent,
+            plane_root_index: backface.plane_root_index,
+            flattens_inherited_transform: backface.flattens_inherited_transform,
+        },
+        SpatialData::AnchorScrollShift(shift) => SpatialNodeShape::AnchorScrollShift {
+            parent,
+            scroll_node_index: shift.scroll_node_index,
+            negate: shift.negate,
+            compensate_horizontal_scroll: shift.compensate_horizontal_scroll,
+            compensate_vertical_scroll: shift.compensate_vertical_scroll,
+        },
+        SpatialData::Dead => SpatialNodeShape::Dead,
+    }
+}
+
+pub(crate) fn frame_node_shape(node: &FrameNode) -> FrameNodeShape {
+    let kind = match &node.data {
+        FrameData::Clip(clip) => FrameShapeKind::Clip { mode: clip.mode },
+        FrameData::ClipPath(_) => FrameShapeKind::ClipPath,
+        FrameData::Effects(_) => FrameShapeKind::Effects,
+        FrameData::Mask(mask) => FrameShapeKind::Mask { origin: mask.origin },
+        FrameData::Dead => FrameShapeKind::Dead,
+    };
+    FrameNodeShape {
+        kind,
+        parent: node.parent,
+        spatial: node.spatial,
+        role: node.role,
+    }
+}
+
+fn effects_filters_are_equal(a: Option<&std::rc::Rc<Vec<u8>>>, b: Option<&std::rc::Rc<Vec<u8>>>) -> bool {
+    match (a, b) {
+        (None, None) => true,
+        (Some(a), Some(b)) => std::rc::Rc::ptr_eq(a, b) || a == b,
+        _ => false,
+    }
+}
+
+pub(crate) fn spatial_payloads_are_equal(a: &SpatialData, b: &SpatialData) -> bool {
+    match (a, b) {
+        (SpatialData::Scroll(a), SpatialData::Scroll(b)) => a == b,
+        (SpatialData::Sticky(a), SpatialData::Sticky(b)) => a == b,
+        (SpatialData::Transform(a), SpatialData::Transform(b)) => a == b,
+        (SpatialData::Perspective(a), SpatialData::Perspective(b)) => a == b,
+        (SpatialData::BackfaceVisibility(a), SpatialData::BackfaceVisibility(b)) => a == b,
+        (SpatialData::AnchorScrollShift(a), SpatialData::AnchorScrollShift(b)) => a == b,
+        (SpatialData::Dead, SpatialData::Dead) => true,
+        _ => false,
+    }
+}
+
+pub(crate) fn frame_payloads_are_equal(a: &FrameData, b: &FrameData) -> bool {
+    match (a, b) {
+        (FrameData::Clip(a), FrameData::Clip(b)) => a == b,
+        (FrameData::ClipPath(a), FrameData::ClipPath(b)) => {
+            std::rc::Rc::ptr_eq(&a.path, &b.path) && a.bounding_rect == b.bounding_rect && a.fill_rule == b.fill_rule
+        }
+        (FrameData::Effects(a), FrameData::Effects(b)) => {
+            a.opacity == b.opacity
+                && a.blend_mode == b.blend_mode
+                && effects_filters_are_equal(a.filter.as_ref(), b.filter.as_ref())
+        }
+        (FrameData::Mask(a), FrameData::Mask(b)) => a == b,
+        (FrameData::Dead, FrameData::Dead) => true,
+        _ => false,
+    }
+}

--- a/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFEImageElement.cpp
@@ -65,7 +65,7 @@ void SVGFEImageElement::process_href(Optional<Utf16String> const& href)
     m_resource_request->add_callbacks(
         [this, resource_request = GC::Root { m_resource_request }] {
             document().style_computer().style_engine().record_element_style_input_change(style_node_id());
-            document().set_needs_accumulated_visual_contexts_update(true);
+            document().schedule_full_accumulated_visual_context_rebuild(Layout::RustFFI::FfiVisualContextGlobalRebuildReason::FilterResourcesChanged);
             document().set_needs_repaint(Badge<SVGFEImageElement> {});
         },
         nullptr);

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -145,6 +145,10 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
             visual_context_tree.version());
         return;
     }
+    if (auto validation = Web::Painting::validate_display_list_references_live_visual_context_nodes(*display_list, visual_context_tree); validation.is_error()) {
+        dbgln("Compositor: Dropping display list update: {}", validation.error());
+        return;
+    }
 
     context->apply_display_list_resource_transaction(move(resource_transaction));
     context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot));

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -139,10 +139,10 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    if (display_list->compatible_visual_context_tree_version() != visual_context_tree.version()) {
-        dbgln("Compositor: Dropping inconsistent display list update (display list version {}, tree version {})",
-            display_list->compatible_visual_context_tree_version(),
-            visual_context_tree.version());
+    if (display_list->compatible_visual_context_tree_structural_epoch() != visual_context_tree.structural_epoch()) {
+        dbgln("Compositor: Dropping inconsistent display list update (display list epoch {}, tree epoch {})",
+            display_list->compatible_visual_context_tree_structural_epoch(),
+            visual_context_tree.structural_epoch());
         return;
     }
     if (auto validation = Web::Painting::validate_display_list_references_live_visual_context_nodes(*display_list, visual_context_tree); validation.is_error()) {

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -152,7 +152,7 @@ void ContextState::install_display_list_update(
     Web::Painting::AccumulatedVisualContextTree visual_context_tree,
     Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    VERIFY(display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
+    VERIFY(display_list->compatible_visual_context_tree_structural_epoch() == visual_context_tree.structural_epoch());
     invalidate_visual_context_tree_for_compositing();
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
@@ -197,10 +197,10 @@ void ContextState::install_display_list_update(
 
 void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction&& resource_transaction)
 {
-    if (!m_display_list || m_display_list->compatible_visual_context_tree_version() != visual_context_tree.version()) {
-        dbgln("Compositor: Dropping stale visual context tree update (tree version {}, display list version {})",
-            visual_context_tree.version(),
-            m_display_list ? m_display_list->compatible_visual_context_tree_version() : 0);
+    if (!m_display_list || m_display_list->compatible_visual_context_tree_structural_epoch() != visual_context_tree.structural_epoch()) {
+        dbgln("Compositor: Dropping stale visual context tree update (tree epoch {}, display list epoch {})",
+            visual_context_tree.structural_epoch(),
+            m_display_list ? m_display_list->compatible_visual_context_tree_structural_epoch() : 0);
         return;
     }
     invalidate_visual_context_tree_for_compositing();

--- a/Tests/Compositor/TestAsyncScrollTree.cpp
+++ b/Tests/Compositor/TestAsyncScrollTree.cpp
@@ -45,7 +45,7 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_empty_display_list(Web::Pa
     return Web::Painting::DisplayList::create_from_command_bytes(visual_context_tree, ByteBuffer {}, {});
 }
 
-TEST_CASE(wheel_hit_testing_rejects_a_different_visual_context_tree_version)
+TEST_CASE(wheel_hit_testing_rejects_a_different_visual_context_tree_structural_epoch)
 {
     auto visual_context_tree = make_visual_context_tree();
     Web::Compositor::AsyncScrollingState state;
@@ -86,10 +86,10 @@ TEST_CASE(wheel_hit_testing_ignores_invalid_visual_context_indices)
 
 TEST_CASE(wheel_hit_testing_prefilters_static_targets_but_tracks_animated_targets)
 {
-    auto make_tree_and_spatial = [](Gfx::FloatMatrix4x4 const& matrix = Gfx::FloatMatrix4x4::identity(), Optional<u64> version = {}) {
+    auto make_tree_and_spatial = [](Gfx::FloatMatrix4x4 const& matrix = Gfx::FloatMatrix4x4::identity(), Optional<u64> structural_epoch = {}) {
         Web::Painting::VisualContextTreeTestBuilder builder;
         auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, matrix);
-        return Tuple { version.has_value() ? builder.finish_with_version(*version) : builder.finish(), spatial };
+        return Tuple { structural_epoch.has_value() ? builder.finish_with_structural_epoch(*structural_epoch) : builder.finish(), spatial };
     };
     auto make_scroll_tree = [](Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Web::Painting::SpatialNodeIndex spatial) {
         Web::Compositor::AsyncScrollingState state;
@@ -113,7 +113,7 @@ TEST_CASE(wheel_hit_testing_prefilters_static_targets_but_tracks_animated_target
     auto static_scroll_tree = make_scroll_tree(static_tree, static_spatial);
     auto moved_matrix = Gfx::FloatMatrix4x4::identity();
     moved_matrix[0, 3] = 10;
-    auto moved_static_tree = move(make_tree_and_spatial(moved_matrix, static_tree.version()).get<0>());
+    auto moved_static_tree = move(make_tree_and_spatial(moved_matrix, static_tree.structural_epoch()).get<0>());
     EXPECT(!hit_test(static_scroll_tree, moved_static_tree).blocked_by_main_thread_region);
 
     auto animated_tree_and_spatial = make_tree_and_spatial();

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -102,7 +102,7 @@ TEST_CASE(visual_context_trees_round_trip_through_ipc_and_reject_corrupted_bytes
     Queue<IPC::Attachment> attachments;
     IPC::Decoder decoder { stream, attachments };
     auto decoded_tree = MUST(decoder.decode<Web::Painting::AccumulatedVisualContextTree>());
-    EXPECT_EQ(decoded_tree.version(), visual_context_tree.version());
+    EXPECT_EQ(decoded_tree.structural_epoch(), visual_context_tree.structural_epoch());
     EXPECT_EQ(decoded_tree.spatial_node_count(), 2u);
     EXPECT_EQ(decoded_tree.frame_node_count(), 1u);
     EXPECT_EQ(decoded_tree.serialize_to_bytes(), visual_context_tree.serialize_to_bytes());
@@ -718,12 +718,12 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_fills_display_list(Web::Pa
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color, async_scrolling_metadata);
 }
 
-static Web::Painting::AccumulatedVisualContextTree make_translated_visual_context_tree(Gfx::FloatPoint translation, Optional<u64> version = {})
+static Web::Painting::AccumulatedVisualContextTree make_translated_visual_context_tree(Gfx::FloatPoint translation, Optional<u64> structural_epoch = {})
 {
     Web::Painting::VisualContextTreeTestBuilder builder;
     builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::translation_matrix(Gfx::FloatVector3 { translation.x(), translation.y(), 0 }));
-    if (version.has_value())
-        return builder.finish_with_version(*version);
+    if (structural_epoch.has_value())
+        return builder.finish_with_structural_epoch(*structural_epoch);
     return builder.finish();
 }
 
@@ -904,7 +904,7 @@ TEST_CASE(tree_only_update_damages_transformed_commands)
     fixture.install(make_fills_display_list(visual_context_tree, { { { 2, 2, 4, 4 }, Gfx::Color::Red, in_spatial_node(1) } }), visual_context_tree);
     fixture.present();
 
-    auto translated_tree = make_translated_visual_context_tree({ 4, 0 }, visual_context_tree.version());
+    auto translated_tree = make_translated_visual_context_tree({ 4, 0 }, visual_context_tree.structural_epoch());
     fixture.compositor_state->update_visual_context_tree(fixture.context_id, translated_tree, {});
     EXPECT_EQ(fixture.present().damage_rect, (Gfx::IntRect { 1, 1, 10, 6 }));
 
@@ -1234,7 +1234,7 @@ TEST_CASE(visual_animation_samples_derive_a_tree_and_leave_the_source_untouched)
 
     auto include_viewport = Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes;
     auto sampled_tree = tree.with_visual_animation_samples(0);
-    EXPECT_EQ(sampled_tree.version(), tree.version());
+    EXPECT_EQ(sampled_tree.structural_epoch(), tree.structural_epoch());
     auto sampled_translation = sampled_tree.accumulated_matrix(spatial, {}, include_viewport)[0, 3];
     EXPECT_EQ(sampled_translation, 4.0f);
     EXPECT_EQ(sampled_tree.effects_opacity(frame), Optional<float> { 0.5f });

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-after-visual-context-change.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-after-visual-context-change.txt
@@ -1,1 +1,0 @@
-scroll node index changed: true

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-is-stable-after-visual-context-change.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-is-stable-after-visual-context-change.txt
@@ -1,0 +1,3 @@
+scroll node index changed: false
+live nodes grew: true
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/anchor-positioning-keeps-full-builds.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/anchor-positioning-keeps-full-builds.txt
@@ -1,0 +1,2 @@
+target y follows the anchor: 80
+full builds with anchors present: 1

--- a/Tests/LibWeb/Text/expected/visual-context/body-background-propagation-flip.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/body-background-propagation-flip.txt
@@ -1,0 +1,5 @@
+rect x with propagated body background: 13
+rect x without propagation: 13
+rect x with propagation restored: 13
+full builds: 0
+incremental updates happened: true

--- a/Tests/LibWeb/Text/expected/visual-context/clip-path-emptiness-flip-re-records-cached-subtree.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/clip-path-emptiness-flip-re-records-cached-subtree.txt
@@ -1,0 +1,4 @@
+hit while clipped away: BODY
+hit after the clip opened: child
+hit after the clip closed again: BODY
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/contain-paint-change-rebuilds-the-box.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/contain-paint-change-rebuilds-the-box.txt
@@ -1,0 +1,4 @@
+overflowing content without containment: child
+overflowing content with paint containment: BODY
+overflowing content after containment is removed: child
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/empty-clip-flip-reveals-content.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/empty-clip-flip-reveals-content.txt
@@ -1,0 +1,5 @@
+hit while clipped away: HTML
+hit after the clip opened: child
+hit after the clip closed again: HTML
+full builds: 0
+incremental updates: 2

--- a/Tests/LibWeb/Text/expected/visual-context/fieldset-legend-change.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/fieldset-legend-change.txt
@@ -1,0 +1,6 @@
+legend hit: legend
+legend grew: true
+grown legend hit: legend
+content hit: content
+full builds: 0
+incremental updates happened: true

--- a/Tests/LibWeb/Text/expected/visual-context/geometry-walk-survives-descendant-output-change.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/geometry-walk-survives-descendant-output-change.txt
@@ -1,0 +1,3 @@
+inside the moved clip: target
+old position after the move: BODY
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/moved-subtree-refreshes-descendant-clip.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/moved-subtree-refreshes-descendant-clip.txt
@@ -1,0 +1,6 @@
+inside the clip before the move: inner
+beside the clip before the move: wrapper
+old position after the move: BODY
+inside the moved clip: inner
+beyond the moved clip: wrapper
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/parent-gaining-a-transform-keeps-descendant-node-indices.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/parent-gaining-a-transform-keeps-descendant-node-indices.txt
@@ -1,0 +1,4 @@
+scroll node index unchanged: true
+live nodes grew: true
+full builds: 0
+scroller x: 13

--- a/Tests/LibWeb/Text/expected/visual-context/repeated-toggle-settles-in-place.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/repeated-toggle-settles-in-place.txt
@@ -1,0 +1,3 @@
+capacity grew on the first toggle: true
+capacity stable afterwards: true
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/scrollability-flip-from-transformed-child-during-full-relayout.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/scrollability-flip-from-transformed-child-during-full-relayout.txt
@@ -1,0 +1,2 @@
+nodes added by the flip: 1
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/slot-reuse-after-removal-repaints-correctly.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/slot-reuse-after-removal-repaints-correctly.txt
@@ -1,0 +1,5 @@
+capacity reused: true
+dead nodes: 0
+hit: second
+second x: 18
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/slot-reuse-bounds-capacity.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/slot-reuse-bounds-capacity.txt
@@ -1,0 +1,4 @@
+capacity bounded: true
+dead nodes bounded: true
+full builds: 0
+epoch advanced: true

--- a/Tests/LibWeb/Text/expected/visual-context/sticky-after-scroller-resize.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/sticky-after-scroller-resize.txt
@@ -1,0 +1,4 @@
+scrollTop: 60
+sticky y after resize and scroll: 0
+scroller y: 0
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/structural-change-allocates-and-tombstones.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/structural-change-allocates-and-tombstones.txt
@@ -1,0 +1,11 @@
+child rect x: 18
+full builds after insertion: 0
+incremental updates after insertion: 1
+live nodes grew: true
+capacity grew: true
+epoch unchanged after insertion: true
+full builds after removal: 0
+live nodes back to the initial count: true
+capacity kept: true
+dead nodes after removal: true
+epoch bumped by the tombstones: true

--- a/Tests/LibWeb/Text/expected/visual-context/transform-style-change-rebuilds-the-box.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/transform-style-change-rebuilds-the-box.txt
@@ -1,0 +1,3 @@
+live nodes added by preserve-3d: 1
+live nodes added after flat again: 0
+full builds: 0

--- a/Tests/LibWeb/Text/expected/visual-context/value-only-update-keeps-tree.txt
+++ b/Tests/LibWeb/Text/expected/visual-context/value-only-update-keeps-tree.txt
@@ -1,0 +1,6 @@
+rect x: 28
+full builds: 0
+incremental updates: 1
+live nodes unchanged: true
+capacity unchanged: true
+epoch unchanged: true

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-node-index-is-stable-after-visual-context-change.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-node-index-is-stable-after-visual-context-change.html
@@ -23,6 +23,8 @@
     test(() => {
         const initialState = internals.asyncScrollingState();
         const initialNode = initialState.scrollNodes.find(node => !node.isViewport);
+        const initialLiveNodes = internals.visualContextTreeNodeCount();
+        const initialBuildCount = internals.accumulatedVisualContextTreeBuildCount();
 
         document.getElementById("before").style.transform = "translateX(0)";
 
@@ -30,5 +32,7 @@
         const updatedNode = updatedState.scrollNodes.find(node => !node.isViewport);
 
         println(`scroll node index changed: ${initialNode.scrollNodeIndex !== updatedNode.scrollNodeIndex}`);
+        println(`live nodes grew: ${internals.visualContextTreeNodeCount() > initialLiveNodes}`);
+        println(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/visual-context/anchor-positioning-keeps-full-builds.html
+++ b/Tests/LibWeb/Text/input/visual-context/anchor-positioning-keeps-full-builds.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #anchor { anchor-name: --a; width: 100px; height: 50px; }
+    #target { position: absolute; position-anchor: --a; top: anchor(bottom); left: anchor(left); width: 20px; height: 20px; }
+</style>
+<div id="anchor"></div>
+<div id="target"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const target = document.getElementById("target");
+        const anchor = document.getElementById("anchor");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+
+        anchor.style.height = "80px";
+        lines.push(`target y follows the anchor: ${target.getBoundingClientRect().y}`);
+        settle();
+        lines.push(`full builds with anchors present: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/body-background-propagation-flip.html
+++ b/Tests/LibWeb/Text/input/visual-context/body-background-propagation-flip.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #box { width: 50px; height: 50px; transform: translateX(5px); }
+</style>
+<div id="box"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const box = document.getElementById("box");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+        const lines = [];
+
+        document.body.style.background = "orange";
+        lines.push(`rect x with propagated body background: ${box.getBoundingClientRect().x}`);
+        document.documentElement.style.background = "white";
+        lines.push(`rect x without propagation: ${box.getBoundingClientRect().x}`);
+        document.documentElement.style.background = "";
+        lines.push(`rect x with propagation restored: ${box.getBoundingClientRect().x}`);
+        settle();
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        lines.push(`incremental updates happened: ${internals.accumulatedVisualContextIncrementalUpdateCount() > incrementalUpdates}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/clip-path-emptiness-flip-re-records-cached-subtree.html
+++ b/Tests/LibWeb/Text/input/visual-context/clip-path-emptiness-flip-re-records-cached-subtree.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #clip { clip-path: inset(50%); width: 50px; height: 50px; }
+    #child { width: 50px; height: 50px; background: green; }
+</style>
+<div id="clip"><div id="child"></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const clip = document.getElementById("clip");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+        lines.push(`hit while clipped away: ${document.elementFromPoint(10, 10).tagName}`);
+
+        clip.style.clipPath = "inset(0)";
+        lines.push(`hit after the clip opened: ${document.elementFromPoint(10, 10).id}`);
+
+        clip.style.clipPath = "inset(50%)";
+        lines.push(`hit after the clip closed again: ${document.elementFromPoint(10, 10).tagName}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/contain-paint-change-rebuilds-the-box.html
+++ b/Tests/LibWeb/Text/input/visual-context/contain-paint-change-rebuilds-the-box.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #host { width: 50px; height: 50px; }
+    #child { width: 100px; height: 50px; background: green; }
+</style>
+<div id="host"><div id="child"></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const host = document.getElementById("host");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+        lines.push(`overflowing content without containment: ${document.elementFromPoint(75, 10).id}`);
+
+        host.style.contain = "paint";
+        lines.push(`overflowing content with paint containment: ${document.elementFromPoint(75, 10).tagName}`);
+
+        host.style.contain = "none";
+        lines.push(`overflowing content after containment is removed: ${document.elementFromPoint(75, 10).id}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/empty-clip-flip-reveals-content.html
+++ b/Tests/LibWeb/Text/input/visual-context/empty-clip-flip-reveals-content.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #clip { overflow: hidden; width: 50px; height: 0; }
+    #child { width: 50px; height: 50px; }
+</style>
+<div id="clip"><div id="child"></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const clip = document.getElementById("clip");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+        const lines = [];
+        lines.push(`hit while clipped away: ${document.elementFromPoint(25, 25).tagName}`);
+
+        clip.style.height = "50px";
+        lines.push(`hit after the clip opened: ${document.elementFromPoint(25, 25).id}`);
+
+        clip.style.height = "0";
+        lines.push(`hit after the clip closed again: ${document.elementFromPoint(25, 25).tagName}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        lines.push(`incremental updates: ${internals.accumulatedVisualContextIncrementalUpdateCount() - incrementalUpdates}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/fieldset-legend-change.html
+++ b/Tests/LibWeb/Text/input/visual-context/fieldset-legend-change.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    fieldset { margin: 0; padding: 20px; border: 4px solid black; width: 200px; }
+    legend { font-size: 16px; }
+</style>
+<fieldset id="fieldset"><legend id="legend">Legend</legend><div id="content" style="height: 40px"></div></fieldset>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const legend = document.getElementById("legend");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+        const lines = [];
+        const legendRect = legend.getBoundingClientRect();
+        lines.push(`legend hit: ${document.elementFromPoint(legendRect.x + 2, legendRect.y + 2).id}`);
+
+        legend.style.fontSize = "32px";
+        const grownRect = legend.getBoundingClientRect();
+        lines.push(`legend grew: ${grownRect.width > legendRect.width && grownRect.height > legendRect.height}`);
+        lines.push(`grown legend hit: ${document.elementFromPoint(grownRect.x + grownRect.width - 2, grownRect.y + 2).id}`);
+        lines.push(`content hit: ${document.elementFromPoint(30, grownRect.y + grownRect.height + 30).id}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        lines.push(`incremental updates happened: ${internals.accumulatedVisualContextIncrementalUpdateCount() > incrementalUpdates}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/geometry-walk-survives-descendant-output-change.html
+++ b/Tests/LibWeb/Text/input/visual-context/geometry-walk-survives-descendant-output-change.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #moving { margin-left: 0; width: 100px; height: 50px; }
+    #barrier { width: 100px; height: 50px; overflow: hidden; transform: translateX(0); }
+    #clip { width: 50px; height: 50px; overflow: hidden; }
+    #target { width: 100px; height: 50px; background: green; }
+</style>
+<div id="moving">
+    <div id="barrier">
+        <div id="clip"><div id="target"></div></div>
+    </div>
+</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const moving = document.getElementById("moving");
+        settle();
+
+        moving.style.clipPath = "inset(0)";
+        settle();
+        moving.style.clipPath = "none";
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+
+        moving.style.marginLeft = "100px";
+        moving.style.clipPath = "inset(0)";
+        const lines = [];
+        lines.push(`inside the moved clip: ${document.elementFromPoint(125, 25).id}`);
+        lines.push(`old position after the move: ${document.elementFromPoint(25, 25).tagName}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/moved-subtree-refreshes-descendant-clip.html
+++ b/Tests/LibWeb/Text/input/visual-context/moved-subtree-refreshes-descendant-clip.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #wrapper { margin-left: 0; }
+    #clip { overflow: hidden; width: 50px; height: 50px; }
+    #inner { width: 200px; height: 20px; }
+</style>
+<div id="wrapper"><div id="clip"><div id="inner"></div></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const wrapper = document.getElementById("wrapper");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+        lines.push(`inside the clip before the move: ${document.elementFromPoint(25, 10).id}`);
+        lines.push(`beside the clip before the move: ${document.elementFromPoint(125, 10).id}`);
+
+        wrapper.style.marginLeft = "100px";
+        lines.push(`old position after the move: ${document.elementFromPoint(25, 10).tagName}`);
+        lines.push(`inside the moved clip: ${document.elementFromPoint(125, 10).id}`);
+        lines.push(`beyond the moved clip: ${document.elementFromPoint(175, 10).id}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/parent-gaining-a-transform-keeps-descendant-node-indices.html
+++ b/Tests/LibWeb/Text/input/visual-context/parent-gaining-a-transform-keeps-descendant-node-indices.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #parent {
+        width: 200px;
+        height: 200px;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        overflow: scroll;
+    }
+
+    #content {
+        width: 500px;
+        height: 500px;
+    }
+</style>
+<div id="parent"><div id="scroller"><div id="content"></div></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const scrollNodeIndex = () => internals.asyncScrollingState().scrollNodes.find(node => !node.isViewport).scrollNodeIndex;
+        settle();
+        const initialIndex = scrollNodeIndex();
+        const liveNodes = internals.visualContextTreeNodeCount();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+
+        document.getElementById("parent").style.transform = "translateX(5px)";
+        settle();
+
+        println(`scroll node index unchanged: ${scrollNodeIndex() === initialIndex}`);
+        println(`live nodes grew: ${internals.visualContextTreeNodeCount() > liveNodes}`);
+        println(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        println(`scroller x: ${document.getElementById("scroller").getBoundingClientRect().x}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/repeated-toggle-settles-in-place.html
+++ b/Tests/LibWeb/Text/input/visual-context/repeated-toggle-settles-in-place.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #box { width: 50px; height: 50px; }
+    #box.lifted { transform: translateY(-2px); }
+</style>
+<div id="box"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const box = document.getElementById("box");
+        settle();
+        const initialCapacity = internals.visualContextTreeNodeCapacity();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const capacities = [];
+        for (let i = 0; i < 6; ++i) {
+            box.classList.add("lifted");
+            settle();
+            capacities.push(internals.visualContextTreeNodeCapacity());
+            box.classList.remove("lifted");
+            settle();
+        }
+        const lines = [
+            `capacity grew on the first toggle: ${capacities[0] > initialCapacity}`,
+            `capacity stable afterwards: ${capacities.every(capacity => capacity === capacities[0])}`,
+            `full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`,
+        ];
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/scrollability-flip-from-transformed-child-during-full-relayout.html
+++ b/Tests/LibWeb/Text/input/visual-context/scrollability-flip-from-transformed-child-during-full-relayout.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #scroller { overflow: hidden; width: 100px; height: 100px; }
+    #slide { width: 50px; height: 50px; transform: translateX(0); }
+    #other { height: 10px; }
+</style>
+<div id="scroller"><div id="slide"></div></div>
+<div id="other"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const scroller = document.getElementById("scroller");
+        const slide = document.getElementById("slide");
+        const other = document.getElementById("other");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const nodesBefore = internals.visualContextTreeNodeCount();
+        slide.style.transform = "translateX(200px)";
+        other.style.height = "20px";
+        settle();
+        println(`nodes added by the flip: ${internals.visualContextTreeNodeCount() - nodesBefore}`);
+        println(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/slot-reuse-after-removal-repaints-correctly.html
+++ b/Tests/LibWeb/Text/input/visual-context/slot-reuse-after-removal-repaints-correctly.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #parent {
+        width: 200px;
+        height: 200px;
+    }
+
+    .clipped {
+        width: 50px;
+        height: 50px;
+        overflow: hidden;
+        transform: translateX(10px);
+        background: blue;
+    }
+</style>
+<div id="parent"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const parent = document.getElementById("parent");
+        settle();
+        const first = document.createElement("div");
+        first.className = "clipped";
+        first.id = "first";
+        parent.appendChild(first);
+        settle();
+        const capacityWithFirst = internals.visualContextTreeNodeCapacity();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+
+        first.remove();
+        settle();
+        const second = document.createElement("div");
+        second.className = "clipped";
+        second.id = "second";
+        parent.appendChild(second);
+        settle();
+
+        println(`capacity reused: ${internals.visualContextTreeNodeCapacity() === capacityWithFirst}`);
+        println(`dead nodes: ${internals.visualContextTreeDeadNodeCount()}`);
+        println(`hit: ${document.elementFromPoint(30, 30).id}`);
+        println(`second x: ${second.getBoundingClientRect().x}`);
+        println(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/slot-reuse-bounds-capacity.html
+++ b/Tests/LibWeb/Text/input/visual-context/slot-reuse-bounds-capacity.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="parent"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const parent = document.getElementById("parent");
+        settle();
+        const initialCapacity = internals.visualContextTreeNodeCapacity();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const epoch = internals.visualContextTreeStructuralEpoch();
+        const iterations = 400;
+        for (let i = 0; i < iterations; ++i) {
+            const child = document.createElement("div");
+            child.style.cssText = "width: 10px; height: 10px; transform: translateX(1px)";
+            parent.appendChild(child);
+            settle();
+            child.remove();
+            settle();
+        }
+        const lines = [
+            `capacity bounded: ${internals.visualContextTreeNodeCapacity() < initialCapacity + iterations}`,
+            `dead nodes bounded: ${internals.visualContextTreeDeadNodeCount() < iterations}`,
+            `full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`,
+            `epoch advanced: ${internals.visualContextTreeStructuralEpoch() > epoch}`,
+        ];
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/sticky-after-scroller-resize.html
+++ b/Tests/LibWeb/Text/input/visual-context/sticky-after-scroller-resize.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; }
+    #scroller { overflow: auto; width: 100px; height: 100px; }
+    #sticky { position: sticky; top: 0; height: 20px; }
+    #filler { height: 500px; }
+</style>
+<div id="scroller"><div id="sticky"></div><div id="filler"></div></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const scroller = document.getElementById("scroller");
+        const sticky = document.getElementById("sticky");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+
+        scroller.style.height = "150px";
+        scroller.scrollTop = 60;
+        lines.push(`scrollTop: ${scroller.scrollTop}`);
+        lines.push(`sticky y after resize and scroll: ${sticky.getBoundingClientRect().y}`);
+        lines.push(`scroller y: ${scroller.getBoundingClientRect().y}`);
+        settle();
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/structural-change-allocates-and-tombstones.html
+++ b/Tests/LibWeb/Text/input/visual-context/structural-change-allocates-and-tombstones.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="sibling" style="width: 100px; height: 100px; transform: translateX(1px)"></div>
+<div id="parent" style="width: 100px; height: 100px"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const parent = document.getElementById("parent");
+        internals.forceIncompatibleVisualContextTreeRebuild();
+        settle();
+        const liveNodes = internals.visualContextTreeNodeCount();
+        const capacity = internals.visualContextTreeNodeCapacity();
+        const epoch = internals.visualContextTreeStructuralEpoch();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+        const lines = [];
+
+        const child = document.createElement("div");
+        child.style.cssText = "width: 50px; height: 50px; overflow: hidden; transform: translateX(10px)";
+        parent.appendChild(child);
+        lines.push(`child rect x: ${child.getBoundingClientRect().x}`);
+        settle();
+        lines.push(`full builds after insertion: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        lines.push(`incremental updates after insertion: ${internals.accumulatedVisualContextIncrementalUpdateCount() - incrementalUpdates}`);
+        lines.push(`live nodes grew: ${internals.visualContextTreeNodeCount() > liveNodes}`);
+        lines.push(`capacity grew: ${internals.visualContextTreeNodeCapacity() > capacity}`);
+        lines.push(`epoch unchanged after insertion: ${internals.visualContextTreeStructuralEpoch() === epoch}`);
+        const capacityWithChild = internals.visualContextTreeNodeCapacity();
+
+        child.remove();
+        settle();
+        lines.push(`full builds after removal: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+        lines.push(`live nodes back to the initial count: ${internals.visualContextTreeNodeCount() === liveNodes}`);
+        lines.push(`capacity kept: ${internals.visualContextTreeNodeCapacity() === capacityWithChild}`);
+        lines.push(`dead nodes after removal: ${internals.visualContextTreeDeadNodeCount() > 0}`);
+        lines.push(`epoch bumped by the tombstones: ${internals.visualContextTreeStructuralEpoch() > epoch}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/transform-style-change-rebuilds-the-box.html
+++ b/Tests/LibWeb/Text/input/visual-context/transform-style-change-rebuilds-the-box.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg width="100" height="100">
+    <g id="group">
+        <rect width="50" height="50" fill="green"/>
+    </g>
+</svg>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const group = document.getElementById("group");
+        settle();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const liveNodes = internals.visualContextTreeNodeCount();
+        const lines = [];
+
+        group.style.transformStyle = "preserve-3d";
+        settle();
+        lines.push(`live nodes added by preserve-3d: ${internals.visualContextTreeNodeCount() - liveNodes}`);
+
+        group.style.transformStyle = "flat";
+        settle();
+        lines.push(`live nodes added after flat again: ${internals.visualContextTreeNodeCount() - liveNodes}`);
+        lines.push(`full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/visual-context/value-only-update-keeps-tree.html
+++ b/Tests/LibWeb/Text/input/visual-context/value-only-update-keeps-tree.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="box" style="width: 100px; height: 100px; opacity: 0.5; transform: translateX(10px)"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const box = document.getElementById("box");
+        settle();
+        const liveNodes = internals.visualContextTreeNodeCount();
+        const capacity = internals.visualContextTreeNodeCapacity();
+        const epoch = internals.visualContextTreeStructuralEpoch();
+        const fullBuilds = internals.accumulatedVisualContextTreeBuildCount();
+        const incrementalUpdates = internals.accumulatedVisualContextIncrementalUpdateCount();
+
+        box.style.opacity = "0.6";
+        box.style.transform = "translateX(20px)";
+        const rect = box.getBoundingClientRect();
+        settle();
+
+        const lines = [
+            `rect x: ${rect.x}`,
+            `full builds: ${internals.accumulatedVisualContextTreeBuildCount() - fullBuilds}`,
+            `incremental updates: ${internals.accumulatedVisualContextIncrementalUpdateCount() - incrementalUpdates}`,
+            `live nodes unchanged: ${internals.visualContextTreeNodeCount() === liveNodes}`,
+            `capacity unchanged: ${internals.visualContextTreeNodeCapacity() === capacity}`,
+            `epoch unchanged: ${internals.visualContextTreeStructuralEpoch() === epoch}`,
+        ];
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
A full traversal rebuilt the accumulated visual context tree after every layout commit and every style change to a node-producing property. Each rebuild numbered every node again, so no paint capture, hit test item or scroll node index survived an update. Node indices are now stable identities. Six preparation commits remove every dependency on pre-order numbering: dependency-order resolution, tombstones with a free list, a structural epoch and captures without node indices. The layout commit, style invalidation and overflow measurement note dirty boxes per document. The incremental pass rebuilds only the dirty boxes, the boxes whose inherited contexts changed and the geometry-dependent nodes under a moved ancestor. It reconciles each rebuilt box in place and keeps the paint captures. Only document-wide reasons still take a full build.