### PR TITLE
LibWeb: Avoid DOM lookups when updating scrollable overflow

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2816,6 +2816,15 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
     if (!m_layout_node_arena)
         return;
 
+    // The update reads each box's scroll-offset flag in place of the offset it mirrors.
+    static bool const verify_scroll_offset_flags = getenv("LIBWEB_VERIFY_SCROLL_OFFSET_FLAGS") != nullptr;
+    if (verify_scroll_offset_flags && m_layout_root) {
+        m_layout_root->for_each_in_inclusive_subtree([](Layout::Node const& node) {
+            node.verify_has_scroll_offset_flag();
+            return TraversalDecision::Continue;
+        });
+    }
+
     auto outcome = Painting::rust_update_scrollable_overflow(*this,
         derived_structure_updates == ScrollableOverflowDerivedStructureUpdates::HandledByFullLayoutCommit);
     if (!outcome.performed_recalculation)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5549,17 +5549,29 @@ CSSPixelPoint Element::scroll_offset(Optional<CSS::PseudoElement> pseudo_element
     return rare_data ? rare_data->scroll_offset : CSSPixelPoint {};
 }
 
+// The layout arena measures a box that holds a scroll offset eagerly after a full commit, so the
+// current box re-derives that fact whenever the stored offset changes. Layout need not be up to
+// date for that: the box is only annotated, not read, and a box that a pending layout tree rebuild
+// replaces is never consulted again, while its replacement derives the fact when it is constructed.
+// That is why the unchecked layout node accessor is the right one here.
 void Element::set_scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type, CSSPixelPoint offset)
 {
     if (pseudo_element_type.has_value()) {
-        if (auto pseudo_element = get_synthetic_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
-            pseudo_element->set_scroll_offset(offset);
-    } else {
-        if (!offset.is_zero())
-            ensure_element_rare_data().scroll_offset = offset;
-        else if (auto* rare_data = element_rare_data())
-            rare_data->scroll_offset = {};
+        auto pseudo_element = get_synthetic_pseudo_element(*pseudo_element_type);
+        if (!pseudo_element.has_value())
+            return;
+        pseudo_element->set_scroll_offset(offset);
+        if (auto* layout_node = pseudo_element->unsafe_layout_node())
+            layout_node->update_has_scroll_offset_flag();
+        return;
     }
+
+    if (!offset.is_zero())
+        ensure_element_rare_data().scroll_offset = offset;
+    else if (auto* rare_data = element_rare_data())
+        rare_data->scroll_offset = {};
+    if (auto* layout_node = unsafe_layout_node())
+        layout_node->update_has_scroll_offset_flag();
 }
 
 Optional<Element::Dir> Element::dir() const

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -46,6 +46,9 @@ void SyntheticPseudoElement::set_layout_node(Layout::NodeWithStyle* value)
     if (m_layout_node && m_layout_node.ptr() != value)
         m_layout_node->pin_style_record_for_detachment();
     m_layout_node = value;
+    // The box becomes the pseudo-element's box here, which is when it starts holding its scroll offset.
+    if (value)
+        value->update_has_scroll_offset_flag();
 }
 
 void SyntheticPseudoElement::update_animated_properties(Badge<Web::Animations::KeyframeEffect> const&, DOM::AbstractElement abstract_element, Web::Animations::KeyframeEffect& effect, Web::Animations::AnimationUpdateContext& context)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -73,6 +73,7 @@ Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, AttachToDOMNode att
     set_flag(RustFFI::NodeFlag::UsesButtonLayout,
         node && is<HTML::HTMLElement>(*node) && static_cast<HTML::HTMLElement const&>(*node).uses_button_layout());
     set_flag(RustFFI::NodeFlag::IsEditingHost, node && node->is_editing_host());
+    update_has_scroll_offset_flag();
 
     if (node && attach_to_dom_node == AttachToDOMNode::Yes)
         node->set_layout_node({}, *this);
@@ -1011,6 +1012,32 @@ void Node::set_generated_for(CSS::PseudoElement type, DOM::Element& element)
     m_pseudo_element_generator = element;
     if (auto* node_with_style = as_if<NodeWithStyle>(*this))
         node_with_style->bind_generated_style_record(element.style_record_identity(type));
+}
+
+// An element's box holds the element's scroll offset. Everything generated for a pseudo-element
+// names it as generator, but only the pseudo-element's own box is what scrolls, so only that box
+// holds the pseudo-element's offset; the generated content inside it holds none.
+bool Node::dom_target_stores_scroll_offset() const
+{
+    if (auto pseudo_element = generated_for_pseudo_element(); pseudo_element.has_value()) {
+        auto synthetic_pseudo_element = pseudo_element_generator()->get_synthetic_pseudo_element(*pseudo_element);
+        return synthetic_pseudo_element.has_value()
+            && synthetic_pseudo_element->unsafe_layout_node() == this
+            && !synthetic_pseudo_element->scroll_offset().is_zero();
+    }
+    if (auto const* element = as_if<DOM::Element>(dom_node()))
+        return !element->scroll_offset({}).is_zero();
+    return false;
+}
+
+void Node::update_has_scroll_offset_flag()
+{
+    set_flag(RustFFI::NodeFlag::HasScrollOffset, dom_target_stores_scroll_offset());
+}
+
+void Node::verify_has_scroll_offset_flag() const
+{
+    VERIFY(has_flag(RustFFI::NodeFlag::HasScrollOffset) == dom_target_stores_scroll_offset());
 }
 
 DOM::Document& Node::document()

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -222,6 +222,12 @@ public:
     bool needs_layout_update() const { return has_flag(RustFFI::NodeFlag::NeedsLayoutUpdate); }
     void set_retains_compositor_animated_content(bool value) { set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, value); }
 
+    // The arena measures a box that holds a scroll offset eagerly after a full commit, so the box carries that fact
+    // as a flag: it is set when a box becomes an element's or a pseudo-element's box, and again whenever the stored
+    // offset changes, each time re-derived from the one place the offset is stored.
+    void update_has_scroll_offset_flag();
+    void verify_has_scroll_offset_flag() const;
+
     // Any invalidation below a node must reach every ancestor's epoch: cached runs capture
     // subtree structure, and unlike intrinsic-size invalidation there is no absolutely-positioned
     // or SVG boundary — those descendants' fragments live in ancestor run trees. The arena runs
@@ -342,6 +348,8 @@ protected:
     {
         return (m_data->flags & static_cast<u32>(flag)) != 0;
     }
+
+    bool dom_target_stores_scroll_offset() const;
 
     void set_flag(RustFFI::NodeFlag flag, bool value)
     {

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -580,14 +580,11 @@ Layout::RustFFI::FfiScrollableOverflowUpdateOutcome rust_update_scrollable_overf
         if (!scroll_offset(box).is_zero())
             set_scroll_offset(box, scroll_offset(box));
     };
-    auto scroll_offset_is_zero = [](void*, void* layout_node_shell) -> bool {
-        return scroll_offset(*static_cast<Layout::Node const*>(layout_node_shell)).is_zero();
-    };
 
     return Layout::RustFFI::layout_arena_update_scrollable_overflow(
         layout_arena_handle(document), viewport_row_slot(document), handled_by_full_layout_commit,
         visual_context_host_callbacks(document), scrollable_overflow_host_callbacks(),
-        nullptr, clamp_scroll_offset_if_nonzero, scroll_offset_is_zero);
+        nullptr, clamp_scroll_offset_if_nonzero);
 }
 
 CSS::ResolvedImage rust_resolve_gradient_for_size(CSS::StyleValue const& gradient_style_value, Layout::NodeWithStyle const& layout_node, CSSPixelSize size)

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -140,6 +140,10 @@ pub enum NodeFlag {
     ChildrenAreInline = 1 << 2,
     IsFlexItem = 1 << 3,
     IsGridItem = 1 << 4,
+    /// The box is an element's or a pseudo-element's own box, and that element or pseudo-element
+    /// stores a scroll offset other than zero. The overflow update measures such a box eagerly
+    /// after a full commit so the offset can be clamped.
+    HasScrollOffset = 1 << 5,
     IsBody = 1 << 6,
     NeedsLayoutUpdate = 1 << 7,
     NeedsOwnGeometryUpdate = 1 << 8,

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -680,6 +680,16 @@ pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
     });
 }
 
+/// Whether a box is measured eagerly after a full commit rather than only when an ancestor's
+/// measurement reaches it: a scroll container, or a box whose element or pseudo-element stores a
+/// scroll offset that the new overflow may have to clamp. The offset lives on the DOM side, which
+/// sets `NodeFlag::HasScrollOffset` whenever it stores one and whenever a box becomes an element's
+/// or pseudo-element's box, so the answer is one style query and one flag read.
+fn box_holds_scroll_state(arena: &LayoutNodeArena, slot: NodeSlotId) -> bool {
+    crate::painting::style_queries::is_scroll_container(arena, slot)
+        || arena.node_flags_if_live(slot) & crate::layout::node_data::NodeFlag::HasScrollOffset as u32 != 0
+}
+
 /// # Safety
 ///
 /// `arena_handle` must be a live handle from `layout_arena_create`, used on the document
@@ -734,7 +744,6 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
     overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
     scroll_offset_context: *mut c_void,
     clamp_scroll_offset_if_nonzero: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    scroll_offset_is_zero: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
 ) -> FfiScrollableOverflowUpdateOutcome {
     abort_on_panic(|| {
         let no_recalculation = FfiScrollableOverflowUpdateOutcome {
@@ -785,16 +794,13 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
             // containers, and boxes holding a scroll offset are measured eagerly.
             let mut eager_measurement_roots = Vec::new();
             {
-                // SAFETY: As above; the callback receives live shells and does not re-enter.
+                // SAFETY: As above.
                 let arena = unsafe { arena_from_handle(arena) };
                 arena.for_each_node_in_layout_subtree_in_pre_order(viewport, |slot| {
                     if !arena.paintable_rows().paintable_row_is_populated(slot) {
                         return;
                     }
-                    let measures_eagerly = slot == viewport
-                        || crate::painting::style_queries::is_scroll_container(arena, slot)
-                        || !unsafe { scroll_offset_is_zero(scroll_offset_context, arena.node_shell(slot)) };
-                    if measures_eagerly {
+                    if slot == viewport || box_holds_scroll_state(arena, slot) {
                         eager_measurement_roots.push(slot);
                     }
                 });
@@ -918,16 +924,9 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
             // measured recursively if an ancestor reaches them. Measuring each one here would
             // repeatedly walk the same containing-block chains after a small subtree update.
             if old_overflow_data.is_none() && slot != viewport {
-                // SAFETY: As above; the callback receives a live shell and does not re-enter.
-                let scroll_offset_is_zero_for_slot = unsafe {
-                    let arena = arena_from_handle(arena);
-                    if crate::painting::style_queries::is_scroll_container(arena, slot) {
-                        None
-                    } else {
-                        Some(scroll_offset_is_zero(scroll_offset_context, arena.node_shell(slot)))
-                    }
-                };
-                if scroll_offset_is_zero_for_slot == Some(true) {
+                // SAFETY: As above.
+                let arena = unsafe { arena_from_handle(arena) };
+                if !box_holds_scroll_state(arena, slot) {
                     continue;
                 }
             }

--- a/Tests/LibWeb/Text/expected/scroll-offset-clamped-after-full-relayout.txt
+++ b/Tests/LibWeb/Text/expected/scroll-offset-clamped-after-full-relayout.txt
@@ -1,0 +1,5 @@
+scrollTop after scrolling: 400
+scrollTop after the overflow shrank: 150
+scrollTop after the box was rebuilt: 120
+scrollTop after the overflow shrank again: 50
+scrollTop after scrolling back: 0

--- a/Tests/LibWeb/Text/input/scroll-offset-clamped-after-full-relayout.html
+++ b/Tests/LibWeb/Text/input/scroll-offset-clamped-after-full-relayout.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        overflow: auto;
+    }
+    .hidden {
+        display: none;
+    }
+</style>
+<script src="include.js"></script>
+<div id="box"><div id="tall" style="height: 1000px"></div></div>
+<div id="filler"></div>
+<script>
+    // A box that holds a scroll offset has its overflow measured eagerly after every full layout,
+    // so an offset that the new overflow no longer reaches is clamped right away, and a box built
+    // anew for a scrolled element measures eagerly too.
+    test(() => {
+        const box = document.getElementById("box");
+        const tall = document.getElementById("tall");
+        const filler = document.getElementById("filler");
+        const relayoutEverything = () => {
+            for (let i = 0; i < 20; ++i)
+                filler.appendChild(document.createElement("div"));
+            box.getBoundingClientRect();
+        };
+
+        box.scrollTop = 400;
+        println(`scrollTop after scrolling: ${box.scrollTop}`);
+
+        tall.style.height = "250px";
+        relayoutEverything();
+        println(`scrollTop after the overflow shrank: ${box.scrollTop}`);
+
+        box.scrollTop = 120;
+        box.classList.add("hidden");
+        box.getBoundingClientRect();
+        box.classList.remove("hidden");
+        box.getBoundingClientRect();
+        println(`scrollTop after the box was rebuilt: ${box.scrollTop}`);
+
+        tall.style.height = "150px";
+        relayoutEverything();
+        println(`scrollTop after the overflow shrank again: ${box.scrollTop}`);
+
+        box.scrollTop = 0;
+        tall.style.height = "1000px";
+        relayoutEverything();
+        println(`scrollTop after scrolling back: ${box.scrollTop}`);
+    });
+</script>

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -80,6 +80,7 @@ void Application::create_platform_options(WebView::BrowserOptions& browser_optio
             "LIBWEB_VERIFY_STYLE_INPUT_REUSE"sv,
             "LIBWEB_VERIFY_COMPUTED_CLOSURE"sv,
             "LIBWEB_VERIFY_STYLE_DIFF_FAST_PATH"sv,
+            "LIBWEB_VERIFY_SCROLL_OFFSET_FLAGS"sv,
         };
         for (auto variable : verification_variables)
             MUST(Core::Environment::set(variable, "1"sv, Core::Environment::Overwrite::Yes));


### PR DESCRIPTION
After every full layout commit, the scrollable overflow update queried the DOM for every box to find the few boxes whose elements store a non-zero scroll offset.

Mirror that state in a layout node flag and keep it synchronized when offsets change or boxes are associated with elements and pseudo-elements. This removes the per-box FFI callback and rare-data lookup while preserving eager measurement and scroll offset clamping. Add verification-mode invariant checks and regression coverage for shrinking overflow and rebuilt boxes.

On StyleBench, the official runner improved from 2.956s (score 88.9) to 2.823s (score 92.6), a 4.5% reduction. The overflow update’s share of a profiled leaf-step window fell from 10.5% to 3.7%.