### PR TITLE
LibWeb: Skip unnecessary work during style reactions

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1427,8 +1427,12 @@ struct ElementDependentInvalidationState {
             return;
         if (auto const& content = layout_node->content(); content.has_value())
             content_counter_style_dependencies = content->counter_style_dependencies;
-        if (auto const& list_style_type = layout_node->list_style_type(); list_style_type.has<RefPtr<CSS::CounterStyle const>>())
-            list_counter_style = list_style_type.get<RefPtr<CSS::CounterStyle const>>();
+        // Only a list item renders a marker, so only its counter style can matter; a display
+        // change to or from list-item rebuilds the box regardless.
+        if (layout_node->display().is_list_item()) {
+            if (auto const& list_style_type = layout_node->list_style_type(); list_style_type.has<RefPtr<CSS::CounterStyle const>>())
+                list_counter_style = list_style_type.get<RefPtr<CSS::CounterStyle const>>();
+        }
         layout_node = nullptr;
         has_snapshot = true;
     }
@@ -1460,8 +1464,10 @@ static void add_element_dependent_invalidation(CSS::RequiredInvalidationAfterSty
         if (auto const& content = old_state.layout_node->content(); content.has_value())
             old_content_dependencies = content->counter_style_dependencies;
         Optional<ValueComparingRefPtr<CSS::CounterStyle const>> old_list_counter_style;
-        if (auto const& list_style_type = old_state.layout_node->list_style_type(); list_style_type.has<RefPtr<CSS::CounterStyle const>>())
-            old_list_counter_style = list_style_type.get<RefPtr<CSS::CounterStyle const>>();
+        if (old_state.layout_node->display().is_list_item()) {
+            if (auto const& list_style_type = old_state.layout_node->list_style_type(); list_style_type.has<RefPtr<CSS::CounterStyle const>>())
+                old_list_counter_style = list_style_type.get<RefPtr<CSS::CounterStyle const>>();
+        }
         compare(old_content_dependencies, old_list_counter_style);
     } else if (old_state.has_snapshot) {
         compare(old_state.content_counter_style_dependencies, old_state.list_counter_style);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1565,8 +1565,16 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styl
     // Any document change that can cause this element's style to change, could also affect its pseudo-elements.
     auto recompute_pseudo_element_style = [&](CSS::PseudoElement pseudo_element, bool has_implicit_style = false) {
         auto old_style_record = style_record_identity(pseudo_element);
-        auto pseudo_element_style = computed_style(pseudo_element);
         auto preserved_style_record = preserved_pseudo_element_styles ? preserved_pseudo_element_styles->at(to_underlying(pseudo_element)) : CSS::StyleRecordID {};
+        // Most elements have no style for most pseudo-elements. Decide that from the record
+        // identities before materializing any record view.
+        if (!has_implicit_style
+            && !old_style_record
+            && !preserved_style_record
+            && !(old_originating_style && old_originating_style->has_pseudo_element_style(pseudo_element))
+            && !(originating_style && originating_style->has_pseudo_element_style(pseudo_element)))
+            return;
+        auto pseudo_element_style = computed_style(pseudo_element);
         if (!old_style_record)
             old_style_record = preserved_style_record;
         auto preserved_pseudo_element_style = style_computer.computed_style_record_view(preserved_style_record);


### PR DESCRIPTION
Skip resolving list counter styles for non-list elements, since only list items can render markers. Also avoid materializing pseudo-element style record views when no pseudo-element style needs recomputation.

This saves 14 ms per StyleBench run and roughly halves style-reaction time in the dynamic media query suite.