### PR TITLE
LibWeb+UI: Support pasting images into editable DOM nodes

### DIFF
--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -248,6 +248,10 @@ void Clipboard::read(JS::Realm& realm, ClipboardReadOptions formats, GC::Ref<Web
 
                 // 2. For each systemClipboardRepresentation in systemClipboardItem:
                 for (auto const& system_clipboard_representation : system_clipboard_item.system_clipboard_representations) {
+                    // AD-HOC: We do not expose file-backed clipboard entries to scripts.
+                    if (!system_clipboard_representation.data.has<ByteString>())
+                        continue;
+
                     // 1. Let mimeType be the result of running the well-known mime type from os specific format
                     //    algorithm given systemClipboardRepresentation’s name.
                     auto mime_type = os_specific_well_known_format(system_clipboard_representation.name);
@@ -353,6 +357,11 @@ void Clipboard::read_text(JS::Realm& realm, GC::Ref<WebIDL::Promise> promise)
                 for (auto const& system_clipboard_item : data) {
                     // 1. For each systemClipboardRepresentation in systemClipboardItem:
                     for (auto const& system_clipboard_representation : system_clipboard_item.system_clipboard_representations) {
+                        // AD-HOC: We do not expose file-backed clipboard entries to scripts.
+                        auto const* data = system_clipboard_representation.data.get_pointer<ByteString>();
+                        if (!data)
+                            continue;
+
                         // 1. Let mimeType be the result of running the well-known mime type from os specific format
                         //    algorithm given systemClipboardRepresentation’s name.
                         auto mime_type = os_specific_well_known_format(system_clipboard_representation.name);
@@ -386,7 +395,7 @@ void Clipboard::read_text(JS::Realm& realm, GC::Ref<WebIDL::Promise> promise)
                             //         2. Return p.
 
                             auto decoder = TextCodec::decoder_for("UTF-8"sv);
-                            auto string = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, system_clipboard_representation.data));
+                            auto string = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, *data));
 
                             WebIDL::resolve_promise(promise, JS::PrimitiveString::create(realm.vm(), Utf16String::from_utf8(string)));
                             return;

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
@@ -253,7 +253,7 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(JS::Realm&
                     auto const& raw_data = clipboard_representation->data;
 
                     // 7. Let cleanData be a copy of rawData.
-                    auto clean_data = MUST(ByteBuffer::copy(raw_data.bytes()));
+                    auto clean_data = MUST(ByteBuffer::copy(raw_data.get<ByteString>().bytes()));
 
                     // FIXME: 8. If mimeType’s essence is in this’s unsanitized MIME types and mimeType’s essence is in the
                     //           optional unsanitized data types list, then do nothing.

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
@@ -20,7 +20,7 @@ template<>
 ErrorOr<Web::Clipboard::SystemClipboardRepresentation> IPC::decode(Decoder& decoder)
 {
     auto name = TRY(decoder.decode<String>());
-    auto data = TRY(decoder.decode<ByteString>());
+    auto data = TRY(decoder.decode<Variant<ByteString, Web::HTML::SelectedFile>>());
 
     return Web::Clipboard::SystemClipboardRepresentation { move(name), move(data) };
 }

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.h
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.h
@@ -8,16 +8,25 @@
 
 #include <AK/ByteString.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/HTML/SelectedFile.h>
 
 namespace Web::Clipboard {
 
 // https://w3c.github.io/clipboard-apis/#system-clipboard-representation
 struct SystemClipboardRepresentation {
     String name;
-    ByteString data;
+
+    // AD-HOC: We store clipboard entries as a ByteString if the original source of the entry was either a text-based
+    //         string or any entry written via navigator.clipboard.write.
+    //
+    //         We store them as a SelectedFile only if the user themself copied a file on their desktop. That file is
+    //         never exposed to navigator.clipboard APIs, which is not specified, but generally matches the behavior of
+    //         other browsers. Users may still explicitly paste files themselves.
+    Variant<ByteString, HTML::SelectedFile> data;
 };
 
 // https://w3c.github.io/clipboard-apis/#system-clipboard-item

--- a/Libraries/LibWeb/HTML/SelectedFile.cpp
+++ b/Libraries/LibWeb/HTML/SelectedFile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,6 +21,33 @@ SelectedFile::SelectedFile(Utf16String name, IPC::File file)
     : m_name(move(name))
     , m_file_or_contents(move(file))
 {
+}
+
+static Variant<IPC::File, ByteBuffer> copy_file_or_contents(SelectedFile const& other)
+{
+    return other.file_or_contents().visit(
+        [](IPC::File const& file) -> Variant<IPC::File, ByteBuffer> {
+            return MUST(IPC::File::clone_fd(file.fd()));
+        },
+        [](ByteBuffer const& contents) -> Variant<IPC::File, ByteBuffer> {
+            return contents;
+        });
+}
+
+SelectedFile::SelectedFile(SelectedFile const& other)
+    : m_name(other.name())
+    , m_file_or_contents(copy_file_or_contents(other))
+{
+}
+
+SelectedFile& SelectedFile::operator=(SelectedFile const& other)
+{
+    if (&other != this) {
+        m_name = other.m_name;
+        m_file_or_contents = copy_file_or_contents(other);
+    }
+
+    return *this;
 }
 
 ByteBuffer SelectedFile::take_contents()

--- a/Libraries/LibWeb/HTML/SelectedFile.h
+++ b/Libraries/LibWeb/HTML/SelectedFile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +24,12 @@ class WEB_API SelectedFile {
 public:
     SelectedFile(Utf16String name, ByteBuffer contents);
     SelectedFile(Utf16String name, IPC::File file);
+
+    SelectedFile(SelectedFile const&);
+    SelectedFile(SelectedFile&&) = default;
+
+    SelectedFile& operator=(SelectedFile const&);
+    SelectedFile& operator=(SelectedFile&&) = default;
 
     Utf16String const& name() const { return m_name; }
     auto const& file_or_contents() const { return m_file_or_contents; }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -43,6 +43,7 @@
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheetList.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/Document.h>
@@ -613,6 +614,18 @@ Utf16String Internals::current_cursor()
 Utf16String Internals::selected_text_for_clipboard()
 {
     return page().focused_navigable().selected_text();
+}
+
+WebIDL::ExceptionOr<void> Internals::set_clipboard_file(Utf16String const& name, Utf16String const& mime_type, Utf16String const& data)
+{
+    auto mime_type_utf8 = mime_type.to_utf8_but_should_be_ported_to_utf16();
+    auto data_utf8 = data.to_utf8_but_should_be_ported_to_utf16();
+
+    HTML::SelectedFile file { name, MUST(ByteBuffer::copy(data_utf8.bytes())) };
+    Clipboard::SystemClipboardRepresentation item { move(mime_type_utf8), move(file) };
+
+    page().client().page_did_insert_clipboard_item({ { move(item) } }, "unspecified"sv);
+    return {};
 }
 
 void Internals::set_marked_text_from_input_method(Utf16String const& text)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -99,6 +99,7 @@ public:
     Utf16String current_cursor();
 
     Utf16String selected_text_for_clipboard();
+    WebIDL::ExceptionOr<void> set_clipboard_file(Utf16String const& name, Utf16String const& mime_type, Utf16String const& data);
 
     void set_marked_text_from_input_method(Utf16String const& text);
     void commit_text_from_input_method(Utf16String const& text, WebIDL::Long replacement_start, WebIDL::Long replacement_length);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -40,6 +40,8 @@ interface Internals {
     const unsigned short MOD_SUPER = 8;
     const unsigned short MOD_KEYPAD = 16;
 
+    const unsigned short MOD_PLATFORM_CTRL = 10; // MOD_CTRL | MOD_SUPER
+
     const unsigned short BUTTON_LEFT = 0;
     const unsigned short BUTTON_MIDDLE = 1;
     const unsigned short BUTTON_RIGHT = 2;
@@ -68,6 +70,8 @@ interface Internals {
     // Returns the text that would be placed on the clipboard if the user copied the current selection now.
     // Excludes nodes whose used value of user-select is 'none' — mirroring what browsers actually copy.
     Utf16DOMString selectedTextForClipboard();
+
+    undefined setClipboardFile(DOMString name, DOMString mimeType, DOMString data);
 
     // Drive marked/preedit-text composition via the same path platform input methods use. setMarkedTextFromInputMethod
     // updates the inline preedit — replacing any previous preedit. commitText finalizes the composition with the given

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Base64.h>
 #include <AK/Debug.h>
 #include <AK/Math.h>
 #include <LibGC/Heap.h>
@@ -1793,26 +1794,54 @@ EventResult EventHandler::perform_paste_action()
     //     action once the contents arrive.
     document->page().request_clipboard_entries(GC::create_function(document->heap(), [document = GC::Ref { *document }](Vector<Clipboard::SystemClipboardItem> items) {
         auto data_store = HTML::DragDataStore::create();
+
+        auto add_text_item = [&](Utf16FlyString type, Utf16String data) {
+            data_store->add_item({
+                .kind = HTML::DragDataStoreItem::Kind::Text,
+                .type_string = move(type),
+                .data = move(data),
+                .file_data = {},
+                .file_name = {},
+            });
+        };
+
+        auto add_file_item = [&](Utf16FlyString type, Utf16String name, ByteBuffer data) {
+            data_store->add_item({
+                .kind = HTML::DragDataStoreItem::Kind::File,
+                .type_string = move(type),
+                .data = {},
+                .file_data = move(data),
+                .file_name = move(name),
+            });
+        };
+
         if (!items.is_empty()) {
-            for (auto const& representation : items.first().system_clipboard_representations) {
-                // NB: The clipboard representation's type may carry parameters, e.g. "text/plain;charset=utf-8".
-                Utf16FlyString type;
-                if (representation.name == "text/plain"sv || representation.name.starts_with_bytes("text/plain;"sv))
-                    type = "text/plain"_utf16_fly_string;
-                else if (representation.name == "text/html"sv || representation.name.starts_with_bytes("text/html;"sv))
-                    type = "text/html"_utf16_fly_string;
-                else
+            for (auto& representation : items.first().system_clipboard_representations) {
+                auto mime_type = MimeSniff::MimeType::parse(representation.name);
+                if (!mime_type.has_value())
                     continue;
 
-                data_store->add_item({
-                    .kind = HTML::DragDataStoreItem::Kind::Text,
-                    .type_string = move(type),
-                    .data = Utf16String::from_utf8_with_replacement_character(representation.data),
-                    .file_data = {},
-                    .file_name = {},
-                });
+                auto essence = Utf16FlyString::from_utf8(mime_type->essence());
+
+                representation.data.visit(
+                    [&](ByteString const& text) {
+                        auto data = String::from_utf8_with_replacement_character(text);
+
+                        if (essence.is_one_of("text/plain"sv, "text/html"sv)) {
+                            add_text_item(move(essence), Utf16String::from_utf8_with_replacement_character(text));
+                        } else if (essence == "image/png"sv) {
+                            // AD-HOC: The spec doesn't say what to do here, but other engines add a file named
+                            //         image.png for any PNG inserted via navigator.clipboard. Note that only PNG
+                            //         images are supported via that API.
+                            add_file_item(move(essence), "image.png"_utf16, text.to_byte_buffer());
+                        }
+                    },
+                    [&](HTML::SelectedFile& file) {
+                        add_file_item(move(essence), file.name(), file.take_contents());
+                    });
             }
         }
+
         if (auto navigable = document->navigable())
             navigable->event_handler().perform_paste_action(data_store);
     }));
@@ -1841,18 +1870,22 @@ EventResult EventHandler::perform_paste_action(NonnullRefPtr<HTML::DragDataStore
     //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
     auto result = EventResult::Handled;
     if (event_was_not_canceled) {
-        Optional<Utf16View> html;
+        Optional<Utf16String> html;
         Utf16View plain_text;
+
         for (auto const& item : data_store->item_list()) {
-            if (item.kind != HTML::DragDataStoreItem::Kind::Text)
-                continue;
-            if (item.type_string == u"text/html"sv)
+            if (item.type_string == "text/html"sv) {
                 html = item.data;
-            else if (item.type_string == u"text/plain"sv)
+            } else if (item.type_string == "text/plain"sv) {
                 plain_text = item.data;
+            } else if (item.type_string.starts_with("image/"sv)) {
+                if (auto base64 = AK::encode_base64(item.file_data); !base64.is_error())
+                    html = Utf16String::formatted("<img src=\"data:{};base64,{}\" />", item.type_string, base64.value());
+            }
         }
+
         if (html.has_value() || !plain_text.is_empty())
-            result = insert_pasted_content(plain_text, html);
+            result = insert_pasted_content(plain_text, html.map([](auto const& html) -> Utf16View { return html; }));
     }
 
     // The trigger starting a paste can finish before the paste action does — so any input-method state pushed to the UI

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1977,8 +1977,10 @@ bool Application::supports_clipboard_type(ClipboardType type) const
 Utf16String Application::clipboard_text(ClipboardType) const
 {
     for (auto const& representation : m_clipboard.system_clipboard_representations) {
-        if (representation.name == "text/plain"sv)
-            return Utf16String::from_utf8(representation.data);
+        if (representation.name == "text/plain"sv) {
+            if (auto const* data = representation.data.get_pointer<ByteString>())
+                return Utf16String::from_utf8(*data);
+        }
     }
     return {};
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1976,9 +1976,7 @@ bool Application::supports_clipboard_type(ClipboardType type) const
 
 Utf16String Application::clipboard_text(ClipboardType) const
 {
-    if (!m_clipboard.has_value())
-        return {};
-    for (auto const& representation : m_clipboard->system_clipboard_representations) {
+    for (auto const& representation : m_clipboard.system_clipboard_representations) {
         if (representation.name == "text/plain"sv)
             return Utf16String::from_utf8(representation.data);
     }
@@ -1995,18 +1993,6 @@ void Application::set_clipboard_text(String text, ClipboardType)
             },
         },
     };
-}
-
-Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
-{
-    if (!m_clipboard.has_value())
-        return {};
-    return m_clipboard->system_clipboard_representations;
-}
-
-void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item)
-{
-    m_clipboard = move(item);
 }
 
 void Application::insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation entry)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -236,8 +236,8 @@ public:
     virtual Utf16String clipboard_text(ClipboardType = ClipboardType::Text) const;
     virtual void set_clipboard_text(String, ClipboardType = ClipboardType::Text);
 
-    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
-    virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem);
+    virtual Web::Clipboard::SystemClipboardItem clipboard_item() const { return m_clipboard; }
+    virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem item) { m_clipboard = move(item); }
     void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation);
 
     struct BrowsingDataSizes {
@@ -579,7 +579,7 @@ private:
     StringView m_user_agent_string;
     StringView m_navigator_compatibility_mode;
 
-    Optional<Web::Clipboard::SystemClipboardItem> m_clipboard;
+    Web::Clipboard::SystemClipboardItem m_clipboard;
 
     FileDownloader m_file_downloader;
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1922,14 +1922,14 @@ void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpa
     client().async_retrieved_clipboard_entries(page_id(), request_id, items);
 }
 
+Web::Clipboard::SystemClipboardItem ViewImplementation::clipboard_item() const
+{
+    return Application::the().clipboard_item();
+}
+
 void ViewImplementation::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item)
 {
     Application::the().insert_clipboard_item(move(item));
-}
-
-Vector<Web::Clipboard::SystemClipboardRepresentation> ViewImplementation::clipboard_entries() const
-{
-    return Application::the().clipboard_entries();
 }
 
 void ViewImplementation::toggle_page_mute_state()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -502,8 +502,9 @@ protected:
     void did_resume_history_traversal(Web::HTML::CrossProcessId operation_id);
     void did_apply_top_level_history_traversal_step(Web::HTML::CrossProcessId operation_id);
     void did_finish_history_traversal(Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult);
+
+    virtual Web::Clipboard::SystemClipboardItem clipboard_item() const;
     virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem);
-    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const;
 
     virtual bool defer_backing_store_release(i32) { return false; }
     virtual void did_accept_presented_backing_store(i32, Gfx::IntRect) { }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -2153,8 +2153,8 @@ void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         Vector<Web::Clipboard::SystemClipboardItem> items;
-        if (auto entries = view->clipboard_entries(); !entries.is_empty())
-            items.empend(move(entries));
+        if (auto item = view->clipboard_item(); !item.system_clipboard_representations.is_empty())
+            items.append(move(item));
 
         view->retrieved_clipboard_entries(request_id, items);
     }

--- a/Tests/LibWeb/Text/expected/Clipboard/clipboard-shortcut-paste-image.txt
+++ b/Tests/LibWeb/Text/expected/Clipboard/clipboard-shortcut-paste-image.txt
@@ -1,0 +1,6 @@
+api read: type=image/png text="api image payload"
+api paste: kind=file type=image/png file=image.png
+api html: <img src="data:image/png;base64,YXBpIGltYWdlIHBheWxvYWQ=">
+native read: null
+native paste: kind=file type=image/gif file=clipboard.gif
+native html: <img src="data:image/gif;base64,bmF0aXZlIGltYWdlIHBheWxvYWQ=">

--- a/Tests/LibWeb/Text/input/Clipboard/clipboard-shortcut-paste-image.html
+++ b/Tests/LibWeb/Text/input/Clipboard/clipboard-shortcut-paste-image.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true"></div>
+<script>
+    promiseTest(async () => {
+        const setupListener = () => {
+            return new Promise(resolve => {
+                editor.addEventListener(
+                    "paste",
+                    event => {
+                        const item = event.clipboardData.items[0];
+                        const file = event.clipboardData.files[0];
+
+                        // Inserting HTML into the page happens just after this event is fired. Defer resolving the
+                        // promise so the test can inspect the HTML.
+                        setTimeout(() => {
+                            resolve(`kind=${item.kind} type=${item.type} file=${file.name}`);
+                        });
+                    },
+                    { once: true }
+                );
+            });
+        };
+
+        const readClipboard = async () => {
+            internals.dispatchUserActivatedEvent(editor, new Event("mousedown"));
+            const items = await navigator.clipboard.read();
+
+            for (const item of items) {
+                const type = item.types.find(type => type.startsWith("image/"));
+
+                if (type) {
+                    const blob = await item.getType(type);
+                    return `type=${blob.type} text="${await blob.text()}"`;
+                }
+            }
+
+            return null;
+        };
+
+        // Inserting a file via navigator.clipboard.write is accessible via navigator.clipboard.read and via
+        // user-initiated shortcuts.
+        {
+            const promise = setupListener();
+
+            internals.dispatchUserActivatedEvent(editor, new Event("mousedown"));
+            await navigator.clipboard.write([
+                new ClipboardItem({
+                    "image/png": new Blob(["api image payload"], { type: "image/png" }),
+                }),
+            ]);
+            println(`api read: ${await readClipboard()}`);
+
+            internals.sendKey(editor, "V", internals.MOD_PLATFORM_CTRL);
+            println(`api paste: ${await promise}`);
+            println(`api html: ${editor.innerHTML}`);
+        }
+
+        editor.innerHTML = "";
+
+        // A native clipboard file is not accessible via navigator.clipboard.read, but is via user-initiated shortcuts.
+        {
+            const promise = setupListener();
+
+            internals.setClipboardFile("clipboard.gif", "image/gif", "native image payload");
+            println(`native read: ${await readClipboard()}`);
+
+            internals.sendKey(editor, "V", internals.MOD_PLATFORM_CTRL);
+            println(`native paste: ${await promise}`);
+            println(`native html: ${editor.innerHTML}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -43,18 +43,6 @@ pid_t TestWebView::web_content_pid() const
     return client().pid();
 }
 
-void TestWebView::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item)
-{
-    m_clipboard_item = move(item);
-}
-
-Vector<Web::Clipboard::SystemClipboardRepresentation> TestWebView::clipboard_entries() const
-{
-    if (!m_clipboard_item.has_value())
-        return {};
-    return m_clipboard_item->system_clipboard_representations;
-}
-
 NonnullRefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> TestWebView::take_screenshot()
 {
     VERIFY(!m_pending_screenshot);

--- a/Tests/LibWeb/test-web/TestWebView.h
+++ b/Tests/LibWeb/test-web/TestWebView.h
@@ -35,13 +35,14 @@ public:
 private:
     TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);
 
-    virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem) override;
-    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual Web::Clipboard::SystemClipboardItem clipboard_item() const override { return m_clipboard_item; }
+    virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem item) override { m_clipboard_item = move(item); }
 
     virtual void did_receive_screenshot(Badge<WebView::WebContentClient>, Gfx::ShareableBitmap const& screenshot) override;
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> m_pending_screenshot;
 
-    Optional<Web::Clipboard::SystemClipboardItem> m_clipboard_item;
+    Web::Clipboard::SystemClipboardItem m_clipboard_item;
+
     NonnullRefPtr<TestPromise> m_test_promise;
 };
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -40,7 +40,7 @@ private:
     virtual void show_download_in_folder(WebView::FileDownloader::Download const&) const override;
 
     virtual Utf16String clipboard_text(ClipboardType) const override;
-    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual Web::Clipboard::SystemClipboardItem clipboard_item() const override;
     virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem) override;
 
     virtual void rebuild_bookmarks_menu() const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -228,7 +228,7 @@ Utf16String Application::clipboard_text(ClipboardType) const
     return {};
 }
 
-Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
+Web::Clipboard::SystemClipboardItem Application::clipboard_item() const
 {
     Vector<Web::Clipboard::SystemClipboardRepresentation> representations;
     auto* paste_board = [NSPasteboard generalPasteboard];
@@ -242,7 +242,7 @@ Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_ent
         representations.empend(mime_type.release_value(), move(data));
     }
 
-    return representations;
+    return { move(representations) };
 }
 
 void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item)

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -11,6 +11,7 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/SessionStore.h>
 #include <LibWebView/URL.h>
+#include <LibWebView/Utilities.h>
 #include <LibWebView/ViewImplementation.h>
 #include <Utilities/Conversions.h>
 #include <Utilities/ExternalURLHandler.h>
@@ -23,6 +24,7 @@
 #import <Interface/LocationSearchField.h>
 #import <Interface/Tab.h>
 #import <Interface/TabController.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -233,13 +235,31 @@ Web::Clipboard::SystemClipboardItem Application::clipboard_item() const
     Vector<Web::Clipboard::SystemClipboardRepresentation> representations;
     auto* paste_board = [NSPasteboard generalPasteboard];
 
-    for (NSPasteboardType type : [paste_board types]) {
-        auto mime_type = Ladybird::mime_type_for_pasteboard_type(type);
-        if (!mime_type.has_value())
-            continue;
+    auto* file_list = [paste_board readObjectsForClasses:@[ [NSURL class] ]
+                                                 options:@{NSPasteboardURLReadingFileURLsOnlyKey : @YES}];
 
-        auto data = Ladybird::ns_data_to_string([paste_board dataForType:type]);
-        representations.empend(mime_type.release_value(), move(data));
+    for (NSURL* url in file_list) {
+        auto file_path = Ladybird::ns_string_to_byte_string([url path]);
+
+        if (auto file = WebView::create_selected_file(file_path); file.is_error()) {
+            warnln("Unable to open clipboard file {}: {}", file_path, file.error());
+        } else if (auto* resource_values = [url resourceValuesForKeys:@[ NSURLContentTypeKey ] error:nil]) {
+            UTType* content_type = resource_values[NSURLContentTypeKey];
+
+            if (auto* mime_type = [content_type preferredMIMEType])
+                representations.empend(Ladybird::ns_string_to_string(mime_type), file.release_value());
+        }
+    }
+
+    if (representations.is_empty()) {
+        for (NSPasteboardType type : [paste_board types]) {
+            auto mime_type = Ladybird::mime_type_for_pasteboard_type(type);
+            if (!mime_type.has_value())
+                continue;
+
+            auto data = Ladybird::ns_data_to_string([paste_board dataForType:type]);
+            representations.empend(mime_type.release_value(), move(data));
+        }
     }
 
     return { move(representations) };
@@ -255,8 +275,10 @@ void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item
         if (!pasteboard_type)
             continue;
 
-        [paste_board setData:Ladybird::string_to_ns_data(entry.data)
-                     forType:pasteboard_type];
+        if (auto const* data = entry.data.get_pointer<ByteString>()) {
+            [paste_board setData:Ladybird::string_to_ns_data(*data)
+                         forType:pasteboard_type];
+        }
     }
 }
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -884,10 +884,10 @@ void Application::set_clipboard_text(String text, ClipboardType type)
     clipboard->setText(qstring_from_ak_string(text), mode);
 }
 
-Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
+Web::Clipboard::SystemClipboardItem Application::clipboard_item() const
 {
     if (browser_options().headless_mode.has_value())
-        return WebView::Application::clipboard_entries();
+        return WebView::Application::clipboard_item();
 
     Vector<Web::Clipboard::SystemClipboardRepresentation> representations;
     auto const* clipboard = QGuiApplication::clipboard();
@@ -903,7 +903,7 @@ Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_ent
         representations.empend(move(mime_type), move(data));
     }
 
-    return representations;
+    return { move(representations) };
 }
 
 void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -8,6 +8,7 @@
 #include <LibURL/InternalURLs.h>
 #include <LibWebView/SessionStore.h>
 #include <LibWebView/URL.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/EventLoopImplementationQt.h>
@@ -41,6 +42,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QMimeDatabase>
 #include <QPointer>
 #include <QSizePolicy>
 #include <QStandardPaths>
@@ -896,11 +898,33 @@ Web::Clipboard::SystemClipboardItem Application::clipboard_item() const
     if (!mime_data)
         return {};
 
-    for (auto const& format : mime_data->formats()) {
-        auto mime_type = ak_string_from_qstring(format);
-        auto data = ak_byte_string_from_qbytearray(mime_data->data(format));
+    if (mime_data->hasUrls()) {
+        QMimeDatabase mime_database;
 
-        representations.empend(move(mime_type), move(data));
+        for (auto const& url : mime_data->urls()) {
+            if (!url.isLocalFile())
+                continue;
+
+            auto file_path = url.toLocalFile();
+
+            if (auto file = WebView::create_selected_file(ak_byte_string_from_qstring(file_path)); file.is_error()) {
+                warnln("Unable to open clipboard file {}: {}", file_path, file.error());
+            } else {
+                auto mime_type = mime_database.mimeTypeForFile(file_path);
+                representations.empend(ak_string_from_qstring(mime_type.name()), file.release_value());
+            }
+        }
+    }
+
+    if (representations.is_empty()) {
+        for (auto const& format : mime_data->formats()) {
+            auto mime_type = ak_string_from_qstring(format);
+            if (mime_type == "text/uri-list"sv)
+                continue;
+
+            auto data = ak_byte_string_from_qbytearray(mime_data->data(format));
+            representations.empend(move(mime_type), move(data));
+        }
     }
 
     return { move(representations) };
@@ -914,8 +938,10 @@ void Application::insert_clipboard_item(Web::Clipboard::SystemClipboardItem item
     }
 
     auto* mime_data = new QMimeData();
-    for (auto const& entry : item.system_clipboard_representations)
-        mime_data->setData(qstring_from_ak_string(entry.name), qbytearray_from_ak_string(entry.data));
+    for (auto const& entry : item.system_clipboard_representations) {
+        if (auto const* data = entry.data.get_pointer<ByteString>())
+            mime_data->setData(qstring_from_ak_string(entry.name), qbytearray_from_ak_string(*data));
+    }
 
     auto* clipboard = QGuiApplication::clipboard();
     clipboard->setMimeData(mime_data);

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -94,7 +94,7 @@ private:
     virtual Utf16String clipboard_text(ClipboardType) const override;
     virtual void set_clipboard_text(String, ClipboardType = ClipboardType::Text) override;
 
-    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual Web::Clipboard::SystemClipboardItem clipboard_item() const override;
     virtual void insert_clipboard_item(Web::Clipboard::SystemClipboardItem) override;
 
     virtual bool supports_vertical_tabs() const override { return true; }


### PR DESCRIPTION
We previously only support pasting text-based content. The UI would give use a `text/uri-list` entry for files, which we now intercept and convert to an `HTML::SelectedFile` (the same mechanism used to transfer files from input elements and drag-and-drop operations).

There is a bit of a digression around how accessing the clipboard works between user-initiated pastes and DOM APIs (`navigator.clipboard.read`). For the former, pasting content is trusted - users are allowed to paste files as they wish.

For the latter, there is a disagreement between major browsers:
* On Linux, both Chrome and Firefox disallow accessing user-copied files via DOM APIs. The read operation will return an empty list.
* On macOS, Chrome will instead paste the file name. Firefox will paste the image itself without restriction.

This implementation follows Chrome's and Firefox's Linux behavior. We can adjust this in the future if the security is deemed unnecessary.

[paste.webm](https://github.com/user-attachments/assets/4041bf85-9f7a-4bbc-a209-fbfc631ea48d)

Fixes #11456