### PR TITLE
LibMedia: Consider media unbuffered until a track is enabled

### DIFF
--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -125,8 +125,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
                 return;
             self->update_duration_from_scan_states();
             self->update_pipeline_state();
-            if (self->on_buffered_ranges_change)
-                self->on_buffered_ranges_change();
+            self->dispatch_buffered_ranges_change();
         });
         self->update_duration_from_scan_states();
 
@@ -381,6 +380,14 @@ void PlaybackManager::check_for_duration_change(AK::Duration duration)
         on_duration_change(m_duration);
 }
 
+void PlaybackManager::set_duration(AK::Duration duration)
+{
+    if (m_duration == duration)
+        return;
+    m_duration = duration;
+    dispatch_buffered_ranges_change();
+}
+
 void PlaybackManager::dispatch_error(DecoderError&& error)
 {
     VERIFY(error.category() != DecoderErrorCategory::EndOfStream);
@@ -390,6 +397,12 @@ void PlaybackManager::dispatch_error(DecoderError&& error)
     m_is_in_error_state = true;
     if (on_error)
         on_error(move(error));
+}
+
+void PlaybackManager::dispatch_buffered_ranges_change()
+{
+    if (on_buffered_ranges_change)
+        on_buffered_ranges_change();
 }
 
 void PlaybackManager::set_clock(NonnullRefPtr<MediaClock> const& clock)
@@ -436,6 +449,7 @@ void PlaybackManager::attach_video_sink(VideoTrackData& track_data, NonnullRefPt
     MUST(video_sink->connect_input(track_data.producer));
     track_data.video_sink = move(video_sink);
     update_pipeline_state();
+    dispatch_buffered_ranges_change();
 }
 
 VideoSinkHandle PlaybackManager::reserve_video_sink_handle(Track const& track)
@@ -469,6 +483,7 @@ void PlaybackManager::disable_video_sink_by_handle(VideoSinkHandle handle)
     }
     track_data->handle = {};
     update_pipeline_state();
+    dispatch_buffered_ranges_change();
 }
 
 void PlaybackManager::set_video_sink_ticking(VideoSinkHandle handle, bool ticking)
@@ -494,6 +509,7 @@ void PlaybackManager::detach_video_sink(VideoSinkHandle handle)
     }
     track_data->sink_status = PipelineStatus::Pending;
     update_pipeline_state();
+    dispatch_buffered_ranges_change();
 }
 
 ErrorOr<PlaybackManager::RemoteVideoEdge> PlaybackManager::create_video_edge(VideoSinkHandle handle, RemoteVideoSink::Delegates delegates)
@@ -555,6 +571,7 @@ void PlaybackManager::enable_an_audio_track(Track const& track)
     }
     track_data.enabled = true;
     update_pipeline_state();
+    dispatch_buffered_ranges_change();
 }
 
 void PlaybackManager::disable_an_audio_track(Track const& track)
@@ -568,6 +585,7 @@ void PlaybackManager::disable_an_audio_track(Track const& track)
     }
     track_data.enabled = false;
     update_pipeline_state();
+    dispatch_buffered_ranges_change();
 }
 
 bool PlaybackManager::track_is_enabled(Track const& track) const

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -641,6 +641,7 @@ AvailableData PlaybackManager::available_data()
 TimeRanges PlaybackManager::buffered_time_ranges() const
 {
     TimeRanges intersection { { AK::Duration::zero(), m_duration } };
+    bool any_track_contributed_ranges = false;
 
     for (auto const& demuxer : m_demuxers) {
         for (auto const& track_state : demuxer->scan_state().tracks) {
@@ -652,8 +653,12 @@ TimeRanges PlaybackManager::buffered_time_ranges() const
             if (track_state.reached_end_of_stream && !track_ranges.is_empty())
                 track_ranges.add_range(track_ranges[track_ranges.size() - 1].start, m_duration);
             intersection = intersection.intersection(track_ranges);
+            any_track_contributed_ranges = true;
         }
     }
+
+    if (!any_track_contributed_ranges)
+        return {};
 
     return intersection;
 }

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -58,7 +58,7 @@ public:
     void set_audio_output_disabled(bool disabled) { m_audio_output_disabled = disabled; }
 
     AK::Duration duration() const { return m_duration; }
-    void set_duration(AK::Duration duration) { m_duration = duration; }
+    void set_duration(AK::Duration);
     AK::Duration current_time() const;
 
     Optional<AK::UnixDateTime> start_time_realtime() const { return m_start_time_realtime; }
@@ -156,6 +156,7 @@ private:
     PipelineStatus combined_pipeline_status() const;
     void check_for_duration_change(AK::Duration);
     void dispatch_error(DecoderError&&);
+    void dispatch_buffered_ranges_change();
 
     template<typename Self>
     decltype(auto) get_video_data_for_track(this Self&& self, Track const& track)

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -198,8 +198,10 @@ void HTMLMediaElement::finalize()
 
     m_screen_wake_lock.clear();
 
-    if (m_playback_manager)
+    if (m_playback_manager) {
         m_playback_manager->on_playback_state_change = nullptr;
+        m_playback_manager->on_buffered_ranges_change = nullptr;
+    }
     release_active_video_sink();
 
     if (m_playback_position_update_timer) {


### PR DESCRIPTION
Otherwise, we report that the entirety of the media is buffered until a segment is appended. Fixes HLS.js (https://hlsjs.video-dev.org/demo/) never appending anything to allow playback to begin.