### PR TITLE
LibGfx: Hash shaping cache lookups with a fast seeded hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ name = "libgfx_rust"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
+ "foldhash 0.1.5",
  "yuv",
 ]
 

--- a/Libraries/LibGfx/Rust/Cargo.toml
+++ b/Libraries/LibGfx/Rust/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 allocator = []
 
 [dependencies]
+foldhash = "0.1"
 yuv = "0.8"
 
 [build-dependencies]

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -191,10 +191,12 @@ struct ShapeForParams {
     shape: CachedShape,
 }
 
+type FastMap<K, V> = std::collections::HashMap<K, V, foldhash::fast::RandomState>;
+
 struct FontShapeCache {
     last_used_tick: u64,
     single_ascii_common_shapes: [Option<Box<CachedShape>>; SINGLE_ASCII_SHAPE_CACHE_SIZE],
-    shapes_by_text: std::collections::HashMap<Box<[u16]>, Vec<ShapeForParams>>,
+    shapes_by_text: FastMap<Box<[u16]>, Vec<ShapeForParams>>,
 }
 
 impl Default for FontShapeCache {
@@ -202,7 +204,7 @@ impl Default for FontShapeCache {
         Self {
             last_used_tick: 0,
             single_ascii_common_shapes: [const { None }; SINGLE_ASCII_SHAPE_CACHE_SIZE],
-            shapes_by_text: std::collections::HashMap::new(),
+            shapes_by_text: FastMap::default(),
         }
     }
 }
@@ -250,7 +252,7 @@ impl FontShapeCache {
 
 #[derive(Default)]
 struct ShapingCache {
-    caches_by_font_id: std::collections::HashMap<u64, FontShapeCache>,
+    caches_by_font_id: FastMap<u64, FontShapeCache>,
     tick: u64,
 }
 

--- a/Libraries/LibGfx/Rust/src/text_layout.rs
+++ b/Libraries/LibGfx/Rust/src/text_layout.rs
@@ -224,25 +224,27 @@ impl FontShapeCache {
                 .get_or_insert_with(|| Box::new(shape_uncached()));
         }
 
-        let is_shaped_already = self
-            .shapes_by_text
-            .get(text)
-            .is_some_and(|shapes| shapes.iter().any(|entry| entry.params.matches(&params)));
-        if !is_shaped_already {
-            if !self.shapes_by_text.contains_key(text) && self.shapes_by_text.len() >= MAX_SHAPE_CACHE_TEXTS_PER_FONT {
+        if !self.shapes_by_text.contains_key(text) {
+            if self.shapes_by_text.len() >= MAX_SHAPE_CACHE_TEXTS_PER_FONT {
                 self.shapes_by_text.clear();
             }
-            let shape = shape_uncached();
-            self.shapes_by_text
-                .entry(Box::from(text))
-                .or_default()
-                .push(ShapeForParams { params, shape });
+            self.shapes_by_text.insert(Box::from(text), Vec::new());
         }
-        self.shapes_by_text
-            .get(text)
-            .and_then(|shapes| shapes.iter().find(|entry| entry.params.matches(&params)))
-            .map(|entry| &entry.shape)
-            .expect("the shape was cached just above")
+        let shapes = self
+            .shapes_by_text
+            .get_mut(text)
+            .expect("the entry was inserted just above");
+        let index = shapes
+            .iter()
+            .position(|entry| entry.params.matches(&params))
+            .unwrap_or_else(|| {
+                shapes.push(ShapeForParams {
+                    params,
+                    shape: shape_uncached(),
+                });
+                shapes.len() - 1
+            });
+        &shapes[index].shape
     }
 }
 


### PR DESCRIPTION
Every shaping cache lookup previously hashed the shaped text with the standard library's default hasher, which dominated the cost of laying out text whose shapes were already cached. Use foldhash's fast variant with a random seed for both cache tables, which keeps page text from forcing hash collisions the way a fixed seed would allow.

Improves these MicroWeb tests:

| Test | Before | After | Improvement |
| --- | --- |--- | --- |
| text/shape-repeated-strings | 25.90..25.95 ms | 24.50..24.85 ms | ~1.3ms |
| text/shape-unique-strings | 28.65..28.90 ms | 27.00..27.25 ms |~1.6 ms |