### PR TITLE
LibSandbox: Allow the persona syscall os_log needs when streaming

### DIFF
--- a/Libraries/LibSandbox/Sandbox.cpp
+++ b/Libraries/LibSandbox/Sandbox.cpp
@@ -325,6 +325,7 @@ ErrorOr<void> apply_macos_sandbox(ReadonlySpan<SeatbeltPath> paths, NetworkAcces
         SYS_openat
         SYS_os_fault_with_payload
         SYS_pathconf
+        SYS_persona
         SYS_pipe
         SYS_poll
         SYS_posix_spawn


### PR DESCRIPTION
**Problem:** With live system log streaming active (Zoom runs two `log stream` processes for as long as a meeting is open; Console.app and a manual `log stream` do the same), creating a WebGL context kills the Compositor — and every WebContent process attached to it then dies too. In `test-web`, that shows up as dozens of tests reported Crashed in one run; in the browser, it takes down every tab at once.

**Cause:** When streaming is active, `os_log` takes its streaming path, which calls `voucher_get_current_persona` and with it, the persona syscall. The Compositor logs through `os_log` the moment WebGL creation initializes SkyLight — so the syscall is reached from inside the sandbox. `Sandbox.cpp` denies every unlisted `syscall-unix` with `send-signal SIGKILL`, and `SYS_persona` isn’t on the list — so the kernel kills the process outright, rather than failing the call.

**Fix:** Add `SYS_persona` to the syscall allowlist. It only reports the persona the process already runs under; nothing is granted that the process couldn’t learn already. Verified on macOS 27 with Zoom’s log streams running: A page calling `getContext("webgl2")` kills the sandboxed Compositor, and survives with the sandbox disabled — and the same page passes with the syscall allowed.
