### PR TITLE
LibWeb: Skip untouched windows without storage event listeners

### DIFF
--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -196,7 +196,17 @@ void Storage::broadcast(Optional<Utf16View> key, Optional<Utf16View> old_value, 
     //         windows, and initialize any storage objects as part of this loop.
     Window::for_each_active([&](auto& window) {
         // * type is storage's type
-        auto storage = obtain_storage_for_window(window, type());
+        auto& document = window.associated_document();
+        auto storage = type() == Type::Local ? document.local_storage_holder() : document.session_storage_holder();
+
+        // OPTIMIZATION: If the window has not accessed this type of storage, firing a storage event at it with no
+        //               storage event listeners is not observable. StorageEvent does not bubble and Window has no
+        //               ancestors to capture through, so avoid lazily creating a Storage object for such windows.
+        if (!storage && !window.has_event_listener(EventNames::storage))
+            return IterationDecision::Continue;
+
+        if (!storage)
+            storage = obtain_storage_for_window(window, type());
         if (!storage)
             return IterationDecision::Continue;
 

--- a/Tests/LibWeb/Text/expected/HTML/session-storage-event-listener-added-before-dispatch.txt
+++ b/Tests/LibWeb/Text/expected/HTML/session-storage-event-listener-added-before-dispatch.txt
@@ -1,0 +1,4 @@
+key: listener-added-before-dispatch
+oldValue: null
+newValue: hello
+storageArea matches: true

--- a/Tests/LibWeb/Text/input/HTML/session-storage-event-listener-added-before-dispatch.html
+++ b/Tests/LibWeb/Text/input/HTML/session-storage-event-listener-added-before-dispatch.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const key = 'listener-added-before-dispatch';
+
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+
+        // Create the iframe's Storage object without registering an event listener.
+        const iframeStorage = iframe.contentWindow.sessionStorage;
+
+        const eventReceived = Promise.withResolvers();
+        sessionStorage.setItem(key, 'hello');
+        iframe.contentWindow.addEventListener('storage', eventReceived.resolve);
+
+        const event = await eventReceived.promise;
+        println(`key: ${event.key}`);
+        println(`oldValue: ${event.oldValue}`);
+        println(`newValue: ${event.newValue}`);
+        println(`storageArea matches: ${event.storageArea === iframeStorage}`);
+
+        sessionStorage.removeItem(key);
+    });
+</script>


### PR DESCRIPTION
Storage::broadcast() queued a task for every other same-origin active window on each storage write and lazily created Storage objects for windows that had neither accessed storage nor registered a listener. Ad-heavy pages make this wasted work particularly expensive.

Skip untouched windows without storage event listeners. Continue queueing events for windows with existing Storage objects because a listener can be registered after the write but before queued dispatch.

Cover late listener registration with a regression test.