### PR TITLE
LibWebView+Compositor: Isolate compositor font IPC

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -34,6 +34,7 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/AutocompleteService.h>
 #include <LibWebView/CompositorClient.h>
+#include <LibWebView/CompositorFontServiceConnection.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/FaviconStore.h>
 #include <LibWebView/FontService.h>
@@ -1424,7 +1425,10 @@ ErrorOr<void> Application::launch_services()
 ErrorOr<void> Application::launch_compositor_process()
 {
     VERIFY(!m_compositor_client);
+    VERIFY(!m_compositor_font_service_connection);
     m_compositor_client = TRY(WebView::launch_compositor_process());
+    m_compositor_font_service_connection = TRY(CompositorFontServiceConnection::create(*m_font_service));
+    m_compositor_client->async_set_font_service_transport(m_compositor_font_service_connection->take_transport_handle());
     m_compositor_client->on_death = [this]() {
         handle_compositor_process_death();
     };
@@ -1450,6 +1454,7 @@ void Application::notify_compositor_gpu_presentation_unavailable()
 void Application::handle_compositor_process_death()
 {
     m_compositor_client = nullptr;
+    m_compositor_font_service_connection = nullptr;
 
     if (Core::EventLoop::current().was_exit_requested())
         return;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -498,6 +498,8 @@ private:
     RefPtr<WasmCompilerClient::Client> m_wasm_compiler_client;
 #endif
     RefPtr<CompositorClient> m_compositor_client;
+    // This must be destroyed before m_font_service, which its IPC thread accesses.
+    RefPtr<CompositorFontServiceConnection> m_compositor_font_service_connection;
     bool m_reported_compositor_gpu_presentation_unavailable { false };
     size_t m_compositor_restart_count { 0 };
     enum class CompositorRecoveryState {

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     CanonicalTraversable.cpp
     BrowserProcess.cpp
     CompositorClient.cpp
+    CompositorFontServiceConnection.cpp
     CompositorConnection.cpp
     CompositorHostBase.cpp
     ConsoleOutput.cpp
@@ -92,6 +93,8 @@ set(GENERATED_SOURCES
     ${GENERATED_SOURCES}
     ../../Services/Compositor/CompositorControlClientEndpoint.h
     ../../Services/Compositor/CompositorControlServerEndpoint.h
+    ../../Services/Compositor/CompositorFontClientEndpoint.h
+    ../../Services/Compositor/CompositorFontServerEndpoint.h
     ../../Services/Compositor/CompositorWebContentClientEndpoint.h
     ../../Services/Compositor/CompositorWebContentServerEndpoint.h
     ../../Services/RequestServer/RequestClientEndpoint.h
@@ -108,6 +111,8 @@ set(GENERATED_SOURCES
 
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorControlClient.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorControlClientEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorControlServer.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorControlServerEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorFontClient.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorFontClientEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorFontServer.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorFontServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorWebContentClient.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorWebContentClientEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorWebContentServer.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorWebContentServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentClientEndpoint.h)

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -8,36 +8,9 @@
 
 #include <LibCore/EventLoop.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/FontService.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
-
-Messages::CompositorControlClient::OpenSystemFontResponse CompositorClient::open_system_font(u64 generation, u64 face_id)
-{
-    auto font = Application::font_service().open_font(generation, face_id);
-    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
-}
-
-Messages::CompositorControlClient::MatchSystemFontResponse CompositorClient::match_system_font(String family, u16 weight, u16 width, u8 slope)
-{
-    auto font = Application::font_service().match_font(family, weight, width, slope);
-    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
-}
-
-Messages::CompositorControlClient::MatchSystemFontForCodePointResponse CompositorClient::match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
-{
-    auto font = Application::font_service().match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
-    return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
-}
-
-Messages::CompositorControlClient::ResolveGenericFontResponse CompositorClient::resolve_generic_font(String family, u16 weight, u8 slope)
-{
-    auto resolved = Application::font_service().resolve_generic_family(family, weight, slope);
-    if (!resolved.has_value())
-        return Optional<String> {};
-    return Optional<String> { resolved->to_string() };
-}
 
 CompositorClient::CompositorClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<CompositorControlClientEndpoint, CompositorControlServerEndpoint>(*this, move(transport))

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -32,11 +32,6 @@ public:
 private:
     virtual void die() override;
 
-    virtual Messages::CompositorControlClient::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override;
-    virtual Messages::CompositorControlClient::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override;
-    virtual Messages::CompositorControlClient::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override;
-    virtual Messages::CompositorControlClient::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override;
-
     virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) override;
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 };

--- a/Libraries/LibWebView/CompositorFontServiceConnection.cpp
+++ b/Libraries/LibWebView/CompositorFontServiceConnection.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/CompositorFontClientEndpoint.h>
+#include <Compositor/CompositorFontServerEndpoint.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/System.h>
+#include <LibGfx/Font/Font.h>
+#include <LibIPC/ConnectionFromClient.h>
+#include <LibIPC/Transport.h>
+#include <LibThreading/Thread.h>
+#include <LibWebView/CompositorFontServiceConnection.h>
+#include <LibWebView/FontService.h>
+
+namespace WebView {
+
+class FontServerConnection final
+    : public IPC::ConnectionFromClient<CompositorFontClientEndpoint, CompositorFontServerEndpoint> {
+public:
+    FontServerConnection(NonnullOwnPtr<IPC::Transport> transport, FontService& font_service)
+        : IPC::ConnectionFromClient<CompositorFontClientEndpoint, CompositorFontServerEndpoint>(*this, move(transport), 1)
+        , m_font_service(font_service)
+    {
+    }
+
+private:
+    virtual void die() override
+    {
+        Core::EventLoop::current().quit(0);
+    }
+
+    virtual Messages::CompositorFontServer::InitTransportResponse init_transport([[maybe_unused]] int peer_pid) override
+    {
+#ifdef AK_OS_WINDOWS
+        m_transport->set_peer_pid(peer_pid);
+        return Core::System::getpid();
+#endif
+        VERIFY_NOT_REACHED();
+    }
+
+    virtual Messages::CompositorFontServer::OpenSystemFontResponse open_system_font(u64 generation, u64 face_id) override
+    {
+        auto font = m_font_service.open_font(generation, face_id);
+        return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+    }
+
+    virtual Messages::CompositorFontServer::MatchSystemFontResponse match_system_font(String family, u16 weight, u16 width, u8 slope) override
+    {
+        auto font = m_font_service.match_font(family, weight, width, slope);
+        return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+    }
+
+    virtual Messages::CompositorFontServer::MatchSystemFontForCodePointResponse match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) override
+    {
+        auto font = m_font_service.match_font_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
+        return { font.face_id, font.ttc_index, to_underlying(font.format), move(font.file) };
+    }
+
+    virtual Messages::CompositorFontServer::ResolveGenericFontResponse resolve_generic_font(String family, u16 weight, u8 slope) override
+    {
+        auto resolved = m_font_service.resolve_generic_family(family, weight, slope);
+        if (!resolved.has_value())
+            return Optional<String> {};
+        return Optional<String> { resolved->to_string() };
+    }
+
+    FontService& m_font_service;
+};
+
+ErrorOr<NonnullRefPtr<CompositorFontServiceConnection>> CompositorFontServiceConnection::create(FontService& font_service)
+{
+    auto connection = adopt_ref(*new CompositorFontServiceConnection(font_service));
+
+    Optional<Error> initialization_error;
+    {
+        Sync::MutexLocker locker(connection->m_mutex);
+        connection->m_initialization_condition.wait_while([&] { return !connection->m_initialized; });
+        initialization_error = move(connection->m_initialization_error);
+    }
+
+    if (initialization_error.has_value())
+        return initialization_error.release_value();
+    return connection;
+}
+
+CompositorFontServiceConnection::CompositorFontServiceConnection(FontService& font_service)
+    : m_font_service(font_service)
+    , m_thread(Threading::Thread::construct("Compositor font IPC"sv, [this] {
+        return thread_main();
+    }))
+{
+    m_thread->start();
+}
+
+CompositorFontServiceConnection::~CompositorFontServiceConnection()
+{
+    RefPtr<Core::WeakEventLoopReference> event_loop;
+    {
+        Sync::MutexLocker locker(m_mutex);
+        event_loop = m_event_loop;
+    }
+
+    if (event_loop) {
+        if (auto strong_event_loop = event_loop->take()) {
+            strong_event_loop->deferred_invoke([] {
+                Core::EventLoop::current().quit(0);
+            });
+        }
+    }
+
+    if (m_thread->needs_to_be_joined())
+        (void)m_thread->join();
+}
+
+IPC::TransportHandle CompositorFontServiceConnection::take_transport_handle()
+{
+    Sync::MutexLocker locker(m_mutex);
+    VERIFY(m_transport_handle.has_value());
+    return m_transport_handle.release_value();
+}
+
+intptr_t CompositorFontServiceConnection::thread_main()
+{
+    Core::EventLoop event_loop;
+    auto paired_or_error = IPC::Transport::create_paired();
+    if (paired_or_error.is_error()) {
+        Sync::MutexLocker locker(m_mutex);
+        m_initialization_error = paired_or_error.release_error();
+        m_initialized = true;
+        m_initialization_condition.broadcast();
+        return 1;
+    }
+
+    auto paired = paired_or_error.release_value();
+    auto connection = adopt_ref(*new FontServerConnection(move(paired.local), m_font_service));
+
+    {
+        Sync::MutexLocker locker(m_mutex);
+        m_event_loop = Core::EventLoop::current_weak();
+        m_transport_handle = move(paired.remote_handle);
+        m_initialized = true;
+        m_initialization_condition.broadcast();
+    }
+
+    auto result = event_loop.exec();
+    if (connection->is_open())
+        connection->shutdown();
+
+    {
+        Sync::MutexLocker locker(m_mutex);
+        m_event_loop.clear();
+    }
+    return result;
+}
+
+}

--- a/Libraries/LibWebView/CompositorFontServiceConnection.h
+++ b/Libraries/LibWebView/CompositorFontServiceConnection.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/RefPtr.h>
+#include <LibCore/Forward.h>
+#include <LibIPC/TransportHandle.h>
+#include <LibSync/ConditionVariable.h>
+#include <LibSync/Mutex.h>
+#include <LibThreading/Forward.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+class WEBVIEW_API CompositorFontServiceConnection final : public AtomicRefCounted<CompositorFontServiceConnection> {
+    AK_MAKE_NONCOPYABLE(CompositorFontServiceConnection);
+    AK_MAKE_NONMOVABLE(CompositorFontServiceConnection);
+
+public:
+    static ErrorOr<NonnullRefPtr<CompositorFontServiceConnection>> create(FontService&);
+    ~CompositorFontServiceConnection();
+
+    IPC::TransportHandle take_transport_handle();
+
+private:
+    explicit CompositorFontServiceConnection(FontService&);
+    intptr_t thread_main();
+
+    FontService& m_font_service;
+    NonnullRefPtr<Threading::Thread> m_thread;
+    Sync::Mutex m_mutex;
+    Sync::ConditionVariable m_initialization_condition { m_mutex };
+    bool m_initialized { false };
+    Optional<Error> m_initialization_error;
+    Optional<IPC::TransportHandle> m_transport_handle;
+    RefPtr<Core::WeakEventLoopReference> m_event_loop;
+};
+
+}

--- a/Libraries/LibWebView/FontService.cpp
+++ b/Libraries/LibWebView/FontService.cpp
@@ -54,6 +54,7 @@ ErrorOr<void> FontService::wait_until_ready()
 
 ErrorOr<FontCatalogDescriptor> FontService::clone_catalog()
 {
+    Sync::MutexLocker locker(m_mutex);
     TRY(wait_until_ready());
     return FontCatalogDescriptor {
         .file = TRY(IPC::File::clone_fd(m_catalog_file.fd())),
@@ -133,7 +134,15 @@ ErrorOr<IPC::File> FontService::create_immutable_font_data(ReadonlyBytes bytes)
 
 Gfx::BrokeredFont FontService::open_font(u64 generation, u64 face_id)
 {
-    if (wait_until_ready().is_error() || generation != m_generation || face_id == 0)
+    Sync::MutexLocker locker(m_mutex);
+    if (wait_until_ready().is_error())
+        return {};
+    return open_font_without_lock(generation, face_id);
+}
+
+Gfx::BrokeredFont FontService::open_font_without_lock(u64 generation, u64 face_id)
+{
+    if (generation != m_generation || face_id == 0)
         return {};
 
     if (auto source = m_font_sources.get(face_id); source.has_value()) {
@@ -165,7 +174,7 @@ Gfx::BrokeredFont FontService::open_font(u64 generation, u64 face_id)
 Gfx::BrokeredFont FontService::materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia> typeface, String cache_key)
 {
     if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
-        return open_font(m_generation, *face_id);
+        return open_font_without_lock(m_generation, *face_id);
 
     auto file = create_immutable_font_data(typeface->font_data());
     if (file.is_error())
@@ -179,16 +188,17 @@ Gfx::BrokeredFont FontService::materialize_typeface(NonnullRefPtr<Gfx::TypefaceS
                                            .format = Gfx::FontFileFormat::OpenType,
                                        });
     m_dynamic_match_cache.set(move(cache_key), face_id);
-    return open_font(m_generation, face_id);
+    return open_font_without_lock(m_generation, face_id);
 }
 
 Gfx::BrokeredFont FontService::match_font(String const& family, u16 weight, u16 width, u8 slope)
 {
+    Sync::MutexLocker locker(m_mutex);
     if (wait_until_ready().is_error())
         return {};
     auto cache_key = MUST(String::formatted("family:{}:{}:{}:{}", family, weight, width, slope));
     if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
-        return open_font(m_generation, *face_id);
+        return open_font_without_lock(m_generation, *face_id);
 
     auto typeface = Gfx::TypefaceSkia::match_family_style(family.bytes_as_string_view(), weight, width, slope);
     if (typeface.is_error() || !typeface.value())
@@ -198,11 +208,12 @@ Gfx::BrokeredFont FontService::match_font(String const& family, u16 weight, u16 
 
 Gfx::BrokeredFont FontService::match_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji)
 {
+    Sync::MutexLocker locker(m_mutex);
     if (wait_until_ready().is_error())
         return {};
     auto cache_key = MUST(String::formatted("character:{}:{}:{}:{}:{}", code_point, weight, width, slope, prefer_color_emoji));
     if (auto face_id = m_dynamic_match_cache.get(cache_key); face_id.has_value())
-        return open_font(m_generation, *face_id);
+        return open_font_without_lock(m_generation, *face_id);
 
     auto typeface = Gfx::TypefaceSkia::find_typeface_for_code_point(code_point, weight, width, slope, prefer_color_emoji);
     if (typeface.is_error() || !typeface.value())
@@ -212,6 +223,7 @@ Gfx::BrokeredFont FontService::match_font_for_code_point(u32 code_point, u16 wei
 
 Optional<FlyString> FontService::resolve_generic_family(String const& family, u16 weight, u8 slope)
 {
+    Sync::MutexLocker locker(m_mutex);
     if (wait_until_ready().is_error())
         return {};
     return Gfx::TypefaceSkia::resolve_generic_family(family.bytes_as_string_view(), weight, slope);

--- a/Libraries/LibWebView/FontService.h
+++ b/Libraries/LibWebView/FontService.h
@@ -12,6 +12,7 @@
 #include <LibGfx/Font/FontCatalog.h>
 #include <LibGfx/Font/SharedFontProvider.h>
 #include <LibGfx/Font/TypefaceSkia.h>
+#include <LibSync/Mutex.h>
 #include <LibThreading/Thread.h>
 #include <LibWebView/Export.h>
 
@@ -57,6 +58,7 @@ private:
     ErrorOr<void> wait_until_ready();
     ErrorOr<IPC::File> create_immutable_font_data(ReadonlyBytes);
     Gfx::BrokeredFont materialize_typeface(NonnullRefPtr<Gfx::TypefaceSkia>, String cache_key);
+    Gfx::BrokeredFont open_font_without_lock(u64 generation, u64 face_id);
 
     NonnullRefPtr<Threading::Thread> m_worker;
     Optional<String> m_build_error;
@@ -67,6 +69,9 @@ private:
     HashMap<u64, FontSource> m_font_sources;
     HashMap<u64, MemoryFontSource> m_memory_font_sources;
     HashMap<String, u64> m_dynamic_match_cache;
+
+    // Font requests arrive on the UI process's renderer connections and the Compositor's dedicated font connection.
+    Sync::Mutex m_mutex;
 };
 
 }

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -20,6 +20,7 @@ class BookmarkStore;
 class CanonicalNavigable;
 class CanonicalTraversable;
 class CompositorClient;
+class CompositorFontServiceConnection;
 class CompositorConnection;
 class CompositorHostBase;
 class CookieJar;

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ContextState.cpp
     ConnectionFromClient.cpp
     ConnectionFromWebContent.cpp
+    FontClient.cpp
     HostWebGLContext.cpp
     OpenGLContext.cpp
     PausedDebuggerOverlay.cpp
@@ -26,6 +27,8 @@ invoke_py_generator(
 set(GENERATED_SOURCES
     CompositorControlClientEndpoint.h
     CompositorControlServerEndpoint.h
+    CompositorFontClientEndpoint.h
+    CompositorFontServerEndpoint.h
     CompositorWebContentClientEndpoint.h
     CompositorWebContentServerEndpoint.h
     ${CMAKE_BINARY_DIR}/Libraries/LibWeb/WebGL/GLFunctions.cpp

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -1,15 +1,9 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/SharedImage.h>
-#include <LibIPC/File.h>
 #include <LibWeb/Compositor/Types.h>
 
 endpoint CompositorControlClient
 {
-    open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
-    match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
-    match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
-    resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
-
     did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, Vector<i32> bitmap_ids, Vector<Gfx::SharedImage> backing_stores) =|
     did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -9,6 +9,7 @@
 endpoint CompositorControlServer
 {
     init_transport(int peer_pid) => (int peer_pid)
+    set_font_service_transport(IPC::TransportHandle handle) =|
     set_font_catalog(IPC::File file, u64 size, u64 generation) =|
 
     connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)

--- a/Services/Compositor/CompositorFontClient.ipc
+++ b/Services/Compositor/CompositorFontClient.ipc
@@ -1,0 +1,3 @@
+endpoint CompositorFontClient
+{
+}

--- a/Services/Compositor/CompositorFontServer.ipc
+++ b/Services/Compositor/CompositorFontServer.ipc
@@ -1,0 +1,11 @@
+#include <AK/Optional.h>
+#include <LibIPC/File.h>
+
+endpoint CompositorFontServer
+{
+    init_transport(int peer_pid) => (int peer_pid)
+    open_system_font(u64 generation, u64 face_id) => (u64 matched_face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font(String family, u16 weight, u16 width, u8 slope) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    match_system_font_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) => (u64 face_id, u32 ttc_index, u8 format, Optional<IPC::File> file)
+    resolve_generic_font(String family, u16 weight, u8 slope) => (Optional<String> resolved_family)
+}

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -52,6 +52,26 @@ Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::i
     VERIFY_NOT_REACHED();
 }
 
+void ConnectionFromClient::set_font_service_transport(IPC::TransportHandle handle)
+{
+    auto transport = handle.create_transport();
+    if (transport.is_error()) {
+        dbgln("Compositor: Unable to create font service transport: {}", transport.error());
+        return;
+    }
+
+    m_font_client = FontClient::construct(transport.release_value());
+#ifdef AK_OS_WINDOWS
+    auto response = m_font_client->send_sync_but_allow_failure<FontClient::InitTransport>(Core::System::getpid());
+    if (!response) {
+        dbgln("Compositor: Unable to initialize font service transport");
+        m_font_client = nullptr;
+        return;
+    }
+    m_font_client->transport().set_peer_pid(response->peer_pid());
+#endif
+}
+
 void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 generation)
 {
     if (m_font_provider) {
@@ -62,7 +82,9 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
 
     Gfx::SharedFontProviderCallbacks callbacks;
     callbacks.open_font = [this](u64 requested_generation, u64 face_id) {
-        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::OpenSystemFont>(requested_generation, face_id);
+        if (!m_font_client)
+            return Gfx::BrokeredFont {};
+        auto response = m_font_client->send_sync_but_allow_failure<Messages::CompositorFontServer::OpenSystemFont>(requested_generation, face_id);
         if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
             return Gfx::BrokeredFont {};
         return Gfx::BrokeredFont {
@@ -73,7 +95,9 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
         };
     };
     callbacks.match_font = [this](String const& family, u16 weight, u16 width, u8 slope) {
-        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::MatchSystemFont>(family, weight, width, slope);
+        if (!m_font_client)
+            return Gfx::BrokeredFont {};
+        auto response = m_font_client->send_sync_but_allow_failure<Messages::CompositorFontServer::MatchSystemFont>(family, weight, width, slope);
         if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
             return Gfx::BrokeredFont {};
         return Gfx::BrokeredFont {
@@ -84,7 +108,9 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
         };
     };
     callbacks.match_font_for_code_point = [this](u32 code_point, u16 weight, u16 width, u8 slope, bool prefer_color_emoji) {
-        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::MatchSystemFontForCodePoint>(code_point, weight, width, slope, prefer_color_emoji);
+        if (!m_font_client)
+            return Gfx::BrokeredFont {};
+        auto response = m_font_client->send_sync_but_allow_failure<Messages::CompositorFontServer::MatchSystemFontForCodePoint>(code_point, weight, width, slope, prefer_color_emoji);
         if (!response || response->format() > to_underlying(Gfx::FontFileFormat::WOFF))
             return Gfx::BrokeredFont {};
         return Gfx::BrokeredFont {
@@ -95,7 +121,9 @@ void ConnectionFromClient::set_font_catalog(IPC::File file, u64 size, u64 genera
         };
     };
     callbacks.resolve_generic_family = [this](String const& family, u16 weight, u8 slope) -> Optional<FlyString> {
-        auto response = send_sync_but_allow_failure<Messages::CompositorControlClient::ResolveGenericFont>(family, weight, slope);
+        if (!m_font_client)
+            return {};
+        auto response = m_font_client->send_sync_but_allow_failure<Messages::CompositorFontServer::ResolveGenericFont>(family, weight, slope);
         if (!response)
             return {};
         auto resolved_family = response->take_resolved_family();

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -11,6 +11,7 @@
 #include <Compositor/CompositorControlClientEndpoint.h>
 #include <Compositor/CompositorControlServerEndpoint.h>
 #include <Compositor/CompositorState.h>
+#include <Compositor/FontClient.h>
 #include <Compositor/Forward.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/TransportHandle.h>
@@ -42,6 +43,7 @@ private:
     virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, Gfx::IntRect damage_rect, i32 bitmap_id) override;
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual void set_font_service_transport(IPC::TransportHandle) override;
     virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, i32 web_content_connection_id) override;
@@ -62,6 +64,7 @@ private:
     HashMap<i32, NonnullRefPtr<ConnectionFromWebContent>> m_web_content_connections;
     NonnullRefPtr<CompositorState> m_compositor_state;
     Gfx::SharedFontProvider* m_font_provider { nullptr };
+    RefPtr<FontClient> m_font_client;
 };
 
 }

--- a/Services/Compositor/FontClient.cpp
+++ b/Services/Compositor/FontClient.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/FontClient.h>
+#include <LibCore/Process.h>
+
+namespace Compositor {
+
+FontClient::FontClient(NonnullOwnPtr<IPC::Transport> transport)
+    : IPC::ConnectionToServer<CompositorFontClientEndpoint, CompositorFontServerEndpoint>(*this, move(transport))
+{
+}
+
+void FontClient::die()
+{
+    Core::Process::terminate_immediately(0);
+}
+
+}

--- a/Services/Compositor/FontClient.h
+++ b/Services/Compositor/FontClient.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Compositor/CompositorFontClientEndpoint.h>
+#include <Compositor/CompositorFontServerEndpoint.h>
+#include <LibIPC/ConnectionToServer.h>
+
+namespace Compositor {
+
+class FontClient final : public IPC::ConnectionToServer<CompositorFontClientEndpoint, CompositorFontServerEndpoint> {
+    C_OBJECT(FontClient);
+
+public:
+    using InitTransport = Messages::CompositorFontServer::InitTransport;
+    virtual ~FontClient() override = default;
+
+private:
+    explicit FontClient(NonnullOwnPtr<IPC::Transport>);
+    virtual void die() override;
+};
+
+}


### PR DESCRIPTION
Serve compositor font broker requests on a dedicated UI-process event loop and transport. This prevents the UI and compositor main threads from forming a synchronous IPC cycle when display-list decoding opens an uncached system font while the UI waits on compositor input handling.

Serialize access to the shared font service and give the IPC thread a stable reference. Its ownership keeps the service alive until the thread is joined. Treat loss of the font channel as compositor loss so the existing recovery path restores it.