### PR TITLE
LibWeb: Implement modulepreload processing

### DIFF
--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -69,6 +69,13 @@ ThrowCompletionOr<GC::Ref<SyntheticModule>> parse_json_module(Realm& realm, Utf1
     return SyntheticModule::create_default_export_synthetic_module(realm, json, move(filename));
 }
 
+// 16.2.1.8.5 CreateTextModule ( source ), https://tc39.es/proposal-import-text/#sec-create-text-module
+GC::Ref<SyntheticModule> create_text_module(Realm& realm, Utf16View source, ByteString filename)
+{
+    // 1. Return CreateDefaultExportSyntheticModule(source).
+    return SyntheticModule::create_default_export_synthetic_module(realm, PrimitiveString::create(realm.vm(), source), move(filename));
+}
+
 // 16.2.1.8.3 SetSyntheticModuleExport ( module, exportName, exportValue ), https://tc39.es/ecma262/#sec-setsyntheticmoduleexport
 ThrowCompletionOr<void> SyntheticModule::set_synthetic_module_export(Utf16FlyString const& export_name, Value export_value)
 {

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -42,5 +42,6 @@ private:
 };
 
 ThrowCompletionOr<GC::Ref<SyntheticModule>> JS_API parse_json_module(Realm& realm, Utf16View source_text, ByteString filename);
+GC::Ref<SyntheticModule> JS_API create_text_module(Realm& realm, Utf16View source, ByteString filename);
 
 }

--- a/Libraries/LibWeb/Fetch/Enums.cpp
+++ b/Libraries/LibWeb/Fetch/Enums.cpp
@@ -194,6 +194,8 @@ Bindings::RequestDestination to_bindings_enum(Optional<Infrastructure::Request::
         return Bindings::RequestDestination::Sharedworker;
     case Infrastructure::Request::Destination::Style:
         return Bindings::RequestDestination::Style;
+    case Infrastructure::Request::Destination::Text:
+        return Bindings::RequestDestination::Text;
     case Infrastructure::Request::Destination::Track:
         return Bindings::RequestDestination::Track;
     case Infrastructure::Request::Destination::Video:

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -96,7 +96,7 @@ bool Request::destination_is_script_like() const
 // https://fetch.spec.whatwg.org/#subresource-request
 bool Request::is_subresource_request() const
 {
-    // A subresource request is a request whose destination is "audio", "audioworklet", "font", "image", "json", "manifest", "paintworklet", "script", "style", "track", "video", "xslt", or the empty string.
+    // A subresource request is a request whose destination is "audio", "audioworklet", "font", "image", "json", "manifest", "paintworklet", "script", "style", "text", "track", "video", "xslt", or the empty string.
     static constexpr Array subresource_request_destinations = {
         Destination::Audio,
         Destination::AudioWorklet,
@@ -107,6 +107,7 @@ bool Request::is_subresource_request() const
         Destination::PaintWorklet,
         Destination::Script,
         Destination::Style,
+        Destination::Text,
         Destination::Track,
         Destination::Video,
         Destination::XSLT,
@@ -408,6 +409,8 @@ StringView request_destination_to_string(Request::Destination destination)
         return "sharedworker"sv;
     case Request::Destination::Style:
         return "style"sv;
+    case Request::Destination::Text:
+        return "text"sv;
     case Request::Destination::Track:
         return "track"sv;
     case Request::Destination::Video:
@@ -464,6 +467,8 @@ static Optional<Request::Destination> translate_potential_destination_impl(auto 
         return Request::Destination::SharedWorker;
     if (potential_destination == "style"sv)
         return Request::Destination::Style;
+    if (potential_destination == "text"sv)
+        return Request::Destination::Text;
     if (potential_destination == "track"sv)
         return Request::Destination::Track;
     if (potential_destination == "video"sv)

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -61,6 +61,7 @@ public:
         ServiceWorker,
         SharedWorker,
         Style,
+        Text,
         Track,
         Video,
         WebIdentity,

--- a/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Libraries/LibWeb/Fetch/Request.cpp
@@ -62,6 +62,8 @@ static Bindings::RequestDestination request_destination_to_bindings(Optional<Inf
         return Bindings::RequestDestination::Sharedworker;
     case Infrastructure::Request::Destination::Style:
         return Bindings::RequestDestination::Style;
+    case Infrastructure::Request::Destination::Text:
+        return Bindings::RequestDestination::Text;
     case Infrastructure::Request::Destination::Track:
         return Bindings::RequestDestination::Track;
     case Infrastructure::Request::Destination::Video:

--- a/Libraries/LibWeb/Fetch/Request.idl
+++ b/Libraries/LibWeb/Fetch/Request.idl
@@ -45,7 +45,7 @@ dictionary RequestInit {
     any window; // can only be set to null
 };
 
-enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style",  "track", "video", "worker", "xslt" };
+enum RequestDestination { "", "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "sharedworker", "style", "text", "track", "video", "worker", "xslt" };
 enum RequestMode { "navigate", "same-origin", "no-cors", "cors" };
 enum RequestCredentials { "omit", "same-origin", "include" };
 enum RequestCache { "default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached" };

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -36,6 +36,7 @@
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/Fetching.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Loader/ResourceLoader.h>
@@ -220,6 +221,8 @@ void HTMLLinkElement::attribute_changed(Utf16FlyString const& name, Optional<Utf
                     m_relationship |= Relationship::Alternate;
                 else if (token.equals_ignoring_ascii_case(u"preload"sv))
                     m_relationship |= Relationship::Preload;
+                else if (token.equals_ignoring_ascii_case(u"modulepreload"sv))
+                    m_relationship |= Relationship::ModulePreload;
                 else if (token.equals_ignoring_ascii_case(u"dns-prefetch"sv))
                     m_relationship |= Relationship::DNSPrefetch;
                 else if (token.equals_ignoring_ascii_case(u"preconnect"sv))
@@ -267,6 +270,11 @@ void HTMLLinkElement::attribute_changed(Utf16FlyString const& name, Optional<Utf
                 // FIXME: - When the type attribute of the link element of an external resource link that is already browsing-context connected, but was previously not obtained due to the type attribute specifying an unsupported type for the request destination, is set, removed, or changed.
                 // FIXME: - When the media attribute of the link element of an external resource link that is already browsing-context connected, but was previously not obtained due to the media attribute not matching the environment, is changed or removed.
                 ;
+        }
+
+        if (!fetch && (m_relationship & Relationship::ModulePreload)) {
+            // - When the external resource link is created on a link element that is already browsing-context connected.
+            fetch = name == AttributeNames::rel && !(old_relationship & Relationship::ModulePreload);
         }
 
         if (!fetch && (m_relationship & Relationship::Stylesheet)) {
@@ -442,8 +450,10 @@ void HTMLLinkElement::fetch_and_process_linked_resource()
         document().remove_from_script_blocking_style_sheet_set(*this);
     }
 
-    if (m_relationship & ~(Relationship::DNSPrefetch | Relationship::Preconnect | Relationship::Preload))
+    if (m_relationship & ~(Relationship::DNSPrefetch | Relationship::Preconnect | Relationship::Preload | Relationship::ModulePreload))
         default_fetch_and_process_linked_resource(fetch_generation);
+    else if (m_relationship & Relationship::ModulePreload)
+        fetch_and_process_linked_modulepreload_resource();
     else if (m_relationship & Relationship::Preload)
         fetch_and_process_linked_preload_resource();
     else if (m_relationship & Relationship::Preconnect)
@@ -588,6 +598,145 @@ void HTMLLinkElement::fetch_and_process_linked_preload_resource()
                 link_element->dispatch_event(create_event_for_element(*link_element, HTML::EventNames::load));
         }
     });
+}
+
+static bool media_attribute_matches_environment(DOM::Document const& document, Utf16View media)
+{
+    if (media.is_empty())
+        return true;
+
+    auto media_queries = parse_media_query_list(CSS::Parser::ParsingParams(document), media);
+    for (auto const& media_query : media_queries) {
+        if (media_query->evaluate(document))
+            return true;
+    }
+    return false;
+}
+
+static Optional<Fetch::Infrastructure::Request::Destination> module_preload_destination_from_as_attribute(Utf16View as_attribute)
+{
+    using Destination = Fetch::Infrastructure::Request::Destination;
+
+    // A module preload destination is "json", "style", "text", or a script-like destination.
+    if (as_attribute.equals_ignoring_ascii_case(u"audioworklet"sv))
+        return Destination::AudioWorklet;
+    if (as_attribute.equals_ignoring_ascii_case(u"paintworklet"sv))
+        return Destination::PaintWorklet;
+    if (as_attribute.equals_ignoring_ascii_case(u"script"sv))
+        return Destination::Script;
+    if (as_attribute.equals_ignoring_ascii_case(u"serviceworker"sv))
+        return Destination::ServiceWorker;
+    if (as_attribute.equals_ignoring_ascii_case(u"sharedworker"sv))
+        return Destination::SharedWorker;
+    if (as_attribute.equals_ignoring_ascii_case(u"worker"sv))
+        return Destination::Worker;
+    if (as_attribute.equals_ignoring_ascii_case(u"style"sv))
+        return Destination::Style;
+    if (as_attribute.equals_ignoring_ascii_case(u"json"sv))
+        return Destination::JSON;
+    if (as_attribute.equals_ignoring_ascii_case(u"text"sv))
+        return Destination::Text;
+
+    // NB: The as attribute is enumerated. Invalid and missing values are in no state, so step 2 uses "script".
+    if (as_attribute.is_empty()
+        || !as_attribute.is_one_of_ignoring_ascii_case(
+            u"audio"sv, u"document"sv, u"embed"sv, u"fetch"sv, u"font"sv, u"frame"sv,
+            u"iframe"sv, u"image"sv, u"manifest"sv, u"object"sv, u"report"sv,
+            u"track"sv, u"video"sv, u"webidentity"sv, u"xslt"sv))
+        return Destination::Script;
+
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload:fetch-and-process-the-linked-resource
+void HTMLLinkElement::fetch_and_process_linked_modulepreload_resource()
+{
+    // However, if the link is an external resource link, then the media attribute is prescriptive. The user agent must
+    // apply the external resource when the media attribute's value matches the environment and the other relevant
+    // conditions apply, and must not apply it otherwise.
+    if (!media_attribute_matches_environment(document(), attribute(AttributeNames::media).value_or({})))
+        return;
+
+    // 1. If el's href attribute's value is the empty string, then return.
+    auto href = attribute(AttributeNames::href).value_or({});
+    if (href.is_empty())
+        return;
+
+    // 2. Let destination be the current state of el's as attribute, or "script" if it is in no state.
+    auto destination = module_preload_destination_from_as_attribute(attribute(AttributeNames::as).value_or({}));
+
+    // 3. If destination is not a module preload destination, then queue an element task on the networking task source
+    //    given el to fire an event named error at el, and return.
+    if (!destination.has_value()) {
+        queue_an_element_task(Task::Source::Networking, [this, fetch_generation = m_current_fetch_generation] {
+            // NB: The fetch can be superseded before this task runs.
+            if (fetch_generation != m_current_fetch_generation)
+                return;
+            dispatch_event(create_event_for_element(*this, HTML::EventNames::error));
+        });
+        return;
+    }
+
+    // 4. Let url be the result of encoding-parsing a URL given el's href attribute's value, relative to el's node document.
+    auto url = document().encoding_parse_url(href);
+
+    // 5. If url is failure, then return.
+    if (!url.has_value())
+        return;
+
+    // 6. Let settings object be el's node document's relevant settings object.
+    auto& settings_object = document().relevant_settings_object();
+
+    // 7. Let credentials mode be the CORS settings attribute credentials mode for el's crossorigin attribute.
+    auto credentials_mode = cors_settings_attribute_credentials_mode(cors_setting_attribute_from_keyword(attribute(AttributeNames::crossorigin).map([](auto const& value) { return value.utf16_view(); })));
+
+    // 8. Let cryptographic nonce be el.[[CryptographicNonce]].
+    auto cryptographic_nonce = nonce();
+
+    // 9. Let integrity metadata be the value of el's integrity attribute, if it is specified, or the empty string otherwise.
+    auto integrity_metadata = attribute(AttributeNames::integrity).value_or({});
+
+    // 10. If el does not have an integrity attribute, then set integrity metadata to the result of resolving a module
+    //     integrity metadata with url and settings object.
+    if (!has_attribute(AttributeNames::integrity))
+        integrity_metadata = resolve_a_module_integrity_metadata(*url, settings_object);
+
+    // 11. Let referrer policy be the current state of el's referrerpolicy attribute.
+    auto referrer_policy = ReferrerPolicy::from_string(attribute(AttributeNames::referrerpolicy).value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
+
+    // 12. Let fetch priority be the current state of el's fetchpriority attribute.
+    auto fetch_priority = Fetch::Infrastructure::request_priority_from_string(attribute(AttributeNames::fetchpriority).value_or({})).value_or(Fetch::Infrastructure::Request::Priority::Auto);
+
+    // 13. Let options be a script fetch options whose cryptographic nonce is cryptographic nonce, integrity metadata is
+    //     integrity metadata, parser metadata is "not-parser-inserted", credentials mode is credentials mode, referrer
+    //     policy is referrer policy, and fetch priority is fetch priority.
+    ScriptFetchOptions options {
+        .cryptographic_nonce = move(cryptographic_nonce),
+        .integrity_metadata = move(integrity_metadata),
+        .parser_metadata = Fetch::Infrastructure::Request::ParserMetadata::NotParserInserted,
+        .credentials_mode = credentials_mode,
+        .referrer_policy = referrer_policy,
+        .fetch_priority = fetch_priority,
+    };
+
+    // 14. Fetch a modulepreload module script graph given url, destination, settings object, and options.
+    GC::Weak weak_this { *this };
+    auto fetch_generation = m_current_fetch_generation;
+    auto on_complete = create_on_fetch_script_complete(GC::Heap::the(), [weak_this, fetch_generation](auto result) {
+        auto link_element = weak_this.ptr();
+        if (!link_element || fetch_generation != link_element->m_current_fetch_generation)
+            return;
+
+        // 1. If result is null, then fire an event named error at el, and return.
+        if (!result) {
+            link_element->dispatch_event(create_event_for_element(*link_element, HTML::EventNames::error));
+            return;
+        }
+
+        // 2. Fire an event named load at el.
+        link_element->dispatch_event(create_event_for_element(*link_element, HTML::EventNames::load));
+    });
+    fetch_modulepreload_module_script_graph(relevant_realm(*this), *url, *destination, settings_object, options, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#linked-resource-fetch-setup-steps
@@ -1102,7 +1251,8 @@ bool HTMLLinkElement::should_fetch_and_process_resource_type() const
     // https://html.spec.whatwg.org/multipage/links.html#link-type-preconnect:fetch-and-process-the-linked-resource
     // https://html.spec.whatwg.org/multipage/links.html#link-type-preload:fetch-and-process-the-linked-resource
     // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
-    if (m_relationship & (Relationship::DNSPrefetch | Relationship::Preconnect | Relationship::Preload | Relationship::Stylesheet))
+    // https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload:fetch-and-process-the-linked-resource
+    if (m_relationship & (Relationship::DNSPrefetch | Relationship::Preconnect | Relationship::Preload | Relationship::ModulePreload | Relationship::Stylesheet))
         return true;
 
     // AD-HOC: The spec is underspecified for fetching and processing rel="icon". See:

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -161,6 +161,7 @@ private:
     void fetch_and_process_linked_dns_prefetch_resource();
     void fetch_and_process_linked_preconnect_resource();
     void fetch_and_process_linked_preload_resource();
+    void fetch_and_process_linked_modulepreload_resource();
 
     bool linked_resource_fetch_setup_steps(Fetch::Infrastructure::Request&);
     bool icon_linked_resource_fetch_setup_steps(Fetch::Infrastructure::Request&);
@@ -183,6 +184,7 @@ private:
             DNSPrefetch = 1 << 3,
             Preconnect = 1 << 4,
             Icon = 1 << 5,
+            ModulePreload = 1 << 6,
         };
     };
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -18,6 +18,7 @@ enum PotentialDestination {
     "serviceworker",
     "sharedworker",
     "style",
+    "text",
     "track",
     "video",
     "webidentity",

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
@@ -19,6 +19,7 @@ use std::ffi::c_void;
 pub enum RustFfiPreloadScannerAction {
     Base = 0,
     Fetch = 1,
+    ModulePreload = 2,
 }
 
 #[repr(C)]
@@ -30,6 +31,13 @@ pub enum RustFfiPreloadScannerDestination {
     Script = 3,
     Style = 4,
     Track = 5,
+    AudioWorklet = 6,
+    JSON = 7,
+    PaintWorklet = 8,
+    ServiceWorker = 9,
+    SharedWorker = 10,
+    Worker = 11,
+    Text = 12,
 }
 
 #[repr(C)]
@@ -47,6 +55,17 @@ pub struct RustFfiPreloadScannerEntry {
     pub url_len: usize,
     pub destination: RustFfiPreloadScannerDestination,
     pub cors_setting: RustFfiPreloadScannerCorsSetting,
+    pub nonce_ptr: *const u8,
+    pub nonce_len: usize,
+    pub integrity_ptr: *const u8,
+    pub integrity_len: usize,
+    pub integrity_present: bool,
+    pub referrer_policy_ptr: *const u8,
+    pub referrer_policy_len: usize,
+    pub fetch_priority_ptr: *const u8,
+    pub fetch_priority_len: usize,
+    pub media_ptr: *const u8,
+    pub media_len: usize,
 }
 
 /// Scan pending parser input for resources the speculative HTML parser can fetch.
@@ -184,6 +203,7 @@ fn process_base(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPrel
         href,
         RustFfiPreloadScannerDestination::None,
         RustFfiPreloadScannerCorsSetting::NoCors,
+        None,
     )
 }
 
@@ -201,6 +221,7 @@ fn process_script(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPr
         src,
         RustFfiPreloadScannerDestination::Script,
         cors_setting_from_attribute(attributes),
+        Some(attributes),
     )
 }
 
@@ -216,24 +237,34 @@ fn process_link(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPrel
         return true;
     };
 
-    let destination = if rel_contains_keyword(rel.as_bytes(), b"stylesheet") {
-        RustFfiPreloadScannerDestination::Style
+    let (action, destination) = if rel_contains_keyword(rel.as_bytes(), b"stylesheet") {
+        (
+            RustFfiPreloadScannerAction::Fetch,
+            RustFfiPreloadScannerDestination::Style,
+        )
+    } else if rel_contains_keyword(rel.as_bytes(), b"modulepreload") {
+        let Some(destination) = translate_modulepreload_destination(attribute_value(attributes, attribute_name!("as")))
+        else {
+            return true;
+        };
+        (RustFfiPreloadScannerAction::ModulePreload, destination)
     } else if rel_contains_keyword(rel.as_bytes(), b"preload") {
         let Some(destination) = translate_preload_destination(attribute_value(attributes, attribute_name!("as")))
         else {
             return true;
         };
-        destination
+        (RustFfiPreloadScannerAction::Fetch, destination)
     } else {
         return true;
     };
 
     emit_entry(
         callback,
-        RustFfiPreloadScannerAction::Fetch,
+        action,
         href,
         destination,
         cors_setting_from_attribute(attributes),
+        Some(attributes),
     )
 }
 
@@ -251,6 +282,7 @@ fn process_img(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPrelo
         src,
         RustFfiPreloadScannerDestination::Image,
         cors_setting_from_attribute(attributes),
+        Some(attributes),
     )
 }
 
@@ -260,13 +292,35 @@ fn emit_entry(
     url: &str,
     destination: RustFfiPreloadScannerDestination,
     cors_setting: RustFfiPreloadScannerCorsSetting,
+    attributes: Option<&[Attribute]>,
 ) -> bool {
+    let attribute_pointer_and_length = |name| {
+        attribute_value(attributes.unwrap_or_default(), name)
+            .map(|value| (value.as_ptr(), value.len()))
+            .unwrap_or((std::ptr::null(), 0))
+    };
+    let (nonce_ptr, nonce_len) = attribute_pointer_and_length(attribute_name!("nonce"));
+    let (integrity_ptr, integrity_len) = attribute_pointer_and_length(attribute_name!("integrity"));
+    let (referrer_policy_ptr, referrer_policy_len) = attribute_pointer_and_length(attribute_name!("referrerpolicy"));
+    let (fetch_priority_ptr, fetch_priority_len) = attribute_pointer_and_length(attribute_name!("fetchpriority"));
+    let (media_ptr, media_len) = attribute_pointer_and_length(attribute_name!("media"));
     let entry = RustFfiPreloadScannerEntry {
         action,
         url_ptr: url.as_ptr(),
         url_len: url.len(),
         destination,
         cors_setting,
+        nonce_ptr,
+        nonce_len,
+        integrity_ptr,
+        integrity_len,
+        integrity_present: !integrity_ptr.is_null(),
+        referrer_policy_ptr,
+        referrer_policy_len,
+        fetch_priority_ptr,
+        fetch_priority_len,
+        media_ptr,
+        media_len,
     };
     callback(&entry)
 }
@@ -293,6 +347,70 @@ fn translate_preload_destination(destination: Option<&str>) -> Option<RustFfiPre
         b"track" => RustFfiPreloadScannerDestination::Track,
         _ => return None,
     })
+}
+
+fn translate_modulepreload_destination(destination: Option<&str>) -> Option<RustFfiPreloadScannerDestination> {
+    let Some(destination) = destination else {
+        return Some(RustFfiPreloadScannerDestination::Script);
+    };
+
+    let destination = destination.as_bytes();
+
+    // A module preload destination is "json", "style", "text", or a script-like destination.
+    if destination.eq_ignore_ascii_case(b"audioworklet") {
+        return Some(RustFfiPreloadScannerDestination::AudioWorklet);
+    }
+    if destination.eq_ignore_ascii_case(b"json") {
+        return Some(RustFfiPreloadScannerDestination::JSON);
+    }
+    if destination.eq_ignore_ascii_case(b"paintworklet") {
+        return Some(RustFfiPreloadScannerDestination::PaintWorklet);
+    }
+    if destination.eq_ignore_ascii_case(b"script") {
+        return Some(RustFfiPreloadScannerDestination::Script);
+    }
+    if destination.eq_ignore_ascii_case(b"serviceworker") {
+        return Some(RustFfiPreloadScannerDestination::ServiceWorker);
+    }
+    if destination.eq_ignore_ascii_case(b"sharedworker") {
+        return Some(RustFfiPreloadScannerDestination::SharedWorker);
+    }
+    if destination.eq_ignore_ascii_case(b"style") {
+        return Some(RustFfiPreloadScannerDestination::Style);
+    }
+    if destination.eq_ignore_ascii_case(b"text") {
+        return Some(RustFfiPreloadScannerDestination::Text);
+    }
+    if destination.eq_ignore_ascii_case(b"worker") {
+        return Some(RustFfiPreloadScannerDestination::Worker);
+    }
+
+    const NON_MODULE_DESTINATIONS: [&[u8]; 15] = [
+        b"audio",
+        b"document",
+        b"embed",
+        b"fetch",
+        b"font",
+        b"frame",
+        b"iframe",
+        b"image",
+        b"manifest",
+        b"object",
+        b"report",
+        b"track",
+        b"video",
+        b"webidentity",
+        b"xslt",
+    ];
+    if NON_MODULE_DESTINATIONS
+        .iter()
+        .any(|candidate| destination.eq_ignore_ascii_case(candidate))
+    {
+        return None;
+    }
+
+    // NB: Invalid and empty values put the enumerated as attribute in no state, so step 2 uses "script".
+    Some(RustFfiPreloadScannerDestination::Script)
 }
 
 fn cors_setting_from_attribute(attributes: &[Attribute]) -> RustFfiPreloadScannerCorsSetting {
@@ -429,6 +547,9 @@ mod tests {
         let entries = collect(
             r#"
                 <link rel="modulepreload PRELOAD" as="fetch" href="./fetch">
+                <link rel="modulepreload" href="./module">
+                <link rel="modulepreload" as="JSON" crossorigin="use-credentials" href="./data">
+                <link rel="modulepreload" as="invalid" href="./invalid-default">
                 <link rel="preload stylesheet" as="image" href="./style">
                 <link rel="preload" as="font" href="./font">
                 <link rel="preload" as="IMAGE" href="./invalid-case">
@@ -440,9 +561,21 @@ mod tests {
             entries,
             vec![
                 ScannedEntry {
-                    action: RustFfiPreloadScannerAction::Fetch,
-                    url: "./fetch".to_string(),
-                    destination: RustFfiPreloadScannerDestination::None,
+                    action: RustFfiPreloadScannerAction::ModulePreload,
+                    url: "./module".to_string(),
+                    destination: RustFfiPreloadScannerDestination::Script,
+                    cors_setting: RustFfiPreloadScannerCorsSetting::NoCors,
+                },
+                ScannedEntry {
+                    action: RustFfiPreloadScannerAction::ModulePreload,
+                    url: "./data".to_string(),
+                    destination: RustFfiPreloadScannerDestination::JSON,
+                    cors_setting: RustFfiPreloadScannerCorsSetting::UseCredentials,
+                },
+                ScannedEntry {
+                    action: RustFfiPreloadScannerAction::ModulePreload,
+                    url: "./invalid-default".to_string(),
+                    destination: RustFfiPreloadScannerDestination::Script,
                     cors_setting: RustFfiPreloadScannerCorsSetting::NoCors,
                 },
                 ScannedEntry {
@@ -482,6 +615,41 @@ mod tests {
                 RustFfiPreloadScannerCorsSetting::UseCredentials,
                 RustFfiPreloadScannerCorsSetting::UseCredentials,
             ]
+        );
+    }
+
+    #[test]
+    fn preserves_modulepreload_fetch_options() {
+        let mut options = None;
+        scan(
+            br#"<link rel="modulepreload" href="./module" nonce="abc" integrity="sha256-xyz" referrerpolicy="origin" fetchpriority="high" media="screen">"#,
+            |entry| {
+                let string = |pointer, length| {
+                    let bytes = unsafe { std::slice::from_raw_parts(pointer, length) };
+                    std::str::from_utf8(bytes).unwrap().to_string()
+                };
+                options = Some((
+                    string(entry.nonce_ptr, entry.nonce_len),
+                    string(entry.integrity_ptr, entry.integrity_len),
+                    entry.integrity_present,
+                    string(entry.referrer_policy_ptr, entry.referrer_policy_len),
+                    string(entry.fetch_priority_ptr, entry.fetch_priority_len),
+                    string(entry.media_ptr, entry.media_len),
+                ));
+                true
+            },
+        );
+
+        assert_eq!(
+            options,
+            Some((
+                "abc".to_string(),
+                "sha256-xyz".to_string(),
+                true,
+                "origin".to_string(),
+                "high".to_string(),
+                "screen".to_string(),
+            ))
         );
     }
 }

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
@@ -8,6 +8,7 @@
 #include <AK/FFIHelpers.h>
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/Realm.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
@@ -17,7 +18,9 @@
 #include <LibWeb/HTML/Parser/SpeculativeHTMLParser.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/Fetching.h>
 #include <LibWeb/HTMLTokenizerRustFFI.h>
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web::HTML {
 
@@ -92,6 +95,20 @@ Optional<Fetch::Infrastructure::Request::Destination> destination_from_preload_s
         return Fetch::Infrastructure::Request::Destination::Style;
     case RustFfiPreloadScannerDestination::Track:
         return Fetch::Infrastructure::Request::Destination::Track;
+    case RustFfiPreloadScannerDestination::AudioWorklet:
+        return Fetch::Infrastructure::Request::Destination::AudioWorklet;
+    case RustFfiPreloadScannerDestination::JSON:
+        return Fetch::Infrastructure::Request::Destination::JSON;
+    case RustFfiPreloadScannerDestination::PaintWorklet:
+        return Fetch::Infrastructure::Request::Destination::PaintWorklet;
+    case RustFfiPreloadScannerDestination::ServiceWorker:
+        return Fetch::Infrastructure::Request::Destination::ServiceWorker;
+    case RustFfiPreloadScannerDestination::SharedWorker:
+        return Fetch::Infrastructure::Request::Destination::SharedWorker;
+    case RustFfiPreloadScannerDestination::Worker:
+        return Fetch::Infrastructure::Request::Destination::Worker;
+    case RustFfiPreloadScannerDestination::Text:
+        return Fetch::Infrastructure::Request::Destination::Text;
     }
     VERIFY_NOT_REACHED();
 }
@@ -122,6 +139,67 @@ void issue_speculative_fetch(JS::Realm& realm, DOM::Document& document, URL::URL
     (void)Fetch::Fetching::fetch(realm, request, algorithms);
 }
 
+Utf16String utf16_string_from_preload_scanner(u8 const* pointer, size_t length)
+{
+    if (length == 0)
+        return {};
+    return Utf16String::from_utf8(ffi_string_view(pointer, length));
+}
+
+bool media_attribute_matches_environment(DOM::Document const& document, RustFfiPreloadScannerEntry const& entry)
+{
+    auto media = utf16_string_from_preload_scanner(entry.media_ptr, entry.media_len);
+    if (media.is_empty())
+        return true;
+
+    auto media_queries = parse_media_query_list(CSS::Parser::ParsingParams(document), media);
+    for (auto const& media_query : media_queries) {
+        if (media_query->evaluate(document))
+            return true;
+    }
+    return false;
+}
+
+void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL const& url, RustFfiPreloadScannerEntry const& entry)
+{
+    auto destination = destination_from_preload_scanner(entry.destination);
+    VERIFY(destination.has_value());
+
+    auto& settings_object = document.relevant_settings_object();
+    auto integrity_metadata = entry.integrity_present
+        ? utf16_string_from_preload_scanner(entry.integrity_ptr, entry.integrity_len)
+        : resolve_a_module_integrity_metadata(url, settings_object);
+    ScriptFetchOptions options {
+        .cryptographic_nonce = utf16_string_from_preload_scanner(entry.nonce_ptr, entry.nonce_len),
+        .integrity_metadata = move(integrity_metadata),
+        .parser_metadata = Fetch::Infrastructure::Request::ParserMetadata::NotParserInserted,
+        .credentials_mode = cors_settings_attribute_credentials_mode(cors_setting_from_preload_scanner(entry.cors_setting)),
+        .referrer_policy = ReferrerPolicy::from_string(utf16_string_from_preload_scanner(entry.referrer_policy_ptr, entry.referrer_policy_len)).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString),
+        .fetch_priority = Fetch::Infrastructure::request_priority_from_string(utf16_string_from_preload_scanner(entry.fetch_priority_ptr, entry.fetch_priority_len)).value_or(Fetch::Infrastructure::Request::Priority::Auto),
+    };
+
+    // NB: A speculative fetch must not populate the module map. A CSP meta element can appear between the parser's
+    //     current position and this link, and the real modulepreload fetch must apply that policy before it can reuse
+    //     the response. This request may warm the HTTP cache, while the real link remains authoritative.
+    auto request = Fetch::Infrastructure::Request::create();
+    request->set_url(url);
+    request->set_mode(Fetch::Infrastructure::Request::Mode::CORS);
+    request->set_referrer(Fetch::Infrastructure::Request::Referrer::Client);
+    request->set_client(&settings_object);
+    request->set_destination(*destination);
+    if (first_is_one_of(*destination,
+            Fetch::Infrastructure::Request::Destination::Worker,
+            Fetch::Infrastructure::Request::Destination::SharedWorker,
+            Fetch::Infrastructure::Request::Destination::ServiceWorker))
+        request->set_mode(Fetch::Infrastructure::Request::Mode::SameOrigin);
+    request->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::Script);
+    set_up_module_script_request(request, options);
+
+    Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+    auto algorithms = Fetch::Infrastructure::FetchAlgorithms::create(move(fetch_algorithms_input));
+    (void)Fetch::Fetching::fetch(settings_object.realm(), request, algorithms);
+}
+
 }
 
 void SpeculativeHTMLParser::process_preload_scanner_entry(RustFfiPreloadScannerEntry const& entry)
@@ -141,6 +219,10 @@ void SpeculativeHTMLParser::process_preload_scanner_entry(RustFfiPreloadScannerE
         return;
 
     case RustFfiPreloadScannerAction::Fetch:
+        break;
+    case RustFfiPreloadScannerAction::ModulePreload:
+        if (!media_attribute_matches_environment(*m_document, entry))
+            return;
         break;
     }
 
@@ -164,7 +246,10 @@ void SpeculativeHTMLParser::process_preload_scanner_entry(RustFfiPreloadScannerE
     // 4. Otherwise, fetch url as if the element was processed normally, and add url to the list of
     //    speculative fetch URLs.
     m_document->add_speculative_fetch_url(*url);
-    issue_speculative_fetch(m_document->relevant_settings_object().realm(), *m_document, *url, destination_from_preload_scanner(entry.destination), cors_setting_from_preload_scanner(entry.cors_setting));
+    if (entry.action == RustFfiPreloadScannerAction::ModulePreload)
+        issue_speculative_modulepreload_fetch(*m_document, *url, entry);
+    else
+        issue_speculative_fetch(m_document->relevant_settings_object().realm(), *m_document, *url, destination_from_preload_scanner(entry.destination), cors_setting_from_preload_scanner(entry.cors_setting));
 }
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -332,8 +332,8 @@ bool is_scripting_disabled(EnvironmentSettingsObject const& settings)
 // https://html.spec.whatwg.org/multipage/webappapis.html#module-type-allowed
 bool module_type_allowed(EnvironmentSettingsObject const&, Utf16View module_type)
 {
-    // 1. If moduleType is not "javascript-or-wasm", "css", or "json", then return false.
-    if (module_type != "javascript-or-wasm"sv && module_type != "css"sv && module_type != "json"sv)
+    // 1. If moduleType is not "javascript-or-wasm", "css", "json", or "text", then return false.
+    if (module_type != "javascript-or-wasm"sv && module_type != "css"sv && module_type != "json"sv && module_type != "text"sv)
         return false;
 
     // FIXME: 2. If moduleType is "css" and the CSSStyleSheet interface is not exposed in settings's realm, then return false.

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -629,7 +629,7 @@ static void set_up_classic_script_request(Fetch::Infrastructure::Request& reques
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#set-up-the-module-script-request
-static void set_up_module_script_request(Fetch::Infrastructure::Request& request, ScriptFetchOptions const& options)
+void set_up_module_script_request(Fetch::Infrastructure::Request& request, ScriptFetchOptions const& options)
 {
     // Set request's cryptographic nonce metadata to options's cryptographic nonce, its integrity metadata to options's
     // integrity metadata, its parser metadata to options's parser metadata, its credentials mode to options's credentials
@@ -1346,6 +1346,43 @@ void fetch_external_module_script_graph(JS::Realm& realm, URL::URL const& url, E
 
     // 1. Fetch a single module script given url, settingsObject, "script", options, settingsObject, "client", true, and with the following steps given result:
     fetch_single_module_script(realm, url, settings_object, Fetch::Infrastructure::Request::Destination::Script, options, settings_object, Web::Fetch::Infrastructure::Request::Referrer::Client, {}, TopLevelModule::Yes, nullptr, steps);
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-modulepreload-module-script-graph
+void fetch_modulepreload_module_script_graph(JS::Realm& realm, URL::URL const& url, Fetch::Infrastructure::Request::Destination destination, EnvironmentSettingsObject& settings_object, ScriptFetchOptions const& options, OnFetchScriptComplete on_complete)
+{
+    auto steps = create_on_fetch_script_complete(GC::Heap::the(), [&realm, &settings_object, destination, on_complete](auto result) mutable {
+        // 1. Run onComplete given result.
+        on_complete->function()(result);
+
+        // 2. Assert: settingsObject's global object implements Window.
+        VERIFY(window_from_global_object(settings_object.global_object()));
+
+        // 3. If result is not null, optionally fetch the descendants of and link result given settingsObject,
+        //    destination, and an empty algorithm.
+        if (result) {
+            auto on_descendants_complete = create_on_fetch_script_complete(GC::Heap::the(), [](auto) { });
+            fetch_descendants_of_and_link_a_module_script(realm, as<ModuleScript>(*result), settings_object, destination, nullptr, on_descendants_complete);
+        }
+    });
+
+    // 1. Fetch a single module script given url, settingsObject, destination, options, settingsObject, "client", true,
+    //    and with the following steps given result.
+    // INTEROP: A modulepreload with an as value of "style", "json", or "text" must populate the same module map
+    //          entry as an import with the corresponding type attribute. The HTML algorithm does not currently pass
+    //          a module request to fetch a single module script, but this behavior is covered by web-platform-tests.
+    Optional<JS::ModuleRequest> module_request;
+    if (destination == Fetch::Infrastructure::Request::Destination::Style) {
+        module_request.emplace();
+        module_request->add_attribute("type"_utf16, "css"_utf16);
+    } else if (destination == Fetch::Infrastructure::Request::Destination::JSON) {
+        module_request.emplace();
+        module_request->add_attribute("type"_utf16, "json"_utf16);
+    } else if (destination == Fetch::Infrastructure::Request::Destination::Text) {
+        module_request.emplace();
+        module_request->add_attribute("type"_utf16, "text"_utf16);
+    }
+    fetch_single_module_script(realm, url, settings_object, destination, options, settings_object, Web::Fetch::Infrastructure::Request::Referrer::Client, module_request, TopLevelModule::Yes, nullptr, steps);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -1050,7 +1050,11 @@ Fetch::Infrastructure::Request::Destination fetch_destination_from_module_type(F
     if (module_type == "css"sv)
         return Fetch::Infrastructure::Request::Destination::Style;
 
-    // 3. Return defaultDestination.
+    // 3. If moduleType is "text", then return "text".
+    if (module_type == "text"sv)
+        return Fetch::Infrastructure::Request::Destination::Text;
+
+    // 4. Return defaultDestination.
     return default_destination;
 }
 
@@ -1075,37 +1079,33 @@ void fetch_single_module_script(JS::Realm& realm,
         module_type = module_type_from_module_request(*module_request);
 
     // 3. Assert: the result of running the module type allowed steps given moduleType and settingsObject is true.
-    //    Otherwise we would not have reached this point because a failure would have been raised when inspecting moduleRequest.[[Assertions]]
-    //    in create a JavaScript module script or fetch a single imported module script.
+    //    Otherwise, we would not have reached this point because a failure would have been raised when inspecting
+    //    moduleRequest.[[Attributes]] in HostLoadImportedModule or fetch a single imported module script.
     VERIFY(module_type_allowed(settings_object, module_type));
 
     // 4. Let moduleMap be settingsObject's module map.
     auto& module_map = settings_object.module_map();
 
-    // 5. If moduleMap[(url, moduleType)] is "fetching", wait in parallel until that entry's value changes,
-    //    then queue a task on the networking task source to proceed with running the following steps.
-    if (module_map.is_fetching(url, module_type)) {
-        module_map.wait_for_change(GC::Heap::the(), url, module_type, [on_complete, &realm](auto entry) -> void {
-            HTML::queue_global_task(HTML::Task::Source::Networking, realm.global_object(), GC::create_function(GC::Heap::the(), [on_complete, entry] {
-                // FIXME: This should run other steps, for now we just assume the script loaded.
-                VERIFY(entry.type == ModuleMap::EntryType::ModuleScript || entry.type == ModuleMap::EntryType::Failed);
-
-                on_complete->function()(entry.module_script);
-            }));
-        });
-
-        return;
-    }
-
-    // 6. If moduleMap[(url, moduleType)] exists, run onComplete given moduleMap[(url, moduleType)], and return.
+    // 5. If moduleMap[(url, moduleType)] is a module script, run onComplete given
+    //    moduleMap[(url, moduleType)], and return.
     auto entry = module_map.get(url, module_type);
-    if (entry.has_value()) {
-        on_complete->function()(entry->module_script);
+    if (entry.has_value() && entry->has<GC::Ref<ModuleScript>>()) {
+        on_complete->function()(entry->get<GC::Ref<ModuleScript>>());
         return;
     }
 
-    // 7. Set moduleMap[(url, moduleType)] to "fetching".
-    module_map.set(url, module_type, { ModuleMap::EntryType::Fetching, nullptr });
+    // 6. If moduleMap[(url, moduleType)] is a list, append onComplete to moduleMap[(url, moduleType)], and return.
+    if (entry.has_value() && entry->has<ModuleMap::CallbackList>()) {
+        module_map.append(url, module_type, GC::create_function(GC::Heap::the(), [on_complete](GC::Ptr<ModuleScript> module_script) {
+            on_complete->function()(module_script);
+        }));
+        return;
+    }
+
+    // 7. Set moduleMap[(url, moduleType)] to « onComplete ».
+    ModuleMap::CallbackList callbacks;
+    callbacks.append(GC::create_function(GC::Heap::the(), [on_complete](GC::Ptr<ModuleScript> module_script) { on_complete->function()(module_script); }));
+    module_map.set(url, module_type, move(callbacks));
 
     // 8. Let request be a new request whose URL is url, mode is "cors", referrer is referrer, and client is fetchClient.
     auto request = Fetch::Infrastructure::Request::create();
@@ -1130,16 +1130,19 @@ void fetch_single_module_script(JS::Realm& realm,
     // 13. If performFetch was given, run performFetch with request, isTopLevel, and with processResponseConsumeBody as defined below.
     //     Otherwise, fetch request with processResponseConsumeBody set to processResponseConsumeBody as defined below.
     //     In both cases, let processResponseConsumeBody given response response and null, failure, or a byte sequence bodyBytes be the following algorithm:
-    auto process_response_consume_body = [request, &module_map, url, module_type, &settings_object, on_complete](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
+    auto process_response_consume_body = [request, &module_map, url, module_type, &settings_object](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
         auto internal_response = response->unsafe_response();
 
         // 1. If any of the following are true:
         //    - bodyBytes is null or failure; or
         //    - response's status is not an ok status,
         if (body_bytes.has<Empty>() || body_bytes.has<Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag>() || !Fetch::Infrastructure::is_ok_status(response->status())) {
-            // then set moduleMap[(url, moduleType)] to null, run onComplete given null, and abort these steps.
-            module_map.set(url, module_type, { ModuleMap::EntryType::Failed, nullptr });
-            on_complete->function()(nullptr);
+            // then:
+            // 1. Let callbacks be moduleMap[(url, moduleType)].
+            // 2. Remove moduleMap[(url, moduleType)].
+            // 3. For each callback of callbacks: run callback given null.
+            // 4. Return.
+            module_map.complete_fetch(url, module_type, nullptr);
             return;
         }
 
@@ -1153,7 +1156,7 @@ void fetch_single_module_script(JS::Realm& realm,
         // FIXME: 5. If referrerPolicy is not the empty string, set options's referrer policy to referrerPolicy.
 
         //  6. If mimeType's essence is "application/wasm" and moduleType is "javascript-or-wasm", then set moduleScript
-        //     to the result of creating a WebAssembly module script given bodyBytes, moduleMapRealm, response's URL, and
+        //     to the result of creating a WebAssembly module script given bodyBytes, settingsObject, response's URL, and
         //     options.
         // FIXME: Pass options.
         if (mime_type.has_value() && mime_type->essence() == "application/wasm"sv && module_type == "javascript-or-wasm"sv) {
@@ -1162,14 +1165,22 @@ void fetch_single_module_script(JS::Realm& realm,
 
         // 7. Otherwise
         else {
-            // 2. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to
-            //    the result of creating a JavaScript module script given sourceText, moduleMapRealm, response's URL,
+            // 1. Let sourceText be the result of UTF-8 decoding bodyBytes.
+            auto decoder = TextCodec::decoder_for("UTF-8"sv);
+            VERIFY(decoder.has_value());
+
+            // 2. If moduleType is "text", then set moduleScript to the result of creating a text module script given
+            //    sourceText and settingsObject.
+            if (module_type == "text"sv) {
+                auto source_text = decode_source_text_to_utf16(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
+                module_script = ModuleScript::create_a_text_module_script(url.to_byte_string(), source_text.utf16_view(), settings_object).release_value_but_fixme_should_propagate_errors();
+            }
+
+            // 3. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to
+            //    the result of creating a JavaScript module script given sourceText, settingsObject, response's URL,
             //    and options.
             // FIXME: Pass options.
             if (mime_type.has_value() && mime_type->is_javascript() && module_type == "javascript-or-wasm"sv) {
-                auto decoder = TextCodec::decoder_for("UTF-8"sv);
-                VERIFY(decoder.has_value());
-                auto on_complete_root = GC::make_root(on_complete);
                 auto settings_root = GC::make_root(settings_object);
                 auto url_string = url.to_byte_string();
                 auto response_url = response->url().value_or({});
@@ -1191,7 +1202,6 @@ void fetch_single_module_script(JS::Realm& realm,
                             bytecode_cache_context = move(bytecode_cache_context),
                             source_hash = move(source_hash),
                             source_length,
-                            on_complete_root = move(on_complete_root),
                             settings_root = move(settings_root)](auto bytecode_cache) mutable {
                             Optional<NonnullRefPtr<JS::SourceCode const>> source_code;
                             if (bytecode_cache) {
@@ -1202,8 +1212,7 @@ void fetch_single_module_script(JS::Realm& realm,
                                     source_byte_storage);
                                 auto module_script = ModuleScript::create_from_bytecode_cache(url_string, *source_code, *settings_root, response_url, bytecode_cache.release_nonnull()).release_value_but_fixme_should_propagate_errors();
                                 if (module_script && module_script->parse_error().is_null()) {
-                                    settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                                    on_complete_root->function()(module_script);
+                                    settings_root->module_map().complete_fetch(url, module_type_string, module_script);
                                     return;
                                 }
                                 source_code = {};
@@ -1222,7 +1231,6 @@ void fetch_single_module_script(JS::Realm& realm,
                                     module_type_string = move(module_type_string),
                                     bytecode_cache_context = move(bytecode_cache_context),
                                     source_hash = move(source_hash),
-                                    on_complete_root = move(on_complete_root),
                                     settings_root = move(settings_root)](auto result, auto source_code) mutable {
                                     auto source_code_for_cache = source_code;
                                     auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
@@ -1239,8 +1247,7 @@ void fetch_single_module_script(JS::Realm& realm,
                                         if (!should_generate_bytecode_cache)
                                             compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
                                     }
-                                    settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                                    on_complete_root->function()(module_script);
+                                    settings_root->module_map().complete_fetch(url, module_type_string, module_script);
                                     if (should_generate_bytecode_cache) {
                                         install_target.begin_generation();
                                         VERIFY(source_hash.has_value());
@@ -1262,7 +1269,6 @@ void fetch_single_module_script(JS::Realm& realm,
                         module_type_string = move(module_type_string),
                         bytecode_cache_context = move(bytecode_cache_context),
                         source_hash = move(source_hash),
-                        on_complete_root = move(on_complete_root),
                         settings_root = move(settings_root)](auto result, auto source_code) mutable {
                         auto source_code_for_cache = source_code;
                         auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
@@ -1279,8 +1285,7 @@ void fetch_single_module_script(JS::Realm& realm,
                             if (!should_generate_bytecode_cache)
                                 compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
                         }
-                        settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
-                        on_complete_root->function()(module_script);
+                        settings_root->module_map().complete_fetch(url, module_type_string, module_script);
                         if (should_generate_bytecode_cache) {
                             install_target.begin_generation();
                             VERIFY(source_hash.has_value());
@@ -1290,35 +1295,33 @@ void fetch_single_module_script(JS::Realm& realm,
                 return;
             }
 
-            // FIXME: 3. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to
-            //    the result of creating a JavaScript module script given sourceText, settingsObject, response's URL, and options.
-
             // 4. If the MIME type essence of mimeType is "text/css" and moduleType is "css", then set moduleScript to
             //    the result of creating a CSS module script given sourceText and settingsObject.
             if (mime_type.has_value() && mime_type->essence() == "text/css"sv && module_type == "css"sv) {
-                auto decoder = TextCodec::decoder_for("UTF-8"sv);
-                VERIFY(decoder.has_value());
                 auto source_text = decode_source_text_to_utf16(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
                 module_script = ModuleScript::create_a_css_module_script(url.to_byte_string(), source_text.utf16_view(), settings_object).release_value_but_fixme_should_propagate_errors();
             }
 
-            // 4. If mimeType is a JSON MIME type and moduleType is "json", then set moduleScript to the result of
+            // 5. If mimeType is a JSON MIME type and moduleType is "json", then set moduleScript to the result of
             //    creating a JSON module script given sourceText and settingsObject.
             if (mime_type.has_value() && mime_type->is_json() && module_type == "json"sv) {
-                auto decoder = TextCodec::decoder_for("UTF-8"sv);
-                VERIFY(decoder.has_value());
                 auto source_text = decode_source_text_to_utf16(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
                 module_script = ModuleScript::create_a_json_module_script(url.to_byte_string(), source_text.utf16_view(), settings_object).release_value_but_fixme_should_propagate_errors();
             }
         }
 
-        // 8. Set moduleMap[(url, moduleType)] to moduleScript, and run onComplete given moduleScript.
-        module_map.set(url, module_type, { ModuleMap::EntryType::ModuleScript, module_script });
-        on_complete->function()(module_script);
+        // 8. Let callbacks be moduleMap[(url, moduleType)].
+        // 9. If moduleScript is null, then remove moduleMap[(url, moduleType)]; otherwise set
+        //    moduleMap[(url, moduleType)] to moduleScript.
+        // 10. For each callback of callbacks: run callback given moduleScript.
+        module_map.complete_fetch(url, module_type, module_script);
     };
 
     if (perform_fetch != nullptr) {
-        perform_fetch->function()(request, is_top_level, move(process_response_consume_body)).release_value_but_fixme_should_propagate_errors();
+        auto result = perform_fetch->function()(request, is_top_level, move(process_response_consume_body));
+        // NB: The perform fetch hook can abort without running processResponseConsumeBody.
+        if (result.is_exception())
+            module_map.complete_fetch(url, module_type, nullptr);
     } else {
         Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
         fetch_algorithms_input.process_response_consume_body = move(process_response_consume_body);

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -90,12 +90,14 @@ WebIDL::ExceptionOr<Optional<URL::URL>> resolve_imports_match(Utf16View normaliz
 Optional<URL::URL> resolve_url_like_module_specifier(Utf16View specifier, URL::URL const& base_url);
 ScriptFetchOptions get_descendant_script_fetch_options(ScriptFetchOptions const& original_options, URL::URL const& url, EnvironmentSettingsObject& settings_object);
 Utf16String resolve_a_module_integrity_metadata(URL::URL const& url, EnvironmentSettingsObject& settings_object);
+void set_up_module_script_request(Fetch::Infrastructure::Request&, ScriptFetchOptions const&);
 void fetch_classic_script(GC::Ref<HTMLScriptElement>, URL::URL const&, EnvironmentSettingsObject& settings_object, ScriptFetchOptions options, CORSSettingAttribute cors_setting, Utf16String character_encoding, OnFetchScriptComplete on_complete);
 WEB_API WebIDL::ExceptionOr<void> fetch_classic_worker_script(URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, PerformTheFetchHook, OnFetchScriptComplete);
 WebIDL::ExceptionOr<GC::Ref<ClassicScript>> fetch_a_classic_worker_imported_script(URL::URL const&, HTML::EnvironmentSettingsObject&, PerformTheFetchHook = nullptr);
 WEB_API WebIDL::ExceptionOr<void> fetch_module_worker_script_graph(URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, PerformTheFetchHook, OnFetchScriptComplete);
 WebIDL::ExceptionOr<void> fetch_worklet_module_worker_script_graph(URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, PerformTheFetchHook, OnFetchScriptComplete);
 void fetch_external_module_script_graph(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& settings_object, ScriptFetchOptions const&, OnFetchScriptComplete on_complete);
+void fetch_modulepreload_module_script_graph(JS::Realm&, URL::URL const&, Fetch::Infrastructure::Request::Destination, EnvironmentSettingsObject& settings_object, ScriptFetchOptions const&, OnFetchScriptComplete on_complete);
 void fetch_inline_module_script_graph(JS::Realm&, ByteString const& filename, Utf16View source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, size_t source_line_number, OnFetchScriptComplete on_complete);
 void fetch_single_imported_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, EnvironmentSettingsObject&, Fetch::Infrastructure::Request::ReferrerType, JS::ModuleRequest const&, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 

--- a/Libraries/LibWeb/HTML/Scripting/ModuleMap.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleMap.cpp
@@ -14,57 +14,46 @@ void ModuleMap::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     for (auto& it : m_values)
-        visitor.visit(it.value.module_script);
-
-    for (auto const& it : m_callbacks)
-        visitor.visit(it.value);
+        it.value.visit(
+            [&](GC::Ref<ModuleScript> module_script) { visitor.visit(module_script); },
+            [&](CallbackList const& callbacks) { visitor.visit(callbacks); });
 }
 
-bool ModuleMap::is_fetching(URL::URL const& url, Utf16View type) const
-{
-    return is(url, type, EntryType::Fetching);
-}
-
-bool ModuleMap::is_failed(URL::URL const& url, Utf16View type) const
-{
-    return is(url, type, EntryType::Failed);
-}
-
-bool ModuleMap::is(URL::URL const& url, Utf16View type, EntryType entry_type) const
-{
-    auto value = m_values.get({ url, type });
-    if (!value.has_value())
-        return false;
-
-    return value->type == entry_type;
-}
-
-Optional<ModuleMap::Entry> ModuleMap::get(URL::URL const& url, Utf16View type) const
+Optional<ModuleMap::Entry const&> ModuleMap::get(URL::URL const& url, Utf16View type) const
 {
     return m_values.get({ url, type });
 }
 
-AK::HashSetResult ModuleMap::set(URL::URL const& url, Utf16View type, Entry entry)
+void ModuleMap::set(URL::URL const& url, Utf16View type, CallbackList callbacks)
 {
-    // NOTE: Re-entering this function while firing wait_for_change callbacks is not allowed.
-    VERIFY(!m_firing_callbacks);
-
-    auto value = m_values.set({ url, type }, entry);
-
-    auto callbacks = m_callbacks.get({ url, type });
-    if (callbacks.has_value()) {
-        m_firing_callbacks = true;
-        for (auto const& callback : *callbacks)
-            callback->function()(entry);
-        m_firing_callbacks = false;
-    }
-
-    return value;
+    VERIFY(!m_values.contains({ url, type }));
+    m_values.set({ url, type }, move(callbacks));
 }
 
-void ModuleMap::wait_for_change(GC::Heap& heap, URL::URL const& url, Utf16View type, Function<void(Entry)> callback)
+void ModuleMap::append(URL::URL const& url, Utf16View type, CallbackFunction callback)
 {
-    m_callbacks.ensure({ url, type }).append(GC::create_function(heap, move(callback)));
+    auto entry = m_values.find({ url, type });
+    VERIFY(entry != m_values.end());
+    entry->value.get<CallbackList>().append(move(callback));
+}
+
+void ModuleMap::complete_fetch(URL::URL const& url, Utf16View type, GC::Ptr<ModuleScript> module_script)
+{
+    auto entry = m_values.take({ url, type });
+    VERIFY(entry.has_value());
+    auto value = entry.release_value();
+    auto callbacks_to_invoke = move(value.get<CallbackList>());
+
+    Vector<GC::Root<GC::Function<void(GC::Ptr<ModuleScript>)>>> callbacks;
+    callbacks.ensure_capacity(callbacks_to_invoke.size());
+    for (auto const& callback : callbacks_to_invoke)
+        callbacks.unchecked_append(GC::make_root(callback));
+
+    if (module_script)
+        m_values.set({ url, type }, GC::Ref { *module_script });
+
+    for (auto const& callback : callbacks)
+        callback->function()(module_script);
 }
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
+#include <AK/Variant.h>
 #include <LibGC/Function.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
@@ -46,37 +47,25 @@ public:
     ModuleMap() = default;
     ~ModuleMap() = default;
 
-    enum class EntryType {
-        Fetching,
-        Failed,
-        ModuleScript
-    };
+    using CallbackFunction = GC::Ref<GC::Function<void(GC::Ptr<ModuleScript>)>>;
+    using CallbackList = Vector<CallbackFunction>;
 
-    struct Entry {
-        EntryType type;
-        GC::Ptr<ModuleScript> module_script;
-    };
+    // A module map is a map keyed by tuples consisting of a URL record and a string. The URL record is the request URL
+    // at which the module was fetched, and the string indicates the type of the module (e.g. "javascript-or-wasm").
+    // The module map's values are either a module script or a list of algorithms (that are waiting for the fetch to
+    // complete).
+    using Entry = Variant<GC::Ref<ModuleScript>, CallbackList>;
 
-    using CallbackFunction = GC::Ref<GC::Function<void(Entry)>>;
+    Optional<Entry const&> get(URL::URL const& url, Utf16View type) const;
 
-    bool is_fetching(URL::URL const& url, Utf16View type) const;
-    bool is_failed(URL::URL const& url, Utf16View type) const;
-
-    bool is(URL::URL const& url, Utf16View type, EntryType) const;
-
-    Optional<Entry> get(URL::URL const& url, Utf16View type) const;
-
-    AK::HashSetResult set(URL::URL const& url, Utf16View type, Entry);
-
-    void wait_for_change(GC::Heap&, URL::URL const& url, Utf16View type, Function<void(Entry)> callback);
+    void set(URL::URL const& url, Utf16View type, CallbackList);
+    void append(URL::URL const& url, Utf16View type, CallbackFunction);
+    void complete_fetch(URL::URL const& url, Utf16View type, GC::Ptr<ModuleScript>);
 
 private:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     HashMap<ModuleLocationTuple, Entry> m_values;
-    HashMap<ModuleLocationTuple, Vector<CallbackFunction>> m_callbacks;
-
-    bool m_firing_callbacks { false };
 };
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -218,6 +218,30 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_json_module_sc
     return script;
 }
 
+// https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-text-module-script
+WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_text_module_script(ByteString const& filename, Utf16View text, EnvironmentSettingsObject& settings)
+{
+    auto& realm = settings.realm();
+
+    // 1. Let script be a new module script that this algorithm will subsequently initialize.
+    // 2. Set script's settings object to settings.
+    // 3. Set script's base URL and fetch options to null.
+    auto script = create_internal(Optional<URL::URL> {}, filename, settings);
+
+    // 4. Set script's parse error and error to rethrow to null.
+    script->set_parse_error(JS::js_null());
+    script->set_error_to_rethrow(JS::js_null());
+
+    // 5. Let result be CreateTextModule(text).
+    auto result = JS::create_text_module(realm, text, filename);
+
+    // 6. Set script's record to result.
+    script->m_record = result;
+
+    // 7. Return script.
+    return script;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-webassembly-module-script
 WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_webassembly_module_script(ByteString const& filename, ByteBuffer body_bytes, EnvironmentSettingsObject& settings, URL::URL base_url)
 {

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -37,6 +37,7 @@ public:
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_javascript_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, ScriptRegistry::IsInlineSource = ScriptRegistry::IsInlineSource::No);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_css_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_json_module_script(ByteString const& filename, Utf16View source, EnvironmentSettingsObject&);
+    static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_text_module_script(ByteString const& filename, Utf16View text, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_webassembly_module_script(ByteString const& filename, ByteBuffer body_bytes, EnvironmentSettingsObject&, URL::URL base_url);
 
     enum class PreventErrorReporting {

--- a/Libraries/LibWeb/Loader/ContentBlocker.cpp
+++ b/Libraries/LibWeb/Loader/ContentBlocker.cpp
@@ -301,6 +301,8 @@ ContentBlocker::ResourceType ContentBlocker::resource_type_from_fetch_metadata(O
             return ResourceType::Script;
         case Request::Destination::Style:
             return ResourceType::Stylesheet;
+        case Request::Destination::Text:
+            return ResourceType::Other;
         case Request::Destination::JSON:
         case Request::Destination::Manifest:
         case Request::Destination::Report:

--- a/Tests/LibWeb/Text/expected/HTML/ModuleLoading/text-module.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ModuleLoading/text-module.txt
@@ -1,0 +1,2 @@
+PASS: text modules expose their source as the default export
+PASS: text modules only expose a default export

--- a/Tests/LibWeb/Text/expected/HTML/modulepreload-csp.txt
+++ b/Tests/LibWeb/Text/expected/HTML/modulepreload-csp.txt
@@ -1,0 +1,1 @@
+PASS: speculative module preload does not bypass a later CSP meta policy

--- a/Tests/LibWeb/Text/expected/HTML/modulepreload.txt
+++ b/Tests/LibWeb/Text/expected/HTML/modulepreload.txt
@@ -1,0 +1,9 @@
+PASS: module preload starts before the parser reaches the module import
+PASS: module preload discovers dependencies before the module import
+PASS: static import reuses the preloaded module graph
+PASS: dynamically inserted module preload is reused by import()
+PASS: cross-origin module preload uses CORS without cross-origin credentials by default
+PASS: crossorigin=use-credentials uses credentialed CORS
+PASS: failed module preload dispatches error and a later import retries
+PASS: text module preload is reused by import()
+PASS: non-matching media suppresses module preload fetching and events

--- a/Tests/LibWeb/Text/input/HTML/ModuleLoading/text-module.html
+++ b/Tests/LibWeb/Text/input/HTML/ModuleLoading/text-module.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const text = "hello from a text module";
+        const module = await import(`data:text/plain,${encodeURIComponent(text)}`, { with: { type: "text" } });
+
+        println(`${module.default === text ? "PASS" : "FAIL"}: text modules expose their source as the default export`);
+        const keys = Reflect.ownKeys(module);
+        println(`${keys.length === 2 && keys[0] === "default" && keys[1] === Symbol.toStringTag ? "PASS" : "FAIL"}: text modules only expose a default export`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/modulepreload-csp.html
+++ b/Tests/LibWeb/Text/input/HTML/modulepreload-csp.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+
+        const server = httpTestServer();
+        const run = crypto.randomUUID();
+        const parserGate = `${run}-parser`;
+        const path = name => `/modulepreload-csp-${run}-${name}`;
+        const javascriptHeaders = { "Content-Type": "text/javascript" };
+
+        const moduleURL = new URL(await server.createEcho("GET", path("cross-origin.js"), {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "text/javascript",
+            },
+            body: "export default 42;",
+        }));
+        moduleURL.hostname = uniqueLocalhostHostname("modulepreload-csp");
+
+        const parserBlockerURL = await server.createEcho("GET", path("parser-blocker.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "",
+            wait_for_unblock: parserGate,
+        });
+
+        const linkStartTag = "<li" + "nk";
+        const scriptStartTag = "<scr" + "ipt";
+        const scriptEndTag = "</scr" + "ipt>";
+        const pageScript = `
+            const link = document.getElementById("preload");
+            const linkEvent = link.dataset.event
+                ? Promise.resolve(link.dataset.event)
+                : new Promise(resolve => {
+                    link.onload = () => resolve("load");
+                    link.onerror = () => resolve("error");
+                });
+
+            let importRejected = false;
+            try {
+                await import(${JSON.stringify(moduleURL.href)});
+            } catch {
+                importRejected = true;
+            }
+
+            parent.postMessage({
+                type: "modulepreload-csp-results",
+                importRejected,
+                linkEvent: await linkEvent,
+                speculativeRequestCount: performance.getEntriesByName(${JSON.stringify(moduleURL.href)}).length,
+            }, "*");
+        `;
+        const pageBody = `<!DOCTYPE html>
+            <head>
+            ${scriptStartTag} src="${parserBlockerURL}">${scriptEndTag}
+            <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+            ${linkStartTag} id="preload" rel="modulepreload" href="${moduleURL.href}" onload="this.dataset.event='load'" onerror="this.dataset.event='error'">
+            ${scriptStartTag} type="module">${pageScript}${scriptEndTag}
+            </head>`;
+        const pageURL = await server.createEcho("GET", path("page.html"), {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: pageBody,
+        });
+
+        const hasRecordedRequest = async url => {
+            const resourceURL = new URL(url);
+            try {
+                const response = await fetch(`${server.baseURL}/recorded-request-headers${resourceURL.pathname}`);
+                return response.ok;
+            } catch {
+                return false;
+            }
+        };
+        const resultsPromise = new Promise(resolve => {
+            window.addEventListener("message", event => {
+                if (event.data.type === "modulepreload-csp-results")
+                    resolve(event.data);
+            });
+        });
+
+        const frame = document.createElement("iframe");
+        frame.src = pageURL;
+        document.body.appendChild(frame);
+
+        while (!await hasRecordedRequest(moduleURL)) { }
+        await fetch(`${server.baseURL}/unblock/${parserGate}`);
+
+        const results = await resultsPromise;
+        println(`${results.speculativeRequestCount === 1 && results.linkEvent === "error" && results.importRejected ? "PASS" : "FAIL"}: speculative module preload does not bypass a later CSP meta policy`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/modulepreload.html
+++ b/Tests/LibWeb/Text/input/HTML/modulepreload.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+
+        const server = httpTestServer();
+        const run = crypto.randomUUID();
+        const moduleGate = `${run}-module`;
+        const parserGate = `${run}-parser`;
+        const path = name => `/modulepreload-${run}-${name}`;
+        const javascriptHeaders = { "Content-Type": "text/javascript" };
+
+        const dependencyURL = await server.createEcho("GET", path("dependency.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "export const dependency = 7;",
+        });
+        const moduleURL = await server.createEcho("GET", path("module.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: `import { dependency } from ${JSON.stringify(dependencyURL)}; export default dependency;`,
+            wait_for_unblock: moduleGate,
+        });
+        const parserBlockerURL = await server.createEcho("GET", path("parser-blocker.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "",
+            wait_for_unblock: parserGate,
+        });
+        const dynamicURL = await server.createEcho("GET", path("dynamic.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "export default 11;",
+        });
+        const failedURL = await server.createEcho("GET", path("failed.js"), {
+            status: 404,
+            headers: javascriptHeaders,
+            body: "",
+        });
+        const textURL = await server.createEcho("GET", path("text.txt"), {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+            body: "hello from a text module",
+        });
+        const nonMatchingMediaURL = await server.createEcho("GET", path("non-matching-media.js"), {
+            status: 200,
+            headers: javascriptHeaders,
+            body: "export default 23;",
+        });
+
+        const crossOriginHost = uniqueLocalhostHostname("modulepreload");
+        const crossOriginURL = url => {
+            const result = new URL(url);
+            result.hostname = crossOriginHost;
+            return result.href;
+        };
+        const credentialedCorsHeaders = {
+            "Access-Control-Allow-Credentials": "true",
+            "Access-Control-Allow-Origin": server.baseURL,
+            "Content-Type": "text/javascript",
+        };
+        const crossOriginSameOriginCredentialsURL = crossOriginURL(await server.createEcho("GET", path("cross-origin-same-origin-credentials.js"), {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "text/javascript",
+            },
+            body: "export default 13;",
+        }));
+        const crossOriginIncludeCredentialsURL = crossOriginURL(await server.createEcho("GET", path("cross-origin-include-credentials.js"), {
+            status: 200,
+            headers: credentialedCorsHeaders,
+            body: "export default 17;",
+        }));
+        const crossOriginWildcardCredentialsURL = crossOriginURL(await server.createEcho("GET", path("cross-origin-wildcard-credentials.js"), {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Credentials": "true",
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "text/javascript",
+            },
+            body: "export default 19;",
+        }));
+
+        const urls = {
+            crossOriginIncludeCredentialsURL,
+            crossOriginSameOriginCredentialsURL,
+            crossOriginWildcardCredentialsURL,
+            dynamicURL,
+            failedURL,
+            textURL,
+        };
+        const pageScript = `
+            import staticValue from ${JSON.stringify(moduleURL)};
+
+            const urls = ${JSON.stringify(urls)};
+            const requestCount = url => performance.getEntriesByName(url).length;
+            const recordedHeaders = async url => {
+                const resourceURL = new URL(url);
+                const response = await fetch(\`/recorded-request-headers\${resourceURL.pathname}\`);
+                const headers = await response.json();
+                return Object.fromEntries(Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]));
+            };
+            const preload = (url, attributes = {}) => new Promise(resolve => {
+                const link = document.createElement("link");
+                link.rel = "modulepreload";
+                link.href = url;
+                Object.assign(link, attributes);
+                link.onload = () => resolve("load");
+                link.onerror = () => resolve("error");
+                document.head.appendChild(link);
+            });
+            const parserInsertedLinkEvent = id => {
+                const link = document.getElementById(id);
+                if (link.dataset.event)
+                    return Promise.resolve(link.dataset.event);
+                return new Promise(resolve => {
+                    link.onload = () => resolve("load");
+                    link.onerror = () => resolve("error");
+                });
+            };
+
+            (async () => {
+                const dynamicEvent = await preload(urls.dynamicURL);
+                const dynamicValue = (await import(urls.dynamicURL)).default;
+
+                const sameOriginCredentialsEvent = await parserInsertedLinkEvent("cross-origin-same-origin-credentials");
+                const sameOriginCredentialsHeaders = await recordedHeaders(urls.crossOriginSameOriginCredentialsURL);
+                const includeCredentialsEvent = await parserInsertedLinkEvent("cross-origin-include-credentials");
+                const includeCredentialsHeaders = await recordedHeaders(urls.crossOriginIncludeCredentialsURL);
+                const wildcardCredentialsEvent = await parserInsertedLinkEvent("cross-origin-wildcard-credentials");
+
+                const failedEvent = await preload(urls.failedURL);
+                let failedImportRejected = false;
+                try {
+                    await import(urls.failedURL);
+                } catch {
+                    failedImportRejected = true;
+                }
+
+                const textEvent = await preload(urls.textURL, { as: "text" });
+                const textValue = (await import(urls.textURL, { with: { type: "text" } })).default;
+
+                parent.postMessage({
+                    type: "modulepreload-results",
+                    results: {
+                        crossOriginIncludeCredentialsEvent: includeCredentialsEvent,
+                        crossOriginIncludeCredentialsOrigin: includeCredentialsHeaders.origin?.length > 0,
+                        crossOriginSameOriginCredentialsEvent: sameOriginCredentialsEvent,
+                        crossOriginSameOriginCredentialsOrigin: sameOriginCredentialsHeaders.origin?.length > 0,
+                        crossOriginWildcardCredentialsEvent: wildcardCredentialsEvent,
+                        dependencyRequestCount: requestCount(${JSON.stringify(dependencyURL)}),
+                        dynamicEvent,
+                        dynamicRequestCount: requestCount(urls.dynamicURL),
+                        dynamicValue,
+                        failedEvent,
+                        failedImportRejected,
+                        failedRequestCount: requestCount(urls.failedURL),
+                        nonMatchingMediaEvent: document.getElementById("non-matching-media").dataset.event ?? "none",
+                        nonMatchingMediaRequestCount: requestCount(${JSON.stringify(nonMatchingMediaURL)}),
+                        staticRequestCount: requestCount(${JSON.stringify(moduleURL)}),
+                        staticValue,
+                        textEvent,
+                        textRequestCount: requestCount(urls.textURL),
+                        textValue,
+                    },
+                }, "*");
+            })().catch(error => parent.postMessage({ type: "modulepreload-error", error: String(error) }, "*"));
+        `;
+        const linkStartTag = "<li" + "nk";
+        const scriptStartTag = "<scr" + "ipt";
+        const scriptEndTag = "</scr" + "ipt>";
+        const pageBody = `<!DOCTYPE html>
+            ${linkStartTag} rel="modulepreload" href="${moduleURL}">
+            ${linkStartTag} id="cross-origin-same-origin-credentials" rel="modulepreload" href="${crossOriginSameOriginCredentialsURL}" onload="this.dataset.event='load'" onerror="this.dataset.event='error'">
+            ${linkStartTag} id="cross-origin-include-credentials" rel="modulepreload" href="${crossOriginIncludeCredentialsURL}" crossorigin="use-credentials" onload="this.dataset.event='load'" onerror="this.dataset.event='error'">
+            ${linkStartTag} id="cross-origin-wildcard-credentials" rel="modulepreload" href="${crossOriginWildcardCredentialsURL}" crossorigin="use-credentials" onload="this.dataset.event='load'" onerror="this.dataset.event='error'">
+            ${linkStartTag} id="non-matching-media" rel="modulepreload" href="${nonMatchingMediaURL}" media="not all" onload="this.dataset.event='load'" onerror="this.dataset.event='error'">
+            ${scriptStartTag} src="${parserBlockerURL}">${scriptEndTag}
+            ${scriptStartTag} type="module">${pageScript}${scriptEndTag}`;
+        const pageURL = await server.createEcho("GET", path("page.html"), {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: pageBody,
+        });
+
+        const hasRecordedRequest = async url => {
+            const resourceURL = new URL(url);
+            try {
+                const response = await fetch(`${server.baseURL}/recorded-request-headers${resourceURL.pathname}`);
+                return response.ok;
+            } catch {
+                return false;
+            }
+        };
+        const waitForRequest = async url => {
+            while (!await hasRecordedRequest(url)) { }
+        };
+        const resultsPromise = new Promise((resolve, reject) => {
+            window.addEventListener("message", event => {
+                if (event.data.type === "modulepreload-results")
+                    resolve(event.data.results);
+                else if (event.data.type === "modulepreload-error")
+                    reject(new Error(event.data.error));
+            });
+        });
+
+        const frame = document.createElement("iframe");
+        frame.src = pageURL;
+        document.body.appendChild(frame);
+
+        await waitForRequest(moduleURL);
+        println("PASS: module preload starts before the parser reaches the module import");
+        await fetch(`${server.baseURL}/unblock/${moduleGate}`);
+
+        await waitForRequest(dependencyURL);
+        println("PASS: module preload discovers dependencies before the module import");
+        await fetch(`${server.baseURL}/unblock/${parserGate}`);
+
+        const results = await resultsPromise;
+        println(`${results.staticValue === 7 && results.staticRequestCount === 1 && results.dependencyRequestCount === 1 ? "PASS" : "FAIL"}: static import reuses the preloaded module graph`);
+        println(`${results.dynamicEvent === "load" && results.dynamicValue === 11 && results.dynamicRequestCount === 1 ? "PASS" : "FAIL"}: dynamically inserted module preload is reused by import()`);
+        println(`${results.crossOriginSameOriginCredentialsEvent === "load" && results.crossOriginSameOriginCredentialsOrigin ? "PASS" : "FAIL"}: cross-origin module preload uses CORS without cross-origin credentials by default`);
+        println(`${results.crossOriginIncludeCredentialsEvent === "load" && results.crossOriginIncludeCredentialsOrigin && results.crossOriginWildcardCredentialsEvent === "error" ? "PASS" : "FAIL"}: crossorigin=use-credentials uses credentialed CORS`);
+        println(`${results.failedEvent === "error" && results.failedImportRejected && results.failedRequestCount === 2 ? "PASS" : "FAIL"}: failed module preload dispatches error and a later import retries`);
+        println(`${results.textEvent === "load" && results.textValue === "hello from a text module" && results.textRequestCount === 1 ? "PASS" : "FAIL"}: text module preload is reused by import()`);
+        println(`${results.nonMatchingMediaEvent === "none" && results.nonMatchingMediaRequestCount === 0 ? "PASS" : "FAIL"}: non-matching media suppresses module preload fetching and events`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Implement `<link rel="modulepreload">` using the HTML module-script fetching algorithms, including typed destinations, CORS credentials, integrity metadata, referrer policy, fetch priority, load and error events, dependency fetching, and module-map reuse.

Extend the Rust preload scanner to discover modulepreload links during parsing and preserve their fetch options through minimal FFI. Speculative requests warm the HTTP cache without populating the module map, ensuring that CSP policies introduced later in document order remain authoritative. Nonmatching media queries suppress both speculative and authoritative fetching.

Align module-map handling with the current HTML specification by sharing in-progress fetches through callback lists and removing failed entries. Add text-module support and retain the existing off-thread compilation path for downloaded JavaScript.