### PR TITLE
RequestServer: Reject forged cookie responses

### DIFF
--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -263,14 +263,14 @@ void RequestClient::request_transferred(u64 request_id)
     (*request)->did_transfer({});
 }
 
-void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url, RequestServer::IsPrivate is_private)
+void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, u64 cookie_request_id, URL::URL url, RequestServer::IsPrivate is_private)
 {
     String cookie;
 
     if (on_retrieve_http_cookie)
         cookie = on_retrieve_http_cookie(url, is_private);
 
-    async_retrieved_http_cookie(client_id, request_id, request_type, cookie);
+    async_retrieved_http_cookie(client_id, request_id, request_type, cookie_request_id, cookie);
 }
 
 void RequestClient::certificate_requested(u64 request_id)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -77,7 +77,7 @@ private:
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>, CameFromCache) override;
     virtual void request_transferred(u64 request_id) override;
 
-    virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url, RequestServer::IsPrivate) override;
+    virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, u64 cookie_request_id, URL::URL url, RequestServer::IsPrivate) override;
 
     virtual void certificate_requested(u64 request_id) override;
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -717,9 +717,15 @@ void ConnectionFromClient::ensure_connection(u64 request_id, URL::URL url, ::Req
     m_active_requests.set(request_id, move(request));
 }
 
-void ConnectionFromClient::retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie)
+void ConnectionFromClient::retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, u64 cookie_request_id, String cookie)
 {
     note_event_tick("ipc-retrieved-cookie"sv);
+
+    if (g_primary_connection != this) {
+        did_misbehave("Non-primary connection sent an HTTP cookie response");
+        return;
+    }
+
     if (auto connection = m_connections.get(client_id); connection.has_value()) {
         auto request = [&]() {
             switch (request_type) {
@@ -728,13 +734,14 @@ void ConnectionFromClient::retrieved_http_cookie(int client_id, u64 request_id, 
             case RequestType::BackgroundRevalidation:
                 return (*connection)->m_active_revalidation_requests.get(request_id);
             case RequestType::Connect:
-                break;
+                did_misbehave("HTTP cookie response has an invalid request type");
+                return decltype((*connection)->m_active_requests.get(request_id)) {};
             }
             VERIFY_NOT_REACHED();
         }();
 
-        if (request.has_value())
-            (*request)->notify_retrieved_http_cookie({}, cookie);
+        if (request.has_value() && !(*request)->notify_retrieved_http_cookie({}, cookie_request_id, cookie))
+            did_misbehave("Duplicate or unexpected HTTP cookie response");
     }
 }
 

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -89,7 +89,7 @@ private:
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(u64 request_id, ByteString, ByteString) override;
     virtual void ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) override;
 
-    virtual void retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie) override;
+    virtual void retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, u64 cookie_request_id, String cookie) override;
 
     virtual void estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) override;
     virtual void remove_cache_entries_accessed_since(u64 clear_cache_request_id, UnixDateTime since) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -572,8 +572,14 @@ void Request::notify_request_unblocked(Badge<HTTP::DiskCache>)
     transition_to_state(State::Init);
 }
 
-void Request::notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringView cookie)
+bool Request::notify_retrieved_http_cookie(Badge<ConnectionFromClient>, u64 cookie_request_id, StringView cookie)
 {
+    if (m_cookie_request_id != cookie_request_id)
+        return true;
+
+    if (m_state != State::RetrieveCookie)
+        return false;
+
     mark_lifecycle_event(this, &WireStats::cookie_completed_at);
 
     if (!cookie.is_empty()) {
@@ -582,6 +588,7 @@ void Request::notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringVi
     }
 
     transition_to_state(State::Fetch);
+    return true;
 }
 
 static constexpr size_t max_aia_fetches_per_request = 5;
@@ -996,8 +1003,10 @@ void Request::handle_retrieve_cookie_state()
     }
 
     if (auto connection = ConnectionFromClient::primary_connection(); connection.has_value()) {
+        static u64 s_next_cookie_request_id = 0;
+        m_cookie_request_id = s_next_cookie_request_id++;
         mark_lifecycle_event(this, &WireStats::cookie_started_at);
-        connection->async_retrieve_http_cookie(m_client->client_id(), m_request_id, m_type, m_url, m_client->is_private());
+        connection->async_retrieve_http_cookie(m_client->client_id(), m_request_id, m_type, *m_cookie_request_id, m_url, m_client->is_private());
     } else {
         m_network_error = Requests::NetworkError::RequestServerDied;
         transition_to_state(State::Error);
@@ -1409,6 +1418,11 @@ ErrorOr<void> Request::transfer_to_client(ConnectionFromClient& client, u64 requ
             m_client->async_request_finished(m_request_id, m_bytes_transferred_to_client, {}, m_network_error.value_or(Requests::NetworkError::Unknown));
     }
     previous_client.async_request_transferred(previous_request_id);
+
+    // NB: A pending cookie lookup names the previous client and request IDs, so its response will be ignored after the
+    //     transfer. Start a new lookup for the request's new owner instead of leaving it stuck in RetrieveCookie.
+    if (m_state == State::RetrieveCookie)
+        handle_retrieve_cookie_state();
 
     // An in-flight AIA fetch is registered with the client that started it, keyed by that client's request id.
     // The transfer above moved this request out of that client's table, so the fetch can no longer find it when it

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -88,7 +88,7 @@ public:
     void release_transfer_lease() { m_transfer_lease.clear(); }
 
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
-    void notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringView cookie);
+    bool notify_retrieved_http_cookie(Badge<ConnectionFromClient>, u64 cookie_request_id, StringView cookie);
     void notify_fetch_complete(Badge<ConnectionFromClient>, int result_code);
     void retry_after_aia(Badge<ConnectionFromClient>);
 
@@ -212,6 +212,7 @@ private:
     Requests::RequestTimingInfo acquire_timing_info() const;
 
     u64 m_request_id { 0 };
+    Optional<u64> m_cookie_request_id;
     RequestType m_type { RequestType::Fetch };
     State m_state { State::Init };
 

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -16,7 +16,7 @@ endpoint RequestClient
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key, Requests::CameFromCache came_from_cache) =|
     request_transferred(u64 request_id) =|
 
-    retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url, ::RequestServer::IsPrivate is_private) =|
+    retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, u64 cookie_request_id, URL::URL url, ::RequestServer::IsPrivate is_private) =|
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -35,7 +35,7 @@ endpoint RequestServer
 
     ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) =|
 
-    retrieved_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, String cookie) =|
+    retrieved_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, u64 cookie_request_id, String cookie) =|
 
     estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) =|
     remove_cache_entries_accessed_since(u64 clear_cache_request_id, UnixDateTime since) =|

--- a/Tests/RequestServer/CMakeLists.txt
+++ b/Tests/RequestServer/CMakeLists.txt
@@ -1,3 +1,6 @@
 ladybird_test(TestAIA.cpp RequestServer LIBS OpenSSL::Crypto OpenSSL::SSL CURL::libcurl)
 target_sources(TestAIA PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/RequestServer/AIA.cpp)
 target_include_directories(TestAIA PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)
+
+ladybird_test(TestCookieResponses.cpp RequestServer LIBS requestserverservice)
+target_include_directories(TestCookieResponses PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)

--- a/Tests/RequestServer/TestCookieResponses.cpp
+++ b/Tests/RequestServer/TestCookieResponses.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibHTTP/Cache/DiskCache.h>
+#include <LibIPC/Transport.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <RequestServer/CURL.h>
+#include <RequestServer/ConnectionFromClient.h>
+#include <RequestServer/ResourceSubstitutionMap.h>
+
+namespace RequestServer {
+
+OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
+
+}
+
+namespace {
+
+struct TestServer {
+    Core::EventLoop event_loop;
+    RequestServer::ConnectionFromClient::ConnectionMap connections;
+    RequestServer::ConnectionFromClient::RequestTransferLeaseMap request_transfer_leases;
+};
+
+class TestConnection {
+public:
+    TestConnection(TestServer& server, RequestServer::ConnectionFromClient::IsPrimaryConnection is_primary_connection)
+        : m_server(server)
+    {
+        static bool libcurl_initialized = [] {
+            MUST(RequestServer::initialize_libcurl());
+            return true;
+        }();
+        (void)libcurl_initialized;
+
+        auto pair = MUST(IPC::Transport::create_paired());
+        m_remote_transport = MUST(pair.remote_handle.create_transport());
+        m_connection = RequestServer::ConnectionFromClient::construct(
+            move(pair.local), is_primary_connection, RequestServer::IsPrivate::No,
+            m_server.connections, m_server.request_transfer_leases, Optional<HTTP::DiskCache&> {}, ByteString {});
+    }
+
+    ~TestConnection()
+    {
+        if (m_connection->is_open())
+            m_connection->shutdown();
+    }
+
+    int client_id() const { return m_connection->client_id(); }
+    bool is_open() const { return m_connection->is_open(); }
+
+    void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, u64 cookie_request_id = 0)
+    {
+        auto message = make<Messages::RequestServer::RetrievedHttpCookie>(client_id, request_id, request_type, cookie_request_id, String {});
+        auto response = dispatch(move(message));
+        VERIFY(!response);
+    }
+
+    void ensure_connection(u64 request_id)
+    {
+        auto url = URL::Parser::basic_parse("https://example.com"sv).release_value();
+        auto message = make<Messages::RequestServer::EnsureConnection>(request_id, move(url), RequestServer::CacheLevel::ResolveOnly);
+        auto response = dispatch(move(message));
+        VERIFY(!response);
+    }
+
+    void stop_request(u64 request_id)
+    {
+        auto message = make<Messages::RequestServer::StopRequest>(request_id);
+        auto response = dispatch(move(message));
+        VERIFY(response);
+    }
+
+    void start_request(u64 request_id)
+    {
+        auto url = URL::Parser::basic_parse("http://localhost"sv).release_value();
+        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), Vector<HTTP::Header> {}, ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::Yes, Core::ProxyData {}, true, Optional<u32> {});
+        auto response = dispatch(move(message));
+        VERIFY(!response);
+    }
+
+    void adopt_request(int source_client_id, u64 source_request_id, u64 target_request_id)
+    {
+        auto message = make<Messages::RequestServer::AdoptRequest>(source_client_id, source_request_id, target_request_id, false);
+        auto response = dispatch(move(message));
+        VERIFY(!response);
+    }
+
+    NonnullOwnPtr<Messages::RequestClient::RetrieveHttpCookie> take_cookie_request()
+    {
+        m_remote_transport->wait_until_readable();
+
+        OwnPtr<Messages::RequestClient::RetrieveHttpCookie> cookie_request;
+        auto should_shutdown = m_remote_transport->read_as_many_messages_as_possible_without_blocking([&](auto&& raw_message) {
+            auto message = MUST(RequestClientEndpoint::decode_message(raw_message.bytes.bytes(), raw_message.attachments));
+            VERIFY(message->message_id() == Messages::RequestClient::RetrieveHttpCookie::static_message_id());
+            VERIFY(!cookie_request);
+            cookie_request = message.template release_nonnull<Messages::RequestClient::RetrieveHttpCookie>();
+        });
+        VERIFY(should_shutdown == IPC::Transport::ShouldShutdown::No);
+        VERIFY(cookie_request);
+        return cookie_request.release_nonnull();
+    }
+
+private:
+    OwnPtr<IPC::MessageBuffer> dispatch(NonnullOwnPtr<IPC::Message> message)
+    {
+        return MUST(static_cast<RequestServerEndpoint::Stub&>(*m_connection).handle(move(message)));
+    }
+
+    TestServer& m_server;
+    OwnPtr<IPC::Transport> m_remote_transport;
+    RefPtr<RequestServer::ConnectionFromClient> m_connection;
+};
+
+}
+
+TEST_CASE(non_primary_connection_cannot_send_cookie_responses)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::No };
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch);
+
+    EXPECT(!connection.is_open());
+}
+
+TEST_CASE(cookie_responses_cannot_target_connect_requests)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Connect);
+
+    EXPECT(!connection.is_open());
+}
+
+TEST_CASE(stale_cookie_response_for_disconnected_client_is_ignored)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+
+    connection.retrieve_http_cookie(-1, 0, RequestServer::RequestType::Fetch);
+
+    EXPECT(connection.is_open());
+}
+
+TEST_CASE(stale_cookie_response_for_cancelled_request_is_ignored)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+    connection.ensure_connection(0);
+    connection.stop_request(0);
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch);
+
+    EXPECT(connection.is_open());
+}
+
+TEST_CASE(stale_cookie_response_cannot_target_replacement_request)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+    connection.start_request(0);
+    auto stale_cookie_request = connection.take_cookie_request();
+    connection.stop_request(0);
+
+    connection.start_request(0);
+    auto current_cookie_request = connection.take_cookie_request();
+    EXPECT_NE(stale_cookie_request->cookie_request_id(), current_cookie_request->cookie_request_id());
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch, stale_cookie_request->cookie_request_id());
+    EXPECT(connection.is_open());
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch, current_cookie_request->cookie_request_id());
+    EXPECT(connection.is_open());
+}
+
+TEST_CASE(duplicate_cookie_response_is_rejected)
+{
+    TestServer server;
+    TestConnection connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+    connection.start_request(0);
+    auto cookie_request = connection.take_cookie_request();
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch, cookie_request->cookie_request_id());
+    EXPECT(connection.is_open());
+
+    connection.retrieve_http_cookie(connection.client_id(), 0, RequestServer::RequestType::Fetch, cookie_request->cookie_request_id());
+    EXPECT(!connection.is_open());
+}
+
+TEST_CASE(transferring_request_reissues_cookie_lookup_for_new_owner)
+{
+    TestServer server;
+    TestConnection primary_connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes };
+    TestConnection source_connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::No };
+    TestConnection target_connection { server, RequestServer::ConnectionFromClient::IsPrimaryConnection::No };
+
+    source_connection.start_request(0);
+    auto initial_cookie_request = primary_connection.take_cookie_request();
+    EXPECT_EQ(initial_cookie_request->client_id(), source_connection.client_id());
+    EXPECT_EQ(initial_cookie_request->request_id(), 0u);
+
+    target_connection.adopt_request(source_connection.client_id(), 0, 1);
+    auto transferred_cookie_request = primary_connection.take_cookie_request();
+    EXPECT_EQ(transferred_cookie_request->client_id(), target_connection.client_id());
+    EXPECT_EQ(transferred_cookie_request->request_id(), 1u);
+
+    EXPECT_NE(initial_cookie_request->cookie_request_id(), transferred_cookie_request->cookie_request_id());
+
+    primary_connection.retrieve_http_cookie(source_connection.client_id(), 0, RequestServer::RequestType::Fetch, initial_cookie_request->cookie_request_id());
+    EXPECT(primary_connection.is_open());
+}


### PR DESCRIPTION
Cookie responses were accepted from any connected renderer and could be delivered repeatedly to a request. Re-entering Fetch replaced the request's tracked curl handle while the old handle retained callbacks to the Request, allowing it to outlive the Request and use freed memory.

Accept cookie responses only from the primary browser connection, and consume them only while the target request is waiting for that response. Disconnect peers that send invalid request types or duplicate and unexpected responses.