### PR TITLE
RequestServer: Stop waiting forever on a stalled disk-cache entry (fixes a GitHub display problem)

### DIFF
--- a/Libraries/LibHTTP/Cache/CacheRequest.h
+++ b/Libraries/LibHTTP/Cache/CacheRequest.h
@@ -8,6 +8,7 @@
 
 #include <AK/Badge.h>
 #include <AK/Optional.h>
+#include <AK/Time.h>
 #include <AK/Weakable.h>
 #include <LibHTTP/Forward.h>
 
@@ -20,6 +21,10 @@ public:
     virtual bool is_revalidation_request() const = 0;
 
     virtual void notify_request_unblocked(Badge<DiskCache>) = 0;
+
+    // The time when this request last made progress. The disk cache reads this to distinguish a request that's still
+    // filling or revalidating an entry — however slowly — from one that's stalled and will never release the entry.
+    virtual Optional<MonotonicTime> last_activity_time() const { return {}; }
 
 protected:
     enum class CacheStatus : u8 {

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -373,6 +373,31 @@ bool DiskCache::check_if_cache_has_open_entry(CacheRequest& request, u64 cache_k
     return false;
 }
 
+Optional<MonotonicTime> DiskCache::last_activity_time_of_open_entries(URL::URL const& url, StringView method) const
+{
+    auto cache_key = create_cache_key(serialize_url_for_cache_storage(url), method);
+
+    auto open_entries = m_open_cache_entries.get(cache_key);
+    if (!open_entries.has_value())
+        return {};
+
+    Optional<MonotonicTime> last_activity_time;
+
+    for (auto const& open_entry : *open_entries) {
+        if (!open_entry.request)
+            continue;
+
+        auto activity_time = open_entry.request->last_activity_time();
+        if (!activity_time.has_value())
+            continue;
+
+        if (!last_activity_time.has_value() || *activity_time > *last_activity_time)
+            last_activity_time = activity_time;
+    }
+
+    return last_activity_time;
+}
+
 void DiskCache::remove_entries_exceeding_cache_limit()
 {
     m_index.remove_entries_exceeding_cache_limit([&](auto cache_key, auto vary_key) {

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -67,6 +67,10 @@ public:
 
     void cache_entry_closed(Badge<CacheEntry>, CacheEntry const&);
 
+    // The time when any request holding open a cache entry for this URL and method last made progress — or nothing, if
+    // no such request reports any. A request waiting on that entry reads it to judge whether the holder has stalled.
+    Optional<MonotonicTime> last_activity_time_of_open_entries(URL::URL const&, StringView method) const;
+
 private:
     DiskCache(Mode, NonnullRefPtr<Database::Database>, LexicalPath cache_directory, CacheIndex);
 

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -29,6 +29,8 @@ namespace RequestServer {
 extern OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
 
 static long s_connect_timeout_seconds = 90L;
+static AK::Duration s_wait_for_cache_timeout = AK::Duration::from_seconds(10);
+static AK::Duration s_revalidation_stall_timeout = AK::Duration::from_seconds(30);
 
 static CURLcode configure_ssl_context(CURL*, [[maybe_unused]] void* ssl_context, [[maybe_unused]] void* aia_collector)
 {
@@ -545,6 +547,16 @@ Request::Request(
         wire_stats().ensure(this).created_at = MonotonicTime::now();
 }
 
+void Request::set_wait_for_cache_timeout(AK::Duration timeout)
+{
+    s_wait_for_cache_timeout = timeout;
+}
+
+void Request::set_revalidation_stall_timeout(AK::Duration timeout)
+{
+    s_revalidation_stall_timeout = timeout;
+}
+
 Request::~Request()
 {
     if constexpr (REQUESTSERVER_DEBUG) {
@@ -567,8 +579,14 @@ Request::~Request()
 
 void Request::notify_request_unblocked(Badge<HTTP::DiskCache>)
 {
-    // FIXME: We may want a timer to limit how long we are waiting for a request before proceeding with a network
-    //        request that skips the disk cache.
+    // The wait may already have timed out, in which case this request went on without the disk cache.
+    if (m_state != State::WaitForCache)
+        return;
+
+    if (m_wait_for_cache_timer) {
+        m_wait_for_cache_timer->stop();
+        m_wait_for_cache_timer = nullptr;
+    }
     transition_to_state(State::Init);
 }
 
@@ -719,7 +737,7 @@ void Request::process()
         handle_read_cache_state();
         break;
     case State::WaitForCache:
-        // Do nothing; we are waiting for the disk cache to notify us to proceed.
+        handle_wait_for_cache_state();
         break;
     case State::WaitForAIA:
         // Do nothing; we are waiting for the AIA intermediate-certificate fetch to notify us to proceed.
@@ -819,6 +837,45 @@ void Request::handle_initial_state()
             return;
     }
 
+    transition_to_state(State::DNSLookup);
+}
+
+void Request::handle_wait_for_cache_state()
+{
+    // The disk cache notifies us once the request holding our cache entry open completes. If that request has stalled,
+    // it never will: a connection that silently died keeps a transfer alive indefinitely, and the entry it holds would
+    // otherwise block every later request for the same URL for the lifetime of this process.
+    if (m_wait_for_cache_timer)
+        return;
+
+    m_wait_for_cache_timer = Core::Timer::create_single_shot(static_cast<int>(s_wait_for_cache_timeout.to_milliseconds()), [this] {
+        wait_for_cache_timed_out();
+    });
+    m_wait_for_cache_timer->start();
+}
+
+void Request::wait_for_cache_timed_out()
+{
+    if (m_state != State::WaitForCache)
+        return;
+
+    dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: Request {} waited {}ms for the cache entry of {} to be released; continuing without the disk cache", m_request_id, s_wait_for_cache_timeout.to_milliseconds(), m_url);
+
+    // A background revalidation exists only to refresh the entry it could not open, so there's nothing left for it
+    // to do.
+    if (m_type == RequestType::BackgroundRevalidation) {
+        transition_to_state(State::Complete);
+        return;
+    }
+
+    if (is_cache_only_request()) {
+        transition_to_state(State::FailedCacheOnly);
+        return;
+    }
+
+    // Fetch over the network without reading from or writing to the disk cache. We remain in the cache's list of
+    // waiting requests, and notify_request_unblocked() ignores the notification when it eventually arrives.
+    m_cache_status = CacheStatus::NotCached;
     transition_to_state(State::DNSLookup);
 }
 
@@ -1103,6 +1160,14 @@ void Request::handle_fetch_state()
 
     if (m_alt_svc_cache_path.has_value())
         set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path->characters());
+
+    // Nobody waits on a background revalidation, so nothing else would ever notice one whose connection silently died.
+    // While it lives, it holds its cache entry open and every request for the same URL waits on it, so give up on it
+    // once it has stopped receiving data.
+    if (m_type == RequestType::BackgroundRevalidation) {
+        set_option(CURLOPT_LOW_SPEED_LIMIT, 1L);
+        set_option(CURLOPT_LOW_SPEED_TIME, static_cast<long>(s_revalidation_stall_timeout.to_seconds()));
+    }
 
     set_option(CURLOPT_CUSTOMREQUEST, m_method.characters());
     set_option(CURLOPT_FOLLOWLOCATION, 0);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -724,6 +724,7 @@ void Request::transition_to_state(State state)
 {
     dbgln_if(REQUESTSERVER_DEBUG, "Request::Transition[{}]: {} -> {} ({} {})", m_request_id, state_name(m_state), state_name(state), m_method, m_url);
     m_state = state;
+    mark_activity();
     process();
 }
 
@@ -844,7 +845,8 @@ void Request::handle_wait_for_cache_state()
 {
     // The disk cache notifies us once the request holding our cache entry open completes. If that request has stalled,
     // it never will: a connection that silently died keeps a transfer alive indefinitely, and the entry it holds would
-    // otherwise block every later request for the same URL for the lifetime of this process.
+    // otherwise block every later request for the same URL for the lifetime of this process. So, check on it once a
+    // wait limit has passed.
     if (m_wait_for_cache_timer)
         return;
 
@@ -859,7 +861,19 @@ void Request::wait_for_cache_timed_out()
     if (m_state != State::WaitForCache)
         return;
 
-    dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: Request {} waited {}ms for the cache entry of {} to be released; continuing without the disk cache", m_request_id, s_wait_for_cache_timeout.to_milliseconds(), m_url);
+    // A request that's still filling or revalidating the entry — however slowly — releases it when it's done. So,
+    // only a holder that's shown no sign of life for a whole wait limit counts as stalled. Otherwise, keep waiting —
+    // and look again once the holder has had a full limit's worth of time to go quiet.
+    if (auto last_activity_time = m_disk_cache->last_activity_time_of_open_entries(m_url, m_method); last_activity_time.has_value()) {
+        auto idle_time = MonotonicTime::now() - *last_activity_time;
+        if (idle_time < s_wait_for_cache_timeout) {
+            auto time_until_stalled = s_wait_for_cache_timeout - idle_time;
+            m_wait_for_cache_timer->start(max(static_cast<int>(time_until_stalled.to_milliseconds()), 1));
+            return;
+        }
+    }
+
+    dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: Request {} gave up waiting for the cache entry of {}: the request holding it has made no progress for {}ms; continuing without the disk cache", m_request_id, m_url, s_wait_for_cache_timeout.to_milliseconds());
 
     // A background revalidation exists only to refresh the entry it could not open, so there's nothing left for it
     // to do.
@@ -1340,6 +1354,7 @@ void Request::handle_error_state()
 size_t Request::on_header_received(void* buffer, size_t size, size_t nmemb, void* user_data)
 {
     auto& request = *static_cast<Request*>(user_data);
+    request.mark_activity();
 
     auto total_size = size * nmemb;
     auto header_line = StringView { static_cast<char const*>(buffer), total_size };
@@ -1374,6 +1389,7 @@ size_t Request::on_header_received(void* buffer, size_t size, size_t nmemb, void
 size_t Request::on_data_received(void* buffer, size_t size, size_t nmemb, void* user_data)
 {
     auto& request = *static_cast<Request*>(user_data);
+    request.mark_activity();
 
     if (request.m_type == RequestType::Fetch || request.m_type == RequestType::BackgroundRevalidation)
         record_chunk(&request, size * nmemb);
@@ -1612,8 +1628,14 @@ ErrorOr<void> Request::write_queued_bytes_without_blocking()
         if (!m_cache_entry_writer.has_value())
             return;
 
-        if (m_cache_entry_writer->write_data(bytes).is_error())
+        if (m_cache_entry_writer->write_data(bytes).is_error()) {
             m_cache_entry_writer.clear();
+            return;
+        }
+
+        // The entry is still filling, even once curl has nothing left to deliver: A client that reads its response
+        // slowly keeps these writes coming long after the transfer is over — so they count as progress too.
+        mark_activity();
     };
 
     if (m_type == RequestType::BackgroundRevalidation) {

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -13,6 +13,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Time.h>
 #include <LibCore/Proxy.h>
+#include <LibCore/Timer.h>
 #include <LibDNS/Resolver.h>
 #include <LibHTTP/Cache/CacheMode.h>
 #include <LibHTTP/Cache/CacheRequest.h>
@@ -86,6 +87,12 @@ public:
 
     ErrorOr<void> transfer_to_client(ConnectionFromClient&, u64 request_id, Optional<Requests::RequestTransferLeaseKey>);
     void release_transfer_lease() { m_transfer_lease.clear(); }
+
+    // The disk cache defers a request while another request holds its cache entry open. These bound how long a
+    // deferred request waits before it goes to the network without the cache, and how long a background revalidation
+    // may go without receiving any data before it's abandoned. Tests shorten both.
+    static void set_wait_for_cache_timeout(AK::Duration);
+    static void set_revalidation_stall_timeout(AK::Duration);
 
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
     bool notify_retrieved_http_cookie(Badge<ConnectionFromClient>, u64 cookie_request_id, StringView cookie);
@@ -180,6 +187,8 @@ private:
 
     void handle_initial_state();
     void handle_read_cache_state();
+    void handle_wait_for_cache_state();
+    void wait_for_cache_timed_out();
     void handle_failed_cache_only_state();
     void handle_serve_substitution_state();
     void handle_dns_lookup_state();
@@ -254,6 +263,7 @@ private:
 
     AllocatingMemoryStream m_response_buffer;
     RefPtr<Core::Notifier> m_client_writer_notifier;
+    RefPtr<Core::Timer> m_wait_for_cache_timer;
     Optional<RequestPipe> m_client_request_pipe;
     Optional<TransferredBodyFile> m_transferred_body_file;
     size_t m_bytes_transferred_to_client { 0 };

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -88,13 +88,14 @@ public:
     ErrorOr<void> transfer_to_client(ConnectionFromClient&, u64 request_id, Optional<Requests::RequestTransferLeaseKey>);
     void release_transfer_lease() { m_transfer_lease.clear(); }
 
-    // The disk cache defers a request while another request holds its cache entry open. These bound how long a
-    // deferred request waits before it goes to the network without the cache, and how long a background revalidation
-    // may go without receiving any data before it's abandoned. Tests shorten both.
+    // The disk cache defers a request while another request holds its cache entry open. These bound how long that other
+    // request may go without making progress before the deferred one goes to the network without the cache — and how
+    // long a background revalidation may go without receiving any data before it's abandoned. Tests shorten both.
     static void set_wait_for_cache_timeout(AK::Duration);
     static void set_revalidation_stall_timeout(AK::Duration);
 
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
+    virtual Optional<MonotonicTime> last_activity_time() const override { return m_last_activity_time; }
     bool notify_retrieved_http_cookie(Badge<ConnectionFromClient>, u64 cookie_request_id, StringView cookie);
     void notify_fetch_complete(Badge<ConnectionFromClient>, int result_code);
     void retry_after_aia(Badge<ConnectionFromClient>);
@@ -201,6 +202,10 @@ private:
     static size_t on_header_received(void* buffer, size_t size, size_t nmemb, void* user_data);
     static size_t on_data_received(void* buffer, size_t size, size_t nmemb, void* user_data);
 
+    // A state change, response bytes from curl, or bytes written to the cache entry count as progress — and a
+    // request waiting on the cache entry this request holds open judges by it whether this request has stalled.
+    void mark_activity() { m_last_activity_time = MonotonicTime::now(); }
+
     ErrorOr<void> detach_curl_handle_from_multi();
     ErrorOr<void> free_curl_structs();
     ErrorOr<void> inform_client_request_started();
@@ -247,6 +252,7 @@ private:
     ByteString m_method;
 
     UnixDateTime m_request_start_time { UnixDateTime::now() };
+    MonotonicTime m_last_activity_time { MonotonicTime::now() };
     NonnullRefPtr<HTTP::HeaderList> m_request_headers;
     ByteBuffer m_request_body;
 

--- a/Tests/RequestServer/CMakeLists.txt
+++ b/Tests/RequestServer/CMakeLists.txt
@@ -4,3 +4,6 @@ target_include_directories(TestAIA PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)
 
 ladybird_test(TestCookieResponses.cpp RequestServer LIBS requestserverservice)
 target_include_directories(TestCookieResponses PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)
+
+ladybird_test(TestDiskCacheWaiters.cpp RequestServer LIBS requestserverservice)
+target_include_directories(TestDiskCacheWaiters PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)

--- a/Tests/RequestServer/TestDiskCacheWaiters.cpp
+++ b/Tests/RequestServer/TestDiskCacheWaiters.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
+#include <LibCore/Timer.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibHTTP/Cache/Utilities.h>
 #include <LibIPC/Transport.h>
@@ -29,11 +30,29 @@ OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
 
 namespace {
 
-// A local HTTP server that answers some connections and leaves others hanging forever with the request unanswered,
-// which is what a network path that silently died looks like to RequestServer.
+// How the local HTTP server answers one connection: Pieces go out one at a time, one per interval. Then, the connection
+// is closed or else left open and silent forever (what a transfer whose network path died looks like to RequestServer).
+struct ServerResponse {
+    enum class CloseAfterLastPiece {
+        No,
+        Yes,
+    };
+
+    static ServerResponse at_once(ByteString response)
+    {
+        return { { move(response) }, AK::Duration {}, CloseAfterLastPiece::Yes };
+    }
+
+    Vector<ByteString> pieces;
+    AK::Duration interval;
+    CloseAfterLastPiece close_after_last_piece { CloseAfterLastPiece::Yes };
+};
+
+// A local HTTP server that answers some connections — either all at once, or else a piece at a time — and leaves others
+// hanging forever, with the request unanswered.
 class StallingServer {
 public:
-    using ResponseForConnection = Function<Optional<ByteString>(size_t connection_index)>;
+    using ResponseForConnection = Function<Optional<ServerResponse>(size_t connection_index)>;
 
     explicit StallingServer(ResponseForConnection response_for_connection)
         : m_response_for_connection(move(response_for_connection))
@@ -46,7 +65,7 @@ public:
             MUST(socket->set_blocking(false));
 
             auto connection_index = m_connections.size();
-            m_connections.append(Connection { move(socket), {} });
+            m_connections.append(Connection { move(socket) });
 
             auto& connection = m_connections.last();
             connection.socket->on_ready_to_read = [this, connection_index] {
@@ -62,10 +81,23 @@ public:
 
     size_t connection_count() const { return m_connections.size(); }
 
+    // How many connections the server had seen by the time it wrote this connection's last piece — so a test can tell
+    // whether a request that was waiting on this transfer held off until it finished.
+    Optional<size_t> connection_count_when_finished(size_t connection_index) const { return m_connections[connection_index].connection_count_when_finished; }
+
 private:
     struct Connection {
+        explicit Connection(NonnullOwnPtr<Core::TCPSocket> socket)
+            : socket(move(socket))
+        {
+        }
+
         NonnullOwnPtr<Core::TCPSocket> socket;
         ByteBuffer request;
+        Optional<ServerResponse> response;
+        size_t next_piece_index { 0 };
+        RefPtr<Core::Timer> piece_timer;
+        Optional<size_t> connection_count_when_finished;
     };
 
     void on_ready_to_read(size_t connection_index)
@@ -83,14 +115,36 @@ private:
         if (!StringView { connection.request }.contains("\r\n\r\n"sv))
             return;
 
-        // The request head is complete. Either answer it now, or never.
+        // The request head is complete. Either start answering it now, or never.
         connection.socket->on_ready_to_read = nullptr;
 
-        if (auto response = m_response_for_connection(connection_index); response.has_value()) {
-            MUST(connection.socket->set_blocking(true));
-            MUST(connection.socket->write_until_depleted(response->bytes()));
-            connection.socket->close();
+        auto response = m_response_for_connection(connection_index);
+        if (!response.has_value())
+            return;
+
+        MUST(connection.socket->set_blocking(true));
+        connection.response = response.release_value();
+        write_next_piece(connection_index);
+    }
+
+    void write_next_piece(size_t connection_index)
+    {
+        auto& connection = m_connections[connection_index];
+        auto const& response = *connection.response;
+
+        MUST(connection.socket->write_until_depleted(response.pieces[connection.next_piece_index++].bytes()));
+
+        if (connection.next_piece_index < response.pieces.size()) {
+            connection.piece_timer = Core::Timer::create_single_shot(static_cast<int>(response.interval.to_milliseconds()), [this, connection_index] {
+                write_next_piece(connection_index);
+            });
+            connection.piece_timer->start();
+            return;
         }
+
+        connection.connection_count_when_finished = m_connections.size();
+        if (response.close_after_last_piece == ServerResponse::CloseAfterLastPiece::Yes)
+            connection.socket->close();
     }
 
     RefPtr<Core::TCPServer> m_server;
@@ -98,7 +152,7 @@ private:
     ResponseForConnection m_response_for_connection;
 };
 
-ByteString http_response(StringView cache_control, StringView body)
+ByteString http_response_head(StringView cache_control, size_t body_length)
 {
     return ByteString::formatted(
         "HTTP/1.1 200 OK\r\n"
@@ -107,9 +161,45 @@ ByteString http_response(StringView cache_control, StringView body)
         "Cache-Control: {}\r\n"
         "ETag: \"v1\"\r\n"
         "Connection: close\r\n"
-        "\r\n"
-        "{}",
-        body.length(), cache_control, body);
+        "\r\n",
+        body_length, cache_control);
+}
+
+ByteString http_response(StringView cache_control, StringView body)
+{
+    return ByteString::formatted("{}{}", http_response_head(cache_control, body.length()), body);
+}
+
+// A response whose body goes out one byte per interval — so the request receiving it keeps making progress for as long
+// as the bytes keep coming. Delivering fewer bytes than the head has promised leaves the connection open and silent
+// after the last one: A transfer that has stalled for good.
+ServerResponse trickled_http_response(StringView cache_control, StringView body, size_t bytes_to_deliver, AK::Duration interval)
+{
+    VERIFY(bytes_to_deliver <= body.length());
+
+    ServerResponse response;
+    response.pieces.append(http_response_head(cache_control, body.length()));
+    for (size_t i = 0; i < bytes_to_deliver; ++i)
+        response.pieces.append(ByteString { body.substring_view(i, 1) });
+
+    response.interval = interval;
+    response.close_after_last_piece = bytes_to_deliver == body.length()
+        ? ServerResponse::CloseAfterLastPiece::Yes
+        : ServerResponse::CloseAfterLastPiece::No;
+    return response;
+}
+
+// A response whose body goes out a piece at a time — so the whole of it reaches curl quickly, without the server ever
+// blocking the event loop on one write.
+ServerResponse chunked_http_response(StringView cache_control, StringView body, size_t piece_size, AK::Duration interval)
+{
+    ServerResponse response;
+    response.pieces.append(http_response_head(cache_control, body.length()));
+    for (size_t offset = 0; offset < body.length(); offset += piece_size)
+        response.pieces.append(ByteString { body.substring_view(offset, min(piece_size, body.length() - offset)) });
+
+    response.interval = interval;
+    return response;
 }
 
 struct TestServer {
@@ -165,14 +255,28 @@ public:
         VERIFY(!response);
     }
 
-    // Pumps the event loop until the request finishes or the budget runs out.
+    // Pumps the event loop until the request finishes or the budget runs out — reading every response as it comes.
     Optional<FinishedRequest> wait_for_request_to_finish(u64 request_id, AK::Duration budget)
     {
+        return wait_for_request_to_finish_reading_slowly(request_id, budget, 64 * KiB, AK::Duration {});
+    }
+
+    // Pumps the event loop until the request finishes or the budget runs out — reading a bounded amount of every
+    // response, no more often than every interval: A client that's slow to consume what it asked for, but never stops.
+    // Reading less than RequestServer has ready leaves it holding the rest.
+    Optional<FinishedRequest> wait_for_request_to_finish_reading_slowly(u64 request_id, AK::Duration budget, size_t bytes_per_read, AK::Duration interval)
+    {
         auto deadline = MonotonicTime::now() + budget;
+        auto next_read = MonotonicTime::now();
 
         while (MonotonicTime::now() < deadline) {
             m_server.event_loop.pump(Core::EventLoop::WaitMode::PollForEvents);
             drain_client_messages();
+
+            if (MonotonicTime::now() >= next_read) {
+                read_from_response_sockets(bytes_per_read);
+                next_read = MonotonicTime::now() + interval;
+            }
 
             if (auto finished = m_finished_requests.get(request_id); finished.has_value())
                 return *finished;
@@ -182,10 +286,30 @@ public:
     }
 
 private:
+    void read_from_response_sockets(size_t max_bytes_per_socket)
+    {
+        if (m_response_read_buffer.size() < max_bytes_per_socket)
+            m_response_read_buffer = MUST(ByteBuffer::create_uninitialized(max_bytes_per_socket));
+
+        for (auto& response_socket : m_response_sockets)
+            (void)response_socket.value->read_some(m_response_read_buffer.span().slice(0, max_bytes_per_socket));
+    }
+
     void drain_client_messages()
     {
         (void)m_remote_transport->read_as_many_messages_as_possible_without_blocking([&](auto&& raw_message) {
             auto message = MUST(RequestClientEndpoint::decode_message(raw_message.bytes.bytes(), raw_message.attachments));
+
+            if (message->message_id() == Messages::RequestClient::RequestStarted::static_message_id()) {
+                auto& started = static_cast<Messages::RequestClient::RequestStarted&>(*message);
+
+                // Take the read end off the message, so it outlives it: A client that lets the pipe close breaks the
+                // transfer, and one that never reads it wedges a response too big for the pipe to hold. The tests read
+                // it at a pace of their own — so, its notifier stays off.
+                auto response_socket = MUST(Core::LocalSocket::adopt_fd(started.fd().take_fd()));
+                response_socket->set_notifications_enabled(false);
+                m_response_sockets.set(started.request_id(), move(response_socket));
+            }
 
             if (message->message_id() == Messages::RequestClient::HeadersBecameAvailable::static_message_id()) {
                 auto& headers = static_cast<Messages::RequestClient::HeadersBecameAvailable&>(*message);
@@ -206,6 +330,8 @@ private:
     OwnPtr<IPC::Transport> m_remote_transport;
     RefPtr<RequestServer::ConnectionFromClient> m_connection;
     HashMap<u64, ByteString> m_cache_statuses;
+    HashMap<u64, NonnullOwnPtr<Core::LocalSocket>> m_response_sockets;
+    ByteBuffer m_response_read_buffer;
     HashMap<u64, FinishedRequest> m_finished_requests;
 };
 
@@ -240,10 +366,10 @@ TEST_CASE(request_waiting_on_a_stalled_cache_entry_writer_eventually_bypasses_th
     TestConnection connection { server, disk_cache };
 
     // The first connection is never answered, so the first request keeps its cache entry writer open forever.
-    StallingServer http_server { [](size_t connection_index) -> Optional<ByteString> {
+    StallingServer http_server { [](size_t connection_index) -> Optional<ServerResponse> {
         if (connection_index == 0)
             return {};
-        return http_response("max-age=60"sv, "hello"sv);
+        return ServerResponse::at_once(http_response("max-age=60"sv, "hello"sv));
     } };
 
     auto url = http_server.url_for_path("/resource"sv);
@@ -268,10 +394,10 @@ TEST_CASE(stalled_background_revalidation_is_abandoned_and_releases_waiting_requ
 
     // The first connection stores a response that is stale immediately but may be served while it is revalidated
     // in the background. The second connection, the revalidation, is never answered.
-    StallingServer http_server { [](size_t connection_index) -> Optional<ByteString> {
+    StallingServer http_server { [](size_t connection_index) -> Optional<ServerResponse> {
         if (connection_index == 1)
             return {};
-        return http_response("max-age=0, stale-while-revalidate=600"sv, "hello"sv);
+        return ServerResponse::at_once(http_response("max-age=0, stale-while-revalidate=600"sv, "hello"sv));
     } };
 
     auto url = http_server.url_for_path("/resource"sv);
@@ -287,4 +413,100 @@ TEST_CASE(stalled_background_revalidation_is_abandoned_and_releases_waiting_requ
     connection.start_request(3, url);
     expect_finished_without_error(connection.wait_for_request_to_finish(3, AK::Duration::from_seconds(10)), "written-to-cache"sv);
     EXPECT_EQ(http_server.connection_count(), 3u);
+}
+
+// A request whose cache entry is held open by a request still receiving data (however slowly) keeps waiting — rather
+// than fetching a second copy over the network. And it reads the entry after that request has finished filling it.
+TEST_CASE(request_waiting_on_a_slow_cache_entry_writer_keeps_waiting_and_reads_the_finished_entry)
+{
+    RequestServer::Request::set_wait_for_cache_timeout(AK::Duration::from_seconds(1));
+    RequestServer::Request::set_revalidation_stall_timeout(AK::Duration::from_seconds(60));
+
+    TestServer server;
+    auto disk_cache = create_test_disk_cache();
+    TestConnection connection { server, disk_cache };
+
+    // The body arrives one byte every 100ms. So, the transfer takes a whole wait limit — without ever going quiet for
+    // more than a tenth of one.
+    StallingServer http_server { [](size_t) -> Optional<ServerResponse> {
+        return trickled_http_response("max-age=60"sv, "0123456789"sv, 10, AK::Duration::from_milliseconds(100));
+    } };
+
+    auto url = http_server.url_for_path("/resource"sv);
+    connection.start_request(1, url);
+    connection.start_request(2, url);
+
+    expect_finished_without_error(connection.wait_for_request_to_finish(1, AK::Duration::from_seconds(10)), "written-to-cache"sv);
+    expect_finished_without_error(connection.wait_for_request_to_finish(2, AK::Duration::from_seconds(10)), "read-from-cache"sv);
+    EXPECT_EQ(http_server.connection_count(), 1u);
+}
+
+// A request whose cache entry is held open by a request that received data for a while, and then stopped for good,
+// bypasses the cache once that request has been quiet for a whole wait limit — and not before.
+TEST_CASE(request_waiting_on_a_cache_entry_writer_that_stopped_receiving_data_bypasses_the_cache_once_it_stalls)
+{
+    RequestServer::Request::set_wait_for_cache_timeout(AK::Duration::from_seconds(1));
+    RequestServer::Request::set_revalidation_stall_timeout(AK::Duration::from_seconds(60));
+
+    TestServer server;
+    auto disk_cache = create_test_disk_cache();
+    TestConnection connection { server, disk_cache };
+
+    // The first connection delivers half of its body, one byte every 100ms, and then falls silent — with the connection
+    // left open. Any later connection is answered at once.
+    StallingServer http_server { [](size_t connection_index) -> Optional<ServerResponse> {
+        if (connection_index == 0)
+            return trickled_http_response("max-age=60"sv, "0123456789abcdefghij"sv, 10, AK::Duration::from_milliseconds(100));
+        return ServerResponse::at_once(http_response("max-age=60"sv, "hello"sv));
+    } };
+
+    auto url = http_server.url_for_path("/resource"sv);
+    connection.start_request(1, url);
+    connection.start_request(2, url);
+
+    expect_finished_without_error(connection.wait_for_request_to_finish(2, AK::Duration::from_seconds(10)), "not-cached"sv);
+    EXPECT_EQ(http_server.connection_count(), 2u);
+
+    // The second connection arrived only after the first had stopped sending: The waiting request held off for as long
+    // as the transfer holding its entry kept receiving data.
+    EXPECT_EQ(http_server.connection_count_when_finished(0).value_or(0), 1u);
+}
+
+// A request whose cache entry is held open by a transfer that's over on the wire, but whose bytes are still going out
+// to a slow client, keeps waiting: The entry is still filling — however slowly — so fetching a second copy would waste
+// a request on a response that's already on its way to disk.
+TEST_CASE(request_waiting_on_a_cache_entry_a_slow_client_is_still_filling_keeps_waiting)
+{
+    RequestServer::Request::set_wait_for_cache_timeout(AK::Duration::from_seconds(1));
+    RequestServer::Request::set_revalidation_stall_timeout(AK::Duration::from_seconds(60));
+
+    TestServer server;
+    auto disk_cache = create_test_disk_cache();
+    TestConnection connection { server, disk_cache };
+
+    // 8 MiB goes out in 32 KiB pieces, so the transfer is over on the wire in well under a second. The client pipe
+    // holds only a small part of that: The rest waits in RequestServer until the client reads what it has.
+    auto body = ByteString::repeated('x', 8 * MiB);
+    StallingServer http_server { [&](size_t) -> Optional<ServerResponse> {
+        return chunked_http_response("max-age=60"sv, body, 32 * KiB, AK::Duration::from_milliseconds(2));
+    } };
+
+    auto url = http_server.url_for_path("/resource"sv);
+    auto started_at = MonotonicTime::now();
+    connection.start_request(1, url);
+    connection.start_request(2, url);
+
+    // The client takes 64 KiB every 25ms: three wait limits or so for the whole body, with the entry filling the whole
+    // way through — and the request waiting on it has to sit through all of it. And that pace isn't arbitrary:
+    // RequestServer writes to the entry only as the pipe takes bytes, and Linux reports a stream socket writable again
+    // only once three quarters of its send buffer have drained. So, the client has to take a few hundred KiB well within
+    // one limit — or the entry goes quiet for a whole one, and the waiting request rightly gives up on it.
+    auto finished = connection.wait_for_request_to_finish_reading_slowly(1, AK::Duration::from_seconds(30), 64 * KiB, AK::Duration::from_milliseconds(25));
+    expect_finished_without_error(finished, "written-to-cache"sv);
+
+    // NB: A pipe that could hold the whole body would end the transfer at once — and leave the wait untested.
+    EXPECT(MonotonicTime::now() - started_at >= AK::Duration::from_seconds(2));
+
+    expect_finished_without_error(connection.wait_for_request_to_finish(2, AK::Duration::from_seconds(10)), "read-from-cache"sv);
+    EXPECT_EQ(http_server.connection_count(), 1u);
 }

--- a/Tests/RequestServer/TestDiskCacheWaiters.cpp
+++ b/Tests/RequestServer/TestDiskCacheWaiters.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteString.h>
+#include <AK/Time.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Socket.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibCore/TCPServer.h>
+#include <LibHTTP/Cache/DiskCache.h>
+#include <LibHTTP/Cache/Utilities.h>
+#include <LibIPC/Transport.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <RequestServer/CURL.h>
+#include <RequestServer/ConnectionFromClient.h>
+#include <RequestServer/Request.h>
+#include <RequestServer/ResourceSubstitutionMap.h>
+
+namespace RequestServer {
+
+OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
+
+}
+
+namespace {
+
+// A local HTTP server that answers some connections and leaves others hanging forever with the request unanswered,
+// which is what a network path that silently died looks like to RequestServer.
+class StallingServer {
+public:
+    using ResponseForConnection = Function<Optional<ByteString>(size_t connection_index)>;
+
+    explicit StallingServer(ResponseForConnection response_for_connection)
+        : m_response_for_connection(move(response_for_connection))
+    {
+        m_server = MUST(Core::TCPServer::try_create());
+        MUST(m_server->listen(IPv4Address { 127, 0, 0, 1 }, 0));
+
+        m_server->on_ready_to_accept = [this] {
+            auto socket = MUST(m_server->accept());
+            MUST(socket->set_blocking(false));
+
+            auto connection_index = m_connections.size();
+            m_connections.append(Connection { move(socket), {} });
+
+            auto& connection = m_connections.last();
+            connection.socket->on_ready_to_read = [this, connection_index] {
+                on_ready_to_read(connection_index);
+            };
+        };
+    }
+
+    URL::URL url_for_path(StringView path) const
+    {
+        return URL::Parser::basic_parse(ByteString::formatted("http://127.0.0.1:{}{}", *m_server->local_port(), path)).release_value();
+    }
+
+    size_t connection_count() const { return m_connections.size(); }
+
+private:
+    struct Connection {
+        NonnullOwnPtr<Core::TCPSocket> socket;
+        ByteBuffer request;
+    };
+
+    void on_ready_to_read(size_t connection_index)
+    {
+        auto& connection = m_connections[connection_index];
+
+        auto buffer = MUST(ByteBuffer::create_uninitialized(4096));
+        auto bytes = MUST(connection.socket->read_some(buffer));
+        if (bytes.is_empty()) {
+            connection.socket->on_ready_to_read = nullptr;
+            return;
+        }
+
+        MUST(connection.request.try_append(bytes));
+        if (!StringView { connection.request }.contains("\r\n\r\n"sv))
+            return;
+
+        // The request head is complete. Either answer it now, or never.
+        connection.socket->on_ready_to_read = nullptr;
+
+        if (auto response = m_response_for_connection(connection_index); response.has_value()) {
+            MUST(connection.socket->set_blocking(true));
+            MUST(connection.socket->write_until_depleted(response->bytes()));
+            connection.socket->close();
+        }
+    }
+
+    RefPtr<Core::TCPServer> m_server;
+    Vector<Connection> m_connections;
+    ResponseForConnection m_response_for_connection;
+};
+
+ByteString http_response(StringView cache_control, StringView body)
+{
+    return ByteString::formatted(
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/plain\r\n"
+        "Content-Length: {}\r\n"
+        "Cache-Control: {}\r\n"
+        "ETag: \"v1\"\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+        "{}",
+        body.length(), cache_control, body);
+}
+
+struct TestServer {
+    Core::EventLoop event_loop;
+    RequestServer::ConnectionFromClient::ConnectionMap connections;
+    RequestServer::ConnectionFromClient::RequestTransferLeaseMap request_transfer_leases;
+};
+
+struct FinishedRequest {
+    Optional<Requests::NetworkError> network_error;
+    // The disk cache's test mode reports how it treated the response: not-cached, written-to-cache or read-from-cache.
+    ByteString cache_status;
+};
+
+class TestConnection {
+public:
+    TestConnection(TestServer& server, HTTP::DiskCache& disk_cache)
+        : m_server(server)
+    {
+        static bool libcurl_initialized = [] {
+            MUST(RequestServer::initialize_libcurl());
+            return true;
+        }();
+        (void)libcurl_initialized;
+
+        auto pair = MUST(IPC::Transport::create_paired());
+        m_remote_transport = MUST(pair.remote_handle.create_transport());
+        m_connection = RequestServer::ConnectionFromClient::construct(
+            move(pair.local), RequestServer::ConnectionFromClient::IsPrimaryConnection::Yes, RequestServer::IsPrivate::No,
+            m_server.connections, m_server.request_transfer_leases, disk_cache, ByteString {});
+#ifdef AK_OS_WINDOWS
+        auto pid = Core::System::getpid();
+        m_connection->transport().set_peer_pid(pid);
+        m_remote_transport->set_peer_pid(pid);
+#endif
+    }
+
+    ~TestConnection()
+    {
+        if (m_connection->is_open())
+            m_connection->shutdown();
+    }
+
+    void start_request(u64 request_id, URL::URL url)
+    {
+        // The disk cache only stores responses to requests that opt in while it runs in test mode.
+        Vector<HTTP::Header> request_headers {
+            { ByteString { HTTP::TEST_CACHE_ENABLED_HEADER }, "1"sv },
+        };
+
+        auto message = make<Messages::RequestServer::StartRequest>(request_id, ByteString { "GET" }, move(url), move(request_headers), ByteBuffer {}, HTTP::CacheMode::Default, HTTP::Cookie::IncludeCredentials::No, Core::ProxyData {}, false, Optional<u32> {});
+        auto response = MUST(static_cast<RequestServerEndpoint::Stub&>(*m_connection).handle(move(message)));
+        VERIFY(!response);
+    }
+
+    // Pumps the event loop until the request finishes or the budget runs out.
+    Optional<FinishedRequest> wait_for_request_to_finish(u64 request_id, AK::Duration budget)
+    {
+        auto deadline = MonotonicTime::now() + budget;
+
+        while (MonotonicTime::now() < deadline) {
+            m_server.event_loop.pump(Core::EventLoop::WaitMode::PollForEvents);
+            drain_client_messages();
+
+            if (auto finished = m_finished_requests.get(request_id); finished.has_value())
+                return *finished;
+        }
+
+        return {};
+    }
+
+private:
+    void drain_client_messages()
+    {
+        (void)m_remote_transport->read_as_many_messages_as_possible_without_blocking([&](auto&& raw_message) {
+            auto message = MUST(RequestClientEndpoint::decode_message(raw_message.bytes.bytes(), raw_message.attachments));
+
+            if (message->message_id() == Messages::RequestClient::HeadersBecameAvailable::static_message_id()) {
+                auto& headers = static_cast<Messages::RequestClient::HeadersBecameAvailable&>(*message);
+                for (auto const& header : headers.response_headers()) {
+                    if (header.name.equals_ignoring_ascii_case(HTTP::TEST_CACHE_STATUS_HEADER))
+                        m_cache_statuses.set(headers.request_id(), header.value);
+                }
+            }
+
+            if (message->message_id() == Messages::RequestClient::RequestFinished::static_message_id()) {
+                auto& finished = static_cast<Messages::RequestClient::RequestFinished&>(*message);
+                m_finished_requests.set(finished.request_id(), FinishedRequest { finished.network_error(), m_cache_statuses.get(finished.request_id()).value_or({}) });
+            }
+        });
+    }
+
+    TestServer& m_server;
+    OwnPtr<IPC::Transport> m_remote_transport;
+    RefPtr<RequestServer::ConnectionFromClient> m_connection;
+    HashMap<u64, ByteString> m_cache_statuses;
+    HashMap<u64, FinishedRequest> m_finished_requests;
+};
+
+HTTP::DiskCache create_test_disk_cache()
+{
+    auto cache_root = LexicalPath::join(Core::StandardPaths::cache_directory(), "Ladybird"sv);
+    return MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, cache_root)).release_value();
+}
+
+void expect_finished_without_error(Optional<FinishedRequest> const& finished, StringView expected_cache_status)
+{
+    EXPECT(finished.has_value());
+    if (!finished.has_value())
+        return;
+
+    if (finished->network_error.has_value())
+        FAIL(ByteString::formatted("Request finished with network error {}", to_underlying(*finished->network_error)));
+    EXPECT_EQ(finished->cache_status, expected_cache_status);
+}
+
+}
+
+// A request whose cache entry is held open by a request that never completes must not wait forever: it goes to
+// the network without the cache once the wait times out.
+TEST_CASE(request_waiting_on_a_stalled_cache_entry_writer_eventually_bypasses_the_cache)
+{
+    RequestServer::Request::set_wait_for_cache_timeout(AK::Duration::from_milliseconds(250));
+    RequestServer::Request::set_revalidation_stall_timeout(AK::Duration::from_seconds(60));
+
+    TestServer server;
+    auto disk_cache = create_test_disk_cache();
+    TestConnection connection { server, disk_cache };
+
+    // The first connection is never answered, so the first request keeps its cache entry writer open forever.
+    StallingServer http_server { [](size_t connection_index) -> Optional<ByteString> {
+        if (connection_index == 0)
+            return {};
+        return http_response("max-age=60"sv, "hello"sv);
+    } };
+
+    auto url = http_server.url_for_path("/resource"sv);
+    connection.start_request(1, url);
+    connection.start_request(2, url);
+
+    auto finished = connection.wait_for_request_to_finish(2, AK::Duration::from_seconds(10));
+    expect_finished_without_error(finished, "not-cached"sv);
+    EXPECT_EQ(http_server.connection_count(), 2u);
+}
+
+// A background revalidation that stops receiving data is abandoned, which closes the cache entry it holds open and
+// lets requests waiting on that entry proceed.
+TEST_CASE(stalled_background_revalidation_is_abandoned_and_releases_waiting_requests)
+{
+    RequestServer::Request::set_wait_for_cache_timeout(AK::Duration::from_seconds(60));
+    RequestServer::Request::set_revalidation_stall_timeout(AK::Duration::from_seconds(1));
+
+    TestServer server;
+    auto disk_cache = create_test_disk_cache();
+    TestConnection connection { server, disk_cache };
+
+    // The first connection stores a response that is stale immediately but may be served while it is revalidated
+    // in the background. The second connection, the revalidation, is never answered.
+    StallingServer http_server { [](size_t connection_index) -> Optional<ByteString> {
+        if (connection_index == 1)
+            return {};
+        return http_response("max-age=0, stale-while-revalidate=600"sv, "hello"sv);
+    } };
+
+    auto url = http_server.url_for_path("/resource"sv);
+    connection.start_request(1, url);
+    expect_finished_without_error(connection.wait_for_request_to_finish(1, AK::Duration::from_seconds(10)), "written-to-cache"sv);
+
+    // Served from the cache, and kicks off the background revalidation that will stall.
+    connection.start_request(2, url);
+    expect_finished_without_error(connection.wait_for_request_to_finish(2, AK::Duration::from_seconds(10)), "read-from-cache"sv);
+
+    // Waits on the entry held by the stalled revalidation. Abandoning a revalidation discards the entry, so once that
+    // happens this request fetches the resource anew, long before the 60 second wait limit could have let it go.
+    connection.start_request(3, url);
+    expect_finished_without_error(connection.wait_for_request_to_finish(3, AK::Duration::from_seconds(10)), "written-to-cache"sv);
+    EXPECT_EQ(http_server.connection_count(), 3u);
+}


### PR DESCRIPTION
This PR has two commits. The first bounds how long a request waits on a disk-cache entry another request holds open; the second makes that bound fire only once the holder has stalled — so that a slow-but-healthy transfer never draws duplicate requests.

### Stop waiting forever on a stalled disk-cache entry

**Problem:** A resource could stop loading for the rest of the browser session. On GitHub’s PR page, the Checks/“merge box” area stayed on its “Loading merge status” placeholder indefinitely — in a tab that had been open across a network outage — and reloading the tab didn’t help. Fetching the same URL with `cache:no-store` — or with a cache-busting query parameter — worked immediately. And a fresh browser instance on the same profile loaded the page fine.

**Cause:** When the disk cache entry for a request’s URL is held open by another request — a writer, or a reader that a revalidation owns — `DiskCache::check_if_cache_has_open_entry()` parks that request in `m_requests_waiting_completion`, and it moves on when `cache_entry_closed()` runs for that entry. Nothing bounded that wait. Meanwhile, a transfer whose connection has silently died never completes on its own — because `RequestServer` gives curl only a connect timeout. And a background revalidation stuck that way is owned by the connection, rather than by any tab — so no reload or navigation cancels it. It kept its cache entry open for the lifetime of the process. Every later request for that URL then queued behind it — forever. `notify_request_unblocked()` already carried a `FIXME` asking for exactly the missing timer.

**Fix:** Give the wait a limit. A request that enters `State::WaitForCache` arms a single-shot timer; if the entry hasn’t been released by the time it fires, the request continues to `State::DNSLookup` with its cache status set to `NotCached` — so it neither reads from nor writes to the disk cache — and `notify_request_unblocked()` ignores the notification that eventually arrives for it. A background revalidation whose wait times out has nothing left to do, and completes instead — and an `only-if-cached` request fails as it would have without an entry. Also, give background revalidations a stall timeout — via `CURLOPT_LOW_SPEED_LIMIT` and `CURLOPT_LOW_SPEED_TIME`: Nobody waits on them, so nothing else would ever notice one that stopped receiving data — and abandoning one fails the revalidation, which discards the entry, and releases the requests waiting on it. Both limits (10 and 30 seconds) are adjustable.

### Bypass a cache entry only once its holder stalls

**Problem:** A large download (or any response taking more than 10s) spawned an additional copy of itself for every later request for the same URL — no matter how healthy the transfer was. A page that kept retrying in the meantime spawned one copy per retry. A resource downloading so slowly as to take above 30s — but not so slowly as to count as a dead network — would draw an unbounded number of requests; a request that takes 30s with an additional copy arriving at 10s would put two requests on the wire; and a wedged network could end up with… a boatload of them.

**Cause:** The wait limit the parent commit added ran on the wall clock from the moment the disk cache parked a request behind the entry that another request held open — its holder. It never asked if the holder was still receiving data. And an entry is held from before the DNS lookup until the body completes. So, a healthy transfer of any length kept later requests parked for as long as it ran — and then, past the limit, sent them to the network on their own.

**Fix:** Have each request note when it last made progress — a state change, response bytes from curl, or bytes written to its cache entry — and have the disk cache report the latest such time across the requests holding an entry open. The entry fills only as fast as the client reads the response, so a slow client keeps those writes coming long after curl has nothing left to deliver — and they count as progress too. When a parked request’s timer fires, it now checks that time: A holder that’s shown no sign of life for a whole limit counts as stalled — and the parked request goes to the network without the cache, as before. Otherwise, it keeps waiting — and looks again once the holder has had a full limit’s worth of time to fall silent for good. So, slow transfers never cause a duplicate fetch: However long it takes, however many requests queue up behind it, they all read the entry once it’s written. A dead transfer still releases its waiters after 10s of silence. And a wedged network gets no request the page didn’t ask for: The waiters go out only once the holder has been silent for the whole limit — and a silent holder may well be dead while the network is fine. (And that all largely matches Firefox’s caching limits — which is what this was actually modeled on.)

