### PR TITLE
Maintain the stacking context structure incrementally

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -1047,8 +1047,6 @@ AnimationUpdateContext::~AnimationUpdateContext()
             : target->unsafe_layout_node();
         if (repaint_layout_node && Painting::has_committed_box(*repaint_layout_node))
             Painting::repaint_after_style_change(*repaint_layout_node, invalidation);
-        if (invalidation.needs_stacking_context_tree_rebuild())
-            element.document().invalidate_stacking_context_tree();
     }
 }
 

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1668,6 +1668,7 @@
   },
   "content-visibility": {
     "style-group": "InheritedBoxValues",
+    "affects-stacking-context": true,
     "animation-type": "custom",
     "inherited": false,
     "initial": "visible",
@@ -2760,6 +2761,7 @@
   },
   "isolation": {
     "style-group": "EffectsValues",
+    "affects-stacking-context": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "auto",
@@ -3356,6 +3358,7 @@
     "style-group": "EffectsValues",
     "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
+    "affects-stacking-context": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "normal",
@@ -3792,6 +3795,7 @@
   "perspective": {
     "style-group": "TransformValues",
     "affects-accumulated-visual-contexts": true,
+    "affects-stacking-context": true,
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
@@ -4908,6 +4912,7 @@
   "transform-style": {
     "style-group": "TransformValues",
     "affects-accumulated-visual-contexts": true,
+    "affects-stacking-context": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "flat",

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -48,6 +48,8 @@ static bool animated_value_creates_stacking_context(PropertyID property_id, Styl
         return value->to_keyword() != Keyword::None && value->to_keyword() != Keyword::Flat;
     case PropertyID::BackfaceVisibility:
         return value->to_keyword() == Keyword::Hidden;
+    case PropertyID::ContentVisibility:
+        return value->to_keyword() == Keyword::Auto;
     default:
         return true;
     }

--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -85,8 +85,6 @@ static void apply_document_style_invalidation_after_style_change(DOM::Document& 
 {
     if (invalidation.needs_repaint())
         document.set_needs_to_record_display_list();
-    if (invalidation.needs_stacking_context_tree_rebuild())
-        document.invalidate_stacking_context_tree();
 }
 
 // Consume everything recorded since the last transaction boundary and publish its match answers.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1867,7 +1867,6 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     // NB: Called during layout update.
     m_layout_root->invalidate_text_blocks_cache();
 
-    invalidate_stacking_context_tree();
     set_needs_to_record_display_list();
     set_needs_to_refresh_scroll_state(true);
 
@@ -5593,14 +5592,6 @@ void Document::set_page_showing(bool page_showing)
         return document_observer.document_page_showing_observer();
     },
         m_page_showing);
-}
-
-void Document::invalidate_stacking_context_tree()
-{
-    // NB: Called during stacking context invalidation.
-    auto const* layout_node = this->unsafe_layout_node();
-    if (layout_node && Painting::has_committed_box(*layout_node))
-        Painting::invalidate_stacking_context(*layout_node);
 }
 
 void Document::check_favicon_after_loading_link_resource()
@@ -10447,7 +10438,6 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         page().client().page_did_change_background_color(canvas_background_color);
     }
 
-    document_paint_state.build_stacking_context_tree_if_needed(*this);
     document_paint_state.refresh_scroll_state(*this);
 
     Painting::InspectorOverlayInputs overlay_inputs;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -11056,7 +11056,7 @@ Utf16String Document::dump_stacking_context_tree()
     if (!has_committed_viewport_box())
         return "No paintable"_utf16;
 
-    paint_state().build_stacking_context_tree_if_needed(*this);
+    update_paint_and_hit_testing_properties_if_needed();
 
     StringBuilder builder;
     Painting::dump_stacking_context_tree(builder, *this);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -528,7 +528,6 @@ public:
     bool is_running_update_layout() const { return m_is_running_update_layout; }
 
     void invalidate_layout_tree(InvalidateLayoutTreeReason);
-    void invalidate_stacking_context_tree();
 
     void tear_down_layout_tree_for_svg_image_document(Badge<SVG::SVGDecodedImageData>);
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -963,6 +963,23 @@ Utf16String Internals::dump_stacking_context_tree()
     return window().associated_document().dump_stacking_context_tree();
 }
 
+Utf16String Internals::stacking_context_structure_verification_report()
+{
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::DumpDisplayList);
+    if (!document.has_committed_viewport_box())
+        return {};
+    document.paint_state().build_stacking_context_tree_if_needed(document);
+    document.update_paint_and_hit_testing_properties_if_needed();
+    StringBuilder builder;
+    Layout::RustFFI::layout_arena_stacking_context_structure_verification_report(
+        document.layout_node_arena().handle(), Painting::viewport_row_slot(document), &builder,
+        [](void* context, u8 const* bytes, size_t byte_count) {
+            static_cast<StringBuilder*>(context)->append(StringView { bytes, byte_count });
+        });
+    return Utf16String::from_utf8_without_validation(builder.string_view());
+}
+
 Utf16String Internals::dump_gc_graph()
 {
     return dump_string_to_utf16(GC::Heap::the().dump_graph().serialized());

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -171,6 +171,19 @@ u64 Internals::visual_context_pending_dirty_box_count()
     return Layout::RustFFI::layout_arena_visual_context_pending_dirty_box_count(document.layout_node_arena().handle());
 }
 
+u64 Internals::layout_tree_pre_order_label_violation_count()
+{
+    auto& document = window().associated_document();
+    return Layout::RustFFI::layout_arena_pre_order_label_violation_count(
+        document.layout_node_arena().handle(), Painting::viewport_row_slot(document));
+}
+
+u64 Internals::layout_tree_pre_order_relabel_count()
+{
+    auto& document = window().associated_document();
+    return Layout::RustFFI::layout_arena_pre_order_relabel_count(document.layout_node_arena().handle());
+}
+
 u64 Internals::visual_context_tree_node_count()
 {
     auto& document = window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -969,7 +969,6 @@ Utf16String Internals::stacking_context_structure_verification_report()
     document.update_layout(DOM::UpdateLayoutReason::DumpDisplayList);
     if (!document.has_committed_viewport_box())
         return {};
-    document.paint_state().build_stacking_context_tree_if_needed(document);
     document.update_paint_and_hit_testing_properties_if_needed();
     StringBuilder builder;
     Layout::RustFFI::layout_arena_stacking_context_structure_verification_report(

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -157,6 +157,7 @@ public:
     Utf16String dump_accessibility_tree();
     Utf16String dump_layout_tree(GC::Ref<DOM::Node>);
     Utf16String dump_stacking_context_tree();
+    Utf16String stacking_context_structure_verification_report();
     Utf16String dump_gc_graph();
     Utf16String dump_session_history();
     Utf16String dump_ui_process_session_history();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -56,6 +56,8 @@ public:
     u64 visual_context_tree_structural_epoch();
     GC::Ref<JS::Object> visual_context_node_indices(DOM::Element&);
     void send_mismatched_visual_context_tree_update_to_compositor();
+    u64 layout_tree_pre_order_label_violation_count();
+    u64 layout_tree_pre_order_relabel_count();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
     WebIDL::ExceptionOr<Utf16String> set_time_zone(Utf16String const& time_zone);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -12,6 +12,8 @@ interface Internals {
     unsigned long long visualContextTreeStructuralEpoch();
     object visualContextNodeIndices(Element element);
     undefined sendMismatchedVisualContextTreeUpdateToCompositor();
+    unsigned long long layoutTreePreOrderLabelViolationCount();
+    unsigned long long layoutTreePreOrderRelabelCount();
     undefined loadReferenceTestMetadata();
 
     Utf16DOMString setTimeZone(Utf16DOMString timeZone);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -133,6 +133,7 @@ interface Internals {
     Utf16DOMString dumpAccessibilityTree();
     Utf16DOMString dumpLayoutTree(Node node);
     Utf16DOMString dumpStackingContextTree();
+    Utf16DOMString stackingContextStructureVerificationReport();
     Utf16DOMString dumpGCGraph();
     Utf16DOMString dumpSessionHistory();
     Utf16DOMString dumpUIProcessSessionHistory();

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -445,7 +445,6 @@ void LayoutRustBridge::run_root_layout(Box& viewport, CSSPixels viewport_inline_
         m_commit_root = nullptr;
     };
 
-    viewport.document().invalidate_stacking_context_tree();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     {
@@ -468,7 +467,6 @@ void LayoutRustBridge::compute_subtree_layout(Box& root)
         m_commit_root = nullptr;
     };
 
-    root.document().invalidate_stacking_context_tree();
     auto viewport_rect = root.document().viewport_rect();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
@@ -492,7 +490,6 @@ void LayoutRustBridge::replay_saved_abspos_layout(Box& box)
         m_commit_root = nullptr;
     };
 
-    box.document().invalidate_stacking_context_tree();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1229,9 +1229,6 @@ bool NodeWithStyle::is_scroll_container() const
 
 void Node::clear_committed_box()
 {
-    if (Painting::has_committed_box(*this))
-        document().invalidate_stacking_context_tree();
-
     invalidate_paint_caches(*this);
     RustFFI::layout_arena_paintable_cleared_from_node(arena_handle(), slot_id(this));
 }

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -983,13 +983,6 @@ void repaint_after_style_change(Layout::Node const& node, CSS::RequiredInvalidat
     }
 }
 
-void invalidate_stacking_context(Layout::Node const& node)
-{
-    if (!has_committed_box(node))
-        return;
-    const_cast<DOM::Document&>(node.document()).paint_state().invalidate_stacking_context_tree();
-}
-
 void clear_overflow_data(Layout::Node const& node)
 {
     Layout::RustFFI::layout_arena_paintable_clear_overflow_data(node.arena_handle(), committed_row_slot(node));

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -276,7 +276,7 @@ bool visible_for_hit_testing(Layout::Node const& node)
 bool has_stacking_context(Layout::Node const& node)
 {
     auto const* row = committed_row(node);
-    return row && row->stacking_context != Layout::RustFFI::NO_STACKING_CONTEXT;
+    return row && row->establishes_stacking_context;
 }
 
 CSS::Display display(Layout::Node const& node)
@@ -529,7 +529,7 @@ Layout::Node const* nearest_self_painting_inline_box(Layout::Node const& node)
     for (auto const* ancestor = node.nearest_fragmented_inline_ancestor(); ancestor; ancestor = ancestor->nearest_fragmented_inline_ancestor()) {
         auto const* row = committed_row(*ancestor);
         if (row && is_inline_paintable(*ancestor)
-            && (row->stacking_context != Layout::RustFFI::NO_STACKING_CONTEXT || is_positioned(*ancestor)))
+            && (row->establishes_stacking_context || is_positioned(*ancestor)))
             return ancestor;
     }
     return nullptr;

--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -973,6 +973,14 @@ void repaint_after_style_change(Layout::Node const& node, CSS::RequiredInvalidat
         set_needs_repaint(node);
     if (invalidation.repaint_propagated_text_decorations)
         rust_invalidate_propagated_text_decoration_caches(node);
+    if (invalidation.needs_stacking_context_tree_rebuild()) {
+        auto& document = const_cast<DOM::Document&>(node.document());
+        document.schedule_accumulated_visual_context_update(node, DOM::Document::AccumulatedVisualContextUpdateScope::Structure);
+        auto const* table_wrapper_carrying_the_moved_table_properties
+            = display(node).is_table_inside() && node.parent() && node.parent()->is_table_wrapper() ? node.parent() : nullptr;
+        if (table_wrapper_carrying_the_moved_table_properties)
+            document.schedule_accumulated_visual_context_update(*table_wrapper_carrying_the_moved_table_properties, DOM::Document::AccumulatedVisualContextUpdateScope::Structure);
+    }
 }
 
 void invalidate_stacking_context(Layout::Node const& node)

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -111,7 +111,6 @@ WEB_API SelectionStyle selection_style_for_node(Layout::Node const&, GC::Ptr<DOM
 WEB_API void set_needs_repaint(Layout::Node const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
 WEB_API void invalidate_paint_cache(Layout::Node const&);
 WEB_API void repaint_after_style_change(Layout::Node const&, CSS::RequiredInvalidationAfterStyleChange const&);
-WEB_API void invalidate_stacking_context(Layout::Node const&);
 WEB_API void clear_overflow_data(Layout::Node const&);
 WEB_API void clear_cached_overflow_data(Layout::Node const&);
 

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -79,19 +79,6 @@ void DocumentPaintState::viewport_row_was_reset(DOM::Document& document)
     m_visual_context_tree_needs_compositor_update = false;
 }
 
-void DocumentPaintState::build_stacking_context_tree_if_needed(DOM::Document& document)
-{
-    if (m_stacking_context_tree_is_valid)
-        return;
-    rust_build_stacking_context_tree(document);
-    m_stacking_context_tree_is_valid = true;
-}
-
-void DocumentPaintState::invalidate_stacking_context_tree()
-{
-    m_stacking_context_tree_is_valid = false;
-}
-
 void DocumentPaintState::refresh_sticky_constraints(DOM::Document& document)
 {
     m_needs_to_refresh_scroll_state = true;

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -30,8 +30,6 @@ public:
     void viewport_row_was_reset(DOM::Document&);
 
     BlockingWheelEventRegionState collect_root_blocking_wheel_event_regions(DOM::Document&);
-    void build_stacking_context_tree_if_needed(DOM::Document&);
-    void invalidate_stacking_context_tree();
 
     void refresh_scroll_state(DOM::Document&);
     void refresh_sticky_constraints(DOM::Document&);
@@ -76,7 +74,6 @@ private:
     void clear_scroll_state(DOM::Document&);
 
     NonnullRefPtr<Layout::NodeArena> m_layout_node_arena;
-    bool m_stacking_context_tree_is_valid { false };
 
     ScrollStateSnapshot m_scroll_state_snapshot;
     bool m_needs_to_refresh_scroll_state { true };

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -674,34 +674,28 @@ void rust_build_stacking_context_tree(DOM::Document& document)
     Layout::RustFFI::layout_arena_build_stacking_context_tree(layout_arena_handle(document), viewport_row_slot(document));
 }
 
-static void dump_stacking_context_node(StringBuilder& builder, void* arena, size_t index, int indent)
-{
-    auto node = Layout::RustFFI::layout_arena_stacking_context_tree_node(arena, index);
-    for (int i = 0; i < indent; ++i)
-        builder.append(' ');
-    if (auto const* layout_node = static_cast<Layout::Node const*>(node.layout_node_shell)) {
-        builder.appendff("SC for {} {} (z-index: ", layout_node->debug_description(), absolute_rect(*layout_node));
-        if (node.has_effective_z_index)
-            builder.appendff("{}", node.effective_z_index);
-        else
-            builder.append("auto"sv);
-        builder.append(')');
-        if (has_css_transform(*layout_node))
-            builder.append(", has_transform"sv);
-    } else {
-        builder.append("SC for (gone)"sv);
-    }
-    builder.append('\n');
-    for (size_t child = 0; child < node.child_count; ++child)
-        dump_stacking_context_node(builder, arena, Layout::RustFFI::layout_arena_stacking_context_tree_child(arena, index, child), indent + 1);
-}
-
 void dump_stacking_context_tree(StringBuilder& builder, DOM::Document const& document)
 {
-    auto* arena = layout_arena_handle(document);
-    if (Layout::RustFFI::layout_arena_stacking_context_tree_node_count(arena) == 0)
-        return;
-    dump_stacking_context_node(builder, arena, 0, 0);
+    Layout::RustFFI::layout_arena_dump_stacking_context_tree(
+        layout_arena_handle(document), viewport_row_slot(document), &builder,
+        [](void* context, Layout::RustFFI::FfiStackingContextDumpEntry entry) {
+            auto& builder = *static_cast<StringBuilder*>(context);
+            for (size_t i = 0; i < entry.depth; ++i)
+                builder.append(' ');
+            if (auto const* layout_node = static_cast<Layout::Node const*>(entry.layout_node_shell)) {
+                builder.appendff("SC for {} {} (z-index: ", layout_node->debug_description(), absolute_rect(*layout_node));
+                if (entry.has_effective_z_index)
+                    builder.appendff("{}", entry.effective_z_index);
+                else
+                    builder.append("auto"sv);
+                builder.append(')');
+                if (has_css_transform(*layout_node))
+                    builder.append(", has_transform"sv);
+            } else {
+                builder.append("SC for (gone)"sv);
+            }
+            builder.append('\n');
+        });
 }
 
 namespace {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -669,11 +669,6 @@ void rust_invalidate_propagated_text_decoration_caches(Layout::Node const& node)
     Layout::RustFFI::layout_arena_paintable_invalidate_paint_cache(node.arena_handle(), committed_row_slot(node), true);
 }
 
-void rust_build_stacking_context_tree(DOM::Document& document)
-{
-    Layout::RustFFI::layout_arena_build_stacking_context_tree(layout_arena_handle(document), viewport_row_slot(document));
-}
-
 void dump_stacking_context_tree(StringBuilder& builder, DOM::Document const& document)
 {
     Layout::RustFFI::layout_arena_dump_stacking_context_tree(

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -22,7 +22,6 @@ namespace Web::Painting {
 
 struct ImagePaint;
 
-WEB_API void rust_build_stacking_context_tree(DOM::Document&);
 WEB_API void dump_stacking_context_tree(StringBuilder&, DOM::Document const&);
 
 struct VisualContextTreeUpdateResult {

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -147,6 +147,9 @@ fn value_creates_stacking_context(property: u16, values: ComputedValuesView<'_>)
         property_id::CONTAINER_TYPE => {
             values.box_values().is_size_container || values.box_values().is_inline_size_container
         }
+        property_id::CONTENT_VISIBILITY => {
+            values.content_visibility() == crate::css::css_enums::content_visibility::AUTO
+        }
         property_id::WILL_CHANGE => will_change_creates_stacking_context(values.misc_reset().will_change.data()),
         _ => true,
     }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1784,6 +1784,7 @@ impl LayoutNodeArena {
         }
 
         self.assign_pre_order_labels_to_inserted_subtree(parent, child);
+        self.note_layout_subtree_attached(child);
         self.note_structural_change_at_and_above(parent);
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -424,10 +424,14 @@ pub(crate) struct FreedSlot {
     pub(crate) detached_children: DetachedShells,
 }
 
+const MAXIMUM_PRE_ORDER_LABEL_STRIDE: u64 = 1 << 32;
+
 pub(crate) struct LayoutNodeArena {
     chunks: Vec<Box<Chunk>>,
     chunks_by_address: Vec<ChunkAddress>,
     slot_metadata: Vec<SlotMetadata>,
+    pre_order_labels: Vec<Cell<u64>>,
+    pre_order_relabel_count: Cell<u64>,
     free_list: Vec<u32>,
     next_index: u32,
     live_count: u32,
@@ -454,6 +458,8 @@ impl LayoutNodeArena {
             chunks: Vec::new(),
             chunks_by_address: Vec::new(),
             slot_metadata: Vec::new(),
+            pre_order_labels: Vec::new(),
+            pre_order_relabel_count: Cell::new(0),
             free_list: Vec::new(),
             next_index: 0,
             live_count: 0,
@@ -549,6 +555,7 @@ impl LayoutNodeArena {
                 self.chunks.push(chunk);
             }
             self.slot_metadata.push(SlotMetadata::default());
+            self.pre_order_labels.push(Cell::new(0));
             // Grown with the slot space up front: nearly every slot gets a run
             // record each layout pass, so register() never has to resize.
             self.run_used_records.get_mut().push(RunRecordSlot::default());
@@ -608,6 +615,7 @@ impl LayoutNodeArena {
         if let Some(reset) = paintable_row_reset {
             self.paintable_row_freed(reset);
         }
+        self.pre_order_labels[index as usize].set(0);
         self.metadata_mut(index).occupied = false;
 
         if let Some(slot) = self.intrinsic_size_caches.get_mut().get_mut(index as usize) {
@@ -725,17 +733,18 @@ impl LayoutNodeArena {
         }
     }
 
-    pub(crate) fn reset_layout_update_flags_in_subtree(&self, root: NodeSlotId) {
-        self.assert_owner_thread();
-        let flags_to_clear = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
+    pub(crate) fn for_each_node_in_layout_subtree_in_pre_order(
+        &self,
+        root: NodeSlotId,
+        mut callback: impl FnMut(NodeSlotId),
+    ) {
         let mut current = root;
         loop {
+            callback(current);
             let data = self.data(current);
-            // SAFETY: data() validated that current names a live slot, and layout tree mutation
-            // is serialized on the arena's owner thread.
+            // SAFETY: data() validated that current names a live slot, and the topology is
+            // stable during this call.
             let (parent, first_child, next_sibling) = unsafe {
-                let flags = &raw mut (*data).flags;
-                flags.write(flags.read() & !flags_to_clear);
                 (
                     (&raw const (*data).parent).read(),
                     (&raw const (*data).first_child).read(),
@@ -771,6 +780,20 @@ impl LayoutNodeArena {
                 break;
             }
         }
+    }
+
+    pub(crate) fn reset_layout_update_flags_in_subtree(&self, root: NodeSlotId) {
+        self.assert_owner_thread();
+        let flags_to_clear = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
+        self.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
+            let data = self.data(node);
+            // SAFETY: data() validated that node names a live slot, and layout tree mutation
+            // is serialized on the arena's owner thread.
+            unsafe {
+                let flags = &raw mut (*data).flags;
+                flags.write(flags.read() & !flags_to_clear);
+            }
+        });
     }
 
     fn node_is_capable_of_forming_a_containing_block(&self, id: NodeSlotId) -> bool {
@@ -916,50 +939,10 @@ impl LayoutNodeArena {
         inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     ) {
         self.assert_owner_thread();
-        let mut current = root;
-        loop {
-            self.recompute_containing_block_for_node(current, inline_cb_lookup);
-            self.derive_abspos_escape_flags_for_node(current);
-
-            let data = self.data(current);
-            // SAFETY: data() validated that current names a live slot, and the
-            // topology is stable during this call.
-            let (parent, first_child, next_sibling) = unsafe {
-                (
-                    (&raw const (*data).parent).read(),
-                    (&raw const (*data).first_child).read(),
-                    (&raw const (*data).next_sibling).read(),
-                )
-            };
-
-            if !first_child.is_invalid() {
-                current = first_child;
-                continue;
-            }
-            if current == root {
-                break;
-            }
-            if !next_sibling.is_invalid() {
-                current = next_sibling;
-                continue;
-            }
-
-            current = parent;
-            while current != root {
-                // SAFETY: Parent links from a live subtree node name live slots in the same tree.
-                let data = self.data(current);
-                let next_sibling = unsafe { (&raw const (*data).next_sibling).read() };
-                if !next_sibling.is_invalid() {
-                    current = next_sibling;
-                    break;
-                }
-                // SAFETY: data() validated current and the topology is stable during this call.
-                current = unsafe { (&raw const (*data).parent).read() };
-            }
-            if current == root {
-                break;
-            }
-        }
+        self.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
+            self.recompute_containing_block_for_node(node, inline_cb_lookup);
+            self.derive_abspos_escape_flags_for_node(node);
+        });
     }
 
     fn slot_for_data(&self, data: *const NodeData) -> (u32, SlotMetadata) {
@@ -997,63 +980,172 @@ impl LayoutNodeArena {
         (index, metadata)
     }
 
+    pub(crate) fn node_pre_order_label(&self, id: NodeSlotId) -> u64 {
+        let _ = self.data(id);
+        self.pre_order_labels[id.slot_index() as usize].get()
+    }
+
+    fn set_node_pre_order_label(&self, id: NodeSlotId, label: u64) {
+        self.pre_order_labels[id.slot_index() as usize].set(label);
+    }
+
+    pub(crate) fn pre_order_relabel_count(&self) -> u64 {
+        self.pre_order_relabel_count.get()
+    }
+
+    pub(crate) fn count_nodes_in_layout_subtree(&self, root: NodeSlotId) -> u64 {
+        let mut count = 0u64;
+        self.for_each_node_in_layout_subtree_in_pre_order(root, |_| count += 1);
+        count
+    }
+
+    fn last_descendant_in_pre_order(&self, node: NodeSlotId) -> NodeSlotId {
+        let mut current = node;
+        loop {
+            // SAFETY: data() validated that current names a live slot, and child links only
+            // name live slots.
+            let last_child = unsafe { (&raw const (*self.data(current)).last_child).read() };
+            if last_child.is_invalid() {
+                return current;
+            }
+            current = last_child;
+        }
+    }
+
+    fn pre_order_label_of_subtree_successor(&self, node: NodeSlotId) -> u64 {
+        let mut current = node;
+        loop {
+            let data = self.data(current);
+            // SAFETY: data() validated that current names a live slot, and the topology links
+            // only name live slots.
+            let (parent, next_sibling) = unsafe {
+                (
+                    (&raw const (*data).parent).read(),
+                    (&raw const (*data).next_sibling).read(),
+                )
+            };
+            if !next_sibling.is_invalid() {
+                return self.node_pre_order_label(next_sibling);
+            }
+            if parent.is_invalid() {
+                return u64::MAX;
+            }
+            current = parent;
+        }
+    }
+
+    fn assign_pre_order_labels_to_inserted_subtree(&self, parent: NodeSlotId, child: NodeSlotId) {
+        let child_data = self.data(child);
+        // SAFETY: data() validated that child names a live slot, and insert_child wrote its
+        // sibling links before this call.
+        let (previous_sibling, next_sibling) = unsafe {
+            (
+                (&raw const (*child_data).previous_sibling).read(),
+                (&raw const (*child_data).next_sibling).read(),
+            )
+        };
+        let lower = if previous_sibling.is_invalid() {
+            self.node_pre_order_label(parent)
+        } else {
+            self.node_pre_order_label(self.last_descendant_in_pre_order(previous_sibling))
+        };
+        let upper = if next_sibling.is_invalid() {
+            self.pre_order_label_of_subtree_successor(parent)
+        } else {
+            self.node_pre_order_label(next_sibling)
+        };
+        debug_assert!(lower < upper, "pre-order labels lost their strict order");
+        let inserted_node_count = self.count_nodes_in_layout_subtree(child);
+        let stride = ((upper - lower) / (inserted_node_count + 1)).min(MAXIMUM_PRE_ORDER_LABEL_STRIDE);
+        if stride >= 2 {
+            // Placement is biased toward the insertion direction, so a one-directional hot
+            // spot consumes the gap linearly instead of halving it.
+            let mut position_in_subtree = 0u64;
+            self.for_each_node_in_layout_subtree_in_pre_order(child, |node| {
+                position_in_subtree += 1;
+                let label = if next_sibling.is_invalid() {
+                    lower + stride * position_in_subtree
+                } else {
+                    upper - stride * (inserted_node_count + 1 - position_in_subtree)
+                };
+                self.set_node_pre_order_label(node, label);
+            });
+            debug_assert!(lower < self.node_pre_order_label(child));
+            debug_assert!(self.node_pre_order_label(self.last_descendant_in_pre_order(child)) < upper);
+            return;
+        }
+        let mut ancestor = parent;
+        loop {
+            // SAFETY: data() validated that ancestor names a live slot, and parent links only
+            // name live slots.
+            let ancestor_parent = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            if ancestor_parent.is_invalid() {
+                self.set_node_pre_order_label(ancestor, 0);
+                let spread_succeeded = self.spread_pre_order_labels_evenly_over_descendants(ancestor, 0, u64::MAX);
+                assert!(spread_succeeded, "pre-order label space exhausted");
+                return;
+            }
+            let ancestor_lower = self.node_pre_order_label(ancestor);
+            let ancestor_upper = self.pre_order_label_of_subtree_successor(ancestor);
+            if self.spread_pre_order_labels_evenly_over_descendants(ancestor, ancestor_lower, ancestor_upper) {
+                return;
+            }
+            ancestor = ancestor_parent;
+        }
+    }
+
+    fn spread_pre_order_labels_evenly_over_descendants(
+        &self,
+        subtree_root: NodeSlotId,
+        lower: u64,
+        upper: u64,
+    ) -> bool {
+        let descendant_count = self.count_nodes_in_layout_subtree(subtree_root) - 1;
+        if descendant_count == 0 {
+            return true;
+        }
+        let step = (upper - lower) / (descendant_count + 1);
+        if step < 2 {
+            return false;
+        }
+        let mut position_in_subtree = 0u64;
+        self.for_each_node_in_layout_subtree_in_pre_order(subtree_root, |node| {
+            if node == subtree_root {
+                return;
+            }
+            position_in_subtree += 1;
+            self.set_node_pre_order_label(node, lower + step * position_in_subtree);
+        });
+        self.pre_order_relabel_count.set(self.pre_order_relabel_count.get() + 1);
+        true
+    }
+
+    #[cfg(debug_assertions)]
+    fn nodes_share_a_layout_tree_root(&self, node: NodeSlotId, other: NodeSlotId) -> bool {
+        let root_of = |mut slot: NodeSlotId| loop {
+            // SAFETY: data() validates the live generation, and parent links only name live
+            // slots in this arena.
+            let parent = unsafe { (&raw const (*self.data(slot)).parent).read() };
+            if parent.is_invalid() {
+                return slot;
+            }
+            slot = parent;
+        };
+        root_of(node) == root_of(other)
+    }
+
     pub(crate) fn is_before(&self, node: &NodeData, other: &NodeData) -> bool {
         let (node_index, node_metadata) = self.slot_for_data(std::ptr::from_ref(node));
         let (other_index, other_metadata) = self.slot_for_data(std::ptr::from_ref(other));
-        let mut node = NodeSlotId::new(node_index, node_metadata.generation);
-        let mut other = NodeSlotId::new(other_index, other_metadata.generation);
+        let node = NodeSlotId::new(node_index, node_metadata.generation);
+        let other = NodeSlotId::new(other_index, other_metadata.generation);
         assert_ne!(node, other, "a layout node cannot precede itself");
-
-        let depth = |mut slot: NodeSlotId| {
-            let mut depth = 0usize;
-            while !slot.is_invalid() {
-                depth += 1;
-                // SAFETY: data() validates the live generation, and the
-                // topology links name slots in this arena.
-                slot = unsafe { (*self.data(slot)).parent };
-            }
-            depth
-        };
-        let node_depth = depth(node);
-        let other_depth = depth(other);
-
-        for _ in other_depth..node_depth {
-            // SAFETY: node is a validated live arena slot.
-            node = unsafe { (*self.data(node)).parent };
-        }
-        for _ in node_depth..other_depth {
-            // SAFETY: other is a validated live arena slot.
-            other = unsafe { (*self.data(other)).parent };
-        }
-        if node == other {
-            return node_depth < other_depth;
-        }
-
-        loop {
-            // SAFETY: Both slots are live and have equal depth.
-            let node_parent = unsafe { (*self.data(node)).parent };
-            // SAFETY: Both slots are live and have equal depth.
-            let other_parent = unsafe { (*self.data(other)).parent };
-            assert_eq!(
-                node_parent.is_invalid(),
-                other_parent.is_invalid(),
-                "layout nodes belong to different trees"
-            );
-            if node_parent == other_parent {
-                break;
-            }
-            node = node_parent;
-            other = other_parent;
-        }
-
-        while !other.is_invalid() {
-            if node == other {
-                return true;
-            }
-            // SAFETY: other is a validated live arena slot.
-            other = unsafe { (*self.data(other)).previous_sibling };
-        }
-        false
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            self.nodes_share_a_layout_tree_root(node, other),
+            "layout nodes belong to different trees"
+        );
+        self.node_pre_order_label(node) < self.node_pre_order_label(other)
     }
 
     pub(crate) fn intrinsic_block_size_cache_get(
@@ -1691,6 +1783,7 @@ impl LayoutNodeArena {
             }
         }
 
+        self.assign_pre_order_labels_to_inserted_subtree(parent, child);
         self.note_structural_change_at_and_above(parent);
     }
 
@@ -2032,6 +2125,45 @@ pub unsafe extern "C" fn layout_arena_intrinsic_measurement_count(arena: *mut c_
         // SAFETY: The C++ wrapper keeps the arena alive for this call and
         // serializes all access on the document thread.
         unsafe { &*arena.cast::<LayoutNodeArena>() }.intrinsic_measurement_count()
+    })
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_pre_order_label_violation_count(arena: *mut c_void, root: NodeSlotId) -> u64 {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        let arena = unsafe { &*arena.cast::<LayoutNodeArena>() };
+        if arena.shell_if_live(root).is_null() {
+            return 0;
+        }
+        let mut violation_count = 0u64;
+        let mut previous_label: Option<u64> = None;
+        arena.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
+            let label = arena.node_pre_order_label(node);
+            if previous_label.is_some_and(|previous| label <= previous) {
+                violation_count += 1;
+            }
+            previous_label = Some(label);
+        });
+        violation_count
+    })
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void) -> u64 {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &*arena.cast::<LayoutNodeArena>() }.pre_order_relabel_count()
     })
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1052,6 +1052,7 @@ fn fresh_visual_context_tree_build(
     let arena = unsafe { arena_from_handle_mut(arena) };
     outcome.mask_node_owners_changed = true;
     apply_walk_assignments(arena, viewport, &mut outcome, state);
+    arena.rebuild_all_stacking_context_entries_from_records(viewport);
     arena.mark_all_paint_caches_dirty();
     state.quarantined_slots_are_releasable = false;
     debug_assert_every_live_node_is_owned(
@@ -1172,6 +1173,7 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
                 IncrementalUpdateResult::Applied(mut outcome) => {
                     let arena_mut = unsafe { arena_from_handle_mut(arena) };
                     apply_walk_assignments(arena_mut, viewport, &mut outcome, &mut state);
+                    arena_mut.resort_stacking_context_entries_flagged_for_resort();
                     let performed_full_build = scope == VisualContextUpdateScope::EveryBox;
                     if performed_full_build {
                         state.build_count += 1;
@@ -2265,6 +2267,27 @@ pub unsafe extern "C" fn layout_arena_for_each_subtree_fragment_rect(
                 unsafe { consume(context, shell, rect) };
             }
         });
+    });
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `consume` copies the byte span synchronously.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_stacking_context_structure_verification_report(
+    arena: *mut c_void,
+    viewport: NodeSlotId,
+    context: *mut c_void,
+    consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
+) {
+    abort_on_panic(|| {
+        let arena = unsafe { arena_from_handle(arena) };
+        let report = crate::painting::stacking_context::verify::verification_report(arena, viewport);
+        if !report.is_empty() {
+            // SAFETY: The consumer copies the byte span synchronously.
+            unsafe { consume(context, report.as_ptr(), report.len()) };
+        }
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1390,7 +1390,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
         }
         let mut output = {
             let paint_state = arena.paint_state().borrow();
-            if !arena.paintable_row_is_populated(viewport) || paint_state.stacking_context_tree.is_none() {
+            if !arena.paintable_row_is_populated(viewport) || arena.stacking_context_entries(viewport).is_none() {
                 return 0;
             }
             let command_cache_source = (!inputs.should_show_line_box_borders)
@@ -1400,6 +1400,7 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
             let output = crate::painting::record::traversal::record_display_list(
                 arena,
                 &paint_state,
+                viewport,
                 &callbacks,
                 &paint_callbacks,
                 &visual_context_callbacks,
@@ -2424,67 +2425,27 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
 
 /// # Safety
 ///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
+/// `emit` copies each entry synchronously.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_stacking_context_tree_node_count(arena: *mut c_void) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .stacking_context_tree
-            .as_ref()
-            .map_or(0, |tree| tree.nodes.len())
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`; `index` in range.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_stacking_context_tree_node(
+pub unsafe extern "C" fn layout_arena_dump_stacking_context_tree(
     arena: *mut c_void,
-    index: usize,
-) -> crate::painting::host::FfiStackingContextNodeExport {
+    viewport: NodeSlotId,
+    context: *mut c_void,
+    emit: unsafe extern "C" fn(*mut c_void, crate::painting::host::FfiStackingContextDumpEntry),
+) {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        let node = &paint_state
-            .stacking_context_tree
-            .as_ref()
-            .expect("no stacking context tree")
-            .nodes[index];
-        crate::painting::host::FfiStackingContextNodeExport {
-            layout_node_shell: if arena.paintable_row_is_populated(node.paintable) {
-                arena.shell_if_live(node.paintable)
-            } else {
-                std::ptr::null_mut()
-            },
-            child_count: node.children.len(),
-            has_effective_z_index: node.effective_z_index.is_some(),
-            effective_z_index: node.effective_z_index.unwrap_or(0),
+        if !arena.paintable_row_is_populated(viewport) {
+            return;
         }
-    })
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`; indices in range.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_stacking_context_tree_child(
-    arena: *mut c_void,
-    index: usize,
-    child: usize,
-) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .stacking_context_tree
-            .as_ref()
-            .expect("no stacking context tree")
-            .nodes[index]
-            .children[child] as usize
-    })
+        crate::painting::stacking_context::dump::for_each_stacking_context_in_dump_order(
+            arena,
+            viewport,
+            // SAFETY: The consumer copies the entry synchronously.
+            &mut |entry| unsafe { emit(context, entry) },
+        );
+    });
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -963,25 +963,6 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_context_copy_node_indices
     });
 }
 
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_build_stacking_context_tree(arena: *mut c_void, root: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let mut paintable_rows = arena.paintable_rows_mut();
-        let tree = {
-            if !paintable_rows.paintable_row_is_populated(root) {
-                return;
-            }
-            crate::painting::stacking_context::build_stacking_context_tree(&mut paintable_rows, root)
-        };
-        paintable_rows.paint_state().borrow_mut().stacking_context_tree = Some(tree);
-        crate::painting::fragment_ownership::assign_fragment_ownership(&paintable_rows, root);
-    });
-}
-
 use crate::painting::host::FfiVisualContextHostCallbacks;
 
 fn apply_walk_assignments(
@@ -1053,6 +1034,8 @@ fn fresh_visual_context_tree_build(
     outcome.mask_node_owners_changed = true;
     apply_walk_assignments(arena, viewport, &mut outcome, state);
     arena.rebuild_all_stacking_context_entries_from_records(viewport);
+    arena.take_line_roots_needing_fragment_ownership();
+    crate::painting::fragment_ownership::assign_fragment_ownership(&arena.paintable_rows(), viewport);
     arena.mark_all_paint_caches_dirty();
     state.quarantined_slots_are_releasable = false;
     debug_assert_every_live_node_is_owned(
@@ -1174,6 +1157,7 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
                     let arena_mut = unsafe { arena_from_handle_mut(arena) };
                     apply_walk_assignments(arena_mut, viewport, &mut outcome, &mut state);
                     arena_mut.resort_stacking_context_entries_flagged_for_resort();
+                    crate::painting::fragment_ownership::assign_fragment_ownership_for_pending_line_roots(arena_mut);
                     let performed_full_build = scope == VisualContextUpdateScope::EveryBox;
                     if performed_full_build {
                         state.build_count += 1;

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -8,7 +8,6 @@ use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::node_painting;
 use crate::painting::paintable_rows::PaintableRowsRead;
-use crate::painting::stacking_context::NO_STACKING_CONTEXT;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FragmentRange {
@@ -63,8 +62,7 @@ pub(crate) fn is_self_painting_inline(layout_arena: &impl PaintableRowsRead, pai
     // containing block: it forms a group that content must be recorded inside.
     let data = layout_arena.paintable_data(paintable);
     node_painting::is_inline(layout_arena, paintable)
-        && (data.stacking_context != NO_STACKING_CONTEXT
-            || crate::painting::style_queries::is_positioned(layout_arena, paintable))
+        && (data.establishes_stacking_context || crate::painting::style_queries::is_positioned(layout_arena, paintable))
 }
 
 pub(crate) fn nearest_fragmented_inline_ancestor(

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -98,8 +98,6 @@ pub(crate) fn nearest_self_painting_inline_box(
 }
 
 pub(crate) fn assign_fragment_ownership(layout_arena: &impl PaintableRowsRead, viewport: NodeSlotId) {
-    // Whether a box is self-painting depends on the stacking context tree, so this runs
-    // whenever that tree is rebuilt.
     let mut stack = vec![viewport];
     while let Some(current) = stack.pop() {
         if let Some(next) = crate::painting::paint_order::next_paint_sibling(layout_arena, current)
@@ -114,6 +112,21 @@ pub(crate) fn assign_fragment_ownership(layout_arena: &impl PaintableRowsRead, v
             && !layout_arena.paintable_side_data(current).inline_box_pieces.is_empty()
         {
             assign_for_block(layout_arena, current);
+        }
+    }
+}
+
+pub(crate) fn assign_fragment_ownership_for_pending_line_roots(layout_arena: &LayoutNodeArena) {
+    let mut line_roots = layout_arena.take_line_roots_needing_fragment_ownership();
+    line_roots.sort_unstable_by_key(|slot| (slot.index, slot.generation()));
+    line_roots.dedup();
+    let paintable_rows = layout_arena.paintable_rows();
+    for line_root in line_roots {
+        if paintable_rows.paintable_row_is_populated(line_root)
+            && node_painting::has_lines(&paintable_rows, line_root)
+            && !layout_arena.paintable_side_data(line_root).inline_box_pieces.is_empty()
+        {
+            assign_for_block(&paintable_rows, line_root);
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
+++ b/Libraries/LibWeb/Rust/src/painting/fragment_ownership.rs
@@ -120,23 +120,19 @@ pub(crate) fn assign_fragment_ownership(layout_arena: &impl PaintableRowsRead, v
     }
 }
 
-fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
+fn piece_paintable_of(layout_arena: &impl PaintableRowsRead, node: NodeSlotId) -> Option<NodeSlotId> {
+    if node.is_invalid() || layout_arena.shell_if_live(node).is_null() {
+        return None;
+    }
+    (layout_arena.paintable_row_is_populated(node) && node_painting::is_inline(layout_arena, node)).then_some(node)
+}
+
+pub(crate) fn compute_fragment_ownership_for_block(
+    layout_arena: &impl PaintableRowsRead,
+    block: NodeSlotId,
+) -> Vec<(NodeSlotId, FragmentOwnershipFilter)> {
     let pieces = layout_arena.paintable_side_data(block).inline_box_pieces.clone();
     let mut block_filter = FragmentOwnershipFilter::everything();
-
-    let piece_paintable_of = |node: NodeSlotId| -> Option<NodeSlotId> {
-        if node.is_invalid() || layout_arena.shell_if_live(node).is_null() {
-            return None;
-        }
-        (layout_arena.paintable_row_is_populated(node) && node_painting::is_inline(layout_arena, node)).then_some(node)
-    };
-
-    // Start every piece's box from a clean slate.
-    for piece in &pieces {
-        if let Some(paintable) = piece_paintable_of(piece.node) {
-            layout_arena.paintable_side_data_mut(paintable).fragment_ownership = None;
-        }
-    }
 
     let mut owners: Vec<NodeSlotId> = Vec::new();
     let mut filters: Vec<FragmentOwnershipFilter> = Vec::new();
@@ -154,7 +150,7 @@ fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
         if piece.fragment_count == 0 {
             continue;
         }
-        let Some(piece_paintable) = piece_paintable_of(piece.node) else {
+        let Some(piece_paintable) = piece_paintable_of(layout_arena, piece.node) else {
             continue;
         };
         if !is_self_painting_inline(layout_arena, piece_paintable) {
@@ -177,9 +173,24 @@ fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
     }
 
     block_filter.excluded.sort_by_key(|range| range.begin);
-    layout_arena.paintable_side_data_mut(block).fragment_ownership = Some(block_filter);
+    let mut owners_with_filters = vec![(block, block_filter)];
     for (owner, mut filter) in owners.into_iter().zip(filters) {
         filter.excluded.sort_by_key(|range| range.begin);
+        owners_with_filters.push((owner, filter));
+    }
+    owners_with_filters
+}
+
+fn assign_for_block(layout_arena: &impl PaintableRowsRead, block: NodeSlotId) {
+    let owners_with_filters = compute_fragment_ownership_for_block(layout_arena, block);
+    // Start every piece's box from a clean slate.
+    let pieces = layout_arena.paintable_side_data(block).inline_box_pieces.clone();
+    for piece in &pieces {
+        if let Some(paintable) = piece_paintable_of(layout_arena, piece.node) {
+            layout_arena.paintable_side_data_mut(paintable).fragment_ownership = None;
+        }
+    }
+    for (owner, filter) in owners_with_filters {
         layout_arena.paintable_side_data_mut(owner).fragment_ownership = Some(filter);
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -327,9 +327,9 @@ pub struct FfiImagePaintFacts {
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct FfiStackingContextNodeExport {
+pub struct FfiStackingContextDumpEntry {
     pub layout_node_shell: *mut c_void,
-    pub child_count: usize,
+    pub depth: usize,
     pub has_effective_z_index: bool,
     pub effective_z_index: i32,
 }

--- a/Libraries/LibWeb/Rust/src/painting/paint_state.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paint_state.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 #[derive(Default)]
 pub struct PaintState {
-    pub(crate) stacking_context_tree: Option<crate::painting::stacking_context::StackingContextTree>,
     pub(crate) visual_context: crate::painting::visual_context::VisualContextState,
     pub(crate) hit_test_list: Option<crate::painting::hit_test::HitTestList>,
     pub(crate) hit_test_list_generation: u64,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -246,6 +246,10 @@ impl<'a> PaintableCommit<'a> {
                 "inline box piece fragment range exceeds the committed fragments"
             );
         }
+        drop(side);
+        if has_pieces {
+            self.arena().note_line_root_needs_fragment_ownership(slot);
+        }
         has_pieces
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -10,8 +10,6 @@ use crate::layout::{inline_level_iterator, used_values};
 use crate::painting::display_list::commands::{ContextRef, SpatialNodeIndex};
 use std::cell::Cell;
 
-pub const NO_STACKING_CONTEXT: u32 = u32::MAX;
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum PaintableFlag {
@@ -53,7 +51,6 @@ pub struct PaintableData {
     pub overflow_measured_this_commit: bool,
     pub overflow_valid_across_recommits: bool,
 
-    pub stacking_context: u32,
     pub establishes_stacking_context: bool,
 
     pub enclosing_scroll_node_index: SpatialNodeIndex,
@@ -80,7 +77,6 @@ impl Default for PaintableData {
             overflow_relative_to_padding_box: FfiOverflowData::default(),
             overflow_measured_this_commit: false,
             overflow_valid_across_recommits: false,
-            stacking_context: u32::MAX,
             establishes_stacking_context: false,
             enclosing_scroll_node_index: SpatialNodeIndex::default(),
             own_scroll_node_index: SpatialNodeIndex::default(),

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -54,6 +54,7 @@ pub struct PaintableData {
     pub overflow_valid_across_recommits: bool,
 
     pub stacking_context: u32,
+    pub establishes_stacking_context: bool,
 
     pub enclosing_scroll_node_index: SpatialNodeIndex,
     pub own_scroll_node_index: SpatialNodeIndex,
@@ -80,6 +81,7 @@ impl Default for PaintableData {
             overflow_measured_this_commit: false,
             overflow_valid_across_recommits: false,
             stacking_context: u32::MAX,
+            establishes_stacking_context: false,
             enclosing_scroll_node_index: SpatialNodeIndex::default(),
             own_scroll_node_index: SpatialNodeIndex::default(),
             has_accumulated_visual_context: false,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -73,6 +73,9 @@ pub(crate) struct PaintableRowStore {
     side_data: RefCell<Vec<PaintableSideData>>,
     paint_caches: RefCell<Vec<PaintCache>>,
     visual_context_records: RefCell<Vec<Option<PaintableVisualContextRecord>>>,
+    pub(crate) stacking_context_entries:
+        RefCell<Vec<Option<Box<crate::painting::stacking_context::entries::StackingContextEntries>>>>,
+    pub(crate) stacking_context_roots_flagged_for_resort: RefCell<Vec<NodeSlotId>>,
     absolute_rect_memo: RefCell<Vec<Option<(NodeSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
     absolute_rect_memo_epoch: Cell<u64>,
     committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
@@ -585,6 +588,7 @@ impl LayoutNodeArena {
         let mut paint_caches = store.paint_caches.borrow_mut();
         let mut absolute_rect_memo = store.absolute_rect_memo.borrow_mut();
         let mut visual_context_records = store.visual_context_records.borrow_mut();
+        let mut stacking_context_entries = store.stacking_context_entries.borrow_mut();
         while side_data.len() <= index {
             if side_data.len().is_multiple_of(PAINTABLE_SLOTS_PER_CHUNK) {
                 chunks.push(new_chunk());
@@ -593,6 +597,7 @@ impl LayoutNodeArena {
             paint_caches.push(PaintCache::default());
             absolute_rect_memo.push(None);
             visual_context_records.push(None);
+            stacking_context_entries.push(None);
         }
 
         chunks[index / PAINTABLE_SLOTS_PER_CHUNK].slots[index % PAINTABLE_SLOTS_PER_CHUNK] = PaintableData {
@@ -603,6 +608,7 @@ impl LayoutNodeArena {
         paint_caches[index].clear();
         absolute_rect_memo[index] = None;
         visual_context_records[index] = None;
+        stacking_context_entries[index] = None;
     }
 
     fn reset_paintable_row(&mut self, mark_caches_dirty_along_paint_chain: bool, reset: PaintableRowReset) {
@@ -612,6 +618,7 @@ impl LayoutNodeArena {
                 .mark_descendant_subtree_caches_dirty_along_paint_chain(id);
         }
         if let Some(record) = self.take_paintable_visual_context_record(id) {
+            self.withdraw_stacking_context_state_of_reset_row(id, Some(record.stacking_context));
             let former_paint_parent =
                 crate::painting::paint_order::paint_parent(&self.paintable_rows(), id).unwrap_or(NodeSlotId::INVALID);
             self.paint_state()
@@ -624,6 +631,7 @@ impl LayoutNodeArena {
                     former_paint_parent,
                 });
         } else {
+            self.withdraw_stacking_context_state_of_reset_row(id, None);
             self.paint_state()
                 .borrow_mut()
                 .visual_context
@@ -638,6 +646,7 @@ impl LayoutNodeArena {
         store.side_data.borrow_mut()[index] = PaintableSideData::default();
         store.paint_caches.borrow()[index].clear();
         store.visual_context_records.borrow_mut()[index] = None;
+        store.stacking_context_entries.borrow_mut()[index] = None;
     }
 
     pub(crate) fn paintable_visual_context_record(
@@ -693,6 +702,14 @@ impl LayoutNodeArena {
         let was_flagged = record.subtree_may_own_geometry_dependent_nodes;
         record.subtree_may_own_geometry_dependent_nodes = true;
         Some(was_flagged)
+    }
+
+    pub(crate) fn set_paintable_record_stacking_context_contribution_registered(&self, id: NodeSlotId) {
+        debug_assert!(self.paintable_row_is_populated(id));
+        let mut records = self.paintable_rows.visual_context_records.borrow_mut();
+        if let Some(record) = records.get_mut(id.slot_index() as usize).and_then(Option::as_mut) {
+            record.stacking_context.contribution_is_registered = true;
+        }
     }
 
     pub(crate) fn note_visual_context_box_dirty(&self, id: NodeSlotId, kind: VisualContextBoxDirtyKind) {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -76,6 +76,7 @@ pub(crate) struct PaintableRowStore {
     pub(crate) stacking_context_entries:
         RefCell<Vec<Option<Box<crate::painting::stacking_context::entries::StackingContextEntries>>>>,
     pub(crate) stacking_context_roots_flagged_for_resort: RefCell<Vec<NodeSlotId>>,
+    line_roots_needing_fragment_ownership: RefCell<Vec<NodeSlotId>>,
     absolute_rect_memo: RefCell<Vec<Option<(NodeSlotId, u64, crate::css::css_pixels::CssPixelRect)>>>,
     absolute_rect_memo_epoch: Cell<u64>,
     committed_fragment_links: RefCell<Vec<CommittedFragmentLinkSlot>>,
@@ -337,7 +338,6 @@ where
             data.overflow_measured_this_commit = false;
             data.local_padding_box_union = used_values::FfiCssPixelRect::default();
             data.local_border_box_union = used_values::FfiCssPixelRect::default();
-            data.stacking_context = crate::painting::stacking_context::NO_STACKING_CONTEXT;
         }
         // The paint cache is deliberately kept; the commit diff marks rows whose committed
         // fragment identity or offset actually changed.
@@ -710,6 +710,17 @@ impl LayoutNodeArena {
         if let Some(record) = records.get_mut(id.slot_index() as usize).and_then(Option::as_mut) {
             record.stacking_context.contribution_is_registered = true;
         }
+    }
+
+    pub(crate) fn note_line_root_needs_fragment_ownership(&self, line_root: NodeSlotId) {
+        self.paintable_rows
+            .line_roots_needing_fragment_ownership
+            .borrow_mut()
+            .push(line_root);
+    }
+
+    pub(crate) fn take_line_roots_needing_fragment_ownership(&self) -> Vec<NodeSlotId> {
+        std::mem::take(&mut *self.paintable_rows.line_roots_needing_fragment_ownership.borrow_mut())
     }
 
     pub(crate) fn note_visual_context_box_dirty(&self, id: NodeSlotId, kind: VisualContextBoxDirtyKind) {

--- a/Libraries/LibWeb/Rust/src/painting/record/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/mod.rs
@@ -27,7 +27,6 @@ use crate::painting::host::{
 };
 use crate::painting::paintable_data::{InlineBoxPieceRecord, PaintableData};
 use crate::painting::paintable_rows::PaintableRowsRef;
-use crate::painting::stacking_context::{NO_STACKING_CONTEXT, StackingContextTree};
 use crate::painting::visual_context::nested::NestedAssignments;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -66,7 +65,6 @@ pub(crate) struct NestedRecordingState {
 pub struct PaintRecorder<'a> {
     pub(crate) layout_arena: &'a PaintableRowsRef<'a>,
     pub(crate) paint_state: &'a crate::painting::paint_state::PaintState,
-    stacking_contexts: &'a StackingContextTree,
     pub(crate) host: &'a FfiHitTestHostCallbacks,
     pub(crate) paint_host: &'a FfiPaintHostCallbacks,
     pub(crate) inputs: FfiRecordingInputs,
@@ -197,7 +195,6 @@ impl<'a> PaintRecorder<'a> {
         PaintRecorder {
             layout_arena: self.layout_arena,
             paint_state: self.paint_state,
-            stacking_contexts: self.stacking_contexts,
             host: self.host,
             paint_host: self.paint_host,
             inputs: self.inputs,
@@ -290,7 +287,7 @@ impl<'a> PaintRecorder<'a> {
     }
 
     fn has_stacking_context(&self, paintable: NodeSlotId) -> bool {
-        self.data(paintable).stacking_context != NO_STACKING_CONTEXT
+        self.data(paintable).establishes_stacking_context
     }
 
     fn layout_kind(&self, paintable: NodeSlotId) -> Option<NodeKind> {

--- a/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/traversal.rs
@@ -20,7 +20,6 @@ use crate::painting::host::{
 use crate::painting::node_painting;
 use crate::painting::record::RecordingOutput;
 use crate::painting::record::masks::MaskLayerSet;
-use crate::painting::stacking_context::NO_STACKING_CONTEXT;
 use crate::painting::style_queries;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -60,6 +59,7 @@ fn to_paint_phase(phase: StackingContextPaintPhase) -> PaintPhase {
 pub(crate) fn record_display_list(
     layout_arena: &LayoutNodeArena,
     paint_state: &crate::painting::paint_state::PaintState,
+    viewport: NodeSlotId,
     host: &FfiHitTestHostCallbacks,
     paint_host: &FfiPaintHostCallbacks,
     visual_context_host: &FfiVisualContextHostCallbacks,
@@ -68,10 +68,6 @@ pub(crate) fn record_display_list(
     command_cache_source: Option<Rc<RecordingOutput>>,
     item_cache_source: Option<Rc<crate::painting::record::cache::HitTestItemCacheSource>>,
 ) -> RecordingOutput {
-    let stacking_contexts = paint_state
-        .stacking_context_tree
-        .as_ref()
-        .expect("recording needs a built stacking context tree");
     let structural_epoch = paint_state.visual_context.structural_epoch();
     let command_cache_source = command_cache_source
         .filter(|source| source.recorded_device_pixels_per_css_pixel == inputs.device_pixels_per_css_pixel);
@@ -79,7 +75,6 @@ pub(crate) fn record_display_list(
     let mut recorder = PaintRecorder {
         layout_arena: &paintable_rows,
         paint_state,
-        stacking_contexts,
         host,
         paint_host,
         inputs,
@@ -95,10 +90,7 @@ pub(crate) fn record_display_list(
         item_cache_source,
         display_list_id: inputs.display_list_id,
         hit_test_list_generation,
-        viewport: stacking_contexts
-            .nodes
-            .first()
-            .map_or(NodeSlotId::INVALID, |root| root.paintable),
+        viewport,
         has_blocking_wheel_event_listeners: false,
         spliced_capture_count: 0,
         uncacheable_paint_generation: 0,
@@ -135,9 +127,7 @@ pub(crate) fn record_display_list(
     }
     recorder.recorder.fill_rect(inputs.bitmap_rect, inputs.background_color);
     recorder.prerecord_nested_display_lists();
-    if !stacking_contexts.nodes.is_empty() {
-        recorder.paint_stacking_context(0);
-    }
+    recorder.paint_stacking_context(viewport);
     crate::painting::record::paint::inspector_overlay::record_inspector_overlays(&mut recorder);
     let mask_display_lists = recorder.recorder.take_mask_display_lists();
     let mut hit_test_list = recorder.list;
@@ -179,8 +169,11 @@ impl PaintRecorder<'_> {
             && !style_queries::is_positioned(self.layout_arena, paintable)
     }
 
-    fn paint_stacking_context(&mut self, index: u32) {
-        let paintable = self.stacking_contexts.nodes[index as usize].paintable;
+    fn paint_stacking_context(&mut self, paintable: NodeSlotId) {
+        debug_assert!(self.layout_arena.paintable_row_is_populated(paintable));
+        if !self.layout_arena.paintable_row_is_populated(paintable) {
+            return;
+        }
         // https://drafts.csswg.org/css-transforms-1/#transform-function-lists
         // If a transform function causes the current transformation matrix of an object to be
         // non-invertible, the object and its content do not get displayed. Retain content whose
@@ -207,18 +200,15 @@ impl PaintRecorder<'_> {
         self.register_mask_display_lists(paintable, MaskLayerSet::CssAndSvg);
 
         let context_before_children = self.recorder.accumulated_visual_context();
-        self.with_context(context_before_children, |this| this.paint_internal(index));
+        self.with_context(context_before_children, |this| this.paint_internal(paintable));
     }
 
-    fn paint_child(&mut self, child: u32) {
+    fn paint_child(&mut self, child: NodeSlotId) {
         self.paint_stacking_context(child);
     }
 
-    fn paint_internal(&mut self, index: u32) {
-        let stacking_contexts = self.stacking_contexts;
-        let node = &stacking_contexts.nodes[index as usize];
-        let paintable = node.paintable;
-        let children = &node.children;
+    fn paint_internal(&mut self, paintable: NodeSlotId) {
+        let entries = self.layout_arena.stacking_context_entries(paintable);
         if self.layout_kind(paintable) == Some(NodeKind::SVGSVGBox) {
             self.paint_node(paintable, PaintPhase::Background);
             self.paint_node(paintable, PaintPhase::Border);
@@ -226,8 +216,20 @@ impl PaintRecorder<'_> {
             // An `<svg>` that establishes a stacking context still has descendants that establish
             // one of their own - a `<foreignObject>` always does - and those are painted by their
             // own context rather than by the SVG walk.
-            for child in children {
-                self.paint_child(*child);
+            if let Some(entries) = &entries {
+                for entry in entries.negative_z_index_child_contexts() {
+                    self.paint_child(entry.slot);
+                }
+                for &descendant in &entries.stack_level_zero_boxes {
+                    if self.layout_arena.paintable_row_is_populated(descendant)
+                        && self.data(descendant).establishes_stacking_context
+                    {
+                        self.paint_child(descendant);
+                    }
+                }
+                for entry in entries.positive_z_index_child_contexts() {
+                    self.paint_child(entry.slot);
+                }
             }
             self.paint_node(paintable, PaintPhase::Outline);
             if self.inputs.should_paint_overlay {
@@ -246,10 +248,9 @@ impl PaintRecorder<'_> {
         // Here, we treat non-positioned stacking contexts as if they were positioned, because CSS 2.0 spec does not
         // account for new properties like `transform` and `opacity` that can create stacking contexts.
         // https://github.com/w3c/csswg-drafts/issues/2717
-        for child in children {
-            let z_index = stacking_contexts.nodes[*child as usize].effective_z_index;
-            if z_index.is_some_and(|z| z < 0) {
-                self.paint_child(*child);
+        if let Some(entries) = &entries {
+            for entry in entries.negative_z_index_child_contexts() {
+                self.paint_child(entry.slot);
             }
         }
 
@@ -261,14 +262,17 @@ impl PaintRecorder<'_> {
             self.paint_node(paintable, PaintPhase::TableCollapsedBorder);
         }
         // Draw the non-positioned floats (step 5)
-        if !self.stacking_contexts.nodes[index as usize]
-            .non_positioned_floating_descendants
-            .is_empty()
+        if entries
+            .as_ref()
+            .is_some_and(|entries| entries.non_positioned_float_count > 0)
         {
             self.paint_descendants(paintable, StackingContextPaintPhase::Floats);
         }
         // Draw inline content, replaced content, etc. (steps 6, 7)
-        if self.stacking_contexts.nodes[index as usize].contains_inline_or_replaced_descendants {
+        if entries
+            .as_ref()
+            .is_some_and(|entries| entries.inline_or_replaced_count > 0)
+        {
             self.paint_descendants(
                 paintable,
                 StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced,
@@ -281,19 +285,17 @@ impl PaintRecorder<'_> {
         // Here, we treat non-positioned stacking contexts as if they were positioned, because CSS 2.0 spec does not
         // account for new properties like `transform` and `opacity` that can create stacking contexts.
         // https://github.com/w3c/csswg-drafts/issues/2717
-        for &descendant in
-            &stacking_contexts.nodes[index as usize].positioned_descendants_and_stacking_contexts_with_stack_level_0
-        {
-            if !self.layout_arena.paintable_row_is_populated(descendant) {
-                continue;
-            }
-            let child_context = self.data(descendant).stacking_context;
-            // At this point, `paintable` is a positioned descendant with z-index: auto.
-            // FIXME: This is basically duplicating logic found elsewhere in this same function. Find a way to make this more elegant.
-            if child_context != NO_STACKING_CONTEXT {
-                self.paint_child(child_context);
-            } else {
-                self.paint_node_as_stacking_context(descendant);
+        if let Some(entries) = &entries {
+            for &descendant in &entries.stack_level_zero_boxes {
+                debug_assert!(self.layout_arena.paintable_row_is_populated(descendant));
+                if !self.layout_arena.paintable_row_is_populated(descendant) {
+                    continue;
+                }
+                if self.data(descendant).establishes_stacking_context {
+                    self.paint_child(descendant);
+                } else {
+                    self.paint_node_as_stacking_context(descendant);
+                }
             }
         }
 
@@ -302,10 +304,9 @@ impl PaintRecorder<'_> {
         // Here, we treat non-positioned stacking contexts as if they were positioned, because CSS 2.0 spec does not
         // account for new properties like `transform` and `opacity` that can create stacking contexts.
         // https://github.com/w3c/csswg-drafts/issues/2717
-        for child in children {
-            let z_index = stacking_contexts.nodes[*child as usize].effective_z_index;
-            if z_index.is_some_and(|z| z >= 1) {
-                self.paint_child(*child);
+        if let Some(entries) = &entries {
+            for entry in entries.positive_z_index_child_contexts() {
+                self.paint_child(entry.slot);
             }
         }
 

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::host::FfiStackingContextDumpEntry;
+
+pub(crate) fn for_each_stacking_context_in_dump_order(
+    arena: &LayoutNodeArena,
+    viewport: NodeSlotId,
+    emit: &mut impl FnMut(FfiStackingContextDumpEntry),
+) {
+    if arena.stacking_context_entries(viewport).is_none() {
+        return;
+    }
+    visit(arena, viewport, 0, emit);
+}
+
+fn visit(arena: &LayoutNodeArena, root: NodeSlotId, depth: usize, emit: &mut impl FnMut(FfiStackingContextDumpEntry)) {
+    let effective_z_index = arena
+        .paintable_visual_context_record(root)
+        .and_then(|record| record.stacking_context.effective_z_index);
+    emit(FfiStackingContextDumpEntry {
+        layout_node_shell: arena.shell_if_live(root),
+        depth,
+        has_effective_z_index: effective_z_index.is_some(),
+        effective_z_index: effective_z_index.unwrap_or(0),
+    });
+    let Some(entries) = arena.stacking_context_entries(root) else {
+        return;
+    };
+    for entry in entries.negative_z_index_child_contexts() {
+        visit(arena, entry.slot, depth + 1, emit);
+    }
+    for &descendant in &entries.stack_level_zero_boxes {
+        if arena.paintable_row_is_populated(descendant)
+            && arena
+                .paintable_rows()
+                .paintable_data(descendant)
+                .establishes_stacking_context
+        {
+            visit(arena, descendant, depth + 1, emit);
+        }
+    }
+    for entry in entries.positive_z_index_child_contexts() {
+        visit(arena, entry.slot, depth + 1, emit);
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
@@ -176,6 +176,11 @@ impl LayoutNodeArena {
                 next.contribution_is_registered = true;
                 return;
             }
+            if previous.paints_inline_content_itself() != next.paints_inline_content_itself()
+                && let Some(line_root) = self.inline_pieces_root(slot)
+            {
+                self.note_line_root_needs_fragment_ownership(line_root);
+            }
             if previous.contribution_is_registered {
                 self.withdraw_stacking_context_contribution(slot, previous);
             }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
@@ -26,6 +26,22 @@ pub(crate) struct StackingContextEntries {
     pub needs_resort: bool,
 }
 
+impl StackingContextEntries {
+    pub(crate) fn negative_z_index_child_contexts(&self) -> &[NonzeroZIndexChildContext] {
+        let first_positive = self
+            .child_contexts_with_nonzero_z_index
+            .partition_point(|entry| entry.z_index < 0);
+        &self.child_contexts_with_nonzero_z_index[..first_positive]
+    }
+
+    pub(crate) fn positive_z_index_child_contexts(&self) -> &[NonzeroZIndexChildContext] {
+        let first_positive = self
+            .child_contexts_with_nonzero_z_index
+            .partition_point(|entry| entry.z_index < 0);
+        &self.child_contexts_with_nonzero_z_index[first_positive..]
+    }
+}
+
 impl LayoutNodeArena {
     pub(crate) fn stacking_context_entries(&self, root: NodeSlotId) -> Option<Ref<'_, StackingContextEntries>> {
         if !self.paintable_row_is_populated(root) {

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/entries.rs
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::StackingContextFacts;
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::paint_order;
+use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
+use std::cell::Ref;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NonzeroZIndexChildContext {
+    pub z_index: i32,
+    pub slot: NodeSlotId,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StackingContextEntries {
+    pub child_contexts_with_nonzero_z_index: Vec<NonzeroZIndexChildContext>,
+    pub stack_level_zero_boxes: Vec<NodeSlotId>,
+    pub non_positioned_float_count: u32,
+    pub inline_or_replaced_count: u32,
+    pub needs_resort: bool,
+}
+
+impl LayoutNodeArena {
+    pub(crate) fn stacking_context_entries(&self, root: NodeSlotId) -> Option<Ref<'_, StackingContextEntries>> {
+        if !self.paintable_row_is_populated(root) {
+            return None;
+        }
+        Ref::filter_map(self.paintable_rows.stacking_context_entries.borrow(), |tables| {
+            tables
+                .get(root.slot_index() as usize)
+                .and_then(|table| table.as_deref())
+        })
+        .ok()
+    }
+
+    pub(crate) fn ensure_stacking_context_entries_for_root(&self, root: NodeSlotId) {
+        debug_assert!(self.paintable_row_is_populated(root));
+        let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+        let table = &mut tables[root.slot_index() as usize];
+        if table.is_none() {
+            *table = Some(Box::default());
+        }
+    }
+
+    pub(crate) fn drop_stacking_context_entries_of_root(&self, root: NodeSlotId) {
+        if let Some(table) = self
+            .paintable_rows
+            .stacking_context_entries
+            .borrow_mut()
+            .get_mut(root.slot_index() as usize)
+        {
+            *table = None;
+        }
+    }
+
+    pub(crate) fn register_stacking_context_contribution(&self, slot: NodeSlotId, facts: &StackingContextFacts) {
+        let enclosing = facts.enclosing_stacking_context;
+        if !self.paintable_row_is_populated(enclosing) {
+            return;
+        }
+        let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+        let Some(table) = tables
+            .get_mut(enclosing.slot_index() as usize)
+            .and_then(|table| table.as_deref_mut())
+        else {
+            return;
+        };
+        if let Some(z_index) = facts.nonzero_z_index_child_contribution() {
+            let label = self.node_pre_order_label(slot);
+            let position = table
+                .child_contexts_with_nonzero_z_index
+                .partition_point(|entry| (entry.z_index, self.node_pre_order_label(entry.slot)) < (z_index, label));
+            table
+                .child_contexts_with_nonzero_z_index
+                .insert(position, NonzeroZIndexChildContext { z_index, slot });
+        } else if facts.contributes_to_stack_level_zero() {
+            let label = self.node_pre_order_label(slot);
+            let position = table
+                .stack_level_zero_boxes
+                .partition_point(|entry| self.node_pre_order_label(*entry) < label);
+            table.stack_level_zero_boxes.insert(position, slot);
+        }
+        if facts.contributes_non_positioned_float() {
+            table.non_positioned_float_count += 1;
+        }
+        if facts.contributes_inline_or_replaced() {
+            table.inline_or_replaced_count += 1;
+        }
+    }
+
+    pub(crate) fn withdraw_stacking_context_contribution(&self, slot: NodeSlotId, facts: &StackingContextFacts) {
+        let enclosing = facts.enclosing_stacking_context;
+        if !self.paintable_row_is_populated(enclosing) {
+            return;
+        }
+        let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+        let Some(table) = tables
+            .get_mut(enclosing.slot_index() as usize)
+            .and_then(|table| table.as_deref_mut())
+        else {
+            return;
+        };
+        if facts.nonzero_z_index_child_contribution().is_some() {
+            if let Some(position) = table
+                .child_contexts_with_nonzero_z_index
+                .iter()
+                .position(|entry| entry.slot == slot)
+            {
+                table.child_contexts_with_nonzero_z_index.remove(position);
+            }
+        } else if facts.contributes_to_stack_level_zero()
+            && let Some(position) = table.stack_level_zero_boxes.iter().position(|entry| *entry == slot)
+        {
+            table.stack_level_zero_boxes.remove(position);
+        }
+        if facts.contributes_non_positioned_float() {
+            table.non_positioned_float_count = table.non_positioned_float_count.saturating_sub(1);
+        }
+        if facts.contributes_inline_or_replaced() {
+            table.inline_or_replaced_count = table.inline_or_replaced_count.saturating_sub(1);
+        }
+    }
+
+    fn flag_stacking_context_entries_for_resort(&self, root: NodeSlotId) {
+        if !self.paintable_row_is_populated(root) {
+            return;
+        }
+        let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+        let Some(table) = tables
+            .get_mut(root.slot_index() as usize)
+            .and_then(|table| table.as_deref_mut())
+        else {
+            return;
+        };
+        if table.needs_resort {
+            return;
+        }
+        table.needs_resort = true;
+        self.paintable_rows
+            .stacking_context_roots_flagged_for_resort
+            .borrow_mut()
+            .push(root);
+    }
+
+    pub(crate) fn apply_stacking_context_facts_delta(
+        &self,
+        slot: NodeSlotId,
+        previous: Option<&StackingContextFacts>,
+        next: &mut StackingContextFacts,
+        was_reattached: bool,
+    ) {
+        if let Some(previous) = previous {
+            if previous.contribution_is_registered && previous.same_contributions_as(next) && !was_reattached {
+                next.contribution_is_registered = true;
+                return;
+            }
+            if previous.contribution_is_registered {
+                self.withdraw_stacking_context_contribution(slot, previous);
+            }
+            if previous.establishes_stacking_context && !next.establishes_stacking_context {
+                self.drop_stacking_context_entries_of_root(slot);
+            }
+        }
+        if next.establishes_stacking_context {
+            self.ensure_stacking_context_entries_for_root(slot);
+        }
+        self.register_stacking_context_contribution(slot, next);
+        next.contribution_is_registered = true;
+        if was_reattached {
+            if let Some(previous) = previous {
+                self.flag_stacking_context_entries_for_resort(previous.enclosing_stacking_context);
+            }
+            self.flag_stacking_context_entries_for_resort(next.enclosing_stacking_context);
+        }
+    }
+
+    pub(crate) fn resort_stacking_context_entries_flagged_for_resort(&self) {
+        let flagged_roots = std::mem::take(
+            &mut *self
+                .paintable_rows
+                .stacking_context_roots_flagged_for_resort
+                .borrow_mut(),
+        );
+        for root in flagged_roots {
+            if !self.paintable_row_is_populated(root) {
+                continue;
+            }
+            let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+            let Some(table) = tables
+                .get_mut(root.slot_index() as usize)
+                .and_then(|table| table.as_deref_mut())
+            else {
+                continue;
+            };
+            table.needs_resort = false;
+            table
+                .child_contexts_with_nonzero_z_index
+                .sort_by_key(|entry| (entry.z_index, self.node_pre_order_label(entry.slot)));
+            table
+                .stack_level_zero_boxes
+                .sort_by_key(|entry| self.node_pre_order_label(*entry));
+        }
+    }
+
+    pub(crate) fn rebuild_all_stacking_context_entries_from_records(&self, viewport: NodeSlotId) {
+        self.paintable_rows
+            .stacking_context_entries
+            .borrow_mut()
+            .iter_mut()
+            .for_each(|table| *table = None);
+        self.paintable_rows
+            .stacking_context_roots_flagged_for_resort
+            .borrow_mut()
+            .clear();
+        let paintable_rows = self.paintable_rows();
+        let mut roots_in_visit_order: Vec<NodeSlotId> = Vec::new();
+        paint_order::for_each_in_paint_subtree(&paintable_rows, viewport, |slot| {
+            let Some(record) = self.paintable_visual_context_record(slot) else {
+                return;
+            };
+            let facts = record.stacking_context;
+            drop(record);
+            if facts.establishes_stacking_context {
+                self.ensure_stacking_context_entries_for_root(slot);
+                roots_in_visit_order.push(slot);
+            }
+            let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+            if let Some(table) = tables
+                .get_mut(facts.enclosing_stacking_context.slot_index() as usize)
+                .and_then(|table| table.as_deref_mut())
+                .filter(|_| self.paintable_row_is_populated(facts.enclosing_stacking_context))
+            {
+                if let Some(z_index) = facts.nonzero_z_index_child_contribution() {
+                    table
+                        .child_contexts_with_nonzero_z_index
+                        .push(NonzeroZIndexChildContext { z_index, slot });
+                } else if facts.contributes_to_stack_level_zero() {
+                    table.stack_level_zero_boxes.push(slot);
+                }
+                if facts.contributes_non_positioned_float() {
+                    table.non_positioned_float_count += 1;
+                }
+                if facts.contributes_inline_or_replaced() {
+                    table.inline_or_replaced_count += 1;
+                }
+            }
+            drop(tables);
+            self.set_paintable_record_stacking_context_contribution_registered(slot);
+        });
+        let mut tables = self.paintable_rows.stacking_context_entries.borrow_mut();
+        for root in roots_in_visit_order {
+            if let Some(table) = tables
+                .get_mut(root.slot_index() as usize)
+                .and_then(|table| table.as_deref_mut())
+            {
+                table
+                    .child_contexts_with_nonzero_z_index
+                    .sort_by_key(|entry| entry.z_index);
+            }
+        }
+    }
+
+    pub(crate) fn withdraw_stacking_context_state_of_reset_row(
+        &self,
+        slot: NodeSlotId,
+        facts: Option<StackingContextFacts>,
+    ) {
+        if let Some(facts) = facts
+            && facts.contribution_is_registered
+        {
+            self.withdraw_stacking_context_contribution(slot, &facts);
+        }
+        self.drop_stacking_context_entries_of_root(slot);
+    }
+
+    pub(crate) fn note_layout_subtree_attached(&self, subtree_root: NodeSlotId) {
+        if self.paintable_row_count() == 0 {
+            return;
+        }
+        self.for_each_node_in_layout_subtree_in_pre_order(subtree_root, |node| {
+            if self.paintable_row_is_populated(node) {
+                self.note_visual_context_box_dirty(node, VisualContextBoxDirtyKind::ReattachedInLayoutTree);
+            }
+        });
+    }
+}

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+pub mod entries;
+pub mod verify;
+
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::node_facts;
@@ -50,6 +53,35 @@ impl StackingContextFacts {
             enclosing_stacking_context: NodeSlotId::INVALID,
             contribution_is_registered: false,
         }
+    }
+
+    pub(crate) fn nonzero_z_index_child_contribution(&self) -> Option<i32> {
+        if self.establishes_stacking_context && self.effective_z_index.unwrap_or(0) != 0 {
+            self.effective_z_index
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn contributes_to_stack_level_zero(&self) -> bool {
+        (self.is_positioned || self.establishes_stacking_context) && self.effective_z_index.unwrap_or(0) == 0
+    }
+
+    pub(crate) fn contributes_non_positioned_float(&self) -> bool {
+        self.is_non_positioned_float
+    }
+
+    pub(crate) fn contributes_inline_or_replaced(&self) -> bool {
+        self.is_inline_or_replaced_without_own_context
+    }
+
+    pub(crate) fn same_contributions_as(&self, other: &Self) -> bool {
+        self.establishes_stacking_context == other.establishes_stacking_context
+            && self.effective_z_index == other.effective_z_index
+            && self.is_positioned == other.is_positioned
+            && self.is_non_positioned_float == other.is_non_positioned_float
+            && self.is_inline_or_replaced_without_own_context == other.is_inline_or_replaced_without_own_context
+            && self.enclosing_stacking_context == other.enclosing_stacking_context
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
@@ -4,12 +4,54 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::node_facts;
 use crate::painting::paintable_rows::PaintableRowsWrite;
 use crate::painting::style_queries::{self, effective_z_index};
 
 pub use crate::painting::paintable_data::NO_STACKING_CONTEXT;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StackingContextFacts {
+    pub establishes_stacking_context: bool,
+    pub effective_z_index: Option<i32>,
+    pub is_positioned: bool,
+    pub is_non_positioned_float: bool,
+    pub is_inline_or_replaced_without_own_context: bool,
+    pub enclosing_stacking_context: NodeSlotId,
+    pub contribution_is_registered: bool,
+}
+
+impl StackingContextFacts {
+    pub(crate) fn gather(arena: &LayoutNodeArena, slot: NodeSlotId, enclosing: NodeSlotId) -> Self {
+        let establishes_stacking_context = style_queries::establishes_stacking_context(arena, slot);
+        let is_positioned = style_queries::is_positioned(arena, slot);
+        let is_inline_or_replaced =
+            style_queries::is_inline(arena, slot) || style_queries::is_replaced_box(arena, slot);
+        Self {
+            establishes_stacking_context,
+            effective_z_index: effective_z_index(arena, slot),
+            is_positioned,
+            is_non_positioned_float: !is_positioned && style_queries::is_floating(arena, slot),
+            is_inline_or_replaced_without_own_context: !establishes_stacking_context && is_inline_or_replaced,
+            enclosing_stacking_context: enclosing,
+            contribution_is_registered: false,
+        }
+    }
+
+    pub(crate) fn for_viewport() -> Self {
+        Self {
+            establishes_stacking_context: true,
+            effective_z_index: None,
+            is_positioned: false,
+            is_non_positioned_float: false,
+            is_inline_or_replaced_without_own_context: false,
+            enclosing_stacking_context: NodeSlotId::INVALID,
+            contribution_is_registered: false,
+        }
+    }
+}
 
 pub struct StackingContextNode {
     pub paintable: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+pub mod dump;
 pub mod entries;
 pub mod verify;
 

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/mod.rs
@@ -10,11 +10,7 @@ pub mod verify;
 
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::node_facts;
-use crate::painting::paintable_rows::PaintableRowsWrite;
 use crate::painting::style_queries::{self, effective_z_index};
-
-pub use crate::painting::paintable_data::NO_STACKING_CONTEXT;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct StackingContextFacts {
@@ -84,133 +80,8 @@ impl StackingContextFacts {
             && self.is_inline_or_replaced_without_own_context == other.is_inline_or_replaced_without_own_context
             && self.enclosing_stacking_context == other.enclosing_stacking_context
     }
-}
 
-pub struct StackingContextNode {
-    pub paintable: NodeSlotId,
-    pub parent: u32,
-    pub children: Vec<u32>,
-    pub index_in_tree_order: usize,
-    pub effective_z_index: Option<i32>,
-    pub positioned_descendants_and_stacking_contexts_with_stack_level_0: Vec<NodeSlotId>,
-    pub non_positioned_floating_descendants: Vec<NodeSlotId>,
-    pub contains_inline_or_replaced_descendants: bool,
-}
-
-#[derive(Default)]
-pub struct StackingContextTree {
-    pub nodes: Vec<StackingContextNode>,
-}
-
-pub(crate) fn build_stacking_context_tree(
-    layout_arena: &mut impl PaintableRowsWrite,
-    root: NodeSlotId,
-) -> StackingContextTree {
-    let mut tree = StackingContextTree::default();
-    tree.nodes.push(StackingContextNode {
-        paintable: root,
-        parent: NO_STACKING_CONTEXT,
-        children: Vec::new(),
-        index_in_tree_order: 0,
-        effective_z_index: effective_z_index(layout_arena, root),
-        positioned_descendants_and_stacking_contexts_with_stack_level_0: Vec::new(),
-        non_positioned_floating_descendants: Vec::new(),
-        contains_inline_or_replaced_descendants: false,
-    });
-    layout_arena.paintable_data_mut(root).stacking_context = 0;
-
-    let mut index_in_tree_order = 1;
-    let mut stack: Vec<NodeSlotId> = Vec::new();
-    let mut child = crate::painting::paint_order::first_paint_child(layout_arena, root);
-    while let Some(first) = child {
-        stack.push(first);
-        child = None;
-        while let Some(current) = stack.pop() {
-            visit(layout_arena, &mut tree, current, &mut index_in_tree_order);
-            if let Some(next) = crate::painting::paint_order::next_paint_sibling(layout_arena, current) {
-                stack.push(next);
-            }
-            if let Some(first_child) = crate::painting::paint_order::first_paint_child(layout_arena, current) {
-                stack.push(first_child);
-            }
-        }
+    pub(crate) fn paints_inline_content_itself(&self) -> bool {
+        self.establishes_stacking_context || self.is_positioned
     }
-
-    sort(&mut tree, 0);
-    tree
-}
-
-fn visit(
-    layout_arena: &mut impl PaintableRowsWrite,
-    tree: &mut StackingContextTree,
-    paintable: NodeSlotId,
-    index_in_tree_order: &mut usize,
-) {
-    let mut ancestor = crate::painting::paint_order::paint_parent(layout_arena, paintable);
-    let mut parent_context = NO_STACKING_CONTEXT;
-    while let Some(candidate) = ancestor {
-        let context = layout_arena.paintable_data(candidate).stacking_context;
-        if context != NO_STACKING_CONTEXT {
-            parent_context = context;
-            break;
-        }
-        ancestor = crate::painting::paint_order::paint_parent(layout_arena, candidate);
-    }
-    // We should always reach the viewport's stacking context.
-    assert_ne!(
-        parent_context, NO_STACKING_CONTEXT,
-        "paintable outside the viewport's stacking context"
-    );
-
-    let establishes_stacking_context =
-        crate::painting::style_queries::establishes_stacking_context(layout_arena, paintable);
-    let z_index = effective_z_index(layout_arena, paintable);
-    let positioned = style_queries::is_positioned(layout_arena, paintable);
-    let floating = style_queries::is_floating(layout_arena, paintable);
-    let inline = style_queries::is_inline(layout_arena, paintable);
-    {
-        let parent = &mut tree.nodes[parent_context as usize];
-        if (positioned || establishes_stacking_context) && z_index.unwrap_or(0) == 0 {
-            parent
-                .positioned_descendants_and_stacking_contexts_with_stack_level_0
-                .push(paintable);
-        }
-        if !positioned && floating {
-            parent.non_positioned_floating_descendants.push(paintable);
-        }
-        let layout_kind = layout_arena.node_kind_if_live(paintable);
-        if !establishes_stacking_context && (inline || layout_kind.is_some_and(node_facts::kind_is_replaced_box)) {
-            parent.contains_inline_or_replaced_descendants = true;
-        }
-    }
-    if !establishes_stacking_context {
-        layout_arena.paintable_data_mut(paintable).stacking_context = NO_STACKING_CONTEXT;
-        return;
-    }
-    let index = tree.nodes.len() as u32;
-    tree.nodes.push(StackingContextNode {
-        paintable,
-        parent: parent_context,
-        children: Vec::new(),
-        index_in_tree_order: *index_in_tree_order,
-        effective_z_index: z_index,
-        positioned_descendants_and_stacking_contexts_with_stack_level_0: Vec::new(),
-        non_positioned_floating_descendants: Vec::new(),
-        contains_inline_or_replaced_descendants: false,
-    });
-    *index_in_tree_order += 1;
-    tree.nodes[parent_context as usize].children.push(index);
-    layout_arena.paintable_data_mut(paintable).stacking_context = index;
-}
-
-fn sort(tree: &mut StackingContextTree, index: u32) {
-    let mut children = std::mem::take(&mut tree.nodes[index as usize].children);
-    children.sort_by_key(|child| {
-        let node = &tree.nodes[*child as usize];
-        (node.effective_z_index.unwrap_or(0), node.index_in_tree_order)
-    });
-    for child in &children {
-        sort(tree, *child);
-    }
-    tree.nodes[index as usize].children = children;
 }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/verify.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/verify.rs
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use super::StackingContextFacts;
+use crate::layout::LayoutNodeArena;
+use crate::layout::node_data::NodeSlotId;
+use crate::painting::node_painting;
+use crate::painting::paint_order;
+use std::collections::HashMap;
+use std::fmt::Write;
+
+const MAXIMUM_REPORT_LINE_COUNT: usize = 32;
+
+struct Report {
+    text: String,
+    line_count: usize,
+}
+
+impl Report {
+    fn note(&mut self, line: std::fmt::Arguments<'_>) {
+        if self.line_count == MAXIMUM_REPORT_LINE_COUNT {
+            self.text.push_str("(report capped)\n");
+        }
+        self.line_count += 1;
+        if self.line_count > MAXIMUM_REPORT_LINE_COUNT {
+            return;
+        }
+        let _ = writeln!(self.text, "{line}");
+    }
+}
+
+#[derive(Default)]
+struct ExpectedEntries {
+    child_contexts_with_nonzero_z_index: Vec<(i32, NodeSlotId)>,
+    stack_level_zero_boxes: Vec<NodeSlotId>,
+    non_positioned_float_count: u32,
+    inline_or_replaced_count: u32,
+}
+
+struct Verifier<'a> {
+    arena: &'a LayoutNodeArena,
+    expected_entries_by_root: HashMap<NodeSlotId, ExpectedEntries>,
+    expected_roots: Vec<NodeSlotId>,
+    previous_label: Option<u64>,
+    report: Report,
+}
+
+impl Verifier<'_> {
+    fn visit(&mut self, slot: NodeSlotId, enclosing: NodeSlotId) {
+        let fresh = StackingContextFacts::gather(self.arena, slot, enclosing);
+        let label = self.arena.node_pre_order_label(slot);
+        if self.previous_label.is_some_and(|previous| label <= previous) {
+            self.report.note(format_args!(
+                "pre-order label of {slot:?} is not greater than the previous label"
+            ));
+        }
+        self.previous_label = Some(label);
+
+        match self.arena.paintable_visual_context_record(slot) {
+            Some(record) => {
+                let stored = record.stacking_context;
+                drop(record);
+                let mut fresh_with_registered_contribution = fresh;
+                fresh_with_registered_contribution.contribution_is_registered = true;
+                if stored != fresh_with_registered_contribution {
+                    self.report.note(format_args!(
+                        "facts of {slot:?} diverge: stored {stored:?}, fresh {fresh_with_registered_contribution:?}"
+                    ));
+                }
+            }
+            None => self.report.note(format_args!("{slot:?} has no visual context record")),
+        }
+        let paintable_rows = self.arena.paintable_rows();
+        if paintable_rows.paintable_data(slot).establishes_stacking_context != fresh.establishes_stacking_context {
+            self.report.note(format_args!(
+                "PaintableData.establishes_stacking_context of {slot:?} diverges from a fresh query"
+            ));
+        }
+
+        if let Some(z_index) = fresh.nonzero_z_index_child_contribution() {
+            self.expected_entries_by_root
+                .entry(enclosing)
+                .or_default()
+                .child_contexts_with_nonzero_z_index
+                .push((z_index, slot));
+        } else if fresh.contributes_to_stack_level_zero() {
+            self.expected_entries_by_root
+                .entry(enclosing)
+                .or_default()
+                .stack_level_zero_boxes
+                .push(slot);
+        }
+        if fresh.contributes_non_positioned_float() {
+            self.expected_entries_by_root
+                .entry(enclosing)
+                .or_default()
+                .non_positioned_float_count += 1;
+        }
+        if fresh.contributes_inline_or_replaced() {
+            self.expected_entries_by_root
+                .entry(enclosing)
+                .or_default()
+                .inline_or_replaced_count += 1;
+        }
+        if fresh.establishes_stacking_context {
+            self.expected_roots.push(slot);
+            self.expected_entries_by_root.entry(slot).or_default();
+        }
+
+        let enclosing_for_children = if fresh.establishes_stacking_context {
+            slot
+        } else {
+            enclosing
+        };
+        let mut children = Vec::new();
+        paint_order::for_each_paint_child(&self.arena.paintable_rows(), slot, |child| children.push(child));
+        for child in children {
+            self.visit(child, enclosing_for_children);
+        }
+
+        let paintable_rows = self.arena.paintable_rows();
+        if node_painting::has_lines(&paintable_rows, slot)
+            && !self.arena.paintable_side_data(slot).inline_box_pieces.is_empty()
+        {
+            for (owner, recomputed_filter) in
+                crate::painting::fragment_ownership::compute_fragment_ownership_for_block(&paintable_rows, slot)
+            {
+                let stored_filter = self.arena.paintable_side_data(owner).fragment_ownership.clone();
+                if stored_filter.as_ref() != Some(&recomputed_filter) {
+                    self.report.note(format_args!(
+                        "fragment ownership of {owner:?} under line root {slot:?} diverges from a fresh computation"
+                    ));
+                }
+            }
+        }
+    }
+
+    fn compare_tables(&mut self) {
+        for root in std::mem::take(&mut self.expected_roots) {
+            let expected = self
+                .expected_entries_by_root
+                .get_mut(&root)
+                .expect("every expected root has an expected entry set");
+            expected
+                .child_contexts_with_nonzero_z_index
+                .sort_by_key(|(z_index, _)| *z_index);
+            let Some(table) = self.arena.stacking_context_entries(root) else {
+                self.report
+                    .note(format_args!("establishing box {root:?} has no entries table"));
+                continue;
+            };
+            let stored_nonzero: Vec<(i32, NodeSlotId)> = table
+                .child_contexts_with_nonzero_z_index
+                .iter()
+                .map(|entry| (entry.z_index, entry.slot))
+                .collect();
+            if stored_nonzero != expected.child_contexts_with_nonzero_z_index {
+                self.report.note(format_args!(
+                    "nonzero z-index child contexts of {root:?} diverge: stored {stored_nonzero:?}, expected {:?}",
+                    expected.child_contexts_with_nonzero_z_index
+                ));
+            }
+            if table.stack_level_zero_boxes != expected.stack_level_zero_boxes {
+                self.report.note(format_args!(
+                    "stack level zero boxes of {root:?} diverge: stored {:?}, expected {:?}",
+                    table.stack_level_zero_boxes, expected.stack_level_zero_boxes
+                ));
+            }
+            if table.non_positioned_float_count != expected.non_positioned_float_count {
+                self.report.note(format_args!(
+                    "float count of {root:?} diverges: stored {}, expected {}",
+                    table.non_positioned_float_count, expected.non_positioned_float_count
+                ));
+            }
+            if table.inline_or_replaced_count != expected.inline_or_replaced_count {
+                self.report.note(format_args!(
+                    "inline or replaced count of {root:?} diverges: stored {}, expected {}",
+                    table.inline_or_replaced_count, expected.inline_or_replaced_count
+                ));
+            }
+            if table.needs_resort {
+                self.report
+                    .note(format_args!("entries table of {root:?} is still flagged for a resort"));
+            }
+        }
+        let stored_table_count = self
+            .arena
+            .paintable_rows
+            .stacking_context_entries
+            .borrow()
+            .iter()
+            .filter(|table| table.is_some())
+            .count();
+        let expected_table_count = self
+            .expected_entries_by_root
+            .keys()
+            .filter(|root| !root.is_invalid())
+            .count();
+        if stored_table_count != expected_table_count {
+            self.report.note(format_args!(
+                "{stored_table_count} entries tables are stored but {expected_table_count} establishing boxes exist"
+            ));
+        }
+    }
+}
+
+pub(crate) fn verification_report(arena: &LayoutNodeArena, viewport: NodeSlotId) -> String {
+    if !arena.paintable_row_is_populated(viewport) {
+        return String::new();
+    }
+    let mut verifier = Verifier {
+        arena,
+        expected_entries_by_root: HashMap::new(),
+        expected_roots: Vec::new(),
+        previous_label: None,
+        report: Report {
+            text: String::new(),
+            line_count: 0,
+        },
+    };
+    verifier.visit(viewport, NodeSlotId::INVALID);
+    verifier.compare_tables();
+    verifier.report.text
+}

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -62,6 +62,7 @@ impl PaintableVisualContextAssignment {
     pub(crate) fn apply(self, layout_arena: &mut impl PaintableRowsWrite) {
         {
             let data = layout_arena.paintable_data_mut(self.slot);
+            data.establishes_stacking_context = self.record.stacking_context.establishes_stacking_context;
             data.enclosing_scroll_node_index = self.enclosing_scroll_node_index;
             data.own_scroll_node_index = self.own_scroll_node_index;
             data.has_accumulated_visual_context = self.has_accumulated_visual_context;
@@ -226,6 +227,11 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     let is_absolute = position == crate::css::css_enums::positioning::ABSOLUTE;
     let is_sticky = position == crate::css::css_enums::positioning::STICKY;
     let layout_node = slot;
+    let stacking_context_facts = crate::painting::stacking_context::StackingContextFacts::gather(
+        layout_arena,
+        slot,
+        inherited.enclosing_stacking_context,
+    );
     let mut assignment = PaintableVisualContextAssignment::from_data(
         slot,
         layout_arena.paintable_data(slot),
@@ -237,6 +243,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
             may_be_root_element,
             owns_geometry_dependent_nodes: false,
             subtree_may_own_geometry_dependent_nodes: false,
+            stacking_context: stacking_context_facts,
         },
     );
     assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;
@@ -593,6 +600,11 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         fixed_position_plane_root,
         flattens_inherited_transform: descendants_flatten_inherited_transform,
         sorting_context_root: sorting_context_root_for_descendants,
+        enclosing_stacking_context: if stacking_context_facts.establishes_stacking_context {
+            slot
+        } else {
+            inherited.enclosing_stacking_context
+        },
     };
     assignment.record.output_for_descendants = descendant_contexts;
     BoxVisualContextBuildOutput {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -208,6 +208,7 @@ pub(crate) fn create_fresh_tree_with_viewport_nodes(
         fixed_position_plane_root: VISUAL_VIEWPORT_NODE_INDEX,
         flattens_inherited_transform: true,
         sorting_context_root: None,
+        enclosing_stacking_context: viewport,
     };
     let mut viewport_assignment = PaintableVisualContextAssignment::from_data(
         viewport,
@@ -220,6 +221,7 @@ pub(crate) fn create_fresh_tree_with_viewport_nodes(
             may_be_root_element: false,
             owns_geometry_dependent_nodes: false,
             subtree_may_own_geometry_dependent_nodes: false,
+            stacking_context: crate::painting::stacking_context::StackingContextFacts::for_viewport(),
         },
     );
     viewport_assignment.enclosing_scroll_node_index = VISUAL_VIEWPORT_NODE_INDEX;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
@@ -19,16 +19,17 @@ pub enum VisualContextBoxDirtyKind {
     StyleValueChange = 5,
     StyleStructuralChange = 6,
     ScrollableOverflowFlipped = 7,
+    ReattachedInLayoutTree = 8,
 }
 
 impl VisualContextBoxDirtyKind {
-    const fn bit(self) -> u8 {
-        1 << (self as u8)
+    const fn bit(self) -> u16 {
+        1 << (self as u16)
     }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct BoxDirtyBits(u8);
+pub struct BoxDirtyBits(u16);
 
 impl BoxDirtyBits {
     pub fn insert(&mut self, kind: VisualContextBoxDirtyKind) {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -704,5 +704,6 @@ fn remap_descendant_contexts(
         sorting_context_root: contexts
             .sorting_context_root
             .map(|index| placement.remap_spatial(index)),
+        enclosing_stacking_context: contexts.enclosing_stacking_context,
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -472,6 +472,7 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
             let existing_record = layout_arena.paintable_visual_context_record(slot);
             let record_existed = existing_record.is_some();
             let previous_output = existing_record.as_ref().map(|record| record.output_for_descendants);
+            let previous_stacking_context_facts = existing_record.as_ref().map(|record| record.stacking_context);
             let previous_has_mask_nodes = existing_record.as_ref().is_some_and(|record| record.has_mask_nodes);
             let may_be_root_element = parent == viewport;
             let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
@@ -536,6 +537,16 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
                 box_owns_geometry_dependent_nodes(layout_arena, tree, slot, &assignment.record.node_handles);
             assignment.record.subtree_may_own_geometry_dependent_nodes =
                 assignment.record.owns_geometry_dependent_nodes || subtree_may_own_geometry_dependent_nodes;
+            if scope != VisualContextUpdateScope::FreshTree {
+                let box_was_reattached =
+                    work_bits.is_some_and(|bits| bits.contains(VisualContextBoxDirtyKind::ReattachedInLayoutTree));
+                layout_arena.apply_stacking_context_facts_delta(
+                    slot,
+                    previous_stacking_context_facts.as_ref(),
+                    &mut assignment.record.stacking_context,
+                    box_was_reattached,
+                );
+            }
 
             let previous_contexts = record_existed.then(|| {
                 let data = layout_arena.paintable_data(slot);

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -1112,6 +1112,7 @@ pub(crate) struct DescendantVisualContexts {
     pub fixed_position_plane_root: SpatialNodeIndex,
     pub flattens_inherited_transform: bool,
     pub sorting_context_root: Option<SpatialNodeIndex>,
+    pub enclosing_stacking_context: NodeSlotId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1123,6 +1124,7 @@ pub(crate) struct PaintableVisualContextRecord {
     pub may_be_root_element: bool,
     pub owns_geometry_dependent_nodes: bool,
     pub subtree_may_own_geometry_dependent_nodes: bool,
+    pub stacking_context: crate::painting::stacking_context::StackingContextFacts,
 }
 
 #[cfg(test)]

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -662,7 +662,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         if (auto* doc = page->page().top_level_browsing_context().active_document()) {
             if (doc->layout_node()) {
                 VERIFY(doc->has_committed_viewport_box());
-                doc->paint_state().build_stacking_context_tree_if_needed(*doc);
+                doc->update_paint_and_hit_testing_properties_if_needed();
                 StringBuilder builder;
                 Web::Painting::dump_stacking_context_tree(builder, *doc);
                 dbgln("{}", builder.string_view());
@@ -2053,7 +2053,7 @@ static void append_stacking_context_tree(Web::Page& page, StringBuilder& builder
         return;
     }
 
-    document->paint_state().build_stacking_context_tree_if_needed(*document);
+    document->update_paint_and_hit_testing_properties_if_needed();
     Web::Painting::dump_stacking_context_tree(builder, *document);
 }
 

--- a/Tests/LibWeb/Text/expected/stacking-context/backface-visibility-follows-the-parent-3d-context.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/backface-visibility-follows-the-parent-3d-context.txt
@@ -1,0 +1,3 @@
+baseline in a 3d context: contexts=[document (anon) scene card] report-ok=true
+parent context flattened: contexts=[document (anon)] report-ok=true
+parent context restored: contexts=[document (anon) scene card] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/box-gaining-and-losing-a-stacking-context-with-positioned-descendants.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/box-gaining-and-losing-a-stacking-context-with-positioned-descendants.txt
@@ -1,0 +1,4 @@
+baseline: contexts=[document (anon) outer pos-zneg pos-z4] report-ok=true
+gainer establishes: contexts=[document (anon) outer gainer pos-zneg pos-z4] report-ok=true
+gainer releases: contexts=[document (anon) outer pos-zneg pos-z4] report-ok=true
+gainer establishes again: contexts=[document (anon) outer gainer pos-zneg pos-z4] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/flex-item-z-index-change-without-relayout.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/flex-item-z-index-change-without-relayout.txt
@@ -1,0 +1,4 @@
+baseline: contexts=[document (anon) item1 item2] report-ok=true
+first item to z 3: contexts=[document (anon) item2 item1] report-ok=true
+first item back to z 1: contexts=[document (anon) item1 item2] report-ok=true
+layout runs during the z-index changes: 0

--- a/Tests/LibWeb/Text/expected/stacking-context/float-toggle.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/float-toggle.txt
@@ -1,0 +1,5 @@
+baseline: report-ok=true
+float left: report-ok=true
+float none: report-ok=true
+positioned float: report-ok=true
+float without position: report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/inline-box-becoming-self-painting.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/inline-box-becoming-self-painting.txt
@@ -1,0 +1,5 @@
+baseline: hit=the-span report-ok=true
+span with opacity: hit=the-span report-ok=true
+span back to plain: hit=the-span report-ok=true
+span positioned: hit=the-span report-ok=true
+span static again: hit=the-span report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/insertion-of-positioned-siblings-before-and-after.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/insertion-of-positioned-siblings-before-and-after.txt
@@ -1,0 +1,5 @@
+baseline: contexts=[document (anon) anchor-box] report-ok=true
+equal z inserted before: contexts=[document (anon) before-equal-z anchor-box] report-ok=true
+equal z inserted after: contexts=[document (anon) before-equal-z anchor-box after-equal-z] report-ok=true
+z 0 sibling inserted: contexts=[document (anon) level-zero before-equal-z anchor-box after-equal-z] report-ok=true
+z -1 sibling inserted: contexts=[document (anon) negative-z level-zero before-equal-z anchor-box after-equal-z] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/layout-tree-mutations-keep-labels-ordered.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/layout-tree-mutations-keep-labels-ordered.txt
@@ -1,0 +1,10 @@
+baseline: violations=0
+append 5: violations=0
+prepend 5: violations=0
+insertions before a fixed reference: violations=0 relabeled=true
+move an existing subtree: violations=0
+wrap committed inline children in an anonymous block: violations=0
+toggle ::first-letter: violations=0
+drop ::first-letter: violations=0
+innerHTML with a table: violations=0
+removals: violations=0

--- a/Tests/LibWeb/Text/expected/stacking-context/layout-tree-mutations-keep-labels-ordered.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/layout-tree-mutations-keep-labels-ordered.txt
@@ -1,10 +1,11 @@
-baseline: violations=0
-append 5: violations=0
-prepend 5: violations=0
+baseline: violations=0 report-ok=true
+append 5: violations=0 report-ok=true
+prepend 5: violations=0 report-ok=true
 insertions before a fixed reference: violations=0 relabeled=true
-move an existing subtree: violations=0
-wrap committed inline children in an anonymous block: violations=0
-toggle ::first-letter: violations=0
-drop ::first-letter: violations=0
-innerHTML with a table: violations=0
-removals: violations=0
+move an existing subtree: violations=0 report-ok=true
+wrap committed inline children in an anonymous block: violations=0 report-ok=true
+wrapped span still hit-tests on top: true
+toggle ::first-letter: violations=0 report-ok=true
+drop ::first-letter: violations=0 report-ok=true
+innerHTML with a table: violations=0 report-ok=true
+removals: violations=0 report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/paint-property-flips-create-and-drop-contexts.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/paint-property-flips-create-and-drop-contexts.txt
@@ -1,0 +1,11 @@
+baseline: contexts=[document (anon)] report-ok=true
+isolation on: contexts=[document (anon) iso] report-ok=true
+isolation off: contexts=[document (anon)] report-ok=true
+mixBlendMode on: contexts=[document (anon) blend] report-ok=true
+mixBlendMode off: contexts=[document (anon)] report-ok=true
+perspective on: contexts=[document (anon) persp] report-ok=true
+perspective off: contexts=[document (anon)] report-ok=true
+transformStyle on: contexts=[document (anon) preserve] report-ok=true
+transformStyle off: contexts=[document (anon)] report-ok=true
+contentVisibility on: contexts=[document (anon) cv] report-ok=true
+contentVisibility off: contexts=[document (anon)] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/position-static-to-relative-with-identical-geometry.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/position-static-to-relative-with-identical-geometry.txt
@@ -1,0 +1,4 @@
+baseline: report-ok=true
+static to relative: report-ok=true
+geometry unchanged: true
+relative back to static: report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/removal-of-a-subtree-containing-stacking-contexts.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/removal-of-a-subtree-containing-stacking-contexts.txt
@@ -1,0 +1,3 @@
+baseline: contexts=[document (anon) sc1 sc2] report-ok=true
+subtree removed: contexts=[document (anon)] report-ok=true
+subtree re-appended: contexts=[document (anon) sc1 sc2] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/svg-foreign-object.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/svg-foreign-object.txt
@@ -1,0 +1,3 @@
+baseline: contexts=[document (anon) fo] report-ok=true
+svg root establishes: contexts=[document (anon) svg-root fo] report-ok=true
+svg root releases: contexts=[document (anon) fo] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/table-z-index-change-moves-the-wrapper.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/table-z-index-change-moves-the-wrapper.txt
@@ -1,0 +1,4 @@
+baseline: contexts=[document (anon) sibling] report-ok=true
+table to z 3: contexts=[document (anon) sibling (anon)] report-ok=true
+table to z 1: contexts=[document (anon) (anon) sibling] report-ok=true
+table back to z auto: contexts=[document (anon) sibling] report-ok=true

--- a/Tests/LibWeb/Text/expected/stacking-context/z-index-change-on-positioned-box.txt
+++ b/Tests/LibWeb/Text/expected/stacking-context/z-index-change-on-positioned-box.txt
@@ -1,0 +1,5 @@
+baseline z 1/2/3: contexts=[document (anon) a b c] report-ok=true
+middle to z 5: contexts=[document (anon) a c b] report-ok=true
+middle to z -1: contexts=[document (anon) b a c] report-ok=true
+middle to z auto: contexts=[document (anon) a c] report-ok=true
+middle to z 0: contexts=[document (anon) b a c] report-ok=true

--- a/Tests/LibWeb/Text/input/stacking-context/backface-visibility-follows-the-parent-3d-context.html
+++ b/Tests/LibWeb/Text/input/stacking-context/backface-visibility-follows-the-parent-3d-context.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="scene" style="transform-style: preserve-3d; width: 60px; height: 30px">
+    <div id="card" style="backface-visibility: hidden">card</div>
+</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const scene = document.getElementById("scene");
+
+        check("baseline in a 3d context");
+        scene.style.transformStyle = "flat";
+        check("parent context flattened");
+        scene.style.transformStyle = "preserve-3d";
+        check("parent context restored");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/box-gaining-and-losing-a-stacking-context-with-positioned-descendants.html
+++ b/Tests/LibWeb/Text/input/stacking-context/box-gaining-and-losing-a-stacking-context-with-positioned-descendants.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="outer" style="isolation: isolate">
+    <div id="gainer">
+        <div id="pos-auto" style="position: relative">one</div>
+        <div id="pos-z4" style="position: relative; z-index: 4">two</div>
+        <div id="pos-zneg" style="position: relative; z-index: -2">three</div>
+    </div>
+</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const gainer = document.getElementById("gainer");
+
+        check("baseline");
+        gainer.style.opacity = "0.5";
+        check("gainer establishes");
+        gainer.style.opacity = "1";
+        check("gainer releases");
+        gainer.style.opacity = "0.5";
+        check("gainer establishes again");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/flex-item-z-index-change-without-relayout.html
+++ b/Tests/LibWeb/Text/input/stacking-context/flex-item-z-index-change-without-relayout.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div style="display: flex">
+    <div id="item1" style="z-index: 1">one</div>
+    <div id="item2" style="z-index: 2">two</div>
+</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const layoutCount = () => internals.fullLayoutCount() + internals.partialLayoutCount();
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+
+        check("baseline");
+        const layoutsBefore = layoutCount();
+        document.getElementById("item1").style.zIndex = "3";
+        check("first item to z 3");
+        document.getElementById("item1").style.zIndex = "1";
+        check("first item back to z 1");
+        lines.push(`layout runs during the z-index changes: ${layoutCount() - layoutsBefore}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/float-toggle.html
+++ b/Tests/LibWeb/Text/input/stacking-context/float-toggle.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="floaty" style="width: 40px">float me</div>
+<div>sibling text</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const floaty = document.getElementById("floaty");
+
+        check("baseline");
+        floaty.style.cssFloat = "left";
+        check("float left");
+        floaty.style.cssFloat = "none";
+        check("float none");
+        floaty.style.cssFloat = "right";
+        floaty.style.position = "relative";
+        check("positioned float");
+        floaty.style.position = "static";
+        check("float without position");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/inline-box-becoming-self-painting.html
+++ b/Tests/LibWeb/Text/input/stacking-context/inline-box-becoming-self-painting.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="line-root" style="font-size: 16px">before <span id="the-span">span text here</span> after</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const lines = [];
+        const span = document.getElementById("the-span");
+        const hitInsideSpan = () => {
+            const rect = span.getBoundingClientRect();
+            const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+            return hit === span ? "the-span" : (hit && hit.id) || (hit && hit.tagName);
+        };
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: hit=${hitInsideSpan()} report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+
+        check("baseline");
+        span.style.opacity = "0.5";
+        check("span with opacity");
+        span.style.opacity = "1";
+        check("span back to plain");
+        span.style.position = "relative";
+        check("span positioned");
+        span.style.position = "static";
+        check("span static again");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/insertion-of-positioned-siblings-before-and-after.html
+++ b/Tests/LibWeb/Text/input/stacking-context/insertion-of-positioned-siblings-before-and-after.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="anchor-box" style="position: relative; z-index: 1">anchor</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const anchor = document.getElementById("anchor-box");
+        const positioned = (id, zIndex) => {
+            const div = document.createElement("div");
+            div.id = id;
+            div.textContent = id;
+            div.style.position = "relative";
+            div.style.zIndex = zIndex;
+            return div;
+        };
+
+        check("baseline");
+        document.body.insertBefore(positioned("before-equal-z", "1"), anchor);
+        check("equal z inserted before");
+        document.body.insertBefore(positioned("after-equal-z", "1"), anchor.nextSibling);
+        check("equal z inserted after");
+        document.body.insertBefore(positioned("level-zero", "0"), anchor);
+        check("z 0 sibling inserted");
+        document.body.insertBefore(positioned("negative-z", "-1"), anchor);
+        check("z -1 sibling inserted");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/layout-tree-mutations-keep-labels-ordered.html
+++ b/Tests/LibWeb/Text/input/stacking-context/layout-tree-mutations-keep-labels-ordered.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #fl.decorated::first-letter { color: red; font-size: 24px; }
+    #mixed span { position: relative; z-index: 1; }
+</style>
+<div id="container">
+    <div>alpha</div>
+    <div id="mover"><span>beta</span> gamma</div>
+    <div id="ref">delta</div>
+</div>
+<div id="mixed">epsilon <span>zeta</span> eta</div>
+<p id="fl">theta iota</p>
+<div id="tbl"></div>
+<div id="tail">tail</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        settle();
+        document.body.appendChild(document.createElement("pre"));
+        settle();
+        const violations = () => internals.layoutTreePreOrderLabelViolationCount();
+        const relabels = () => internals.layoutTreePreOrderRelabelCount();
+        const container = document.getElementById("container");
+        const ref = document.getElementById("ref");
+        const lines = [];
+        const step = (name, action) => {
+            action();
+            settle();
+            lines.push(`${name}: violations=${violations()}`);
+        };
+
+        step("baseline", () => {});
+        step("append 5", () => {
+            for (let i = 0; i < 5; ++i) {
+                const div = document.createElement("div");
+                div.textContent = `appended ${i}`;
+                container.appendChild(div);
+            }
+        });
+        step("prepend 5", () => {
+            for (let i = 0; i < 5; ++i) {
+                const div = document.createElement("div");
+                div.textContent = `prepended ${i}`;
+                container.insertBefore(div, container.firstChild);
+            }
+        });
+        const relabelsBeforeInsertions = relabels();
+        let insertionsBeforeRelabel = 0;
+        while (relabels() === relabelsBeforeInsertions && insertionsBeforeRelabel < 200) {
+            const div = document.createElement("div");
+            div.textContent = "wedge";
+            container.insertBefore(div, ref);
+            settle();
+            ++insertionsBeforeRelabel;
+        }
+        lines.push(`insertions before a fixed reference: violations=${violations()} relabeled=${relabels() > relabelsBeforeInsertions}`);
+        step("move an existing subtree", () => {
+            container.appendChild(document.getElementById("mover"));
+        });
+        step("wrap committed inline children in an anonymous block", () => {
+            const div = document.createElement("div");
+            div.textContent = "block sibling";
+            document.getElementById("mixed").appendChild(div);
+        });
+        step("toggle ::first-letter", () => {
+            document.getElementById("fl").classList.add("decorated");
+        });
+        step("drop ::first-letter", () => {
+            document.getElementById("fl").classList.remove("decorated");
+        });
+        step("innerHTML with a table", () => {
+            document.getElementById("tbl").innerHTML = "<table><tr><td>cell</td></tr></table>";
+        });
+        step("removals", () => {
+            container.remove();
+            document.getElementById("tbl").remove();
+        });
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/layout-tree-mutations-keep-labels-ordered.html
+++ b/Tests/LibWeb/Text/input/stacking-context/layout-tree-mutations-keep-labels-ordered.html
@@ -9,7 +9,7 @@
     <div id="mover"><span>beta</span> gamma</div>
     <div id="ref">delta</div>
 </div>
-<div id="mixed">epsilon <span>zeta</span> eta</div>
+<div id="mixed">epsilon <span id="mixed-span">zeta</span> eta</div>
 <p id="fl">theta iota</p>
 <div id="tbl"></div>
 <div id="tail">tail</div>
@@ -21,13 +21,17 @@
         settle();
         const violations = () => internals.layoutTreePreOrderLabelViolationCount();
         const relabels = () => internals.layoutTreePreOrderRelabelCount();
+        const report = () => internals.stackingContextStructureVerificationReport();
         const container = document.getElementById("container");
         const ref = document.getElementById("ref");
         const lines = [];
         const step = (name, action) => {
             action();
             settle();
-            lines.push(`${name}: violations=${violations()}`);
+            const r = report();
+            lines.push(`${name}: violations=${violations()} report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
         };
 
         step("baseline", () => {});
@@ -63,6 +67,12 @@
             div.textContent = "block sibling";
             document.getElementById("mixed").appendChild(div);
         });
+        {
+            const span = document.getElementById("mixed-span");
+            const rect = span.getBoundingClientRect();
+            const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+            lines.push(`wrapped span still hit-tests on top: ${hit === span}`);
+        }
         step("toggle ::first-letter", () => {
             document.getElementById("fl").classList.add("decorated");
         });

--- a/Tests/LibWeb/Text/input/stacking-context/paint-property-flips-create-and-drop-contexts.html
+++ b/Tests/LibWeb/Text/input/stacking-context/paint-property-flips-create-and-drop-contexts.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .box { width: 40px; height: 10px; }
+</style>
+<div id="iso" class="box">a</div>
+<div id="blend" class="box">b</div>
+<div id="persp" class="box">c</div>
+<div id="preserve" class="box">d</div>
+<div id="cv" class="box">e</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+
+        check("baseline");
+        const flips = [
+            ["iso", "isolation", "isolate", "auto"],
+            ["blend", "mixBlendMode", "multiply", "normal"],
+            ["persp", "perspective", "100px", "none"],
+            ["preserve", "transformStyle", "preserve-3d", "flat"],
+            ["cv", "contentVisibility", "auto", "visible"],
+        ];
+        for (const [id, property, on, off] of flips) {
+            const element = document.getElementById(id);
+            element.style[property] = on;
+            check(`${property} on`);
+            element.style[property] = off;
+            check(`${property} off`);
+        }
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/position-static-to-relative-with-identical-geometry.html
+++ b/Tests/LibWeb/Text/input/stacking-context/position-static-to-relative-with-identical-geometry.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target">static content</div>
+<div>sibling content</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const target = document.getElementById("target");
+
+        check("baseline");
+        const positionBefore = target.getBoundingClientRect().top;
+        target.style.position = "relative";
+        check("static to relative");
+        lines.push(`geometry unchanged: ${target.getBoundingClientRect().top === positionBefore}`);
+        target.style.position = "static";
+        check("relative back to static");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/removal-of-a-subtree-containing-stacking-contexts.html
+++ b/Tests/LibWeb/Text/input/stacking-context/removal-of-a-subtree-containing-stacking-contexts.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="holder">
+    <div id="sc1" style="opacity: 0.5">
+        <div id="sc2" style="position: relative; z-index: 2">nested</div>
+        <div id="sl0" style="position: relative">level zero</div>
+    </div>
+</div>
+<div>keeps the page alive</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const holder = document.getElementById("holder");
+        const parent = holder.parentNode;
+
+        check("baseline");
+        holder.remove();
+        check("subtree removed");
+        parent.insertBefore(holder, parent.firstChild);
+        check("subtree re-appended");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/svg-foreign-object.html
+++ b/Tests/LibWeb/Text/input/stacking-context/svg-foreign-object.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg id="svg-root" width="120" height="60">
+    <rect width="20" height="20" fill="green"/>
+    <foreignObject id="fo" x="20" width="80" height="40">
+        <div id="fo-child" style="position: relative">fo content</div>
+    </foreignObject>
+</svg>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const svgRoot = document.getElementById("svg-root");
+
+        check("baseline");
+        svgRoot.style.opacity = "0.5";
+        check("svg root establishes");
+        svgRoot.style.opacity = "1";
+        check("svg root releases");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/table-z-index-change-moves-the-wrapper.html
+++ b/Tests/LibWeb/Text/input/stacking-context/table-z-index-change-moves-the-wrapper.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<table id="tbl" style="position: relative"><tr><td>cell</td></tr></table>
+<div id="sibling" style="position: relative; z-index: 2">sibling</div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const table = document.getElementById("tbl");
+
+        check("baseline");
+        table.style.zIndex = "3";
+        check("table to z 3");
+        table.style.zIndex = "1";
+        check("table to z 1");
+        table.style.zIndex = "auto";
+        check("table back to z auto");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/stacking-context/z-index-change-on-positioned-box.html
+++ b/Tests/LibWeb/Text/input/stacking-context/z-index-change-on-positioned-box.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .rel { position: relative; width: 40px; height: 10px; }
+</style>
+<div id="a" class="rel" style="z-index: 1"></div>
+<div id="b" class="rel" style="z-index: 2"></div>
+<div id="c" class="rel" style="z-index: 3"></div>
+<script>
+    test(() => {
+        const settle = () => document.elementFromPoint(0, 0);
+        const report = () => internals.stackingContextStructureVerificationReport();
+        const contexts = () => internals.dumpStackingContextTree().split("\n")
+            .filter(line => line.includes("SC for"))
+            .map(line => { const m = line.match(/#([A-Za-z0-9_-]+)/); return m ? m[1] : "(anon)"; })
+            .join(" ");
+        const lines = [];
+        const check = (name) => {
+            settle();
+            const r = report();
+            lines.push(`${name}: contexts=[${contexts()}] report-ok=${r === ""}`);
+            if (r !== "")
+                lines.push(r);
+        };
+        const b = document.getElementById("b");
+
+        check("baseline z 1/2/3");
+        b.style.zIndex = "5";
+        check("middle to z 5");
+        b.style.zIndex = "-1";
+        check("middle to z -1");
+        b.style.zIndex = "auto";
+        check("middle to z auto");
+        b.style.zIndex = "0";
+        check("middle to z 0");
+
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
The display list recorder walked a stacking context tree that an O(N) paint-tree walk rebuilt after every layout run, box removal and z-index change, with a second O(N) fragment-ownership walk chained to every rebuild. Stacking-context-level display list splice caching needs the recorder to touch only the dirty path, so this branch makes the structure incremental and deletes the rebuild.