### PR TITLE
LibWeb: Skip style resource walks for styles without images

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1015,6 +1015,9 @@ enum class StyleRecordDependencyFlag : u8 {
     DependsOnViewportMetrics = 1 << 0,
     FontMetricsDependOnViewportMetrics = 1 << 1,
     InDisplayNoneSubtree = 1 << 2,
+    // Bit 3 is the engine's publication-time inherited-group swap eligibility, never stored on a record.
+    // The record holds an <image> in a property whose images a layout node loads and observes.
+    HoldsImageValues = 1 << 4,
 };
 
 // The box group payload stores display values in the Rust-defined explicit

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -505,6 +505,16 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
 
 void NodeWithStyle::attach_style_resources()
 {
+    // The style engine notes at publication whether a record holds an <image> anywhere this node would load and
+    // observe one. Nearly every style holds none, and that answer is one flag read; the walk below stays for the
+    // styles that do.
+    auto dependency_flags = document().style_computer().style_engine().style_record_dependency_flags(m_style_record_identity);
+    if (!(dependency_flags & to_underlying(CSS::StyleRecordDependencyFlag::HoldsImageValues))) {
+        m_cursor_style_values.clear();
+        clear_image_observers();
+        return;
+    }
+
     auto load_image = [&](CSS::AbstractImageStyleValue const* image) {
         if (image)
             const_cast<CSS::AbstractImageStyleValue&>(*image).load_any_resources(*this);

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -49,6 +49,7 @@ pub use crate::css::computed_value_types::{
     RetainedTextDecorationLineList, SVGResetValues, SizingValues, SurroundValues, TextResetValues, TransformValues,
 };
 use crate::css::retained_fly_string::{RetainedUtf16FlyString, RetainedUtf16FlyStringList};
+use crate::css::style_value::StyleValueData;
 use crate::css::style_value::{retained_list_drop, retained_list_partial_eq};
 
 /// Reference count value marking an intentionally leaked payload.
@@ -1304,6 +1305,64 @@ pub(crate) fn style_group_payloads_equal(group_index: usize, a: *const c_void, b
     // SAFETY: Published style-group payloads remain live for the call and both use the registered
     // group type at `group_index`.
     unsafe { payloads_equal(vtable(group_index), a, b) }
+}
+
+/// Whether a layered image property holds an `<image>` in any layer. The value is one layer or a
+/// comma-separated list of them.
+fn layer_values_hold_image(handle: &ComputedStyleValueHandle) -> bool {
+    // StyleValueList::Separator: Space is 0, Comma is 1.
+    const COMMA: u8 = 1;
+    match handle.data() {
+        Some(StyleValueData::ValueList { values, separator, .. }) if *separator == COMMA => {
+            values.as_slice().iter().any(|layer| layer.data().is_image())
+        }
+        Some(value) => value.is_image(),
+        None => false,
+    }
+}
+
+unsafe fn payload_holds_image_values(table: &StyleGroupVTable, payload: *const c_void) -> bool {
+    match table.lifecycle {
+        StyleGroupLifecycle::Background => unsafe {
+            layer_values_hold_image(&(*(payload as *const BackgroundValues)).background_image)
+        },
+        StyleGroupLifecycle::Mask => unsafe { layer_values_hold_image(&(*(payload as *const MaskValues)).mask_image) },
+        StyleGroupLifecycle::Border => unsafe {
+            (*(payload as *const BorderValues))
+                .border_image_source
+                .data()
+                .is_some_and(StyleValueData::is_image)
+        },
+        StyleGroupLifecycle::InheritedList => unsafe {
+            (*(payload as *const InheritedListValues))
+                .list_style_image
+                .data()
+                .is_some_and(StyleValueData::is_image)
+        },
+        StyleGroupLifecycle::InheritedUI => unsafe {
+            let cursors = &(*(payload as *const InheritedUIValues)).cursor;
+            !cursors.pointer.is_null()
+                && std::slice::from_raw_parts(cursors.pointer, cursors.length)
+                    .iter()
+                    .any(|cursor| cursor.is_cursor_value)
+        },
+        _ => false,
+    }
+}
+
+/// Whether any of a record's group payloads holds an `<image>` in a property whose images a layout
+/// node loads and observes: the background and mask layers, the cursor, the border-image source and
+/// the list-style image. Nearly every style holds none, and a record answers that with one flag
+/// instead of materializing its layers to find out.
+pub(crate) fn style_group_payloads_hold_image_values(payloads: &[*const c_void]) -> bool {
+    if replaying_style_groups() {
+        return false;
+    }
+    payloads.iter().enumerate().any(|(group_index, &payload)| {
+        // SAFETY: Published style-group payloads remain live for the call and use the registered
+        // group type at `group_index`.
+        !payload.is_null() && unsafe { payload_holds_image_values(vtable(group_index), payload) }
+    })
 }
 
 pub(crate) fn default_group_payload(group_index: usize) -> *const c_void {

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -2221,8 +2221,11 @@ pub unsafe extern "C" fn style_engine_publish_computed_groups(
         let inherited_group_swap_eligible = longhand_table.is_some_and(|table| {
             inherited_group_swap_candidate && table.property_inheritance_is_standard() && !table.display_is_list_item()
         });
+        let holds_image_values = crate::css::computed_values::style_group_payloads_hold_image_values(payloads)
+            || crate::css::computed_values::style_group_payloads_hold_image_values(animation_overlay_payloads);
         let dependency_flags = longhand_table.map_or(0, |table| table.publication_dependency_flags())
-            | (u8::from(inherited_group_swap_eligible) * super::computed::INHERITED_GROUP_SWAP_ELIGIBLE);
+            | (u8::from(inherited_group_swap_eligible) * super::computed::INHERITED_GROUP_SWAP_ELIGIBLE)
+            | (u8::from(holds_image_values) * super::computed::HOLDS_IMAGE_VALUES);
         let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
         if animation_overlay_identity != 0 && animated_overlay.is_null() {
             return FfiStyleRecordDelta::default();

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -46,10 +46,13 @@ use crate::css::style_value::retained_value_depends_on_color_scheme;
 use crate::css::style_value::retained_value_depends_on_current_color;
 use crate::css::style_value::retained_value_may_depend_on_font_metrics;
 
-// The high bit is a node-local production capability carried with publication and stripped before
-// the semantic fixed metadata is interned or exposed through a style-record view.
+// Bit 3 is a node-local production capability carried with publication and stripped before the
+// semantic fixed metadata is interned or exposed through a style-record view.
 pub(crate) const INHERITED_GROUP_SWAP_ELIGIBLE: u8 = 1 << 3;
-const COMPUTED_VALUE_DEPENDENCY_FLAGS: u8 = INHERITED_GROUP_SWAP_ELIGIBLE - 1;
+/// The record holds an `<image>` in a property whose images a layout node loads and observes.
+/// Derived from the published payloads; see `style_group_payloads_hold_image_values`.
+pub(crate) const HOLDS_IMAGE_VALUES: u8 = 1 << 4;
+const COMPUTED_VALUE_DEPENDENCY_FLAGS: u8 = (INHERITED_GROUP_SWAP_ELIGIBLE - 1) | HOLDS_IMAGE_VALUES;
 
 define_id! { pub struct ComputedGroupID(); }
 

--- a/Libraries/LibWeb/Rust/src/css/style_value.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_value.rs
@@ -2395,6 +2395,20 @@ impl StyleValueData {
 }
 
 impl StyleValueData {
+    /// Whether this is an `<image>` value: a URL image, an `image-set()` or a gradient.
+    pub(crate) fn is_image(&self) -> bool {
+        matches!(
+            self,
+            Self::Image { .. }
+                | Self::ImageSet { .. }
+                | Self::LinearGradient { .. }
+                | Self::RadialGradient { .. }
+                | Self::ConicGradient { .. }
+        )
+    }
+}
+
+impl StyleValueData {
     /// A content hash consistent with `PartialEq`: equal values always produce equal hashes.
     ///
     /// Consistency holds by construction because the hash only ever omits fields, and derived


### PR DESCRIPTION
Most computed styles contain no image values, but attaching style resources still materializes and walks several image-bearing properties on every style application.

Record whether published base or animation style groups contain images, then let layout nodes skip that work when none are present. The flag is interned with the style record metadata, keeping it consistent with the published values.

StyleBench total improved from 3.118s (score 83.6) to 3.050s (score 85.6), a 2.2% reduction. The “Adding classes” harness step dropped from 43.5ms to 39.2ms.