### PR TITLE
Store default scroll shift anchors in the Rust layout arena

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2998,10 +2998,9 @@ bool Document::can_compute_client_rects_without_accumulated_visual_contexts_upda
             continue;
         if (node_with_style->has_css_transform() || node_with_style->perspective().has_value() || node_with_style->is_sticky_position())
             return false;
-        if (m_may_have_default_scroll_shift_anchor) {
-            if (auto const* box = as_if<Layout::Box>(*node); box && box->default_scroll_shift_anchor())
-                return false;
-        }
+        if (auto const* box = as_if<Layout::Box>(*node);
+            box && (box->compensates_for_horizontal_scroll() || box->compensates_for_vertical_scroll()))
+            return false;
         // A scroll container's contents move, but its own border box does not.
         if (node != &layout_node) {
             if (!Painting::scroll_offset(*node).is_zero())

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -497,8 +497,6 @@ public:
     void update_layout(UpdateLayoutReason);
     void update_layout(UpdateLayoutReason, ThrottledAnimationSamplingScope);
     void note_content_visibility_auto_style() { m_may_have_content_visibility_auto_style = true; }
-    void note_default_scroll_shift_anchor() { m_may_have_default_scroll_shift_anchor = true; }
-    [[nodiscard]] bool may_have_default_scroll_shift_anchor() const { return m_may_have_default_scroll_shift_anchor; }
     enum class PartialRelayoutResult : u8 {
         NotEligible,
         Done,
@@ -1580,7 +1578,6 @@ private:
     NonnullRefPtr<Painting::ChromeWidgetRegistry> m_chrome_widget_registry;
     RefPtr<Layout::Viewport> m_layout_root;
     bool m_may_have_content_visibility_auto_style { false };
-    bool m_may_have_default_scroll_shift_anchor { false };
 
     GC::Ptr<Node> m_hovered_node;
     GC::Ptr<Node> m_inspected_node;

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -43,15 +43,6 @@ void Box::drop_cached_intrinsic_sizes()
     node_arena().drop_intrinsic_size_cache(node_data());
 }
 
-void Box::set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)
-{
-    m_default_scroll_shift_anchor = move(anchor);
-    set_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll, compensates_for_horizontal_scroll);
-    set_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll, compensates_for_vertical_scroll);
-    if (m_default_scroll_shift_anchor)
-        document().note_default_scroll_shift_anchor();
-}
-
 static ImageProvider const& image_provider_for_element(DOM::Element const& element)
 {
     if (auto const* image = as_if<HTML::HTMLImageElement>(element))

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -66,8 +66,6 @@ public:
     bool abspos_descendant_escapes() const { return has_flag(RustFFI::NodeFlag::AbsposDescendantEscapes); }
     void set_abspos_descendant_escapes(bool value) { set_flag(RustFFI::NodeFlag::AbsposDescendantEscapes, value); }
 
-    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll);
-    Node* default_scroll_shift_anchor() const { return m_default_scroll_shift_anchor.ptr(); }
     bool compensates_for_horizontal_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll); }
     bool compensates_for_vertical_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll); }
 
@@ -86,7 +84,6 @@ private:
 
     virtual bool is_box() const final { return true; }
 
-    WeakPtr<Node> m_default_scroll_shift_anchor;
     OwnPtr<ImageProvider> m_owned_image_provider;
 };
 

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -652,13 +652,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             auto const* dom_node = static_cast<Box const*>(node)->dom_node();
             return dom_node ? dom_node->unique_id().value() : -1;
         },
-        .set_default_scroll_shift = [](void*, void* node, void* anchor, bool horizontal, bool vertical) {
-            auto& box = *static_cast<Box*>(node);
-            if (!anchor) {
-                box.set_default_scroll_shift({}, false, false);
-                return;
-            }
-            box.set_default_scroll_shift(static_cast<Box*>(anchor)->make_weak_ptr(), horizontal, vertical); },
     };
 }
 

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -420,7 +420,6 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             inputs.visual_viewport_offset_x = offset.x();
             inputs.visual_viewport_offset_y = offset.y();
             inputs.visual_viewport_scale = visual_viewport.scale();
-            inputs.may_have_default_scroll_shift_anchor = document.may_have_default_scroll_shift_anchor();
             inputs.viewport_wheel_overflow_x = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Horizontal)));
             inputs.viewport_wheel_overflow_y = static_cast<u8>(to_underlying(overflow_value_applied_to_viewport_for_wheel_scrolling(document, ScrollDirection::Vertical)));
             return inputs;
@@ -478,13 +477,6 @@ Layout::RustFFI::FfiVisualContextHostCallbacks visual_context_host_callbacks(DOM
             Layout::RustFFI::layout_arena_paint_push_bytes(sink, filter_data.data(), filter_data.size());
             result.has_filter = true;
             return result;
-        },
-        .default_scroll_shift_anchor = [](void*, void* layout_node_shell) -> Layout::RustFFI::NodeSlotId {
-            if (auto const* box = as_if<Layout::Box>(static_cast<Layout::Node const*>(layout_node_shell))) {
-                if (auto const* anchor_box = as_if<Layout::Box>(box->default_scroll_shift_anchor()))
-                    return Layout::Node::slot_id(anchor_box);
-            }
-            return Layout::RustFFI::NodeSlotId { Layout::RustFFI::INVALID_NODE_SLOT_INDEX };
         },
     };
 }

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -563,16 +563,9 @@ impl AbsposEngine {
         entry_coordinate_space_box: Node,
     ) -> Option<formatting_context::ResolvedAnchorInsets> {
         // Clear a stale default scroll shift before any early return.
-        // SAFETY: The node is live and a null anchor clears the weak target.
-        unsafe {
-            (self.callbacks.set_default_scroll_shift)(
-                self.callbacks.context,
-                self.callbacks.shell(node),
-                std::ptr::null_mut(),
-                false,
-                false,
-            );
-        }
+        self.callbacks
+            .arena()
+            .set_default_scroll_shift(node, NodeSlotId::INVALID, false, false);
 
         let style = self.style(node);
         let top_contains_anchor = style.inset_top().contains_anchor_function();
@@ -680,17 +673,12 @@ impl AbsposEngine {
         }
 
         if resolution_state.compensates_for_horizontal_scroll || resolution_state.compensates_for_vertical_scroll {
-            // SAFETY: The anchor and positioned box remain live through the
-            // pass; C++ stores the anchor as a weak pointer.
-            unsafe {
-                (self.callbacks.set_default_scroll_shift)(
-                    self.callbacks.context,
-                    self.callbacks.shell(node),
-                    self.callbacks.shell(resolution_state.default_anchor_box),
-                    resolution_state.compensates_for_horizontal_scroll,
-                    resolution_state.compensates_for_vertical_scroll,
-                );
-            }
+            self.callbacks.arena().set_default_scroll_shift(
+                node,
+                resolution_state.default_anchor_box,
+                resolution_state.compensates_for_horizontal_scroll,
+                resolution_state.compensates_for_vertical_scroll,
+            );
         }
 
         Some(resolved)
@@ -1971,16 +1959,9 @@ impl AbsposEngine {
                 self.resolve_anchor_insets(child_box, Some(&position_area_geometry), child.coordinate_space_box);
             // https://drafts.csswg.org/css-anchor-position/#scroll
             // A non-none position-area makes the box compensate for its default anchor's scroll in both axes.
-            // SAFETY: Both boxes remain live throughout this synchronous layout pass.
-            unsafe {
-                (self.callbacks.set_default_scroll_shift)(
-                    self.callbacks.context,
-                    self.callbacks.shell(child_box),
-                    self.callbacks.shell(anchor_box),
-                    true,
-                    true,
-                );
-            }
+            self.callbacks
+                .arena()
+                .set_default_scroll_shift(child_box, anchor_box, true, true);
             (position_area_containing_block_info, resolved)
         } else {
             let resolved =

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -917,7 +917,6 @@ pub struct FfiLayoutFcCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> svg_formatting_context::FfiFloatRect,
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub node_unique_id: unsafe extern "C" fn(*mut c_void) -> i64,
-    pub set_default_scroll_shift: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool, bool),
 }
 
 impl FfiLayoutFcCallbacks {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -323,6 +323,12 @@ struct SavedAbsposLayoutInputsSlot {
     inputs: Option<Box<AbsposLayoutInputs>>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct DefaultScrollShiftAnchorSlot {
+    generation: u8,
+    anchor: NodeSlotId,
+}
+
 #[derive(Default)]
 pub(crate) struct TextContent {
     pub(crate) text: Vec<u16>,
@@ -439,6 +445,8 @@ pub(crate) struct LayoutNodeArena {
     table_cell_measurement_cache_misses: Cell<u64>,
     intrinsic_measurements: Cell<u64>,
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
+    default_scroll_shift_anchors: RefCell<Vec<DefaultScrollShiftAnchorSlot>>,
+    any_default_scroll_shift_anchor_ever_stored: Cell<bool>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
     replaced_content_facts: Vec<ReplacedContentFactsSlot>,
@@ -467,6 +475,8 @@ impl LayoutNodeArena {
             table_cell_measurement_cache_misses: Cell::new(0),
             intrinsic_measurements: Cell::new(0),
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
+            default_scroll_shift_anchors: RefCell::new(Vec::new()),
+            any_default_scroll_shift_anchor_ever_stored: Cell::new(false),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
             replaced_content_facts: Vec::new(),
@@ -623,6 +633,9 @@ impl LayoutNodeArena {
         }
         if let Some(slot) = self.saved_abspos_layout_inputs.get_mut().get_mut(index as usize) {
             *slot = SavedAbsposLayoutInputsSlot::default();
+        }
+        if let Some(slot) = self.default_scroll_shift_anchors.get_mut().get_mut(index as usize) {
+            *slot = DefaultScrollShiftAnchorSlot::default();
         }
         self.paintable_rows.reset_committed_fragment_link_slot(index);
         if let Some(slot) = self.text_contents.get_mut(index as usize) {
@@ -1394,6 +1407,62 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn set_default_scroll_shift(
+        &self,
+        id: NodeSlotId,
+        anchor: NodeSlotId,
+        compensates_for_horizontal_scroll: bool,
+        compensates_for_vertical_scroll: bool,
+    ) {
+        let anchor_is_live = self.slot_is_live(anchor);
+        {
+            let mut slots = self.default_scroll_shift_anchors.borrow_mut();
+            let index = id.slot_index() as usize;
+            if anchor_is_live {
+                if slots.len() <= index {
+                    slots.resize_with(index + 1, DefaultScrollShiftAnchorSlot::default);
+                }
+                slots[index] = DefaultScrollShiftAnchorSlot {
+                    generation: id.generation(),
+                    anchor,
+                };
+            } else if let Some(slot) = slots.get_mut(index) {
+                *slot = DefaultScrollShiftAnchorSlot::default();
+            }
+        }
+        self.set_node_flag(
+            id,
+            NodeFlag::CompensatesForHorizontalScroll,
+            anchor_is_live && compensates_for_horizontal_scroll,
+        );
+        self.set_node_flag(
+            id,
+            NodeFlag::CompensatesForVerticalScroll,
+            anchor_is_live && compensates_for_vertical_scroll,
+        );
+        if anchor_is_live {
+            self.any_default_scroll_shift_anchor_ever_stored.set(true);
+        }
+    }
+
+    pub(crate) fn default_scroll_shift_anchor(&self, id: NodeSlotId) -> NodeSlotId {
+        if !self.any_default_scroll_shift_anchor_ever_stored.get() {
+            return NodeSlotId::INVALID;
+        }
+        let slots = self.default_scroll_shift_anchors.borrow();
+        let Some(slot) = slots.get(id.slot_index() as usize) else {
+            return NodeSlotId::INVALID;
+        };
+        if slot.generation != id.generation() || !self.slot_is_live(slot.anchor) {
+            return NodeSlotId::INVALID;
+        }
+        slot.anchor
+    }
+
+    pub(crate) fn may_have_default_scroll_shift_anchor(&self) -> bool {
+        self.any_default_scroll_shift_anchor_ever_stored.get()
+    }
+
     pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<super::fragment_tree::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
         let link = self
@@ -1931,15 +2000,17 @@ impl LayoutNodeArena {
         ))
     }
 
-    pub(crate) fn shell_if_live(&self, id: NodeSlotId) -> *mut c_void {
+    pub(crate) fn slot_is_live(&self, id: NodeSlotId) -> bool {
         if id.is_invalid() {
-            return std::ptr::null_mut();
+            return false;
         }
-        let index = id.slot_index() as usize;
-        let Some(metadata) = self.slot_metadata.get(index) else {
-            return std::ptr::null_mut();
-        };
-        if !metadata.occupied || metadata.generation != id.generation() {
+        self.slot_metadata
+            .get(id.slot_index() as usize)
+            .is_some_and(|metadata| metadata.occupied && metadata.generation == id.generation())
+    }
+
+    pub(crate) fn shell_if_live(&self, id: NodeSlotId) -> *mut c_void {
+        if !self.slot_is_live(id) {
             return std::ptr::null_mut();
         }
         // SAFETY: The metadata check established a live slot of this generation.
@@ -2432,6 +2503,69 @@ mod tests {
         assert_ne!(second.generation, first.generation);
         arena
             .free(second.slot, second.generation)
+            .detached_children
+            .release_all();
+    }
+
+    #[test]
+    fn default_scroll_shift_anchors_behave_like_weak_references() {
+        let mut arena = LayoutNodeArena::new();
+        let positioned = arena.allocate();
+        let anchor = arena.allocate();
+
+        arena.set_default_scroll_shift(positioned.slot, anchor.slot, true, false);
+        assert!(arena.may_have_default_scroll_shift_anchor());
+        assert_eq!(arena.default_scroll_shift_anchor(positioned.slot), anchor.slot);
+        // SAFETY: The allocation remains live and the arena keeps its address stable.
+        let flags = unsafe { (*positioned.data).flags };
+        assert_ne!(flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
+        assert_eq!(flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
+
+        arena
+            .free(anchor.slot, anchor.generation)
+            .detached_children
+            .release_all();
+        assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
+
+        let anchor_slot_reoccupant = arena.allocate();
+        assert_eq!(anchor_slot_reoccupant.slot.slot_index(), anchor.slot.slot_index());
+        assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
+
+        arena.set_default_scroll_shift(positioned.slot, anchor_slot_reoccupant.slot, true, true);
+        assert_eq!(
+            arena.default_scroll_shift_anchor(positioned.slot),
+            anchor_slot_reoccupant.slot
+        );
+        arena.set_default_scroll_shift(positioned.slot, NodeSlotId::INVALID, false, false);
+        assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
+        // SAFETY: The allocation remains live and the arena keeps its address stable.
+        let cleared_flags = unsafe { (*positioned.data).flags };
+        assert_eq!(cleared_flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
+        assert_eq!(cleared_flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
+
+        arena
+            .free(positioned.slot, positioned.generation)
+            .detached_children
+            .release_all();
+        let positioned_slot_reoccupant = arena.allocate();
+        assert_eq!(
+            positioned_slot_reoccupant.slot.slot_index(),
+            positioned.slot.slot_index()
+        );
+        arena.set_default_scroll_shift(positioned_slot_reoccupant.slot, anchor_slot_reoccupant.slot, true, true);
+        arena
+            .free(positioned_slot_reoccupant.slot, positioned_slot_reoccupant.generation)
+            .detached_children
+            .release_all();
+        let next_reoccupant = arena.allocate();
+        assert!(arena.default_scroll_shift_anchor(next_reoccupant.slot).is_invalid());
+
+        arena
+            .free(next_reoccupant.slot, next_reoccupant.generation)
+            .detached_children
+            .release_all();
+        arena
+            .free(anchor_slot_reoccupant.slot, anchor_slot_reoccupant.generation)
             .detached_children
             .release_all();
     }

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1102,7 +1102,7 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
         }) {
             reason = reason.max(VisualContextGlobalRebuildReason::TreeInputsChanged);
         }
-        if inputs.may_have_default_scroll_shift_anchor {
+        if arena_ref.may_have_default_scroll_shift_anchor() {
             reason = reason.max(VisualContextGlobalRebuildReason::AnchorsRegistered);
         }
         if state.tree.as_deref().is_some_and(|tree| tree.should_compact()) {

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -61,7 +61,6 @@ pub struct FfiVisualContextTreeInputs {
     pub visual_viewport_offset_x: f64,
     pub visual_viewport_offset_y: f64,
     pub visual_viewport_scale: f64,
-    pub may_have_default_scroll_shift_anchor: bool,
     pub viewport_wheel_overflow_x: u8,
     pub viewport_wheel_overflow_y: u8,
 }
@@ -89,8 +88,6 @@ pub struct FfiVisualContextHostCallbacks {
     pub root_background_source: unsafe extern "C" fn(*mut c_void) -> FfiRootBackgroundSource,
     pub svg_mask_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgMaskFacts,
     pub resolve_effects_filter: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiResolvedEffectsFilter,
-    pub default_scroll_shift_anchor:
-        unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::node_data::NodeSlotId,
 }
 
 impl FfiVisualContextHostCallbacks {
@@ -130,13 +127,6 @@ impl FfiVisualContextHostCallbacks {
             filter_bytes: resolved.has_filter.then_some(bytes),
             svg_filter_bounds: resolved.svg_filter_bounds,
         }
-    }
-    pub(crate) fn default_scroll_shift_anchor(
-        &self,
-        layout_node_shell: *mut c_void,
-    ) -> crate::layout::node_data::NodeSlotId {
-        // SAFETY: The C++ host answers synchronously from a live layout node shell.
-        unsafe { (self.default_scroll_shift_anchor)(self.context, layout_node_shell) }
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -7,7 +7,7 @@
 use super::scroll_state::{NO_SCROLL_STATE_SLOT, ScrollState, ScrollStateSlot};
 use super::*;
 use crate::layout::node_data::{NodeFlag, NodeSlotId};
-use crate::painting::host::{FfiRootBackgroundSource, FfiVisualContextHostCallbacks, FfiVisualContextTreeInputs};
+use crate::painting::host::{FfiRootBackgroundSource, FfiVisualContextHostCallbacks};
 use crate::painting::paintable_data::*;
 use crate::painting::paintable_geometry;
 use crate::painting::paintable_rows::{PaintableRowsRead, PaintableRowsWrite};
@@ -17,7 +17,6 @@ pub(crate) struct BoxBuildEnvironment<'a, Arena> {
     pub layout_arena: &'a Arena,
     pub callbacks: &'a FfiVisualContextHostCallbacks,
     pub pixel_ratio: f64,
-    pub tree_inputs: FfiVisualContextTreeInputs,
     pub root_background_source: FfiRootBackgroundSource,
 }
 
@@ -215,13 +214,7 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
     let layout_arena = env.layout_arena;
     let first_spatial_node_index = sink.next_spatial_node_index().0;
     let first_frame_node_index = sink.next_frame_node_index().0;
-    let facts = super::build::BoxFacts::gather(
-        layout_arena,
-        env.callbacks,
-        slot,
-        env.pixel_ratio,
-        env.tree_inputs.may_have_default_scroll_shift_anchor,
-    );
+    let facts = super::build::BoxFacts::gather(layout_arena, env.callbacks, slot, env.pixel_ratio, true);
     let position = crate::painting::style_queries::position(layout_arena, slot);
     let is_fixed = position == crate::css::css_enums::positioning::FIXED;
     let is_absolute = position == crate::css::css_enums::positioning::ABSOLUTE;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -85,7 +85,7 @@ impl BoxFacts {
         callbacks: &FfiVisualContextHostCallbacks,
         slot: NodeSlotId,
         pixel_ratio: f64,
-        may_have_default_scroll_shift_anchor: bool,
+        consults_default_scroll_shift_anchors: bool,
     ) -> Self {
         let mut facts = Self {
             transform: None,
@@ -101,9 +101,8 @@ impl BoxFacts {
             backface_hidden: false,
             establishes_or_extends_3d_rendering_context: false,
             may_have_clip: false,
-            default_scroll_shift_anchor: if may_have_default_scroll_shift_anchor {
-                let node = slot;
-                callbacks.default_scroll_shift_anchor(layout_arena.shell_if_live(node))
+            default_scroll_shift_anchor: if consults_default_scroll_shift_anchors {
+                layout_arena.default_scroll_shift_anchor(slot)
             } else {
                 NodeSlotId::INVALID
             },

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -267,19 +267,14 @@ struct DeferredAnchorPositionedBox {
 
 struct WalkAnchorScrollShiftResolver<'a, Arena> {
     layout_arena: &'a Arena,
-    callbacks: &'a FfiVisualContextHostCallbacks,
     scroll_state: &'a ScrollState,
     assignments: &'a [PaintableVisualContextAssignment],
     assignment_index_by_slot: &'a HashMap<NodeSlotId, usize>,
-    may_have_default_scroll_shift_anchor: bool,
 }
 
 impl<Arena: PaintableRowsRead> AnchorScrollShiftResolver for WalkAnchorScrollShiftResolver<'_, Arena> {
     fn default_scroll_shift_anchor(&self, slot: NodeSlotId) -> NodeSlotId {
-        if !self.may_have_default_scroll_shift_anchor {
-            return NodeSlotId::INVALID;
-        }
-        default_scroll_shift_anchor_of(self.layout_arena, self.callbacks, slot)
+        self.layout_arena.default_scroll_shift_anchor(slot)
     }
 
     fn enclosing_scroll_node_index(&self, slot: NodeSlotId) -> SpatialNodeIndex {
@@ -295,14 +290,6 @@ impl<Arena: PaintableRowsRead> AnchorScrollShiftResolver for WalkAnchorScrollShi
     fn scroll_state(&self) -> &ScrollState {
         self.scroll_state
     }
-}
-
-fn default_scroll_shift_anchor_of(
-    layout_arena: &impl PaintableRowsRead,
-    callbacks: &FfiVisualContextHostCallbacks,
-    slot: NodeSlotId,
-) -> NodeSlotId {
-    callbacks.default_scroll_shift_anchor(layout_arena.shell_if_live(slot))
 }
 
 fn anchor_is_awaiting_build(
@@ -372,7 +359,6 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
         layout_arena,
         callbacks,
         pixel_ratio: tree_inputs.device_pixels_per_css_pixel,
-        tree_inputs,
         root_background_source,
     };
     let viewport_output = layout_arena
@@ -426,7 +412,7 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
         scope.rebuilds_every_box() || plan.revalidate_children_of.contains(&viewport),
     );
 
-    let defers_anchor_positioned = scope.rebuilds_every_box() && tree_inputs.may_have_default_scroll_shift_anchor;
+    let defers_anchor_positioned = scope.rebuilds_every_box() && layout_arena.may_have_default_scroll_shift_anchor();
     let mut deferred_anchor_positioned: Vec<DeferredAnchorPositionedBox> = Vec::new();
     let mut deferred_awaiting_build: HashSet<NodeSlotId> = HashSet::new();
     loop {
@@ -443,7 +429,7 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
         };
         let slot = pending.slot;
         if may_defer_this_box {
-            let anchor = default_scroll_shift_anchor_of(layout_arena, callbacks, slot);
+            let anchor = layout_arena.default_scroll_shift_anchor(slot);
             if !anchor.is_invalid() {
                 deferred_awaiting_build.insert(slot);
                 deferred_anchor_positioned.push(DeferredAnchorPositionedBox { pending, anchor });
@@ -483,11 +469,9 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
                         .as_ref()
                         .map(|scroll_state| WalkAnchorScrollShiftResolver {
                             layout_arena,
-                            callbacks,
                             scroll_state,
                             assignments: &assignments,
                             assignment_index_by_slot: &assignment_index_by_slot,
-                            may_have_default_scroll_shift_anchor: tree_inputs.may_have_default_scroll_shift_anchor,
                         });
                 build_box_visual_context_nodes(
                     &environment,


### PR DESCRIPTION
The default anchor made a full FFI round trip. The abspos engine resolved the anchor as a slot id. It then called into C++, which kept the anchor as a WeakPtr on the layout box. The visual context build then called back into C++ to turn that WeakPtr into a slot id again.

Now a generation-stamped side table on the layout arena keeps the anchor. Slot generations give the same weak semantics as the WeakPtr. The write and both reads stay inside Rust.