### PR TITLE
Tests: Count incremental updates in the lazy visual context test

### DIFF
--- a/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
+++ b/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
@@ -1,11 +1,11 @@
 offset width: 110
 offset width: 120
 offset width: 130
-builds after layout-only reads: 0
+visual context updates after layout-only reads: 0
 extra layouts after clean read: 0
 bounding rect width: 130
-builds after identity transform read: 0
+visual context updates after identity transform read: 0
 bounding rect with transformed child: 130
-builds after unrelated transform read: 0
+visual context updates after unrelated transform read: 0
 transformed rect x: 18
-builds after non-identity transform read: 1
+visual context updates after non-identity transform read: 1

--- a/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
+++ b/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
@@ -4,9 +4,11 @@
 <script>
     test(() => {
         const target = document.getElementById('target');
+        const visualContextUpdateCount = () =>
+            internals.accumulatedVisualContextTreeBuildCount() + internals.accumulatedVisualContextIncrementalUpdateCount();
 
         target.getBoundingClientRect();
-        const initialBuildCount = internals.accumulatedVisualContextTreeBuildCount();
+        const initialUpdateCount = visualContextUpdateCount();
         const lines = [];
 
         for (const width of [110, 120, 130]) {
@@ -14,23 +16,23 @@
             lines.push(`offset width: ${target.offsetWidth}`);
         }
 
-        lines.push(`builds after layout-only reads: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        lines.push(`visual context updates after layout-only reads: ${visualContextUpdateCount() - initialUpdateCount}`);
         const fullLayoutCount = internals.fullLayoutCount();
         target.offsetWidth;
         lines.push(`extra layouts after clean read: ${internals.fullLayoutCount() - fullLayoutCount}`);
 
         lines.push(`bounding rect width: ${target.getBoundingClientRect().width}`);
-        lines.push(`builds after identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        lines.push(`visual context updates after identity transform read: ${visualContextUpdateCount() - initialUpdateCount}`);
 
         const transformedChild = document.createElement('div');
         transformedChild.style.transform = 'translateX(10px)';
         target.appendChild(transformedChild);
         lines.push(`bounding rect with transformed child: ${target.getBoundingClientRect().width}`);
-        lines.push(`builds after unrelated transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        lines.push(`visual context updates after unrelated transform read: ${visualContextUpdateCount() - initialUpdateCount}`);
 
         target.style.transform = 'translateX(10px)';
         lines.push(`transformed rect x: ${target.getBoundingClientRect().x}`);
-        lines.push(`builds after non-identity transform read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+        lines.push(`visual context updates after non-identity transform read: ${visualContextUpdateCount() - initialUpdateCount}`);
 
         for (const line of lines)
             println(line);


### PR DESCRIPTION
The test reads only the full build counter. A rendering update can paint before DOMContentLoaded, so a visual context tree already exists when the test callback runs. The non-identity transform read then applies an incremental update instead of a full build. The last line reports 0 instead of 1. The test-web repeat gate hit this once in 100 runs at full concurrency. A forced tree build before the baseline reproduces it on every run.

Count full builds and incremental updates together. Both outcomes resolve the deferred visual context work exactly once, and layout-only reads must trigger neither.