### PR TITLE
LibWeb: Deduplicate custom property references with a hash set

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1972,10 +1972,12 @@ void Element::finish_recording_style_custom_property_references()
     m_style_input_record->style_depends_on_size_container_query = m_style_depends_on_size_container_query;
     m_style_input_record->style_depends_on_style_container_query = m_style_depends_on_style_container_query;
     auto& references = m_style_input_record->custom_property_references;
-    quick_sort(references);
-    for (size_t index = references.size(); index > 1; --index) {
-        if (references[index - 1] == references[index - 2])
-            references.remove(index - 1);
+    if (references.size() > 1) {
+        HashTable<Utf16FlyString> seen;
+        seen.ensure_capacity(references.size());
+        references.remove_all_matching([&](auto const& name) {
+            return seen.set(name) != HashSetResult::InsertedNewEntry;
+        });
     }
 }
 


### PR DESCRIPTION
Element::finish_recording_style_custom_property_references() sorted the recorded names with quick_sort and removed duplicates with repeated Vector::remove calls, running after every element style recompute. On var()-heavy pages this content-sorts hundreds of names per element; it showed up as ~5% of WebContent main-thread time loading nytimes.com.

No consumer needs the list sorted, only duplicate-free, and Utf16FlyString has O(1) hash and equality, so dedup with a HashTable and a single O(n) compaction pass instead.