### PR TITLE
LibWeb: Resolve 3D plane transforms in visual context dependency order

### DIFF
--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -96,6 +96,7 @@ struct ReplayDriver<'a, Painter: ReplayPainter> {
     painter: &'a mut Painter,
     palette: ReplayPaletteStorage,
     frame_has_empty_effective_clip: Vec<bool>,
+    spatial_dependency_order: Vec<u32>,
     tree_has_sorting_contexts: bool,
     replay_base_matrix: FloatMatrix4x4,
     // The palette entry the canvas matrix currently equals, if known; popping a frame resets the
@@ -141,6 +142,7 @@ fn replay_mask_of(mask: &crate::painting::visual_context::MaskData) -> ReplayMas
 
 fn fill_replay_palette_in_dependency_order(
     tree: &VisualContextTree,
+    spatial_dependency_order: &[u32],
     scroll_offsets: &[FloatPoint],
     replay_base_matrix: FloatMatrix4x4,
     palette: &mut ReplayPaletteStorage,
@@ -160,7 +162,7 @@ fn fill_replay_palette_in_dependency_order(
     palette.backface_culled.resize(spatial_nodes.len(), false);
     palette.flattens_inherited_transform.clear();
     palette.flattens_inherited_transform.resize(spatial_nodes.len(), false);
-    for index in tree.spatial_dependency_order() {
+    for &index in spatial_dependency_order {
         let i = index as usize;
         let node = &spatial_nodes[i];
         let parent = node.parent.0 as usize;
@@ -237,7 +239,13 @@ fn fill_replay_palette_in_dependency_order(
 
 impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
     fn build_transform_palette(&mut self, scroll_offsets: &[FloatPoint]) {
-        fill_replay_palette_in_dependency_order(self.tree, scroll_offsets, self.replay_base_matrix, &mut self.palette);
+        fill_replay_palette_in_dependency_order(
+            self.tree,
+            &self.spatial_dependency_order,
+            scroll_offsets,
+            self.replay_base_matrix,
+            &mut self.palette,
+        );
     }
 
     fn ensure_ctm_space(&mut self, spatial: SpatialNodeIndex) {
@@ -381,10 +389,11 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
         } else {
             let root_isolation_frame = tree.root_isolation_frame;
             let plane_clip_base_length = usize::from(root_isolation_frame.is_some());
-            let contexts = tree.resolve_sorting_contexts();
+            let contexts = tree.resolve_sorting_contexts_in_order(&self.spatial_dependency_order);
             let parent_by_node: Vec<SpatialNodeIndex> = tree.spatial_nodes.iter().map(|node| node.parent).collect();
             let leaf_to_context_palette = resolve_leaf_to_context_matrices(
                 &contexts,
+                &self.spatial_dependency_order,
                 &parent_by_node,
                 &self.palette.local_matrices,
                 &self.palette.flattens_inherited_transform,
@@ -455,6 +464,7 @@ pub fn replay_display_list(
         painter,
         palette: scratch.palette,
         frame_has_empty_effective_clip: scratch.frame_has_empty_effective_clip,
+        spatial_dependency_order: tree.spatial_dependency_order(),
         tree_has_sorting_contexts: tree.spatial_nodes.iter().any(|node| {
             matches!(&node.data, SpatialData::Transform(transform) if transform.sorting_context_root_index.is_some())
         }),
@@ -539,9 +549,21 @@ mod tests {
 
         let base = scale_matrix(2.0, 2.0, 1.0);
         let mut in_order_palette = ReplayPaletteStorage::default();
-        fill_replay_palette_in_dependency_order(&in_order, &[], base, &mut in_order_palette);
+        fill_replay_palette_in_dependency_order(
+            &in_order,
+            &in_order.spatial_dependency_order(),
+            &[],
+            base,
+            &mut in_order_palette,
+        );
         let mut permuted_palette = ReplayPaletteStorage::default();
-        fill_replay_palette_in_dependency_order(&permuted, &[], base, &mut permuted_palette);
+        fill_replay_palette_in_dependency_order(
+            &permuted,
+            &permuted.spatial_dependency_order(),
+            &[],
+            base,
+            &mut permuted_palette,
+        );
         let pairs = [
             (VISUAL_VIEWPORT_NODE_INDEX, VISUAL_VIEWPORT_NODE_INDEX),
             (parent, permuted_parent),

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -475,6 +475,7 @@ pub fn allocate_structural_epoch() -> u64 {
 
 pub fn resolve_leaf_to_context_matrices(
     contexts: &SortingContexts,
+    nodes_in_dependency_order: &[u32],
     parent_by_node: &[SpatialNodeIndex],
     local_matrix_by_node: &[FloatMatrix4x4],
     flattens_inherited_transform_by_node: &[bool],
@@ -482,16 +483,17 @@ pub fn resolve_leaf_to_context_matrices(
     if contexts.is_empty() {
         return Vec::new();
     }
-    let mut matrices = Vec::with_capacity(local_matrix_by_node.len());
-    for (index, local_matrix) in local_matrix_by_node.iter().enumerate() {
+    let mut matrices = vec![FloatMatrix4x4::identity(); local_matrix_by_node.len()];
+    for &index in nodes_in_dependency_order {
+        let index = index as usize;
         let context = contexts.context_by_node[index];
         if context.0 as usize == index || index == 0 {
-            matrices.push(FloatMatrix4x4::identity());
             continue;
         }
+        let local_matrix = local_matrix_by_node[index];
         let parent = parent_by_node[index].0 as usize;
         if parent == context.0 as usize {
-            matrices.push(*local_matrix);
+            matrices[index] = local_matrix;
             continue;
         }
         let mut base = matrices[parent];
@@ -505,7 +507,7 @@ pub fn resolve_leaf_to_context_matrices(
                 .unwrap_or(FloatMatrix4x4::identity())
                 .multiplied(base);
         }
-        matrices.push(base.multiplied(*local_matrix));
+        matrices[index] = base.multiplied(local_matrix);
     }
     matrices
 }
@@ -1058,7 +1060,11 @@ impl VisualContextTree {
     }
 
     pub fn resolve_sorting_contexts(&self) -> SortingContexts {
-        resolve_sorting_contexts_over_nodes(self.spatial_nodes.len(), &self.spatial_dependency_order(), |index| {
+        self.resolve_sorting_contexts_in_order(&self.spatial_dependency_order())
+    }
+
+    pub fn resolve_sorting_contexts_in_order(&self, nodes_in_dependency_order: &[u32]) -> SortingContexts {
+        resolve_sorting_contexts_over_nodes(self.spatial_nodes.len(), nodes_in_dependency_order, |index| {
             let node = &self.spatial_nodes[index];
             let sorting_context_root = if let SpatialData::Transform(transform) = &node.data {
                 transform.sorting_context_root_index
@@ -1723,11 +1729,26 @@ mod tests {
 
     fn resolve_matrices(parents: &[u32], roots: &[Option<u32>], locals: &[FloatMatrix4x4]) -> Vec<FloatMatrix4x4> {
         let dependency_order: Vec<u32> = (0..parents.len() as u32).collect();
-        let contexts = resolve_sorting_contexts_over_nodes(parents.len(), &dependency_order, |index| {
+        resolve_matrices_in_order(parents, roots, locals, &dependency_order)
+    }
+
+    fn resolve_matrices_in_order(
+        parents: &[u32],
+        roots: &[Option<u32>],
+        locals: &[FloatMatrix4x4],
+        dependency_order: &[u32],
+    ) -> Vec<FloatMatrix4x4> {
+        let contexts = resolve_sorting_contexts_over_nodes(parents.len(), dependency_order, |index| {
             (SpatialNodeIndex(parents[index]), roots[index].map(SpatialNodeIndex))
         });
         let parent_by_node: Vec<SpatialNodeIndex> = parents.iter().map(|parent| SpatialNodeIndex(*parent)).collect();
-        resolve_leaf_to_context_matrices(&contexts, &parent_by_node, locals, &vec![false; parents.len()])
+        resolve_leaf_to_context_matrices(
+            &contexts,
+            dependency_order,
+            &parent_by_node,
+            locals,
+            &vec![false; parents.len()],
+        )
     }
 
     #[test]
@@ -1757,5 +1778,32 @@ mod tests {
         assert_eq!(matrices[2], locals[2]);
         assert_eq!(matrices[3], locals[2].multiplied(locals[3]));
         assert_eq!(matrices[4], locals[3].multiplied(locals[4]));
+    }
+
+    #[test]
+    fn leaf_to_context_matrices_compose_over_a_context_root_at_a_higher_index() {
+        let locals = [
+            FloatMatrix4x4::identity(),
+            translation_matrix(0.0, 0.0, 3.0),
+            translation_matrix(0.0, 2.0, 0.0),
+            translation_matrix(1.0, 0.0, 0.0),
+        ];
+        let matrices = resolve_matrices_in_order(&[0, 2, 3, 0], &[None, None, Some(3), None], &locals, &[0, 3, 2, 1]);
+        assert_eq!(matrices[3], FloatMatrix4x4::identity());
+        assert_eq!(matrices[2], locals[2]);
+        assert_eq!(matrices[1], locals[2].multiplied(locals[1]));
+    }
+
+    #[test]
+    fn leaf_to_context_matrices_leave_a_tombstoned_slot_at_identity() {
+        let locals = [
+            FloatMatrix4x4::identity(),
+            translation_matrix(0.0, 0.0, 3.0),
+            translation_matrix(0.0, 2.0, 0.0),
+            translation_matrix(1.0, 0.0, 0.0),
+        ];
+        let matrices = resolve_matrices_in_order(&[0, 2, 3, 0], &[None, None, Some(3), None], &locals, &[0, 3, 2]);
+        assert_eq!(matrices[1], FloatMatrix4x4::identity());
+        assert_eq!(matrices[2], locals[2]);
     }
 }


### PR DESCRIPTION
Commit 44623b896d4 made visual context node references resolve in dependency order, since a rebuilt tree can place a node in a lower slot than the nodes it depends on. The transforms mapping each 3D plane into its sorting context were still resolved in slot order, so resolution could read past the end of the partially built results and crash. These transforms now follow the same dependency order. Slots left behind by removed nodes are skipped and keep an identity transform.

Fixes a crash on https://cssdoom.wtf.