### PR TITLE
LibWeb: Keep a form's associated elements in tree order 

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -91,6 +91,7 @@
 #include <LibWeb/HTML/CustomElements/CustomStateSet.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
@@ -3021,6 +3022,9 @@ void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, No
 void Element::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<Node> old_ancestor)
 {
     Base::moved_from(is_subtree_root, old_ancestor);
+
+    if (is_subtree_root == IsSubtreeRoot::Yes)
+        HTML::FormAssociatedElement::reposition_associated_elements_after_move({}, *this);
 }
 
 void Element::children_changed(ChildrenChangedMetadata const& metadata)

--- a/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -94,6 +94,23 @@ void HTMLCollection::update_name_to_element_mappings_if_needed() const
     m_cached_document->register_valid_html_collection_cache(AttributeInvalidationType::IdOrName);
 }
 
+void HTMLCollection::collect_elements_into(Vector<GC::RawPtr<Element>>& elements) const
+{
+    if (m_scope == Scope::Descendants) {
+        m_root->for_each_in_subtree_of_type<Element>([&](auto& element) {
+            if (m_filter(element))
+                elements.append(element);
+            return TraversalDecision::Continue;
+        });
+    } else {
+        m_root->for_each_child_of_type<Element>([&](auto& element) {
+            if (m_filter(element))
+                elements.append(element);
+            return IterationDecision::Continue;
+        });
+    }
+}
+
 void HTMLCollection::update_cache_if_needed() const
 {
     auto& document = root()->document();
@@ -109,19 +126,7 @@ void HTMLCollection::update_cache_if_needed() const
 
     m_cached_elements.clear();
     m_cached_name_to_element_mappings = nullptr;
-    if (m_scope == Scope::Descendants) {
-        m_root->for_each_in_subtree_of_type<Element>([&](auto& element) {
-            if (m_filter(element))
-                m_cached_elements.append(element);
-            return TraversalDecision::Continue;
-        });
-    } else {
-        m_root->for_each_child_of_type<Element>([&](auto& element) {
-            if (m_filter(element))
-                m_cached_elements.append(element);
-            return IterationDecision::Continue;
-        });
-    }
+    collect_elements_into(m_cached_elements);
 
     if (m_sort) {
         insertion_sort(m_cached_elements, [this](auto const& a, auto const& b) {

--- a/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -73,6 +73,8 @@ protected:
     GC::Ref<ParentNode const> root() const { return *m_root; }
     bool element_matches_filter(Element const& element) const { return m_filter(element); }
 
+    virtual void collect_elements_into(Vector<GC::RawPtr<Element>>&) const;
+
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
 private:

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -180,8 +180,12 @@ void FormAssociatedElement::set_form(HTMLFormElement* form)
         ensure_form_associated_rare_data().form = form;
     else if (auto* rare_data = form_associated_rare_data())
         rare_data->form = nullptr;
-    if (form)
+
+    auto in_associated_elements_list = form && &element.root() == &form->root();
+    if (in_associated_elements_list)
         form->add_associated_element({}, element);
+    if (auto* rare_data = form_associated_rare_data())
+        rare_data->in_associated_elements_list = in_associated_elements_list;
     if (old_form.ptr() != form) {
         element.document().bump_form_controls_version();
         form_associated_element_form_owner_changed();
@@ -245,10 +249,16 @@ void FormAssociatedElement::set_parser_inserted(Badge<HTMLParser>)
 void FormAssociatedElement::form_node_was_inserted()
 {
     // 1. If the form-associated element's parser inserted flag is set, then return.
-    auto const* rare_data = form_associated_rare_data();
+    auto* rare_data = form_associated_rare_data();
     if (rare_data && rare_data->parser_inserted) {
-        if (auto* form = this->form(); form && is_submit_button())
-            form->default_button_state_maybe_changed();
+        if (auto* form = this->form()) {
+            if (!rare_data->in_associated_elements_list) {
+                form->add_associated_element({}, form_associated_element_to_html_element());
+                rare_data->in_associated_elements_list = true;
+            }
+            if (is_submit_button())
+                form->default_button_state_maybe_changed();
+        }
         return;
     }
 
@@ -274,6 +284,27 @@ void FormAssociatedElement::form_node_was_moved()
         reset_form_owner();
     else if (form && is_submit_button())
         form->default_button_state_maybe_changed();
+}
+
+void FormAssociatedElement::reposition_associated_elements_after_move(Badge<DOM::Element>, DOM::Node& moved_subtree_root)
+{
+    HashMap<GC::Ref<HTMLFormElement>, Vector<GC::Ref<HTMLElement>>> moved_elements_by_form;
+    moved_subtree_root.for_each_in_inclusive_subtree_of_type<HTMLElement>([&](HTMLElement& element) {
+        if (!element.is_form_associated_element())
+            return TraversalDecision::Continue;
+
+        FormAssociatedElement& form_associated_element = element;
+        auto const* rare_data = form_associated_element.form_associated_rare_data();
+        if (!rare_data || !rare_data->in_associated_elements_list)
+            return TraversalDecision::Continue;
+
+        if (auto* form = form_associated_element.form())
+            moved_elements_by_form.ensure(*form).append(element);
+        return TraversalDecision::Continue;
+    });
+
+    for (auto& [form, moved_elements] : moved_elements_by_form)
+        form->reposition_moved_associated_elements({}, moved_elements);
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:category-listed-3

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -307,6 +307,16 @@ void FormAssociatedElement::reposition_associated_elements_after_move(Badge<DOM:
         form->reposition_moved_associated_elements({}, moved_elements);
 }
 
+void FormAssociatedElement::submit_button_state_changed()
+{
+    auto const* rare_data = form_associated_rare_data();
+    if (!rare_data || !rare_data->in_associated_elements_list)
+        return;
+
+    if (auto* form = this->form())
+        form->associated_element_submit_button_state_changed({}, form_associated_element_to_html_element());
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:category-listed-3
 void FormAssociatedElement::form_node_attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& value)
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -247,7 +247,7 @@ void FormAssociatedElement::form_node_was_inserted()
     // 1. If the form-associated element's parser inserted flag is set, then return.
     auto const* rare_data = form_associated_rare_data();
     if (rare_data && rare_data->parser_inserted) {
-        if (auto* form = this->form())
+        if (auto* form = this->form(); form && is_submit_button())
             form->default_button_state_maybe_changed();
         return;
     }
@@ -263,8 +263,6 @@ void FormAssociatedElement::form_node_was_removed()
     auto* form = this->form();
     if (form && &form_associated_element_to_html_element().root() != &form->root())
         reset_form_owner();
-    else if (form)
-        form->default_button_state_maybe_changed();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:attr-fae-form-2
@@ -274,7 +272,7 @@ void FormAssociatedElement::form_node_was_moved()
     auto* form = this->form();
     if (form && &form_associated_element_to_html_element().root() != &form->root())
         reset_form_owner();
-    else if (form)
+    else if (form && is_submit_button())
         form->default_button_state_maybe_changed();
 }
 
@@ -331,7 +329,8 @@ void FormAssociatedElement::reset_form_owner()
     if (auto* form = this->form(); form
         && (!is_listed() || !html_element.has_attribute(HTML::AttributeNames::form))
         && html_element.first_ancestor_of_type<HTMLFormElement>() == form) {
-        form->default_button_state_maybe_changed();
+        if (is_submit_button())
+            form->default_button_state_maybe_changed();
         return;
     }
 
@@ -371,10 +370,12 @@ void FormAssociatedElement::reset_form_owner()
     if (new_form != old_form.ptr() && html_element.is_form_associated_custom_element())
         html_element.enqueue_a_form_associated_callback_reaction(new_form);
 
-    if (old_form)
-        old_form->default_button_state_maybe_changed();
-    if (new_form && new_form != old_form.ptr())
-        new_form->default_button_state_maybe_changed();
+    if (is_submit_button()) {
+        if (old_form)
+            old_form->default_button_state_maybe_changed();
+        if (new_form && new_form != old_form.ptr())
+            new_form->default_button_state_maybe_changed();
+    }
 }
 
 void FormAssociatedElement::form_associated_element_was_inserted()

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -54,6 +54,8 @@ public:
 
     void set_parser_inserted(Badge<HTMLParser>);
 
+    static void reposition_associated_elements_after_move(Badge<DOM::Element>, DOM::Node& moved_subtree_root);
+
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed
     virtual bool is_listed() const;
 
@@ -201,6 +203,8 @@ protected:
 
         // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#parser-inserted-flag
         bool parser_inserted { false };
+
+        bool in_associated_elements_list { false };
 
         // State used only by form-associated custom elements.
         OwnPtr<FACERareData> face_rare_data;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -170,6 +170,7 @@ protected:
     void form_node_was_removed();
     void form_node_was_moved();
     void form_node_attribute_changed(Utf16FlyString const&, Optional<Utf16String> const&);
+    void submit_button_state_changed();
 
     struct FACERareData {
         ValidityStateFlags validity_flags {};

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -85,6 +85,7 @@ void HTMLButtonElement::form_associated_element_attribute_changed(Utf16FlyString
     PopoverTargetAttributes::associated_attribute_changed(name, value, namespace_);
 
     if (name.is_one_of(AttributeNames::type, AttributeNames::command, AttributeNames::commandfor)) {
+        submit_button_state_changed();
         if (auto* form = this->form())
             form->default_button_state_maybe_changed();
     }

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
@@ -40,6 +40,16 @@ HTMLFormControlsCollection::HTMLFormControlsCollection(DOM::ParentNode& root, Sc
 
 HTMLFormControlsCollection::~HTMLFormControlsCollection() = default;
 
+void HTMLFormControlsCollection::collect_elements_into(Vector<GC::RawPtr<DOM::Element>>& elements) const
+{
+    // OPTIMIZATION: A form keeps its associated elements in tree order, so the collection is filtered from those
+    //               rather than from a walk of the whole tree the form is in.
+    for (auto const& element : m_form->associated_elements_in_tree_order({})) {
+        if (element_matches_filter(*element))
+            elements.append(*element);
+    }
+}
+
 void HTMLFormControlsCollection::visit_edges(GC::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.h
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.h
@@ -26,6 +26,8 @@ public:
 private:
     HTMLFormControlsCollection(DOM::ParentNode& root, Scope, HTMLFormElement& form, ESCAPING Function<bool(DOM::Element const&)> filter);
 
+    virtual void collect_elements_into(Vector<GC::RawPtr<DOM::Element>>&) const override;
+
     virtual void visit_edges(GC::Cell::Visitor&) override;
 
     GC::Ref<HTMLFormElement> m_form;

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
@@ -59,7 +60,7 @@ void HTMLFormElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_elements);
-    visitor.visit(m_associated_elements);
+    visitor.visit(m_associated_elements_in_tree_order);
     visitor.visit(m_planned_navigation);
     visitor.visit(m_rel_list);
     visitor.visit(m_past_names_map);
@@ -367,7 +368,7 @@ void HTMLFormElement::reset_form()
 
     // 2. If reset is true, then invoke the reset algorithm of each resettable element whose form owner is form.
     if (reset) {
-        GC::RootVector<GC::Ref<HTMLElement>> associated_elements_copy { m_associated_elements };
+        GC::RootVector<GC::Ref<HTMLElement>> associated_elements_copy { m_associated_elements_in_tree_order };
         for (auto element : associated_elements_copy) {
             auto& form_associated_element = as<FormAssociatedElement>(*element);
             if (form_associated_element.is_resettable())
@@ -421,14 +422,39 @@ void HTMLFormElement::reset()
     m_locked_for_reset = false;
 }
 
+size_t HTMLFormElement::tree_order_insertion_index(HTMLElement const& element) const
+{
+    return lower_bound_index(m_associated_elements_in_tree_order, element, [](auto const& entry, auto const& new_element) {
+        return new_element.is_before(*entry) ? 1 : -1;
+    });
+}
+
 void HTMLFormElement::add_associated_element(Badge<FormAssociatedElement>, HTMLElement& element)
 {
-    m_associated_elements.append(element);
+    VERIFY(&element.root() == &root());
+    m_associated_elements_in_tree_order.insert(tree_order_insertion_index(element), element);
+}
+
+void HTMLFormElement::reposition_moved_associated_elements(Badge<FormAssociatedElement>, Vector<GC::Ref<HTMLElement>> const& moved_elements)
+{
+    if (moved_elements.size() == m_associated_elements_in_tree_order.size())
+        return;
+
+    HashTable<HTMLElement const*> moved_element_set;
+    for (auto const& element : moved_elements)
+        moved_element_set.set(element.ptr());
+
+    m_associated_elements_in_tree_order.remove_all_matching([&](auto const& entry) { return moved_element_set.contains(entry.ptr()); });
+
+    auto index = tree_order_insertion_index(*moved_elements.first());
+    for (size_t i = 0; i < moved_elements.size(); ++i)
+        m_associated_elements_in_tree_order.insert(index + i, moved_elements[i]);
 }
 
 void HTMLFormElement::remove_associated_element(Badge<FormAssociatedElement>, HTMLElement& element)
 {
-    m_associated_elements.remove_first_matching([&](auto& entry) { return entry.ptr() == &element; });
+    if (auto index = m_associated_elements_in_tree_order.find_first_index_if([&](auto const& entry) { return entry.ptr() == &element; }); index.has_value())
+        m_associated_elements_in_tree_order.remove(*index);
 
     // If an element listed in a form element's past names map changes form owner, then its entries must be removed from that map.
     m_past_names_map.remove_all_matching([&](auto&, auto const& entry) { return entry.node.ptr() == &element; });
@@ -1050,7 +1076,7 @@ GC::Ptr<DOM::Element> HTMLFormElement::item(size_t index) const
 bool HTMLFormElement::is_supported_property_name(Utf16FlyString const& name) const
 {
     // NB: This is a simplified version of ::supported_property_names() that does not require sorting or allocations.
-    for (auto const& candidate : m_associated_elements) {
+    for (auto const& candidate : m_associated_elements_in_tree_order) {
         if (is_form_control(*candidate, *this) || is<HTMLImageElement>(*candidate)) {
             if (first_is_one_of(name, candidate->id(), candidate->name()))
                 return true;
@@ -1081,7 +1107,7 @@ Vector<Utf16FlyString> HTMLFormElement::supported_property_names() const
 
     // 2. For each listed element candidate whose form owner is the form element, with the exception of any
     //    input elements whose type attribute is in the Image Button state:
-    for (auto const& candidate : m_associated_elements) {
+    for (auto const& candidate : m_associated_elements_in_tree_order) {
         if (!is_form_control(*candidate, *this))
             continue;
 
@@ -1097,11 +1123,11 @@ Vector<Utf16FlyString> HTMLFormElement::supported_property_names() const
     }
 
     // 3. For each img element candidate whose form owner is the form element:
-    for (auto const& candidate : m_associated_elements) {
+    for (auto const& candidate : m_associated_elements_in_tree_order) {
         if (!is<HTMLImageElement>(*candidate))
             continue;
 
-        // Every element in m_associated_elements has this as the form owner.
+        // Every element in m_associated_elements_in_tree_order has this as the form owner.
 
         // 1. If candidate has an id attribute, add an entry to sourced names with that id attribute's value as the
         //    string, candidate as the element, and id as the source.
@@ -1218,21 +1244,17 @@ Variant<Empty, GC::Ref<DOM::Node>, GC::Ref<RadioNodeList>> HTMLFormElement::name
 FormAssociatedElement* HTMLFormElement::default_button() const
 {
     // A form element's default button is the first submit button in tree order whose form owner is that form element.
-    FormAssociatedElement* default_button = nullptr;
-
-    for (auto const& element : m_associated_elements) {
-        if (!element->is_submit_button())
-            continue;
-        if (!default_button || element->is_before(default_button->form_associated_element_to_html_element()))
-            default_button = element.ptr();
+    for (auto const& element : m_associated_elements_in_tree_order) {
+        if (element->is_submit_button())
+            return element.ptr();
     }
 
-    return default_button;
+    return nullptr;
 }
 
 bool HTMLFormElement::has_invalid_associated_element() const
 {
-    for (auto const& element : m_associated_elements) {
+    for (auto const& element : m_associated_elements_in_tree_order) {
         if (element->is_candidate_for_constraint_validation() && !element->satisfies_its_constraints())
             return true;
     }
@@ -1282,7 +1304,7 @@ size_t HTMLFormElement::number_of_fields_blocking_implicit_submission() const
     // Local Date and Time, Number.
     size_t count = 0;
 
-    for (auto element : m_associated_elements) {
+    for (auto element : m_associated_elements_in_tree_order) {
         if (!is<HTMLInputElement>(*element))
             continue;
 

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -1125,7 +1125,8 @@ Vector<Utf16FlyString> HTMLFormElement::supported_property_names() const
     //    where the source is either id, name, or past, and, if the source is past, an age.
     struct SourcedName {
         Utf16FlyString name;
-        GC::Ptr<DOM::Element const> element;
+        // NB: The associated elements are in tree order, so this index stands in for the element's tree position.
+        size_t element_index;
         enum class Source {
             Id,
             Name,
@@ -1137,23 +1138,25 @@ Vector<Utf16FlyString> HTMLFormElement::supported_property_names() const
 
     // 2. For each listed element candidate whose form owner is the form element, with the exception of any
     //    input elements whose type attribute is in the Image Button state:
-    for (auto const& candidate : m_associated_elements_in_tree_order) {
+    for (size_t element_index = 0; element_index < m_associated_elements_in_tree_order.size(); ++element_index) {
+        auto const& candidate = m_associated_elements_in_tree_order[element_index];
         if (!is_form_control(*candidate, *this))
             continue;
 
         // 1. If candidate has an id attribute, add an entry to sourced names with that id attribute's value as the
         //    string, candidate as the element, and id as the source.
         if (candidate->id().has_value())
-            sourced_names.append(SourcedName { candidate->id().value(), candidate, SourcedName::Source::Id, {} });
+            sourced_names.append(SourcedName { candidate->id().value(), element_index, SourcedName::Source::Id, {} });
 
         // 2. If candidate has a name attribute, add an entry to sourced names with that name attribute's value as the
         //    string, candidate as the element, and name as the source.
         if (candidate->name().has_value())
-            sourced_names.append(SourcedName { candidate->name().value(), candidate, SourcedName::Source::Name, {} });
+            sourced_names.append(SourcedName { candidate->name().value(), element_index, SourcedName::Source::Name, {} });
     }
 
     // 3. For each img element candidate whose form owner is the form element:
-    for (auto const& candidate : m_associated_elements_in_tree_order) {
+    for (size_t element_index = 0; element_index < m_associated_elements_in_tree_order.size(); ++element_index) {
+        auto const& candidate = m_associated_elements_in_tree_order[element_index];
         if (!is<HTMLImageElement>(*candidate))
             continue;
 
@@ -1162,27 +1165,29 @@ Vector<Utf16FlyString> HTMLFormElement::supported_property_names() const
         // 1. If candidate has an id attribute, add an entry to sourced names with that id attribute's value as the
         //    string, candidate as the element, and id as the source.
         if (candidate->id().has_value())
-            sourced_names.append(SourcedName { candidate->id().value(), candidate, SourcedName::Source::Id, {} });
+            sourced_names.append(SourcedName { candidate->id().value(), element_index, SourcedName::Source::Id, {} });
 
         // 2. If candidate has a name attribute, add an entry to sourced names with that name attribute's value as the
         //    string, candidate as the element, and name as the source.
         if (candidate->name().has_value())
-            sourced_names.append(SourcedName { candidate->name().value(), candidate, SourcedName::Source::Name, {} });
+            sourced_names.append(SourcedName { candidate->name().value(), element_index, SourcedName::Source::Name, {} });
     }
 
     // 4. For each entry past entry in the past names map add an entry to sourced names with the past entry's name as
     //    the string, past entry's element as the element, past as the source, and the length of time past entry has
     //    been in the past names map as the age.
     auto const now = MonotonicTime::now();
-    for (auto const& entry : m_past_names_map)
-        sourced_names.append(SourcedName { entry.key, static_cast<DOM::Element const*>(entry.value.node.ptr()), SourcedName::Source::Past, now - entry.value.insertion_time });
+    for (auto const& entry : m_past_names_map) {
+        auto element_index = m_associated_elements_in_tree_order.find_first_index_if([&](auto const& element) { return element.ptr() == entry.value.node.ptr(); });
+        sourced_names.append(SourcedName { entry.key, element_index.value(), SourcedName::Source::Past, now - entry.value.insertion_time });
+    }
 
     // 5. Sort sourced names by tree order of the element entry of each tuple, sorting entries with the same element by
     //    putting entries whose source is id first, then entries whose source is name, and finally entries whose source
     //    is past, and sorting entries with the same element and source by their age, oldest first.
     quick_sort(sourced_names, [](auto const& lhs, auto const& rhs) -> bool {
-        if (lhs.element != rhs.element)
-            return lhs.element->is_before(*rhs.element);
+        if (lhs.element_index != rhs.element_index)
+            return lhs.element_index < rhs.element_index;
         if (lhs.source != rhs.source)
             return lhs.source < rhs.source;
         return lhs.age < rhs.age;

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -729,14 +729,10 @@ Vector<GC::Ref<DOM::Element>> HTMLFormElement::get_submittable_elements()
 {
     Vector<GC::Ref<DOM::Element>> submittable_elements;
 
-    root().for_each_in_subtree([&](auto& node) {
-        if (auto* form_associated_element = as_if<FormAssociatedElement>(node)) {
-            if (form_associated_element->is_submittable() && form_associated_element->form() == this)
-                submittable_elements.append(form_associated_element->form_associated_element_to_html_element());
-        }
-
-        return TraversalDecision::Continue;
-    });
+    for (auto const& element : m_associated_elements_in_tree_order) {
+        if (element->is_submittable())
+            submittable_elements.append(element);
+    }
 
     return submittable_elements;
 }

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -1221,58 +1221,76 @@ Variant<Empty, GC::Ref<DOM::Node>, GC::Ref<RadioNodeList>> HTMLFormElement::name
     // 1. Let candidates be a live RadioNodeList object containing all the listed elements, whose form owner is the form
     //    element, that have either an id attribute or a name attribute equal to name, with the exception of input
     //    elements whose type attribute is in the Image Button state, in tree order.
-    auto filter = [this, name](auto& node) -> bool {
-        if (!is<DOM::Element>(node))
+    auto filter = [this, name](DOM::Node const& node) -> bool {
+        auto const* element = as_if<DOM::Element>(node);
+        if (!element)
             return false;
-        auto const& element = static_cast<DOM::Element const&>(node);
 
         // Form controls are defined as listed elements, with the exception of input elements in the Image Button state,
         // whose form owner is the form element.
-        if (!is_form_control(element, *this))
+        if (!is_form_control(*element, *this))
             return false;
 
-        return name == element.id() || name == element.name();
+        return name == element->id() || name == element->name();
     };
-    auto candidates = RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, move(filter), DOM::LiveNodeList::Kind::FormControls);
 
     // 2. If candidates is empty, let candidates be a live RadioNodeList object containing all the img elements,
     //    whose form owner is the form element, that have either an id attribute or a name attribute equal to name,
     //    in tree order.
-    if (candidates->length() == 0) {
-        candidates = RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, [this, name](auto& node) -> bool {
-            if (!is<HTMLImageElement>(node))
-                return false;
+    auto image_filter = [this, name](DOM::Node const& node) -> bool {
+        auto const* element = as_if<HTMLImageElement>(node);
+        if (!element)
+            return false;
 
-            auto const& element = static_cast<HTMLImageElement const&>(node);
-            if (element.form() != this)
-                return false;
+        if (element->form() != this)
+            return false;
 
-            return name == element.id() || name == element.name();
-        });
-    }
+        return name == element->id() || name == element->name();
+    };
 
-    auto length = candidates->length();
+    // OPTIMIZATION: The associated elements are in tree order, so the candidates are found by walking them instead of
+    //               by building a live list over the whole tree. Only step 4 hands a list to the caller, so that is
+    //               the only place one is built.
+    GC::Ptr<DOM::Node> first_candidate;
+    size_t candidate_count = 0;
+    auto count_candidates = [&](auto const& candidate_filter) {
+        first_candidate = nullptr;
+        candidate_count = 0;
+        for (auto const& element : m_associated_elements_in_tree_order) {
+            if (!candidate_filter(*element))
+                continue;
+            if (!first_candidate)
+                first_candidate = element;
+            ++candidate_count;
+        }
+    };
+
+    count_candidates(filter);
+    auto candidates_are_images = candidate_count == 0;
+    if (candidates_are_images)
+        count_candidates(image_filter);
 
     // 3. If candidates is empty, name is the name of one of the entries in the form element's past names map: return the object associated with name in that map.
-    if (length == 0) {
+    if (candidate_count == 0) {
         auto it = m_past_names_map.find(name);
         if (it != m_past_names_map.end())
             return GC::Ref { const_cast<DOM::Node&>(*it->value.node) };
+        return Empty {};
     }
 
     // 4. If candidates contains more than one node, return candidates.
-    if (length > 1)
-        return candidates;
+    if (candidate_count > 1) {
+        if (candidates_are_images)
+            return RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, move(image_filter));
+        return RadioNodeList::create(root, DOM::LiveNodeList::Scope::Descendants, move(filter), DOM::LiveNodeList::Kind::FormControls);
+    }
 
     // 5. Otherwise, candidates contains exactly one node. Add a mapping from name to the node in candidates in the form
     //    element's past names map, replacing the previous entry with the same name, if any.
-    auto* node = candidates->item(0);
-    if (!node)
-        return Empty {};
-    m_past_names_map.set(name, HTMLFormElement::PastNameEntry { .node = node, .insertion_time = MonotonicTime::now() });
+    m_past_names_map.set(name, HTMLFormElement::PastNameEntry { .node = first_candidate, .insertion_time = MonotonicTime::now() });
 
     // 6. Return the node in candidates.
-    return GC::Ref { const_cast<DOM::Node&>(*node) };
+    return GC::Ref { *first_candidate };
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#default-button

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -429,10 +429,38 @@ size_t HTMLFormElement::tree_order_insertion_index(HTMLElement const& element) c
     });
 }
 
+void HTMLFormElement::recompute_default_button(size_t start_index)
+{
+    m_default_button = nullptr;
+    for (size_t i = start_index; i < m_associated_elements_in_tree_order.size(); ++i) {
+        if (m_associated_elements_in_tree_order[i]->is_submit_button()) {
+            m_default_button = m_associated_elements_in_tree_order[i];
+            break;
+        }
+    }
+}
+
 void HTMLFormElement::add_associated_element(Badge<FormAssociatedElement>, HTMLElement& element)
 {
     VERIFY(&element.root() == &root());
-    m_associated_elements_in_tree_order.insert(tree_order_insertion_index(element), element);
+    auto index = tree_order_insertion_index(element);
+    auto was_appended = index == m_associated_elements_in_tree_order.size();
+    m_associated_elements_in_tree_order.insert(index, element);
+
+    // OPTIMIZATION: An element that follows every other one cannot precede the default button, so the common case of
+    //               building a form front to back never compares tree positions here.
+    if (element.is_submit_button() && (!m_default_button || (!was_appended && element.is_before(*m_default_button))))
+        m_default_button = element;
+}
+
+void HTMLFormElement::associated_element_submit_button_state_changed(Badge<FormAssociatedElement>, HTMLElement& element)
+{
+    if (element.is_submit_button()) {
+        if (!m_default_button || element.is_before(*m_default_button))
+            m_default_button = element;
+    } else if (m_default_button.ptr().ptr() == &element) {
+        recompute_default_button();
+    }
 }
 
 void HTMLFormElement::reposition_moved_associated_elements(Badge<FormAssociatedElement>, Vector<GC::Ref<HTMLElement>> const& moved_elements)
@@ -449,12 +477,18 @@ void HTMLFormElement::reposition_moved_associated_elements(Badge<FormAssociatedE
     auto index = tree_order_insertion_index(*moved_elements.first());
     for (size_t i = 0; i < moved_elements.size(); ++i)
         m_associated_elements_in_tree_order.insert(index + i, moved_elements[i]);
+
+    recompute_default_button();
 }
 
 void HTMLFormElement::remove_associated_element(Badge<FormAssociatedElement>, HTMLElement& element)
 {
-    if (auto index = m_associated_elements_in_tree_order.find_first_index_if([&](auto const& entry) { return entry.ptr() == &element; }); index.has_value())
+    if (auto index = m_associated_elements_in_tree_order.find_first_index_if([&](auto const& entry) { return entry.ptr() == &element; }); index.has_value()) {
         m_associated_elements_in_tree_order.remove(*index);
+
+        if (m_default_button.ptr().ptr() == &element)
+            recompute_default_button(*index);
+    }
 
     // If an element listed in a form element's past names map changes form owner, then its entries must be removed from that map.
     m_past_names_map.remove_all_matching([&](auto&, auto const& entry) { return entry.node.ptr() == &element; });
@@ -1244,12 +1278,7 @@ Variant<Empty, GC::Ref<DOM::Node>, GC::Ref<RadioNodeList>> HTMLFormElement::name
 FormAssociatedElement* HTMLFormElement::default_button() const
 {
     // A form element's default button is the first submit button in tree order whose form owner is that form element.
-    for (auto const& element : m_associated_elements_in_tree_order) {
-        if (element->is_submit_button())
-            return element.ptr();
-    }
-
-    return nullptr;
+    return m_default_button.ptr().ptr();
 }
 
 bool HTMLFormElement::has_invalid_associated_element() const

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -116,6 +116,8 @@ public:
 
     void reposition_moved_associated_elements(Badge<FormAssociatedElement>, Vector<GC::Ref<HTMLElement>> const& moved_elements);
 
+    ReadonlySpan<GC::Ref<HTMLElement>> associated_elements_in_tree_order(Badge<HTMLFormControlsCollection>) const { return m_associated_elements_in_tree_order; }
+
     void associated_element_submit_button_state_changed(Badge<FormAssociatedElement>, HTMLElement&);
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -114,6 +114,8 @@ public:
 
     RadioButtonGroupRegistry& ensure_radio_button_group_registry();
 
+    void reposition_moved_associated_elements(Badge<FormAssociatedElement>, Vector<GC::Ref<HTMLElement>> const& moved_elements);
+
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);
 
@@ -136,6 +138,8 @@ private:
     ErrorOr<void> mail_as_body(URL::URL parsed_action, GC::ConservativeVector<XHR::FormDataEntry> entry_list, EncodingTypeAttributeState encoding_type, Utf16String encoding, GC::Ref<Navigable> target_navigable, NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
     void plan_to_navigate_to(URL::URL url, DocumentResource post_resource, GC::ConservativeVector<XHR::FormDataEntry> entry_list, GC::Ref<Navigable> target_navigable, NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
 
+    size_t tree_order_insertion_index(HTMLElement const&) const;
+
     size_t number_of_fields_blocking_implicit_submission() const;
     void update_default_button_state_for_style(DOM::Element* element_with_known_previous_state, bool previous_state);
 
@@ -144,7 +148,7 @@ private:
     // https://html.spec.whatwg.org/multipage/forms.html#locked-for-reset
     bool m_locked_for_reset { false };
 
-    Vector<GC::Ref<HTMLElement>> m_associated_elements;
+    Vector<GC::Ref<HTMLElement>> m_associated_elements_in_tree_order;
 
     GC::Ptr<RadioButtonGroupRegistry> m_radio_button_group_registry;
     GC::Weak<HTMLElement> m_default_button_for_style_invalidation;

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -116,6 +116,8 @@ public:
 
     void reposition_moved_associated_elements(Badge<FormAssociatedElement>, Vector<GC::Ref<HTMLElement>> const& moved_elements);
 
+    void associated_element_submit_button_state_changed(Badge<FormAssociatedElement>, HTMLElement&);
+
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);
 
@@ -139,6 +141,7 @@ private:
     void plan_to_navigate_to(URL::URL url, DocumentResource post_resource, GC::ConservativeVector<XHR::FormDataEntry> entry_list, GC::Ref<Navigable> target_navigable, NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
 
     size_t tree_order_insertion_index(HTMLElement const&) const;
+    void recompute_default_button(size_t start_index = 0);
 
     size_t number_of_fields_blocking_implicit_submission() const;
     void update_default_button_state_for_style(DOM::Element* element_with_known_previous_state, bool previous_state);
@@ -151,6 +154,8 @@ private:
     Vector<GC::Ref<HTMLElement>> m_associated_elements_in_tree_order;
 
     GC::Ptr<RadioButtonGroupRegistry> m_radio_button_group_registry;
+    GC::Weak<HTMLElement> m_default_button;
+
     GC::Weak<HTMLElement> m_default_button_for_style_invalidation;
     bool m_default_button_for_style_invalidation_initialized { false };
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1749,7 +1749,7 @@ void HTMLInputElement::type_attribute_changed(TypeAttributeState old_state, Type
     // 4. Update the element's rendering and behavior to the new state's.
     m_type = new_state;
     update_radio_button_group_registration();
-    if (auto* form = this->form())
+    if (auto* form = this->form(); form && (is_submit_button(old_state) || is_submit_button(new_state)))
         form->default_button_state_maybe_changed(*this, was_default);
     else
         CSS::Invalidation::invalidate_style_after_default_state_change(*this, was_default);
@@ -3368,10 +3368,15 @@ bool HTMLInputElement::is_button() const
 
 bool HTMLInputElement::is_submit_button() const
 {
+    return is_submit_button(type_state());
+}
+
+bool HTMLInputElement::is_submit_button(TypeAttributeState type_state)
+{
     // https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit):concept-submit-button
     // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image):concept-submit-button
-    return type_state() == TypeAttributeState::SubmitButton
-        || type_state() == TypeAttributeState::ImageButton;
+    return type_state == TypeAttributeState::SubmitButton
+        || type_state == TypeAttributeState::ImageButton;
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1749,10 +1749,12 @@ void HTMLInputElement::type_attribute_changed(TypeAttributeState old_state, Type
     // 4. Update the element's rendering and behavior to the new state's.
     m_type = new_state;
     update_radio_button_group_registration();
-    if (auto* form = this->form(); form && (is_submit_button(old_state) || is_submit_button(new_state)))
+    if (auto* form = this->form(); form && (is_submit_button(old_state) || is_submit_button(new_state))) {
+        submit_button_state_changed();
         form->default_button_state_maybe_changed(*this, was_default);
-    else
+    } else {
         CSS::Invalidation::invalidate_style_after_default_state_change(*this, was_default);
+    }
     CSS::Invalidation::invalidate_style_after_read_write_state_change(*this, was_read_write);
     clear_element_reference_pseudo_elements();
     auto should_materialize_shadow_tree = shadow_root() || has_style();

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -198,6 +198,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/forms.html#concept-submit-button
     virtual bool is_submit_button() const override;
+    static bool is_submit_button(TypeAttributeState);
 
     bool is_single_line() const;
 

--- a/Tests/LibWeb/Text/expected/form-elements-keeps-form-alive.txt
+++ b/Tests/LibWeb/Text/expected/form-elements-keeps-form-alive.txt
@@ -1,2 +1,2 @@
 form wrapper alive while collection is held: false
-collection.length: 0
+collection.length: 1


### PR DESCRIPTION
This PR ensures that the list of associated elements each form keeps is maintained in tree order. This allows us to take a form's submittable elements, its supported property names, its named property lookups, and its elements collection directly from that list, instead of walking the whole tree the form is in or sorting by comparing tree positions. The form's default button is also cached and updated as controls join, leave, move, or change type, and it is only reconsidered when a submit button is involved.

I made some benchmarks to show the performance improvements of these changes and have also compared them to jitless Chromium:

| Page | Phase | `master` | This branch | Chromium (jitless) |
|---|---|---|---|---|
| [10000 text inputs](https://gist.github.com/tcl3/97b3f616f10e66e1576391bf8579b84e) | parse | 216 ms | 32 ms | 12.5 ms |
| | remove the form | 356 ms | 2.4 ms | 2.9 ms |
| [2000 submit buttons](https://gist.github.com/tcl3/15d17ac29085760b86cae3e51a903580) | parse | 13.0 s | 6.5 ms | 2.6 ms |
| | first style and layout with `:default` | 19.8 s | 62 ms | 18.5 ms |
| [20000 text inputs, then 500 submit buttons](https://gist.github.com/tcl3/c5c39ea8326378597d6f4e7ab9d258d9) | parse | 660 ms | 64 ms | 196 ms |
| | toggle the 500 button types | 1.2 s | 1.5 ms | 185 ms |
| [50 controls in a 100k-node document](https://gist.github.com/tcl3/02940c097852d1eaefd596292173a080) | 200x `checkValidity()` | 2.19 s | 1.7 ms | 0.1 ms |
| | 200x `new FormData(form)` | 2.18 s | 3.8 ms | 0.6 ms |
| [3000 named controls](https://gist.github.com/tcl3/6a5b0f7ffb61721c11097e2ae623cc70) | 10x `Object.keys(form)` | 29.1 s | 21.6 s | 2.5 ms |
| [1000 named controls in a 100k-node document](https://gist.github.com/tcl3/b5f2716b3db524ffb9a5f422be6158bd) | 1000x `form[name]` | 5.17 s | 90 ms | 1.1 ms |
| | 1000x radio group lookup | 5.21 s | 117 ms | 0.2 ms |
| [100 controls in a 100k-node document](https://gist.github.com/tcl3/24cb2e5e39fb5f27fb5158109bdef3de) | 300x `form.elements.length` after a mutation | 1.48 s | 2.2 ms | 2.8 ms |