### PR TITLE
LibWeb+LibGfx: Move glyph runs and the shaping cache to Rust

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -27,6 +27,7 @@
 #include <harfbuzz/hb.h>
 
 extern "C" {
+u64 ladybird_gfx_font_id(void const*);
 float ladybird_gfx_font_glyph_width(void const*, u32);
 u32 ladybird_gfx_font_glyph_id(void const*, u32);
 bool ladybird_gfx_font_contains_glyph(void const*, u32);
@@ -254,6 +255,12 @@ bool Font::is_emoji_font() const
     return m_is_emoji_font == TriState::True;
 }
 
+}
+
+extern "C" u64 ladybird_gfx_font_id(void const* font)
+{
+    VERIFY(font);
+    return static_cast<Gfx::Font const*>(font)->id();
 }
 
 extern "C" float ladybird_gfx_font_glyph_width(void const* font, u32 code_point)

--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -201,15 +201,6 @@ SkFont Font::skia_font(float scale) const
     return sk_font;
 }
 
-Font::ShapingCache::~ShapingCache() = default;
-
-void Font::ShapingCache::clear()
-{
-    map.clear();
-    for (auto& slot : single_ascii_character_map)
-        slot = nullptr;
-}
-
 static bool hb_face_has_table(hb_face_t* face, hb_tag_t tag)
 {
     hb_blob_t* blob = hb_face_reference_table(face, tag);

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -11,9 +11,7 @@
 
 #include <AK/AtomicRefCounted.h>
 #include <AK/FlyString.h>
-#include <AK/HashMap.h>
 #include <AK/Optional.h>
-#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Utf16String.h>
 #include <LibGfx/Font/Font.h>
@@ -25,17 +23,6 @@ struct hb_font_t;
 struct hb_buffer_t;
 
 namespace Gfx {
-
-struct ShapedGlyphs;
-
-struct ShapingCacheKey {
-    Utf16String text;
-    u8 text_type { 0 };
-    u32 letter_spacing_bit_pattern { 0 };
-    u32 word_spacing_bit_pattern { 0 };
-
-    bool operator==(ShapingCacheKey const&) const = default;
-};
 
 struct FontPixelMetrics {
     float x_height { 0 };
@@ -106,15 +93,6 @@ public:
     FontVariationSettings const& variation_settings() const { return m_font_variation_settings; }
     ShapeFeatures const& features() const { return m_shape_features; }
 
-    struct ShapingCache {
-        HashMap<ShapingCacheKey, OwnPtr<ShapedGlyphs>> map;
-        OwnPtr<ShapedGlyphs> single_ascii_character_map[128];
-
-        ~ShapingCache();
-        void clear();
-    };
-    ShapingCache& shaping_cache() const { return m_shaping_cache; }
-
     bool is_emoji_font() const;
 
 private:
@@ -133,8 +111,6 @@ private:
     mutable RefPtr<Font const> m_bold_variant;
     mutable hb_font_t* m_harfbuzz_font { nullptr };
 
-    mutable ShapingCache m_shaping_cache;
-
     mutable TriState m_is_emoji_font { TriState::Unknown };
 
     NonnullRefPtr<Typeface const> m_typeface;
@@ -145,18 +121,6 @@ private:
     FontPixelMetrics m_pixel_metrics;
 
     float m_pixel_size { 0.0f };
-};
-
-}
-
-namespace AK {
-
-template<>
-struct Traits<Gfx::ShapingCacheKey> : public DefaultTraits<Gfx::ShapingCacheKey> {
-    static unsigned hash(Gfx::ShapingCacheKey const& key)
-    {
-        return pair_int_hash(key.text.hash(), pair_int_hash(key.text_type, pair_int_hash(key.letter_spacing_bit_pattern, key.word_spacing_bit_pattern)));
-    }
 };
 
 }

--- a/Libraries/LibGfx/Rust/src/font.rs
+++ b/Libraries/LibGfx/Rust/src/font.rs
@@ -9,6 +9,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 unsafe extern "C" {
+    fn ladybird_gfx_font_id(font: *const c_void) -> u64;
     fn ladybird_gfx_font_glyph_width(font: *const c_void, code_point: u32) -> f32;
     fn ladybird_gfx_font_glyph_id(font: *const c_void, code_point: u32) -> u32;
     fn ladybird_gfx_font_contains_glyph(font: *const c_void, code_point: u32) -> bool;
@@ -59,6 +60,15 @@ impl<'a> FontRef<'a> {
             raw: NonNull::new(raw.cast_mut()).expect("Gfx::Font pointer must not be null"),
             _lifetime: PhantomData,
         }
+    }
+
+    /// The font's process-unique id. Ids are never recycled, so a dead font's
+    /// id can never alias a live font's.
+    #[inline]
+    pub fn id(self) -> u64 {
+        // SAFETY: FontRef's constructor requires the Gfx::Font to remain live
+        // for this reference's lifetime.
+        unsafe { ladybird_gfx_font_id(self.raw.as_ptr()) }
     }
 
     #[inline]

--- a/Libraries/LibGfx/Rust/src/font.rs
+++ b/Libraries/LibGfx/Rust/src/font.rs
@@ -17,6 +17,11 @@ unsafe extern "C" {
     fn ladybird_gfx_font_pixel_metrics(font: *const c_void, ascent: *mut f32, descent: *mut f32);
     fn ladybird_gfx_font_pixel_size(font: *const c_void) -> f32;
     fn ladybird_gfx_font_x_height(font: *const c_void) -> f32;
+    fn ladybird_gfx_font_measure_text_width(
+        font: *const c_void,
+        text_utf16: *const u16,
+        length_in_code_units: usize,
+    ) -> f32;
     fn ladybird_gfx_font_cascade_list_font_for_code_point(
         list: *const c_void,
         code_point: u32,
@@ -114,6 +119,12 @@ impl<'a> FontRef<'a> {
         // SAFETY: FontRef's constructor requires the Gfx::Font to remain live
         // for this reference's lifetime.
         unsafe { ladybird_gfx_font_x_height(self.raw.as_ptr()) }
+    }
+
+    pub fn measure_text_width(self, text: &[u16]) -> f32 {
+        // SAFETY: The font is live for this reference's lifetime, and the text
+        // slice stays valid for the synchronous measuring call.
+        unsafe { ladybird_gfx_font_measure_text_width(self.raw.as_ptr(), text.as_ptr(), text.len()) }
     }
 
     pub fn is_emoji_font(self) -> bool {

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -68,18 +68,18 @@ unsafe extern "C" {
 
     fn ladybird_gfx_glyph_run_unref(retained: *mut c_void);
 
-    fn ladybird_gfx_glyph_run_create(
+    fn ladybird_gfx_glyph_run_bounding_box(
         font: *const c_void,
         glyphs: *const DrawGlyph,
         glyph_count: usize,
-        text_type: TextType,
-        width: f32,
-    ) -> *mut c_void;
-
-    fn ladybird_gfx_glyph_run_bounding_box(retained: *const c_void, scale: f32, out_rect: *mut f32);
+        scale: f32,
+        out_rect: *mut f32,
+    );
 
     fn ladybird_gfx_glyph_run_glyph_intercepts(
-        retained: *const c_void,
+        font: *const c_void,
+        glyphs: *const DrawGlyph,
+        glyph_count: usize,
         scale: f32,
         y_top: f32,
         y_bottom: f32,
@@ -88,7 +88,7 @@ unsafe extern "C" {
     );
 }
 
-pub struct RetainedGlyphRun {
+struct RetainedGlyphRun {
     raw: NonNull<c_void>,
 }
 
@@ -100,61 +100,51 @@ impl Drop for RetainedGlyphRun {
     }
 }
 
-impl RetainedGlyphRun {
-    #[inline]
-    #[must_use]
-    pub fn as_raw(&self) -> *mut c_void {
-        self.raw.as_ptr()
+#[must_use]
+pub fn glyph_run_bounding_box(font: FontRef<'_>, glyphs: &[DrawGlyph], scale: f32) -> [f32; 4] {
+    let mut out_rect = [0.0f32; 4];
+    // SAFETY: FontRef keeps the font live and the glyph slice stays valid for
+    // the synchronous call, which fills the four floats out_rect points at.
+    unsafe {
+        ladybird_gfx_glyph_run_bounding_box(
+            font.as_ptr(),
+            glyphs.as_ptr(),
+            glyphs.len(),
+            scale,
+            out_rect.as_mut_ptr(),
+        );
     }
-
-    #[must_use]
-    pub fn bounding_box(&self, scale: f32) -> [f32; 4] {
-        let mut out_rect = [0.0f32; 4];
-        // SAFETY: The handle keeps the GlyphRun live and out_rect points at
-        // four floats the synchronous call fills in.
-        unsafe { ladybird_gfx_glyph_run_bounding_box(self.raw.as_ptr(), scale, out_rect.as_mut_ptr()) };
-        out_rect
-    }
-
-    #[must_use]
-    pub fn glyph_intercepts(&self, scale: f32, y_top: f32, y_bottom: f32) -> Vec<f32> {
-        unsafe extern "C" fn push(sink: *mut c_void, value: f32) {
-            // SAFETY: `sink` is the Vec passed below, live for the synchronous call.
-            unsafe { (*sink.cast::<Vec<f32>>()).push(value) };
-        }
-        let mut intercepts: Vec<f32> = Vec::new();
-        // SAFETY: The handle keeps the GlyphRun live; the push callback runs
-        // synchronously against the local Vec.
-        unsafe {
-            ladybird_gfx_glyph_run_glyph_intercepts(
-                self.raw.as_ptr(),
-                scale,
-                y_top,
-                y_bottom,
-                (&raw mut intercepts).cast(),
-                push,
-            );
-        }
-        intercepts
-    }
+    out_rect
 }
 
-/// # Safety
-///
-/// `font` must point at a live `Gfx::Font`.
 #[must_use]
-pub unsafe fn create_glyph_run(
-    font: *const c_void,
+pub fn glyph_run_glyph_intercepts(
+    font: FontRef<'_>,
     glyphs: &[DrawGlyph],
-    text_type: TextType,
-    width: f32,
-) -> RetainedGlyphRun {
-    // SAFETY: The caller guarantees the font is live; the glyph slice stays
-    // valid for the synchronous call, which copies it.
-    let raw = unsafe { ladybird_gfx_glyph_run_create(font, glyphs.as_ptr(), glyphs.len(), text_type, width) };
-    RetainedGlyphRun {
-        raw: NonNull::new(raw).expect("Gfx glyph run creation must return a retained GlyphRun"),
+    scale: f32,
+    y_top: f32,
+    y_bottom: f32,
+) -> Vec<f32> {
+    unsafe extern "C" fn push(sink: *mut c_void, value: f32) {
+        // SAFETY: `sink` is the Vec passed below, live for the synchronous call.
+        unsafe { (*sink.cast::<Vec<f32>>()).push(value) };
     }
+    let mut intercepts: Vec<f32> = Vec::new();
+    // SAFETY: FontRef keeps the font live and the glyph slice stays valid for
+    // the synchronous call; the push callback runs against the local Vec.
+    unsafe {
+        ladybird_gfx_glyph_run_glyph_intercepts(
+            font.as_ptr(),
+            glyphs.as_ptr(),
+            glyphs.len(),
+            scale,
+            y_top,
+            y_bottom,
+            (&raw mut intercepts).cast(),
+            push,
+        );
+    }
+    intercepts
 }
 
 #[derive(Debug)]

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -6,7 +6,6 @@
 
 use crate::font::FontRef;
 use std::ffi::c_void;
-use std::ptr::NonNull;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -52,7 +51,6 @@ pub struct ShapedRunView {
     pub width: f32,
     pub trailing_whitespace_length_in_code_units: usize,
     pub trailing_whitespace_advance: f32,
-    pub retained: *mut c_void,
 }
 
 unsafe extern "C" {
@@ -61,12 +59,9 @@ unsafe extern "C" {
         text_utf16: *const u16,
         length_in_code_units: usize,
         text_type: TextType,
-        baseline_start_x: f32,
         letter_spacing: f32,
         word_spacing: f32,
     ) -> ShapedRunView;
-
-    fn ladybird_gfx_glyph_run_unref(retained: *mut c_void);
 
     fn ladybird_gfx_glyph_run_bounding_box(
         font: *const c_void,
@@ -86,18 +81,6 @@ unsafe extern "C" {
         sink: *mut c_void,
         push: unsafe extern "C" fn(*mut c_void, f32),
     );
-}
-
-struct RetainedGlyphRun {
-    raw: NonNull<c_void>,
-}
-
-impl Drop for RetainedGlyphRun {
-    fn drop(&mut self) {
-        // SAFETY: Whoever constructed this guard transferred exactly one
-        // retained GlyphRun reference into it, and this releases it once.
-        unsafe { ladybird_gfx_glyph_run_unref(self.raw.as_ptr()) };
-    }
 }
 
 #[must_use]
@@ -198,30 +181,33 @@ pub fn shape_text(
             text.as_ptr(),
             text.len(),
             text_type,
-            baseline_start_x,
             letter_spacing,
             word_spacing,
         )
     };
-    let retained = RetainedGlyphRun {
-        raw: NonNull::new(view.retained).expect("Gfx::shape_text must return a retained GlyphRun"),
-    };
     assert!(view.glyph_count == 0 || !view.glyphs.is_null());
-    let glyphs = if view.glyph_count == 0 {
-        Vec::new()
+    let cached_glyphs = if view.glyph_count == 0 {
+        &[]
     } else {
-        // SAFETY: retained keeps the GlyphRun and its glyph storage live while
-        // the view is copied into Rust-owned storage.
-        unsafe { std::slice::from_raw_parts(view.glyphs, view.glyph_count) }.to_vec()
+        // SAFETY: The view points into the font's shaping cache, which nothing
+        // mutates before this synchronous copy into Rust-owned storage is done.
+        unsafe { std::slice::from_raw_parts(view.glyphs, view.glyph_count) }
     };
-    let width = view.width;
-    let trailing_whitespace_length_in_code_units = view.trailing_whitespace_length_in_code_units;
-    let trailing_whitespace_advance = view.trailing_whitespace_advance;
-    drop(retained);
+    let glyphs = if baseline_start_x == 0.0 {
+        cached_glyphs.to_vec()
+    } else {
+        cached_glyphs
+            .iter()
+            .map(|glyph| DrawGlyph {
+                x: glyph.x + baseline_start_x,
+                ..*glyph
+            })
+            .collect()
+    };
     ShapedText {
         glyphs,
-        width,
-        trailing_whitespace_length_in_code_units,
-        trailing_whitespace_advance,
+        width: view.width,
+        trailing_whitespace_length_in_code_units: view.trailing_whitespace_length_in_code_units,
+        trailing_whitespace_advance: view.trailing_whitespace_advance,
     }
 }

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -172,6 +172,11 @@ impl ShapedText {
     }
 
     #[inline]
+    pub fn into_glyphs(self) -> Vec<DrawGlyph> {
+        self.glyphs
+    }
+
+    #[inline]
     pub fn width(&self) -> f32 {
         self.width
     }

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -43,25 +43,17 @@ pub struct DrawGlyph {
     pub should_paint: bool,
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct ShapedRunView {
-    pub glyphs: *const DrawGlyph,
-    pub glyph_count: usize,
-    pub width: f32,
-    pub trailing_whitespace_length_in_code_units: usize,
-    pub trailing_whitespace_advance: f32,
-}
-
 unsafe extern "C" {
-    fn ladybird_gfx_shape_text(
+    fn ladybird_gfx_shape_text_uncached(
         font: *const c_void,
         text_utf16: *const u16,
         length_in_code_units: usize,
         text_type: TextType,
         letter_spacing: f32,
         word_spacing: f32,
-    ) -> ShapedRunView;
+        sink: *mut c_void,
+        emit: unsafe extern "C" fn(*mut c_void, *const DrawGlyph, usize, f32, usize, f32),
+    );
 
     fn ladybird_gfx_glyph_run_bounding_box(
         font: *const c_void,
@@ -165,38 +157,186 @@ impl ShapedText {
     }
 }
 
-pub fn shape_text(
+const SINGLE_ASCII_SHAPE_CACHE_SIZE: usize = 128;
+const MAX_SHAPE_CACHE_FONTS: usize = 64;
+const MAX_SHAPE_CACHE_TEXTS_PER_FONT: usize = 4096;
+
+#[derive(Clone, Copy)]
+struct ShapeParams {
+    text_type: TextType,
+    letter_spacing: f32,
+    word_spacing: f32,
+}
+
+impl ShapeParams {
+    // Spacing values are compared bitwise so that, like the C++ shaping cache
+    // key, every distinct bit pattern gets its own entry.
+    fn matches(&self, other: &ShapeParams) -> bool {
+        self.text_type == other.text_type
+            && self.letter_spacing.to_bits() == other.letter_spacing.to_bits()
+            && self.word_spacing.to_bits() == other.word_spacing.to_bits()
+    }
+}
+
+#[derive(Default)]
+struct CachedShape {
+    glyphs: Vec<DrawGlyph>,
+    width: f32,
+    trailing_whitespace_length_in_code_units: usize,
+    trailing_whitespace_advance: f32,
+}
+
+struct ShapeForParams {
+    params: ShapeParams,
+    shape: CachedShape,
+}
+
+struct FontShapeCache {
+    last_used_tick: u64,
+    single_ascii_common_shapes: [Option<Box<CachedShape>>; SINGLE_ASCII_SHAPE_CACHE_SIZE],
+    shapes_by_text: std::collections::HashMap<Box<[u16]>, Vec<ShapeForParams>>,
+}
+
+impl Default for FontShapeCache {
+    fn default() -> Self {
+        Self {
+            last_used_tick: 0,
+            single_ascii_common_shapes: [const { None }; SINGLE_ASCII_SHAPE_CACHE_SIZE],
+            shapes_by_text: std::collections::HashMap::new(),
+        }
+    }
+}
+
+impl FontShapeCache {
+    fn shape_for(
+        &mut self,
+        text: &[u16],
+        params: ShapeParams,
+        shape_uncached: impl FnOnce() -> CachedShape,
+    ) -> &CachedShape {
+        if let &[code_unit] = text
+            && (code_unit as usize) < SINGLE_ASCII_SHAPE_CACHE_SIZE
+            && params.text_type == TextType::Common
+            && params.letter_spacing == 0.0
+            && params.word_spacing == 0.0
+        {
+            return self.single_ascii_common_shapes[code_unit as usize]
+                .get_or_insert_with(|| Box::new(shape_uncached()));
+        }
+
+        let is_shaped_already = self
+            .shapes_by_text
+            .get(text)
+            .is_some_and(|shapes| shapes.iter().any(|entry| entry.params.matches(&params)));
+        if !is_shaped_already {
+            if !self.shapes_by_text.contains_key(text) && self.shapes_by_text.len() >= MAX_SHAPE_CACHE_TEXTS_PER_FONT {
+                self.shapes_by_text.clear();
+            }
+            let shape = shape_uncached();
+            self.shapes_by_text
+                .entry(Box::from(text))
+                .or_default()
+                .push(ShapeForParams { params, shape });
+        }
+        self.shapes_by_text
+            .get(text)
+            .and_then(|shapes| shapes.iter().find(|entry| entry.params.matches(&params)))
+            .map(|entry| &entry.shape)
+            .expect("the shape was cached just above")
+    }
+}
+
+#[derive(Default)]
+struct ShapingCache {
+    caches_by_font_id: std::collections::HashMap<u64, FontShapeCache>,
+    tick: u64,
+}
+
+impl ShapingCache {
+    fn shape_for(
+        &mut self,
+        font_id: u64,
+        text: &[u16],
+        params: ShapeParams,
+        shape_uncached: impl FnOnce() -> CachedShape,
+    ) -> &CachedShape {
+        self.tick += 1;
+        if !self.caches_by_font_id.contains_key(&font_id) && self.caches_by_font_id.len() >= MAX_SHAPE_CACHE_FONTS {
+            self.evict_least_recently_used_font();
+        }
+        let font_cache = self.caches_by_font_id.entry(font_id).or_default();
+        font_cache.last_used_tick = self.tick;
+        font_cache.shape_for(text, params, shape_uncached)
+    }
+
+    fn evict_least_recently_used_font(&mut self) {
+        let least_recently_used_font_id = self
+            .caches_by_font_id
+            .iter()
+            .min_by_key(|(_, font_cache)| font_cache.last_used_tick)
+            .map(|(font_id, _)| *font_id);
+        if let Some(font_id) = least_recently_used_font_id {
+            self.caches_by_font_id.remove(&font_id);
+        }
+    }
+}
+
+thread_local! {
+    static SHAPING_CACHE: std::cell::RefCell<ShapingCache> = std::cell::RefCell::new(ShapingCache::default());
+}
+
+fn shape_text_uncached(
     font: FontRef<'_>,
     text: &[u16],
     text_type: TextType,
-    baseline_start_x: f32,
     letter_spacing: f32,
     word_spacing: f32,
-) -> ShapedText {
-    // SAFETY: FontRef keeps the font live, and the text slice remains valid
-    // for the duration of the synchronous shaping call.
-    let view = unsafe {
-        ladybird_gfx_shape_text(
+) -> CachedShape {
+    unsafe extern "C" fn emit(
+        sink: *mut c_void,
+        glyphs: *const DrawGlyph,
+        glyph_count: usize,
+        width: f32,
+        trailing_whitespace_length_in_code_units: usize,
+        trailing_whitespace_advance: f32,
+    ) {
+        // SAFETY: `sink` is the CachedShape passed below, and the glyph
+        // pointer stays valid for this synchronous callback.
+        let shape = unsafe { &mut *sink.cast::<CachedShape>() };
+        assert!(glyph_count == 0 || !glyphs.is_null());
+        if glyph_count != 0 {
+            // SAFETY: The C++ side hands a pointer to glyph_count glyphs that
+            // outlive the callback.
+            shape.glyphs = unsafe { std::slice::from_raw_parts(glyphs, glyph_count) }.to_vec();
+        }
+        shape.width = width;
+        shape.trailing_whitespace_length_in_code_units = trailing_whitespace_length_in_code_units;
+        shape.trailing_whitespace_advance = trailing_whitespace_advance;
+    }
+    let mut shape = CachedShape::default();
+    // SAFETY: FontRef keeps the font live and the text slice stays valid for
+    // the synchronous shaping call; emit runs against the local CachedShape.
+    unsafe {
+        ladybird_gfx_shape_text_uncached(
             font.as_ptr(),
             text.as_ptr(),
             text.len(),
             text_type,
             letter_spacing,
             word_spacing,
-        )
-    };
-    assert!(view.glyph_count == 0 || !view.glyphs.is_null());
-    let cached_glyphs = if view.glyph_count == 0 {
-        &[]
-    } else {
-        // SAFETY: The view points into the font's shaping cache, which nothing
-        // mutates before this synchronous copy into Rust-owned storage is done.
-        unsafe { std::slice::from_raw_parts(view.glyphs, view.glyph_count) }
-    };
+            (&raw mut shape).cast(),
+            emit,
+        );
+    }
+    shape
+}
+
+fn shaped_text_with_baseline_start(shape: &CachedShape, baseline_start_x: f32) -> ShapedText {
     let glyphs = if baseline_start_x == 0.0 {
-        cached_glyphs.to_vec()
+        shape.glyphs.clone()
     } else {
-        cached_glyphs
+        shape
+            .glyphs
             .iter()
             .map(|glyph| DrawGlyph {
                 x: glyph.x + baseline_start_x,
@@ -206,8 +346,135 @@ pub fn shape_text(
     };
     ShapedText {
         glyphs,
-        width: view.width,
-        trailing_whitespace_length_in_code_units: view.trailing_whitespace_length_in_code_units,
-        trailing_whitespace_advance: view.trailing_whitespace_advance,
+        width: shape.width,
+        trailing_whitespace_length_in_code_units: shape.trailing_whitespace_length_in_code_units,
+        trailing_whitespace_advance: shape.trailing_whitespace_advance,
+    }
+}
+
+pub fn shape_text(
+    font: FontRef<'_>,
+    text: &[u16],
+    text_type: TextType,
+    baseline_start_x: f32,
+    letter_spacing: f32,
+    word_spacing: f32,
+) -> ShapedText {
+    let params = ShapeParams {
+        text_type,
+        letter_spacing,
+        word_spacing,
+    };
+    SHAPING_CACHE.with_borrow_mut(|cache| {
+        let shape = cache.shape_for(font.id(), text, params, || {
+            shape_text_uncached(font, text, text_type, letter_spacing, word_spacing)
+        });
+        shaped_text_with_baseline_start(shape, baseline_start_x)
+    })
+}
+
+#[cfg(test)]
+mod shaping_cache_tests {
+    use super::*;
+
+    fn shape_with_glyph_count(glyph_count: usize) -> CachedShape {
+        CachedShape {
+            glyphs: vec![DrawGlyph::default(); glyph_count],
+            width: glyph_count as f32,
+            trailing_whitespace_length_in_code_units: 0,
+            trailing_whitespace_advance: 0.0,
+        }
+    }
+
+    fn params_with_letter_spacing(letter_spacing: f32) -> ShapeParams {
+        ShapeParams {
+            text_type: TextType::Common,
+            letter_spacing,
+            word_spacing: 0.0,
+        }
+    }
+
+    #[test]
+    fn repeated_lookups_shape_once() {
+        let mut cache = ShapingCache::default();
+        let text: Vec<u16> = "word".encode_utf16().collect();
+        let mut shape_calls = 0;
+        for _ in 0..3 {
+            let shape = cache.shape_for(1, &text, params_with_letter_spacing(0.0), || {
+                shape_calls += 1;
+                shape_with_glyph_count(4)
+            });
+            assert_eq!(shape.glyphs.len(), 4);
+        }
+        assert_eq!(shape_calls, 1);
+    }
+
+    #[test]
+    fn distinct_params_for_the_same_text_shape_separately() {
+        let mut cache = ShapingCache::default();
+        let text: Vec<u16> = "word".encode_utf16().collect();
+        cache.shape_for(1, &text, params_with_letter_spacing(0.0), || shape_with_glyph_count(1));
+        let mut second_params_shaped = false;
+        cache.shape_for(1, &text, params_with_letter_spacing(2.0), || {
+            second_params_shaped = true;
+            shape_with_glyph_count(2)
+        });
+        assert!(second_params_shaped);
+        let shape = cache.shape_for(1, &text, params_with_letter_spacing(0.0), || unreachable!());
+        assert_eq!(shape.glyphs.len(), 1);
+    }
+
+    #[test]
+    fn single_ascii_fast_path_requires_common_text_without_spacing() {
+        let mut cache = ShapingCache::default();
+        let text = [b'a' as u16];
+        cache.shape_for(1, &text, params_with_letter_spacing(0.0), || shape_with_glyph_count(1));
+        let font_cache = &cache.caches_by_font_id[&1];
+        assert!(font_cache.single_ascii_common_shapes[b'a' as usize].is_some());
+        assert!(font_cache.shapes_by_text.is_empty());
+
+        cache.shape_for(1, &text, params_with_letter_spacing(2.0), || shape_with_glyph_count(1));
+        let font_cache = &cache.caches_by_font_id[&1];
+        assert_eq!(font_cache.shapes_by_text.len(), 1);
+    }
+
+    #[test]
+    fn least_recently_used_font_is_evicted_at_capacity() {
+        let mut cache = ShapingCache::default();
+        let text = [b'a' as u16];
+        for font_id in 0..MAX_SHAPE_CACHE_FONTS as u64 {
+            cache.shape_for(font_id, &text, params_with_letter_spacing(0.0), || {
+                shape_with_glyph_count(1)
+            });
+        }
+        cache.shape_for(0, &text, params_with_letter_spacing(0.0), || unreachable!());
+
+        let one_font_over_capacity = MAX_SHAPE_CACHE_FONTS as u64;
+        cache.shape_for(one_font_over_capacity, &text, params_with_letter_spacing(0.0), || {
+            shape_with_glyph_count(1)
+        });
+        assert_eq!(cache.caches_by_font_id.len(), MAX_SHAPE_CACHE_FONTS);
+        assert!(cache.caches_by_font_id.contains_key(&0));
+        assert!(!cache.caches_by_font_id.contains_key(&1));
+    }
+
+    #[test]
+    fn overflowing_the_per_font_text_capacity_clears_that_font_only() {
+        let mut cache = ShapingCache::default();
+        for text_index in 0..MAX_SHAPE_CACHE_TEXTS_PER_FONT as u32 {
+            let text: Vec<u16> = format!("text-{text_index}").encode_utf16().collect();
+            cache.shape_for(1, &text, params_with_letter_spacing(0.0), || shape_with_glyph_count(1));
+        }
+        let other_font_text: Vec<u16> = "other".encode_utf16().collect();
+        cache.shape_for(2, &other_font_text, params_with_letter_spacing(0.0), || {
+            shape_with_glyph_count(1)
+        });
+
+        let overflowing_text: Vec<u16> = "one-more".encode_utf16().collect();
+        cache.shape_for(1, &overflowing_text, params_with_letter_spacing(0.0), || {
+            shape_with_glyph_count(1)
+        });
+        assert_eq!(cache.caches_by_font_id[&1].shapes_by_text.len(), 1);
+        assert_eq!(cache.caches_by_font_id[&2].shapes_by_text.len(), 1);
     }
 }

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -50,7 +50,12 @@ NonnullRefPtr<GlyphRun> GlyphRun::slice(size_t start, size_t length) const
 
 FloatRect GlyphRun::bounding_box(float scale) const
 {
-    auto font_ascent = m_font->pixel_metrics().ascent;
+    return glyph_run_bounding_box(m_font, m_glyphs, scale);
+}
+
+FloatRect glyph_run_bounding_box(Font const& font, ReadonlySpan<DrawGlyph> glyphs, float scale)
+{
+    auto font_ascent = font.pixel_metrics().ascent;
 
     // NOTE: This is a plain min/max rather than FloatRect::unite(), because a run with a single glyph must still
     //       produce a (zero-sized) origin box that gets expanded by the font bounds below.
@@ -59,7 +64,7 @@ FloatRect GlyphRun::bounding_box(float scale) const
     float min_y = NumericLimits<float>::max();
     float max_x = NumericLimits<float>::lowest();
     float max_y = NumericLimits<float>::lowest();
-    for (auto const& glyph : m_glyphs) {
+    for (auto const& glyph : glyphs) {
         if (!glyph.should_paint)
             continue;
         auto origin_x = glyph.position.x() * scale;
@@ -75,9 +80,9 @@ FloatRect GlyphRun::bounding_box(float scale) const
     if (!has_painted_glyphs)
         return {};
 
-    auto font_bounding_box = m_font->typeface().bounding_box_in_font_units();
+    auto font_bounding_box = font.typeface().bounding_box_in_font_units();
     if (!font_bounding_box.is_empty()) {
-        auto font_units_to_pixels = m_font->pixel_size() * scale / font_bounding_box.units_per_em;
+        auto font_units_to_pixels = font.pixel_size() * scale / font_bounding_box.units_per_em;
         // Font units have y pointing up, device pixels have y pointing down.
         auto left = min_x + font_bounding_box.x_min * font_units_to_pixels;
         auto right = max_x + font_bounding_box.x_max * font_units_to_pixels;
@@ -87,17 +92,17 @@ FloatRect GlyphRun::bounding_box(float scale) const
     }
 
     // The font doesn't record an overall bounding box (e.g. bitmap-only fonts), so unite the glyphs' own extents.
-    auto* hb_font = m_font->harfbuzz_font();
+    auto* hb_font = font.harfbuzz_font();
     int x_scale = 0;
     int y_scale = 0;
     hb_font_get_scale(hb_font, &x_scale, &y_scale);
     if (x_scale <= 0 || y_scale <= 0)
         return {};
-    auto units_to_pixels_x = m_font->pixel_size() * scale / x_scale;
-    auto units_to_pixels_y = m_font->pixel_size() * scale / y_scale;
+    auto units_to_pixels_x = font.pixel_size() * scale / x_scale;
+    auto units_to_pixels_y = font.pixel_size() * scale / y_scale;
 
     FloatRect bounds;
-    for (auto const& glyph : m_glyphs) {
+    for (auto const& glyph : glyphs) {
         if (!glyph.should_paint)
             continue;
         hb_glyph_extents_t extents;
@@ -345,23 +350,23 @@ hb_draw_funcs_t* ink_extent_draw_funcs()
 
 }
 
-Vector<float> GlyphRun::get_glyph_intercepts(float scale, float y_top, float y_bottom) const
+Vector<float> glyph_run_glyph_intercepts(Font const& font, ReadonlySpan<DrawGlyph> glyphs, float scale, float y_top, float y_bottom)
 {
     if (!(scale > 0) || !__builtin_isfinite(scale))
         return {};
 
-    auto* hb_font = m_font->harfbuzz_font();
+    auto* hb_font = font.harfbuzz_font();
     int x_scale = 0;
     int y_scale = 0;
     hb_font_get_scale(hb_font, &x_scale, &y_scale);
     if (x_scale <= 0 || y_scale <= 0)
         return {};
-    auto units_to_pixels_x = static_cast<double>(m_font->pixel_size()) * scale / x_scale;
-    auto units_to_pixels_y = static_cast<double>(m_font->pixel_size()) * scale / y_scale;
-    auto font_ascent = m_font->pixel_metrics().ascent;
+    auto units_to_pixels_x = static_cast<double>(font.pixel_size()) * scale / x_scale;
+    auto units_to_pixels_y = static_cast<double>(font.pixel_size()) * scale / y_scale;
+    auto font_ascent = font.pixel_metrics().ascent;
 
     Vector<float> intervals;
-    for (auto const& glyph : m_glyphs) {
+    for (auto const& glyph : glyphs) {
         if (!glyph.should_paint)
             continue;
         auto origin_x = static_cast<double>(glyph.position.x()) * scale;
@@ -663,9 +668,8 @@ static_assert(offsetof(Gfx::FFI::DrawGlyph, should_paint) == offsetof(Gfx::DrawG
 extern "C" {
 Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float, float);
 void ladybird_gfx_glyph_run_unref(void*);
-void* ladybird_gfx_glyph_run_create(void const*, Gfx::FFI::DrawGlyph const*, size_t, Gfx::FFI::TextType, float);
-void ladybird_gfx_glyph_run_bounding_box(void const*, float, float*);
-void ladybird_gfx_glyph_run_glyph_intercepts(void const*, float, float, float, void*, void (*)(void*, float));
+void ladybird_gfx_glyph_run_bounding_box(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float*);
+void ladybird_gfx_glyph_run_glyph_intercepts(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float, float, void*, void (*)(void*, float));
 }
 
 extern "C" Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(
@@ -708,31 +712,20 @@ extern "C" void ladybird_gfx_glyph_run_unref(void* retained)
     static_cast<Gfx::GlyphRun*>(retained)->unref();
 }
 
-extern "C" void* ladybird_gfx_glyph_run_create(
+extern "C" void ladybird_gfx_glyph_run_bounding_box(
     void const* font,
     Gfx::FFI::DrawGlyph const* glyphs,
     size_t glyph_count,
-    Gfx::FFI::TextType text_type,
-    float width)
+    float scale,
+    float* out_rect)
 {
     VERIFY(font);
     VERIFY(glyphs || glyph_count == 0);
-    Vector<Gfx::DrawGlyph> copied_glyphs;
-    copied_glyphs.ensure_capacity(glyph_count);
-    copied_glyphs.unchecked_append(reinterpret_cast<Gfx::DrawGlyph const*>(glyphs), glyph_count);
-    auto run = adopt_ref(*new Gfx::GlyphRun(
-        move(copied_glyphs),
-        *static_cast<Gfx::Font const*>(font),
-        static_cast<Gfx::GlyphRun::TextType>(text_type),
-        width));
-    return &run.leak_ref();
-}
-
-extern "C" void ladybird_gfx_glyph_run_bounding_box(void const* retained, float scale, float* out_rect)
-{
-    VERIFY(retained);
     VERIFY(out_rect);
-    auto bounds = static_cast<Gfx::GlyphRun const*>(retained)->bounding_box(scale);
+    auto bounds = Gfx::glyph_run_bounding_box(
+        *static_cast<Gfx::Font const*>(font),
+        { reinterpret_cast<Gfx::DrawGlyph const*>(glyphs), glyph_count },
+        scale);
     out_rect[0] = bounds.x();
     out_rect[1] = bounds.y();
     out_rect[2] = bounds.width();
@@ -740,15 +733,24 @@ extern "C" void ladybird_gfx_glyph_run_bounding_box(void const* retained, float 
 }
 
 extern "C" void ladybird_gfx_glyph_run_glyph_intercepts(
-    void const* retained,
+    void const* font,
+    Gfx::FFI::DrawGlyph const* glyphs,
+    size_t glyph_count,
     float scale,
     float y_top,
     float y_bottom,
     void* sink,
     void (*push)(void*, float))
 {
-    VERIFY(retained);
+    VERIFY(font);
+    VERIFY(glyphs || glyph_count == 0);
     VERIFY(push);
-    for (auto value : static_cast<Gfx::GlyphRun const*>(retained)->get_glyph_intercepts(scale, y_top, y_bottom))
+    auto intercepts = Gfx::glyph_run_glyph_intercepts(
+        *static_cast<Gfx::Font const*>(font),
+        { reinterpret_cast<Gfx::DrawGlyph const*>(glyphs), glyph_count },
+        scale,
+        y_top,
+        y_bottom);
+    for (auto value : intercepts)
         push(sink, value);
 }

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -48,11 +48,6 @@ NonnullRefPtr<GlyphRun> GlyphRun::slice(size_t start, size_t length) const
     return adopt_ref(*new GlyphRun(move(sliced_glyphs), m_font, m_text_type, width));
 }
 
-FloatRect GlyphRun::bounding_box(float scale) const
-{
-    return glyph_run_bounding_box(m_font, m_glyphs, scale);
-}
-
 FloatRect glyph_run_bounding_box(Font const& font, ReadonlySpan<DrawGlyph> glyphs, float scale)
 {
     auto font_ascent = font.pixel_metrics().ascent;
@@ -671,6 +666,7 @@ static_assert(offsetof(Gfx::FFI::DrawGlyph, should_paint) == offsetof(Gfx::DrawG
 
 extern "C" {
 void ladybird_gfx_shape_text_uncached(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float, void*, void (*)(void*, Gfx::FFI::DrawGlyph const*, size_t, float, size_t, float));
+float ladybird_gfx_font_measure_text_width(void const*, u16 const*, size_t);
 void ladybird_gfx_glyph_run_bounding_box(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float*);
 void ladybird_gfx_glyph_run_glyph_intercepts(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float, float, void*, void (*)(void*, float));
 }
@@ -704,6 +700,19 @@ extern "C" void ladybird_gfx_shape_text_uncached(
         shape->width,
         shape->trailing_whitespace.length_in_code_units,
         shape->trailing_whitespace.advance);
+}
+
+extern "C" float ladybird_gfx_font_measure_text_width(
+    void const* font,
+    u16 const* text_utf16,
+    size_t length_in_code_units)
+{
+    VERIFY(font);
+    VERIFY(text_utf16 || length_in_code_units == 0);
+    auto text = length_in_code_units == 0
+        ? Utf16View {}
+        : Utf16View { reinterpret_cast<char16_t const*>(text_utf16), length_in_code_units };
+    return Gfx::measure_text_width(text, *static_cast<Gfx::Font const*>(font));
 }
 
 extern "C" void ladybird_gfx_glyph_run_bounding_box(

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -584,20 +584,11 @@ static NonnullOwnPtr<ShapedGlyphs> build_origin_relative_shape(Utf16View const& 
     return make<ShapedGlyphs>(move(glyphs), point.x(), trailing_whitespace);
 }
 
-NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, float word_spacing, Utf16View const& string, Font const& font, GlyphRun::TextType text_type, TrailingWhitespace* out_trailing_whitespace)
+// The returned reference points into the font's shaping cache and stays valid until the next
+// shaping call for the same font, or until the cache is cleared.
+static ShapedGlyphs const& shape_text_through_cache(Utf16View const& string, Font const& font, GlyphRun::TextType text_type, float letter_spacing, float word_spacing)
 {
     auto& shaping_cache = font.shaping_cache();
-
-    auto build_glyph_run = [&](ShapedGlyphs const& shape) -> NonnullRefPtr<GlyphRun> {
-        if (out_trailing_whitespace)
-            *out_trailing_whitespace = shape.trailing_whitespace;
-        Vector<DrawGlyph> glyphs = shape.glyphs;
-        if (!baseline_start.is_zero()) {
-            for (auto& glyph : glyphs)
-                glyph.position.translate_by(baseline_start);
-        }
-        return adopt_ref(*new GlyphRun(move(glyphs), font, text_type, shape.width));
-    };
 
     // FIXME: The cache currently grows unbounded. We should have some limit and LRU mechanism.
     if (string.length_in_code_units() == 1 && letter_spacing == 0.f && word_spacing == 0.f && text_type == GlyphRun::TextType::Common) {
@@ -606,7 +597,7 @@ NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spaci
             auto& cache_slot = shaping_cache.single_ascii_character_map[code_unit];
             if (!cache_slot)
                 cache_slot = build_origin_relative_shape(string, font, text_type, letter_spacing, word_spacing);
-            return build_glyph_run(*cache_slot);
+            return *cache_slot;
         }
     }
 
@@ -622,13 +613,26 @@ NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spaci
                 && candidate.key.text == string;
         });
         it != shaping_cache.map.end()) {
-        return build_glyph_run(*it->value);
+        return *it->value;
     }
 
     auto shape = build_origin_relative_shape(string, font, text_type, letter_spacing, word_spacing);
-    auto run = build_glyph_run(*shape);
+    auto const& cached_shape = *shape;
     shaping_cache.map.set({ Utf16String::from_utf16(string), text_type_bits, letter_spacing_bit_pattern, word_spacing_bit_pattern }, move(shape));
-    return run;
+    return cached_shape;
+}
+
+NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, float word_spacing, Utf16View const& string, Font const& font, GlyphRun::TextType text_type, TrailingWhitespace* out_trailing_whitespace)
+{
+    auto const& shape = shape_text_through_cache(string, font, text_type, letter_spacing, word_spacing);
+    if (out_trailing_whitespace)
+        *out_trailing_whitespace = shape.trailing_whitespace;
+    Vector<DrawGlyph> glyphs = shape.glyphs;
+    if (!baseline_start.is_zero()) {
+        for (auto& glyph : glyphs)
+            glyph.position.translate_by(baseline_start);
+    }
+    return adopt_ref(*new GlyphRun(move(glyphs), font, text_type, shape.width));
 }
 
 float measure_text_width(Utf16View const& string, Font const& font, float letter_spacing)
@@ -666,8 +670,7 @@ static_assert(offsetof(Gfx::FFI::DrawGlyph, glyph_id) == offsetof(Gfx::DrawGlyph
 static_assert(offsetof(Gfx::FFI::DrawGlyph, should_paint) == offsetof(Gfx::DrawGlyph, should_paint));
 
 extern "C" {
-Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float, float);
-void ladybird_gfx_glyph_run_unref(void*);
+Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float);
 void ladybird_gfx_glyph_run_bounding_box(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float*);
 void ladybird_gfx_glyph_run_glyph_intercepts(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float, float, void*, void (*)(void*, float));
 }
@@ -677,7 +680,6 @@ extern "C" Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(
     u16 const* text_utf16,
     size_t length_in_code_units,
     Gfx::FFI::TextType text_type,
-    float baseline_start_x,
     float letter_spacing,
     float word_spacing)
 {
@@ -686,30 +688,19 @@ extern "C" Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(
     auto text = length_in_code_units == 0
         ? Utf16View {}
         : Utf16View { reinterpret_cast<char16_t const*>(text_utf16), length_in_code_units };
-    Gfx::TrailingWhitespace trailing_whitespace;
-    auto run = Gfx::shape_text(
-        { baseline_start_x, 0 },
-        letter_spacing,
-        word_spacing,
+    auto const& shape = Gfx::shape_text_through_cache(
         text,
         *static_cast<Gfx::Font const*>(font),
         static_cast<Gfx::GlyphRun::TextType>(text_type),
-        &trailing_whitespace);
-    auto* retained = &run.leak_ref();
+        letter_spacing,
+        word_spacing);
     return {
-        .glyphs = reinterpret_cast<Gfx::FFI::DrawGlyph const*>(retained->glyphs().data()),
-        .glyph_count = retained->glyphs().size(),
-        .width = retained->width(),
-        .trailing_whitespace_length_in_code_units = trailing_whitespace.length_in_code_units,
-        .trailing_whitespace_advance = trailing_whitespace.advance,
-        .retained = retained,
+        .glyphs = reinterpret_cast<Gfx::FFI::DrawGlyph const*>(shape.glyphs.data()),
+        .glyph_count = shape.glyphs.size(),
+        .width = shape.width,
+        .trailing_whitespace_length_in_code_units = shape.trailing_whitespace.length_in_code_units,
+        .trailing_whitespace_advance = shape.trailing_whitespace.advance,
     };
-}
-
-extern "C" void ladybird_gfx_glyph_run_unref(void* retained)
-{
-    VERIFY(retained);
-    static_cast<Gfx::GlyphRun*>(retained)->unref();
 }
 
 extern "C" void ladybird_gfx_glyph_run_bounding_box(

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -500,7 +500,13 @@ static size_t length_of_trailing_whitespace_run(Utf16View const& string)
     return length;
 }
 
-static NonnullOwnPtr<ShapedGlyphs> build_origin_relative_shape(Utf16View const& string, Font const& font, GlyphRun::TextType text_type, float letter_spacing, float word_spacing)
+struct ShapedGlyphs {
+    Vector<DrawGlyph> glyphs;
+    float width { 0 };
+    TrailingWhitespace trailing_whitespace;
+};
+
+static ShapedGlyphs build_origin_relative_shape(Utf16View const& string, Font const& font, GlyphRun::TextType text_type, float letter_spacing, float word_spacing)
 {
     auto const& metrics = font.pixel_metrics();
     auto* buffer = setup_text_shaping(string, font, text_type);
@@ -576,58 +582,19 @@ static NonnullOwnPtr<ShapedGlyphs> build_origin_relative_shape(Utf16View const& 
 
     hb_buffer_destroy(buffer);
 
-    return make<ShapedGlyphs>(move(glyphs), point.x(), trailing_whitespace);
-}
-
-// The returned reference points into the font's shaping cache and stays valid until the next
-// shaping call for the same font, or until the cache is cleared.
-static ShapedGlyphs const& shape_text_through_cache(Utf16View const& string, Font const& font, GlyphRun::TextType text_type, float letter_spacing, float word_spacing)
-{
-    auto& shaping_cache = font.shaping_cache();
-
-    // FIXME: The cache currently grows unbounded. We should have some limit and LRU mechanism.
-    if (string.length_in_code_units() == 1 && letter_spacing == 0.f && word_spacing == 0.f && text_type == GlyphRun::TextType::Common) {
-        auto code_unit = string.code_unit_at(0);
-        if (code_unit < 128) {
-            auto& cache_slot = shaping_cache.single_ascii_character_map[code_unit];
-            if (!cache_slot)
-                cache_slot = build_origin_relative_shape(string, font, text_type, letter_spacing, word_spacing);
-            return *cache_slot;
-        }
-    }
-
-    auto text_type_bits = static_cast<u8>(to_underlying(text_type));
-    auto letter_spacing_bit_pattern = bit_cast<u32>(letter_spacing);
-    auto word_spacing_bit_pattern = bit_cast<u32>(word_spacing);
-    auto key_hash = pair_int_hash(string.hash(), pair_int_hash(text_type_bits, pair_int_hash(letter_spacing_bit_pattern, word_spacing_bit_pattern)));
-
-    if (auto it = shaping_cache.map.find(key_hash, [&](auto const& candidate) {
-            return candidate.key.text_type == text_type_bits
-                && candidate.key.letter_spacing_bit_pattern == letter_spacing_bit_pattern
-                && candidate.key.word_spacing_bit_pattern == word_spacing_bit_pattern
-                && candidate.key.text == string;
-        });
-        it != shaping_cache.map.end()) {
-        return *it->value;
-    }
-
-    auto shape = build_origin_relative_shape(string, font, text_type, letter_spacing, word_spacing);
-    auto const& cached_shape = *shape;
-    shaping_cache.map.set({ Utf16String::from_utf16(string), text_type_bits, letter_spacing_bit_pattern, word_spacing_bit_pattern }, move(shape));
-    return cached_shape;
+    return ShapedGlyphs { move(glyphs), point.x(), trailing_whitespace };
 }
 
 NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, float word_spacing, Utf16View const& string, Font const& font, GlyphRun::TextType text_type, TrailingWhitespace* out_trailing_whitespace)
 {
-    auto const& shape = shape_text_through_cache(string, font, text_type, letter_spacing, word_spacing);
+    auto shape = build_origin_relative_shape(string, font, text_type, letter_spacing, word_spacing);
     if (out_trailing_whitespace)
         *out_trailing_whitespace = shape.trailing_whitespace;
-    Vector<DrawGlyph> glyphs = shape.glyphs;
     if (!baseline_start.is_zero()) {
-        for (auto& glyph : glyphs)
+        for (auto& glyph : shape.glyphs)
             glyph.position.translate_by(baseline_start);
     }
-    return adopt_ref(*new GlyphRun(move(glyphs), font, text_type, shape.width));
+    return adopt_ref(*new GlyphRun(move(shape.glyphs), font, text_type, shape.width));
 }
 
 float measure_text_width(Utf16View const& string, Font const& font, float letter_spacing)
@@ -695,11 +662,11 @@ extern "C" void ladybird_gfx_shape_text_uncached(
         word_spacing);
     emit(
         sink,
-        reinterpret_cast<Gfx::FFI::DrawGlyph const*>(shape->glyphs.data()),
-        shape->glyphs.size(),
-        shape->width,
-        shape->trailing_whitespace.length_in_code_units,
-        shape->trailing_whitespace.advance);
+        reinterpret_cast<Gfx::FFI::DrawGlyph const*>(shape.glyphs.data()),
+        shape.glyphs.size(),
+        shape.width,
+        shape.trailing_whitespace.length_in_code_units,
+        shape.trailing_whitespace.advance);
 }
 
 extern "C" float ladybird_gfx_font_measure_text_width(

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -670,37 +670,40 @@ static_assert(offsetof(Gfx::FFI::DrawGlyph, glyph_id) == offsetof(Gfx::DrawGlyph
 static_assert(offsetof(Gfx::FFI::DrawGlyph, should_paint) == offsetof(Gfx::DrawGlyph, should_paint));
 
 extern "C" {
-Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float);
+void ladybird_gfx_shape_text_uncached(void const*, u16 const*, size_t, Gfx::FFI::TextType, float, float, void*, void (*)(void*, Gfx::FFI::DrawGlyph const*, size_t, float, size_t, float));
 void ladybird_gfx_glyph_run_bounding_box(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float*);
 void ladybird_gfx_glyph_run_glyph_intercepts(void const*, Gfx::FFI::DrawGlyph const*, size_t, float, float, float, void*, void (*)(void*, float));
 }
 
-extern "C" Gfx::FFI::ShapedRunView ladybird_gfx_shape_text(
+extern "C" void ladybird_gfx_shape_text_uncached(
     void const* font,
     u16 const* text_utf16,
     size_t length_in_code_units,
     Gfx::FFI::TextType text_type,
     float letter_spacing,
-    float word_spacing)
+    float word_spacing,
+    void* sink,
+    void (*emit)(void*, Gfx::FFI::DrawGlyph const*, size_t, float, size_t, float))
 {
     VERIFY(font);
     VERIFY(text_utf16 || length_in_code_units == 0);
+    VERIFY(emit);
     auto text = length_in_code_units == 0
         ? Utf16View {}
         : Utf16View { reinterpret_cast<char16_t const*>(text_utf16), length_in_code_units };
-    auto const& shape = Gfx::shape_text_through_cache(
+    auto shape = Gfx::build_origin_relative_shape(
         text,
         *static_cast<Gfx::Font const*>(font),
         static_cast<Gfx::GlyphRun::TextType>(text_type),
         letter_spacing,
         word_spacing);
-    return {
-        .glyphs = reinterpret_cast<Gfx::FFI::DrawGlyph const*>(shape.glyphs.data()),
-        .glyph_count = shape.glyphs.size(),
-        .width = shape.width,
-        .trailing_whitespace_length_in_code_units = shape.trailing_whitespace.length_in_code_units,
-        .trailing_whitespace_advance = shape.trailing_whitespace.advance,
-    };
+    emit(
+        sink,
+        reinterpret_cast<Gfx::FFI::DrawGlyph const*>(shape->glyphs.data()),
+        shape->glyphs.size(),
+        shape->width,
+        shape->trailing_whitespace.length_in_code_units,
+        shape->trailing_whitespace.advance);
 }
 
 extern "C" void ladybird_gfx_glyph_run_bounding_box(

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -60,8 +60,6 @@ public:
 
     [[nodiscard]] NonnullRefPtr<GlyphRun> slice(size_t start, size_t length) const;
 
-    [[nodiscard]] FloatRect bounding_box(float scale) const;
-
 private:
     Vector<DrawGlyph> m_glyphs;
     NonnullRefPtr<Font const> m_font;

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -33,12 +33,6 @@ struct TrailingWhitespace {
     float advance { 0 };
 };
 
-struct ShapedGlyphs {
-    Vector<DrawGlyph> glyphs;
-    float width { 0 };
-    TrailingWhitespace trailing_whitespace;
-};
-
 class GlyphRun : public AtomicRefCounted<GlyphRun> {
 public:
     enum class TextType {

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -60,15 +60,7 @@ public:
 
     [[nodiscard]] NonnullRefPtr<GlyphRun> slice(size_t start, size_t length) const;
 
-    // Conservative bounds of the painted glyphs in device pixels, relative to the run's baseline origin (glyph
-    // positions scaled by `scale`, with the font ascent added to y). The bounding box of the glyph origins is
-    // expanded by the font's overall glyph bounding box, falling back to tight per-glyph extents when the font
-    // doesn't record one.
     [[nodiscard]] FloatRect bounding_box(float scale) const;
-
-    // Pairs of [start, end] device-pixel x values, relative to the run's baseline origin, where glyph ink intersects
-    // the horizontal band [y_top, y_bottom]. One pair per painted glyph that has ink inside the band, in run order.
-    [[nodiscard]] Vector<float> get_glyph_intercepts(float scale, float y_top, float y_bottom) const;
 
 private:
     Vector<DrawGlyph> m_glyphs;
@@ -76,6 +68,16 @@ private:
     TextType m_text_type;
     float m_width { 0 };
 };
+
+// Conservative bounds of the painted glyphs in device pixels, relative to the run's baseline origin (glyph
+// positions scaled by `scale`, with the font ascent added to y). The bounding box of the glyph origins is
+// expanded by the font's overall glyph bounding box, falling back to tight per-glyph extents when the font
+// doesn't record one.
+[[nodiscard]] FloatRect glyph_run_bounding_box(Font const&, ReadonlySpan<DrawGlyph>, float scale);
+
+// Pairs of [start, end] device-pixel x values, relative to the run's baseline origin, where glyph ink intersects
+// the horizontal band [y_top, y_bottom]. One pair per painted glyph that has ink inside the band, in run order.
+[[nodiscard]] Vector<float> glyph_run_glyph_intercepts(Font const&, ReadonlySpan<DrawGlyph>, float scale, float y_top, float y_bottom);
 
 NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, float word_spacing, Utf16View const&, Gfx::Font const& font, GlyphRun::TextType, TrailingWhitespace* = nullptr);
 Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const&, FontCascadeList const&, float letter_spacing = 0.f);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -1238,38 +1238,26 @@ Layout::RustFFI::FfiPaintHostCallbacks paint_host_callbacks(PaintHostContext& co
                 display_list->set_mask_display_list_id(FrameNodeIndex { static_cast<u32>(mask_pairs[i * 2]) }, DisplayListResourceId { mask_pairs[i * 2 + 1] });
             return context.resource_storage.add_display_list(move(display_list), visual_context_tree).value();
         },
-        .overlay_label = [](void* context_pointer, void* layout_node_shell, u16 const* text_units, size_t text_unit_count, size_t utf16_fly_string_raw, float css_font_size, void* sink) -> Layout::RustFFI::FfiOverlayLabelFacts {
-            auto& context = *static_cast<PaintHostContext*>(context_pointer);
-            Utf16String text;
-            if (layout_node_shell) {
-                auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
-                auto border_rect = absolute_border_box_rect(layout_node);
-                Utf16StringBuilder builder;
-                builder.appendff("{}", layout_node.debug_description());
-                builder.appendff(" {}x{} @ {},{}", border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
-                text = builder.to_string();
-            } else if (utf16_fly_string_raw) {
-                text = Utf16FlyString::from_raw(utf16_fly_string_raw).to_utf16_string();
-            } else {
-                text = Utf16String::from_utf16(Utf16View { reinterpret_cast<char16_t const*>(text_units), text_unit_count });
-            }
-            auto font = Platform::FontPlugin::the().default_font(css_font_size);
-            auto label_font = font->with_size(font->point_size() * context.device_pixels_per_css_pixel);
-            auto glyph_run = Gfx::shape_text({}, 0, 0, text.utf16_view(), label_font, Gfx::GlyphRun::TextType::Ltr);
-            for (auto const& glyph : glyph_run->glyphs())
-                Layout::RustFFI::layout_arena_paint_push_overlay_glyph(sink, glyph.glyph_id, glyph.position.x(), glyph.position.y());
-            auto bounds = glyph_run->bounding_box(1.0f);
-            auto metrics = label_font->pixel_metrics();
-            return Layout::RustFFI::FfiOverlayLabelFacts {
-                .font_id = context.resource_storage.add_font(glyph_run->font()).value(),
-                .css_width = font->width(text),
-                .css_pixel_size = font->pixel_size(),
-                .device_glyph_width = glyph_run->width(),
-                .device_ascent = metrics.ascent,
-                .device_descent = metrics.descent,
-                .blob_bounds = bounds,
-            };
+        .overlay_label_font = [](void*, float point_size) -> void const* {
+            auto font = Platform::FontPlugin::the().default_font(point_size);
+            VERIFY(font);
+            // The platform font caches keep the font alive; the caller retains
+            // it within the synchronous call.
+            return font.ptr();
         },
+        .overlay_node_label_text = [](void*, void* layout_node_shell, void* sink, void (*emit)(void*, u16 const*, size_t)) {
+            auto const& layout_node = *static_cast<Layout::Node const*>(layout_node_shell);
+            auto border_rect = absolute_border_box_rect(layout_node);
+            Utf16StringBuilder builder;
+            builder.appendff("{}", layout_node.debug_description());
+            builder.appendff(" {}x{} @ {},{}", border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
+            auto text = builder.to_string();
+            auto view = text.utf16_view();
+            Vector<u16> units;
+            units.ensure_capacity(view.length_in_code_units());
+            for (size_t i = 0; i < view.length_in_code_units(); ++i)
+                units.unchecked_append(view.code_unit_at(i));
+            emit(sink, units.data(), units.size()); },
     };
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -6623,8 +6623,6 @@ mod ffi_test_stubs {
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_font_unref(_raw: *const std::ffi::c_void) {}
     #[unsafe(no_mangle)]
-    extern "C" fn ladybird_gfx_glyph_run_unref(_retained: *mut std::ffi::c_void) {}
-    #[unsafe(no_mangle)]
     extern "C" fn ladybird_gfx_path_destroy(path: *mut std::ffi::c_void) {
         if !path.is_null() {
             // SAFETY: Every stand-in path comes from the `Box<u8>` the deserializer stub leaked to the caller.

--- a/Libraries/LibWeb/Rust/src/layout/font.rs
+++ b/Libraries/LibWeb/Rust/src/layout/font.rs
@@ -20,13 +20,6 @@ pub(crate) fn font_glyph_id(font: *const c_void, code_point: u32) -> u32 {
     unsafe { libgfx_rust::font::FontRef::from_raw(font) }.glyph_id_for_code_point(code_point)
 }
 
-pub(crate) struct ShapedRun {
-    pub(crate) glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
-    pub(crate) width: f32,
-    pub(crate) trailing_whitespace_length_in_code_units: usize,
-    pub(crate) trailing_whitespace_advance: f32,
-}
-
 pub(crate) fn shape_text_with_font(
     font: *const c_void,
     text: &[u16],
@@ -34,29 +27,10 @@ pub(crate) fn shape_text_with_font(
     baseline_start_x: f32,
     letter_spacing: f32,
     word_spacing: f32,
-) -> ShapedRun {
+) -> libgfx_rust::text_layout::ShapedText {
     // SAFETY: Font pointers in layout snapshots are borrowed from the host for
     // the synchronous layout pass.
     let font = unsafe { libgfx_rust::font::FontRef::from_raw(font) };
     let text_type = libgfx_rust::text_layout::TextType::try_from(text_type).expect("invalid Gfx::GlyphRun::TextType");
-    let shaped =
-        libgfx_rust::text_layout::shape_text(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
-    let glyphs = shaped
-        .glyphs()
-        .iter()
-        .map(|glyph| inline_level_iterator::FfiDrawGlyph {
-            x: glyph.x,
-            y: glyph.y,
-            length_in_code_units: glyph.length_in_code_units,
-            glyph_width: glyph.glyph_width,
-            glyph_id: glyph.glyph_id,
-            should_paint: glyph.should_paint,
-        })
-        .collect();
-    ShapedRun {
-        glyphs,
-        width: shaped.width(),
-        trailing_whitespace_length_in_code_units: shaped.trailing_whitespace_length_in_code_units(),
-        trailing_whitespace_advance: shaped.trailing_whitespace_advance(),
-    }
+    libgfx_rust::text_layout::shape_text(font, text, text_type, baseline_start_x, letter_spacing, word_spacing)
 }

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -55,7 +55,7 @@ pub(crate) fn apply(line_boxes: &mut [line_box::LineBoxData], provider: &impl El
 
             let glyph_data = line.fragments[index].glyphs.as_mut().unwrap();
             glyph_data.glyphs.truncate(keep_count);
-            glyph_data.glyphs.push(inline_level_iterator::FfiDrawGlyph {
+            glyph_data.glyphs.push(libgfx_rust::text_layout::DrawGlyph {
                 x: last_kept_end,
                 y: glyph_block_offset,
                 length_in_code_units: 1,

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -47,15 +47,15 @@ fn shape_glyph_data(
     word_spacing: f32,
 ) -> (line_box_fragment::GlyphData, line_box_fragment::TrailingWhitespace) {
     let shaped = font::shape_text_with_font(font, text, text_type, baseline_start_x, letter_spacing, word_spacing);
+    let trailing_whitespace = line_box_fragment::TrailingWhitespace {
+        length_in_code_units: shaped.trailing_whitespace_length_in_code_units(),
+        inline_size: CssPixels::nearest_value_for_f32(shaped.trailing_whitespace_advance()),
+    };
     let glyph_data = line_box_fragment::GlyphData {
-        glyphs: shaped.glyphs,
+        width: shaped.width(),
+        glyphs: shaped.into_glyphs(),
         font,
         text_type,
-        width: shaped.width,
-    };
-    let trailing_whitespace = line_box_fragment::TrailingWhitespace {
-        length_in_code_units: shaped.trailing_whitespace_length_in_code_units,
-        inline_size: CssPixels::nearest_value_for_f32(shaped.trailing_whitespace_advance),
     };
     (glyph_data, trailing_whitespace)
 }
@@ -889,15 +889,4 @@ impl InlineLevelIterator {
     pub(crate) fn take_visited_fragmented_inlines(&mut self) -> Vec<Node> {
         std::mem::take(&mut self.visited_fragmented_inlines)
     }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-#[repr(C)]
-pub struct FfiDrawGlyph {
-    pub x: f32,
-    pub y: f32,
-    pub length_in_code_units: usize,
-    pub glyph_width: f32,
-    pub glyph_id: u32,
-    pub should_paint: bool,
 }

--- a/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_box_fragment.rs
@@ -18,7 +18,7 @@ pub(crate) fn is_ascii_space(code_unit: u16) -> bool {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct GlyphData {
-    pub(crate) glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
+    pub(crate) glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
     pub(crate) font: *const c_void,
     pub(crate) text_type: u8,
     // GlyphRun::width is not updated by the C++ fragment merge machine.

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1616,21 +1616,6 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
 
 /// # Safety
 ///
-/// `sink` must be the pointer handed to the callback, used synchronously.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_paint_push_overlay_glyph(sink: *mut c_void, glyph_id: u32, x: f32, y: f32) {
-    abort_on_panic(|| {
-        // SAFETY: `sink` is the Vec pointer handed out by FfiPaintHostCallbacks::overlay_label.
-        let glyphs = unsafe { &mut *sink.cast::<Vec<crate::painting::display_list::commands::DisplayListGlyph>>() };
-        glyphs.push(crate::painting::display_list::commands::DisplayListGlyph {
-            position: libgfx_rust::FloatPoint { x, y },
-            glyph_id,
-        });
-    });
-}
-
-/// # Safety
-///
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_last_recording_spliced_capture_count(arena: *mut c_void) -> usize {

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -74,18 +74,6 @@ pub struct FfiFlexOverlayInput {
     pub color: Color,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-#[repr(C)]
-pub struct FfiOverlayLabelFacts {
-    pub font_id: u64,
-    pub css_width: f32,
-    pub css_pixel_size: f32,
-    pub device_glyph_width: f32,
-    pub device_ascent: f32,
-    pub device_descent: f32,
-    pub blob_bounds: FloatRect,
-}
-
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct FfiImageIntrinsicFacts {
@@ -414,15 +402,13 @@ pub struct FfiPaintHostCallbacks {
     ) -> FfiSvgPaintStyle,
     pub nested_display_list_from_tree:
         unsafe extern "C" fn(*mut c_void, FfiRecordedDisplayList, *const c_void, *const u64, usize) -> u64,
-    pub overlay_label: unsafe extern "C" fn(
+    pub overlay_label_font: unsafe extern "C" fn(*mut c_void, f32) -> *const c_void,
+    pub overlay_node_label_text: unsafe extern "C" fn(
         *mut c_void,
         *mut c_void,
-        *const u16,
-        usize,
-        usize,
-        f32,
         *mut c_void,
-    ) -> FfiOverlayLabelFacts,
+        unsafe extern "C" fn(*mut c_void, *const u16, usize),
+    ),
 }
 
 #[derive(Default)]
@@ -440,30 +426,31 @@ impl FfiPaintHostCallbacks {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.
         unsafe { (self.async_scroll_facts)(self.context, layout_node_shell) }
     }
-    pub(crate) fn overlay_label(
-        &self,
-        layout_node_shell: *mut c_void,
-        text: &[u16],
-        utf16_fly_string_raw: usize,
-        css_font_size: f32,
-    ) -> (
-        FfiOverlayLabelFacts,
-        Vec<crate::painting::display_list::commands::DisplayListGlyph>,
-    ) {
-        let mut glyphs: Vec<crate::painting::display_list::commands::DisplayListGlyph> = Vec::new();
-        // SAFETY: The C++ host pushes into the sink through the exported function, synchronously.
-        let facts = unsafe {
-            (self.overlay_label)(
-                self.context,
-                layout_node_shell,
-                text.as_ptr(),
-                text.len(),
-                utf16_fly_string_raw,
-                css_font_size,
-                (&raw mut glyphs).cast(),
-            )
-        };
-        (facts, glyphs)
+    /// Resolves the platform default UI font at `point_size`. The returned
+    /// `Gfx::Font` pointer is borrowed; the platform font caches keep it live
+    /// for the synchronous window in which the caller retains it.
+    pub(crate) fn overlay_label_font(&self, point_size: f32) -> *const c_void {
+        // SAFETY: The C++ host answers synchronously.
+        unsafe { (self.overlay_label_font)(self.context, point_size) }
+    }
+
+    pub(crate) fn overlay_node_label_text(&self, layout_node_shell: *mut c_void) -> Vec<u16> {
+        unsafe extern "C" fn emit(sink: *mut c_void, units: *const u16, count: usize) {
+            // SAFETY: `sink` is the Vec passed below, and the units stay live
+            // for this synchronous callback.
+            let text = unsafe { &mut *sink.cast::<Vec<u16>>() };
+            assert!(count == 0 || !units.is_null());
+            if count != 0 {
+                // SAFETY: The C++ host hands a pointer to count code units
+                // that outlive the callback.
+                text.extend_from_slice(unsafe { std::slice::from_raw_parts(units, count) });
+            }
+        }
+        let mut text: Vec<u16> = Vec::new();
+        // SAFETY: The C++ host answers synchronously from a live layout node
+        // shell; emit runs against the local Vec.
+        unsafe { (self.overlay_node_label_text)(self.context, layout_node_shell, (&raw mut text).cast(), emit) };
+        text
     }
     pub(crate) fn text_control_selection(&self, layout_node_shell: *mut c_void) -> FfiTextControlSelection {
         // SAFETY: The C++ host answers synchronously from a live layout node shell.

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -8,9 +8,7 @@ use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::{NodeKind, NodeSlotId};
-use crate::layout::{
-    formatting_context, fragment_tree, inline_formatting_context, inline_level_iterator, node_facts, used_values,
-};
+use crate::layout::{formatting_context, fragment_tree, inline_formatting_context, node_facts, used_values};
 use crate::painting::node_painting;
 use crate::painting::paintable_data::*;
 use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
@@ -282,25 +280,12 @@ impl<'a> PaintableCommit<'a> {
                 let glyph_run = fragment.glyphs.as_ref().map(|glyph_data| {
                     let text_type = libgfx_rust::text_layout::TextType::try_from(glyph_data.text_type)
                         .expect("committed glyph run carries a valid text type");
-                    const _: () = assert!(
-                        std::mem::size_of::<inline_level_iterator::FfiDrawGlyph>()
-                            == std::mem::size_of::<libgfx_rust::text_layout::DrawGlyph>()
-                    );
-                    const _: () = assert!(
-                        std::mem::align_of::<inline_level_iterator::FfiDrawGlyph>()
-                            == std::mem::align_of::<libgfx_rust::text_layout::DrawGlyph>()
-                    );
-                    // SAFETY: FfiDrawGlyph mirrors libgfx's DrawGlyph layout (asserted above), and
-                    // the glyph slice stays valid for the synchronous creation call.
-                    let glyphs_for_gfx: &[libgfx_rust::text_layout::DrawGlyph] = unsafe {
-                        std::slice::from_raw_parts(glyph_data.glyphs.as_ptr().cast(), glyph_data.glyphs.len())
-                    };
                     // SAFETY: The layout pass borrowed the font from a live cascade list, which is
                     // live for the duration of this commit.
                     let retained = unsafe {
                         libgfx_rust::text_layout::create_glyph_run(
                             glyph_data.font,
-                            glyphs_for_gfx,
+                            &glyph_data.glyphs,
                             text_type,
                             glyph_data.width,
                         )

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -277,26 +277,11 @@ impl<'a> PaintableCommit<'a> {
                 let (x, y) = fragment.offset();
                 let (x, y) = (x + fragment.relpos_delta.x, y + fragment.relpos_delta.y);
                 let (width, height) = fragment.size();
-                let glyph_run = fragment.glyphs.as_ref().map(|glyph_data| {
-                    let text_type = libgfx_rust::text_layout::TextType::try_from(glyph_data.text_type)
-                        .expect("committed glyph run carries a valid text type");
-                    // SAFETY: The layout pass borrowed the font from a live cascade list, which is
-                    // live for the duration of this commit.
-                    let retained = unsafe {
-                        libgfx_rust::text_layout::create_glyph_run(
-                            glyph_data.font,
-                            &glyph_data.glyphs,
-                            text_type,
-                            glyph_data.width,
-                        )
-                    };
-                    GlyphRunRecord {
-                        glyphs: glyph_data.glyphs.clone(),
-                        // SAFETY: The layout pass borrowed the font from a live cascade list; retaining
-                        // it here keeps it alive for as long as the fragment record.
-                        font: unsafe { libgfx_rust::font::RetainedFont::retain(glyph_data.font) },
-                        retained,
-                    }
+                let glyph_run = fragment.glyphs.as_ref().map(|glyph_data| GlyphRunRecord {
+                    glyphs: glyph_data.glyphs.clone(),
+                    // SAFETY: The layout pass borrowed the font from a live cascade list; retaining
+                    // it here keeps it alive for as long as the fragment record.
+                    font: unsafe { libgfx_rust::font::RetainedFont::retain(glyph_data.font) },
                 });
                 let (
                     dom_start_offset_in_node,

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -6,7 +6,7 @@
 
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::{inline_level_iterator, used_values};
+use crate::layout::used_values;
 use crate::painting::display_list::commands::{ContextRef, SpatialNodeIndex};
 use std::cell::Cell;
 
@@ -134,7 +134,7 @@ pub struct LineRecord {
 }
 
 pub struct GlyphRunRecord {
-    pub glyphs: Vec<inline_level_iterator::FfiDrawGlyph>,
+    pub glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
     pub font: libgfx_rust::font::RetainedFont,
     pub retained: libgfx_rust::text_layout::RetainedGlyphRun,
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_data.rs
@@ -136,7 +136,22 @@ pub struct LineRecord {
 pub struct GlyphRunRecord {
     pub glyphs: Vec<libgfx_rust::text_layout::DrawGlyph>,
     pub font: libgfx_rust::font::RetainedFont,
-    pub retained: libgfx_rust::text_layout::RetainedGlyphRun,
+}
+
+impl GlyphRunRecord {
+    fn font_ref(&self) -> libgfx_rust::font::FontRef<'_> {
+        // SAFETY: The record's RetainedFont keeps the font live for the
+        // lifetime of the returned borrow.
+        unsafe { libgfx_rust::font::FontRef::from_raw(self.font.as_raw()) }
+    }
+
+    pub fn bounding_box(&self, scale: f32) -> [f32; 4] {
+        libgfx_rust::text_layout::glyph_run_bounding_box(self.font_ref(), &self.glyphs, scale)
+    }
+
+    pub fn glyph_intercepts(&self, scale: f32, y_top: f32, y_bottom: f32) -> Vec<f32> {
+        libgfx_rust::text_layout::glyph_run_glyph_intercepts(self.font_ref(), &self.glyphs, scale, y_top, y_bottom)
+    }
 }
 
 pub struct FragmentRecord {

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/inspector_overlay.rs
@@ -11,7 +11,7 @@ use crate::layout::grid_formatting_context;
 use crate::layout::node_data::NodeSlotId;
 use crate::painting::display_list::commands::{ContextRef, DisplayListGlyph, FontResourceId};
 use crate::painting::display_list::recorder::GlyphRunForRecording;
-use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput, FfiOverlayLabelFacts};
+use crate::painting::host::{FfiFlexOverlayInput, FfiGridOverlayInput};
 use crate::painting::paintable_geometry;
 use crate::painting::record::PaintRecorder;
 use libgfx_rust::{Color, FloatPoint, IntPoint, IntRect, LineStyle, Orientation};
@@ -90,20 +90,21 @@ fn paint_box_model_highlight(recorder: &mut PaintRecorder<'_>, paintable: NodeSl
     paint_inspector_rect(recorder, border_rect, Color::from_rgb(0, 255, 0));
     paint_inspector_rect(recorder, content_rect, Color::from_rgb(255, 0, 255));
 
-    let (facts, glyphs) = recorder
+    let text = recorder
         .paint_host
-        .overlay_label(recorder.layout_node_shell(paintable), &[], 0, 12.0);
+        .overlay_node_label_text(recorder.layout_node_shell(paintable));
+    let label = shape_overlay_label(recorder, &text, 12.0);
     let mut size_text_rect = border_rect;
     size_text_rect.y = border_rect.y + border_rect.height;
-    size_text_rect.width = CssPixels::nearest_value_for_f32(facts.css_width) + CssPixels::from_integer(4);
-    size_text_rect.height = CssPixels::nearest_value_for_f32(facts.css_pixel_size) + CssPixels::from_integer(4);
+    size_text_rect.width = CssPixels::nearest_value_for_f32(label.css_width) + CssPixels::from_integer(4);
+    size_text_rect.height = CssPixels::nearest_value_for_f32(label.css_pixel_size) + CssPixels::from_integer(4);
     let device_rect = converter.enclosing_device_rect(size_text_rect);
     let inputs = recorder.inputs;
     recorder.recorder.fill_rect(device_rect, inputs.tooltip_color);
     recorder
         .recorder
         .draw_rect(device_rect, inputs.tooltip_border_color, false);
-    draw_label(recorder, &facts, &glyphs, device_rect, inputs.tooltip_text_color);
+    draw_label(recorder, &label, device_rect, inputs.tooltip_text_color);
 }
 
 fn paint_flex_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, input: &FfiFlexOverlayInput) {
@@ -260,44 +261,32 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
             .recorder
             .fill_rect(converter.enclosing_device_rect(rect), rect_color);
     };
-    let paint_label =
-        |recorder: &mut PaintRecorder<'_>, top_left: CssPixelPoint, text: &[u16], fly_string_raw: usize| {
-            let (facts, glyphs) = recorder
-                .paint_host
-                .overlay_label(std::ptr::null_mut(), text, fly_string_raw, 10.0);
-            let label_width = label_width_for(&facts);
-            let label_rect = CssPixelRect {
-                x: top_left.x,
-                y: top_left.y,
-                width: label_width,
-                height: label_height,
-            };
-            let label_device_rect = converter.enclosing_device_rect(label_rect);
-            let label_background = color.with_alpha(235);
-            recorder.recorder.fill_rect(label_device_rect, label_background);
-            recorder
-                .recorder
-                .draw_rect(label_device_rect, color.with_alpha(255), false);
-            draw_label(
-                recorder,
-                &facts,
-                &glyphs,
-                label_device_rect,
-                input.label_foreground_color,
-            );
+    let paint_label = |recorder: &mut PaintRecorder<'_>, top_left: CssPixelPoint, text: &[u16]| {
+        let label = shape_overlay_label(recorder, text, 10.0);
+        let label_width = label_width_for(&label);
+        let label_rect = CssPixelRect {
+            x: top_left.x,
+            y: top_left.y,
+            width: label_width,
+            height: label_height,
         };
-    let paint_centered_label =
-        |recorder: &mut PaintRecorder<'_>, rect: CssPixelRect, text: &[u16], fly_string_raw: usize| {
-            let (facts, _) = recorder
-                .paint_host
-                .overlay_label(std::ptr::null_mut(), text, fly_string_raw, 10.0);
-            let label_width = label_width_for(&facts);
-            let top_left = CssPixelPoint {
-                x: rect.center().x - label_width.div_as_fraction(two),
-                y: rect.center().y - label_height.div_as_fraction(two),
-            };
-            paint_label(recorder, top_left, text, fly_string_raw);
+        let label_device_rect = converter.enclosing_device_rect(label_rect);
+        let label_background = color.with_alpha(235);
+        recorder.recorder.fill_rect(label_device_rect, label_background);
+        recorder
+            .recorder
+            .draw_rect(label_device_rect, color.with_alpha(255), false);
+        draw_label(recorder, &label, label_device_rect, input.label_foreground_color);
+    };
+    let paint_centered_label = |recorder: &mut PaintRecorder<'_>, rect: CssPixelRect, text: &[u16]| {
+        let label = shape_overlay_label(recorder, text, 10.0);
+        let label_width = label_width_for(&label);
+        let top_left = CssPixelPoint {
+            x: rect.center().x - label_width.div_as_fraction(two),
+            y: rect.center().y - label_height.div_as_fraction(two),
         };
+        paint_label(recorder, top_left, text);
+    };
 
     let line_start_for_number = |lines: &[grid_formatting_context::GridLayoutLine], number: u32| -> Option<CssPixels> {
         lines.iter().find(|line| line.number == number).map(|line| line.start)
@@ -358,7 +347,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                     x: x + two,
                     y: line_top + two,
                 };
-                paint_label(recorder, top_left, &line_number_label(column_line), 0);
+                paint_label(recorder, top_left, &line_number_label(column_line));
             }
         }
 
@@ -398,7 +387,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                     x: line_left + two,
                     y: y + two,
                 };
-                paint_label(recorder, top_left, &line_number_label(row_line), 0);
+                paint_label(recorder, top_left, &line_number_label(row_line));
             }
         }
 
@@ -410,7 +399,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                     width: column_track.breadth,
                     height: content_rect.height.min(label_height + CssPixels::from_integer(4)),
                 };
-                paint_centered_label(recorder, track_rect, &track_size_label(column_track), 0);
+                paint_centered_label(recorder, track_rect, &track_size_label(column_track));
             }
 
             for row_track in &fragment.rows.tracks {
@@ -420,7 +409,7 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                     width: content_rect.width.min(CssPixels::from_integer(72)),
                     height: row_track.breadth,
                 };
-                paint_centered_label(recorder, track_rect, &track_size_label(row_track), 0);
+                paint_centered_label(recorder, track_rect, &track_size_label(row_track));
             }
         }
 
@@ -447,45 +436,96 @@ fn paint_grid_overlay(recorder: &mut PaintRecorder<'_>, paintable: NodeSlotId, i
                 let visible_area_rect = area_rect.intersected(viewport_rect);
                 if !visible_area_rect.is_empty() {
                     let name = area.name.encode_utf16().collect::<Vec<_>>();
-                    paint_centered_label(recorder, visible_area_rect, &name, 0);
+                    paint_centered_label(recorder, visible_area_rect, &name);
                 }
             }
         }
     }
 }
 
-fn label_width_for(facts: &FfiOverlayLabelFacts) -> CssPixels {
-    let label_padding = CssPixels::from_integer(4);
-    CssPixels::nearest_value_for_f32(facts.css_width) + label_padding * 2usize
+struct OverlayLabel {
+    font_id: u64,
+    css_width: f32,
+    css_pixel_size: f32,
+    device_glyph_width: f32,
+    device_ascent: f32,
+    device_descent: f32,
+    blob_bounds: [f32; 4],
+    glyphs: Vec<DisplayListGlyph>,
 }
 
-fn draw_label(
-    recorder: &mut PaintRecorder<'_>,
-    facts: &FfiOverlayLabelFacts,
-    glyphs: &[DisplayListGlyph],
-    rect: IntRect,
-    color: Color,
-) {
+fn shape_overlay_label(recorder: &mut PaintRecorder<'_>, text: &[u16], css_font_size: f32) -> OverlayLabel {
+    let device_scale = recorder.inputs.device_pixels_per_css_pixel as f32;
+    // SAFETY: The host resolves the fonts from the platform font caches, which
+    // keep them live through this synchronous call; retaining them here keeps
+    // them alive for the rest of the recording.
+    let css_font =
+        unsafe { libgfx_rust::font::RetainedFont::retain(recorder.paint_host.overlay_label_font(css_font_size)) };
+    // SAFETY: See above.
+    let device_font = unsafe {
+        libgfx_rust::font::RetainedFont::retain(recorder.paint_host.overlay_label_font(css_font_size * device_scale))
+    };
+    // SAFETY: The RetainedFont handles keep both fonts live for these borrows.
+    let css_font_ref = unsafe { libgfx_rust::font::FontRef::from_raw(css_font.as_raw()) };
+    // SAFETY: See above.
+    let device_font_ref = unsafe { libgfx_rust::font::FontRef::from_raw(device_font.as_raw()) };
+    let shaped = libgfx_rust::text_layout::shape_text(
+        device_font_ref,
+        text,
+        libgfx_rust::text_layout::TextType::Ltr,
+        0.0,
+        0.0,
+        0.0,
+    );
+    let blob_bounds = libgfx_rust::text_layout::glyph_run_bounding_box(device_font_ref, shaped.glyphs(), 1.0);
+    let (device_ascent, device_descent) = device_font_ref.pixel_metrics_ascent_descent();
+    let font_id = recorder.register_font(device_font.as_raw());
+    let glyphs = shaped
+        .glyphs()
+        .iter()
+        .map(|glyph| DisplayListGlyph {
+            position: FloatPoint { x: glyph.x, y: glyph.y },
+            glyph_id: glyph.glyph_id,
+        })
+        .collect();
+    OverlayLabel {
+        font_id,
+        css_width: css_font_ref.measure_text_width(text),
+        css_pixel_size: css_font_ref.pixel_size(),
+        device_glyph_width: shaped.width(),
+        device_ascent,
+        device_descent,
+        blob_bounds,
+        glyphs,
+    }
+}
+
+fn label_width_for(label: &OverlayLabel) -> CssPixels {
+    let label_padding = CssPixels::from_integer(4);
+    CssPixels::nearest_value_for_f32(label.css_width) + label_padding * 2usize
+}
+
+fn draw_label(recorder: &mut PaintRecorder<'_>, label: &OverlayLabel, rect: IntRect, color: Color) {
     if rect.width <= 0 || rect.height <= 0 || color.alpha() == 0 {
         return;
     }
     let baseline_start = FloatPoint {
-        x: rect.x as f32 + (rect.width as f32 - facts.device_glyph_width) / 2.0,
+        x: rect.x as f32 + (rect.width as f32 - label.device_glyph_width) / 2.0,
         y: rect.y as f32
-            + facts.device_ascent
-            + (rect.height as f32 - (facts.device_ascent + facts.device_descent)) / 2.0,
+            + label.device_ascent
+            + (rect.height as f32 - (label.device_ascent + label.device_descent)) / 2.0,
     };
     let glyph_bounding_rect = IntRect::new(
-        (facts.blob_bounds.x + baseline_start.x).round_ties_even() as i32,
-        (facts.blob_bounds.y + baseline_start.y).round_ties_even() as i32,
-        facts.blob_bounds.width.round_ties_even() as i32,
-        facts.blob_bounds.height.round_ties_even() as i32,
+        (label.blob_bounds[0] + baseline_start.x).round_ties_even() as i32,
+        (label.blob_bounds[1] + baseline_start.y).round_ties_even() as i32,
+        label.blob_bounds[2].round_ties_even() as i32,
+        label.blob_bounds[3].round_ties_even() as i32,
     );
     recorder.recorder.draw_glyph_run(
         baseline_start,
         GlyphRunForRecording {
-            font_id: FontResourceId(facts.font_id),
-            glyphs,
+            font_id: FontResourceId(label.font_id),
+            glyphs: &label.glyphs,
         },
         color,
         rect,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text.rs
@@ -221,7 +221,7 @@ pub(crate) fn glyph_run_emission(
     fragment_absolute_rect: CssPixelRect,
     scale: f64,
 ) -> GlyphRunEmission {
-    let blob_bounds = run.retained.bounding_box(scale as f32);
+    let blob_bounds = run.bounding_box(scale as f32);
     let baseline_start = FloatPoint {
         x: (fragment_absolute_rect.x.to_float() as f64 * scale) as f32,
         y: ((fragment_absolute_rect.y.to_float() + fragment.baseline.to_float()) as f64 * scale) as f32,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/text_decoration.rs
@@ -305,7 +305,7 @@ fn compute_skip_ink_segments(
     let y_top = line_y as f32 - half_thickness - blob_origin_y;
     let y_bottom = line_y as f32 + half_thickness - blob_origin_y;
 
-    let intervals = run.retained.glyph_intercepts(scale as f32, y_top, y_bottom);
+    let intervals = run.glyph_intercepts(scale as f32, y_top, y_bottom);
     if intervals.is_empty() {
         return vec![DecorationSegment {
             start_x: span_start_x,

--- a/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
+++ b/Libraries/LibWeb/Rust/src/painting/text_fragment.rs
@@ -7,7 +7,7 @@
 use crate::css::css_pixels::CssPixelRect;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::node_data::NodeSlotId;
-use crate::layout::{inline_level_iterator, node_facts};
+use crate::layout::node_facts;
 use crate::painting::paintable_data::FragmentRecord;
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::PaintableRowsRead;
@@ -229,7 +229,7 @@ pub(crate) fn selection_offsets_for_dom_range(
 }
 
 fn for_each_cluster_in_glyph_run(
-    glyphs: &[inline_level_iterator::FfiDrawGlyph],
+    glyphs: &[libgfx_rust::text_layout::DrawGlyph],
     fragment_length_in_code_units: usize,
     mut callback: impl FnMut(usize, usize, f32) -> bool,
 ) {

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -76,7 +76,7 @@ TEST_CASE(glyph_run_bounding_box_contains_glyph_extents)
     auto run = shape(font, "abc"sv);
     EXPECT_EQ(run->glyphs().size(), 3u);
 
-    auto bounds = run->bounding_box(1);
+    auto bounds = Gfx::glyph_run_bounding_box(font, run->glyphs(), 1);
     EXPECT(!bounds.is_empty());
 
     auto* hb_font = font->harfbuzz_font();
@@ -97,14 +97,14 @@ TEST_CASE(glyph_run_bounding_box_contains_glyph_extents)
         EXPECT(bounds.contains(glyph_bounds));
     }
 
-    auto scaled_bounds = run->bounding_box(2);
+    auto scaled_bounds = Gfx::glyph_run_bounding_box(font, run->glyphs(), 2);
     EXPECT_APPROXIMATE(scaled_bounds.x(), bounds.x() * 2);
     EXPECT_APPROXIMATE(scaled_bounds.y(), bounds.y() * 2);
     EXPECT_APPROXIMATE(scaled_bounds.width(), bounds.width() * 2);
     EXPECT_APPROXIMATE(scaled_bounds.height(), bounds.height() * 2);
 
     auto empty_run = shape(font, ""sv);
-    EXPECT(empty_run->bounding_box(1).is_empty());
+    EXPECT(Gfx::glyph_run_bounding_box(font, empty_run->glyphs(), 1).is_empty());
 }
 
 // Glyph intercepts report one [start, end] interval per glyph whose ink crosses the band, in run order and in

--- a/Tests/LibGfx/TestFont.cpp
+++ b/Tests/LibGfx/TestFont.cpp
@@ -116,7 +116,7 @@ TEST_CASE(glyph_run_intercepts)
 
     // Bands are relative to the run's baseline origin; ink above the baseline has negative y.
     auto mid_x_height = -font->pixel_metrics().x_height / 2;
-    auto intercepts = run->get_glyph_intercepts(1, mid_x_height - 1, mid_x_height + 1);
+    auto intercepts = Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 1, mid_x_height - 1, mid_x_height + 1);
     EXPECT_EQ(intercepts.size(), 6u);
     float previous_end = 0;
     for (size_t i = 0; i + 1 < intercepts.size(); i += 2) {
@@ -127,13 +127,13 @@ TEST_CASE(glyph_run_intercepts)
     }
 
     // At twice the scale the intervals scale with it.
-    auto scaled_intercepts = run->get_glyph_intercepts(2, (mid_x_height - 1) * 2, (mid_x_height + 1) * 2);
+    auto scaled_intercepts = Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 2, (mid_x_height - 1) * 2, (mid_x_height + 1) * 2);
     EXPECT_EQ(scaled_intercepts.size(), 6u);
     for (size_t i = 0; i < intercepts.size(); ++i)
         EXPECT(AK::fabs(scaled_intercepts[i] - intercepts[i] * 2) < 0.01f);
 
     // A band far above the ascender touches no ink.
-    EXPECT(run->get_glyph_intercepts(1, -200, -190).is_empty());
+    EXPECT(Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 1, -200, -190).is_empty());
 
     // A band just below the top of the 'b' ascender is only reached by that glyph.
     auto* hb_font = font->harfbuzz_font();
@@ -143,11 +143,11 @@ TEST_CASE(glyph_run_intercepts)
     hb_glyph_extents_t b_extents {};
     EXPECT(hb_font_get_glyph_extents(hb_font, run->glyphs()[1].glyph_id, &b_extents));
     auto b_top = -b_extents.y_bearing * font->pixel_size() / y_scale;
-    auto ascender_intercepts = run->get_glyph_intercepts(1, b_top + 0.5f, b_top + 1.5f);
+    auto ascender_intercepts = Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 1, b_top + 0.5f, b_top + 1.5f);
     EXPECT_EQ(ascender_intercepts.size(), 2u);
     EXPECT(ascender_intercepts[0] >= run->glyphs()[1].position.x());
     EXPECT(ascender_intercepts[1] <= run->glyphs()[2].position.x());
 
     // A degenerate scale produces nothing.
-    EXPECT(run->get_glyph_intercepts(0, mid_x_height - 1, mid_x_height + 1).is_empty());
+    EXPECT(Gfx::glyph_run_glyph_intercepts(font, run->glyphs(), 0, mid_x_height - 1, mid_x_height + 1).is_empty());
 }


### PR DESCRIPTION
The Rust layout->painting pipeline still leaned on C++ Gfx::GlyphRun: every text fragment retained one, every shaping call materialized one, and the per-font shaping cache lived in C++ behind an FFI hop.

- Use libgfx_rust's DrawGlyph end-to-end; delete layout's duplicate type
- Stop retaining a GlyphRun per paintable fragment; the bounding-box and skip-ink FFI take (font, glyph span) directly
- Stop materializing a GlyphRun per shaping call
- Move the shaping cache to Rust: thread-local, keyed by the font's never-recycled id, bounded. C++ is called only on a miss to run HarfBuzz once
- Shape inspector overlay labels through the Rust path via two lean host hooks
- Delete the C++ shaping cache; the only remaining Gfx::shape_text consumer is Canvas2D text, which now shapes uncached