### PR TITLE
LibWeb: Notify the rejection tracker when marking a promise as handled

### DIFF
--- a/Libraries/LibWeb/WebIDL/Promise.cpp
+++ b/Libraries/LibWeb/WebIDL/Promise.cpp
@@ -263,6 +263,18 @@ void mark_promise_as_handled(Promise const& promise)
 {
     // To mark as handled a Promise<T> promise, set promise.[[Promise]].[[PromiseIsHandled]] to true.
     auto& promise_object = as<JS::Promise>(*promise.promise());
+
+    // AD-HOC: If the promise was already rejected, tell the host it is now handled, matching what
+    //         PerformPromiseThen does when a handler is attached to a rejected promise. This pulls the
+    //         promise out of the about-to-be-notified rejected promises list, so specs that reject a
+    //         promise and then mark it as handled (the Streams API does this on every reader and writer
+    //         release) don't leave a trail of queued unhandled-rejection notification tasks behind.
+    if (promise_object.state() == JS::Promise::State::Rejected && !promise_object.is_handled()) {
+        auto& vm = promise_object.vm();
+        if (vm.host_promise_rejection_tracker)
+            vm.host_promise_rejection_tracker(promise_object, JS::Promise::RejectionOperation::Handle);
+    }
+
     promise_object.set_is_handled();
 }
 


### PR DESCRIPTION
WebIDL's mark-as-handled only set [[PromiseIsHandled]], so a promise that was rejected and then marked as handled stayed in the global's about-to-be-notified rejected promises list. Each one queued an unhandled-rejection notification task that would find the promise handled and do nothing.

The Streams API does reject-then-mark-handled on every reader and writer release, and stream-heavy pages pay for it: loading nytimes.com left 1878 rejected promises in the list (mostly "Writer's stream lock has been released" and "Reader has been released" TypeErrors), queueing 1108 no-op notification tasks in 30 seconds. Other engines avoid this by marking such promises handled before rejecting them.

Invoke HostPromiseRejectionTracker with the "handle" operation when marking an already-rejected, not-yet-handled promise as handled, the same call PerformPromiseThen makes when a handler is attached to a rejected promise. This removes the promise from the notification list immediately: the same page now queues 1 notification task instead of 1108.