### PR TITLE
LibWebView: Shut down compositor font event loop safely

### DIFF
--- a/Libraries/LibCore/EventLoopImplementation.cpp
+++ b/Libraries/LibCore/EventLoopImplementation.cpp
@@ -22,6 +22,24 @@ EventLoopImplementation::EventLoopImplementation()
 
 EventLoopImplementation::~EventLoopImplementation() = default;
 
+void EventLoopImplementation::request_exit(int code)
+{
+    m_exit_code.store(code, AK::MemoryOrder::memory_order_relaxed);
+    m_exit_requested.store(true, AK::MemoryOrder::memory_order_release);
+}
+
+bool EventLoopImplementation::was_exit_requested() const
+{
+    return m_exit_requested.load(AK::MemoryOrder::memory_order_acquire);
+}
+
+Optional<int> EventLoopImplementation::exit_code_if_requested() const
+{
+    if (!m_exit_requested.load(AK::MemoryOrder::memory_order_acquire))
+        return {};
+    return m_exit_code.load(AK::MemoryOrder::memory_order_relaxed);
+}
+
 void EventLoopImplementation::deferred_invoke(Function<void()>&& invokee)
 {
     m_thread_event_queue.deferred_invoke(move(invokee));

--- a/Libraries/LibCore/EventLoopImplementation.h
+++ b/Libraries/LibCore/EventLoopImplementation.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
 #include <AK/Function.h>
+#include <AK/Optional.h>
 #include <LibCore/Export.h>
 #include <LibCore/Forward.h>
 
@@ -56,13 +58,20 @@ public:
     virtual size_t pump(PumpMode) = 0;
     virtual void quit(int) = 0;
     virtual void wake() = 0;
-    virtual bool was_exit_requested() const = 0;
+    virtual bool was_exit_requested() const;
 
     virtual void deferred_invoke(Function<void()>&&);
 
 protected:
     EventLoopImplementation();
+    void request_exit(int);
+    Optional<int> exit_code_if_requested() const;
+
     ThreadEventQueue& m_thread_event_queue;
+
+private:
+    Atomic<int> m_exit_code { 0 };
+    Atomic<bool> m_exit_requested { false };
 };
 
 }

--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -204,8 +204,8 @@ EventLoopImplementationUnix::~EventLoopImplementationUnix() = default;
 int EventLoopImplementationUnix::exec()
 {
     for (;;) {
-        if (m_exit_requested)
-            return m_exit_code;
+        if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+            return exit_code.release_value();
         pump(PumpMode::WaitForEvents);
     }
     VERIFY_NOT_REACHED();
@@ -220,8 +220,7 @@ size_t EventLoopImplementationUnix::pump(PumpMode mode)
 
 void EventLoopImplementationUnix::quit(int code)
 {
-    m_exit_requested = true;
-    m_exit_code = code;
+    request_exit(code);
 }
 
 void EventLoopImplementationUnix::wake()

--- a/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -47,14 +47,10 @@ public:
     virtual int exec() override;
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
-    virtual bool was_exit_requested() const override { return m_exit_requested; }
 
     virtual void wake() override;
 
 private:
-    bool m_exit_requested { false };
-    int m_exit_code { 0 };
-
     // The write end of the wake pipe, copied by value so it remains valid even
     // if ThreadData is destroyed before this event loop (e.g. during exit()).
     int m_wake_pipe_write_fd;

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -265,8 +265,8 @@ EventLoopImplementationWindows::~EventLoopImplementationWindows()
 int EventLoopImplementationWindows::exec()
 {
     for (;;) {
-        if (m_exit_requested)
-            return m_exit_code;
+        if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+            return exit_code.release_value();
         pump(PumpMode::WaitForEvents);
     }
     VERIFY_NOT_REACHED();
@@ -367,8 +367,7 @@ size_t EventLoopImplementationWindows::pump(PumpMode pump_mode)
 
 void EventLoopImplementationWindows::quit(int code)
 {
-    m_exit_requested = true;
-    m_exit_code = code;
+    request_exit(code);
 }
 
 void EventLoopImplementationWindows::wake()

--- a/Libraries/LibCore/EventLoopImplementationWindows.h
+++ b/Libraries/LibCore/EventLoopImplementationWindows.h
@@ -43,12 +43,8 @@ public:
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
     virtual void wake() override;
-    virtual bool was_exit_requested() const override { return m_exit_requested; }
 
 private:
-    bool m_exit_requested { false };
-    int m_exit_code { 0 };
-
     // The wake event handle of this event loop needs to be accessible from other threads.
     void* m_wake_event;
 };

--- a/Libraries/LibWebView/CompositorFontServiceConnection.cpp
+++ b/Libraries/LibWebView/CompositorFontServiceConnection.cpp
@@ -105,9 +105,8 @@ CompositorFontServiceConnection::~CompositorFontServiceConnection()
 
     if (event_loop) {
         if (auto strong_event_loop = event_loop->take()) {
-            strong_event_loop->deferred_invoke([] {
-                Core::EventLoop::current().quit(0);
-            });
+            strong_event_loop->quit(0);
+            strong_event_loop->wake();
         }
     }
 

--- a/Tests/LibCore/TestLibCoreEventLoop.cpp
+++ b/Tests/LibCore/TestLibCoreEventLoop.cpp
@@ -9,6 +9,7 @@
 #include <AK/Vector.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
+#include <LibSync/ConditionVariable.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 
@@ -44,6 +45,50 @@ TEST_CASE(wake_after_thread_exit)
     }
 
     worker_loop.clear();
+}
+
+TEST_CASE(quit_event_loop_from_another_thread)
+{
+    Core::EventLoop main_loop;
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::Mutex mutex;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::ConditionVariable condition { mutex };
+    IGNORE_USE_IN_ESCAPING_LAMBDA RefPtr<Core::WeakEventLoopReference> weak_ref;
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool exec_started { false };
+
+    auto thread = Threading::Thread::construct("Worker"sv, [&] {
+        Core::EventLoop event_loop;
+        {
+            Sync::MutexLocker locker { mutex };
+            weak_ref = Core::EventLoop::current_weak();
+        }
+        event_loop.deferred_invoke([&] {
+            Sync::MutexLocker locker { mutex };
+            exec_started = true;
+            condition.broadcast();
+        });
+        return event_loop.exec();
+    });
+    thread->start();
+
+    RefPtr<Core::WeakEventLoopReference> event_loop;
+    {
+        Sync::MutexLocker locker { mutex };
+        condition.wait_while([&] { return !exec_started; });
+        event_loop = weak_ref;
+    }
+
+    {
+        auto strong_event_loop = event_loop->take();
+        VERIFY(strong_event_loop);
+        EXPECT(!strong_event_loop->was_exit_requested());
+        strong_event_loop->quit(42);
+        EXPECT(strong_event_loop->was_exit_requested());
+        strong_event_loop->wake();
+    }
+
+    auto exit_code = MUST(thread->join<void*>());
+    EXPECT_EQ(reinterpret_cast<intptr_t>(exit_code), 42);
 }
 
 TEST_CASE(single_shot_timer_fires_once)

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -1,8 +1,29 @@
+find_package(Qt6 QUIET COMPONENTS Core)
+if (NOT Qt6_FOUND)
+    return()
+endif()
+
+add_library(QtEventLoopTestMain OBJECT
+    QtEventLoopTestMain.cpp
+    "${LADYBIRD_SOURCE_DIR}/Libraries/LibTest/AssertionHandler.cpp"
+)
+target_link_libraries(QtEventLoopTestMain PRIVATE AK LibCore LibTest Qt::Core)
+
+ladybird_test("TestEventLoopImplementation.cpp" UI/Qt
+    CUSTOM_MAIN "$<TARGET_OBJECTS:QtEventLoopTestMain>"
+    LIBS LibSync LibThreading Qt::Core
+)
+target_sources(TestEventLoopImplementation PRIVATE
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQt.cpp"
+    "${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQtEventTarget.cpp"
+)
+set_target_properties(TestEventLoopImplementation PROPERTIES AUTOMOC ON)
+
 if (NOT LINUX)
     return()
 endif()
 
-find_package(Qt6 QUIET COMPONENTS Core Gui Widgets)
+find_package(Qt6 QUIET COMPONENTS Gui Widgets)
 if (NOT Qt6_FOUND)
     return()
 endif()

--- a/Tests/UI/Qt/QtEventLoopTestMain.cpp
+++ b/Tests/UI/Qt/QtEventLoopTestMain.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/Vector.h>
+#include <LibCore/EventLoopImplementation.h>
+#include <LibTest/TestSuite.h>
+#include <UI/Qt/EventLoopImplementationQt.h>
+
+#include <QCoreApplication>
+
+int main(int argc, char** argv)
+{
+    if (argc < 1 || !argv[0] || '\0' == *argv[0]) {
+        warnln("Test main does not have a valid test name!");
+        return 1;
+    }
+
+    QCoreApplication application(argc, argv);
+    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
+
+    Vector<StringView> arguments;
+    arguments.ensure_capacity(argc);
+    for (auto i = 0; i < argc; ++i)
+        arguments.append({ argv[i], strlen(argv[i]) });
+
+    auto result = Test::TestSuite::the().main(argv[0], arguments);
+    Test::TestSuite::release();
+    return result != 0;
+}

--- a/Tests/UI/Qt/TestEventLoopImplementation.cpp
+++ b/Tests/UI/Qt/TestEventLoopImplementation.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibSync/ConditionVariable.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/Thread.h>
+
+#include <QAbstractEventDispatcher>
+
+TEST_CASE(quit_event_loop_from_another_thread)
+{
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::Mutex mutex;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::ConditionVariable condition { mutex };
+    IGNORE_USE_IN_ESCAPING_LAMBDA RefPtr<Core::WeakEventLoopReference> weak_ref;
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool exec_started { false };
+
+    auto thread = Threading::Thread::construct("Qt event loop"sv, [&] {
+        Core::EventLoop event_loop;
+        {
+            Sync::MutexLocker locker { mutex };
+            weak_ref = Core::EventLoop::current_weak();
+        }
+        auto* event_dispatcher = QAbstractEventDispatcher::instance();
+        VERIFY(event_dispatcher);
+        QObject::connect(event_dispatcher, &QAbstractEventDispatcher::aboutToBlock, [&] {
+            Sync::MutexLocker locker { mutex };
+            exec_started = true;
+            condition.broadcast();
+        });
+        return event_loop.exec();
+    });
+    thread->start();
+
+    RefPtr<Core::WeakEventLoopReference> event_loop;
+    {
+        Sync::MutexLocker locker { mutex };
+        condition.wait_while([&] { return !exec_started; });
+        event_loop = weak_ref;
+    }
+
+    {
+        auto strong_event_loop = event_loop->take();
+        VERIFY(strong_event_loop);
+        EXPECT(!strong_event_loop->was_exit_requested());
+        strong_event_loop->quit(42);
+        EXPECT(strong_event_loop->was_exit_requested());
+        strong_event_loop->wake();
+    }
+
+    auto exit_code = MUST(thread->join<void*>());
+    EXPECT_EQ(reinterpret_cast<intptr_t>(exit_code), 42);
+}

--- a/UI/Qt/EventLoopImplementationQt.cpp
+++ b/UI/Qt/EventLoopImplementationQt.cpp
@@ -20,6 +20,7 @@
 #include <UI/Qt/EventLoopImplementationQt.h>
 #include <UI/Qt/EventLoopImplementationQtEventTarget.h>
 
+#include <QAbstractEventDispatcher>
 #include <QCoreApplication>
 #include <QEvent>
 #include <QEventLoop>
@@ -215,16 +216,26 @@ static void dispatch_signal(int signal_number)
 
 EventLoopImplementationQt::EventLoopImplementationQt()
     : m_event_loop(make<QEventLoop>())
+    , m_event_dispatcher(QAbstractEventDispatcher::instance())
 {
+    VERIFY(m_event_dispatcher);
 }
 
 EventLoopImplementationQt::~EventLoopImplementationQt() = default;
 
 int EventLoopImplementationQt::exec()
 {
+    if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+        return exit_code.release_value();
+
     if (is_main_loop())
         return QCoreApplication::exec();
-    return m_event_loop->exec();
+
+    for (;;) {
+        pump(PumpMode::WaitForEvents);
+        if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+            return exit_code.release_value();
+    }
 }
 
 size_t EventLoopImplementationQt::pump(PumpMode mode)
@@ -241,23 +252,31 @@ size_t EventLoopImplementationQt::pump(PumpMode mode)
 
 void EventLoopImplementationQt::quit(int code)
 {
-    if (is_main_loop())
+    request_exit(code);
+    if (!is_main_loop())
+        return;
+
+    auto* application = QCoreApplication::instance();
+    VERIFY(application);
+    if (QThread::currentThread() == application->thread()) {
         QCoreApplication::exit(code);
-    else
-        m_event_loop->exit(code);
+        return;
+    }
+
+    QMetaObject::invokeMethod(application, [code] { QCoreApplication::exit(code); }, Qt::QueuedConnection);
 }
 
 void EventLoopImplementationQt::wake()
 {
     if (!is_main_loop())
-        m_event_loop->wakeUp();
+        m_event_dispatcher->wakeUp();
 }
 
 bool EventLoopImplementationQt::was_exit_requested() const
 {
-    if (is_main_loop())
-        return QCoreApplication::closingDown();
-    return !m_event_loop->isRunning();
+    if (Core::EventLoopImplementation::was_exit_requested())
+        return true;
+    return is_main_loop() && QCoreApplication::closingDown();
 }
 
 void EventLoopImplementationQt::set_main_loop()

--- a/UI/Qt/EventLoopImplementationQt.h
+++ b/UI/Qt/EventLoopImplementationQt.h
@@ -10,6 +10,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <LibCore/EventLoopImplementation.h>
 
+class QAbstractEventDispatcher;
 class QEvent;
 class QEventLoop;
 class QSocketNotifier;
@@ -73,6 +74,7 @@ private:
     bool is_main_loop() const { return m_main_loop; }
 
     NonnullOwnPtr<QEventLoop> m_event_loop;
+    QAbstractEventDispatcher* m_event_dispatcher { nullptr };
     bool m_main_loop { false };
 };
 


### PR DESCRIPTION
The shutdown callback for the compositor font thread was queued on its event queue. Qt secondary event loops do not drain that queue, so the UI process blocked forever while joining the thread. Other event loop backends can also stay blocked after quit until explicitly awakened.

Request exit directly through the guarded event loop reference and wake the loop before joining the thread. Normal application shutdown and test-web teardown now both complete without leaving the thread behind.