### PR TITLE
LibWeb: Avoid rebuilding computed styles while sampling animations

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -32,8 +32,8 @@ GC_DEFINE_ALLOCATOR(AnimationEffect);
 
 AnimationUpdateContext::ElementData::ElementData() = default;
 
-AnimationUpdateContext::ElementData::ElementData(RefPtr<CSS::AnimatedProperties const> animated_properties_before_update, RefPtr<CSS::ComputedStyleWorkingSet> target_style)
-    : animated_properties_before_update(move(animated_properties_before_update))
+AnimationUpdateContext::ElementData::ElementData(CSS::StyleRecordID style_record_before_update, RefPtr<CSS::ComputedStyleWorkingSet> target_style)
+    : style_record_before_update(style_record_before_update)
     , target_style(move(target_style))
 {
 }
@@ -826,98 +826,13 @@ void AnimationEffect::visit_edges(GC::Cell::Visitor& visitor)
     visitor.visit(m_associated_animation);
 }
 
-static CSS::StyleValue const* animated_property_value(CSS::AnimatedProperties const* properties, CSS::PropertyID property_id)
+static ReadonlySpan<CSS::ComputedValuesFFI::FfiAnimatedOverlayEntry> animated_overlay_entries(CSS::ComputedValuesFFI::AnimatedOverlay const* overlay)
 {
-    if (!properties || !properties->has_property(property_id))
-        return nullptr;
-    return &properties->property(property_id);
-}
-
-struct AnimatedPropertyInvalidation {
-    CSS::RequiredInvalidationAfterStyleChange invalidation;
-    u32 changed_non_inherited_style_groups { 0 };
-    bool requires_base_style_recomputation { false };
-    bool requires_layout_node_style_application { false };
-    bool requires_style_resource_update { false };
-};
-
-static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_properties(CSS::AnimatedProperties const* old_properties, CSS::AnimatedProperties const* new_properties, DOM::AbstractElement const& target)
-{
-    AnimatedPropertyInvalidation result;
-    bool text_decoration_line_animated = false;
-    auto process_property = [&](CSS::PropertyID property_id) {
-        auto const* old_value = animated_property_value(old_properties, property_id);
-        auto const* new_value = animated_property_value(new_properties, property_id);
-        RefPtr<CSS::StyleValue const> old_effective_value;
-        RefPtr<CSS::StyleValue const> new_effective_value;
-        // Box-type adjustments can add a synthetic animated value for a property not covered by
-        // the effect. Compare that value with the effective style instead of treating it as new.
-        if (!old_value || !new_value) {
-            auto current_style = target.computed_style();
-            if (!old_value && current_style) {
-                old_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::Yes);
-                old_value = old_effective_value.ptr();
-            }
-            if (!new_value && current_style) {
-                new_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::No);
-                new_value = new_effective_value.ptr();
-            }
-        }
-        if (!old_value && !new_value)
-            return;
-        if (old_value && new_value && old_value->equals(*new_value))
-            return;
-        if (first_is_one_of(property_id,
-                CSS::PropertyID::Direction,
-                CSS::PropertyID::Display,
-                CSS::PropertyID::Float,
-                CSS::PropertyID::OverflowX,
-                CSS::PropertyID::OverflowY,
-                CSS::PropertyID::Position,
-                CSS::PropertyID::TextAlign))
-            result.requires_base_style_recomputation = true;
-        if (CSS::is_inherited_property(property_id))
-            result.requires_layout_node_style_application = true;
-        if (first_is_one_of(property_id,
-                CSS::PropertyID::BackgroundImage,
-                CSS::PropertyID::BorderImageSource,
-                CSS::PropertyID::MaskImage))
-            result.requires_style_resource_update = true;
-        auto property_invalidation = compute_property_invalidation(property_id, old_value, new_value);
-        bool const root_background_color_animation_may_move_body_background_propagation = property_id == CSS::PropertyID::BackgroundColor && !target.pseudo_element().has_value() && target.element().is_document_element();
-        if (root_background_color_animation_may_move_body_background_propagation)
-            property_invalidation.ensure_at_least(CSS::AccumulatedVisualContextInvalidation::Rebuild);
-        if (!property_invalidation.is_none() && CSS::is_inherited_property(property_id)) {
-            auto group = CSS::ComputedValues::style_group_of_property(property_id);
-            if (group.has_value() && to_underlying(*group) < CSS::ComputedValues::inherited_style_group_count)
-                property_invalidation.mark_inherited_style_group_changed(to_underlying(*group));
-            else
-                property_invalidation.mark_all_inherited_style_groups_changed();
-        }
-        if (!CSS::is_inherited_property(property_id))
-            result.changed_non_inherited_style_groups |= CSS::ComputedValues::style_group_bit_of_property(property_id);
-        if (property_id == CSS::PropertyID::TextDecorationLine)
-            text_decoration_line_animated = true;
-        result.invalidation |= property_invalidation;
-    };
-    if (old_properties) {
-        for (auto const& entry : old_properties->entries())
-            process_property(static_cast<CSS::PropertyID>(entry.property));
-    }
-    if (new_properties) {
-        for (auto const& entry : new_properties->entries()) {
-            auto property_id = static_cast<CSS::PropertyID>(entry.property);
-            if (!old_properties || !old_properties->has_property(property_id))
-                process_property(property_id);
-        }
-    }
-    // Animated properties other than text-decoration-line cannot make an undecorated box decorated.
-    if (result.invalidation.repaint_propagated_text_decorations && !text_decoration_line_animated) {
-        auto target_style = target.computed_style();
-        if (target_style && target_style->text_decoration_line().is_empty())
-            result.invalidation.repaint_propagated_text_decorations = false;
-    }
-    return result;
+    if (!overlay)
+        return {};
+    size_t count = 0;
+    auto const* entries = CSS::ComputedValuesFFI::rust_animated_overlay_entries(overlay, &count);
+    return { entries, count };
 }
 
 AnimationUpdateContext::~AnimationUpdateContext()
@@ -956,20 +871,26 @@ AnimationUpdateContext::~AnimationUpdateContext()
         }
         if (!effects_to_collect.is_empty())
             target->document().style_computer().collect_animations_into(element, effects_to_collect.span(), *style, CSS::StyleComputer::AnimationRefresh::Yes);
-        auto animated_properties_after_update = style->animated_properties_snapshot();
-        auto animated_property_invalidation = compute_required_invalidation_for_animated_properties(it.value.animated_properties_before_update.ptr(), animated_properties_after_update.ptr(), element);
-        auto invalidation = animated_property_invalidation.invalidation;
-
-        if (invalidation.is_none())
+        auto& style_computer = target->document().style_computer();
+        if (!style_computer.style_engine().animation_overlay_changed(it.value.style_record_before_update, style->animated_overlay()))
             continue;
 
         auto computed_values = [&] {
             auto previous_values = element.computed_style();
             if (previous_values)
-                return target->document().style_computer().build_animated_computed_values(*style, element, element.style_scope(), *previous_values);
-            return target->document().style_computer().build_computed_values(*style, element, element.style_scope());
+                return style_computer.build_animated_computed_values(*style, element, element.style_scope(), *previous_values);
+            return style_computer.build_computed_values(*style, element, element.style_scope());
         }();
-        if (animated_properties_after_update && !animated_properties_after_update->is_empty()
+        Array<void const*, to_underlying(CSS::StyleGroupIndex::Count)> payloads;
+        for (size_t index = 0; index < payloads.size(); ++index)
+            payloads[index] = computed_values->style_group_payload(static_cast<CSS::StyleGroupIndex>(index));
+        auto animated_property_invalidation = style_computer.style_engine().compare_animation_overlay(
+            it.value.style_record_before_update,
+            style->animated_overlay(),
+            payloads,
+            !element.pseudo_element().has_value() && target->is_document_element());
+        auto invalidation = CSS::decode_style_invalidation(animated_property_invalidation.invalidation);
+        if (style->animated_overlay() && !animated_overlay_entries(style->animated_overlay()).is_empty()
             && target->document().is_in_style_stabilization_epoch()
             && (target->document().style_stabilization_has_style_reactions() || animated_property_invalidation.requires_base_style_recomputation)) {
             target->document().style_computer().record_transition_stabilization_baseline(element);

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -385,6 +385,8 @@ WebIDL::ExceptionOr<void> AnimationEffect::update_timing(Bindings::OptionalEffec
 void AnimationEffect::set_associated_animation(GC::Ptr<Animation> value)
 {
     m_associated_animation = value;
+    if (auto* keyframe_effect = as_if<KeyframeEffect>(*this))
+        keyframe_effect->invalidate_animation_preparation();
 
     // NB: The normalization of the specified timing depends on the timeline of the associated animation.
     normalize_specified_timing();

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Bitmap.h>
 #include <AK/ScopeGuard.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Animations/Animation.h>
@@ -838,44 +837,36 @@ struct AnimatedPropertyInvalidation {
     CSS::RequiredInvalidationAfterStyleChange invalidation;
     u32 changed_non_inherited_style_groups { 0 };
     bool requires_base_style_recomputation { false };
+    bool requires_layout_node_style_application { false };
+    bool requires_style_resource_update { false };
 };
 
 static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_properties(CSS::AnimatedProperties const* old_properties, CSS::AnimatedProperties const* new_properties, DOM::AbstractElement const& target)
 {
     AnimatedPropertyInvalidation result;
-    auto current_style = target.computed_style();
-    auto old_and_new_properties = MUST(Bitmap::create(CSS::number_of_longhand_properties, 0));
     bool text_decoration_line_animated = false;
-    if (old_properties) {
-        for (auto const& entry : old_properties->entries())
-            old_and_new_properties.set(entry.property - to_underlying(CSS::first_longhand_property_id), 1);
-    }
-    if (new_properties) {
-        for (auto const& entry : new_properties->entries())
-            old_and_new_properties.set(entry.property - to_underlying(CSS::first_longhand_property_id), 1);
-    }
-    for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
-        if (!old_and_new_properties.get(i - to_underlying(CSS::first_longhand_property_id)))
-            continue;
-        auto property_id = static_cast<CSS::PropertyID>(i);
+    auto process_property = [&](CSS::PropertyID property_id) {
         auto const* old_value = animated_property_value(old_properties, property_id);
         auto const* new_value = animated_property_value(new_properties, property_id);
         RefPtr<CSS::StyleValue const> old_effective_value;
         RefPtr<CSS::StyleValue const> new_effective_value;
         // Box-type adjustments can add a synthetic animated value for a property not covered by
         // the effect. Compare that value with the effective style instead of treating it as new.
-        if (!old_value && current_style) {
-            old_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::Yes);
-            old_value = old_effective_value.ptr();
-        }
-        if (!new_value && current_style) {
-            new_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::No);
-            new_value = new_effective_value.ptr();
+        if (!old_value || !new_value) {
+            auto current_style = target.computed_style();
+            if (!old_value && current_style) {
+                old_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::Yes);
+                old_value = old_effective_value.ptr();
+            }
+            if (!new_value && current_style) {
+                new_effective_value = current_style->computed_style_value(property_id, CSS::ComputedValues::WithAnimationsApplied::No);
+                new_value = new_effective_value.ptr();
+            }
         }
         if (!old_value && !new_value)
-            continue;
+            return;
         if (old_value && new_value && old_value->equals(*new_value))
-            continue;
+            return;
         if (first_is_one_of(property_id,
                 CSS::PropertyID::Direction,
                 CSS::PropertyID::Display,
@@ -885,6 +876,13 @@ static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_p
                 CSS::PropertyID::Position,
                 CSS::PropertyID::TextAlign))
             result.requires_base_style_recomputation = true;
+        if (CSS::is_inherited_property(property_id))
+            result.requires_layout_node_style_application = true;
+        if (first_is_one_of(property_id,
+                CSS::PropertyID::BackgroundImage,
+                CSS::PropertyID::BorderImageSource,
+                CSS::PropertyID::MaskImage))
+            result.requires_style_resource_update = true;
         auto property_invalidation = compute_property_invalidation(property_id, old_value, new_value);
         bool const root_background_color_animation_may_move_body_background_propagation = property_id == CSS::PropertyID::BackgroundColor && !target.pseudo_element().has_value() && target.element().is_document_element();
         if (root_background_color_animation_may_move_body_background_propagation)
@@ -901,6 +899,17 @@ static AnimatedPropertyInvalidation compute_required_invalidation_for_animated_p
         if (property_id == CSS::PropertyID::TextDecorationLine)
             text_decoration_line_animated = true;
         result.invalidation |= property_invalidation;
+    };
+    if (old_properties) {
+        for (auto const& entry : old_properties->entries())
+            process_property(static_cast<CSS::PropertyID>(entry.property));
+    }
+    if (new_properties) {
+        for (auto const& entry : new_properties->entries()) {
+            auto property_id = static_cast<CSS::PropertyID>(entry.property);
+            if (!old_properties || !old_properties->has_property(property_id))
+                process_property(property_id);
+        }
     }
     // Animated properties other than text-decoration-line cannot make an undecorated box decorated.
     if (result.invalidation.repaint_propagated_text_decorations && !text_decoration_line_animated) {
@@ -965,7 +974,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
             && (target->document().style_stabilization_has_style_reactions() || animated_property_invalidation.requires_base_style_recomputation)) {
             target->document().style_computer().record_transition_stabilization_baseline(element);
         }
-        auto publication = target->document().style_computer().publish_computed_style_inputs(element, *computed_values);
+        auto publication = target->document().style_computer().publish_animation_overlay(element, *computed_values);
         target->refresh_computed_style(element.pseudo_element(), publication.new_style_record);
 
         // Box-type, overflow, and text-alignment adjustments consume the unadjusted base values,
@@ -1002,13 +1011,19 @@ AnimationUpdateContext::~AnimationUpdateContext()
                     inherited_style_groups);
         }
 
-        // NB: Called from animation update context destructor during style recalculation.
+        // NB: refresh_computed_style() already publishes the new record to the layout node. Only
+        // inherited values and image resources require the additional C++ style side effects.
+        auto apply_layout_node_style_side_effects = [&](Layout::NodeWithStyle& layout_node, CSS::StyleRecordID style_record) {
+            if (animated_property_invalidation.requires_layout_node_style_application)
+                layout_node.apply_style(style_record);
+            else if (animated_property_invalidation.requires_style_resource_update)
+                layout_node.attach_style_resources();
+        };
         if (!element.pseudo_element().has_value()) {
-            if (target->unsafe_layout_node())
-                target->unsafe_layout_node()->apply_style(target->style_record_identity());
-        } else {
-            if (auto pseudo_element_node = target->pseudo_element_unsafe_layout_node(element.pseudo_element().value()))
-                pseudo_element_node->apply_style(target->style_record_identity(element.pseudo_element()));
+            if (auto* layout_node = target->unsafe_layout_node())
+                apply_layout_node_style_side_effects(*layout_node, target->style_record_identity());
+        } else if (auto pseudo_element_node = target->pseudo_element_unsafe_layout_node(element.pseudo_element().value())) {
+            apply_layout_node_style_side_effects(*pseudo_element_node, target->style_record_identity(element.pseudo_element()));
         }
 
         if (invalidation.changes_containing_block_establishment)

--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/Utf16String.h>
 #include <AK/Variant.h>
-#include <LibGC/ConservativeHashMap.h>
 #include <LibGC/ConservativeVector.h>
 #include <LibWeb/Animations/TimeValue.h>
 #include <LibWeb/Bindings/AnimationEffect.h>
@@ -59,7 +59,7 @@ struct AnimationUpdateContext {
     ~AnimationUpdateContext();
 
     // NOTE: This is lazily populated by KeyframeEffects as their respective animations are applied to an element.
-    GC::ConservativeHashMap<DOM::AbstractElement, ElementData> elements;
+    HashMap<DOM::AbstractElement, ElementData> elements;
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-animationeffect-interface

--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -16,12 +16,7 @@
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/CSS/EasingFunction.h>
 #include <LibWeb/CSS/PropertyNameAndID.h>
-
-namespace Web::CSS {
-
-class AnimatedProperties;
-
-}
+#include <LibWeb/CSS/StyleRecordID.h>
 
 namespace Web::Animations {
 
@@ -45,12 +40,12 @@ Bindings::OptionalEffectTiming to_optional_effect_timing(Bindings::EffectTiming 
 struct AnimationUpdateContext {
     struct ElementData {
         ElementData();
-        ElementData(RefPtr<CSS::AnimatedProperties const>, RefPtr<CSS::ComputedStyleWorkingSet>);
+        ElementData(CSS::StyleRecordID, RefPtr<CSS::ComputedStyleWorkingSet>);
         ElementData(ElementData&&);
         ElementData& operator=(ElementData&&);
         ~ElementData();
 
-        RefPtr<CSS::AnimatedProperties const> animated_properties_before_update;
+        CSS::StyleRecordID style_record_before_update;
         RefPtr<CSS::ComputedStyleWorkingSet> target_style;
         GC::ConservativeVector<GC::Ref<KeyframeEffect>> effects;
     };

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Atomic.h>
 #include <AK/Bitmap.h>
 #include <AK/QuickSort.h>
 #include <LibGC/Heap.h>
@@ -32,6 +33,8 @@
 namespace Web::Animations {
 
 GC_DEFINE_ALLOCATOR(KeyframeEffect);
+
+static Atomic<u64> s_next_animation_preparation_identity { 1 };
 
 template<typename T>
 WebIDL::ExceptionOr<Variant<T, Vector<T>>> convert_value_to_maybe_list(JS::Realm& realm, JS::Value value, Function<WebIDL::ExceptionOr<T>(JS::Value)>& value_converter)
@@ -849,6 +852,7 @@ void KeyframeEffect::set_target(GC::Ptr<DOM::Element> target)
     }
     m_target_element = target;
 
+    invalidate_animation_preparation();
     invalidate_effect();
     // FIXME: We don't remove the animated style from the old target element as part of normal animated style update and
     //        it will remain "stuck" until it's style is fully invalidated for some other reason.
@@ -869,6 +873,7 @@ WebIDL::ExceptionOr<void> KeyframeEffect::set_pseudo_element(Optional<Utf16Strin
     // NOTE: The actual definition is in pseudo_element_parsing().
     m_target_pseudo_selector = TRY(pseudo_element_parsing(value));
 
+    invalidate_animation_preparation();
     invalidate_effect();
     // FIXME: We don't remove the animated style from the old target element as part of normal animated style update and
     //        it will remain "stuck" until it's style is fully invalidated for some other reason.
@@ -904,6 +909,7 @@ Optional<CSS::PseudoElement> KeyframeEffect::pseudo_element_type() const
 void KeyframeEffect::set_composite(Bindings::CompositeOperation value)
 {
     m_composite = value;
+    invalidate_animation_preparation();
     invalidate_effect();
 }
 
@@ -920,6 +926,7 @@ void KeyframeEffect::set_key_frame_set(RefPtr<KeyFrameSet const> key_frame_set)
         }
     }
     m_key_frame_set = move(key_frame_set);
+    invalidate_animation_preparation();
     invalidate_effect();
 }
 
@@ -1026,10 +1033,14 @@ void KeyframeEffect::set_keyframes(Vector<BaseKeyframe> keyframes)
     generate_initial_and_final_frames(keyframe_set, m_target_properties);
     m_key_frame_set = keyframe_set;
 
+    invalidate_animation_preparation();
     invalidate_effect();
 }
 
-KeyframeEffect::KeyframeEffect() = default;
+KeyframeEffect::KeyframeEffect()
+    : m_animation_preparation_identity(s_next_animation_preparation_identity.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
+{
+}
 
 void KeyframeEffect::invalidate_effect()
 {
@@ -1217,7 +1228,7 @@ void KeyframeEffect::update_computed_properties_for_style(AnimationUpdateContext
         if (!computed_values)
             return AnimationUpdateContext::ElementData {};
         auto old_animated_properties = computed_values->animated_properties_snapshot();
-        auto computed_properties = style_computer.reconstruct_computed_properties(*computed_values);
+        auto computed_properties = style_computer.reconstruct_computed_properties_for_animation(*computed_values);
         computed_properties->reset_non_inherited_animated_properties({});
         return AnimationUpdateContext::ElementData { move(old_animated_properties), move(computed_properties) };
     });

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1205,16 +1205,11 @@ void KeyframeEffect::update_computed_properties(AnimationUpdateContext& context)
 
     // An effect that animates `display` can be the very thing holding its `display: none` target visible, and
     // the update being skipped is the one that applies or removes that override, so it must always run.
-    bool affects_display = false;
-    if (auto const* key_frame_set = this->key_frame_set()) {
-        for (auto it = key_frame_set->keyframes_by_key.begin(); !affects_display && it != key_frame_set->keyframes_by_key.end(); ++it)
-            affects_display = it->properties.contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Display));
-    }
-    if (!affects_display && target->has_inclusive_ancestor_with_display_none_ignoring_animations()) {
-        // FIXME: Reaching this point means we failed to cancel animation for an element that started
-        //        being nested in "display: none".
-        //        For now this hack is needed to avoid lots of unnecessary work.
-        return;
+    if (!target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Display))) {
+        auto style_record = target->style_record_identity();
+        auto dependency_flags = target->document().style_computer().style_engine().style_record_dependency_flags(style_record);
+        if (dependency_flags & to_underlying(CSS::StyleRecordDependencyFlag::InDisplayNoneSubtree))
+            return;
     }
 
     target->update_animated_properties({}, pseudo_element_type(), *this, context);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1219,11 +1219,11 @@ void KeyframeEffect::update_computed_properties_for_style(AnimationUpdateContext
 {
     auto& style_computer = abstract_element.element().document().style_computer();
     auto& element_data = context.elements.ensure(abstract_element, [&abstract_element, &style_computer] {
-        auto computed_values = abstract_element.computed_style();
-        if (!computed_values)
+        auto style_record = abstract_element.style_record_identity();
+        if (!style_record)
             return AnimationUpdateContext::ElementData {};
-        auto old_animated_properties = computed_values->animated_properties_snapshot();
-        auto computed_properties = style_computer.reconstruct_computed_properties_for_animation(*computed_values);
+        auto computed_properties = style_computer.reconstruct_computed_properties_for_animation(style_record);
+        auto old_animated_properties = computed_properties->animated_properties_snapshot();
         computed_properties->reset_non_inherited_animated_properties({});
         return AnimationUpdateContext::ElementData { move(old_animated_properties), move(computed_properties) };
     });

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1223,9 +1223,7 @@ void KeyframeEffect::update_computed_properties_for_style(AnimationUpdateContext
         if (!style_record)
             return AnimationUpdateContext::ElementData {};
         auto computed_properties = style_computer.reconstruct_computed_properties_for_animation(style_record);
-        auto old_animated_properties = computed_properties->animated_properties_snapshot();
-        computed_properties->reset_non_inherited_animated_properties({});
-        return AnimationUpdateContext::ElementData { move(old_animated_properties), move(computed_properties) };
+        return AnimationUpdateContext::ElementData { style_record, move(computed_properties) };
     });
 
     if (!element_data.target_style)

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -180,6 +180,9 @@ public:
     void set_is_observation_relevant_compositor_animation(bool value) { m_is_observation_relevant_compositor_animation = value; }
     bool is_observation_relevant_compositor_animation() const { return m_is_observation_relevant_compositor_animation; }
     void request_observation_sample();
+    u64 animation_preparation_identity() const { return m_animation_preparation_identity; }
+    u64 animation_preparation_generation() const { return m_animation_preparation_generation; }
+    void invalidate_animation_preparation() { ++m_animation_preparation_generation; }
     bool request_element_scoped_observation_sample(u64 task_generation)
     {
         if (m_last_element_scoped_observation_sample_task_generation == task_generation)
@@ -238,6 +241,8 @@ private:
     Vector<GC::Ref<JS::Object>> m_keyframe_objects_cache {};
 
     RefPtr<KeyFrameSet const> m_key_frame_set {};
+    u64 m_animation_preparation_identity { 0 };
+    u64 m_animation_preparation_generation { 0 };
     Optional<CompositorKeyframeValueCache> m_compositor_opacity_keyframe_value_cache;
     Optional<CompositorKeyframeValueCache> m_compositor_transform_keyframe_value_cache;
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -128,20 +128,20 @@ NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_with_base
     return working_set;
 }
 
-NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_for_animation_update(ComputedValues const& style)
+NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_for_animation_update(ComputedValuesFFI::ComputedLonghandTable const* table, ComputedValuesFFI::AnimatedOverlay const* overlay)
 {
-    auto const* table = style.base_values().computed_longhand_table();
     VERIFY(table);
-    auto* retained_table = const_cast<ComputedValuesFFI::ComputedLonghandTable*>(ComputedValuesFFI::rust_computed_longhand_table_retain(static_cast<ComputedValuesFFI::ComputedLonghandTable const*>(table)));
+    auto* retained_table = const_cast<ComputedValuesFFI::ComputedLonghandTable*>(ComputedValuesFFI::rust_computed_longhand_table_retain(table));
     auto working_set = create_with_longhand_table(retained_table);
     working_set->m_computed_longhand_table_is_shared = true;
-    if (auto animated_properties = style.animated_properties_snapshot()) {
+    if (overlay) {
+        auto animated_properties = adopt_ref(*new AnimatedProperties(overlay));
         working_set->m_had_animated_post_compute_adjustment_property = animated_properties->has_property(PropertyID::Display)
             || animated_properties->has_property(PropertyID::Position)
             || animated_properties->has_property(PropertyID::Float)
             || animated_properties->has_property(PropertyID::LineHeight)
             || animated_properties->has_property(PropertyID::TextAlign);
-        working_set->m_animated_properties = adopt_ref(*new AnimatedProperties(*animated_properties));
+        working_set->m_animated_properties = move(animated_properties);
     }
     return working_set;
 }

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -59,6 +59,7 @@ ComputedStyleWorkingSet::ComputedStyleWorkingSet(ComputedValuesFFI::ComputedLong
 
 ComputedStyleWorkingSet::ComputedStyleWorkingSet(ShareFrozenTable, ComputedStyleWorkingSet const& other)
     : m_computed_longhand_table(const_cast<ComputedValuesFFI::ComputedLonghandTable*>(ComputedValuesFFI::rust_computed_longhand_table_retain(other.m_computed_longhand_table)))
+    , m_computed_longhand_table_is_shared(true)
     , m_mint_cache(other.m_mint_cache)
 {
 }
@@ -129,10 +130,31 @@ NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_with_base
 
 NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_for_animation_update(ComputedValues const& style)
 {
-    auto working_set = create_with_base_values_from(style);
-    if (auto animated_properties = style.animated_properties_snapshot())
+    auto const* table = style.base_values().computed_longhand_table();
+    VERIFY(table);
+    auto* retained_table = const_cast<ComputedValuesFFI::ComputedLonghandTable*>(ComputedValuesFFI::rust_computed_longhand_table_retain(static_cast<ComputedValuesFFI::ComputedLonghandTable const*>(table)));
+    auto working_set = create_with_longhand_table(retained_table);
+    working_set->m_computed_longhand_table_is_shared = true;
+    if (auto animated_properties = style.animated_properties_snapshot()) {
+        working_set->m_had_animated_post_compute_adjustment_property = animated_properties->has_property(PropertyID::Display)
+            || animated_properties->has_property(PropertyID::Position)
+            || animated_properties->has_property(PropertyID::Float)
+            || animated_properties->has_property(PropertyID::LineHeight)
+            || animated_properties->has_property(PropertyID::TextAlign);
         working_set->m_animated_properties = adopt_ref(*new AnimatedProperties(*animated_properties));
+    }
     return working_set;
+}
+
+void ComputedStyleWorkingSet::ensure_mutable_computed_longhand_table()
+{
+    if (!m_computed_longhand_table_is_shared)
+        return;
+    auto* table = ComputedValuesFFI::rust_computed_longhand_table_create();
+    ComputedValuesFFI::rust_computed_longhand_table_copy_from(table, m_computed_longhand_table);
+    ComputedValuesFFI::rust_computed_longhand_table_release(m_computed_longhand_table);
+    m_computed_longhand_table = table;
+    m_computed_longhand_table_is_shared = false;
 }
 
 void ComputedStyleWorkingSet::freeze_computed_longhand_table()
@@ -439,6 +461,21 @@ void ComputedStyleWorkingSet::finish_animated_overlay_rust_mutation(Badge<StyleC
 {
     if (m_animated_properties && m_animated_properties->is_empty())
         m_animated_properties = nullptr;
+}
+
+bool ComputedStyleWorkingSet::requires_animated_post_compute_adjustments() const
+{
+    return m_had_animated_post_compute_adjustment_property
+        || has_animated_property(PropertyID::Display)
+        || has_animated_property(PropertyID::Position)
+        || has_animated_property(PropertyID::Float)
+        || has_animated_property(PropertyID::LineHeight)
+        || has_animated_property(PropertyID::TextAlign);
+}
+
+void ComputedStyleWorkingSet::prepare_for_animated_post_compute_adjustments(Badge<StyleComputer>)
+{
+    ensure_mutable_computed_longhand_table();
 }
 
 void ComputedStyleWorkingSet::did_apply_style_finalization_from_rust(u16 invalidated_longhands)

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -127,6 +127,14 @@ NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_with_base
     return working_set;
 }
 
+NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_for_animation_update(ComputedValues const& style)
+{
+    auto working_set = create_with_base_values_from(style);
+    if (auto animated_properties = style.animated_properties_snapshot())
+        working_set->m_animated_properties = adopt_ref(*new AnimatedProperties(*animated_properties));
+    return working_set;
+}
+
 void ComputedStyleWorkingSet::freeze_computed_longhand_table()
 {
     ComputedValuesFFI::rust_computed_longhand_table_freeze(m_computed_longhand_table);
@@ -482,8 +490,7 @@ void ComputedStyleWorkingSet::reset_non_inherited_animated_properties(Badge<Anim
 
     auto& animated_properties = mutable_animated_properties();
     animated_properties.reset_non_inherited_properties();
-    if (animated_properties.is_empty())
-        m_animated_properties = nullptr;
+    // Keep the overlay alive because it may own reusable animation preparation.
 
     if (should_clear_computed_font_list_cache)
         clear_computed_font_list_cache();

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.cpp
@@ -135,12 +135,12 @@ NonnullRefPtr<ComputedStyleWorkingSet> ComputedStyleWorkingSet::create_for_anima
     auto working_set = create_with_longhand_table(retained_table);
     working_set->m_computed_longhand_table_is_shared = true;
     if (overlay) {
-        auto animated_properties = adopt_ref(*new AnimatedProperties(overlay));
-        working_set->m_had_animated_post_compute_adjustment_property = animated_properties->has_property(PropertyID::Display)
-            || animated_properties->has_property(PropertyID::Position)
-            || animated_properties->has_property(PropertyID::Float)
-            || animated_properties->has_property(PropertyID::LineHeight)
-            || animated_properties->has_property(PropertyID::TextAlign);
+        working_set->m_had_animated_post_compute_adjustment_property = ComputedValuesFFI::rust_animated_overlay_contains(overlay, to_underlying(PropertyID::Display))
+            || ComputedValuesFFI::rust_animated_overlay_contains(overlay, to_underlying(PropertyID::Position))
+            || ComputedValuesFFI::rust_animated_overlay_contains(overlay, to_underlying(PropertyID::Float))
+            || ComputedValuesFFI::rust_animated_overlay_contains(overlay, to_underlying(PropertyID::LineHeight))
+            || ComputedValuesFFI::rust_animated_overlay_contains(overlay, to_underlying(PropertyID::TextAlign));
+        auto animated_properties = adopt_ref(*new AnimatedProperties(overlay, AnimatedProperties::InheritedOnly {}));
         working_set->m_animated_properties = move(animated_properties);
     }
     return working_set;
@@ -183,6 +183,12 @@ AnimatedProperties::AnimatedProperties(AnimatedProperties const& other)
 AnimatedProperties::AnimatedProperties(ComputedValuesFFI::AnimatedOverlay const* overlay)
     : m_identity(s_next_animated_properties_identity.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
     , m_overlay(ComputedValuesFFI::rust_animated_overlay_clone(overlay))
+{
+}
+
+AnimatedProperties::AnimatedProperties(ComputedValuesFFI::AnimatedOverlay const* overlay, InheritedOnly)
+    : m_identity(s_next_animated_properties_identity.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
+    , m_overlay(ComputedValuesFFI::rust_animated_overlay_clone_inherited(overlay))
 {
 }
 
@@ -257,12 +263,6 @@ void AnimatedProperties::set_property(PropertyID id, NonnullRefPtr<StyleValue co
     m_wrapper_cache.set(id, move(value));
 }
 
-void AnimatedProperties::reset_non_inherited_properties()
-{
-    ComputedValuesFFI::rust_animated_overlay_reset_non_inherited(m_overlay);
-    m_wrapper_cache.clear();
-}
-
 bool ComputedStyleWorkingSet::is_property_important(PropertyID property_id) const
 {
     return ComputedValuesFFI::rust_computed_longhand_table_is_important(m_computed_longhand_table, to_underlying(property_id));
@@ -312,6 +312,11 @@ void ComputedStyleWorkingSet::remove_inheritance_dependent_specified_value(Prope
 RefPtr<AnimatedProperties const> ComputedStyleWorkingSet::animated_properties_snapshot() const
 {
     return m_animated_properties;
+}
+
+ComputedValuesFFI::AnimatedOverlay const* ComputedStyleWorkingSet::animated_overlay() const
+{
+    return m_animated_properties ? m_animated_properties->overlay() : nullptr;
 }
 
 bool ComputedStyleWorkingSet::has_animated_property(PropertyID property_id) const
@@ -506,31 +511,6 @@ void ComputedStyleWorkingSet::clear_animated_properties(Badge<StyleComputer>)
 
     m_animated_properties = nullptr;
     clear_computed_font_list_cache();
-}
-
-void ComputedStyleWorkingSet::reset_non_inherited_animated_properties(Badge<Animations::KeyframeEffect>)
-{
-    bool has_non_inherited_property = false;
-    bool should_clear_computed_font_list_cache = false;
-    for (auto const& property : animated_properties().entries()) {
-        if (property.inherited)
-            continue;
-        has_non_inherited_property = true;
-        if (property_affects_computed_font_list(static_cast<PropertyID>(property.property))) {
-            should_clear_computed_font_list_cache = true;
-            break;
-        }
-    }
-
-    if (!has_non_inherited_property)
-        return;
-
-    auto& animated_properties = mutable_animated_properties();
-    animated_properties.reset_non_inherited_properties();
-    // Keep the overlay alive because it may own reusable animation preparation.
-
-    if (should_clear_computed_font_list_cache)
-        clear_computed_font_list_cache();
 }
 
 NonnullRefPtr<StyleValue const> wrap_computed_longhand_slot(void const* value_data, GC::Ptr<CSSStyleSheet> style_sheet)

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -103,9 +103,8 @@ public:
     void remove_inheritance_dependent_specified_value(PropertyID);
 
     RefPtr<AnimatedProperties const> animated_properties_snapshot() const;
+    ComputedValuesFFI::AnimatedOverlay const* animated_overlay() const;
     bool has_animated_property(PropertyID property_id) const;
-    void reset_non_inherited_animated_properties(Badge<Animations::KeyframeEffect>);
-
     bool is_property_important(PropertyID property_id) const;
     bool is_property_inherited(PropertyID property_id) const;
     bool is_animated_property_inherited(PropertyID property_id) const;
@@ -247,9 +246,12 @@ private:
 
 class AnimatedProperties final : public RefCounted<AnimatedProperties> {
 public:
+    struct InheritedOnly { };
+
     AnimatedProperties();
     AnimatedProperties(AnimatedProperties const&);
     explicit AnimatedProperties(ComputedValuesFFI::AnimatedOverlay const*);
+    AnimatedProperties(ComputedValuesFFI::AnimatedOverlay const*, InheritedOnly);
     ~AnimatedProperties();
 
     u64 identity() const { return m_identity; }
@@ -274,7 +276,6 @@ public:
     StyleValue const& property(PropertyID) const;
 
     void set_property(PropertyID, NonnullRefPtr<StyleValue const>, AnimatedPropertyResultOfTransition, ComputedStyleWorkingSet::Inherited);
-    void reset_non_inherited_properties();
     void clear_wrapper_cache() { m_wrapper_cache.clear(); }
 
 private:

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -121,6 +121,8 @@ public:
     ComputedValuesFFI::AnimatedOverlay const* animated_overlay(Badge<StyleComputer>) const;
     void finish_animated_overlay_rust_mutation(Badge<StyleComputer>);
     void did_apply_style_finalization_from_rust(u16 invalidated_longhands);
+    bool requires_animated_post_compute_adjustments() const;
+    void prepare_for_animated_post_compute_adjustments(Badge<StyleComputer>);
     void set_animated_custom_property(Badge<StyleComputer>, Utf16FlyString name, NonnullRefPtr<StyleValue const> value);
     void clear_animated_properties(Badge<StyleComputer>);
     OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> const& animated_custom_properties() const { return m_animated_custom_properties; }
@@ -215,8 +217,13 @@ private:
 
     AnimatedProperties const& animated_properties() const;
     AnimatedProperties& mutable_animated_properties();
-    ComputedValuesFFI::FfiComputedStyleMetadata& metadata() { return *ComputedValuesFFI::rust_computed_longhand_table_metadata(m_computed_longhand_table); }
+    ComputedValuesFFI::FfiComputedStyleMetadata& metadata()
+    {
+        ensure_mutable_computed_longhand_table();
+        return *ComputedValuesFFI::rust_computed_longhand_table_metadata(m_computed_longhand_table);
+    }
     ComputedValuesFFI::FfiComputedStyleMetadata const& metadata() const { return *ComputedValuesFFI::rust_computed_longhand_table_metadata(m_computed_longhand_table); }
+    void ensure_mutable_computed_longhand_table();
     void set_animated_property_internal(PropertyID, NonnullRefPtr<StyleValue const>, AnimatedPropertyResultOfTransition, Inherited);
     void clear_computed_font_list_cache()
     {
@@ -228,8 +235,10 @@ private:
     // and evaluation flags plus the recorded inheritance-dependent specified values,
     // written by the store funnels and the flag setters and frozen when the drive completes.
     ComputedValuesFFI::ComputedLonghandTable* m_computed_longhand_table { nullptr };
+    bool m_computed_longhand_table_is_shared { false };
     NonnullRefPtr<WrapperMintCache> m_mint_cache;
     RefPtr<AnimatedProperties> m_animated_properties;
+    bool m_had_animated_post_compute_adjustment_property { false };
     OrderedHashMap<Utf16FlyString, NonnullRefPtr<StyleValue const>> m_animated_custom_properties;
 
     mutable RefPtr<Gfx::FontCascadeList const> m_cached_computed_font_list;

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -66,7 +66,7 @@ public:
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_longhand_table(ComputedValuesFFI::ComputedLonghandTable*);
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedStyleWorkingSet const&);
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedValues const&);
-    static NonnullRefPtr<ComputedStyleWorkingSet> create_for_animation_update(ComputedValues const&);
+    static NonnullRefPtr<ComputedStyleWorkingSet> create_for_animation_update(ComputedValuesFFI::ComputedLonghandTable const*, ComputedValuesFFI::AnimatedOverlay const*);
     ~ComputedStyleWorkingSet();
 
     // Freezes the computed longhand table once the drive has stored every longhand. The

--- a/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
+++ b/Libraries/LibWeb/CSS/ComputedStyleWorkingSet.h
@@ -66,6 +66,7 @@ public:
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_longhand_table(ComputedValuesFFI::ComputedLonghandTable*);
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedStyleWorkingSet const&);
     static NonnullRefPtr<ComputedStyleWorkingSet> create_with_base_values_from(ComputedValues const&);
+    static NonnullRefPtr<ComputedStyleWorkingSet> create_for_animation_update(ComputedValues const&);
     ~ComputedStyleWorkingSet();
 
     // Freezes the computed longhand table once the drive has stored every longhand. The

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4190,7 +4190,7 @@ NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::reconstruct_computed_prope
     auto style = ComputedStyleWorkingSet::create_for_animation_update(
         static_cast<ComputedValuesFFI::ComputedLonghandTable const*>(record.longhand_table),
         static_cast<ComputedValuesFFI::AnimatedOverlay const*>(record.animated_overlay));
-    if (style->has_animated_property(PropertyID::Display)) {
+    if (record.animated_overlay && ComputedValuesFFI::rust_animated_overlay_contains(static_cast<ComputedValuesFFI::AnimatedOverlay const*>(record.animated_overlay), to_underlying(PropertyID::Display))) {
         auto const* box = static_cast<ComputedValuesFFI::BoxValues const*>(record.base_payloads[to_underlying(StyleGroupIndex::BoxValues)]);
         style->set_display_before_box_type_transformation(display_from_ffi_display(box->display));
     }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -818,6 +818,15 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         }
         return initial_custom_property_value(m_document->get_registered_custom_property(name), *m_document);
     };
+
+    struct ActiveEffect {
+        GC::Ref<Animations::KeyframeEffect> effect;
+        GC::Ref<Animations::Animation> animation;
+        double current_key { 0 };
+    };
+    Vector<ActiveEffect, 1> active_effects;
+    Vector<StyleValueFFI::FfiAnimationPreparationEffect, 1> preparation_effects;
+    Vector<double, 1> current_keys;
     for (auto effect : effects) {
         auto animation = effect->associated_animation();
         auto output_progress = effect->transformed_progress();
@@ -827,6 +836,62 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
         auto& keyframes = key_frame_set.keyframes_by_key;
         if (keyframes.size() < 2)
             continue;
+        double current_key = *output_progress * 100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor;
+        current_key = clamp(current_key, static_cast<double>(NumericLimits<i64>::min()), static_cast<double>(NumericLimits<i64>::max()));
+        active_effects.append({ effect, *animation, current_key });
+        preparation_effects.append({
+            .identity = effect->animation_preparation_identity(),
+            .generation = effect->animation_preparation_generation(),
+        });
+        current_keys.append(current_key);
+    }
+    if (active_effects.is_empty()) {
+        computed_properties.clear_animated_properties(Badge<StyleComputer> {});
+        return;
+    }
+
+    StyleValueFFI::FfiAnimationPreparationKey preparation_key {
+        .effects = preparation_effects.data(),
+        .effect_count = preparation_effects.size(),
+    };
+    auto const* animation_overlay = computed_properties.animated_overlay(Badge<StyleComputer> {});
+    if (StyleValueFFI::rust_animation_preparation_matches(animation_overlay, &preparation_key)) {
+        auto* mutable_animation_overlay = computed_properties.prepare_animated_overlay_for_rust_mutation(Badge<StyleComputer> {});
+        StyleValueFFI::FfiAnimationContext animation_context {};
+        animation_context.current_color = static_cast<StyleValueFFI::StyleValueData const*>(computed_properties.effective_property_data(PropertyID::Color));
+        if (auto const* layout_node = abstract_element.element().unsafe_layout_node(); layout_node && Painting::has_committed_box(*layout_node)) {
+            auto reference_box = Painting::transform_reference_box(*layout_node);
+            animation_context.has_transform_reference_box = true;
+            animation_context.transform_reference_box_width = reference_box.width().to_double();
+            animation_context.transform_reference_box_height = reference_box.height().to_double();
+        }
+        StyleValueFFI::FfiComputedAnimationBatch computed_batch {
+            .context = animation_context,
+            .preparation_key = &preparation_key,
+            .current_keys = current_keys.data(),
+            .current_key_count = current_keys.size(),
+            .cache_preparation = true,
+            .resolved_animation_storage = nullptr,
+            .computed_keyframe_storage = nullptr,
+            .underlying_longhand_table = computed_properties.computed_longhand_table(),
+            .overlay = mutable_animation_overlay,
+            .custom_underlying_values = nullptr,
+            .custom_initial_values = nullptr,
+            .custom_value_count = 0,
+            .custom_results = nullptr,
+            .custom_result_count = nullptr,
+        };
+        StyleValueFFI::rust_evaluate_animations(&computed_batch);
+        computed_properties.finish_animated_overlay_rust_mutation(Badge<StyleComputer> {});
+        clear_computation_context_caches();
+        return;
+    }
+
+    for (auto const& active_effect : active_effects) {
+        auto effect = active_effect.effect;
+        auto animation = active_effect.animation;
+        auto const& key_frame_set = *effect->key_frame_set();
+        auto& keyframes = key_frame_set.keyframes_by_key;
         StyleValueFFI::FfiAnimationStyleSheetResourceContext style_sheet_resource_context {};
         if (key_frame_set.style_sheet_resource_context.has_value()) {
             auto bytes = key_frame_set.style_sheet_resource_context->base_url.bytes();
@@ -912,18 +977,17 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
                 });
             }
         }
-        double current_key = *output_progress * 100.0 * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor;
-        current_key = clamp(current_key, static_cast<double>(NumericLimits<i64>::min()), static_cast<double>(NumericLimits<i64>::max()));
         ffi_effects.append({
             .first_keyframe_index = first_keyframe_index,
             .keyframe_count = ffi_keyframes.size() - first_keyframe_index,
-            .current_key = current_key,
+            .current_key = active_effect.current_key,
             .result_of_transition = animation->is_css_transition(),
         });
     }
 
-    if (keyframe_declarations.is_empty())
+    if (keyframe_declarations.is_empty()) {
         return;
+    }
 
     Vector<PropertyNameAndID> custom_properties_by_name_id;
     struct CustomPropertyAnimationInfo {
@@ -1158,6 +1222,14 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
 
         return StyleValueFFI::FfiComputedAnimationBatch {
             .context = animation_context,
+            .preparation_key = &preparation_key,
+            .current_keys = current_keys.data(),
+            .current_key_count = current_keys.size(),
+            .cache_preparation = custom_properties_by_name_id.is_empty()
+                && !resolved_batch.uses_tree_counting_function
+                && resolved_batch.container_relative_length_unit_mask == 0
+                && !resolved_batch.needs_document_base_url
+                && resolved_batch.unfixed_random_sharing_count == 0,
             .resolved_animation_storage = resolved_batch.storage,
             .computed_keyframe_storage = computed_keyframe_batch.storage,
             .underlying_longhand_table = computed_properties.computed_longhand_table(),
@@ -4085,6 +4157,14 @@ void StyleComputer::apply_animated_properties_to_reconstruction(ComputedStyleWor
             entry.result_of_transition ? AnimatedPropertyResultOfTransition::Yes : AnimatedPropertyResultOfTransition::No,
             entry.inherited ? ComputedStyleWorkingSet::Inherited::Yes : ComputedStyleWorkingSet::Inherited::No);
     }
+}
+
+NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::reconstruct_computed_properties_for_animation(ComputedValues const& computed_values) const
+{
+    auto style = ComputedStyleWorkingSet::create_for_animation_update(computed_values);
+    if (auto const* animated_properties = computed_values.animated_properties(); animated_properties && animated_properties->has_property(PropertyID::Display))
+        style->set_display_before_box_type_transformation(computed_values.base_values().display());
+    return style;
 }
 
 // Whether the element's own shape can be read off a fixed set of questions, so that two elements

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -730,7 +730,10 @@ void StyleComputer::collect_animations_into(DOM::AbstractElement abstract_elemen
             parent->add_children_explicitly_inherited_non_inherited_style_groups(m_keyframes_inherited_non_inherited_style_groups);
         m_keyframes_inherited_non_inherited_style_groups = 0;
     }
-    finalize_style(computed_properties, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::AnimatedBoxType);
+    if (computed_properties.requires_animated_post_compute_adjustments()) {
+        computed_properties.prepare_for_animated_post_compute_adjustments(Badge<StyleComputer> {});
+        finalize_style(computed_properties, abstract_element, ComputedValuesFFI::FfiStyleFinalizationMode::AnimatedBoxType);
+    }
 }
 
 void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract_element, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>> effects, ComputedStyleWorkingSet& computed_properties) const
@@ -3729,6 +3732,27 @@ StyleEngine::StyleRecordDelta StyleComputer::publish_computed_style_inputs(DOM::
         }
     }
     return publication;
+}
+
+StyleEngine::StyleRecordDelta StyleComputer::publish_animation_overlay(DOM::AbstractElement abstract_element, ComputedValues const& values) const
+{
+    auto animated_properties = values.animated_properties();
+    Array<void const*, to_underlying(StyleGroupIndex::Count)> payloads;
+    ReadonlySpan<void const*> payload_span;
+    if (animated_properties) {
+        for (size_t index = 0; index < payloads.size(); ++index)
+            payloads[index] = values.style_group_payload(static_cast<StyleGroupIndex>(index));
+        payload_span = payloads;
+    }
+    auto publication = const_cast<StyleComputer&>(*this).style_engine().publish_animation_overlay(
+        abstract_element.element().style_node_id(),
+        pseudo_element_to_ffi(abstract_element.pseudo_element()),
+        animated_properties ? animated_properties->identity() : 0,
+        animated_properties ? animated_properties->overlay() : nullptr,
+        payload_span);
+    if (publication.has_value())
+        return publication.release_value();
+    return publish_computed_style_inputs(abstract_element, values);
 }
 
 StyleRecordID StyleComputer::intern_computed_style_inputs(DOM::AbstractElement abstract_element, ComputedValues const& values) const

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4183,11 +4183,17 @@ void StyleComputer::apply_animated_properties_to_reconstruction(ComputedStyleWor
     }
 }
 
-NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::reconstruct_computed_properties_for_animation(ComputedValues const& computed_values) const
+NonnullRefPtr<ComputedStyleWorkingSet> StyleComputer::reconstruct_computed_properties_for_animation(StyleRecordID style_record) const
 {
-    auto style = ComputedStyleWorkingSet::create_for_animation_update(computed_values);
-    if (auto const* animated_properties = computed_values.animated_properties(); animated_properties && animated_properties->has_property(PropertyID::Display))
-        style->set_display_before_box_type_transformation(computed_values.base_values().display());
+    auto record = m_style_engine.style_record_view(style_record);
+    VERIFY(record.present);
+    auto style = ComputedStyleWorkingSet::create_for_animation_update(
+        static_cast<ComputedValuesFFI::ComputedLonghandTable const*>(record.longhand_table),
+        static_cast<ComputedValuesFFI::AnimatedOverlay const*>(record.animated_overlay));
+    if (style->has_animated_property(PropertyID::Display)) {
+        auto const* box = static_cast<ComputedValuesFFI::BoxValues const*>(record.base_payloads[to_underlying(StyleGroupIndex::BoxValues)]);
+        style->set_display_before_box_type_transformation(display_from_ffi_display(box->display));
+    }
     return style;
 }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -4129,13 +4129,23 @@ NonnullRefPtr<ComputedValues const> StyleComputer::build_animated_computed_value
 
     VERIFY(computation_context_cache_is_empty());
     ScopeGuard clear_computation_context_cache = [&] { clear_computation_context_caches(); };
-    auto const& computation_context = get_computation_context_for_property(PropertyID::Color, computed_properties, abstract_element);
-    ColorResolutionContext color_resolution_context {
-        .color_scheme = computation_context.color_scheme,
-        .current_color = InitialValues::color(),
-        .current_color_style_value_data = computed_properties.effective_property_data(PropertyID::Color),
-        .calculation_resolution_context = { .length_resolution_context = computation_context.length_resolution_context },
-    };
+    auto color_resolution_context = [&] {
+        if ((groups_to_apply & (1u << to_underlying(StyleGroupIndex::FontValues))) == 0) {
+            return ColorResolutionContext {
+                .color_scheme = previous_values.color_scheme(),
+                .current_color = InitialValues::color(),
+                .current_color_style_value_data = computed_properties.effective_property_data(PropertyID::Color),
+                .calculation_resolution_context = { .length_resolution_context = Length::ResolutionContext::for_element(abstract_element, previous_values) },
+            };
+        }
+        auto const& computation_context = get_computation_context_for_property(PropertyID::Color, computed_properties, abstract_element);
+        return ColorResolutionContext {
+            .color_scheme = computation_context.color_scheme,
+            .current_color = InitialValues::color(),
+            .current_color_style_value_data = computed_properties.effective_property_data(PropertyID::Color),
+            .calculation_resolution_context = { .length_resolution_context = computation_context.length_resolution_context },
+        };
+    }();
 
     auto base_values = ComputedValues::Builder { previous_values.base_values() }.build();
     auto animated_values = ComputedValues::create_over_base(computed_properties, document(), style_scope, move(color_resolution_context), *base_values, groups_to_apply);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -173,7 +173,7 @@ public:
     [[nodiscard]] NonnullRefPtr<ComputedValues const> build_animated_computed_values(ComputedStyleWorkingSet&, DOM::AbstractElement, StyleScope const&, ComputedValues const& previous_values) const;
     [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> reconstruct_computed_properties(ComputedValues const&) const;
     void apply_animated_properties_to_reconstruction(ComputedStyleWorkingSet&, ComputedValues const&) const;
-    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> reconstruct_computed_properties_for_animation(ComputedValues const&) const;
+    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> reconstruct_computed_properties_for_animation(StyleRecordID) const;
 
     void begin_transition_stabilization_epoch();
     void record_transition_stabilization_baseline(DOM::AbstractElement) const;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -172,6 +172,7 @@ public:
     [[nodiscard]] NonnullRefPtr<ComputedValues const> build_animated_computed_values(ComputedStyleWorkingSet&, DOM::AbstractElement, StyleScope const&, ComputedValues const& previous_values) const;
     [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> reconstruct_computed_properties(ComputedValues const&) const;
     void apply_animated_properties_to_reconstruction(ComputedStyleWorkingSet&, ComputedValues const&) const;
+    [[nodiscard]] NonnullRefPtr<ComputedStyleWorkingSet> reconstruct_computed_properties_for_animation(ComputedValues const&) const;
 
     void begin_transition_stabilization_epoch();
     void record_transition_stabilization_baseline(DOM::AbstractElement) const;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -114,6 +114,7 @@ public:
     // Publish a computed style built outside the ordinary cascade path, such as an inherited-group
     // swap, so StyleEngine's final node-to-style relation remains authoritative.
     [[nodiscard]] StyleEngine::StyleRecordDelta publish_computed_style_inputs(DOM::AbstractElement, ComputedValues const&) const;
+    [[nodiscard]] StyleEngine::StyleRecordDelta publish_animation_overlay(DOM::AbstractElement, ComputedValues const&) const;
     // Give a layout-only variant of an element or pseudo-element style an authoritative record
     // without replacing the StyleEngine assignment of its DOM target.
     [[nodiscard]] StyleRecordID intern_computed_style_inputs(DOM::AbstractElement, ComputedValues const&) const;

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -235,6 +235,14 @@ StyleEngine::StyleRecordDelta StyleEngine::publish_computed_groups(StyleNodeID n
     return { StyleRecordID { delta.old_style_record }, StyleRecordID { delta.new_style_record } };
 }
 
+Optional<StyleEngine::StyleRecordDelta> StyleEngine::publish_animation_overlay(StyleNodeID node, u8 pseudo_kind, u64 animation_overlay_identity, void const* animated_overlay, ReadonlySpan<void const*> payloads)
+{
+    auto delta = StyleEngineFFI::style_engine_publish_animation_overlay(m_impl, node.value(), pseudo_kind, animation_overlay_identity, animated_overlay, payloads.data(), payloads.size());
+    if (delta.new_style_record == 0)
+        return {};
+    return StyleRecordDelta { StyleRecordID { delta.old_style_record }, StyleRecordID { delta.new_style_record } };
+}
+
 StyleEngine::StyleRecordDelta StyleEngine::assign_shared_style_record(StyleNodeID node, u8 pseudo_kind, StyleRecordID style_record, bool inherited_group_swap_eligible)
 {
     auto delta = StyleEngineFFI::style_engine_assign_shared_style_record(m_impl, node.value(), pseudo_kind, style_record.value(), ComputedValues::inherited_style_group_count, inherited_group_swap_eligible);

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -264,6 +264,16 @@ u32 StyleEngine::compare_style_records(StyleRecordID old_style_record, StyleReco
     return StyleEngineFFI::style_engine_compare_style_records(m_impl, old_style_record.value(), new_style_record.value(), font_lists_equal, element_folds_transform_into_layout);
 }
 
+bool StyleEngine::animation_overlay_changed(StyleRecordID old_style_record, void const* animated_overlay) const
+{
+    return StyleEngineFFI::style_engine_animation_overlay_changed(m_impl, old_style_record.value(), animated_overlay);
+}
+
+StyleEngineFFI::FfiAnimationInvalidation StyleEngine::compare_animation_overlay(StyleRecordID old_style_record, void const* animated_overlay, ReadonlySpan<void const*> payloads, bool is_document_element) const
+{
+    return StyleEngineFFI::style_engine_compare_animation_overlay(m_impl, old_style_record.value(), animated_overlay, payloads.data(), payloads.size(), is_document_element);
+}
+
 StyleEngine::StyleRecordView StyleEngine::style_record_view(StyleRecordID style_record) const
 {
     return StyleEngineFFI::style_engine_style_record_view(m_impl, style_record.value());

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -102,6 +102,7 @@ public:
     // return its previous and current StyleRecordID assignments. A zero node interns an unassigned
     // record for a style target which is not registered in the engine.
     [[nodiscard]] StyleRecordDelta publish_computed_groups(StyleNodeID node, u8 pseudo_kind, ReadonlySpan<void const*> payloads, size_t inherited_group_count, u64 custom_property_environment, bool inherited_group_swap_candidate, u64 counter_style_environment_identity, u64 animation_overlay_identity, void const* animated_overlay, ReadonlySpan<void const*> animation_overlay_payloads, void const* computed_longhand_table);
+    [[nodiscard]] Optional<StyleRecordDelta> publish_animation_overlay(StyleNodeID node, u8 pseudo_kind, u64 animation_overlay_identity, void const* animated_overlay, ReadonlySpan<void const*> payloads);
     [[nodiscard]] StyleRecordDelta assign_shared_style_record(StyleNodeID node, u8 pseudo_kind, StyleRecordID style_record, bool inherited_group_swap_eligible);
     // The borrowed payload array is stable while a base record exists or an animation-overlay
     // generation remains assigned or pinned.

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -109,6 +109,8 @@ public:
     [[nodiscard]] void const* style_record_payloads(StyleRecordID style_record) const;
     [[nodiscard]] u8 style_record_dependency_flags(StyleRecordID style_record) const;
     [[nodiscard]] u32 compare_style_records(StyleRecordID old_style_record, StyleRecordID new_style_record, bool font_lists_equal, bool element_folds_transform_into_layout) const;
+    [[nodiscard]] bool animation_overlay_changed(StyleRecordID old_style_record, void const* animated_overlay) const;
+    [[nodiscard]] StyleEngineFFI::FfiAnimationInvalidation compare_animation_overlay(StyleRecordID old_style_record, void const* animated_overlay, ReadonlySpan<void const*> payloads, bool is_document_element) const;
     [[nodiscard]] StyleRecordView style_record_view(StyleRecordID style_record) const;
     void decide_transitions(StyleRecordID before_style_record, void const* after_longhand_table, void const* after_animated_overlay, StyleValueFFI::FfiTransitionInput&, StyleValueFFI::FfiTransitionAction*) const;
     // Remove the retained input identities for one pseudo-element kind and return its removal.

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/StyleEngineBridge.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterStyleValue.h>
@@ -14,6 +16,32 @@
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 
 namespace Web::CSS {
+
+RequiredInvalidationAfterStyleChange decode_style_invalidation(u32 packed)
+{
+    using enum StyleEngineFFI::FfiStyleInvalidationField;
+    static_assert(ComputedValues::inherited_style_group_count <= 7);
+    RequiredInvalidationAfterStyleChange result;
+    result.ensure_at_least(static_cast<InvalidationLevel>(packed & to_underlying(LevelMask)));
+    result.ensure_at_least(static_cast<AccumulatedVisualContextInvalidation>((packed >> to_underlying(VisualContextShift)) & to_underlying(LevelMask)));
+    if (result.needs_layout_tree_rebuild())
+        result.set_layout_tree_rebuild_root(static_cast<LayoutTreeRebuildRoot>((packed >> to_underlying(RebuildRootShift)) & to_underlying(LevelMask)));
+    if (packed & to_underlying(RebuildStackingContext))
+        result.set_needs_stacking_context_tree_rebuild();
+    if (packed & to_underlying(RecalculateScrollableOverflow))
+        result.set_needs_scrollable_overflow_recalculation();
+    result.needs_scroll_container_resnap = packed & to_underlying(ResnapScrollContainer);
+    result.recompute_descendant_styles = packed & to_underlying(RecomputeDescendants);
+    auto inherited_groups = static_cast<u8>((packed >> to_underlying(InheritedGroupsShift)) & to_underlying(InheritedGroupsMask));
+    for (u8 group = 0; group < ComputedValues::inherited_style_group_count; ++group) {
+        if (inherited_groups & (1 << group))
+            result.mark_inherited_style_group_changed(group);
+    }
+    result.changes_containing_block_establishment = packed & to_underlying(ChangesContainingBlock);
+    result.repaint_propagated_text_decorations = packed & to_underlying(RepaintTextDecorations);
+    result.non_inherited_property_inheritance_sources_changed = packed & to_underlying(NonInheritedInheritanceSource);
+    return result;
+}
 
 static bool animated_value_creates_stacking_context(PropertyID property_id, StyleValue const* value)
 {

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -156,5 +156,6 @@ private:
 };
 
 RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::PropertyID, StyleValue const* old_value, StyleValue const* new_value);
+RequiredInvalidationAfterStyleChange decode_style_invalidation(u32 packed);
 
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1391,28 +1391,9 @@ void Element::run_attribute_change_steps(Utf16FlyString const& local_name, Optio
 
 static CSS::StyleComputer::ComputedStyleInvalidation decode_style_record_invalidation(u32 packed)
 {
-    using enum CSS::StyleEngineFFI::FfiStyleInvalidationField;
-    static_assert(CSS::ComputedValues::inherited_style_group_count <= 7);
     CSS::StyleComputer::ComputedStyleInvalidation result;
-    result.invalidation.ensure_at_least(static_cast<CSS::InvalidationLevel>(packed & to_underlying(LevelMask)));
-    result.invalidation.ensure_at_least(static_cast<CSS::AccumulatedVisualContextInvalidation>((packed >> to_underlying(VisualContextShift)) & to_underlying(LevelMask)));
-    if (result.invalidation.needs_layout_tree_rebuild())
-        result.invalidation.set_layout_tree_rebuild_root(static_cast<CSS::LayoutTreeRebuildRoot>((packed >> to_underlying(RebuildRootShift)) & to_underlying(LevelMask)));
-    if (packed & to_underlying(RebuildStackingContext))
-        result.invalidation.set_needs_stacking_context_tree_rebuild();
-    if (packed & to_underlying(RecalculateScrollableOverflow))
-        result.invalidation.set_needs_scrollable_overflow_recalculation();
-    result.invalidation.needs_scroll_container_resnap = packed & to_underlying(ResnapScrollContainer);
-    result.invalidation.recompute_descendant_styles = packed & to_underlying(RecomputeDescendants);
-    auto inherited_groups = static_cast<u8>((packed >> to_underlying(InheritedGroupsShift)) & to_underlying(InheritedGroupsMask));
-    for (u8 group = 0; group < CSS::ComputedValues::inherited_style_group_count; ++group) {
-        if (inherited_groups & (1 << group))
-            result.invalidation.mark_inherited_style_group_changed(group);
-    }
-    result.invalidation.changes_containing_block_establishment = packed & to_underlying(ChangesContainingBlock);
-    result.invalidation.repaint_propagated_text_decorations = packed & to_underlying(RepaintTextDecorations);
-    result.invalidation.non_inherited_property_inheritance_sources_changed = packed & to_underlying(NonInheritedInheritanceSource);
-    result.any_computed_value_changed = packed & to_underlying(AnyComputedValueChanged);
+    result.invalidation = CSS::decode_style_invalidation(packed);
+    result.any_computed_value_changed = packed & to_underlying(CSS::StyleEngineFFI::FfiStyleInvalidationField::AnyComputedValueChanged);
     return result;
 }
 struct ElementDependentInvalidationState {

--- a/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
@@ -73,6 +73,31 @@ pub struct FfiAnimatedOverlayEntry {
 }
 
 impl AnimatedOverlay {
+    fn clone_inherited(&self) -> Self {
+        let entries = self
+            .entries
+            .iter()
+            .filter(|entry| entry.inherited)
+            .map(|entry| AnimatedOverlayEntry {
+                property: entry.property,
+                value: entry.value.clone(),
+                inherited: true,
+                result_of_transition: entry.result_of_transition,
+            })
+            .collect();
+        let mut overlay = Self {
+            entries,
+            ffi_entries: Vec::new(),
+            animation_preparation: self.animation_preparation.clone(),
+        };
+        overlay.refresh_ffi_entries();
+        overlay
+    }
+
+    pub(crate) fn entries(&self) -> &[AnimatedOverlayEntry] {
+        &self.entries
+    }
+
     pub(crate) fn get(&self, property: u16) -> Option<&AnimatedOverlayEntry> {
         self.entries.iter().find(|entry| entry.property == property)
     }
@@ -140,6 +165,24 @@ pub unsafe extern "C" fn rust_animated_overlay_clone(overlay: *const AnimatedOve
     abort_on_panic(|| Box::into_raw(Box::new(unsafe { &*overlay }.clone())))
 }
 
+/// Returns a new overlay holding retained copies of `overlay`'s inherited entries.
+///
+/// # Safety
+/// `overlay` must be a valid overlay.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_animated_overlay_clone_inherited(
+    overlay: *const AnimatedOverlay,
+) -> *mut AnimatedOverlay {
+    abort_on_panic(|| Box::into_raw(Box::new(unsafe { &*overlay }.clone_inherited())))
+}
+
+/// # Safety
+/// `overlay` must be a valid overlay.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_animated_overlay_contains(overlay: *const AnimatedOverlay, property: u16) -> bool {
+    abort_on_panic(|| unsafe { &*overlay }.get(property).is_some())
+}
+
 /// # Safety
 /// `overlay` must be a valid overlay that is not used after this call.
 #[unsafe(no_mangle)]
@@ -166,19 +209,6 @@ pub unsafe extern "C" fn rust_animated_overlay_set(
         };
         let overlay = unsafe { &mut *overlay };
         overlay.set_owned(property, retained, inherited, result_of_transition);
-        overlay.refresh_ffi_entries();
-    });
-}
-
-/// Removes every non-inherited entry from the overlay.
-///
-/// # Safety
-/// `overlay` must be a valid overlay.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_animated_overlay_reset_non_inherited(overlay: *mut AnimatedOverlay) {
-    abort_on_panic(|| {
-        let overlay = unsafe { &mut *overlay };
-        overlay.entries.retain(|entry| entry.inherited);
         overlay.refresh_ffi_entries();
     });
 }

--- a/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
@@ -17,6 +17,7 @@
 //! longhand table.
 
 use std::ffi::c_void;
+use std::rc::Rc;
 
 use crate::abort_on_panic;
 use crate::css::style_value::RetainedStyleValueData;
@@ -25,6 +26,7 @@ use crate::css::style_value::RetainedStyleValueData;
 pub struct AnimatedOverlay {
     entries: Vec<AnimatedOverlayEntry>,
     ffi_entries: Vec<FfiAnimatedOverlayEntry>,
+    pub(crate) animation_preparation: Option<Rc<crate::css::animation::PreparedAnimationBatch>>,
 }
 
 impl Clone for AnimatedOverlay {
@@ -42,6 +44,7 @@ impl Clone for AnimatedOverlay {
         let mut overlay = Self {
             entries,
             ffi_entries: Vec::new(),
+            animation_preparation: self.animation_preparation.clone(),
         };
         overlay.refresh_ffi_entries();
         overlay
@@ -123,6 +126,7 @@ pub extern "C" fn rust_animated_overlay_create() -> *mut AnimatedOverlay {
         Box::into_raw(Box::new(AnimatedOverlay {
             entries: Vec::new(),
             ffi_entries: Vec::new(),
+            animation_preparation: None,
         }))
     })
 }

--- a/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
@@ -20,34 +20,21 @@ use std::ffi::c_void;
 use std::rc::Rc;
 
 use crate::abort_on_panic;
-use crate::css::style_value::RetainedStyleValueData;
+use crate::css::style_value::{RetainedStyleValueData, StyleValueData, release_style_value, retain_style_value};
 
 #[derive(Default)]
 pub struct AnimatedOverlay {
-    entries: Vec<AnimatedOverlayEntry>,
-    ffi_entries: Vec<FfiAnimatedOverlayEntry>,
+    entries: Vec<FfiAnimatedOverlayEntry>,
     pub(crate) animation_preparation: Option<Rc<crate::css::animation::PreparedAnimationBatch>>,
 }
 
 impl Clone for AnimatedOverlay {
     fn clone(&self) -> Self {
-        let entries = self
-            .entries
-            .iter()
-            .map(|entry| AnimatedOverlayEntry {
-                property: entry.property,
-                value: entry.value.clone(),
-                inherited: entry.inherited,
-                result_of_transition: entry.result_of_transition,
-            })
-            .collect();
-        let mut overlay = Self {
+        let entries = self.entries.clone();
+        Self {
             entries,
-            ffi_entries: Vec::new(),
             animation_preparation: self.animation_preparation.clone(),
-        };
-        overlay.refresh_ffi_entries();
-        overlay
+        }
     }
 }
 
@@ -57,13 +44,8 @@ impl Drop for AnimatedOverlay {
     }
 }
 
-pub(crate) struct AnimatedOverlayEntry {
-    pub(crate) property: u16,
-    pub(crate) value: RetainedStyleValueData,
-    pub(crate) inherited: bool,
-    pub(crate) result_of_transition: bool,
-}
-
+/// The authoritative Rust-owned entry. C++ only borrows spans of this representation; while an
+/// entry is stored in the overlay, `value` owns one strong reference.
 #[repr(C)]
 pub struct FfiAnimatedOverlayEntry {
     pub property: u16,
@@ -72,33 +54,62 @@ pub struct FfiAnimatedOverlayEntry {
     pub result_of_transition: bool,
 }
 
-impl AnimatedOverlay {
-    fn clone_inherited(&self) -> Self {
-        let entries = self
-            .entries
-            .iter()
-            .filter(|entry| entry.inherited)
-            .map(|entry| AnimatedOverlayEntry {
-                property: entry.property,
-                value: entry.value.clone(),
-                inherited: true,
-                result_of_transition: entry.result_of_transition,
-            })
-            .collect();
-        let mut overlay = Self {
-            entries,
-            ffi_entries: Vec::new(),
-            animation_preparation: self.animation_preparation.clone(),
-        };
-        overlay.refresh_ffi_entries();
-        overlay
+impl FfiAnimatedOverlayEntry {
+    fn from_owned(property: u16, value: RetainedStyleValueData, inherited: bool, result_of_transition: bool) -> Self {
+        let pointer = value.pointer().cast();
+        std::mem::forget(value);
+        Self {
+            property,
+            value: pointer,
+            inherited,
+            result_of_transition,
+        }
     }
 
-    pub(crate) fn entries(&self) -> &[AnimatedOverlayEntry] {
+    pub(crate) fn value(&self) -> &StyleValueData {
+        unsafe { &*self.value.cast() }
+    }
+
+    pub(crate) fn value_pointer(&self) -> *const StyleValueData {
+        self.value.cast()
+    }
+
+    pub(crate) fn clone_value(&self) -> RetainedStyleValueData {
+        unsafe { RetainedStyleValueData::from_retained_pointer(retain_style_value(self.value_pointer())) }
+    }
+}
+
+impl Clone for FfiAnimatedOverlayEntry {
+    fn clone(&self) -> Self {
+        Self::from_owned(
+            self.property,
+            self.clone_value(),
+            self.inherited,
+            self.result_of_transition,
+        )
+    }
+}
+
+impl Drop for FfiAnimatedOverlayEntry {
+    fn drop(&mut self) {
+        unsafe { release_style_value(self.value_pointer()) };
+    }
+}
+
+impl AnimatedOverlay {
+    fn clone_inherited(&self) -> Self {
+        let entries = self.entries.iter().filter(|entry| entry.inherited).cloned().collect();
+        Self {
+            entries,
+            animation_preparation: self.animation_preparation.clone(),
+        }
+    }
+
+    pub(crate) fn entries(&self) -> &[FfiAnimatedOverlayEntry] {
         &self.entries
     }
 
-    pub(crate) fn get(&self, property: u16) -> Option<&AnimatedOverlayEntry> {
+    pub(crate) fn get(&self, property: u16) -> Option<&FfiAnimatedOverlayEntry> {
         self.entries.iter().find(|entry| entry.property == property)
     }
 
@@ -113,35 +124,17 @@ impl AnimatedOverlay {
         inherited: bool,
         result_of_transition: bool,
     ) {
-        let entry = AnimatedOverlayEntry {
-            property,
-            value,
-            inherited,
-            result_of_transition,
-        };
+        let entry = FfiAnimatedOverlayEntry::from_owned(property, value, inherited, result_of_transition);
         match self.entries.iter_mut().find(|entry| entry.property == property) {
             Some(existing) => *existing = entry,
             None => self.entries.push(entry),
         }
     }
-
-    pub(crate) fn refresh_ffi_entries(&mut self) {
-        self.ffi_entries = self
-            .entries
-            .iter()
-            .map(|entry| FfiAnimatedOverlayEntry {
-                property: entry.property,
-                value: entry.value.pointer().cast(),
-                inherited: entry.inherited,
-                result_of_transition: entry.result_of_transition,
-            })
-            .collect();
-    }
 }
 
 /// The single implementation of the overlay read rule: important base values
 /// override animated but not transitioned properties.
-pub(crate) fn overlay_wins(entry: &AnimatedOverlayEntry, base_value_is_important: bool) -> bool {
+pub(crate) fn overlay_wins(entry: &FfiAnimatedOverlayEntry, base_value_is_important: bool) -> bool {
     entry.result_of_transition || !base_value_is_important
 }
 
@@ -150,7 +143,6 @@ pub extern "C" fn rust_animated_overlay_create() -> *mut AnimatedOverlay {
     abort_on_panic(|| {
         Box::into_raw(Box::new(AnimatedOverlay {
             entries: Vec::new(),
-            ffi_entries: Vec::new(),
             animation_preparation: None,
         }))
     })
@@ -209,7 +201,6 @@ pub unsafe extern "C" fn rust_animated_overlay_set(
         };
         let overlay = unsafe { &mut *overlay };
         overlay.set_owned(property, retained, inherited, result_of_transition);
-        overlay.refresh_ffi_entries();
     });
 }
 
@@ -224,7 +215,7 @@ pub unsafe extern "C" fn rust_animated_overlay_entries(
     count: *mut usize,
 ) -> *const FfiAnimatedOverlayEntry {
     abort_on_panic(|| {
-        let entries = &unsafe { &*overlay }.ffi_entries;
+        let entries = &unsafe { &*overlay }.entries;
         unsafe { *count = entries.len() };
         entries.as_ptr()
     })
@@ -245,6 +236,7 @@ pub unsafe extern "C" fn rust_animated_overlay_effective_value(
         unsafe { &*overlay }
             .get(property)
             .filter(|entry| overlay_wins(entry, base_value_is_important))
-            .map_or(std::ptr::null(), |entry| entry.value.pointer().cast())
+            .map_or(std::ptr::null(), FfiAnimatedOverlayEntry::value_pointer)
+            .cast()
     })
 }

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -387,6 +387,7 @@ fn evaluate_easing_descriptor(descriptor: &FfiEasingDescriptor, input_progress: 
     }
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiAnimationFontMetrics {
     pub font_size: f64,
@@ -396,6 +397,7 @@ pub struct FfiAnimationFontMetrics {
     pub line_height: f64,
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiAnimationLengthResolutionContext {
     pub viewport_width: f64,
@@ -406,6 +408,7 @@ pub struct FfiAnimationLengthResolutionContext {
     pub root_font_metrics_depend_on_viewport_metrics: bool,
 }
 
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiAnimationContext {
     pub allow_discrete: bool,
@@ -451,9 +454,26 @@ pub struct FfiAnimationBatch {
     pub important_property_bitmap_length: usize,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiAnimationPreparationEffect {
+    pub identity: u64,
+    pub generation: u64,
+}
+
+#[repr(C)]
+pub struct FfiAnimationPreparationKey {
+    pub effects: *const FfiAnimationPreparationEffect,
+    pub effect_count: usize,
+}
+
 #[repr(C)]
 pub struct FfiComputedAnimationBatch {
     pub context: FfiAnimationContext,
+    pub preparation_key: *const FfiAnimationPreparationKey,
+    pub current_keys: *const f64,
+    pub current_key_count: usize,
+    pub cache_preparation: bool,
     pub resolved_animation_storage: *mut std::ffi::c_void,
     pub computed_keyframe_storage: *mut std::ffi::c_void,
     pub underlying_longhand_table: *const std::ffi::c_void,
@@ -775,7 +795,7 @@ fn resolve_animation_declarations(
         }
     }
     let mut value_plans = Vec::new();
-    for effect in effects {
+    for (effect_index, effect) in effects.iter().enumerate() {
         let keyframe_end = effect
             .first_keyframe_index
             .checked_add(effect.keyframe_count)
@@ -804,7 +824,7 @@ fn resolve_animation_declarations(
                 property_id,
                 custom_name_id,
                 result_of_transition: effect.result_of_transition,
-                current_key: effect.current_key,
+                effect_index,
                 property_indices,
             });
         }
@@ -882,7 +902,7 @@ struct AnimationValuePlan {
     property_id: u16,
     custom_name_id: u32,
     result_of_transition: bool,
-    current_key: f64,
+    effect_index: usize,
     property_indices: Vec<usize>,
 }
 
@@ -7134,57 +7154,146 @@ pub unsafe extern "C" fn rust_resolve_animation_declarations(
     })
 }
 
-/// Complete the Rust-owned animation plan and compose every interval without
-/// consulting C++ or the DOM. This consumes both Rust allocations produced by
-/// declaration resolution and keyframe longhand computation.
+struct AnimationPreparationKey {
+    effects: Vec<FfiAnimationPreparationEffect>,
+}
+
+impl AnimationPreparationKey {
+    unsafe fn from_ffi(key: &FfiAnimationPreparationKey) -> Self {
+        Self {
+            effects: unsafe { std::slice::from_raw_parts(key.effects, key.effect_count) }.to_vec(),
+        }
+    }
+
+    unsafe fn matches_ffi(&self, key: &FfiAnimationPreparationKey) -> bool {
+        self.effects.as_slice() == unsafe { std::slice::from_raw_parts(key.effects, key.effect_count) }
+    }
+}
+
+pub(crate) struct PreparedAnimationBatch {
+    key: AnimationPreparationKey,
+    resolved: ResolvedAnimationDeclarations,
+    // Retain the allocations referenced by `keyframes_by_value`.
+    _computed_keyframe_values: Vec<RetainedStyleValueData>,
+    keyframes_by_value: Vec<Vec<FfiAnimationKeyframeValue>>,
+    context: FfiAnimationContext,
+}
+
+/// Whether an animated overlay already holds the endpoint preparation identified by `key`.
 ///
 /// # Safety
-/// `computed` must point to a live batch. Both storage pointers must be live,
-/// unconsumed results from their producing calls. `underlying_longhand_table`
-/// and `overlay` must point at live values, and the overlay must be uniquely
-/// owned for the duration of the call.
+/// `overlay` and `key` must point at live values and the key's effect range must be readable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_animation_preparation_matches(
+    overlay: *const std::ffi::c_void,
+    key: *const FfiAnimationPreparationKey,
+) -> bool {
+    crate::abort_on_panic(|| {
+        if overlay.is_null() || key.is_null() {
+            return false;
+        }
+        let overlay = unsafe { &*overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
+        let key = unsafe { &*key };
+        overlay
+            .animation_preparation
+            .as_ref()
+            .is_some_and(|preparation| unsafe { preparation.key.matches_ffi(key) })
+    })
+}
+
+/// Complete the Rust-owned animation plan and compose every interval without
+/// consulting C++ or the DOM. On the first sample this consumes the Rust allocations produced by
+/// declaration resolution and keyframe longhand computation. Later samples can reuse that
+/// preparation from the animated overlay.
+///
+/// # Safety
+/// `computed` must point to a live batch. Its preparation key and current-key range must be
+/// readable. On a cache miss both storage pointers must be live, unconsumed results from their
+/// producing calls. `underlying_longhand_table` and `overlay` must point at live values, and the
+/// overlay must be uniquely owned for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAnimationBatch) -> usize {
     crate::abort_on_panic(|| {
         crate::css::ffi_stats::rust_style_ffi_note_animation_evaluation();
         let computed = unsafe { &*computed };
-        assert!(!computed.resolved_animation_storage.is_null());
-        assert!(!computed.computed_keyframe_storage.is_null());
+        assert!(!computed.preparation_key.is_null());
         assert!(!computed.underlying_longhand_table.is_null());
-        let resolved = unsafe {
-            Box::from_raw(
-                computed
-                    .resolved_animation_storage
-                    .cast::<ResolvedAnimationDeclarations>(),
-            )
-        };
-        let computed_keyframe_values = unsafe {
-            crate::css::style_compute::take_animation_keyframe_longhand_values(computed.computed_keyframe_storage)
-        };
-        assert_eq!(computed_keyframe_values.len(), resolved.properties.len());
+        assert!(!computed.overlay.is_null());
+        let preparation_key = unsafe { &*computed.preparation_key };
+        let current_keys = unsafe { std::slice::from_raw_parts(computed.current_keys, computed.current_key_count) };
+        let overlay = unsafe { &mut *computed.overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
+        let preparation = overlay
+            .animation_preparation
+            .as_ref()
+            .filter(|preparation| unsafe { preparation.key.matches_ffi(preparation_key) })
+            .cloned()
+            .unwrap_or_else(|| {
+                assert!(!computed.resolved_animation_storage.is_null());
+                assert!(!computed.computed_keyframe_storage.is_null());
+                let resolved = *unsafe {
+                    Box::from_raw(
+                        computed
+                            .resolved_animation_storage
+                            .cast::<ResolvedAnimationDeclarations>(),
+                    )
+                };
+                let computed_keyframe_values = unsafe {
+                    crate::css::style_compute::take_animation_keyframe_longhand_values(
+                        computed.computed_keyframe_storage,
+                    )
+                };
+                assert_eq!(computed_keyframe_values.len(), resolved.properties.len());
+                let keyframes_by_value = resolved
+                    .value_plans
+                    .iter()
+                    .map(|plan| {
+                        plan.property_indices
+                            .iter()
+                            .map(|&property_index| {
+                                let property = &resolved.properties[property_index];
+                                let keyframe = &resolved.keyframes[property.keyframe_index];
+                                FfiAnimationKeyframeValue {
+                                    key: keyframe.key,
+                                    value: computed_keyframe_values[property_index].pointer(),
+                                    easing: keyframe.easing_descriptor(),
+                                    composite: keyframe.composite,
+                                }
+                            })
+                            .collect()
+                    })
+                    .collect();
+                std::rc::Rc::new(PreparedAnimationBatch {
+                    key: unsafe { AnimationPreparationKey::from_ffi(preparation_key) },
+                    resolved,
+                    _computed_keyframe_values: computed_keyframe_values,
+                    keyframes_by_value,
+                    context: computed.context,
+                })
+            });
+        if computed.cache_preparation {
+            overlay.animation_preparation = Some(preparation.clone());
+        } else {
+            overlay.animation_preparation = None;
+        }
+        let resolved = &preparation.resolved;
+        let mut context = preparation.context;
+        context.current_color = computed.context.current_color;
+        context.has_transform_reference_box = computed.context.has_transform_reference_box;
+        context.transform_reference_box_width = computed.context.transform_reference_box_width;
+        context.transform_reference_box_height = computed.context.transform_reference_box_height;
         let underlying_longhand_table = unsafe {
             &*computed
                 .underlying_longhand_table
                 .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
         };
 
-        let mut keyframes_by_value = Vec::with_capacity(resolved.value_plans.len());
-        for plan in &resolved.value_plans {
-            let mut keyframes = Vec::with_capacity(plan.property_indices.len());
-            for &property_index in &plan.property_indices {
-                let property = &resolved.properties[property_index];
-                let keyframe = &resolved.keyframes[property.keyframe_index];
-                keyframes.push(FfiAnimationKeyframeValue {
-                    key: keyframe.key,
-                    value: computed_keyframe_values[property_index].pointer(),
-                    easing: keyframe.easing_descriptor(),
-                    composite: keyframe.composite,
-                });
-            }
-            keyframes_by_value.push(keyframes);
-        }
-        let mut inputs = Vec::with_capacity(resolved.value_plans.len());
-        for (plan, keyframes) in resolved.value_plans.iter().zip(&keyframes_by_value) {
+        // https://www.w3.org/TR/web-animations-1/#effect-stacks
+        // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
+        //     next effect affecting the same property.
+        let mut custom_final_values = Vec::<(u32, RetainedStyleValueData)>::new();
+        let mut previous_values = Vec::<(u16, u32, *const StyleValueData)>::with_capacity(resolved.value_plans.len());
+        for (plan, keyframes) in resolved.value_plans.iter().zip(&preparation.keyframes_by_value) {
+            assert!(plan.effect_index < current_keys.len());
             let (underlying, initial) = if plan.custom_name_id != 0 {
                 let custom_index = (plan.custom_name_id - 1) as usize;
                 assert!(custom_index < computed.custom_value_count);
@@ -7201,25 +7310,16 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
                     crate::css::style_compute::initial_value_data(plan.property_id),
                 )
             };
-            inputs.push(FfiAnimationValueInput {
+            let input = FfiAnimationValueInput {
                 property_id: plan.property_id,
                 custom_name_id: plan.custom_name_id,
                 result_of_transition: plan.result_of_transition,
                 underlying,
                 initial,
-                current_key: plan.current_key,
+                current_key: current_keys[plan.effect_index],
                 keyframes: keyframes.as_ptr(),
                 keyframe_count: keyframes.len(),
-            });
-        }
-        let overlay = unsafe { &mut *computed.overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
-
-        // https://www.w3.org/TR/web-animations-1/#effect-stacks
-        // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
-        //     next effect affecting the same property.
-        let mut custom_final_values = Vec::<(u32, RetainedStyleValueData)>::new();
-        let mut previous_values = Vec::<(u16, u32, *const StyleValueData)>::new();
-        for input in &inputs {
+            };
             let previous_value = previous_values
                 .iter()
                 .rev()
@@ -7227,7 +7327,7 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
                     *property_id == input.property_id && *custom_name_id == input.custom_name_id
                 })
                 .map(|(_, _, value)| unsafe { &**value });
-            let result = evaluate_animation_value(&computed.context, input, previous_value);
+            let result = evaluate_animation_value(&context, &input, previous_value);
             if !result.apply {
                 assert!(result.value.is_null());
                 continue;
@@ -7280,7 +7380,7 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
             unsafe { computed.custom_result_count.write(written) };
         }
         overlay.refresh_ffi_entries();
-        inputs.len()
+        resolved.value_plans.len()
     })
 }
 

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -7379,7 +7379,6 @@ pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAn
             }
             unsafe { computed.custom_result_count.write(written) };
         }
-        overlay.refresh_ffi_entries();
         resolved.value_plans.len()
     })
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -581,7 +581,7 @@ impl ComputedLonghandTable {
             && overlay_wins(entry, self.is_important(property_id))
         {
             return FfiEffectiveLonghandValue {
-                value: entry.value.pointer().cast(),
+                value: entry.value,
                 source: EFFECTIVE_LONGHAND_SOURCE_OVERLAY,
             };
         }

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -2338,6 +2338,53 @@ pub unsafe extern "C" fn style_engine_publish_computed_groups(
     })
 }
 
+/// Replaces only the animation overlay on an already-published target. Recording falls back to
+/// `style_engine_publish_computed_groups`, which captures the complete base-style input.
+///
+/// # Safety
+/// `engine` must be live. `animated_overlay` must be null when `animation_overlay_identity` is
+/// zero and otherwise point at a live animation overlay. `payloads` must contain live group
+/// payloads for a non-empty overlay.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn style_engine_publish_animation_overlay(
+    engine: *mut c_void,
+    node: u32,
+    pseudo_kind: u8,
+    animation_overlay_identity: u64,
+    animated_overlay: *const c_void,
+    payloads: *const *const c_void,
+    payload_count: usize,
+) -> FfiStyleRecordDelta {
+    abort_on_panic(|| {
+        let Some(node) = StyleNodeID::from_raw(node) else {
+            return FfiStyleRecordDelta::default();
+        };
+        if animation_overlay_identity != 0 && animated_overlay.is_null() {
+            return FfiStyleRecordDelta::default();
+        }
+        if payload_count != 0 && payloads.is_null() {
+            return FfiStyleRecordDelta::default();
+        }
+        let payloads = match payload_count {
+            0 => &[],
+            _ => unsafe { std::slice::from_raw_parts(payloads, payload_count) },
+        };
+        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+        let Some(publication) = engine.publish_animation_overlay_impl(
+            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+            animation_overlay_identity,
+            animated_overlay.cast(),
+            payloads,
+        ) else {
+            return FfiStyleRecordDelta::default();
+        };
+        FfiStyleRecordDelta {
+            old_style_record: publication.previous_style_record.raw(),
+            new_style_record: publication.style_record.raw(),
+        }
+    })
+}
+
 /// Assigns an already-interned base style record to one element or pseudo-element.
 /// Returns an empty delta when recording is active so the caller can use the fully recorded
 /// publication path instead.

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -92,6 +92,16 @@ pub enum FfiStyleInvalidationField {
     CacheHit = 1 << 21,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiAnimationInvalidation {
+    pub invalidation: u32,
+    pub changed_non_inherited_style_groups: u32,
+    pub requires_base_style_recomputation: bool,
+    pub requires_layout_node_style_application: bool,
+    pub requires_style_resource_update: bool,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum FfiStyleDeltaGap {
@@ -2506,6 +2516,44 @@ pub unsafe extern "C" fn style_engine_compare_style_records(
             font_lists_equal,
             element_folds_transform_into_layout,
         )
+    })
+}
+
+/// Returns whether a candidate animation overlay changes any effective value in a style record.
+///
+/// # Safety
+/// `engine` and `animated_overlay` must be live for this call, and the style record must remain
+/// pinned or assigned.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn style_engine_animation_overlay_changed(
+    engine: *const c_void,
+    old_style_record: u64,
+    animated_overlay: *const c_void,
+) -> bool {
+    abort_on_panic(|| {
+        let engine = unsafe { &*engine.cast::<StyleEngine>() };
+        engine.animation_overlay_changed(old_style_record, animated_overlay.cast())
+    })
+}
+
+/// Computes property-dependent damage for the sparse changed values in an animation overlay.
+///
+/// # Safety
+/// `engine`, `animated_overlay`, and every group payload must be live for this call, and the style
+/// record must remain pinned or assigned.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn style_engine_compare_animation_overlay(
+    engine: *const c_void,
+    old_style_record: u64,
+    animated_overlay: *const c_void,
+    payloads: *const *const c_void,
+    payload_count: usize,
+    is_document_element: bool,
+) -> FfiAnimationInvalidation {
+    abort_on_panic(|| {
+        let engine = unsafe { &*engine.cast::<StyleEngine>() };
+        let payloads = unsafe { std::slice::from_raw_parts(payloads, payload_count) };
+        engine.compare_animation_overlay(old_style_record, animated_overlay.cast(), payloads, is_document_element)
     })
 }
 

--- a/Libraries/LibWeb/Rust/src/css/style/computed.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/computed.rs
@@ -515,6 +515,15 @@ struct AnimationOverlayPublication {
     record_updated: bool,
 }
 
+pub struct AnimationOverlayUpdate {
+    pub previous_style_record: FinalStyleRecordID,
+    pub style_record: FinalStyleRecordID,
+    pub slot_allocated: bool,
+    pub slot_released: bool,
+    pub record_updated: bool,
+    pub live_records: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ComputedStyleTarget {
     node: StyleNodeID,
@@ -1274,6 +1283,52 @@ impl ComputedGroupSets {
                     .final_style_record
             },
         )
+    }
+
+    pub fn publish_animation_overlay(
+        &mut self,
+        target: ComputedStyleTarget,
+        source_identity: u64,
+        animated_overlay: *const crate::css::animated_overlay::AnimatedOverlay,
+        payloads: &[*const c_void],
+    ) -> Option<AnimationOverlayUpdate> {
+        let (base_style_record, current_slot) = if target.is_pseudo() {
+            let assignment = self.pseudo_row(target.node, target.pseudo_kind)?.assignment?;
+            (assignment.style_record, assignment.animation_overlay_slot)
+        } else {
+            let index = target.node.element_index()? as usize;
+            (
+                *self.style_record_column.get(index)?.as_ref()?,
+                self.columns.animation_overlay_slot(index),
+            )
+        };
+        let previous_style_record = self.final_style_record(base_style_record, current_slot);
+        let mut animated_overlay =
+            (!animated_overlay.is_null()).then(|| Box::new(unsafe { &*animated_overlay }.clone()));
+        let publication = self.update_animation_overlay(
+            current_slot,
+            base_style_record,
+            source_identity,
+            &mut animated_overlay,
+            payloads,
+        );
+        if target.is_pseudo() {
+            self.ensure_pseudo_row(target.node, target.pseudo_kind)
+                .assignment
+                .as_mut()?
+                .animation_overlay_slot = publication.slot;
+        } else {
+            self.columns
+                .set_animation_overlay_slot(target.node.element_index()? as usize, publication.slot);
+        }
+        Some(AnimationOverlayUpdate {
+            previous_style_record,
+            style_record: publication.final_style_record,
+            slot_allocated: publication.slot_allocated,
+            slot_released: publication.slot_released,
+            record_updated: publication.record_updated,
+            live_records: self.live_animation_overlay_assignments,
+        })
     }
 
     pub fn publish(

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -392,6 +392,34 @@ impl StyleEngine {
         publication
     }
 
+    pub(super) fn publish_animation_overlay_impl(
+        &mut self,
+        target: computed::ComputedStyleTarget,
+        source_identity: u64,
+        animated_overlay: *const crate::css::animated_overlay::AnimatedOverlay,
+        payloads: &[*const std::ffi::c_void],
+    ) -> Option<computed::AnimationOverlayUpdate> {
+        if self.recording_id().is_some() {
+            return None;
+        }
+        let publication =
+            self.computed_group_sets
+                .publish_animation_overlay(target, source_identity, animated_overlay, payloads)?;
+        self.settle_computed_memory();
+        if publication.slot_allocated {
+            self.counters.bump(Counter::AnimationOverlaySlotsAllocated);
+        }
+        if publication.slot_released {
+            self.counters.bump(Counter::AnimationOverlaySlotsReleased);
+        }
+        if publication.record_updated {
+            self.counters.bump(Counter::AnimationOverlayRecordsUpdated);
+        }
+        self.counters
+            .set(Counter::LiveAnimationOverlayRecords, publication.live_records as u64);
+        Some(publication)
+    }
+
     pub(crate) fn publish_exact_cascade_state(
         &mut self,
         target: computed::ComputedStyleTarget,

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -529,7 +529,7 @@ fn effective_value<'a>(view: &super::computed::StyleRecordView<'a>, property: u1
     if let Some(entry) = unsafe { view.animated_overlay.as_ref() }.and_then(|overlay| overlay.get(property))
         && overlay_wins(entry, table.is_important(property))
     {
-        return entry.value.data();
+        return entry.value();
     }
     unsafe { &*view.longhand_values[index].cast::<StyleValueData>() }
 }
@@ -544,7 +544,7 @@ fn effective_value_with_overlay(
     if let Some(entry) = overlay.and_then(|overlay| overlay.get(property))
         && overlay_wins(entry, table.is_important(property))
     {
-        return entry.value.data();
+        return entry.value();
     }
     view.longhand_values[index].cast()
 }

--- a/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/style_invalidation.rs
@@ -5,7 +5,7 @@
  */
 
 use super::StyleEngine;
-use super::bridge::FfiStyleInvalidationField;
+use super::bridge::{FfiAnimationInvalidation, FfiStyleInvalidationField};
 use crate::css::animated_overlay::{AnimatedOverlay, overlay_wins};
 use crate::css::computed_value_views::ComputedValuesView;
 use crate::css::computed_values::style_group_payloads_equal;
@@ -42,6 +42,10 @@ struct StyleInvalidation {
 }
 
 impl StyleInvalidation {
+    fn is_none(self) -> bool {
+        self.pack() == 0
+    }
+
     fn ensure_level(&mut self, level: u8) {
         self.level = self.level.max(level);
         if level >= INVALIDATION_REBUILD_LAYOUT_TREE {
@@ -530,6 +534,49 @@ fn effective_value<'a>(view: &super::computed::StyleRecordView<'a>, property: u1
     unsafe { &*view.longhand_values[index].cast::<StyleValueData>() }
 }
 
+fn effective_value_with_overlay(
+    view: &super::computed::StyleRecordView<'_>,
+    overlay: Option<&AnimatedOverlay>,
+    property: u16,
+) -> *const StyleValueData {
+    let index = usize::from(property - FIRST_LONGHAND_PROPERTY_ID);
+    let table = unsafe { &*view.longhand_table };
+    if let Some(entry) = overlay.and_then(|overlay| overlay.get(property))
+        && overlay_wins(entry, table.is_important(property))
+    {
+        return entry.value.data();
+    }
+    view.longhand_values[index].cast()
+}
+
+fn animation_overlay_properties<'a>(
+    old_overlay: Option<&'a AnimatedOverlay>,
+    new_overlay: Option<&'a AnimatedOverlay>,
+) -> impl Iterator<Item = u16> + 'a {
+    old_overlay
+        .into_iter()
+        .flat_map(AnimatedOverlay::entries)
+        .map(|entry| entry.property)
+        .chain(
+            new_overlay
+                .into_iter()
+                .flat_map(AnimatedOverlay::entries)
+                .filter(move |entry| old_overlay.is_none_or(|overlay| overlay.get(entry.property).is_none()))
+                .map(|entry| entry.property),
+        )
+}
+
+fn animation_value_changed(
+    record: &super::computed::StyleRecordView<'_>,
+    old_overlay: Option<&AnimatedOverlay>,
+    new_overlay: Option<&AnimatedOverlay>,
+    property: u16,
+) -> bool {
+    let old = effective_value_with_overlay(record, old_overlay, property);
+    let new = effective_value_with_overlay(record, new_overlay, property);
+    old != new && unsafe { *old != *new }
+}
+
 fn inheritance_dependent_values_equal(
     old: &crate::css::computed_longhand_table::ComputedLonghandTable,
     new: &crate::css::computed_longhand_table::ComputedLonghandTable,
@@ -548,6 +595,98 @@ fn inheritance_dependent_values_equal(
 }
 
 impl StyleEngine {
+    pub(crate) fn animation_overlay_changed(
+        &self,
+        old_style_record: u64,
+        animated_overlay: *const AnimatedOverlay,
+    ) -> bool {
+        let old_record = self
+            .computed_group_sets
+            .style_record_view(old_style_record)
+            .unwrap_or_else(|| panic!("old style record {old_style_record:#x} is not live"));
+        let old_overlay = unsafe { old_record.animated_overlay.as_ref() };
+        let new_overlay = unsafe { animated_overlay.as_ref() };
+        animation_overlay_properties(old_overlay, new_overlay)
+            .any(|property| animation_value_changed(&old_record, old_overlay, new_overlay, property))
+    }
+
+    pub(crate) fn compare_animation_overlay(
+        &self,
+        old_style_record: u64,
+        animated_overlay: *const AnimatedOverlay,
+        payloads: &[*const std::ffi::c_void],
+        is_document_element: bool,
+    ) -> FfiAnimationInvalidation {
+        let old_record = self
+            .computed_group_sets
+            .style_record_view(old_style_record)
+            .unwrap_or_else(|| panic!("old style record {old_style_record:#x} is not live"));
+        assert_eq!(payloads.len(), old_record.payloads.len());
+        let old_overlay = unsafe { old_record.animated_overlay.as_ref() };
+        let new_overlay = unsafe { animated_overlay.as_ref() };
+        let old_values = ComputedValuesView::new(old_record.payloads);
+        let new_values = ComputedValuesView::new(payloads);
+        let mut ffi_result = FfiAnimationInvalidation::default();
+        let mut invalidation = StyleInvalidation::default();
+        let mut text_decoration_line_animated = false;
+
+        for property in animation_overlay_properties(old_overlay, new_overlay) {
+            if !animation_value_changed(&old_record, old_overlay, new_overlay, property) {
+                continue;
+            }
+            if matches!(
+                property,
+                property_id::DIRECTION
+                    | property_id::DISPLAY
+                    | property_id::FLOAT
+                    | property_id::OVERFLOW_X
+                    | property_id::OVERFLOW_Y
+                    | property_id::POSITION
+                    | property_id::TEXT_ALIGN
+            ) {
+                ffi_result.requires_base_style_recomputation = true;
+            }
+            if property_metadata::property_is_inherited(property) {
+                ffi_result.requires_layout_node_style_application = true;
+            } else {
+                ffi_result.changed_non_inherited_style_groups |=
+                    property_metadata::property_style_group_index(property)
+                        .map_or((1 << payloads.len()) - 1, |group| 1 << group);
+            }
+            if matches!(
+                property,
+                property_id::BACKGROUND_IMAGE | property_id::BORDER_IMAGE_SOURCE | property_id::MASK_IMAGE
+            ) {
+                ffi_result.requires_style_resource_update = true;
+            }
+
+            let mut property_damage = property_invalidation(property, old_values, new_values);
+            if property == property_id::BACKGROUND_COLOR && is_document_element {
+                property_damage.ensure_visual_context(VISUAL_CONTEXT_REBUILD);
+            }
+            if !property_damage.is_none() && property_metadata::property_is_inherited(property) {
+                match property_metadata::property_style_group_index(property) {
+                    Some(group) if group < 7 => property_damage.inherited_groups |= 1 << group,
+                    _ => property_damage.inherited_groups = ALL_INHERITED_STYLE_GROUPS,
+                }
+            }
+            if property == property_id::TEXT_DECORATION_LINE {
+                text_decoration_line_animated = true;
+            }
+            invalidation.merge(property_damage);
+        }
+
+        // Animated properties other than text-decoration-line cannot make an undecorated box decorated.
+        if invalidation.repaint_text_decorations
+            && !text_decoration_line_animated
+            && old_values.text_reset().text_decoration_lines.as_slice().is_empty()
+        {
+            invalidation.repaint_text_decorations = false;
+        }
+        ffi_result.invalidation = invalidation.pack();
+        ffi_result
+    }
+
     pub(crate) fn compare_style_records(
         &mut self,
         old_style_record: u64,

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -3010,7 +3010,7 @@ impl ParentSnapshot<'_> {
             .and_then(|overlay| overlay.get(property_id))
             && overlay_wins(entry, self.is_important(property_id))
         {
-            return Some(entry.value.data());
+            return Some(entry.value());
         }
         for (property, value) in self.table.retained_inheritance_dependent_values() {
             if property == property_id
@@ -3026,7 +3026,7 @@ impl ParentSnapshot<'_> {
         if let Some(entry) = self.animated_property(property_id)
             && overlay_wins(entry, self.is_important(property_id))
         {
-            return Some(entry.value.data());
+            return Some(entry.value());
         }
         self.value(property_id)
     }
@@ -3043,7 +3043,7 @@ impl ParentSnapshot<'_> {
             .is_some_and(|overlay| !overlay.is_empty())
     }
 
-    fn animated_property(&self, property_id: u16) -> Option<&crate::css::animated_overlay::AnimatedOverlayEntry> {
+    fn animated_property(&self, property_id: u16) -> Option<&crate::css::animated_overlay::FfiAnimatedOverlayEntry> {
         self.inherited_value_overlay
             .or(self.stored_animated_overlay)
             .and_then(|overlay| overlay.get(property_id))
@@ -4304,7 +4304,7 @@ unsafe fn drive_property_computation(
             {
                 animated_overlay.set_owned(
                     property_id,
-                    animated_property.value.clone(),
+                    animated_property.clone_value(),
                     true,
                     animated_property.result_of_transition,
                 );
@@ -4438,9 +4438,6 @@ unsafe fn drive_property_computation(
         );
         if pending_effective_color_scheme >= 0 {
             longhand_table.set_effective_color_scheme(pending_effective_color_scheme);
-        }
-        if let Some(animated_overlay) = unsafe { animated_overlay.as_mut() } {
-            animated_overlay.refresh_ffi_entries();
         }
         if phase != LONGHAND_DRIVE_PHASE_REMAINING {
             return;
@@ -6547,9 +6544,6 @@ fn finalize_style(
         longhand_table.set_important(prop::TEXT_ALIGN, false);
         longhand_table.set_inherited(prop::TEXT_ALIGN, finalization.text_align.inherited);
         finalization.invalidated_longhands |= FINALIZED_TEXT_ALIGN;
-    }
-    if let Some(overlay) = animated_overlay {
-        overlay.refresh_ffi_entries();
     }
     finalization
 }

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5295,7 +5295,15 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
         let mut depends_on_viewport_metrics = false;
         let mut font_metrics_depend_on_viewport_metrics = false;
         for indices in longhands_by_keyframe.values() {
-            let mut table = ComputedLonghandTable::copied_for_drive(underlying_longhand_table);
+            // The keyframe drive reads only the selected longhands and the coordination inputs
+            // seeded below. Starting from the underlying table would retain and release every
+            // unrelated longhand for every keyframe on every animation sample.
+            let mut table = ComputedLonghandTable::new();
+            // Background lists coordinate against the underlying background-image layer count
+            // when background-image is not selected by this keyframe.
+            if let Some(value) = underlying_longhand_table.get(property_id::BACKGROUND_IMAGE) {
+                table.set(property_id::BACKGROUND_IMAGE, value.clone_retained(), -1);
+            }
             let mut store = CascadedPropertyStore::new();
             for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
                 if !is_required_driver_input(property_id) {

--- a/Libraries/LibWeb/Rust/src/css/transition.rs
+++ b/Libraries/LibWeb/Rust/src/css/transition.rs
@@ -271,7 +271,7 @@ fn computed_value(
     if let Some(entry) = overlay.and_then(|overlay| overlay.get(property_id))
         && crate::css::animated_overlay::overlay_wins(entry, table.is_important(property_id))
     {
-        return entry.value.pointer();
+        return entry.value_pointer();
     }
     table
         .get(property_id)
@@ -310,9 +310,9 @@ fn prepare_transition_values(
         .and_then(|overlay| overlay.get(property.property_id))
         .filter(|entry| !entry.result_of_transition)
     {
-        property.before_change_value = entry.value.pointer();
-        property.after_change_value = entry.value.pointer();
-        let originates_from_current_color = value_is_current_color(entry.value.pointer());
+        property.before_change_value = entry.value_pointer();
+        property.after_change_value = entry.value_pointer();
+        let originates_from_current_color = value_is_current_color(entry.value_pointer());
         if property.has_running_transition {
             property.current_value = computed_value(after_table, after_overlay, property.property_id);
         }

--- a/Tests/LibWeb/Text/expected/css/animation-effect-batch-rust.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-effect-batch-rust.txt
@@ -3,3 +3,12 @@ width: 20px
 color: rgb(128, 128, 128)
 animation evaluations: 1
 keyframe longhand drives: 1
+resampled opacity: 0.6
+resampled width: 25px
+resampled color: rgb(191, 191, 191)
+resample animation evaluations: 1
+resample keyframe longhand drives: 0
+base-mutated width: 125px
+base mutation longhand drives: 1
+mutated width: 135px
+keyframe mutation longhand drives: 1

--- a/Tests/LibWeb/Text/input/css/animation-effect-batch-rust.html
+++ b/Tests/LibWeb/Text/input/css/animation-effect-batch-rust.html
@@ -19,7 +19,7 @@
                 ],
                 100
             ),
-            target.animate({ width: ["10px", "30px"] }, 100),
+            target.animate({ width: ["10px", "30px"] }, { duration: 100, composite: "add" }),
             target.animate({ color: ["black", "white"] }, 100),
         ];
         for (const animation of animations) {
@@ -37,5 +37,31 @@
 
         println(`animation evaluations: ${counters.animationEvaluationEntries}`);
         println(`keyframe longhand drives: ${counters.animationKeyframeLonghandEntries}`);
+
+        for (const animation of animations)
+            animation.currentTime = 75;
+
+        internals.resetStyleFfiCounters();
+        internals.updateStyle();
+        const resampleCounters = internals.styleFfiCounters();
+        println(`resampled opacity: ${style.opacity}`);
+        println(`resampled width: ${style.width}`);
+        println(`resampled color: ${style.color}`);
+        println(`resample animation evaluations: ${resampleCounters.animationEvaluationEntries}`);
+        println(`resample keyframe longhand drives: ${resampleCounters.animationKeyframeLonghandEntries}`);
+
+        target.style.width = "100px";
+        internals.resetStyleFfiCounters();
+        internals.updateStyle();
+        const baseMutationCounters = internals.styleFfiCounters();
+        println(`base-mutated width: ${style.width}`);
+        println(`base mutation longhand drives: ${baseMutationCounters.animationKeyframeLonghandEntries}`);
+
+        animations[2].effect.setKeyframes({ width: ["20px", "40px"] });
+        internals.resetStyleFfiCounters();
+        internals.updateStyle();
+        const keyframeMutationCounters = internals.styleFfiCounters();
+        println(`mutated width: ${style.width}`);
+        println(`keyframe mutation longhand drives: ${keyframeMutationCounters.animationKeyframeLonghandEntries}`);
     });
 </script>


### PR DESCRIPTION
Animation updates on [linear.app](https://linear.app) previously consumed 2.5 seconds during a 10-second loading profile. With these changes, they consume 0.2 seconds, a 92% reduction.

Animation sampling currently materializes C++ computed-style views, clones complete longhand tables and animation overlays, and rebuilds wrapper collections on every frame. This spends substantial time allocating, retaining, and releasing style data that is mostly unchanged.

Keep animation sampling on sparse Rust-owned overlays instead. Cache reusable keyframe preparation, seed updates directly from style records, preserve only inherited animated values between samples, and compare overlays directly in Rust. Reuse the immutable base style and font metrics where possible, while retaining the existing fallback paths for post-compute adjustments and animated font properties.