### PR TITLE
LibWeb: "Defer" real system clipboard reads from `clipboard.read` to `ClipboardItem.getType`

### DIFF
--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -197,7 +197,7 @@ static bool check_clipboard_write_permission(JS::Realm& realm)
     return false;
 }
 
-// https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext
+// https://w3c.github.io/clipboard-apis/#dom-clipboard-read
 void Clipboard::read(JS::Realm& realm, ClipboardReadOptions formats, GC::Ref<WebIDL::Promise> promise)
 {
     // 3. If formats is not empty, then:

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -147,7 +147,7 @@ static void write_blobs_and_option_to_clipboard(JS::Realm& realm, ReadonlySpan<G
         auto payload = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, item->raw_bytes()));
 
         // 4. Insert payload and presentationStyle into the system clipboard using formatString as the native clipboard format.
-        representations.empend(payload.to_byte_string(), move(format_string));
+        representations.empend(move(format_string), payload.to_byte_string());
     }
 
     window.page().client().page_did_insert_clipboard_item({ move(representations) }, presentation_style);
@@ -244,7 +244,7 @@ void Clipboard::read(JS::Realm& realm, ClipboardReadOptions formats, GC::Ref<Web
                 for (auto const& system_clipboard_representation : system_clipboard_item.system_clipboard_representations) {
                     // 1. Let mimeType be the result of running the well-known mime type from os specific format
                     //    algorithm given systemClipboardRepresentation’s name.
-                    auto mime_type = os_specific_well_known_format(system_clipboard_representation.mime_type);
+                    auto mime_type = os_specific_well_known_format(system_clipboard_representation.name);
 
                     // 2. If mimeType is null, continue this loop.
                     if (mime_type.is_empty())
@@ -360,7 +360,7 @@ void Clipboard::read_text(JS::Realm& realm, GC::Ref<WebIDL::Promise> promise)
                     for (auto const& system_clipboard_representation : system_clipboard_item.system_clipboard_representations) {
                         // 1. Let mimeType be the result of running the well-known mime type from os specific format
                         //    algorithm given systemClipboardRepresentation’s name.
-                        auto mime_type = os_specific_well_known_format(system_clipboard_representation.mime_type);
+                        auto mime_type = os_specific_well_known_format(system_clipboard_representation.name);
 
                         // 2. If mimeType is null, continue this loop.
                         if (mime_type.is_empty())

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Enumerate.h>
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/PrimitiveString.h>
@@ -47,16 +48,17 @@ static GC::Ptr<FileAPI::Blob> clipboard_item_data_blob(JS::Value value)
     return Bindings::impl_from<FileAPI::Blob>(&value.as_object());
 }
 
-static void resolve_clipboard_items_promise(JS::Realm& realm, WebIDL::Promise& promise, GC::RootVector<GC::Ref<ClipboardItem>> const& items)
+static void resolve_clipboard_items_promise(JS::Realm& realm, WebIDL::Promise& promise, ReadonlySpan<GC::Ref<ClipboardItem>> items)
 {
+    auto& wrapper_world = Bindings::host_defined_wrapper_world(realm);
     auto clipboard_items = MUST(JS::Array::create(realm, 0));
-    for (size_t i = 0; i < items.size(); ++i)
-        MUST(clipboard_items->create_data_property(JS::PropertyKey { i }, Bindings::wrap(Bindings::host_defined_wrapper_world(realm), realm, items.at(i))));
+    for (auto [i, item] : enumerate(items))
+        MUST(clipboard_items->create_data_property(JS::PropertyKey { i }, Bindings::wrap(wrapper_world, realm, item)));
     WebIDL::resolve_promise(promise, clipboard_items);
 }
 
 // https://w3c.github.io/clipboard-apis/#os-specific-well-known-format
-static String os_specific_well_known_format(MimeSniff::MimeType const& mime_type)
+String os_specific_well_known_format(MimeSniff::MimeType const& mime_type)
 {
     // 1. Let wellKnownFormat be an empty string.
     String well_known_format {};
@@ -96,17 +98,8 @@ static String os_specific_well_known_format(MimeSniff::MimeType const& mime_type
     return well_known_format;
 }
 
-static String os_specific_well_known_format(StringView mime_type_string)
-{
-    // NOTE: Here we always takes the Linux case, and defer to the browser process to handle OS specific implementations.
-    auto mime_type = MimeSniff::MimeType::parse(mime_type_string);
-    if (!mime_type.has_value())
-        return {};
-
-    return os_specific_well_known_format(*mime_type);
-}
-
-static String os_specific_well_known_format(Utf16View mime_type_string)
+template<typename T>
+static String os_specific_well_known_format(T const& mime_type_string)
 {
     // NOTE: Here we always takes the Linux case, and defer to the browser process to handle OS specific implementations.
     auto mime_type = MimeSniff::MimeType::parse(mime_type_string);
@@ -230,14 +223,25 @@ void Clipboard::read(JS::Realm& realm, ClipboardReadOptions formats, GC::Ref<Web
             return;
         }
 
-        // 3. Let data be a copy of the system clipboard data.
+        // 3. Let data be the system clipboard data.
         HTML::relevant_window(realm.global_object()).page().request_clipboard_entries(GC::create_function(GC::Heap::the(), [&realm, promise, formats = move(formats)](Vector<SystemClipboardItem> data) mutable {
             HTML::TemporaryExecutionContext execution_context { realm };
 
-            // 4. Let items be a sequence<clipboard item>.
-            GC::RootVector<GC::Ref<ClipboardItem>> items;
+            // 4. Let snapshotChangeCount be the current clipboard change count.
+            // FIXME: We are meant to independently track any changes to the system clipboard in the UI. We are also
+            //        meant to only fetch metadata about the system clipboard at this point, and defer reading the
+            //        actual data until ClipboardItem.getType() is invoked.
+            size_t snapshot_change_count = 0;
 
-            // 5. For each systemClipboardItem in data:
+            // 5. Let items be a sequence of ordered maps, each entry having keys "item" (a clipboard item) and
+            //    "originating" (a system clipboard item or null).
+            struct ReadItem {
+                GC::Ref<ClipboardItem> item;
+                Optional<SystemClipboardItem> originating;
+            };
+            GC::ConservativeVector<ReadItem> items;
+
+            // 6. For each systemClipboardItem in data:
             for (auto const& system_clipboard_item : data) {
                 // 1. Let item be a new clipboard item.
                 auto item = ClipboardItem::create();
@@ -252,78 +256,67 @@ void Clipboard::read(JS::Realm& realm, ClipboardReadOptions formats, GC::Ref<Web
                     if (mime_type.is_empty())
                         continue;
 
-                    auto decoder = TextCodec::decoder_for("UTF-8"sv);
-                    auto string = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, system_clipboard_representation.data));
-
                     // 3. Let representation be a new representation.
                     ClipboardItem::Representation representation {
                         // 4. Set representation’s MIME type to mimeType.
                         .mime_type = Utf16String::from_utf8(mime_type),
 
-                        // 7. Resolve representation’s data with systemClipboardRepresentation’s data.
-                        .data = WebIDL::create_resolved_promise(realm, JS::PrimitiveString::create(realm.vm(), Utf16String::from_utf8(string))),
+                        // 5. Set representation’s data to a new promise in realm.
+                        .data = WebIDL::create_promise(realm),
                     };
 
-                    // 5. Let isUnsanitized be false.
-                    auto is_unsanitized = false;
-
-                    // 6. If formats is not empty, then:
-                    if (formats.unsanitized.has_value()) {
-                        // 1. For each format in formats["unsanitized"]:
-                        for (auto const& format : *formats.unsanitized) {
-                            // 1. If format is equal to MIME type, set isUnsanitized to true.
-                            if (format == representation.mime_type) {
-                                is_unsanitized = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    // 8. The user agent, MAY sanitize representation’s data, unless representation’s MIME type's essence
-                    //    is "image/png", which should remain unsanitized to preserve meta data, or if it satisfies the
-                    //    below conditions:
-                    //     1. representation’s MIME type is in optional unsanitized data types list.
-                    //     2. isUnsanitized is true.
-                    // FIXME: Sanitization is an underspecified spec feature. See:
-                    //        https://github.com/w3c/clipboard-apis/issues/73
-                    (void)is_unsanitized;
-
-                    // 9. Append representation to item’s list of representations.
+                    // 6. Append representation to item’s list of representations.
                     item->append_representation(move(representation));
-
-                    // 10. Set isUnsanitized to false.
-                    is_unsanitized = false;
                 }
 
-                // 3. If item’s list of representations size is greater than 0, append item to items.
+                // 3. If item’s list of representations size is greater than 0, append the ordered map
+                //    «[ "item" → item, "originating" → systemClipboardItem ]» to items.
                 if (!item->representations().is_empty())
-                    items.append(item);
+                    items.empend(item, system_clipboard_item);
             }
 
-            // 6. If items has a size > 0, then:
+            // 7. If items has a size > 0, then:
             if (!items.is_empty()) {
-                // FIXME: 1. Let firstItem be items[0]
+                // FIXME: 1. Let firstItem be items[0]["item"]
                 // FIXME: 2. Run the read web custom format algorithm given firstItem.
             }
-            // 7. Else:
+            // 8. Else:
             else {
                 // FIXME: 1. Let customItem be a new clipboard item.
                 // FIXME: 2. Run the read web custom format algorithm given customItem.
-                // FIXME: 3. If customItem’s list of representations size is greater than 0, append customItem to items.
+                // FIXME: 3. If customItem’s list of representations size is greater than 0, append the ordered map
+                //           «[ "item" → customItem, "originating" → null ]» to items.
             }
 
-            // 8. Queue a global task on the clipboard task source, given realm’s global object, to perform the below steps:
-            queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(GC::Heap::the(), [&realm, promise, items = move(items)]() mutable {
+            // 9. Queue a global task on the clipboard task source, given realm’s global object, to perform the below steps:
+            queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(GC::Heap::the(), [&realm, promise, formats = move(formats), snapshot_change_count, items = move(items)]() mutable {
                 HTML::TemporaryExecutionContext execution_context { realm };
 
                 // 1. Let clipboardItems be a sequence<ClipboardItem>.
-                // 2. For each clipboard item underlyingItem of items:
-                //     1. Let clipboardItem be the result of running the steps of create a ClipboardItem object given
-                //        underlyingItem and realm.
-                //     2. Append clipboardItem to clipboardItems.
+                auto clipboard_items = GC::Heap::the().allocate<GC::HeapVector<GC::Ref<ClipboardItem>>>();
 
-                // 2. Resolve p with clipboardItems.
-                resolve_clipboard_items_promise(realm, promise, items);
+                // 2. For each ordered map entry of items:
+                for (auto& [item, originating] : items) {
+                    // 1. Let clipboardItem be the result of running the steps of create a ClipboardItem object given
+                    //    entry["item"] and realm.
+                    auto clipboard_item = item;
+
+                    // 2. Set clipboardItem’s clipboard change count at read to snapshotChangeCount.
+                    clipboard_item->set_clipboard_change_count_at_read(snapshot_change_count);
+
+                    // 3. Set clipboardItem’s originating system clipboard item to entry["originating"].
+                    clipboard_item->set_originating_system_clipboard_item(move(originating));
+
+                    // 4. If formats is not empty, set clipboardItem’s unsanitized MIME types to formats["unsanitized"].
+                    if (formats.unsanitized.has_value())
+                        clipboard_item->set_unsanitized_mime_types(*formats.unsanitized);
+
+                    // 5. Append clipboardItem to clipboardItems.
+                    clipboard_items->elements().append(clipboard_item);
+                }
+
+                // 3. Resolve p with clipboardItems.
+                resolve_clipboard_items_promise(realm, promise, clipboard_items->elements());
             }));
         }));
     }));

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -143,11 +143,13 @@ static void write_blobs_and_option_to_clipboard(JS::Realm& realm, ReadonlySpan<G
         }
 
         // 3. Let payload be the result of UTF-8 decoding item’s underlying byte sequence.
-        auto decoder = TextCodec::decoder_for("UTF-8"sv);
-        auto payload = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, item->raw_bytes()));
+        // FIXME: Spec issue: UTF-8 decoding here does not make sense. This would make a simple clipboard.write ->
+        //        clipboard.read sequence for PNG data corrupt.
+        //        https://github.com/w3c/clipboard-apis/issues/217
+        ByteString payload { item->raw_bytes() };
 
         // 4. Insert payload and presentationStyle into the system clipboard using formatString as the native clipboard format.
-        representations.empend(move(format_string), payload.to_byte_string());
+        representations.empend(move(format_string), move(payload));
     }
 
     window.page().client().page_did_insert_clipboard_item({ move(representations) }, presentation_style);

--- a/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -43,4 +43,6 @@ private:
     Clipboard();
 };
 
+String os_specific_well_known_format(MimeSniff::MimeType const&);
+
 }

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
@@ -7,9 +7,12 @@
 #include <LibGC/Heap.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
+#include <LibWeb/Clipboard/Clipboard.h>
 #include <LibWeb/Clipboard/ClipboardItem.h>
 #include <LibWeb/FileAPI/Blob.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/MimeSniff/MimeType.h>
+#include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::Clipboard {
@@ -119,9 +122,19 @@ WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> ClipboardItem::create(GC::OrderedRoo
     return create(items, options.presentation_style);
 }
 
-PresentationStyle ClipboardItem::presentation_style() const
+ClipboardItem::ClipboardItem()
+    : m_presentation_style(PresentationStyle::Unspecified)
 {
-    return m_presentation_style;
+}
+
+ClipboardItem::~ClipboardItem() = default;
+
+void ClipboardItem::visit_edges(GC::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto& representation : m_representations)
+        visitor.visit(representation.data);
+    visitor.visit(m_representations_with_resolvers);
 }
 
 void ClipboardItem::append_representation(Representation representation)
@@ -131,7 +144,7 @@ void ClipboardItem::append_representation(Representation representation)
 }
 
 // https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm& realm, Utf16String const& type) const
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm& realm, Utf16String const& type)
 {
     // 2. Let isCustom be false.
     bool is_custom = false;
@@ -155,7 +168,7 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm&
 
     auto mime_type_serialized = mime_type->serialized();
 
-    // 6. Let itemTypeList be this's clipboard item's list of representations.
+    // 6. Let itemTypeList be this’s clipboard item’s list of representations.
     auto const& item_type_list = representations();
 
     // 7.  Let p be a new promise in realm.
@@ -164,13 +177,106 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm&
     // 8. For each representation in itemTypeList:
     for (auto const& representation : item_type_list) {
         // 1. If representation’s MIME type is mimeType and representation’s isCustom is isCustom, then:
-        if (representation.mime_type == Utf16String::from_utf8(mime_type_serialized) && representation.is_custom == is_custom) {
-            // 1. Let representationDataPromise be the representation’s data.
+        if (representation.mime_type == mime_type_serialized && representation.is_custom == is_custom) {
+            // FIXME: 1. If this’s clipboard change count at read is not null, and the current clipboard change count is not
+            //           equal to this’s clipboard change count at read, then reject p with an "InvalidStateError" DOMException
+            //           in realm, and return p.
+
+            // 2. If this’s clipboard change count at read is not null, then:
+            if (m_clipboard_change_count_at_read.has_value()) {
+                // 1. Let key be mimeType’s essence. If isCustom is true, prefix key with `"web "`.
+                auto key = mime_type->essence();
+                if (is_custom)
+                    key = MUST(String::formatted("web {}", mime_type->essence()));
+
+                // 2. If this’s representations with resolvers[key] exists, then return this’s representations with resolvers[key].
+                if (auto resolver = m_representations_with_resolvers.get(key); resolver.has_value())
+                    return resolver.release_value();
+
+                // 3. Set this’s representations with resolvers[key] to p.
+                m_representations_with_resolvers.set(key, promise);
+
+                // 4. Run the following steps in parallel:
+                Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(GC::Heap::the(), [this, &realm, promise, mime_type = mime_type.release_value(), is_custom]() {
+                    // 1. Let clipboardItem be this’s originating system clipboard item.
+                    auto const& clipboard_item = m_originating_system_clipboard_item;
+
+                    // 2. If clipboardItem is null, then queue a global task on the clipboard task source, given realm’s
+                    //    global object, to reject p with an "InvalidStateError" DOMException in realm, then abort these
+                    //    steps.
+                    if (!clipboard_item.has_value()) {
+                        queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(GC::Heap::the(), [&realm, promise]() {
+                            HTML::TemporaryExecutionContext execution_context { realm };
+                            WebIDL::reject_promise(promise, WebIDL::InvalidStateError::create("This clipboard item is missing an originating system clipboard entry"_utf16));
+                        }));
+                        return;
+                    }
+
+                    String os_format_name;
+
+                    // 3. If isCustom is true, then:
+                    if (is_custom) {
+                        // FIXME: 1. Let mapName be the os specific custom map name.
+                        // FIXME: 2. Let mapRepresentation be the system clipboard representation in clipboardItem’s list of system
+                        //           clipboard representations whose name is mapName. If there is no such system clipboard
+                        //           representation, then queue a global task on the clipboard task source, given realm’s global
+                        //           object, to reject p with a "NotFoundError" DOMException in realm, then abort these steps.
+                        // FIXME: 3. Let webCustomFormatMapString be the JSON string deserialized from mapRepresentation’s data.
+                        // FIXME: 4. Let osFormatName be the value in webCustomFormatMapString whose key matches mimeType
+                        //           serialized.
+                        // FIXME: 5. If osFormatName is not found, then queue a global task on the clipboard task source, given
+                        //           realm’s global object, to reject p with a "NotFoundError" DOMException in realm, then abort
+                        //           these steps.
+                    }
+                    // 4. Else, let osFormatName be the result of running os specific well-known format given mimeType.
+                    else {
+                        os_format_name = os_specific_well_known_format(mime_type);
+                    }
+
+                    // 5. Let clipboardRepresentation be the system clipboard representation in clipboardItem’s list of
+                    //    system clipboard representations whose name is osFormatName. If there is no such system clipboard
+                    //    representation, then queue a global task on the clipboard task source, given realm’s global object,
+                    //    to reject p with a "NotFoundError" DOMException in realm, then abort these steps.
+                    auto clipboard_representation = clipboard_item->system_clipboard_representations.first_matching([&](auto const& item) {
+                        return item.name == os_format_name;
+                    });
+
+                    if (!clipboard_representation.has_value()) {
+                        queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(GC::Heap::the(), [&realm, promise, os_format_name]() {
+                            HTML::TemporaryExecutionContext execution_context { realm };
+                            WebIDL::reject_promise(promise, WebIDL::NotFoundError::create(realm, Utf16String::formatted("No data found for MIME type: {}", os_format_name)));
+                        }));
+                        return;
+                    }
+
+                    // 6. Let rawData be clipboardRepresentation’s data.
+                    auto const& raw_data = clipboard_representation->data;
+
+                    // 7. Let cleanData be a copy of rawData.
+                    auto clean_data = MUST(ByteBuffer::copy(raw_data.bytes()));
+
+                    // FIXME: 8. If mimeType’s essence is in this’s unsanitized MIME types and mimeType’s essence is in the
+                    //           optional unsanitized data types list, then do nothing.
+                    // FIXME: 9. Else, if mimeType’s essence is not "image/png", the user agent MAY sanitize cleanData.
+
+                    // 10. Let blob be a Blob whose type is mimeType serialized and whose underlying byte sequence is cleanData.
+                    auto blob = FileAPI::Blob::create(move(clean_data), mime_type.serialized_as_utf16());
+
+                    // 11. Queue a global task on the clipboard task source, given realm’s global object, to resolve p with blob.
+                    queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(GC::Heap::the(), [&realm, promise, blob]() {
+                        HTML::TemporaryExecutionContext execution_context { realm };
+                        resolve_clipboard_item_blob_promise(realm, promise, blob);
+                    }));
+                }));
+            }
+
+            // 3. Let representationDataPromise be the representation’s data.
             auto representation_data_promise = representation.data;
 
-            // 2. React to representationDataPromise:
+            // 4. React to representationDataPromise:
             WebIDL::react_to_promise(
                 *representation_data_promise,
+                // 1. If representationDataPromise was fulfilled with value v, then:
                 GC::create_function(GC::Heap::the(), [&realm, promise, mime_type_serialized](JS::Value value) -> WebIDL::ExceptionOr<JS::Value> {
                     // 1. If v is a DOMString, then follow the below steps:
                     if (value.is_string()) {
@@ -200,7 +306,7 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm&
                     return JS::js_undefined();
                 }));
 
-            // 3. Return p.
+            // 5. Return p.
             return promise;
         }
     }
@@ -219,21 +325,6 @@ bool ClipboardItem::supports(Utf16String const& type)
     // 2. If not, then return false.
     // TODO: Implement optional data types, like web custom formats and image/svg+xml.
     return type == "text/plain"_utf16 || type == "text/html"_utf16 || type == "image/png"_utf16;
-}
-
-ClipboardItem::ClipboardItem()
-    : m_presentation_style(PresentationStyle::Unspecified)
-{
-}
-
-ClipboardItem::~ClipboardItem() = default;
-
-void ClipboardItem::visit_edges(GC::Cell::Visitor& visitor)
-{
-    Base::visit_edges(visitor);
-    for (auto& representation : m_representations) {
-        visitor.visit(representation.data);
-    }
 }
 
 }

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.h
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.h
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibWeb/Bindings/ClipboardItem.h>
 #include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/DataTransfer.h>
@@ -42,24 +43,46 @@ public:
 
     virtual ~ClipboardItem() override;
 
-    PresentationStyle presentation_style() const;
+    PresentationStyle presentation_style() const { return m_presentation_style; }
 
     Vector<Utf16String> const& types() const { return m_types; }
 
-    Vector<Representation> const& representations() const { return m_representations; }
-    void append_representation(Representation);
-    WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> get_type(JS::Realm&, Utf16String const& type) const;
+    WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> get_type(JS::Realm&, Utf16String const& type);
 
     static bool supports(Utf16String const& type);
+
+    Vector<Representation> const& representations() const { return m_representations; }
+    void append_representation(Representation);
+
+    void set_clipboard_change_count_at_read(size_t count) { m_clipboard_change_count_at_read = count; }
+    void set_originating_system_clipboard_item(Optional<SystemClipboardItem> item) { m_originating_system_clipboard_item = move(item); }
+    void set_unsanitized_mime_types(Vector<Utf16String> types) { m_unsanitized_mime_types = move(types); }
 
 private:
     ClipboardItem();
 
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
-    PresentationStyle m_presentation_style;
-    Vector<Utf16String> m_types;
+    // https://w3c.github.io/clipboard-apis/#list-of-representations
     Vector<Representation> m_representations;
+
+    // https://w3c.github.io/clipboard-apis/#presentation-style
+    PresentationStyle m_presentation_style;
+
+    // https://w3c.github.io/clipboard-apis/#clipboarditem-types-array
+    Vector<Utf16String> m_types;
+
+    // https://w3c.github.io/clipboard-apis/#clipboarditem-clipboard-change-count-at-read
+    Optional<size_t> m_clipboard_change_count_at_read;
+
+    // https://w3c.github.io/clipboard-apis/#clipboarditem-originating-system-clipboard-item
+    Optional<SystemClipboardItem> m_originating_system_clipboard_item;
+
+    // https://w3c.github.io/clipboard-apis/#clipboarditem-unsanitized-mime-types
+    Vector<Utf16String> m_unsanitized_mime_types;
+
+    // https://w3c.github.io/clipboard-apis/#clipboarditem-representations-with-resolvers
+    HashMap<String, GC::Ref<WebIDL::Promise>> m_representations_with_resolvers;
 };
 
 }

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
@@ -11,18 +11,18 @@
 template<>
 ErrorOr<void> IPC::encode(Encoder& encoder, Web::Clipboard::SystemClipboardRepresentation const& output)
 {
+    TRY(encoder.encode(output.name));
     TRY(encoder.encode(output.data));
-    TRY(encoder.encode(output.mime_type));
     return {};
 }
 
 template<>
 ErrorOr<Web::Clipboard::SystemClipboardRepresentation> IPC::decode(Decoder& decoder)
 {
+    auto name = TRY(decoder.decode<String>());
     auto data = TRY(decoder.decode<ByteString>());
-    auto mime_type = TRY(decoder.decode<String>());
 
-    return Web::Clipboard::SystemClipboardRepresentation { move(data), move(mime_type) };
+    return Web::Clipboard::SystemClipboardRepresentation { move(name), move(data) };
 }
 
 template<>

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.h
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.h
@@ -16,8 +16,8 @@ namespace Web::Clipboard {
 
 // https://w3c.github.io/clipboard-apis/#system-clipboard-representation
 struct SystemClipboardRepresentation {
+    String name;
     ByteString data;
-    String mime_type;
 };
 
 // https://w3c.github.io/clipboard-apis/#system-clipboard-item

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1782,7 +1782,7 @@ EventResult EventHandler::perform_cut_action()
     return EventResult::Handled;
 }
 
-// https://w3c.github.io/clipboard-apis/#the-paste-action
+// https://w3c.github.io/clipboard-apis/#paste-action
 EventResult EventHandler::perform_paste_action()
 {
     auto document = m_navigable->active_document();
@@ -1820,7 +1820,7 @@ EventResult EventHandler::perform_paste_action()
     return EventResult::Handled;
 }
 
-// https://w3c.github.io/clipboard-apis/#the-paste-action
+// https://w3c.github.io/clipboard-apis/#paste-action
 // This is the paste action from the point where the content to paste is already in hand, either because async retrieval
 // of the system clipboard's contents above finished, or because the paste arrived through LocalNavigable::paste() —
 // which the UI process hands the content to paste directly.

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1680,7 +1680,7 @@ static void write_data_transfer_to_clipboard(DOM::Document& document, HTML::Drag
         if (item.type_string != u"text/plain"sv && item.type_string != u"text/html"sv)
             continue;
         auto mime_type = item.type_string == u"text/plain"sv ? "text/plain"_string : "text/html"_string;
-        representations.empend(item.data.to_byte_string(), move(mime_type));
+        representations.empend(move(mime_type), item.data.to_byte_string());
     }
     if (!representations.is_empty())
         document.page().client().page_did_insert_clipboard_item({ move(representations) }, "unspecified"sv);
@@ -1709,9 +1709,9 @@ EventResult EventHandler::perform_copy_action()
         auto html = m_navigable->selected_html_for_clipboard();
         Vector<Clipboard::SystemClipboardRepresentation> representations;
         if (!html.is_empty())
-            representations.empend(html.to_byte_string(), "text/html"_string);
+            representations.empend("text/html"_string, html.to_byte_string());
         if (!text.is_empty())
-            representations.empend(text.to_byte_string(), "text/plain"_string);
+            representations.empend("text/plain"_string, text.to_byte_string());
         if (!representations.is_empty())
             document->page().client().page_did_insert_clipboard_item({ move(representations) }, "unspecified"sv);
 
@@ -1754,9 +1754,9 @@ EventResult EventHandler::perform_cut_action()
                 //    text/html and text/plain clipboard formats when content in a web page is selected.
                 Vector<Clipboard::SystemClipboardRepresentation> representations;
                 if (!html.is_empty())
-                    representations.empend(html.to_byte_string(), "text/html"_string);
+                    representations.empend("text/html"_string, html.to_byte_string());
                 if (!text.is_empty())
-                    representations.empend(text.to_byte_string(), "text/plain"_string);
+                    representations.empend("text/plain"_string, text.to_byte_string());
                 document->page().client().page_did_insert_clipboard_item({ move(representations) }, "unspecified"sv);
 
                 // 2. Remove the contents of the selection from the document and collapse the selection.
@@ -1797,9 +1797,9 @@ EventResult EventHandler::perform_paste_action()
             for (auto const& representation : items.first().system_clipboard_representations) {
                 // NB: The clipboard representation's type may carry parameters, e.g. "text/plain;charset=utf-8".
                 Utf16FlyString type;
-                if (representation.mime_type == "text/plain"sv || representation.mime_type.starts_with_bytes("text/plain;"sv))
+                if (representation.name == "text/plain"sv || representation.name.starts_with_bytes("text/plain;"sv))
                     type = "text/plain"_utf16_fly_string;
-                else if (representation.mime_type == "text/html"sv || representation.mime_type.starts_with_bytes("text/html;"sv))
+                else if (representation.name == "text/html"sv || representation.name.starts_with_bytes("text/html;"sv))
                     type = "text/html"_utf16_fly_string;
                 else
                     continue;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1979,7 +1979,7 @@ Utf16String Application::clipboard_text(ClipboardType) const
     if (!m_clipboard.has_value())
         return {};
     for (auto const& representation : m_clipboard->system_clipboard_representations) {
-        if (representation.mime_type == "text/plain"sv)
+        if (representation.name == "text/plain"sv)
             return Utf16String::from_utf8(representation.data);
     }
     return {};
@@ -1990,8 +1990,8 @@ void Application::set_clipboard_text(String text, ClipboardType)
     m_clipboard = Web::Clipboard::SystemClipboardItem {
         .system_clipboard_representations = {
             {
+                .name = "text/plain"_string,
                 .data = text.to_byte_string(),
-                .mime_type = "text/plain"_string,
             },
         },
     };
@@ -2148,14 +2148,14 @@ void Application::initialize_actions()
         if (auto view = active_web_view(); view.has_value())
             view->selected_text()->when_resolved([this](auto& text) {
                 if (!text.is_empty())
-                    insert_clipboard_entry({ text, "text/plain"_string });
+                    insert_clipboard_entry({ "text/plain"_string, text });
             });
     });
     m_cut_selection_action = Action::create("Cut"sv, ActionID::CutSelection, [this]() {
         if (auto view = active_web_view(); view.has_value())
             view->cut_selected_text()->when_resolved([this](auto& text) {
                 if (!text.is_empty())
-                    insert_clipboard_entry({ text, "text/plain"_string });
+                    insert_clipboard_entry({ "text/plain"_string, text });
             });
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -3394,7 +3394,7 @@ void ViewImplementation::initialize_context_menus()
         download_context_menu_url(PromptForPath::Yes);
     });
     m_copy_url_action = Action::create("Copy URL"sv, ActionID::CopyURL, [this]() {
-        Application::the().insert_clipboard_entry({ url_text_to_copy(m_context_menu_url), "text/plain"_string });
+        Application::the().insert_clipboard_entry({ "text/plain"_string, url_text_to_copy(m_context_menu_url) });
     });
 
     m_open_image_action = Action::create("Open Image"sv, ActionID::OpenImage, [this]() {
@@ -3415,7 +3415,7 @@ void ViewImplementation::initialize_context_menus()
         if (encoded.is_error())
             return;
 
-        Application::the().insert_clipboard_entry({ ByteString { encoded.value().bytes() }, "image/png"_string });
+        Application::the().insert_clipboard_entry({ "image/png"_string, ByteString { encoded.value().bytes() } });
     });
 
     m_open_audio_action = Action::create("Open Audio"sv, ActionID::OpenAudio, [this]() {
@@ -3591,7 +3591,7 @@ void ViewImplementation::initialize_context_menus()
         if (!bookmark.has_value() || !bookmark->is_bookmark())
             return;
 
-        application.insert_clipboard_entry({ url_text_to_copy(bookmark->bookmark().url), "text/plain"_string });
+        application.insert_clipboard_entry({ "text/plain"_string, url_text_to_copy(bookmark->bookmark().url) });
     }));
     m_bookmark_context_menu->add_separator();
     m_bookmark_context_menu->add_action(Action::create("Edit Bookmark..."sv, ActionID::EditBookmark, []() {

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -358,6 +358,9 @@ Text/input/wpt-import/web-locks/query.https.any.html
 ; Requires reaching into the contentWindow of an <object>, which fails for file:// origins.
 Text/input/HTML/HTMLObjectElement-contentWindow.html
 
+; Requires fetching a URL with CORS.
+Text/input/Clipboard/clipboard-png-identity.html
+
 [Skipped]
 ; Needs vertical-rl inline geometry fidelity beyond the binary transpose
 Ref/input/wpt-import/css/css-position/position-absolute-in-inline-006.html

--- a/Tests/LibWeb/Text/expected/Clipboard/clipboard-png-identity.txt
+++ b/Tests/LibWeb/Text/expected/Clipboard/clipboard-png-identity.txt
@@ -1,0 +1,3 @@
+Size: 572
+Type: image/png
+PNG managed to round-trip: true

--- a/Tests/LibWeb/Text/input/Clipboard/clipboard-png-identity.html
+++ b/Tests/LibWeb/Text/input/Clipboard/clipboard-png-identity.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    async function fetchUrlToBlob(url) {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        return await response.blob();
+    }
+
+    async function compareBlobs(blob1, blob2) {
+        if (blob1.size !== blob2.size) return false;
+        if (blob1.type !== blob2.type) return false;
+
+        const buffer1 = await blob1.arrayBuffer();
+        const buffer2 = await blob2.arrayBuffer();
+
+        const view1 = new DataView(buffer1);
+        const view2 = new DataView(buffer2);
+
+        for (let i = 0; i < buffer1.byteLength; i++) {
+            if (view1.getUint8(i) !== view2.getUint8(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    promiseTest(async () => {
+        const fetchedBlob = await fetchUrlToBlob("../../../Assets/120.png");
+
+        internals.dispatchUserActivatedEvent(document.body, new Event("mousedown"));
+        await navigator.clipboard.write([new ClipboardItem({ "image/png": fetchedBlob })]);
+
+        internals.dispatchUserActivatedEvent(document.body, new Event("mousedown"));
+        const items = await navigator.clipboard.read();
+
+        for (const item of items) {
+            const imageType = item.types.find(type => type.startsWith("image/"));
+            if (!imageType) {
+                continue;
+            }
+
+            const clipboardBlob = await item.getType(imageType);
+            println(`Size: ${clipboardBlob.size}`);
+            println(`Type: ${clipboardBlob.type}`);
+
+            const roundTrip = await compareBlobs(fetchedBlob, clipboardBlob);
+            println(`PNG managed to round-trip: ${roundTrip}`);
+            break;
+        }
+    });
+</script>

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -234,7 +234,7 @@ Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_ent
             continue;
 
         auto data = Ladybird::ns_data_to_string([paste_board dataForType:type]);
-        representations.empend(move(data), mime_type.release_value());
+        representations.empend(mime_type.release_value(), move(data));
     }
 
     return representations;
@@ -246,7 +246,7 @@ void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item
     [paste_board clearContents];
 
     for (auto const& entry : item.system_clipboard_representations) {
-        NSPasteboardType pasteboard_type = Ladybird::pasteboard_type_for_mime_type(entry.mime_type);
+        NSPasteboardType pasteboard_type = Ladybird::pasteboard_type_for_mime_type(entry.name);
         if (!pasteboard_type)
             continue;
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -897,10 +897,10 @@ Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_ent
         return {};
 
     for (auto const& format : mime_data->formats()) {
-        auto data = ak_byte_string_from_qbytearray(mime_data->data(format));
         auto mime_type = ak_string_from_qstring(format);
+        auto data = ak_byte_string_from_qbytearray(mime_data->data(format));
 
-        representations.empend(move(data), move(mime_type));
+        representations.empend(move(mime_type), move(data));
     }
 
     return representations;
@@ -915,7 +915,7 @@ void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item
 
     auto* mime_data = new QMimeData();
     for (auto const& entry : item.system_clipboard_representations)
-        mime_data->setData(qstring_from_ak_string(entry.mime_type), qbytearray_from_ak_string(entry.data));
+        mime_data->setData(qstring_from_ak_string(entry.name), qbytearray_from_ak_string(entry.data));
 
     auto* clipboard = QGuiApplication::clipboard();
     clipboard->setMimeData(mime_data);


### PR DESCRIPTION
This corresponds to the following spec change:
https://github.com/w3c/clipboard-apis/commit/6201fd15cf28cfefbcf3b920dd04edfc0fa61753

The gist of this change is that we are meant to separately fetch meta information about the system clipboard when `clipboard.read` is invoked, and only read the real data when `ClipboardItem.getType` is invoked. To do so, we must also track any time the system clipboard changes for any reason. If it changed during the time between these invocations, we would abort the `getType` operation. (The spec is very hand-wavy about all of this).

In this patch, we don't separate these operations yet. We continue to get the full clipboard data immediately, and are not independently tracking the system clipboard for changes in each UI.

What this spec change does afford us is removing a UTF-8 decoding of the system clipboard data. We now funnel the raw data into a Blob without any encoding interpretation. This let's us round-trip a PNG through the clipboard API without corrupting that PNG via wobbly UTF-8 decoding.

Ref #11456 - in order to support pasting images, first have to make the images non-corrupt!