### PR TITLE
Replay run cache entries for width-stable atomic inlines

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -43,27 +43,72 @@ pub(super) struct FcRunCacheKey {
     root_cells: used_values::UsedValuesCellState,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct RunInputsTheStoredRunNeverObserved {
+    pub(super) percentage_block_basis_and_block_size_definiteness: bool,
+    pub(super) definite_available_inline_sizes_at_or_above: Option<CssPixels>,
+    pub(super) percentage_inline_basis: bool,
+}
+
+impl RunInputsTheStoredRunNeverObserved {
+    fn proven_by_stored_run(outputs: &formatting_context::RunOutputs) -> Self {
+        Self {
+            percentage_block_basis_and_block_size_definiteness: !outputs.result.depends_on_percentage_block_size,
+            definite_available_inline_sizes_at_or_above: outputs
+                .atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+            percentage_inline_basis: outputs
+                .atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above
+                .is_some(),
+        }
+    }
+
+    fn accepted_when_reusing_stale_line_data_after_structural_inline_damage(
+        outputs: &formatting_context::RunOutputs,
+    ) -> Self {
+        Self {
+            definite_available_inline_sizes_at_or_above: None,
+            percentage_inline_basis: false,
+            ..Self::proven_by_stored_run(outputs)
+        }
+    }
+
+    fn relaxes_any_input(self) -> bool {
+        let Self {
+            percentage_block_basis_and_block_size_definiteness,
+            definite_available_inline_sizes_at_or_above,
+            percentage_inline_basis,
+        } = self;
+        percentage_block_basis_and_block_size_definiteness
+            || definite_available_inline_sizes_at_or_above.is_some()
+            || percentage_inline_basis
+    }
+}
+
 impl FcRunCacheKey {
-    fn matches(&self, probe: &Self, entry_depends_on_percentage_block_size: bool) -> bool {
+    fn matches(&self, probe: &Self, unobserved: RunInputsTheStoredRunNeverObserved) -> bool {
         if self == probe {
             return true;
         }
-        if entry_depends_on_percentage_block_size {
+        if !unobserved.relaxes_any_input() {
             return false;
         }
         self.fc_type == probe.fc_type
             && self.root_cells == probe.root_cells
-            && layout_inputs_match_ignoring_percentage_block_size(&self.input, &probe.input)
+            && layout_inputs_match_ignoring_unobserved(&self.input, &probe.input, unobserved)
     }
 }
 
-fn available_block_sizes_are_interchangeable(a: AvailableSize, b: AvailableSize) -> bool {
+fn available_block_sizes_match(a: AvailableSize, b: AvailableSize, block_size_definiteness_unobserved: bool) -> bool {
     let is_definite_or_indefinite =
         |size: AvailableSize| matches!(size, AvailableSize::Definite(_) | AvailableSize::Indefinite);
-    a == b || (is_definite_or_indefinite(a) && is_definite_or_indefinite(b))
+    a == b || (block_size_definiteness_unobserved && is_definite_or_indefinite(a) && is_definite_or_indefinite(b))
 }
 
-fn layout_inputs_match_ignoring_percentage_block_size(a: &LayoutInput, b: &LayoutInput) -> bool {
+fn layout_inputs_match_ignoring_unobserved(
+    a: &LayoutInput,
+    b: &LayoutInput,
+    unobserved: RunInputsTheStoredRunNeverObserved,
+) -> bool {
     let LayoutInput {
         available_space,
         containing_block_constraints,
@@ -73,18 +118,48 @@ fn layout_inputs_match_ignoring_percentage_block_size(a: &LayoutInput, b: &Layou
     } = *a;
     let ContainingBlockConstraints {
         percentage_basis_inline_size,
-        percentage_basis_block_size: _,
-        quirks_mode_percentage_basis_block_size: _,
+        percentage_basis_block_size,
+        quirks_mode_percentage_basis_block_size,
     } = containing_block_constraints;
-    available_space.inline_size == b.available_space.inline_size
-        && available_block_sizes_are_interchangeable(available_space.block_size, b.available_space.block_size)
-        && percentage_basis_inline_size == b.containing_block_constraints.percentage_basis_inline_size
-        && content_box_position_in_bfc_root == b.content_box_position_in_bfc_root
-        && participation == b.participation
-        && sizing_directives_match_ignoring_percentage_block_size(&sizing, &b.sizing)
+    if participation != b.participation || content_box_position_in_bfc_root != b.content_box_position_in_bfc_root {
+        return false;
+    }
+    let available_inline_sizes_match = available_space.inline_size == b.available_space.inline_size
+        || match (
+            unobserved.definite_available_inline_sizes_at_or_above,
+            available_space.inline_size,
+            b.available_space.inline_size,
+        ) {
+            (Some(threshold), AvailableSize::Definite(_), AvailableSize::Definite(probe)) => probe >= threshold,
+            _ => false,
+        };
+    let inline_bases_match = percentage_basis_inline_size
+        == b.containing_block_constraints.percentage_basis_inline_size
+        || unobserved.percentage_inline_basis;
+    let block_bases_match = (percentage_basis_block_size == b.containing_block_constraints.percentage_basis_block_size
+        && quirks_mode_percentage_basis_block_size
+            == b.containing_block_constraints.quirks_mode_percentage_basis_block_size)
+        || unobserved.percentage_block_basis_and_block_size_definiteness;
+    available_inline_sizes_match
+        && available_block_sizes_match(
+            available_space.block_size,
+            b.available_space.block_size,
+            unobserved.percentage_block_basis_and_block_size_definiteness,
+        )
+        && inline_bases_match
+        && block_bases_match
+        && sizing_directives_match_ignoring_unobserved(
+            &sizing,
+            &b.sizing,
+            unobserved.percentage_block_basis_and_block_size_definiteness,
+        )
 }
 
-fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectives, b: &RootSizingDirectives) -> bool {
+fn sizing_directives_match_ignoring_unobserved(
+    a: &RootSizingDirectives,
+    b: &RootSizingDirectives,
+    block_size_definiteness_unobserved: bool,
+) -> bool {
     let RootSizingDirectives {
         forced_content_inline_size,
         forced_content_block_size,
@@ -116,7 +191,11 @@ fn sizing_directives_match_ignoring_percentage_block_size(a: &RootSizingDirectiv
             (None, None) => true,
             (Some(a_space), Some(b_space)) => {
                 a_space.inline_size == b_space.inline_size
-                    && available_block_sizes_are_interchangeable(a_space.block_size, b_space.block_size)
+                    && available_block_sizes_match(
+                        a_space.block_size,
+                        b_space.block_size,
+                        block_size_definiteness_unobserved,
+                    )
             }
             _ => false,
         }
@@ -177,6 +256,9 @@ impl FcRunCacheEntry {
             result: self.outputs.result,
             root,
             root_outcome: self.outputs.root_outcome.clone(),
+            atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above: self
+                .outputs
+                .atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
         }
     }
 }
@@ -266,10 +348,10 @@ impl FcRunCacheArenaStore {
         if entry.validity != validity {
             return None;
         }
-        if !entry
-            .key
-            .matches(key, entry.outputs.result.depends_on_percentage_block_size)
-        {
+        if !entry.key.matches(
+            key,
+            RunInputsTheStoredRunNeverObserved::proven_by_stored_run(&entry.outputs),
+        ) {
             return None;
         }
         Some(entry.clone())
@@ -288,7 +370,12 @@ impl FcRunCacheArenaStore {
         let entries = self.entries.borrow();
         let entry = entries.get(slot as usize)?.as_ref()?;
         if entry.validity.slot_generation != validity.slot_generation
-            || !entry.key.matches(key, entry.outputs.result.depends_on_percentage_block_size)
+            || !entry.key.matches(
+                key,
+                RunInputsTheStoredRunNeverObserved::accepted_when_reusing_stale_line_data_after_structural_inline_damage(
+                    &entry.outputs,
+                ),
+            )
             // Each child-list edit bumps once when topology changes and once
             // when the parent is marked for layout-tree-update layout.
             || validity
@@ -581,6 +668,23 @@ fn verify_cached_entry_against_fresh_run(root_slot: u32, cached: &FcRunCacheEntr
         fresh.outputs.root_outcome.rare.as_ref(),
     );
     assert_unplaced_roots_match(root_slot, cached.outputs.root.as_ref(), fresh.outputs.root.as_ref());
+    assert_available_inline_size_threshold_matches_after_the_cells_it_derives_from(root_slot, cached, fresh);
+}
+
+fn assert_available_inline_size_threshold_matches_after_the_cells_it_derives_from(
+    root_slot: u32,
+    cached: &FcRunCacheEntry,
+    fresh: &FcRunCacheEntry,
+) {
+    assert!(
+        cached
+            .outputs
+            .atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above
+            == fresh
+                .outputs
+                .atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+        "run cache shadow: available inline size independence diverged for slot {root_slot}"
+    );
 }
 
 /// The comparable view of the payloads both `UsedValuesRareData` and
@@ -799,5 +903,127 @@ fn collect_diverged_fragment_fields(
     }
     if !line_data_matches(cached.line_data.as_deref(), fresh.line_data.as_deref()) {
         diverged.push("line_data");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(available_inline: AvailableSize, percentage_basis_inline_size: Option<CssPixels>) -> FcRunCacheKey {
+        FcRunCacheKey {
+            fc_type: formatting_context::FfiFormattingContextType::Block,
+            input: LayoutInput::new(
+                AvailableSpace {
+                    inline_size: available_inline,
+                    block_size: AvailableSize::Indefinite,
+                },
+                ContainingBlockConstraints {
+                    percentage_basis_inline_size,
+                    ..ContainingBlockConstraints::default()
+                },
+                ParticipationInParentFormattingContext::AtomicInline,
+            ),
+            root_cells: used_values::UsedValuesCellState::capture(&UsedValues::default()),
+        }
+    }
+
+    fn px(value: i64) -> CssPixels {
+        CssPixels::from_integer(value)
+    }
+
+    fn inline_inputs_unobserved_at_or_above(threshold: i64) -> RunInputsTheStoredRunNeverObserved {
+        RunInputsTheStoredRunNeverObserved {
+            percentage_block_basis_and_block_size_definiteness: false,
+            definite_available_inline_sizes_at_or_above: Some(px(threshold)),
+            percentage_inline_basis: true,
+        }
+    }
+
+    #[test]
+    fn identical_keys_match_without_relaxations() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        assert!(stored.matches(&stored, RunInputsTheStoredRunNeverObserved::default()));
+    }
+
+    #[test]
+    fn a_different_available_inline_size_misses_without_the_inline_relaxation() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        let probe = key(AvailableSize::definite(px(320)), Some(px(320)));
+        assert!(!stored.matches(&probe, RunInputsTheStoredRunNeverObserved::default()));
+        assert!(!stored.matches(
+            &probe,
+            RunInputsTheStoredRunNeverObserved {
+                percentage_block_basis_and_block_size_definiteness: true,
+                definite_available_inline_sizes_at_or_above: None,
+                percentage_inline_basis: false,
+            }
+        ));
+    }
+
+    #[test]
+    fn the_inline_guarantees_are_granted_separately() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        let only_available_inline_sizes_unobserved = RunInputsTheStoredRunNeverObserved {
+            definite_available_inline_sizes_at_or_above: Some(px(0)),
+            ..RunInputsTheStoredRunNeverObserved::default()
+        };
+        let only_inline_basis_unobserved = RunInputsTheStoredRunNeverObserved {
+            percentage_inline_basis: true,
+            ..RunInputsTheStoredRunNeverObserved::default()
+        };
+        let wider_with_same_basis = key(AvailableSize::definite(px(320)), Some(px(300)));
+        assert!(stored.matches(&wider_with_same_basis, only_available_inline_sizes_unobserved));
+        assert!(!stored.matches(&wider_with_same_basis, only_inline_basis_unobserved));
+        let same_width_with_other_basis = key(AvailableSize::definite(px(300)), Some(px(320)));
+        assert!(stored.matches(&same_width_with_other_basis, only_inline_basis_unobserved));
+        assert!(!stored.matches(&same_width_with_other_basis, only_available_inline_sizes_unobserved));
+    }
+
+    #[test]
+    fn the_inline_relaxation_accepts_available_sizes_at_or_above_the_threshold() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        assert!(stored.matches(
+            &key(AvailableSize::definite(px(320)), Some(px(320))),
+            inline_inputs_unobserved_at_or_above(100)
+        ));
+        assert!(stored.matches(
+            &key(AvailableSize::definite(px(100)), Some(px(100))),
+            inline_inputs_unobserved_at_or_above(100)
+        ));
+        assert!(!stored.matches(
+            &key(AvailableSize::definite(px(99)), Some(px(99))),
+            inline_inputs_unobserved_at_or_above(100)
+        ));
+    }
+
+    #[test]
+    fn the_inline_relaxation_needs_definite_available_sizes_on_both_sides() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        assert!(!stored.matches(
+            &key(AvailableSize::MaxContent, None),
+            inline_inputs_unobserved_at_or_above(0)
+        ));
+        let stored_intrinsic = key(AvailableSize::MaxContent, None);
+        assert!(!stored_intrinsic.matches(
+            &key(AvailableSize::definite(px(300)), Some(px(300))),
+            inline_inputs_unobserved_at_or_above(0)
+        ));
+    }
+
+    #[test]
+    fn the_inline_relaxation_leaves_every_other_input_exact() {
+        let stored = key(AvailableSize::definite(px(300)), Some(px(300)));
+        let mutators: [fn(&mut FcRunCacheKey); 4] = [
+            |probe| probe.input.containing_block_constraints.percentage_basis_block_size = Some(px(10)),
+            |probe| probe.input.available_space.block_size = AvailableSize::definite(px(10)),
+            |probe| probe.input.sizing.adopt_automatic_content_block_size = true,
+            |probe| probe.input.participation = ParticipationInParentFormattingContext::Float,
+        ];
+        for mutate in mutators {
+            let mut probe = key(AvailableSize::definite(px(320)), Some(px(320)));
+            mutate(&mut probe);
+            assert!(!stored.matches(&probe, inline_inputs_unobserved_at_or_above(0)));
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -814,6 +814,7 @@ pub(crate) struct RunOutputs {
     pub(crate) result: ChildLayoutResult,
     pub(crate) root: Option<fragment_tree::UnplacedRootFragment>,
     pub(crate) root_outcome: RunRootOutcome,
+    pub(crate) atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above: Option<CssPixels>,
 }
 
 pub(crate) enum ChildLayoutOutcome {
@@ -1098,6 +1099,7 @@ impl FormattingContextRun {
         &self,
         result: ChildLayoutResult,
         root: Option<fragment_tree::UnplacedRootFragment>,
+        atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above: Option<CssPixels>,
     ) -> RunOutputs {
         let record = self.records.used_values(self.box_);
         let root_outcome = RunRootOutcome {
@@ -1110,6 +1112,7 @@ impl FormattingContextRun {
             result,
             root,
             root_outcome,
+            atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
         }
     }
 }
@@ -1375,16 +1378,31 @@ fn eagerly_resolve_atomic_flex_root_auto_block_size(
     );
 }
 
-fn apply_root_sizing_directives(run: &FormattingContextRun, input: &LayoutInput) -> LayoutInput {
-    match input.participation {
+struct RootSizingOutcome {
+    body_input: LayoutInput,
+    atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above: Option<CssPixels>,
+}
+
+fn apply_root_sizing_directives(
+    run: &FormattingContextRun,
+    input: &LayoutInput,
+    fc_type: FfiFormattingContextType,
+) -> RootSizingOutcome {
+    let mut atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above = None;
+    let body_input = match input.participation {
         ParticipationInParentFormattingContext::BlockLevel => dimension_block_level_root(run, input),
         ParticipationInParentFormattingContext::Float => body_input_with_inner_available_space(run, input),
         ParticipationInParentFormattingContext::AtomicInline => {
-            run.sizing().dimension_atomic_root(
+            let run_cache_may_store_this_block_formatting_context_run = fc_type == FfiFormattingContextType::Block
+                && run.layout_mode == LayoutMode::Normal
+                && !run.purpose.is_measurement()
+                && fc_run_cache::fc_run_cache_mode_from_environment() != fc_run_cache::FcRunCacheMode::Disabled;
+            atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above = run.sizing().dimension_atomic_root(
                 run.box_,
                 input.available_space,
                 input.containing_block_constraints,
                 run.layout_mode,
+                run_cache_may_store_this_block_formatting_context_run,
             );
             let mut body_input = body_input_with_inner_available_space(run, input);
             let inline_definite_space = AvailableSpace {
@@ -1431,6 +1449,10 @@ fn apply_root_sizing_directives(run: &FormattingContextRun, input: &LayoutInput)
             }
             *input
         }
+    };
+    RootSizingOutcome {
+        body_input,
+        atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
     }
 }
 
@@ -1680,7 +1702,10 @@ fn execute_formatting_context_run(
         run.records
             .store_table_inline_layout(table_inline_layout.table_box(), table_inline_layout);
     }
-    let body_input = apply_root_sizing_directives(run, &input);
+    let RootSizingOutcome {
+        body_input,
+        atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+    } = apply_root_sizing_directives(run, &input, fc_type);
 
     let cached_atomic_block_size = if matches!(
         input.participation,
@@ -1823,7 +1848,11 @@ fn execute_formatting_context_run(
 
     let registered_abspos_children_could_never_be_laid_out = run.fragments.is_none();
     if registered_abspos_children_could_never_be_laid_out {
-        return run.outputs(result, take_run_fragments());
+        return run.outputs(
+            result,
+            take_run_fragments(),
+            atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+        );
     }
     if let Some(implementation) = implementation {
         match &implementation {
@@ -1840,12 +1869,20 @@ fn execute_formatting_context_run(
             }
             FormattingContextImplementation::Svg(_) | FormattingContextImplementation::ReplacedWithChildren => {}
             FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => {
-                return run.outputs(result, take_run_fragments());
+                return run.outputs(
+                    result,
+                    take_run_fragments(),
+                    atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+                );
             }
         }
     }
     run.records.used_values(run.box_).seal_own_metrics();
-    run.outputs(result, take_run_fragments())
+    run.outputs(
+        result,
+        take_run_fragments(),
+        atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above,
+    )
 }
 
 fn finalize_atomic_root_block_size(
@@ -1974,6 +2011,7 @@ pub(crate) fn layout_inside_child(
             input.available_space,
             input.containing_block_constraints,
             layout_mode,
+            false,
         );
         sizing.resolve_used_block_size_if_treated_as_auto(
             child,
@@ -2064,6 +2102,7 @@ fn absorb_run_outputs(
         result,
         root,
         root_outcome,
+        atomic_root_sizing_repeats_for_available_inline_sizes_at_or_above: _,
     } = outputs;
     root_outcome.apply_to_record(parent_used);
     if let (Some(fragments), Some(root)) = (parent_fragments, root) {

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -6,6 +6,12 @@
 
 use super::*;
 
+pub(crate) struct AtomicRootInlineSizeResolution {
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) width_was_treated_as_auto: bool,
+    pub(crate) max_content_size_that_fit_the_definite_available_inner_space: Option<CssPixels>,
+}
+
 pub(crate) struct SizingContext {
     purpose: formatting_context::LayoutPurpose,
     records: std::rc::Rc<RunRecords>,
@@ -1261,7 +1267,8 @@ impl SizingContext {
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
         layout_mode: LayoutMode,
-    ) {
+        report_for_run_cache_the_available_inline_sizes_this_sizing_repeats_for: bool,
+    ) -> Option<CssPixels> {
         let containing_inline_size = available_space.inline_size.to_px_or_zero();
         let style = self.style(node);
         self.resolve_box_model_metrics_against_inline_basis(node, containing_inline_size);
@@ -1294,18 +1301,85 @@ impl SizingContext {
             if native_control_block_size_constraint_is_active || block_size_is_definite_from_aspect_ratio {
                 self.used(node).has_definite_block_size.set(true);
             }
-            return;
+            return None;
         }
 
-        let inline_size = self.calculate_atomic_root_content_inline_size(node, available_space, constraints, None);
-        self.used(node).set_content_inline_size(inline_size);
+        let resolution = self.calculate_atomic_root_content_inline_size(node, available_space, constraints, None);
+        self.used(node).set_content_inline_size(resolution.content_inline_size);
+        let sizing_repeats_for_available_inline_sizes_at_or_above =
+            report_for_run_cache_the_available_inline_sizes_this_sizing_repeats_for
+                .then(|| {
+                    self.available_inline_size_at_or_above_which_this_atomic_root_sizing_repeats(
+                        node,
+                        available_space,
+                        &resolution,
+                    )
+                })
+                .flatten();
 
         let inline_definite_space = AvailableSpace {
-            inline_size: AvailableSize::definite(inline_size),
+            inline_size: AvailableSize::definite(resolution.content_inline_size),
             block_size: AvailableSize::Indefinite,
         };
         self.resolve_used_block_size_if_not_treated_as_auto(node, inline_definite_space, constraints);
         self.make_button_content_box_definite(node, layout_mode, available_space, constraints, None);
+        sizing_repeats_for_available_inline_sizes_at_or_above
+    }
+
+    fn available_inline_size_at_or_above_which_this_atomic_root_sizing_repeats(
+        &self,
+        node: Node,
+        available_space: AvailableSpace,
+        resolution: &AtomicRootInlineSizeResolution,
+    ) -> Option<CssPixels> {
+        if !matches!(available_space.inline_size, AvailableSize::Definite(_)) {
+            return None;
+        }
+        let facts = self.facts(node);
+        let button_content_is_measured_against_the_raw_available_space = facts.uses_button_layout();
+        let aspect_ratio_transfers_the_available_size_between_axes = facts.has_preferred_aspect_ratio();
+        let box_model_or_width_resolves_a_percentage_against_the_inline_basis =
+            self.measurement_root_observes_percentage_inline_basis(node);
+        if button_content_is_measured_against_the_raw_available_space
+            || aspect_ratio_transfers_the_available_size_between_axes
+            || box_model_or_width_resolves_a_percentage_against_the_inline_basis
+        {
+            return None;
+        }
+        let style = self.style(node);
+        let percentage_free_length_or_intrinsic_keyword_never_reads_the_available_inline_size =
+            |size: &ComputedSize| size.is_length_percentage() || size.is_min_content() || size.is_max_content();
+        let width = style.width();
+        if !resolution.width_was_treated_as_auto
+            && !percentage_free_length_or_intrinsic_keyword_never_reads_the_available_inline_size(width)
+        {
+            return None;
+        }
+        let min_width = style.min_width();
+        if !min_width.is_auto()
+            && !percentage_free_length_or_intrinsic_keyword_never_reads_the_available_inline_size(min_width)
+        {
+            return None;
+        }
+        let max_width = style.max_width();
+        if !max_width.is_none()
+            && !percentage_free_length_or_intrinsic_keyword_never_reads_the_available_inline_size(max_width)
+        {
+            return None;
+        }
+        let block_axis_intrinsic_keywords_measure_against_the_available_inline_size =
+            style.height().is_intrinsic_sizing_constraint()
+                || style.min_height().is_intrinsic_sizing_constraint()
+                || style.max_height().is_intrinsic_sizing_constraint();
+        if block_axis_intrinsic_keywords_measure_against_the_available_inline_size {
+            return None;
+        }
+        if !resolution.width_was_treated_as_auto {
+            let every_definite_available_inline_size = CssPixels::default();
+            return Some(every_definite_available_inline_size);
+        }
+        let max_content_size = resolution.max_content_size_that_fit_the_definite_available_inner_space?;
+        Some(max_content_size + self.used(node).horizontal_margin_border_padding())
     }
 
     fn calculate_atomic_root_content_inline_size(
@@ -1314,20 +1388,17 @@ impl SizingContext {
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
         intrinsic_content_inline_size: Option<CssPixels>,
-    ) -> CssPixels {
+    ) -> AtomicRootInlineSizeResolution {
         let style = self.style(node);
-        let unconstrained_inline_size = if self.should_treat_inline_size_as_auto(node, available_space) {
+        let mut max_content_size_that_fit_the_definite_available_inner_space = None;
+        let width_was_treated_as_auto = self.should_treat_inline_size_as_auto(node, available_space);
+        let unconstrained_inline_size = if width_was_treated_as_auto {
             if matches!(available_space.inline_size, AvailableSize::Definite(_)) {
-                let used = self.used(node);
-                let available = available_space.inline_size.to_px_or_zero()
-                    - used.margin_left.get()
-                    - used.border_left.get()
-                    - used.padding_left.get()
-                    - used.padding_right.get()
-                    - used.border_right.get()
-                    - used.margin_right.get();
+                let available =
+                    available_space.inline_size.to_px_or_zero() - self.used(node).horizontal_margin_border_padding();
                 let preferred = self.calculate_max_content_inline_size(node, constraints);
                 if preferred <= available {
+                    max_content_size_that_fit_the_definite_available_inner_space = Some(preferred);
                     preferred
                 } else {
                     self.calculate_min_content_inline_size(node, constraints)
@@ -1366,7 +1437,11 @@ impl SizingContext {
                 constraints,
             ));
         }
-        inline_size
+        AtomicRootInlineSizeResolution {
+            content_inline_size: inline_size,
+            width_was_treated_as_auto,
+            max_content_size_that_fit_the_definite_available_inner_space,
+        }
     }
 
     pub(crate) fn paired_min_content_inline_size_for_atomic_root(
@@ -1390,15 +1465,18 @@ impl SizingContext {
         } else {
             CssPixels::default()
         };
-        Some(self.calculate_atomic_root_content_inline_size(
-            node,
-            AvailableSpace {
-                inline_size: AvailableSize::MinContent,
-                ..available_space
-            },
-            constraints,
-            Some(min_content_inline_size),
-        ))
+        Some(
+            self.calculate_atomic_root_content_inline_size(
+                node,
+                AvailableSpace {
+                    inline_size: AvailableSize::MinContent,
+                    ..available_space
+                },
+                constraints,
+                Some(min_content_inline_size),
+            )
+            .content_inline_size,
+        )
     }
 
     fn calculate_stretch_fit_inline_size(&self, node: Node, available: AvailableSize) -> CssPixels {
@@ -1410,14 +1488,7 @@ impl SizingContext {
         if !matches!(available, AvailableSize::Definite(_)) {
             return CssPixels::default();
         }
-        let used = self.used(node);
-        available.to_px_or_zero()
-            - used.margin_left.get()
-            - used.margin_right.get()
-            - used.padding_left.get()
-            - used.padding_right.get()
-            - used.border_left.get()
-            - used.border_right.get()
+        available.to_px_or_zero() - self.used(node).horizontal_margin_border_padding()
     }
 
     fn calculate_stretch_fit_block_size(&self, node: Node, available: AvailableSize) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -704,6 +704,15 @@ impl UsedValues {
         self.border_bottom_collapsed(collapsed) + self.padding_bottom.get()
     }
 
+    pub(crate) fn horizontal_margin_border_padding(&self) -> CssPixels {
+        self.margin_left.get()
+            + self.border_left.get()
+            + self.padding_left.get()
+            + self.padding_right.get()
+            + self.border_right.get()
+            + self.margin_right.get()
+    }
+
     pub(crate) fn border_box_inline_size(&self, collapsed: bool) -> CssPixels {
         self.border_box_left(collapsed) + self.content_inline_size.get() + self.border_box_right(collapsed)
     }
@@ -862,13 +871,7 @@ pub(crate) fn create_used_values(
             {
                 let available = containing_block_size_for_axis(Axis::Inline);
                 return Some(clamp_to_max_dimension_value(
-                    available
-                        - used.margin_left.get()
-                        - used.margin_right.get()
-                        - used.padding_left.get()
-                        - used.padding_right.get()
-                        - used.border_left.get()
-                        - used.border_right.get(),
+                    available - used.horizontal_margin_border_padding(),
                 ));
             }
             return None;

--- a/Tests/LibWeb/Text/expected/layout-run-cache-inline-block-available-width-hits.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-inline-block-available-width-hits.txt
@@ -1,0 +1,3 @@
+hit delta: 1
+before: 0,0,50,20
+after: 0,0,50,20

--- a/Tests/LibWeb/Text/expected/layout-run-cache-inline-block-available-width-misses.txt
+++ b/Tests/LibWeb/Text/expected/layout-run-cache-inline-block-available-width-misses.txt
@@ -1,0 +1,3 @@
+hit delta: 0
+before: 0,0,240,20
+after: 0,0,200,40

--- a/Tests/LibWeb/Text/input/layout-run-cache-inline-block-available-width-hits.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-inline-block-available-width-hits.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #widened-container { width: 300px; }
+    #inline-block-whose-max-content-still-fits { display: inline-block; vertical-align: top; }
+    #content { width: 50px; height: 20px; }
+</style>
+<div id="widened-container"><div id="inline-block-whose-max-content-still-fits"><div id="content"></div></div></div>
+<script>
+    function rectToString(rect) {
+        return `${rect.left},${rect.top},${rect.width},${rect.height}`;
+    }
+
+    asyncTest(async (done) => {
+        document.body.offsetHeight;
+        const onlyCacheRoot = document.getElementById("inline-block-whose-max-content-still-fits");
+        const before = rectToString(onlyCacheRoot.getBoundingClientRect());
+
+        const hitsBefore = internals.layoutRunCacheHitCount();
+        document.getElementById("widened-container").style.width = "320px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`before: ${before}`);
+        println(`after: ${rectToString(onlyCacheRoot.getBoundingClientRect())}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-run-cache-inline-block-available-width-misses.html
+++ b/Tests/LibWeb/Text/input/layout-run-cache-inline-block-available-width-misses.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #narrowed-container { width: 300px; }
+    #inline-block-whose-max-content-no-longer-fits { display: inline-block; vertical-align: top; }
+    .wide { display: inline-block; width: 120px; height: 20px; vertical-align: top; }
+</style>
+<div id="narrowed-container"><div id="inline-block-whose-max-content-no-longer-fits"><div class="wide"></div><div class="wide"></div></div></div>
+<script>
+    function rectToString(rect) {
+        return `${rect.left},${rect.top},${rect.width},${rect.height}`;
+    }
+
+    asyncTest(async (done) => {
+        document.body.offsetHeight;
+        const onlyCacheRoot = document.getElementById("inline-block-whose-max-content-no-longer-fits");
+        const before = rectToString(onlyCacheRoot.getBoundingClientRect());
+
+        const hitsBefore = internals.layoutRunCacheHitCount();
+        document.getElementById("narrowed-container").style.width = "200px";
+        document.body.offsetHeight;
+
+        println(`hit delta: ${internals.layoutRunCacheHitCount() - hitsBefore}`);
+        println(`before: ${before}`);
+        println(`after: ${rectToString(onlyCacheRoot.getBoundingClientRect())}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
A clean inline-block whose parent merely handed it a different available inline size (and therefore a different inline percentage basis) missed the formatting-context run cache on every pass, although its own sizing had resolved a definite shrink-to-fit width from cached intrinsic sizes and its body only ever saw that resolved width. On StyleBench 87% of those misses re-produced byte-identical outputs.

An atomic inline root of a block formatting context now reports, from its root sizing, the smallest definite available inline size that yields exactly this sizing: max-content plus the horizontal box model for a `width: auto` whose max-content fit the available inner space, or zero for a percentage-free definite width, which never reads the available size. Anything that makes the root read the available size or the inline basis disqualifies it: a percentage or calc() with a percentage in width min-width, max-width, margins or paddings; fit-content; replaced sizing or an aspect ratio; intrinsic sizing keywords in the height properties; button layout; a clamp by the available space. Descendants resolve percentages against the root's own content box, never against the basis the root received. The value is computed only for cacheable runs and travels with the run outputs rather than on every UsedValues record.

The cache key comparison gains two relaxations next to the existing percentage-block-size one, granted together by such an entry: a probe may differ in a definite available inline size at or above the threshold and in the inline percentage basis. Every other input stays exact, the structural inline-damage path keeps exact keys, and the shadow oracle verifies the recorded threshold alongside the outputs.

StyleBench: score 107 -> 117