### PR TITLE
LibWeb: Port the stacking context dump to Rust

### DIFF
--- a/Libraries/LibWeb/Painting/BoxViews.cpp
+++ b/Libraries/LibWeb/Painting/BoxViews.cpp
@@ -296,11 +296,6 @@ bool is_fixed_position(Layout::Node const& node)
     return has_committed_box(node) && as<Layout::NodeWithStyle>(node).is_fixed_position();
 }
 
-bool has_css_transform(Layout::Node const& node)
-{
-    return has_committed_box(node) && as<Layout::NodeWithStyle>(node).has_css_transform();
-}
-
 bool uses_collapsing_borders_model(Layout::Node const& node)
 {
     return Layout::RustFFI::layout_arena_paintable_uses_collapsing_borders_model(node.arena_handle(), committed_row_slot(node));

--- a/Libraries/LibWeb/Painting/BoxViews.h
+++ b/Libraries/LibWeb/Painting/BoxViews.h
@@ -64,7 +64,6 @@ WEB_API Optional<int> effective_z_index(Layout::Node const&);
 WEB_API CSS::Display display(Layout::Node const&);
 WEB_API bool is_positioned(Layout::Node const&);
 WEB_API bool is_fixed_position(Layout::Node const&);
-WEB_API bool has_css_transform(Layout::Node const&);
 WEB_API bool uses_collapsing_borders_model(Layout::Node const&);
 WEB_API SelectionState selection_state(Layout::Node const&);
 WEB_API CSS::StyleRecordID style_record_identity(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -723,26 +723,16 @@ Utf16String serialize_painting_dump(
 
 void dump_stacking_context_tree(StringBuilder& builder, DOM::Document const& document)
 {
+    Layout::RustFFI::FfiStackingContextDumpCallbacks callbacks {
+        .context = &builder,
+        .debug_description = [](void*, void* layout_node_shell, void* description_sink) {
+            auto description = static_cast<Layout::Node const*>(layout_node_shell)->debug_description();
+            auto bytes = description.bytes();
+            Layout::RustFFI::layout_arena_paint_push_bytes(description_sink, bytes.data(), bytes.size()); },
+        .append_text = [](void* context, u8 const* bytes, size_t byte_count) { static_cast<StringBuilder*>(context)->append(StringView { bytes, byte_count }); },
+    };
     Layout::RustFFI::layout_arena_dump_stacking_context_tree(
-        layout_arena_handle(document), viewport_row_slot(document), &builder,
-        [](void* context, Layout::RustFFI::FfiStackingContextDumpEntry entry) {
-            auto& builder = *static_cast<StringBuilder*>(context);
-            for (size_t i = 0; i < entry.depth; ++i)
-                builder.append(' ');
-            if (auto const* layout_node = static_cast<Layout::Node const*>(entry.layout_node_shell)) {
-                builder.appendff("SC for {} {} (z-index: ", layout_node->debug_description(), absolute_rect(*layout_node));
-                if (entry.has_effective_z_index)
-                    builder.appendff("{}", entry.effective_z_index);
-                else
-                    builder.append("auto"sv);
-                builder.append(')');
-                if (has_css_transform(*layout_node))
-                    builder.append(", has_transform"sv);
-            } else {
-                builder.append("SC for (gone)"sv);
-            }
-            builder.append('\n');
-        });
+        layout_arena_handle(document), viewport_row_slot(document), callbacks);
 }
 
 namespace {

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -3099,6 +3099,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             manifest_dir.join("src/painting/host/paint.rs"),
             manifest_dir.join("src/painting/host/replay.rs"),
             manifest_dir.join("src/painting/display_list/dump.rs"),
+            manifest_dir.join("src/painting/stacking_context/dump.rs"),
             manifest_dir.join("src/painting/ffi.rs"),
         ],
         &out_dir,

--- a/Libraries/LibWeb/Rust/src/painting/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/dump.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::css::css_pixels::CssPixels;
+use crate::css::css_pixels::{CssPixelRect, CssPixels};
 use crate::layout::node_data::NodeKind;
 use crate::layout::node_data::NodeSlotId;
 use crate::layout::node_facts;
@@ -24,22 +24,42 @@ fn push_usize(out: &mut Vec<u8>, value: usize) {
     out.extend_from_slice(value.to_string().as_bytes());
 }
 
-fn push_css_pixels(out: &mut Vec<u8>, value: CssPixels) {
+pub(crate) struct Utf8Sink<'a>(pub(crate) &'a mut Vec<u8>);
+
+impl Write for Utf8Sink<'_> {
+    fn write_str(&mut self, text: &str) -> std::fmt::Result {
+        self.0.extend_from_slice(text.as_bytes());
+        Ok(())
+    }
+}
+
+pub(crate) fn push_css_pixels(output: &mut impl Write, value: CssPixels) {
     let raw = value.raw_value();
     if raw < 0 {
-        out.push(b'-');
+        let _ = output.write_char('-');
     }
     let magnitude = raw.unsigned_abs();
-    out.extend_from_slice((magnitude / 64).to_string().as_bytes());
+    let _ = write!(output, "{}", magnitude / 64);
     let frac = magnitude % 64;
     if frac != 0 {
-        let mut digits = format!("{:06}", u64::from(frac) * 15625).into_bytes();
-        while digits.last() == Some(&b'0') {
+        let mut digits = format!("{:06}", u64::from(frac) * 15625);
+        while digits.ends_with('0') {
             digits.pop();
         }
-        out.push(b'.');
-        out.extend_from_slice(&digits);
+        let _ = write!(output, ".{digits}");
     }
+}
+
+pub(crate) fn push_css_pixel_rect(output: &mut impl Write, rect: CssPixelRect) {
+    let _ = output.write_char('[');
+    push_css_pixels(output, rect.x);
+    let _ = output.write_char(',');
+    push_css_pixels(output, rect.y);
+    let _ = output.write_char(' ');
+    push_css_pixels(output, rect.width);
+    let _ = output.write_char('x');
+    push_css_pixels(output, rect.height);
+    let _ = output.write_char(']');
 }
 
 fn push_code_point(out: &mut Vec<u8>, code_point: u32) {
@@ -99,17 +119,10 @@ fn dump_fragment(
     push_usize(out, fragment.start_offset);
     out.extend_from_slice(b", length: ");
     push_usize(out, fragment.length_in_code_units);
-    out.extend_from_slice(b", rect: [");
-    let rect = text_fragment::absolute_rect(layout_arena, fragment);
-    push_css_pixels(out, rect.x);
-    out.push(b',');
-    push_css_pixels(out, rect.y);
-    out.push(b' ');
-    push_css_pixels(out, rect.width);
-    out.push(b'x');
-    push_css_pixels(out, rect.height);
-    out.extend_from_slice(b"] baseline: ");
-    push_css_pixels(out, fragment.baseline);
+    out.extend_from_slice(b", rect: ");
+    push_css_pixel_rect(&mut Utf8Sink(out), text_fragment::absolute_rect(layout_arena, fragment));
+    out.extend_from_slice(b" baseline: ");
+    push_css_pixels(&mut Utf8Sink(out), fragment.baseline);
     out.push(b'\n');
     if fragment.length_in_code_units > 0 {
         push_indent(out, indent);

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -750,11 +750,7 @@ pub unsafe extern "C" fn layout_arena_paintable_uses_collapsing_borders_model(
 pub unsafe extern "C" fn layout_arena_paintable_absolute_rect(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelRect {
     abort_on_panic(|| {
         let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelRect::default();
-        }
-        crate::painting::paintable_geometry::absolute_rect(&paintable_rows, slot).into()
+        crate::painting::paintable_geometry::absolute_rect_or_default(&arena.paintable_rows(), slot).into()
     })
 }
 
@@ -2406,31 +2402,6 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
         if let Some(tracks) = crate::painting::paintable_geometry::committed_used_grid_tracks(arena, paintable) {
             tracks.with_ffi_views(|columns, rows| unsafe { consume(context, columns, rows) });
         }
-    });
-}
-
-/// # Safety
-///
-/// `arena` must be a live handle from `layout_arena_create`, used on the document thread;
-/// `emit` copies each entry synchronously.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_dump_stacking_context_tree(
-    arena: *mut c_void,
-    viewport: NodeSlotId,
-    context: *mut c_void,
-    emit: unsafe extern "C" fn(*mut c_void, crate::painting::host::FfiStackingContextDumpEntry),
-) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(viewport) {
-            return;
-        }
-        crate::painting::stacking_context::dump::for_each_stacking_context_in_dump_order(
-            arena,
-            viewport,
-            // SAFETY: The consumer copies the entry synchronously.
-            &mut |entry| unsafe { emit(context, entry) },
-        );
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/host/paint.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/paint.rs
@@ -325,15 +325,6 @@ pub struct FfiImagePaintFacts {
     pub list_height: i32,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub struct FfiStackingContextDumpEntry {
-    pub layout_node_shell: *mut c_void,
-    pub depth: usize,
-    pub has_effective_z_index: bool,
-    pub effective_z_index: i32,
-}
-
 // A recording lent to C++ for the duration of one call. An empty Vec's pointer is dangling, so
 // the C++ side never dereferences a pointer whose count is zero.
 #[derive(Clone, Copy, Debug)]

--- a/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_geometry.rs
@@ -175,6 +175,13 @@ pub(crate) fn committed_svg_viewport_percentage_basis(arena: &impl PaintableRows
     })
 }
 
+pub(crate) fn absolute_rect_or_default(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
+    if !arena.paintable_row_is_populated(slot) {
+        return CssPixelRect::default();
+    }
+    absolute_rect(arena, slot)
+}
+
 pub(crate) fn absolute_rect(arena: &impl PaintableRowsRead, slot: NodeSlotId) -> CssPixelRect {
     if let Some(rect) = arena.memoized_absolute_rect(slot) {
         return rect;

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
@@ -4,36 +4,88 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::css::css_pixels::CssPixelRect;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
-use crate::painting::host::FfiStackingContextDumpEntry;
+use crate::painting::dump::push_css_pixel_rect;
+use crate::painting::paintable_geometry;
+use crate::painting::style_queries;
+use std::ffi::c_void;
+use std::fmt::Write;
 
-pub(crate) fn for_each_stacking_context_in_dump_order(
-    arena: &LayoutNodeArena,
-    viewport: NodeSlotId,
-    emit: &mut impl FnMut(FfiStackingContextDumpEntry),
-) {
-    if arena.stacking_context_entries(viewport).is_none() {
-        return;
-    }
-    visit(arena, viewport, 0, emit);
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiStackingContextDumpCallbacks {
+    pub context: *mut c_void,
+    pub debug_description:
+        unsafe extern "C" fn(context: *mut c_void, layout_node_shell: *mut c_void, description_sink: *mut c_void),
+    pub append_text: unsafe extern "C" fn(context: *mut c_void, bytes: *const u8, byte_count: usize),
 }
 
-fn visit(arena: &LayoutNodeArena, root: NodeSlotId, depth: usize, emit: &mut impl FnMut(FfiStackingContextDumpEntry)) {
-    let effective_z_index = arena
-        .paintable_visual_context_record(root)
-        .and_then(|record| record.stacking_context.effective_z_index);
-    emit(FfiStackingContextDumpEntry {
-        layout_node_shell: arena.shell_if_live(root),
-        depth,
-        has_effective_z_index: effective_z_index.is_some(),
-        effective_z_index: effective_z_index.unwrap_or(0),
+impl FfiStackingContextDumpCallbacks {
+    fn debug_description(&self, layout_node_shell: *mut c_void) -> String {
+        let mut description = Vec::new();
+        // SAFETY: The C++ host fills the description sink synchronously through the exported push
+        // function.
+        unsafe { (self.debug_description)(self.context, layout_node_shell, (&raw mut description).cast()) };
+        String::from_utf8_lossy(&description).into_owned()
+    }
+
+    fn append_text(&self, text: &str) {
+        // SAFETY: The C++ sink copies the completed dump synchronously.
+        unsafe { (self.append_text)(self.context, text.as_ptr(), text.len()) };
+    }
+}
+
+/// # Safety
+///
+/// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
+/// `debug_description` is called synchronously with a `Vec<u8>` sink the host fills through
+/// `layout_arena_paint_push_bytes`, and `append_text` copies the completed dump synchronously.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_dump_stacking_context_tree(
+    arena: *mut c_void,
+    viewport: NodeSlotId,
+    callbacks: FfiStackingContextDumpCallbacks,
+) {
+    crate::abort_on_panic(|| {
+        // SAFETY: The caller guarantees a live arena handle borrowed for this call.
+        let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+        if arena.stacking_context_entries(viewport).is_none() {
+            return;
+        }
+        let mut output = String::new();
+        visit(&mut output, arena, viewport, 0, &callbacks);
+        callbacks.append_text(&output);
     });
+}
+
+fn visit(
+    output: &mut String,
+    arena: &LayoutNodeArena,
+    root: NodeSlotId,
+    depth: usize,
+    callbacks: &FfiStackingContextDumpCallbacks,
+) {
+    let layout_node_shell = arena.shell_if_live(root);
+    output.extend(std::iter::repeat_n(' ', depth));
+    if layout_node_shell.is_null() {
+        output.push_str("SC for (gone)\n");
+    } else {
+        push_line(
+            output,
+            &callbacks.debug_description(layout_node_shell),
+            paintable_geometry::absolute_rect_or_default(&arena.paintable_rows(), root),
+            effective_z_index(arena, root),
+            has_css_transform(arena, root),
+        );
+    }
+
     let Some(entries) = arena.stacking_context_entries(root) else {
         return;
     };
     for entry in entries.negative_z_index_child_contexts() {
-        visit(arena, entry.slot, depth + 1, emit);
+        visit(output, arena, entry.slot, depth + 1, callbacks);
     }
     for &descendant in &entries.stack_level_zero_boxes {
         if arena.paintable_row_is_populated(descendant)
@@ -42,10 +94,71 @@ fn visit(arena: &LayoutNodeArena, root: NodeSlotId, depth: usize, emit: &mut imp
                 .paintable_data(descendant)
                 .establishes_stacking_context
         {
-            visit(arena, descendant, depth + 1, emit);
+            visit(output, arena, descendant, depth + 1, callbacks);
         }
     }
     for entry in entries.positive_z_index_child_contexts() {
-        visit(arena, entry.slot, depth + 1, emit);
+        visit(output, arena, entry.slot, depth + 1, callbacks);
+    }
+}
+
+fn push_line(
+    output: &mut String,
+    description: &str,
+    rect: CssPixelRect,
+    effective_z_index: Option<i32>,
+    has_transform: bool,
+) {
+    let _ = write!(output, "SC for {description} ");
+    push_css_pixel_rect(output, rect);
+    output.push_str(" (z-index: ");
+    if let Some(z_index) = effective_z_index {
+        let _ = write!(output, "{z_index}");
+    } else {
+        output.push_str("auto");
+    }
+    output.push(')');
+    if has_transform {
+        output.push_str(", has_transform");
+    }
+    output.push('\n');
+}
+
+fn effective_z_index(arena: &LayoutNodeArena, slot: NodeSlotId) -> Option<i32> {
+    arena
+        .paintable_visual_context_record(slot)
+        .and_then(|record| record.stacking_context.effective_z_index)
+}
+
+fn has_css_transform(arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
+    arena.paintable_row_is_populated(slot)
+        && arena
+            .node_style_if_live(slot)
+            .is_some_and(|style| style_queries::has_css_transform(arena, slot, style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::push_line;
+    use crate::css::css_pixels::{CssPixelRect, CssPixels};
+
+    #[test]
+    fn stacking_context_lines_match_the_canonical_format() {
+        let rect = CssPixelRect::new(
+            CssPixels::from_integer(1),
+            CssPixels::from_integer(2),
+            CssPixels::from_integer(30),
+            CssPixels::from_integer(40),
+        );
+        let mut output = String::new();
+        push_line(&mut output, "Viewport<#document>", rect, None, false);
+        push_line(&mut output, "BlockContainer<DIV>#target.a.b", rect, Some(-1), true);
+        assert_eq!(
+            output,
+            concat!(
+                "SC for Viewport<#document> [1,2 30x40] (z-index: auto)\n",
+                "SC for BlockContainer<DIV>#target.a.b [1,2 30x40] (z-index: -1), has_transform\n",
+            )
+        );
     }
 }


### PR DESCRIPTION
The tree walk already ran in Rust, emitting one entry per node for a C++ callback that owned the whole line format and re-entered Rust through the box views to fetch the rect and the transform flag. Move the formatting next to the walk, reaching the host only for the layout node's debug description, which needs DOM data the arena does not hold.

The CSS pixel formatters now write into any fmt::Write sink so the byte oriented fragment dump can share them, and the populated row guard around absolute_rect moves next to the geometry it guards. Painting's has_css_transform view had no other caller, so it goes.