### PR TITLE
LibWeb: Skip rendered text conversions that change nothing for most text

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -561,7 +561,8 @@ bool TextNode::sync_text_content_to_arena() const
         view.length_in_code_units(),
         text().is_ascii_whitespace(),
         Unicode::may_require_bidi_processing(view),
-        dom_start_offset());
+        dom_start_offset(),
+        !m_text_dependent_cache->text_for_rendering_edits.is_empty());
     m_arena_text_content_in_sync = true;
     return arena_text_content_changed;
 }

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -627,8 +627,16 @@ TextNode::TextForRendering TextNode::compute_text_for_rendering(TextForRendering
         edits = move(sliced_edits);
     }
 
-    // The logic below deals with converting whitespace characters. If we don't have them, return early.
-    if (text.is_empty() || !any_of(text, is_ascii_space)) {
+    // The logic below converts tabs and segment breaks. Text without them is rendered as it is.
+    auto text_has_tab_or_newline = [&] {
+        auto view = text.utf16_view();
+        if (view.has_ascii_storage()) {
+            auto ascii = view.ascii_span();
+            return memchr(ascii.data(), '\n', ascii.size()) || memchr(ascii.data(), '\t', ascii.size());
+        }
+        return any_of(view.utf16_span(), [](char16_t code_unit) { return code_unit == u'\n' || code_unit == u'\t'; });
+    };
+    if (!text_has_tab_or_newline()) {
         return { move(text), move(edits) };
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -335,6 +335,9 @@ pub(crate) struct TextContent {
     pub(crate) untransformed_text_is_ascii_whitespace: bool,
     pub(crate) may_require_bidi_processing: bool,
     pub(crate) dom_start_offset: usize,
+    /// Whether rendering changed the length of any part of the DOM text. Otherwise a rendered
+    /// offset converts to a DOM offset by adding the DOM start offset alone.
+    pub(crate) rendered_text_has_edits: bool,
     grapheme_segmenter: std::cell::OnceCell<super::text_chunker::GraphemeSegmenter>,
 }
 
@@ -1554,6 +1557,7 @@ impl LayoutNodeArena {
         untransformed_text_is_ascii_whitespace: bool,
         may_require_bidi_processing: bool,
         dom_start_offset: usize,
+        rendered_text_has_edits: bool,
     ) -> bool {
         self.assert_owner_thread();
         self.data(id);
@@ -1569,6 +1573,7 @@ impl LayoutNodeArena {
                         || content.untransformed_text_is_ascii_whitespace != untransformed_text_is_ascii_whitespace
                         || content.may_require_bidi_processing != may_require_bidi_processing
                         || content.dom_start_offset != dom_start_offset
+                        || content.rendered_text_has_edits != rendered_text_has_edits
                 }
                 None => true,
             };
@@ -1582,6 +1587,7 @@ impl LayoutNodeArena {
                 untransformed_text_is_ascii_whitespace,
                 may_require_bidi_processing,
                 dom_start_offset,
+                rendered_text_has_edits,
                 grapheme_segmenter: std::cell::OnceCell::new(),
             })),
         };
@@ -2057,6 +2063,11 @@ impl LayoutNodeArena {
         if shell.is_null() || !self.node_kind_if_live(id).is_some_and(super::node_facts::kind_is_text) {
             return offset;
         }
+        if let Some(content) = self.text_content(id)
+            && !content.rendered_text_has_edits
+        {
+            return content.dom_start_offset + offset.min(content.text.len());
+        }
         // SAFETY: shell_if_live() returned the live C++ TextNode corresponding to this text layout node.
         unsafe {
             ladybird_layout_text_node_dom_offset_for_rendered_text_offset(
@@ -2076,6 +2087,12 @@ impl LayoutNodeArena {
         let shell = self.shell_if_live(id);
         if shell.is_null() || !self.node_kind_if_live(id).is_some_and(super::node_facts::kind_is_text) {
             return offset;
+        }
+        if let Some(content) = self.text_content(id)
+            && !content.rendered_text_has_edits
+        {
+            let dom_end_offset = content.dom_start_offset + content.text.len();
+            return offset.clamp(content.dom_start_offset, dom_end_offset) - content.dom_start_offset;
         }
         // SAFETY: shell_if_live() returned the live C++ TextNode corresponding to this text layout node.
         unsafe {
@@ -2351,6 +2368,7 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
     untransformed_text_is_ascii_whitespace: bool,
     may_require_bidi_processing: bool,
     dom_start_offset: usize,
+    rendered_text_has_edits: bool,
 ) -> bool {
     abort_on_panic(|| {
         assert!(!arena.is_null(), "layout node arena handle is null");
@@ -2377,6 +2395,7 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
             untransformed_text_is_ascii_whitespace,
             may_require_bidi_processing,
             dom_start_offset,
+            rendered_text_has_edits,
         )
     })
 }


### PR DESCRIPTION
Layout derives a rendered string from each DOM text node. It later maps offsets between the rendered string and the DOM text. Both the derivation and the offset mapping did full work even when rendering left the text unchanged. These commits return the text as it is when it has no tab or newline to convert. They also map offsets by adding the start offset when rendering changed no lengths.

This unnecessary work was noticeable in profiles of text heavy pages.