### PR TITLE
LibWeb: Implement Worker.terminate()

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -370,8 +370,11 @@ void MessagePort::dispatch_pending_messages()
 void MessagePort::queue_message_task(SerializedTransferRecord&& serialize_with_transfer_result)
 {
     auto& global = relevant_global_object();
+    auto message_task_generation = m_message_task_generation;
     queue_global_task(Task::Source::PostedMessage, global,
-        GC::create_function(GC::Heap::the(), [this, serialize_with_transfer_result = move(serialize_with_transfer_result)]() mutable {
+        GC::create_function(GC::Heap::the(), [this, message_task_generation, serialize_with_transfer_result = move(serialize_with_transfer_result)]() mutable {
+            if (message_task_generation != m_message_task_generation)
+                return;
             this->post_message_task_steps(serialize_with_transfer_result);
         }));
 }
@@ -491,6 +494,12 @@ void MessagePort::close()
     m_pending_incoming_messages.clear();
     m_pending_outgoing_messages.clear();
     m_should_shutdown_on_enable = false;
+}
+
+void MessagePort::discard_pending_messages()
+{
+    m_pending_incoming_messages.clear();
+    ++m_message_task_generation;
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessageerror

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -68,6 +68,7 @@ public:
     void start();
 
     void close();
+    void discard_pending_messages();
 
     void set_onmessageerror(GC::Ptr<WebIDL::CallbackType>);
     GC::Ptr<WebIDL::CallbackType> onmessageerror();
@@ -116,6 +117,7 @@ private:
 
     Vector<SerializedTransferRecord> m_pending_incoming_messages;
     Vector<SerializedTransferRecord> m_pending_outgoing_messages;
+    u64 m_message_task_generation { 0 };
     bool m_should_shutdown_on_enable { false };
     bool m_enabled { false };
 };

--- a/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Libraries/LibWeb/HTML/Worker.cpp
@@ -121,9 +121,25 @@ void run_a_worker(Variant<GC::Ref<Worker>, GC::Ref<SharedWorker>> worker, URL::U
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker-terminate
 WebIDL::ExceptionOr<void> Worker::terminate()
 {
-    dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Terminate");
+    // The terminate() method steps are to terminate a worker given this's worker.
 
-    // FIXME: The terminate() method steps are to terminate a worker given this's worker.
+    // 1. Set the worker's WorkerGlobalScope object's closing flag to true.
+    // 2. If there are any tasks queued in the WorkerGlobalScope object's relevant agent's event loop's task queues,
+    //    discard them without processing them.
+    // 3. Abort the script currently running in the worker.
+    // 4. If the worker's WorkerGlobalScope object is actually a DedicatedWorkerGlobalScope object (i.e. the worker is
+    //    a dedicated worker), then empty the port message queue of the port that the worker's implicit port is
+    //    entangled with.
+    // AD-HOC: Discarding pending messages empties the outside port's message queue. Closing the outside port prevents
+    //         any new messages from being delivered to this Worker. Terminating the agent closes the dedicated worker
+    //         process, which aborts its script and discards its event loop.
+    m_outside_port->discard_pending_messages();
+    m_outside_port->close();
+    if (m_agent) {
+        m_agent->terminate();
+        m_agent = nullptr;
+    }
+
     return {};
 }
 

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -152,6 +152,18 @@ void WorkerAgentParent::did_close_worker(WorkerAgentOwnerToken owner_token)
     parent->value->release_startup_keep_alive();
 }
 
+void WorkerAgentParent::terminate()
+{
+    if (m_agent_id == 0)
+        return;
+
+    worker_agent_parents().remove(m_owner_token);
+    release_startup_keep_alive();
+
+    auto agent_id = exchange(m_agent_id, 0);
+    Bindings::principal_host_defined_page(m_outside_settings->realm()).client().close_worker_agent(agent_id, m_owner_token);
+}
+
 void WorkerAgentParent::release_startup_keep_alive()
 {
     m_outside_settings->release_worker_agent_from_startup_keep_alive(*this);

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -30,6 +30,8 @@ public:
     static WEB_API void did_report_worker_exception(WorkerAgentOwnerToken, Utf16String message, Utf16String filename, u32 lineno, u32 colno);
     static WEB_API void did_close_worker(WorkerAgentOwnerToken);
 
+    void terminate();
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;


### PR DESCRIPTION
Close the dedicated worker's outside message port and release its worker agent when terminate() is called. Empty the port's message queue. Invalidate delivery tasks already moved into the event loop, and ask the browser process to shut down the worker immediately.

This prevents messages from being dispatched after termination and pages that repeatedly create and terminate workers from accumulating worker processes and IPC connections.