### PR TITLE
LibWeb: Reduce structural style invalidation overhead

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -354,7 +354,15 @@ impl StyleEngine {
                     .collect();
                 self.retain_selector_incidences(&programs, root);
             }
-            let mut resident_nodes: Vec<StyleNodeID> = if outer_arrivals.is_empty() {
+            // Only program routing joins against the resident nodes, and a transaction of pure
+            // DOM inputs has no program joins at all. Walking every element of the document to
+            // enumerate them for such a transaction would be the flush's single largest cost.
+            let program_routing_needs_resident_nodes = !outer_arrivals.is_empty()
+                && transaction
+                    .inputs
+                    .iter()
+                    .any(|input| !transaction.program_joins_for(input.key).is_empty());
+            let mut resident_nodes: Vec<StyleNodeID> = if !program_routing_needs_resident_nodes {
                 Vec::new()
             } else if regions.topology_node_count() == connected_element_count {
                 regions
@@ -428,7 +436,7 @@ impl StyleEngine {
                     &program_delta.arriving_rules,
                     &program_delta.departed_scopes,
                     ProgramRoutingContext {
-                        resident_nodes: (!outer_arrivals.is_empty()).then_some(resident_nodes.as_slice()),
+                        resident_nodes: program_routing_needs_resident_nodes.then_some(resident_nodes.as_slice()),
                         winner_program_version: transaction.program_base_version,
                         document_root: root,
                         attachment_scopes: None,
@@ -449,7 +457,7 @@ impl StyleEngine {
                         &program_delta.arriving_rules,
                         &program_delta.departed_scopes,
                         ProgramRoutingContext {
-                            resident_nodes: (!outer_arrivals.is_empty()).then_some(resident_nodes.as_slice()),
+                            resident_nodes: program_routing_needs_resident_nodes.then_some(resident_nodes.as_slice()),
                             winner_program_version: transaction.program_base_version,
                             document_root: root,
                             attachment_scopes: Some(scopes),

--- a/Libraries/LibWeb/Rust/src/css/style/flush.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/flush.rs
@@ -43,6 +43,13 @@ impl StyleEngine {
         let initial_tree_was_bulk_loaded = self.initial_tree_bulk_load_is_pending && document_root_arrival_is_pending;
         let publish_document_root_arrival = document_root_arrival_is_pending;
 
+        // Whatever the last flush's late exact asks left in the flush-local workspace was measured
+        // in the previous topology. Every exact evaluation below reads current-side sibling
+        // geometry from it, so it starts empty here, before this transaction's tree is applied.
+        let stale_match_workspace_bytes = self.match_workspace.capacity_bytes();
+        self.match_workspace = MatchEvaluationWorkspace::default();
+        self.memory
+            .release(MemoryCategory::BatchScratch, stale_match_workspace_bytes);
         let mut transaction = self.drain_transaction();
         self.apply_staged_transaction(&mut transaction);
         if transaction.is_empty() {

--- a/Libraries/LibWeb/Rust/src/css/style/planning.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/planning.rs
@@ -1482,11 +1482,15 @@ impl ExactTreeEvaluation {
         counters: &mut Counters,
     ) -> Result<ExactEntryResult, Incomplete> {
         let (compiled, entry) = program;
-        // The workspace can retain current-side relation answers from matching before this tree
-        // transaction. Evaluate the new side from the authoritative tree instead of reusing
-        // positions measured in the previous topology.
+        // The new side reads the authoritative tree, which every candidate of this transaction
+        // shares. The workspace's current tree side was reset when the transaction began, so the
+        // sibling positions it memoizes were all measured in this topology, and a sequence that
+        // several positional entries ask about is counted once rather than once per candidate.
         let evaluate_new = |counters: &mut Counters| {
-            MatchEvaluator::new(tree, facts).matches_entry_without_program_caches(compiled, entry, node, counters)
+            MatchEvaluator::new(tree, facts)
+                .with_match_workspace(match_workspace, MatchEvaluationSide::Current)
+                .indexing_stepped_positions_only()
+                .matches_entry_without_program_caches(compiled, entry, node, counters)
         };
         let evaluate_old = |view: &TransactionFactView, counters: &mut Counters| match view.is_present(
             tree,

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -1377,6 +1377,15 @@ impl StyleEngine {
             return;
         }
         let sequence_match_workspace = MatchEvaluationWorkspace::default();
+        // What an entry's selector says about the parent of its positional test holds for the
+        // whole sequence, so it is decided once per entry here rather than once per moved child.
+        const PARENT_UNDECIDED: u8 = 0;
+        const PARENT_ADMITS: u8 = 1;
+        const PARENT_REJECTS: u8 = 2;
+        let mut parent_verdicts = vec![PARENT_UNDECIDED; entries.len()];
+        let parent_verdict_bytes = (parent_verdicts.capacity() * size_of::<u8>()) as u64;
+        self.memory
+            .reserve_required(MemoryCategory::BatchScratch, parent_verdict_bytes);
         // Where in the sequence the earliest and the latest change happened. A change nobody could
         // place leaves the whole sequence moved, because that is all that is still provable.
         let (first_moved, last_moved) = match change.span {
@@ -1493,7 +1502,15 @@ impl StyleEngine {
                     let path = routing.path_of(entry.route);
                     // A whole sibling sequence shares one parent, so what the selector says the
                     // parent of the positional test is rejects the sequence in one lookup.
-                    if !engine.node_carries_any(routing.parent_dispatch_of(entry.route), parent, None) {
+                    let parent_verdict = &mut parent_verdicts[entry_index];
+                    if *parent_verdict == PARENT_UNDECIDED {
+                        *parent_verdict =
+                            match engine.node_carries_any(routing.parent_dispatch_of(entry.route), parent, None) {
+                                true => PARENT_ADMITS,
+                                false => PARENT_REJECTS,
+                            };
+                    }
+                    if *parent_verdict == PARENT_REJECTS {
                         continue;
                     }
                     // A non-relational positional input sits in one compound of the selector. A
@@ -1572,6 +1589,8 @@ impl StyleEngine {
                 }
             }
         }
+        drop(parent_verdicts);
+        self.memory.release(MemoryCategory::BatchScratch, parent_verdict_bytes);
         let sequence_match_workspace_bytes = sequence_match_workspace.capacity_bytes();
         self.memory
             .reserve_required(MemoryCategory::BatchScratch, sequence_match_workspace_bytes);

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -2152,16 +2152,21 @@ impl StyleEngine {
         let mut candidates = Vec::new();
         let attributed_rule = site.attribution();
         regions.for_each_batch(&batch, |candidate| {
+            // A node the entry's subject cannot name matches it on neither side, so it has no
+            // delta to contribute - whether or not an earlier route already planned it. Filtering
+            // before the already-planned check keeps every entry whose batch merely contains a
+            // planned node from queueing a full exact evaluation of that node later.
+            if !(self.node_carries_any(site.subject, candidate, site.in_flux)
+                && self.node_carries_all(site.subject_required, candidate, site.in_flux)
+                && self.path_meets_waypoints(site.path, site.waypoints, candidate, site.in_flux))
+            {
+                return;
+            }
             if regions.contains_node(candidate) {
                 self.record_already_planned_selector_truth(candidate, site);
                 return;
             }
-            if self.node_carries_any(site.subject, candidate, site.in_flux)
-                && self.node_carries_all(site.subject_required, candidate, site.in_flux)
-                && self.path_meets_waypoints(site.path, site.waypoints, candidate, site.in_flux)
-            {
-                candidates.push(candidate);
-            }
+            candidates.push(candidate);
         });
         let charged_bytes = if batch_is_cached {
             (candidates.capacity() * size_of::<StyleNodeID>()) as u64

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -4368,6 +4368,20 @@ pub(super) struct MatchFactRow<'a> {
     pub(super) row: u32,
 }
 
+/// Which positional tests an evaluator answers from its workspace's shared sibling index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PositionalIndexPolicy {
+    /// Every test, and every answer is memoized. A traversal that styles whole sequences asks
+    /// many programs about the same children, which amortizes building each index.
+    All,
+    /// Only tests with a step, which have to count the whole sequence anyway, and no memo. A
+    /// bounded test such as `:first-child` stops at its near end, so a narrow exact ask over
+    /// scattered candidates answers it more cheaply than materializing every sequence it walks
+    /// through - and asks the same test about the same node too rarely for a memo to pay for
+    /// its insertion.
+    SteppedOnly,
+}
+
 pub struct MatchEvaluator<'a> {
     tree: &'a StyleNodeTree,
     facts: &'a StyleNodeFacts,
@@ -4389,6 +4403,7 @@ pub struct MatchEvaluator<'a> {
     /// walk runs, and restored after, so that a nested `:has()` names its own anchor.
     relative_anchor: Cell<Option<StyleNodeID>>,
     match_workspace: Option<(&'a MatchEvaluationWorkspace, MatchEvaluationSide)>,
+    positional_index_policy: PositionalIndexPolicy,
     transitive_relation_program: Cell<Option<SelectorProgramID>>,
     /// Where a completed simple relational evaluation records its outcome, when the caller is
     /// evaluating the live tree and current facts. See `MatchEvaluator::observing_witnesses`.
@@ -5061,6 +5076,7 @@ impl<'a> MatchEvaluator<'a> {
             root_matches_parentless_node: true,
             relative_anchor: Cell::new(None),
             match_workspace: None,
+            positional_index_policy: PositionalIndexPolicy::All,
             transitive_relation_program: Cell::new(None),
             witnesses: None,
         }
@@ -5109,6 +5125,14 @@ impl<'a> MatchEvaluator<'a> {
         side: MatchEvaluationSide,
     ) -> Self {
         self.match_workspace = Some((workspace, side));
+        self
+    }
+
+    /// Answer only stepped positional tests from the workspace's sibling index, and memoize no
+    /// positional answer. See [`PositionalIndexPolicy::SteppedOnly`].
+    #[must_use]
+    pub(super) fn indexing_stepped_positions_only(mut self) -> Self {
+        self.positional_index_policy = PositionalIndexPolicy::SteppedOnly;
         self
     }
 
@@ -5823,7 +5847,9 @@ impl<'a> MatchEvaluator<'a> {
                 Ok(false)
             }
             SelectorOp::NthPosition(position) => {
-                if position.of_selector.is_none()
+                let memoizes_answers = self.positional_index_policy == PositionalIndexPolicy::All;
+                if memoizes_answers
+                    && position.of_selector.is_none()
                     && let Some((workspace, side)) = self.match_workspace
                     && let Some(answer) = workspace.positional_answer(position, node, side)
                 {
@@ -5831,7 +5857,8 @@ impl<'a> MatchEvaluator<'a> {
                 }
                 counters.bump(Counter::StructuralTests);
                 let result = self.matches_nth(program, position, node, counters);
-                if position.of_selector.is_none()
+                if memoizes_answers
+                    && position.of_selector.is_none()
                     && let Some((workspace, side)) = self.match_workspace
                     && let Ok(answer) = result
                 {
@@ -6243,6 +6270,7 @@ impl<'a> MatchEvaluator<'a> {
         counters: &mut Counters,
     ) -> Result<bool, Incomplete> {
         if position.of_selector.is_none()
+            && (position.step != 0 || self.positional_index_policy == PositionalIndexPolicy::All)
             && let Some(index) = self.indexed_sibling_position(position, node, counters)?
         {
             return Ok(matches_an_plus_b(position.step, position.offset, index));


### PR DESCRIPTION
Tighten style invalidation routing and exact evaluation for positional selectors.

- Filter exact-batch candidates before already-planned bookkeeping, halving the time spent resolving already-planned selector truth in StyleBench’s nth pseudo-class suite.
- Skip whole-document resident-node enumeration for pure DOM transactions. For a single leaf insertion into a 20,000-element document, this removes the flush’s largest cost.
- Cache parent-compound verdicts once per touched sequence and account for the scratch storage.
- Reuse a topology-safe sibling-position index for stepped positional tests. The repeated scans previously consumed 8-10% of a StyleBench nth pseudo-class flush.

Bounded positional tests keep their cheaper direct path, while stepped tests share the index across candidates and entries.