### PR TITLE
LibWeb: Fix text control focus while pinch zoomed

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -384,7 +384,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
         return EventResult::Accepted;
 
     if (!chrome_widget)
-        run_mousedown_default_actions(*document, visual_viewport_position, viewport_position, button, modifiers, click_count);
+        run_mousedown_default_actions(*document, visual_viewport_position, button, modifiers, click_count);
 
     return EventResult::Handled;
 }
@@ -2260,7 +2260,7 @@ GC::Ptr<DOM::Node> EventHandler::focus_candidate_for_position(CSSPixelPoint visu
 static bool selection_contains_position(DOM::Document&, Painting::CaretPosition const&);
 #endif
 
-void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count)
+void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPixelPoint visual_viewport_position, unsigned button, unsigned modifiers, int click_count)
 {
     if (m_middle_button_scroll_handler) {
         m_middle_button_scroll_handler = nullptr;
@@ -2297,7 +2297,7 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
         return;
 #endif
 
-    auto caret_position = prepare_mouse_selection(document, visual_viewport_position, viewport_position);
+    auto caret_position = prepare_mouse_selection(document, visual_viewport_position);
     if (!caret_position.has_value())
         return;
 
@@ -2335,7 +2335,7 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
     }
 }
 
-Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position)
+Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Document& document, CSSPixelPoint visual_viewport_position)
 {
     document.update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseDown);
     if (!has_committed_root_box())
@@ -2355,7 +2355,7 @@ Optional<Painting::CaretPosition> EventHandler::prepare_mouse_selection(DOM::Doc
 
     auto focus_candidate = editing_host_before_focus;
     if (!focus_candidate)
-        focus_candidate = focus_candidate_for_position(viewport_position);
+        focus_candidate = focus_candidate_for_position(visual_viewport_position);
     if (focus_candidate)
         HTML::run_focusing_steps(focus_candidate, nullptr, HTML::FocusTrigger::Click);
     else if (auto focused_area = document.focused_area())
@@ -2417,8 +2417,7 @@ bool EventHandler::select_word_for_dictionary_lookup(CSSPixelPoint visual_viewpo
         return *dispatch_result == EventResult::Handled;
     }
 
-    auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
-    return select_word_at_position(*document, visual_viewport_position, viewport_position);
+    return select_word_at_position(*document, visual_viewport_position);
 }
 
 static bool form_control_selection_contains_position(InputEventsTarget& target, Painting::CaretPosition const& caret_position)
@@ -2461,9 +2460,9 @@ static bool selection_contains_position(DOM::Document& document, Painting::Caret
     return contains_position.value();
 }
 
-bool EventHandler::select_word_at_position(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position)
+bool EventHandler::select_word_at_position(DOM::Document& document, CSSPixelPoint visual_viewport_position)
 {
-    auto caret_position = prepare_mouse_selection(document, visual_viewport_position, viewport_position);
+    auto caret_position = prepare_mouse_selection(document, visual_viewport_position);
     if (!caret_position.has_value())
         return false;
 
@@ -2488,8 +2487,7 @@ void EventHandler::start_selection_from_preserved_mousedown(DOM::Document& docum
     if (!m_mousedown_visual_viewport_position.has_value())
         return;
 
-    auto viewport_position = document.visual_viewport()->map_to_layout_viewport(*m_mousedown_visual_viewport_position);
-    auto caret_position = prepare_mouse_selection(document, *m_mousedown_visual_viewport_position, viewport_position);
+    auto caret_position = prepare_mouse_selection(document, *m_mousedown_visual_viewport_position);
     if (!caret_position.has_value())
         return;
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -124,20 +124,20 @@ private:
     Optional<Target> target_for_mouse_position(CSSPixelPoint position);
     GC::Ptr<DOM::Node> focus_candidate_for_position(CSSPixelPoint) const;
 
-    void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
+    void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
 
     void maybe_show_context_menu(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
     bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
-    Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
+    Optional<Painting::CaretPosition> prepare_mouse_selection(DOM::Document&, CSSPixelPoint visual_viewport_position);
     bool initiate_character_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect, bool shift_held);
     bool initiate_word_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool initiate_paragraph_selection(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
     bool select_context_menu_text(DOM::Document&, CSSPixelPoint visual_viewport_position);
     bool select_context_menu_url_token(DOM::Document&, Painting::CaretPosition const&, CSS::UserSelect);
 #if defined(AK_OS_MACOS)
-    bool select_word_at_position(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position);
+    bool select_word_at_position(DOM::Document&, CSSPixelPoint visual_viewport_position);
     void start_selection_from_preserved_mousedown(DOM::Document&);
     void finish_selection_from_preserved_mousedown(DOM::Document&, CSSPixelPoint visual_viewport_position);
 #endif

--- a/Tests/LibWeb/Text/expected/pinch-zoom-text-control-caret-placement.txt
+++ b/Tests/LibWeb/Text/expected/pinch-zoom-text-control-caret-placement.txt
@@ -1,0 +1,2 @@
+focused: true
+positions match: true

--- a/Tests/LibWeb/Text/input/pinch-zoom-text-control-caret-placement.html
+++ b/Tests/LibWeb/Text/input/pinch-zoom-text-control-caret-placement.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    input {
+        display: block;
+        margin: 40px 100px;
+        width: 300px;
+        font: 16px monospace;
+    }
+</style>
+<input value="abcdefghijklmnopqrstuvwxyz">
+<input value="abcdefghijklmnopqrstuvwxyz">
+<script>
+test(() => {
+    const inputs = document.querySelectorAll("input");
+    const pointInside = input => {
+        const rect = input.getBoundingClientRect();
+        return {
+            x: rect.left + 100,
+            y: rect.top + rect.height / 2,
+        };
+    };
+
+    const unzoomedPoint = pointInside(inputs[0]);
+    internals.click(unzoomedPoint.x, unzoomedPoint.y);
+    const unzoomedPosition = inputs[0].selectionStart;
+
+    internals.pinch(200, 150, 1.0);
+    const viewport = window.visualViewport;
+    const layoutPoint = pointInside(inputs[1]);
+    const visualPoint = {
+        x: (layoutPoint.x - viewport.offsetLeft) * viewport.scale,
+        y: (layoutPoint.y - viewport.offsetTop) * viewport.scale,
+    };
+    internals.click(visualPoint.x, visualPoint.y);
+
+    println(`focused: ${document.activeElement === inputs[1]}`);
+    println(`positions match: ${inputs[1].selectionStart === unzoomedPosition}`);
+});
+</script>


### PR DESCRIPTION
Use visual viewport coordinates when hit testing for the focus candidate during mouse selection. Passing layout viewport coordinates applied the visual viewport transform twice, so clicks on unfocused text controls could miss them and leave the caret at the wrong position.

Add a regression test comparing equivalent unzoomed and zoomed clicks.