### PR TITLE
LibWeb: Restore compilation with GCC 14

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -117,7 +117,11 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_viewport_
 
 void AccumulatedVisualContextTree::set_visual_animations(Vector<Compositor::VisualAnimation> animations)
 {
-    m_visual_animations = animations.is_empty() ? nullptr : adopt_ref(*new VisualAnimationList(move(animations)));
+    if (animations.is_empty()) {
+        m_visual_animations = nullptr;
+    } else {
+        m_visual_animations = adopt_ref(*new VisualAnimationList(move(animations)));
+    }
 }
 
 AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation_samples(i64 monotonic_time_ns) const

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -163,7 +163,11 @@ void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<C
         }
     }
     m_visual_animations = animations;
-    m_visual_context_tree_visual_animations = animations.is_empty() ? nullptr : adopt_ref(*new VisualAnimationList(move(animations)));
+    if (animations.is_empty()) {
+        m_visual_context_tree_visual_animations = nullptr;
+    } else {
+        m_visual_context_tree_visual_animations = adopt_ref(*new VisualAnimationList(move(animations)));
+    }
     m_visual_context_tree_needs_compositor_update = true;
     if (animation_parameters_changed)
         ++document.style_invalidation_counters().compositor_visual_animation_updates;


### PR DESCRIPTION
Previously, empty visual animation lists were assigned with conditional expressions whose branches mix a null pointer with a non-null pointer. GCC 14 does not support this, which caused CI to break.

Replace the ternary with an equivalent if else statement.