### PR TITLE
UI/AppKit: Support worker thread event loops

### DIFF
--- a/Tests/UI/AppKit/AppKitEventLoopTestMain.mm
+++ b/Tests/UI/AppKit/AppKitEventLoopTestMain.mm
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/Vector.h>
+#include <Application/EventLoopImplementationMacOS.h>
+#include <LibCore/EventLoopImplementation.h>
+#include <LibTest/TestSuite.h>
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, char** argv)
+{
+    if (argc < 1 || !argv[0] || '\0' == *argv[0]) {
+        warnln("Test main does not have a valid test name!");
+        return 1;
+    }
+
+    [NSApplication sharedApplication];
+    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerMacOS);
+
+    Vector<StringView> arguments;
+    arguments.ensure_capacity(argc);
+    for (auto i = 0; i < argc; ++i)
+        arguments.append({ argv[i], strlen(argv[i]) });
+
+    auto result = Test::TestSuite::the().main(argv[0], arguments);
+    Test::TestSuite::release();
+    return result != 0;
+}

--- a/Tests/UI/AppKit/CMakeLists.txt
+++ b/Tests/UI/AppKit/CMakeLists.txt
@@ -2,6 +2,22 @@ if (NOT APPLE)
     return()
 endif()
 
+add_library(AppKitEventLoopTestMain OBJECT
+    AppKitEventLoopTestMain.mm
+    "${LADYBIRD_SOURCE_DIR}/Libraries/LibTest/AssertionHandler.cpp"
+)
+target_include_directories(AppKitEventLoopTestMain PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")
+target_link_libraries(AppKitEventLoopTestMain PRIVATE AK LibCore LibTest "-framework Cocoa")
+
+ladybird_test("TestEventLoopImplementation.cpp" UI/AppKit
+    CUSTOM_MAIN "$<TARGET_OBJECTS:AppKitEventLoopTestMain>"
+    NAME TestAppKitEventLoopImplementation
+    LIBS LibSync LibThreading
+)
+target_sources(TestAppKitEventLoopImplementation PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Application/EventLoopImplementationMacOS.mm")
+target_include_directories(TestAppKitEventLoopImplementation PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")
+target_link_libraries(TestAppKitEventLoopImplementation PRIVATE "-framework Cocoa")
+
 ladybird_test("TestClipboardTypes.mm" UI/AppKit NAME TestAppKitClipboardTypes LIBS LibWebView)
 target_sources(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit/Application/ClipboardTypes.mm")
 target_include_directories(TestAppKitClipboardTypes PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/AppKit")

--- a/Tests/UI/AppKit/TestEventLoopImplementation.cpp
+++ b/Tests/UI/AppKit/TestEventLoopImplementation.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibCore/ThreadEventQueue.h>
+#include <LibSync/ConditionVariable.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/Thread.h>
+
+TEST_CASE(quit_event_loop_before_worker_run_loop_waits)
+{
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::Mutex mutex;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Sync::ConditionVariable condition { mutex };
+    IGNORE_USE_IN_ESCAPING_LAMBDA RefPtr<Core::WeakEventLoopReference> weak_ref;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Core::ThreadEventQueue* thread_event_queue { nullptr };
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool may_exec { false };
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool callback_is_running { false };
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool callback_may_return { false };
+
+    auto thread = Threading::Thread::construct("AppKit event loop"sv, [&] {
+        Core::EventLoop event_loop;
+        {
+            Sync::MutexLocker locker { mutex };
+            weak_ref = Core::EventLoop::current_weak();
+            thread_event_queue = &Core::ThreadEventQueue::current();
+            condition.broadcast();
+            condition.wait_while([&] { return !may_exec; });
+        }
+        return event_loop.exec();
+    });
+    thread->start();
+
+    RefPtr<Core::WeakEventLoopReference> event_loop;
+    Core::ThreadEventQueue* event_queue;
+    {
+        Sync::MutexLocker locker { mutex };
+        condition.wait_while([&] { return !thread_event_queue; });
+        event_loop = weak_ref;
+        event_queue = thread_event_queue;
+    }
+
+    event_queue->deferred_invoke([&] {
+        Sync::MutexLocker locker { mutex };
+        callback_is_running = true;
+        condition.broadcast();
+        condition.wait_while([&] { return !callback_may_return; });
+    });
+
+    {
+        Sync::MutexLocker locker { mutex };
+        may_exec = true;
+        condition.broadcast();
+        condition.wait_while([&] { return !callback_is_running; });
+    }
+
+    {
+        auto strong_event_loop = event_loop->take();
+        VERIFY(strong_event_loop);
+        EXPECT(!strong_event_loop->was_exit_requested());
+        strong_event_loop->quit(42);
+        EXPECT(strong_event_loop->was_exit_requested());
+    }
+
+    {
+        Sync::MutexLocker locker { mutex };
+        callback_may_return = true;
+        condition.broadcast();
+    }
+
+    auto exit_code = MUST(thread->join<void*>());
+    EXPECT_EQ(reinterpret_cast<intptr_t>(exit_code), 42);
+}

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -39,7 +39,12 @@ Core::EventLoop& Application::create_platform_event_loop()
         [::Application sharedApplication];
     }
 
-    return WebView::Application::create_platform_event_loop();
+    auto& event_loop = WebView::Application::create_platform_event_loop();
+
+    if (!browser_options().headless_mode.has_value())
+        static_cast<EventLoopImplementationMacOS&>(event_loop.impl()).set_main_loop();
+
+    return event_loop;
 }
 
 Optional<String> Application::ui_font_family() const

--- a/UI/AppKit/Application/EventLoopImplementationMacOS.h
+++ b/UI/AppKit/Application/EventLoopImplementationMacOS.h
@@ -30,9 +30,6 @@ public:
 
 class EventLoopImplementationMacOS final : public Core::EventLoopImplementation {
 public:
-    // FIXME: This currently only manages the main NSApp event loop, as that is all we currently
-    //        interact with. When we need multiple event loops, or an event loop that isn't the
-    //        NSApp loop, we will need to create our own CFRunLoop.
     static NonnullOwnPtr<EventLoopImplementationMacOS> create();
 
     virtual int exec() override;
@@ -42,6 +39,8 @@ public:
     virtual void deferred_invoke(Function<void()>&&) override;
     virtual bool was_exit_requested() const override;
 
+    void set_main_loop();
+
     virtual ~EventLoopImplementationMacOS() override;
 
 private:
@@ -50,7 +49,7 @@ private:
     struct Impl;
     NonnullOwnPtr<Impl> m_impl;
 
-    int m_exit_code { 0 };
+    bool m_main_loop { false };
 };
 
 }

--- a/UI/AppKit/Application/EventLoopImplementationMacOS.mm
+++ b/UI/AppKit/Application/EventLoopImplementationMacOS.mm
@@ -7,6 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/HashMap.h>
 #include <AK/IDAllocator.h>
+#include <AK/NumericLimits.h>
 #include <AK/Singleton.h>
 #include <AK/TemporaryChange.h>
 #include <Application/EventLoopImplementationMacOS.h>
@@ -444,12 +445,32 @@ NonnullOwnPtr<EventLoopImplementationMacOS> EventLoopImplementationMacOS::create
 
 int EventLoopImplementationMacOS::exec()
 {
-    [NSApp run];
-    return m_exit_code;
+    if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+        return exit_code.release_value();
+
+    if (m_main_loop) {
+        [NSApp run];
+        if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+            return exit_code.release_value();
+        return 0;
+    }
+
+    for (;;) {
+        pump(PumpMode::WaitForEvents);
+        if (auto exit_code = exit_code_if_requested(); exit_code.has_value())
+            return exit_code.release_value();
+    }
 }
 
 size_t EventLoopImplementationMacOS::pump(PumpMode mode)
 {
+    if (!m_main_loop) {
+        auto result = m_thread_event_queue.process();
+        auto duration = mode == PumpMode::WaitForEvents && result == 0 ? NumericLimits<double>::max() : 0;
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, duration, true);
+        return result + m_thread_event_queue.process();
+    }
+
     auto* wait_until = mode == PumpMode::WaitForEvents ? [NSDate distantFuture] : [NSDate distantPast];
 
     auto* event = [NSApp nextEventMatchingMask:NSEventMaskAny
@@ -471,8 +492,14 @@ size_t EventLoopImplementationMacOS::pump(PumpMode mode)
 
 void EventLoopImplementationMacOS::quit(int exit_code)
 {
-    m_exit_code = exit_code;
-    [NSApp stop:nil];
+    request_exit(exit_code);
+    if (m_main_loop) {
+        [NSApp stop:nil];
+    } else {
+        CFRunLoopSourceSignal(m_impl->deferred_source);
+        CFRunLoopWakeUp(m_impl->run_loop);
+        CFRunLoopStop(m_impl->run_loop);
+    }
 }
 
 void EventLoopImplementationMacOS::wake()
@@ -490,7 +517,15 @@ void EventLoopImplementationMacOS::deferred_invoke(Function<void()>&& invokee)
 
 bool EventLoopImplementationMacOS::was_exit_requested() const
 {
-    return ![NSApp isRunning];
+    if (Core::EventLoopImplementation::was_exit_requested())
+        return true;
+    return m_main_loop && ![NSApp isRunning];
+}
+
+void EventLoopImplementationMacOS::set_main_loop()
+{
+    VERIFY(CFRunLoopGetCurrent() == CFRunLoopGetMain());
+    m_main_loop = true;
 }
 
 }


### PR DESCRIPTION
The lack of support was exposed by the recent compositor font work. Fixes a crash on AppKit startup:
```
💣 Program crashed: System trap at 0x0000000194b1aa08

Platform: arm64 macOS 26.6.2 (25G83)

Thread 13 "Compositor font" crashed:

  0 0x0000000194b1aa08 NSUpdateCycleInitialize + 888 in AppKit
  1 0x00000001941d5040 -[NSApplication run] + 116 in AppKit
  2 Ladybird::EventLoopImplementationMacOS::exec() + 32 in Ladybird at /Users/lukewilde/Repositories/ladybird/UI/AppKit/Application/EventLoopImplementationMacOS.mm:447:5

   445│ int EventLoopImplementationMacOS::exec()
   446│ {
   447│     [NSApp run];                                                                                                                                                                                           
      │     ▲
   448│     return m_exit_code;
   449│ }

  3 WebView::CompositorFontServiceConnection::thread_main() + 596 in liblagom-webview.0.1.0.dylib at /Users/lukewilde/Repositories/ladybird/Libraries/LibWebView/CompositorFontServiceConnection.cpp:147:30

   145│     }
   146│ 
   147│     auto result = event_loop.exec();                                                                                                                                                                       
      │                              ▲
   148│     if (connection->is_open())
   149│         connection->shutdown();

  4 operator() + 76 in liblagom-threading.0.1.0.dylib at /Users/lukewilde/Repositories/ladybird/AK/Function.h:147:25

   145│                 const_cast<Function*>(this)->clear(false);
   146│         });
   147│         return wrapper->call(forward<In>(in)...);                                                                                                                                                          
      │                         ▲
   148│     }
   149│

  5 operator() + 304 in liblagom-threading.0.1.0.dylib at /Users/lukewilde/Repositories/ladybird/Libraries/LibThreading/Thread.cpp:101:30

    99│             }
   100│ 
   101│             auto exit_code = self->m_action();                                                                                                                                                             
      │                              ▲
   102│ 
   103│             auto expected = Threading::ThreadState::Running;

  6 Threading::Thread::start()::$_0::__invoke(void*) + 340 in liblagom-threading.0.1.0.dylib at /Users/lukewilde/Repositories/ladybird/Libraries/LibThreading/Thread.cpp:84:9

    82│         &m_tid,
    83│         attr_ptr,
    84│         [](void* arg) -> void* {                                                                                                                                                                           
      │         ▲
    85│             auto self = adopt_ref(*static_cast<Thread*>(arg));
    86│

  7 0x000000018fcefc58 _pthread_start + 136 in libsystem_pthread.dylib
... 

Backtrace took 0.86s
```