### PR TITLE
LibWeb: Blink text carets in the compositor

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -29,7 +29,6 @@
 #include <LibGC/Heap.h>
 #include <LibGC/RootHashTable.h>
 #include <LibGC/RootVector.h>
-#include <LibGC/Timer.h>
 #include <LibHTTP/Cookie/Cookie.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibJS/Console.h>
@@ -634,33 +633,6 @@ Document::Document(Page& page, GC::Ref<EventTarget> relevant_global_event_target
 
     m_is_decoded_svg = m_page->client().is_svg_page_client();
 
-    m_cursor_blink_timer = GC::Heap::the().allocate<GC::Timer>();
-    // NB: In test mode, the caret must not blink so we can deterministically generate display lists. The blink state
-    //     is set whenever the cursor moves (see reset_cursor_blink_cycle()), so the caret is still painted.
-    if (!HTML::Window::in_test_mode()) {
-        m_cursor_blink_timer->start_repeating(500, GC::create_function(GC::Heap::the(), [this] {
-            auto cursor_position = this->cursor_position();
-            if (!cursor_position)
-                return;
-
-            auto navigable = this->navigable();
-            if (!navigable || !navigable->is_focused())
-                return;
-
-            auto node = cursor_position->node();
-            if (auto* text = as_if<DOM::Text>(*node)) {
-                auto* layout_text_node = as_if<Layout::TextNode>(text->unsafe_layout_node());
-                if (!layout_text_node)
-                    return;
-                m_cursor_blink_state = !m_cursor_blink_state;
-                layout_text_node->set_needs_repaint();
-            } else if (auto const* layout_node = node->unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
-                m_cursor_blink_state = !m_cursor_blink_state;
-                Painting::set_needs_repaint(*layout_node);
-            }
-        }));
-    }
-
     HTML::main_thread_event_loop().register_document({}, *this);
 }
 
@@ -870,7 +842,6 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_open_dialogs_list);
     visitor.visit(m_dialog_pointerdown_target);
     visitor.visit(m_console_client);
-    visitor.visit(m_cursor_blink_timer);
     visitor.visit(m_previously_repainted_cursor_position);
     if (m_hit_test_display_list)
         m_hit_test_display_list->visit_edges(visitor);
@@ -10228,11 +10199,7 @@ Optional<CSSPixelRect> Document::current_caret_rect()
 
 void Document::reset_cursor_blink_cycle()
 {
-    m_cursor_blink_state = true;
-
-    // In testing mode, disable timed blinking so we can deterministically generate display lists.
-    if (!HTML::Window::in_test_mode())
-        m_cursor_blink_timer->restart();
+    m_cursor_blink_cycle_start_time_ns = MonotonicTime::now().nanoseconds();
 }
 
 void Document::set_cursor_position_needs_repaint()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1285,7 +1285,7 @@ public:
     void set_cursor_position_needs_repaint();
     Optional<CSSPixelRect> current_caret_rect();
 
-    bool cursor_blink_state() const { return m_cursor_blink_state; }
+    i64 cursor_blink_cycle_start_time_ns() const { return m_cursor_blink_cycle_start_time_ns; }
 
     // Back-pointer to the navigable whose active document is this document.
     // Maintained by LocalNavigable when it sets/clears its active document.
@@ -1973,8 +1973,7 @@ private:
 
     GC::Ptr<JS::ConsoleClient> m_console_client;
 
-    GC::Ptr<GC::Timer> m_cursor_blink_timer;
-    bool m_cursor_blink_state { false };
+    i64 m_cursor_blink_cycle_start_time_ns { 0 };
 
     // The cursor position most recently invalidated for caret painting, so that moving the caret to another node
     // also repaints the node it moved away from.

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -506,7 +506,7 @@ bool should_paint_cursor(Layout::Node const& node)
         return false;
 
     auto const& document = node.document();
-    if (!document.cursor_blink_state() || !document.navigable()->is_focused())
+    if (!document.navigable()->is_focused())
         return false;
 
     auto cursor_position = document.cursor_position();

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -56,6 +56,11 @@ void FillRect::dump(StringBuilder& builder) const
     builder.appendff(" rect={} color={}", rect, color);
 }
 
+void PaintCaret::dump(StringBuilder& builder) const
+{
+    builder.appendff(" rect={} color={} should_blink={}", rect, color, should_blink);
+}
+
 void DrawScaledDecodedImageFrame::dump(StringBuilder& builder) const
 {
     builder.appendff(" dst_rect={}", dst_rect);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -17,6 +17,7 @@ namespace Web::Painting {
 #define ENUMERATE_DISPLAY_LIST_COMMANDS(V)                                             \
     V(DrawGlyphRun, draw_glyph_run)                                                    \
     V(FillRect, fill_rect)                                                             \
+    V(PaintCaret, paint_caret)                                                         \
     V(DrawScaledDecodedImageFrame, draw_scaled_decoded_image_frame)                    \
     V(DrawRepeatedDecodedImageFrame, draw_repeated_decoded_image_frame)                \
     V(DrawRepeatedDisplayList, draw_repeated_display_list)                             \
@@ -64,6 +65,17 @@ constexpr bool display_list_command_is_compositor_metadata(DisplayListCommandTyp
 
 inline Gfx::IntRect DrawGlyphRun::bounding_rect() const { return glyph_bounding_rect; }
 inline Gfx::IntRect FillRect::bounding_rect() const { return rect; }
+inline Gfx::IntRect PaintCaret::bounding_rect() const { return rect; }
+constexpr i64 caret_blink_interval_ns = 500'000'000;
+inline bool caret_is_visible_at_time(PaintCaret const& caret, i64 monotonic_time_ns)
+{
+    if (!caret.should_blink)
+        return true;
+    auto elapsed_ns = monotonic_time_ns > caret.blink_cycle_start_time_ns
+        ? monotonic_time_ns - caret.blink_cycle_start_time_ns
+        : 0;
+    return (elapsed_ns / caret_blink_interval_ns) % 2 == 0;
+}
 inline Gfx::IntRect DrawScaledDecodedImageFrame::bounding_rect() const { return Gfx::enclosing_int_rect(dst_rect); }
 inline Gfx::IntRect DrawRepeatedDecodedImageFrame::bounding_rect() const { return clip_rect; }
 inline Gfx::IntRect DrawRepeatedDisplayList::bounding_rect() const { return clip_rect; }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/TemporaryChange.h>
+#include <AK/Time.h>
 #include <core/SkBitmap.h>
 #include <core/SkBlurTypes.h>
 #include <core/SkCanvas.h>
@@ -224,6 +225,18 @@ void DisplayListPlayerSkia::play_command(FillRect const& command)
     paint.setAntiAlias(true);
     paint.setColor(to_skia_color(command.color));
     canvas.drawRect(to_skia_rect(rect), paint);
+}
+
+void DisplayListPlayerSkia::play_command(PaintCaret const& command)
+{
+    if (!caret_is_visible_at_time(command, MonotonicTime::now().nanoseconds()))
+        return;
+
+    auto& canvas = surface().canvas();
+    SkPaint paint;
+    paint.setAntiAlias(true);
+    paint.setColor(to_skia_color(command.color));
+    canvas.drawRect(to_skia_rect(command.rect), paint);
 }
 
 void DisplayListPlayerSkia::play_command(DrawCompositedContext const& command)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -34,6 +34,7 @@
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Layout/LayoutRustFFI.h>
@@ -913,6 +914,8 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
             facts.paints = true;
             facts.rect = caret->rect;
             facts.color = caret->color;
+            facts.blink_cycle_start_time_ns = layout_node.document().cursor_blink_cycle_start_time_ns();
+            facts.should_blink = !HTML::Window::in_test_mode();
             return facts;
         },
         .layer_image_prepare = [](void*, void* layout_node_shell, Layout::RustFFI::FfiLayerImageList list, u32 computed_index) -> Layout::RustFFI::FfiLayerImagePrepareFacts {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
@@ -14,6 +14,7 @@ use libgfx_rust::*;
 pub enum DisplayListCommandType {
     DrawGlyphRun,
     FillRect,
+    PaintCaret,
     DrawScaledDecodedImageFrame,
     DrawRepeatedDecodedImageFrame,
     DrawRepeatedDisplayList,
@@ -73,6 +74,7 @@ impl DisplayListCommandType {
         match self {
             Self::DrawGlyphRun => "DrawGlyphRun",
             Self::FillRect => "FillRect",
+            Self::PaintCaret => "PaintCaret",
             Self::DrawScaledDecodedImageFrame => "DrawScaledDecodedImageFrame",
             Self::DrawRepeatedDecodedImageFrame => "DrawRepeatedDecodedImageFrame",
             Self::DrawRepeatedDisplayList => "DrawRepeatedDisplayList",
@@ -669,6 +671,28 @@ ffi_bytes_fields!(FillRect { rect, color });
 
 impl DisplayListCommand for FillRect {
     const COMMAND_TYPE: DisplayListCommandType = DisplayListCommandType::FillRect;
+    fn bounding_rect(&self) -> Option<IntRect> {
+        Some(self.rect)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+pub struct PaintCaret {
+    pub rect: IntRect,
+    pub color: Color,
+    pub blink_cycle_start_time_ns: i64,
+    pub should_blink: bool,
+}
+ffi_bytes_fields!(PaintCaret {
+    rect,
+    color,
+    blink_cycle_start_time_ns,
+    should_blink
+});
+
+impl DisplayListCommand for PaintCaret {
+    const COMMAND_TYPE: DisplayListCommandType = DisplayListCommandType::PaintCaret;
     fn bounding_rect(&self) -> Option<IntRect> {
         Some(self.rect)
     }

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -331,6 +331,21 @@ impl DisplayListRecorder {
         self.append_command(&FillRect { rect, color }, &[]);
     }
 
+    pub fn paint_caret(&mut self, rect: IntRect, color: Color, blink_cycle_start_time_ns: i64, should_blink: bool) {
+        if rect.is_empty() || color.alpha() == 0 {
+            return;
+        }
+        self.append_command(
+            &PaintCaret {
+                rect,
+                color,
+                blink_cycle_start_time_ns,
+                should_blink,
+            },
+            &[],
+        );
+    }
+
     pub fn fill_rect_transparent(&mut self, rect: IntRect) {
         if rect.is_empty() {
             return;

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -268,6 +268,8 @@ pub struct FfiCursorFacts {
     pub paints: bool,
     pub rect: used_values::FfiCssPixelRect,
     pub color: Color,
+    pub blink_cycle_start_time_ns: i64,
+    pub should_blink: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -488,7 +488,10 @@ pub(crate) fn paint_cursor(recorder: &mut PaintRecorder<'_>, block: NodeSlotId, 
         return;
     }
     let converter = recorder.converter;
-    recorder
-        .recorder
-        .fill_rect(converter.rounded_device_rect(CssPixelRect::from(facts.rect)), color);
+    recorder.recorder.paint_caret(
+        converter.rounded_device_rect(CssPixelRect::from(facts.rect)),
+        color,
+        facts.blink_cycle_start_time_ns,
+        facts.should_blink,
+    );
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -73,7 +73,9 @@ void CompositorState::create_context(Web::Compositor::CompositorContextId contex
         VERIFY(context_id == Web::Compositor::compositor_context_id_for_page(*page_id));
 
     auto& context = *m_contexts.ensure(context_id, [&] {
-        return make<ContextState>(page_id, web_content_client, m_canvas_surface_registry, m_async_scrolling_enabled);
+        return make<ContextState>(page_id, web_content_client, m_canvas_surface_registry, m_async_scrolling_enabled, [this, context_id](Gfx::IntRect damage_rect) {
+            schedule_caret_repaint(context_id, damage_rect);
+        });
     });
     resize_backing_stores_if_needed(context_id, context);
 }
@@ -654,6 +656,17 @@ void CompositorState::schedule_pending_present_frame_if_unblocked(Web::Composito
         return;
 
     schedule_pending_present_frame(context_id, context);
+}
+
+void CompositorState::schedule_caret_repaint(Web::Compositor::CompositorContextId context_id, Gfx::IntRect damage_rect)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+    auto viewport_rect = context->viewport_rect_for_ui_overlay();
+    if (!viewport_rect.has_value())
+        return;
+    schedule_present_frame(context_id, *context, { *viewport_rect, damage_rect });
 }
 
 VSyncScheduler& CompositorState::vsync_scheduler_for_display(Optional<u64> display_id)

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -165,6 +165,7 @@ private:
     void schedule_pending_present_frame_on_vsync(Web::Compositor::CompositorContextId, ContextState&);
     void schedule_containing_context_present(ContextState&);
     void schedule_pending_present_frame_if_unblocked(Web::Compositor::CompositorContextId, ContextState&);
+    void schedule_caret_repaint(Web::Compositor::CompositorContextId, Gfx::IntRect damage_rect);
     VSyncScheduler& vsync_scheduler_for_display(Optional<u64> display_id);
     void present_pending_frames_on_vsync(Optional<u64> display_id);
     void publish_backing_stores(Web::Compositor::CompositorContextId, ContextState&, BackingStoreManager::Publication&&);

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -32,6 +32,16 @@ static void for_each_drawn_canvas(Web::Painting::DisplayList const& display_list
     });
 }
 
+template<typename Callback>
+static void for_each_caret(Web::Painting::DisplayList const& display_list, Callback callback)
+{
+    display_list.for_each_command_header([&](Web::Painting::DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        if (header.command_type != Web::Painting::DisplayListCommandType::PaintCaret)
+            return;
+        callback(header, Web::Painting::read_display_list_object<Web::Painting::PaintCaret>(payload));
+    });
+}
+
 static void set_or_append_pending_scroll_offset(
     Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets,
     Web::Compositor::AsyncScrollOffset const& scroll_offset)
@@ -86,11 +96,12 @@ static void clamp_visual_viewport_transform_to_viewport(Web::Painting::Transform
     transform.matrix[1, 3] = clamp(transform.matrix[1, 3], min_y, 0.0f);
 }
 
-ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client, Web::Painting::CanvasSurfaceRegistry const& canvas_surface_registry, bool async_scrolling_enabled)
+ContextState::ContextState(Optional<u64> page_id, CompositorStateWebContentClient& web_content_client, Web::Painting::CanvasSurfaceRegistry const& canvas_surface_registry, bool async_scrolling_enabled, Function<void(Gfx::IntRect)> schedule_caret_repaint)
     : m_web_content_client(web_content_client)
     , m_canvas_surface_registry(canvas_surface_registry)
     , m_page_id(page_id)
     , m_async_scrolling_enabled(async_scrolling_enabled)
+    , m_schedule_caret_repaint(move(schedule_caret_repaint))
 {
     if (page_id.has_value())
         m_presents_to_client = true;
@@ -100,6 +111,10 @@ ContextState::~ContextState()
 {
     discard_sampled_visual_context_tree();
     stop_backing_store_shrink_timer();
+    if (m_caret_blink_timer) {
+        m_caret_blink_timer->on_timeout = {};
+        m_caret_blink_timer->stop();
+    }
 }
 
 bool ContextState::is_owned_by(CompositorStateWebContentClient const& web_content_client) const
@@ -159,6 +174,7 @@ void ContextState::install_display_list_update(
     m_visual_animation_sample_time_ns.clear();
     m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
+    update_caret_blink_timer();
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(m_visual_context_tree->visual_viewport_transform(), *m_async_visual_viewport_transform))
         m_async_visual_viewport_transform.clear();
 
@@ -193,6 +209,71 @@ void ContextState::install_display_list_update(
     rebuild_wheel_hit_test_targets();
     m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
     m_has_async_scrolling_state = true;
+}
+
+void ContextState::update_caret_blink_timer()
+{
+    Optional<i64> blink_cycle_start_time_ns;
+    for_each_caret(*m_display_list, [&](auto const&, auto const& caret) {
+        if (caret.should_blink)
+            blink_cycle_start_time_ns = caret.blink_cycle_start_time_ns;
+    });
+
+    if (blink_cycle_start_time_ns == m_caret_blink_cycle_start_time_ns)
+        return;
+    m_caret_blink_cycle_start_time_ns = blink_cycle_start_time_ns;
+
+    if (m_caret_blink_timer)
+        m_caret_blink_timer->stop();
+    if (!m_caret_blink_cycle_start_time_ns.has_value() || !m_schedule_caret_repaint)
+        return;
+
+    if (!m_caret_blink_timer) {
+        m_caret_blink_timer = Core::Timer::create_single_shot(500, [this] {
+            auto damage_rect = caret_damage_rect();
+            if (!damage_rect.is_empty())
+                m_schedule_caret_repaint(damage_rect);
+            schedule_next_caret_blink();
+        });
+    }
+    schedule_next_caret_blink();
+}
+
+void ContextState::schedule_next_caret_blink()
+{
+    if (!m_caret_blink_cycle_start_time_ns.has_value() || !m_caret_blink_timer)
+        return;
+
+    auto now_ns = MonotonicTime::now().nanoseconds();
+    auto elapsed_ns = now_ns > *m_caret_blink_cycle_start_time_ns
+        ? now_ns - *m_caret_blink_cycle_start_time_ns
+        : 0;
+    auto delay_ns = Web::Painting::caret_blink_interval_ns - elapsed_ns % Web::Painting::caret_blink_interval_ns;
+    auto delay_ms = max(static_cast<int>((delay_ns + 999'999) / 1'000'000), 1);
+    m_caret_blink_timer->restart(delay_ms);
+}
+
+Gfx::IntRect ContextState::caret_damage_rect()
+{
+    if (!m_display_list || !m_visual_context_tree.has_value())
+        return {};
+
+    auto const& visual_context_tree = visual_context_tree_for_compositing();
+    Gfx::IntRect damage_rect;
+    for_each_caret(*m_display_list, [&](auto const& header, auto const& caret) {
+        if (!caret.should_blink)
+            return;
+        auto rect = visual_context_tree.transform_rect_to_viewport(header.context.spatial, header.bounding_rect.template to_type<float>(), m_scroll_state_snapshot);
+        if (!isfinite(rect.x()) || !isfinite(rect.y()) || !isfinite(rect.width()) || !isfinite(rect.height())) {
+            damage_rect = { {}, m_viewport_size };
+            return;
+        }
+        rect.intersect(Gfx::IntRect { {}, m_viewport_size }.to_type<float>());
+        if (!rect.is_empty())
+            damage_rect.unite(Gfx::enclosing_int_rect(rect).inflated(1, 1, 1, 1));
+    });
+    damage_rect.intersect({ {}, m_viewport_size });
+    return damage_rect;
 }
 
 void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualContextTree visual_context_tree, Web::Painting::DisplayListResourceTransaction&& resource_transaction)
@@ -381,7 +462,7 @@ ContextState::ContextUpdateResult ContextState::handle_pinch_event(Web::PinchEve
 
     return {
         .accepted = true,
-        .frame_to_present = PendingFrame::repainting_changes(m_async_scrolling_viewport_rect),
+        .frame_to_present = PendingFrame::repainting_everything(m_async_scrolling_viewport_rect),
         .should_request_rendering_update = false,
     };
 }

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -86,7 +86,7 @@ public:
         Gfx::IntRect damage_rect;
     };
 
-    ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, Web::Painting::CanvasSurfaceRegistry const&, bool async_scrolling_enabled);
+    ContextState(Optional<u64> page_id, CompositorStateWebContentClient&, Web::Painting::CanvasSurfaceRegistry const&, bool async_scrolling_enabled, Function<void(Gfx::IntRect)> schedule_caret_repaint = {});
     ~ContextState();
 
     bool is_owned_by(CompositorStateWebContentClient const&) const;
@@ -132,6 +132,7 @@ public:
     Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_testing() const { return current_visual_context_tree(); }
     bool has_sampled_visual_animation_values_for_testing() const { return m_sampled_visual_context_tree.has_value(); }
     u64 visual_context_tree_copy_count_for_testing() const { return m_visual_context_tree_copy_count; }
+    Gfx::IntRect caret_damage_rect_for_testing() { return caret_damage_rect(); }
     ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Web::Compositor::SnapContainerHandling);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
 
@@ -214,6 +215,9 @@ private:
     Gfx::IntRect frame_damage_for(PendingFrame const&);
     Gfx::IntRect damage_since_last_raster(Gfx::IntSize viewport_size);
     void remember_rasterized_frame(Gfx::IntSize viewport_size);
+    void update_caret_blink_timer();
+    void schedule_next_caret_blink();
+    Gfx::IntRect caret_damage_rect();
 
     CompositorStateWebContentClient& m_web_content_client;
     Web::Painting::CanvasSurfaceRegistry const& m_canvas_surface_registry;
@@ -261,6 +265,9 @@ private:
     Optional<WebView::PausedDebuggerOverlayAction> m_paused_debugger_overlay_hovered_action;
     Web::Compositor::WindowResizingInProgress m_window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
+    Function<void(Gfx::IntRect)> m_schedule_caret_repaint;
+    RefPtr<Core::Timer> m_caret_blink_timer;
+    Optional<i64> m_caret_blink_cycle_start_time_ns;
     Optional<u64> m_display_id;
     double m_display_refresh_rate { 60.0 };
     Web::Compositor::ContextVisibility m_visibility { Web::Compositor::ContextVisibility::Visible };

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -57,6 +57,25 @@ static bool spin_event_loop_until(Core::EventLoop& event_loop, int timeout_in_mi
     return !timed_out;
 }
 
+TEST_CASE(caret_blink_phase_is_sampled_from_its_web_content_reset_time)
+{
+    Web::Painting::PaintCaret caret {
+        .rect = { 1, 2, 1, 10 },
+        .color = Gfx::Color::Black,
+        .blink_cycle_start_time_ns = 1'000'000'000,
+        .should_blink = true,
+    };
+
+    EXPECT(Web::Painting::caret_is_visible_at_time(caret, 1'000'000'000));
+    EXPECT(Web::Painting::caret_is_visible_at_time(caret, 1'499'999'999));
+    EXPECT(!Web::Painting::caret_is_visible_at_time(caret, 1'500'000'000));
+    EXPECT(!Web::Painting::caret_is_visible_at_time(caret, 1'999'999'999));
+    EXPECT(Web::Painting::caret_is_visible_at_time(caret, 2'000'000'000));
+
+    caret.should_blink = false;
+    EXPECT(Web::Painting::caret_is_visible_at_time(caret, NumericLimits<i64>::max()));
+}
+
 // Round-trips a freshly built display list through the IPC encoder, so the context receives it
 // the way the compositor process would.
 static NonnullRefPtr<Web::Painting::DisplayList> decode_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, ByteBuffer command_bytes, Optional<Gfx::Color> surface_clear_color = {}, Optional<Web::Painting::DisplayList::AsyncScrollingMetadata> async_scrolling_metadata = {})
@@ -86,6 +105,48 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting
         append_display_list_command(command_bytes, command, command.rect, context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color);
+}
+
+TEST_CASE(caret_damage_uses_the_sampled_visual_context_tree)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto visual_context_tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+            .visual_context_node_indices = { spatial.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+                { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 20 } } } },
+            },
+        },
+    });
+
+    Web::Painting::PaintCaret caret {
+        .rect = { 10, 10, 1, 10 },
+        .color = Gfx::Color::Black,
+        .blink_cycle_start_time_ns = anchor.nanoseconds(),
+        .should_blink = true,
+    };
+    ByteBuffer command_bytes;
+    append_display_list_command(command_bytes, caret, caret.rect, { spatial, Web::Painting::NO_FRAME_NODE });
+
+    context.viewport_size_updated({ 100, 100 }, Web::Compositor::WindowResizingInProgress::No);
+    context.install_display_list_update(
+        decode_display_list(visual_context_tree, move(command_bytes)),
+        visual_context_tree,
+        {});
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+
+    EXPECT_EQ(context.caret_damage_rect_for_testing(), Gfx::IntRect(19, 9, 3, 12));
 }
 
 TEST_CASE(visual_context_trees_round_trip_through_ipc_and_reject_corrupted_bytes)
@@ -391,6 +452,8 @@ TEST_CASE(pinch_zoom_copies_the_visual_context_tree_once_per_update)
             .scale_delta = 0.1,
         });
         EXPECT(result.accepted);
+        VERIFY(result.frame_to_present.has_value());
+        EXPECT_EQ(result.frame_to_present->forced_damage_rect, (Gfx::IntRect { 0, 0, 100, 100 }));
         EXPECT_EQ(context.visual_context_tree_copy_count_for_testing(), update);
     }
 }

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -6,6 +6,6 @@ AccumulatedVisualContext Tree:
     [f0 in s0] effects=[]
 
 DisplayList:
-FillRect@s1/f0 rect=[8,8 1x16] color=rgb(0, 0, 0)
+PaintCaret@s1/f0 rect=[8,8 1x16] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[6,6 104x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -11,6 +11,6 @@ DisplayList:
 FillRect@s1/f0 rect=[8,8 106x20] color=rgb(255, 255, 255)
 FillPath@s1/f0 path_bounding_rect=[8,8 106x20]
 DrawGlyphRun@s1/f2 rect=[11,10 37x16] translation=[11,22.796875] color=rgb(0, 0, 0)
-FillRect@s1/f2 rect=[11,10 1x16] color=rgb(0, 0, 0)
+PaintCaret@s1/f2 rect=[11,10 1x16] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[6,6 110x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -17,6 +17,6 @@ FillPath@s1/f0 path_bounding_rect=[222,8 206x20]
 DrawGlyphRun@s1/f0 rect=[214,13 8x16] translation=[214,25.796875] color=rgb(0, 0, 0)
 DrawGlyphRun@s1/f2 rect=[11,10 28x16] translation=[11,22.796875] color=rgb(0, 0, 0)
 DrawGlyphRun@s1/f4 rect=[225,10 28x16] translation=[225,22.796875] color=rgb(0, 0, 0)
-FillRect@s1/f4 rect=[225,10 1x16] color=rgb(0, 0, 0)
+PaintCaret@s1/f4 rect=[225,10 1x16] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[220,6 210x24]
 

--- a/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
+++ b/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
@@ -85,7 +85,7 @@ DisplayList:
 FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
 FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
 DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
-FillRect@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0)
+PaintCaret@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
 DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
 DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
@@ -129,7 +129,7 @@ DisplayList:
 FillRect@s1/f0 rect=[0,0 86x22] color=rgb(255, 255, 255)
 FillPath@s1/f0 path_bounding_rect=[0,0 86x22]
 DrawGlyphRun@s1/f1 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
-FillRect@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0)
+PaintCaret@s1/f1 rect=[22,3 1x16] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[-2,-2 90x26]
 DrawLine@s1/f0 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
 DrawLine@s1/f0 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -10,7 +10,7 @@ DisplayList:
 FillRect@s1/f0 rect=[8,8 106x32] color=rgb(255, 255, 255)
 FillPath@s1/f0 path_bounding_rect=[8,8 106x32]
 DrawGlyphRun@s1/f1 rect=[11,11 30x13] translation=[11,21.390625] color=rgb(0, 0, 0)
-FillRect@s1/f1 rect=[11,11 1x13] color=rgb(0, 0, 0)
+PaintCaret@s1/f1 rect=[11,11 1x13] color=rgb(0, 0, 0) should_blink=false
 FillPath@s1/f0 path_bounding_rect=[6,6 110x36]
 DrawLine@s1/f0 from=[109,37] to=[111,35] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
 DrawLine@s1/f0 from=[108,37] to=[111,34] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid

--- a/Tests/LibWeb/Text/expected/input-scrolls-caret-width-into-view.txt
+++ b/Tests/LibWeb/Text/expected/input-scrolls-caret-width-into-view.txt
@@ -1,3 +1,3 @@
 scrolls to caret: true
-rect=[18,8 1x16] color=rgb(0, 0, 0)
+rect=[18,8 1x16] color=rgb(0, 0, 0) should_blink=false
 RTL caret needs no scroll: true

--- a/Tests/LibWeb/Text/input/input-scrolls-caret-width-into-view.html
+++ b/Tests/LibWeb/Text/input/input-scrolls-caret-width-into-view.html
@@ -18,7 +18,7 @@ test(() => {
     const innerText = internals.getShadowRoot(input).querySelector("div > div");
     println(`scrolls to caret: ${innerText.scrollLeft > 0}`);
     for (const line of internals.dumpDisplayList().split("\n")) {
-        if (line.includes("FillRect") && line.includes("1x16") && line.includes("rgb(0, 0, 0)"))
+        if (line.includes("PaintCaret") && line.includes("1x16") && line.includes("rgb(0, 0, 0)"))
             println(line.slice(line.indexOf("rect=")));
     }
 


### PR DESCRIPTION
Replace WebContent's cursor timer with a caret display-list command that carries the blink-cycle anchor. Let the compositor sample caret visibility and schedule narrowly damaged frames at each blink boundary. This keeps the phase steady while the page main thread is busy.

Compute caret damage from the same composited visual tree used for rasterization so blinking follows async pinch and animation transforms. Repaint the full viewport for root pinch transforms so preserved GPU targets cannot retain pixels from intermediate zoom frames. Keep test-mode carets deterministic and cover sampled damage bounds.