### PR TITLE
LibWeb: Make layout NodeData private to the Rust arena

### DIFF
--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -27,11 +27,8 @@
 namespace Web::Layout {
 
 Box::Box(DOM::Document& document, GC::Ptr<DOM::Node> node, CSS::LayoutStyle style, RustFFI::NodeKind kind)
-    : NodeWithStyle(document, node, move(style))
+    : NodeWithStyle(document, node, move(style), kind)
 {
-    set_node_kind(kind);
-    if (RustFFI::layout_node_kind_is_replaced_box(kind))
-        set_flag(RustFFI::NodeFlag::IsReplacedElement, true);
 }
 
 Box::~Box()

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -139,11 +139,6 @@ StringView Node::class_name() const
     VERIFY_NOT_REACHED();
 }
 
-void Node::enroll_for_arena_replaced_content_facts_sync_if_eligible()
-{
-    RustFFI::layout_arena_enroll_node_for_replaced_content_facts_sync_if_eligible(arena_handle(), slot_id(this));
-}
-
 void Node::bump_fragment_cache_epoch_of_self_and_ancestors()
 {
     RustFFI::layout_arena_bump_fragment_cache_epoch_of_self_and_ancestors(arena_handle(), slot_id(this));
@@ -352,7 +347,6 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     synchronize_table_span_data();
-    enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (m_owned_computed_values)
         pin_style_record_for_cxx_consumers();
 }
@@ -480,7 +474,6 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     // A style change can introduce the properties that make a node carry replaced-content facts,
     // such as size containment arriving on a kept layout node.
-    enroll_for_arena_replaced_content_facts_sync_if_eligible();
     propagate_style_to_anonymous_wrappers();
     attach_style_resources();
     // A pseudo layout node can outlive replacement of the DOM pseudo's record until the layout
@@ -703,7 +696,6 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
-    enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (m_owned_computed_values)
         pin_style_record_for_cxx_consumers();
 
@@ -750,7 +742,6 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
     set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
-    enroll_for_arena_replaced_content_facts_sync_if_eligible();
     if (should_repin_style_record)
         pin_style_record_for_cxx_consumers();
 
@@ -806,7 +797,7 @@ void NodeWithStyle::publish_style_record_to_node_data()
 {
     auto const* payloads = document().style_computer().style_engine().style_record_payloads(m_style_record_identity);
     VERIFY(payloads);
-    node_data().style = payloads;
+    RustFFI::layout_arena_set_node_style_payloads(arena_handle(), slot_id(this), payloads);
     if (content_visibility() == CSS::ContentVisibility::Auto)
         document().note_content_visibility_auto_style();
 
@@ -994,7 +985,7 @@ void Node::set_generated_for(CSS::PseudoElement type, DOM::Element& element)
 {
     static_assert(encode_generated_for(CSS::PseudoElement::After) == RustFFI::GENERATED_FOR_AFTER);
     static_assert(encode_generated_for(CSS::PseudoElement::Marker) == RustFFI::GENERATED_FOR_MARKER);
-    m_data->generated_for = encode_generated_for(type);
+    RustFFI::layout_arena_set_node_generated_for(arena_handle(), slot_id(this), encode_generated_for(type));
     m_pseudo_element_generator = element;
     if (auto* node_with_style = as_if<NodeWithStyle>(*this))
         node_with_style->bind_generated_style_record(element.style_record_identity(type));

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -40,10 +40,10 @@
 
 namespace Web::Layout {
 
-NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document)
+NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document, RustFFI::FfiNodeConstructionFacts const& construction_facts)
     : m_arena(document.layout_node_arena())
 {
-    auto allocation = m_arena->allocate();
+    auto allocation = m_arena->allocate(construction_facts);
     m_slot = allocation.slot;
     m_data = allocation.data;
 }
@@ -53,25 +53,26 @@ NodeArenaAllocation::~NodeArenaAllocation()
     m_arena->free(m_slot);
 }
 
-Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, AttachToDOMNode attach_to_dom_node)
-    : NodeArenaAllocation(document)
+static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, void* shell)
+{
+    return {
+        .kind = kind,
+        .shell = shell,
+        .is_anonymous = node == nullptr,
+        .is_html_input_element = node && is<HTML::HTMLInputElement>(*node),
+        .is_html_html_element = node && node->is_html_html_element(),
+        .is_document_element = node && node.ptr() == document.document_element(),
+        .is_in_user_agent_shadow_tree = node && node->containing_shadow_root() && node->containing_shadow_root()->is_user_agent_internal(),
+        .uses_button_layout = node && is<HTML::HTMLElement>(*node) && static_cast<HTML::HTMLElement const&>(*node).uses_button_layout(),
+        .is_editing_host = node && node->is_editing_host(),
+        .is_body = node && node == GC::Ptr { document.body() },
+    };
+}
+
+Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, AttachToDOMNode attach_to_dom_node)
+    : NodeArenaAllocation(document, build_node_construction_facts(document, node, kind, this))
     , m_dom_node(node ? *node : document)
 {
-    m_data->shell = this;
-    set_node_kind(RustFFI::NodeKind::Node);
-    set_flag(RustFFI::NodeFlag::Anonymous, node == nullptr);
-    // Some native controls use a generic box so they can host their internal shadow tree, but
-    // remain replaced elements for CSS box generation and inline layout. (Box's constructor
-    // sets the flag for the replaced box kinds.)
-    set_flag(RustFFI::NodeFlag::IsReplacedElement, node && is<HTML::HTMLInputElement>(*node));
-    set_flag(RustFFI::NodeFlag::IsHtmlInputElement, node && is<HTML::HTMLInputElement>(*node));
-    set_flag(RustFFI::NodeFlag::IsHtmlHtmlElement, node && node->is_html_html_element());
-    set_flag(RustFFI::NodeFlag::IsDocumentElement, node && node.ptr() == document.document_element());
-    set_flag(RustFFI::NodeFlag::IsInUserAgentShadowTree,
-        node && node->containing_shadow_root() && node->containing_shadow_root()->is_user_agent_internal());
-    set_flag(RustFFI::NodeFlag::UsesButtonLayout,
-        node && is<HTML::HTMLElement>(*node) && static_cast<HTML::HTMLElement const&>(*node).uses_button_layout());
-    set_flag(RustFFI::NodeFlag::IsEditingHost, node && node->is_editing_host());
     update_has_scroll_offset_flag();
 
     if (node && attach_to_dom_node == AttachToDOMNode::Yes)
@@ -86,12 +87,6 @@ Node::~Node()
 RustFFI::NodeSlotId Node::slot_id(Node const* node)
 {
     return node ? node->m_slot : RustFFI::NodeSlotId_INVALID;
-}
-
-void Node::set_node_kind(RustFFI::NodeKind kind)
-{
-    m_data->kind = kind;
-    enroll_for_arena_replaced_content_facts_sync_if_eligible();
 }
 
 StringView Node::class_name() const
@@ -146,12 +141,7 @@ StringView Node::class_name() const
 
 void Node::enroll_for_arena_replaced_content_facts_sync_if_eligible()
 {
-    if (m_enrolled_for_arena_replaced_content_facts_sync)
-        return;
-    if (!RustFFI::layout_node_data_may_have_replaced_content_facts(m_data))
-        return;
-    m_enrolled_for_arena_replaced_content_facts_sync = true;
-    RustFFI::layout_arena_enroll_node_for_replaced_content_facts_sync(arena_handle(), slot_id(this));
+    RustFFI::layout_arena_enroll_node_for_replaced_content_facts_sync_if_eligible(arena_handle(), slot_id(this));
 }
 
 void Node::bump_fragment_cache_epoch_of_self_and_ancestors()
@@ -334,9 +324,8 @@ bool NodeWithStyle::is_sticky_position() const
 }
 
 NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, CSS::LayoutStyle style, RustFFI::NodeKind kind)
-    : Node(document, node)
+    : Node(document, node, kind)
 {
-    set_node_kind(kind);
     VERIFY(style);
     if (!!style.style_record_identity()) {
         m_style_record_identity = style.style_record_identity();
@@ -347,8 +336,6 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
         m_owned_computed_values = style.values();
         m_style_record_identity = document.style_computer().intern_anonymous_layout_style(*style.values());
     }
-    set_flag(RustFFI::NodeFlag::HasStyle, true);
-    set_flag(RustFFI::NodeFlag::IsBody, node && node == GC::Ptr { document.body() });
     // NB: Nodes constructed from an interned style record own no ComputedValues; read anchor names through the record view there.
     bool has_anchor_names = false;
     bool insets_use_anchor_functions = false;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -46,12 +46,11 @@ NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document)
     auto allocation = m_arena->allocate();
     m_slot = allocation.slot;
     m_data = allocation.data;
-    m_slot_generation = allocation.generation;
 }
 
 NodeArenaAllocation::~NodeArenaAllocation()
 {
-    m_arena->free(m_slot, m_slot_generation);
+    m_arena->free(m_slot);
 }
 
 Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, AttachToDOMNode attach_to_dom_node)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -72,6 +72,7 @@ static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Docu
 Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, AttachToDOMNode attach_to_dom_node)
     : NodeArenaAllocation(document, build_node_construction_facts(document, node, kind, this))
     , m_dom_node(node ? *node : document)
+    , m_kind(kind)
 {
     update_has_scroll_offset_flag();
 
@@ -151,12 +152,12 @@ void* Node::arena_handle() const
 
 Box const* Node::containing_block() const
 {
-    return static_cast<Box const*>(tree_node_from_slot_if_live(m_data->containing_block));
+    return static_cast<Box const*>(containing_block_node_if_live());
 }
 
 Box* Node::containing_block()
 {
-    return static_cast<Box*>(tree_node_from_slot_if_live(m_data->containing_block));
+    return static_cast<Box*>(containing_block_node_if_live());
 }
 
 void Node::pin_style_record_for_detachment()
@@ -606,12 +607,12 @@ bool NodeWithStyle::is_inline_table() const
 
 bool Node::is_atomic_inline() const
 {
-    return RustFFI::layout_node_data_is_atomic_inline(m_data);
+    return RustFFI::layout_arena_node_is_atomic_inline(arena_handle(), slot_id(this));
 }
 
 bool Node::is_fragmented_inline() const
 {
-    return RustFFI::layout_node_data_is_fragmented_inline(m_data);
+    return RustFFI::layout_arena_node_is_fragmented_inline(arena_handle(), slot_id(this));
 }
 
 // https://drafts.csswg.org/css-transforms-1/#transformable-element
@@ -797,6 +798,7 @@ void NodeWithStyle::publish_style_record_to_node_data()
 {
     auto const* payloads = document().style_computer().style_engine().style_record_payloads(m_style_record_identity);
     VERIFY(payloads);
+    m_style_payloads = payloads;
     RustFFI::layout_arena_set_node_style_payloads(arena_handle(), slot_id(this), payloads);
     if (content_visibility() == CSS::ContentVisibility::Auto)
         document().note_content_visibility_auto_style();

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -43,9 +43,7 @@ namespace Web::Layout {
 NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document, RustFFI::FfiNodeConstructionFacts const& construction_facts)
     : m_arena(document.layout_node_arena())
 {
-    auto allocation = m_arena->allocate(construction_facts);
-    m_slot = allocation.slot;
-    m_data = allocation.data;
+    m_slot = m_arena->allocate(construction_facts);
 }
 
 NodeArenaAllocation::~NodeArenaAllocation()

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -66,7 +66,6 @@ protected:
     NonnullRefPtr<NodeArena> m_arena;
     RustFFI::NodeSlotId m_slot {};
     RustFFI::NodeData* m_data { nullptr };
-    u32 m_slot_generation { 0 };
 };
 
 class WEB_API Node

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -80,20 +80,20 @@ public:
     StringView class_name() const;
 
     static RustFFI::NodeSlotId slot_id(Node const*);
-    RustFFI::NodeKind kind() const { return m_data->kind; }
+    RustFFI::NodeKind kind() const { return m_kind; }
     u32 arena_slot_index() const { return m_slot.index; }
     void* arena_handle() const;
     NodeArena& node_arena() const { return *m_arena; }
 
-    Node* parent_ptr() { return tree_node_from_slot(m_data->parent); }
-    Node const* parent_ptr() const { return tree_node_from_slot(m_data->parent); }
-    Node* first_child_ptr() { return tree_node_from_slot(m_data->first_child); }
-    Node const* first_child_ptr() const { return tree_node_from_slot(m_data->first_child); }
-    Node* last_child_ptr() { return tree_node_from_slot(m_data->last_child); }
-    Node* next_sibling_ptr() { return tree_node_from_slot(m_data->next_sibling); }
-    Node const* next_sibling_ptr() const { return tree_node_from_slot(m_data->next_sibling); }
-    Node* previous_sibling_ptr() { return tree_node_from_slot(m_data->previous_sibling); }
-    bool has_children() const { return m_data->first_child.index != RustFFI::NodeSlotId_INVALID.index; }
+    Node* parent_ptr() { return linked_node(RustFFI::FfiNodeLink::Parent); }
+    Node const* parent_ptr() const { return linked_node(RustFFI::FfiNodeLink::Parent); }
+    Node* first_child_ptr() { return linked_node(RustFFI::FfiNodeLink::FirstChild); }
+    Node const* first_child_ptr() const { return linked_node(RustFFI::FfiNodeLink::FirstChild); }
+    Node* last_child_ptr() { return linked_node(RustFFI::FfiNodeLink::LastChild); }
+    Node* next_sibling_ptr() { return linked_node(RustFFI::FfiNodeLink::NextSibling); }
+    Node const* next_sibling_ptr() const { return linked_node(RustFFI::FfiNodeLink::NextSibling); }
+    Node* previous_sibling_ptr() { return linked_node(RustFFI::FfiNodeLink::PreviousSibling); }
+    bool has_children() const { return first_child_ptr() != nullptr; }
 
     RefPtr<Node> first_child() { return first_child_ptr(); }
     RefPtr<Node const> first_child() const { return first_child_ptr(); }
@@ -239,19 +239,19 @@ public:
     void set_needs_own_geometry_update() { set_flag(RustFFI::NodeFlag::NeedsOwnGeometryUpdate, true); }
     void set_needs_layout_update(DOM::SetNeedsLayoutReason, LayoutUpdatePropagation = LayoutUpdatePropagation::ThroughAncestors);
 
-    bool is_generated_for_pseudo_element() const { return m_data->generated_for != 0; }
+    bool is_generated_for_pseudo_element() const { return generated_for() != 0; }
     Optional<CSS::PseudoElement> generated_for_pseudo_element() const
     {
         if (!is_generated_for_pseudo_element())
             return {};
-        return static_cast<CSS::PseudoElement>(m_data->generated_for - 1);
+        return static_cast<CSS::PseudoElement>(generated_for() - 1);
     }
     // The principal box of a pseudo-element has no DOM node, but unlike an anonymous wrapper it has its own
     // computed style.
     bool is_pseudo_element_principal_box() const;
-    bool is_generated_for_before_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::Before); }
-    bool is_generated_for_after_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::After); }
-    bool is_generated_for_backdrop_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::Backdrop); }
+    bool is_generated_for_before_pseudo_element() const { return generated_for() == encode_generated_for(CSS::PseudoElement::Before); }
+    bool is_generated_for_after_pseudo_element() const { return generated_for() == encode_generated_for(CSS::PseudoElement::After); }
+    bool is_generated_for_backdrop_pseudo_element() const { return generated_for() == encode_generated_for(CSS::PseudoElement::Backdrop); }
     void set_generated_for(CSS::PseudoElement type, DOM::Element&);
 
     void clear_committed_box();
@@ -345,7 +345,7 @@ protected:
 
     bool has_flag(RustFFI::NodeFlag flag) const
     {
-        return (m_data->flags & static_cast<u32>(flag)) != 0;
+        return (RustFFI::layout_arena_node_flags(m_arena->handle(), m_slot) & static_cast<u32>(flag)) != 0;
     }
 
     bool dom_target_stores_scroll_offset() const;
@@ -354,9 +354,6 @@ protected:
     {
         RustFFI::layout_arena_set_node_flag(m_arena->handle(), m_slot, flag, value);
     }
-
-    RustFFI::NodeData& node_data() { return *m_data; }
-    RustFFI::NodeData const& node_data() const { return *m_data; }
 
 private:
     friend class NodeWithStyle;
@@ -367,18 +364,18 @@ private:
         return static_cast<u8>(pseudo_element) + 1;
     }
 
-    Node* tree_node_from_slot(RustFFI::NodeSlotId id) const
+    Node* linked_node(RustFFI::FfiNodeLink link) const
     {
-        if (id.index == RustFFI::NodeSlotId_INVALID.index)
-            return nullptr;
-        return static_cast<Node*>(RustFFI::layout_arena_node_data(m_arena->handle(), id)->shell);
+        return static_cast<Node*>(RustFFI::layout_arena_node_link_shell(m_arena->handle(), m_slot, link));
     }
 
-    // Unlike tree_node_from_slot, tolerates freed and stale slots by resolving them to null.
-    Node* tree_node_from_slot_if_live(RustFFI::NodeSlotId id) const
+    // Tolerates a freed containing block slot by resolving it to null.
+    Node* containing_block_node_if_live() const
     {
-        return static_cast<Node*>(RustFFI::layout_arena_node_shell_if_live(m_arena->handle(), id));
+        return static_cast<Node*>(RustFFI::layout_arena_node_containing_block_shell_if_live(m_arena->handle(), m_slot));
     }
+
+    u8 generated_for() const { return RustFFI::layout_arena_node_generated_for(m_arena->handle(), m_slot); }
 
 protected:
 private:
@@ -386,6 +383,7 @@ private:
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
     GC::Root<DOM::Node> m_dom_node;
     GC::Weak<DOM::Element> m_pseudo_element_generator;
+    RustFFI::NodeKind m_kind { RustFFI::NodeKind::Unset };
 };
 
 class WEB_API NodeWithStyle : public Node {
@@ -417,8 +415,8 @@ public:
     template<typename StyleGroup>
     StyleGroup const& style_group() const
     {
-        VERIFY(node_data().style);
-        auto const* payloads = static_cast<void const* const*>(node_data().style);
+        VERIFY(m_style_payloads);
+        auto const* payloads = static_cast<void const* const*>(m_style_payloads);
         auto const* payload = payloads[StyleGroup::style_group_index];
         VERIFY(payload);
         return *static_cast<StyleGroup const*>(payload);
@@ -696,6 +694,7 @@ private:
 
     void rebuild_image_observers();
     CSS::ComputedValues const& owned_computed_values() const;
+    void const* m_style_payloads { nullptr };
     RefPtr<CSS::ComputedValues const> m_owned_computed_values;
     CSS::StyleRecordID m_style_record_identity;
     // Layout nodes are ref-counted rather than GC cells, so this owner cannot be a traced GC::Ptr.

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -352,10 +352,7 @@ protected:
 
     void set_flag(RustFFI::NodeFlag flag, bool value)
     {
-        if (value)
-            m_data->flags |= static_cast<u32>(flag);
-        else
-            m_data->flags &= ~static_cast<u32>(flag);
+        RustFFI::layout_arena_set_node_flag(m_arena->handle(), m_slot, flag, value);
     }
 
     RustFFI::NodeData& node_data() { return *m_data; }
@@ -384,8 +381,6 @@ private:
     }
 
 protected:
-    void enroll_for_arena_replaced_content_facts_sync_if_eligible();
-
 private:
     // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -31,25 +31,6 @@ namespace Web::Layout {
 static_assert(sizeof(RustFFI::NodeSlotId) == sizeof(u32));
 static_assert(offsetof(RustFFI::NodeSlotId, index) == 0);
 
-static_assert(sizeof(RustFFI::NodeData) == 64);
-static_assert(offsetof(RustFFI::NodeData, parent) == 0);
-static_assert(offsetof(RustFFI::NodeData, first_child) == 4);
-static_assert(offsetof(RustFFI::NodeData, last_child) == 8);
-static_assert(offsetof(RustFFI::NodeData, previous_sibling) == 12);
-static_assert(offsetof(RustFFI::NodeData, next_sibling) == 16);
-static_assert(offsetof(RustFFI::NodeData, containing_block) == 20);
-static_assert(offsetof(RustFFI::NodeData, inline_containing_block) == 24);
-static_assert(offsetof(RustFFI::NodeData, kind) == 28);
-static_assert(offsetof(RustFFI::NodeData, generated_for) == 29);
-static_assert(offsetof(RustFFI::NodeData, intrinsic_cache_epoch) == 30);
-static_assert(offsetof(RustFFI::NodeData, flags) == 32);
-static_assert(offsetof(RustFFI::NodeData, fragment_cache_epoch) == 36);
-static_assert(offsetof(RustFFI::NodeData, slot_generation) == 40);
-static_assert(offsetof(RustFFI::NodeData, table_column_span) == 42);
-static_assert(offsetof(RustFFI::NodeData, table_row_span) == 44);
-static_assert(offsetof(RustFFI::NodeData, style) == 48);
-static_assert(offsetof(RustFFI::NodeData, shell) == 56);
-
 static_assert(sizeof(RustFFI::NodeKind) == sizeof(u8));
 static_assert(sizeof(RustFFI::NodeFlag) == sizeof(u32));
 
@@ -65,7 +46,6 @@ protected:
 
     NonnullRefPtr<NodeArena> m_arena;
     RustFFI::NodeSlotId m_slot {};
-    RustFFI::NodeData* m_data { nullptr };
 };
 
 class WEB_API Node

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -60,7 +60,7 @@ enum class LayoutUpdatePropagation : u8 {
 
 class NodeArenaAllocation {
 protected:
-    explicit NodeArenaAllocation(DOM::Document&);
+    NodeArenaAllocation(DOM::Document&, RustFFI::FfiNodeConstructionFacts const&);
     ~NodeArenaAllocation();
 
     NonnullRefPtr<NodeArena> m_arena;
@@ -341,7 +341,7 @@ public:
     };
 
 protected:
-    Node(DOM::Document&, GC::Ptr<DOM::Node>, AttachToDOMNode = AttachToDOMNode::Yes);
+    Node(DOM::Document&, GC::Ptr<DOM::Node>, RustFFI::NodeKind, AttachToDOMNode = AttachToDOMNode::Yes);
 
     bool has_flag(RustFFI::NodeFlag flag) const
     {
@@ -384,7 +384,6 @@ private:
     }
 
 protected:
-    void set_node_kind(RustFFI::NodeKind);
     void enroll_for_arena_replaced_content_facts_sync_if_eligible();
 
 private:
@@ -392,8 +391,6 @@ private:
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
     GC::Root<DOM::Node> m_dom_node;
     GC::Weak<DOM::Element> m_pseudo_element_generator;
-
-    bool m_enrolled_for_arena_replaced_content_facts_sync { false };
 };
 
 class WEB_API NodeWithStyle : public Node {

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -23,9 +23,9 @@ NodeArena::~NodeArena()
     RustFFI::layout_arena_destroy(m_handle);
 }
 
-RustFFI::NodeAllocation NodeArena::allocate()
+RustFFI::NodeAllocation NodeArena::allocate(RustFFI::FfiNodeConstructionFacts const& construction_facts)
 {
-    auto allocation = RustFFI::layout_arena_allocate(m_handle);
+    auto allocation = RustFFI::layout_arena_allocate(m_handle, construction_facts);
     VERIFY(allocation.data);
     return allocation;
 }

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -30,9 +30,9 @@ RustFFI::NodeAllocation NodeArena::allocate()
     return allocation;
 }
 
-void NodeArena::free(RustFFI::NodeSlotId slot, u32 generation)
+void NodeArena::free(RustFFI::NodeSlotId slot)
 {
-    RustFFI::layout_arena_free(m_handle, slot, generation);
+    RustFFI::layout_arena_free(m_handle, slot);
 }
 
 u64 NodeArena::formatting_context_run_cache_hit_count() const

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -23,11 +23,9 @@ NodeArena::~NodeArena()
     RustFFI::layout_arena_destroy(m_handle);
 }
 
-RustFFI::NodeAllocation NodeArena::allocate(RustFFI::FfiNodeConstructionFacts const& construction_facts)
+RustFFI::NodeSlotId NodeArena::allocate(RustFFI::FfiNodeConstructionFacts const& construction_facts)
 {
-    auto allocation = RustFFI::layout_arena_allocate(m_handle, construction_facts);
-    VERIFY(allocation.data);
-    return allocation;
+    return RustFFI::layout_arena_allocate(m_handle, construction_facts);
 }
 
 void NodeArena::free(RustFFI::NodeSlotId slot)

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -31,7 +31,7 @@ public:
     NodeArena();
     ~NodeArena();
 
-    RustFFI::NodeAllocation allocate();
+    RustFFI::NodeAllocation allocate(RustFFI::FfiNodeConstructionFacts const&);
     void free(RustFFI::NodeSlotId);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -19,10 +19,9 @@ namespace Web::Layout {
 class Node;
 class TextNode;
 
-static_assert(sizeof(RustFFI::NodeAllocation) == 24);
+static_assert(sizeof(RustFFI::NodeAllocation) == 16);
 static_assert(offsetof(RustFFI::NodeAllocation, slot) == 0);
 static_assert(offsetof(RustFFI::NodeAllocation, data) == 8);
-static_assert(offsetof(RustFFI::NodeAllocation, generation) == 16);
 
 class WEB_API NodeArena : public RefCounted<NodeArena> {
     AK_MAKE_NONCOPYABLE(NodeArena);
@@ -33,7 +32,7 @@ public:
     ~NodeArena();
 
     RustFFI::NodeAllocation allocate();
-    void free(RustFFI::NodeSlotId, u32 generation);
+    void free(RustFFI::NodeSlotId);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
     u64 table_cell_measurement_cache_miss_count() const;

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -19,10 +19,6 @@ namespace Web::Layout {
 class Node;
 class TextNode;
 
-static_assert(sizeof(RustFFI::NodeAllocation) == 16);
-static_assert(offsetof(RustFFI::NodeAllocation, slot) == 0);
-static_assert(offsetof(RustFFI::NodeAllocation, data) == 8);
-
 class WEB_API NodeArena : public RefCounted<NodeArena> {
     AK_MAKE_NONCOPYABLE(NodeArena);
     AK_MAKE_NONMOVABLE(NodeArena);
@@ -31,7 +27,7 @@ public:
     NodeArena();
     ~NodeArena();
 
-    RustFFI::NodeAllocation allocate(RustFFI::FfiNodeConstructionFacts const&);
+    RustFFI::NodeSlotId allocate(RustFFI::FfiNodeConstructionFacts const&);
     void free(RustFFI::NodeSlotId);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -25,25 +25,22 @@
 namespace Web::Layout {
 
 TextNode::TextNode(DOM::Document& document, DOM::Text& text)
-    : Node(document, &text)
+    : Node(document, &text, RustFFI::NodeKind::TextNode)
 {
-    set_node_kind(RustFFI::NodeKind::TextNode);
     enroll_for_arena_text_content_sync();
     update_produces_line_box_fragment_when_empty_flag();
 }
 
 TextNode::TextNode(DOM::Document& document, DOM::Text& text, AttachToDOMNode attach_to_dom_node, RustFFI::NodeKind kind)
-    : Node(document, &text, attach_to_dom_node)
+    : Node(document, &text, kind, attach_to_dom_node)
 {
-    set_node_kind(kind);
     enroll_for_arena_text_content_sync();
     update_produces_line_box_fragment_when_empty_flag();
 }
 
 TextNode::TextNode(DOM::Document& document, RustFFI::NodeKind kind)
-    : Node(document, nullptr)
+    : Node(document, nullptr, kind)
 {
-    set_node_kind(kind);
     enroll_for_arena_text_content_sync();
 }
 

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -3025,16 +3025,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         Path::new("HTML/Parser/RustFFI.h"),
     );
 
-    // Layout tree-builder header - namespace Web::Layout::RustFFI. The node arena and its
-    // node records are read directly by the C++ layout tree wrappers.
+    // Layout tree-builder header - namespace Web::Layout::RustFFI. The C++ layout tree
+    // wrappers drive the node arena through slot ids.
     let mut tree_builder_config = base_config.clone();
     tree_builder_config.namespaces = Some(vec!["Web".to_string(), "Layout".to_string(), "RustFFI".to_string()]);
     tree_builder_config.export.include = vec![
         "FfiNodeKindFacts".to_string(),
         "FfiReplacedContentFacts".to_string(),
         "FfiStylePayloads".to_string(),
-        "NodeAllocation".to_string(),
-        "NodeData".to_string(),
         "NodeFlag".to_string(),
         "NodeKind".to_string(),
         "NodeSlotId".to_string(),

--- a/Libraries/LibWeb/Rust/src/css/absolutize.rs
+++ b/Libraries/LibWeb/Rust/src/css/absolutize.rs
@@ -1643,49 +1643,47 @@ pub unsafe extern "C" fn rust_style_value_absolutize(
     scheme: u8,
 ) -> FfiAbsolutizedValue {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueQueryEntry);
-    crate::abort_on_panic(|| {
-        let value = unsafe { &*value.cast::<StyleValueData>() };
-        let length = unsafe { length.cast::<FfiLengthResolutionContext>().as_ref() };
-        // Without a length context the recursion still handles everything that does not
-        // resolve lengths; a zeroed context would silently mis-resolve, so decline instead.
-        let Some(length) = length else {
-            return match value {
-                value if crate::css::style_compute::value_absolutization_is_identity(value) => FfiAbsolutizedValue {
-                    kind: ABSOLUTIZED_UNCHANGED,
-                    data: core::ptr::null(),
-                },
-                _ => FfiAbsolutizedValue {
-                    kind: ABSOLUTIZED_DECLINED,
-                    data: core::ptr::null(),
-                },
-            };
-        };
-        let context = AbsolutizationContext {
-            length,
-            scheme: has_scheme.then_some(scheme),
-            resolved_viewport_relative_length: Cell::new(false),
-            tree_counting: None,
-            random_base_values: &[],
-            document_base_url: &[],
-            style_sheet_resource_context: None,
-        };
-        match absolutize(value, &context) {
-            Some(Absolutized::Unchanged) => FfiAbsolutizedValue {
+    let value = unsafe { &*value.cast::<StyleValueData>() };
+    let length = unsafe { length.cast::<FfiLengthResolutionContext>().as_ref() };
+    // Without a length context the recursion still handles everything that does not
+    // resolve lengths; a zeroed context would silently mis-resolve, so decline instead.
+    let Some(length) = length else {
+        return match value {
+            value if crate::css::style_compute::value_absolutization_is_identity(value) => FfiAbsolutizedValue {
                 kind: ABSOLUTIZED_UNCHANGED,
                 data: core::ptr::null(),
             },
-            Some(Absolutized::Changed(new_value)) => {
-                let pointer = new_value.pointer();
-                core::mem::forget(new_value);
-                FfiAbsolutizedValue {
-                    kind: ABSOLUTIZED_CHANGED,
-                    data: pointer.cast(),
-                }
-            }
-            None => FfiAbsolutizedValue {
+            _ => FfiAbsolutizedValue {
                 kind: ABSOLUTIZED_DECLINED,
                 data: core::ptr::null(),
             },
+        };
+    };
+    let context = AbsolutizationContext {
+        length,
+        scheme: has_scheme.then_some(scheme),
+        resolved_viewport_relative_length: Cell::new(false),
+        tree_counting: None,
+        random_base_values: &[],
+        document_base_url: &[],
+        style_sheet_resource_context: None,
+    };
+    match absolutize(value, &context) {
+        Some(Absolutized::Unchanged) => FfiAbsolutizedValue {
+            kind: ABSOLUTIZED_UNCHANGED,
+            data: core::ptr::null(),
+        },
+        Some(Absolutized::Changed(new_value)) => {
+            let pointer = new_value.pointer();
+            core::mem::forget(new_value);
+            FfiAbsolutizedValue {
+                kind: ABSOLUTIZED_CHANGED,
+                data: pointer.cast(),
+            }
         }
-    })
+        None => FfiAbsolutizedValue {
+            kind: ABSOLUTIZED_DECLINED,
+            data: core::ptr::null(),
+        },
+    }
 }

--- a/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
+++ b/Libraries/LibWeb/Rust/src/css/animated_overlay.rs
@@ -19,7 +19,6 @@
 use std::ffi::c_void;
 use std::rc::Rc;
 
-use crate::abort_on_panic;
 use crate::css::style_value::{RetainedStyleValueData, StyleValueData, release_style_value, retain_style_value};
 
 #[derive(Default)]
@@ -140,12 +139,10 @@ pub(crate) fn overlay_wins(entry: &FfiAnimatedOverlayEntry, base_value_is_import
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_animated_overlay_create() -> *mut AnimatedOverlay {
-    abort_on_panic(|| {
-        Box::into_raw(Box::new(AnimatedOverlay {
-            entries: Vec::new(),
-            animation_preparation: None,
-        }))
-    })
+    Box::into_raw(Box::new(AnimatedOverlay {
+        entries: Vec::new(),
+        animation_preparation: None,
+    }))
 }
 
 /// Returns a new overlay holding retained copies of `overlay`'s entries.
@@ -154,7 +151,7 @@ pub extern "C" fn rust_animated_overlay_create() -> *mut AnimatedOverlay {
 /// `overlay` must be a valid overlay.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_animated_overlay_clone(overlay: *const AnimatedOverlay) -> *mut AnimatedOverlay {
-    abort_on_panic(|| Box::into_raw(Box::new(unsafe { &*overlay }.clone())))
+    Box::into_raw(Box::new(unsafe { &*overlay }.clone()))
 }
 
 /// Returns a new overlay holding retained copies of `overlay`'s inherited entries.
@@ -165,21 +162,21 @@ pub unsafe extern "C" fn rust_animated_overlay_clone(overlay: *const AnimatedOve
 pub unsafe extern "C" fn rust_animated_overlay_clone_inherited(
     overlay: *const AnimatedOverlay,
 ) -> *mut AnimatedOverlay {
-    abort_on_panic(|| Box::into_raw(Box::new(unsafe { &*overlay }.clone_inherited())))
+    Box::into_raw(Box::new(unsafe { &*overlay }.clone_inherited()))
 }
 
 /// # Safety
 /// `overlay` must be a valid overlay.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_animated_overlay_contains(overlay: *const AnimatedOverlay, property: u16) -> bool {
-    abort_on_panic(|| unsafe { &*overlay }.get(property).is_some())
+    unsafe { &*overlay }.get(property).is_some()
 }
 
 /// # Safety
 /// `overlay` must be a valid overlay that is not used after this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_animated_overlay_free(overlay: *mut AnimatedOverlay) {
-    abort_on_panic(|| drop(unsafe { Box::from_raw(overlay) }));
+    drop(unsafe { Box::from_raw(overlay) });
 }
 
 /// Stores or replaces the overlay entry for a longhand, retaining `value`.
@@ -195,13 +192,11 @@ pub unsafe extern "C" fn rust_animated_overlay_set(
     inherited: bool,
     result_of_transition: bool,
 ) {
-    abort_on_panic(|| {
-        let retained = unsafe {
-            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
-        };
-        let overlay = unsafe { &mut *overlay };
-        overlay.set_owned(property, retained, inherited, result_of_transition);
-    });
+    let retained = unsafe {
+        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
+    };
+    let overlay = unsafe { &mut *overlay };
+    overlay.set_owned(property, retained, inherited, result_of_transition);
 }
 
 /// Returns the overlay's borrowed entries, valid until its next mutation.
@@ -214,11 +209,9 @@ pub unsafe extern "C" fn rust_animated_overlay_entries(
     overlay: *const AnimatedOverlay,
     count: *mut usize,
 ) -> *const FfiAnimatedOverlayEntry {
-    abort_on_panic(|| {
-        let entries = &unsafe { &*overlay }.entries;
-        unsafe { *count = entries.len() };
-        entries.as_ptr()
-    })
+    let entries = &unsafe { &*overlay }.entries;
+    unsafe { *count = entries.len() };
+    entries.as_ptr()
 }
 
 /// The overlay's effective value for a longhand under the overlay read rule,
@@ -232,11 +225,9 @@ pub unsafe extern "C" fn rust_animated_overlay_effective_value(
     property: u16,
     base_value_is_important: bool,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        unsafe { &*overlay }
-            .get(property)
-            .filter(|entry| overlay_wins(entry, base_value_is_important))
-            .map_or(std::ptr::null(), FfiAnimatedOverlayEntry::value_pointer)
-            .cast()
-    })
+    unsafe { &*overlay }
+        .get(property)
+        .filter(|entry| overlay_wins(entry, base_value_is_important))
+        .map_or(std::ptr::null(), FfiAnimatedOverlayEntry::value_pointer)
+        .cast()
 }

--- a/Libraries/LibWeb/Rust/src/css/animation.rs
+++ b/Libraries/LibWeb/Rust/src/css/animation.rs
@@ -361,7 +361,7 @@ pub unsafe extern "C" fn rust_evaluate_easing(
     input_progress: f64,
     before_flag: bool,
 ) -> f64 {
-    crate::abort_on_panic(|| evaluate_easing_descriptor(unsafe { &*descriptor }, input_progress, before_flag))
+    evaluate_easing_descriptor(unsafe { &*descriptor }, input_progress, before_flag)
 }
 
 fn evaluate_easing_descriptor(descriptor: &FfiEasingDescriptor, input_progress: f64, before_flag: bool) -> f64 {
@@ -7107,51 +7107,48 @@ fn evaluate_animation_value(
 pub unsafe extern "C" fn rust_resolve_animation_declarations(
     batch: *const FfiAnimationBatch,
 ) -> FfiResolvedAnimationProperties {
-    crate::abort_on_panic(|| {
-        let batch = unsafe { &*batch };
-        let declarations = unsafe { std::slice::from_raw_parts(batch.declarations, batch.declaration_count) };
-        let effects = unsafe { std::slice::from_raw_parts(batch.effects, batch.effect_count) };
-        let keyframes = unsafe { std::slice::from_raw_parts(batch.keyframes, batch.keyframe_count) };
-        let important_property_bitmap = unsafe {
-            std::slice::from_raw_parts(batch.important_property_bitmap, batch.important_property_bitmap_length)
+    let batch = unsafe { &*batch };
+    let declarations = unsafe { std::slice::from_raw_parts(batch.declarations, batch.declaration_count) };
+    let effects = unsafe { std::slice::from_raw_parts(batch.effects, batch.effect_count) };
+    let keyframes = unsafe { std::slice::from_raw_parts(batch.keyframes, batch.keyframe_count) };
+    let important_property_bitmap =
+        unsafe { std::slice::from_raw_parts(batch.important_property_bitmap, batch.important_property_bitmap_length) };
+    let resolved = resolve_animation_declarations(
+        declarations,
+        effects,
+        keyframes,
+        batch.writing_mode,
+        batch.direction,
+        important_property_bitmap,
+    );
+    if resolved.properties.is_empty() {
+        return FfiResolvedAnimationProperties {
+            properties: std::ptr::null(),
+            count: 0,
+            animation_value_count: 0,
+            uses_tree_counting_function: false,
+            container_relative_length_unit_mask: 0,
+            needs_document_base_url: false,
+            unfixed_random_sharings: std::ptr::null(),
+            unfixed_random_sharing_count: 0,
+            storage: std::ptr::null_mut(),
         };
-        let resolved = resolve_animation_declarations(
-            declarations,
-            effects,
-            keyframes,
-            batch.writing_mode,
-            batch.direction,
-            important_property_bitmap,
-        );
-        if resolved.properties.is_empty() {
-            return FfiResolvedAnimationProperties {
-                properties: std::ptr::null(),
-                count: 0,
-                animation_value_count: 0,
-                uses_tree_counting_function: false,
-                container_relative_length_unit_mask: 0,
-                needs_document_base_url: false,
-                unfixed_random_sharings: std::ptr::null(),
-                unfixed_random_sharing_count: 0,
-                storage: std::ptr::null_mut(),
-            };
-        }
-        let resolved = Box::new(resolved);
-        let properties = resolved.properties.as_ptr();
-        let count = resolved.properties.len();
-        let animation_value_count = resolved.value_plans.len();
-        FfiResolvedAnimationProperties {
-            properties,
-            count,
-            animation_value_count,
-            uses_tree_counting_function: resolved.uses_tree_counting_function,
-            container_relative_length_unit_mask: resolved.container_relative_length_unit_mask,
-            needs_document_base_url: resolved.needs_document_base_url,
-            unfixed_random_sharings: resolved.unfixed_random_sharings.as_ptr(),
-            unfixed_random_sharing_count: resolved.unfixed_random_sharings.len(),
-            storage: Box::into_raw(resolved).cast(),
-        }
-    })
+    }
+    let resolved = Box::new(resolved);
+    let properties = resolved.properties.as_ptr();
+    let count = resolved.properties.len();
+    let animation_value_count = resolved.value_plans.len();
+    FfiResolvedAnimationProperties {
+        properties,
+        count,
+        animation_value_count,
+        uses_tree_counting_function: resolved.uses_tree_counting_function,
+        container_relative_length_unit_mask: resolved.container_relative_length_unit_mask,
+        needs_document_base_url: resolved.needs_document_base_url,
+        unfixed_random_sharings: resolved.unfixed_random_sharings.as_ptr(),
+        unfixed_random_sharing_count: resolved.unfixed_random_sharings.len(),
+        storage: Box::into_raw(resolved).cast(),
+    }
 }
 
 struct AnimationPreparationKey {
@@ -7188,17 +7185,15 @@ pub unsafe extern "C" fn rust_animation_preparation_matches(
     overlay: *const std::ffi::c_void,
     key: *const FfiAnimationPreparationKey,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        if overlay.is_null() || key.is_null() {
-            return false;
-        }
-        let overlay = unsafe { &*overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
-        let key = unsafe { &*key };
-        overlay
-            .animation_preparation
-            .as_ref()
-            .is_some_and(|preparation| unsafe { preparation.key.matches_ffi(key) })
-    })
+    if overlay.is_null() || key.is_null() {
+        return false;
+    }
+    let overlay = unsafe { &*overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
+    let key = unsafe { &*key };
+    overlay
+        .animation_preparation
+        .as_ref()
+        .is_some_and(|preparation| unsafe { preparation.key.matches_ffi(key) })
 }
 
 /// Complete the Rust-owned animation plan and compose every interval without
@@ -7213,174 +7208,170 @@ pub unsafe extern "C" fn rust_animation_preparation_matches(
 /// overlay must be uniquely owned for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_evaluate_animations(computed: *const FfiComputedAnimationBatch) -> usize {
-    crate::abort_on_panic(|| {
-        crate::css::ffi_stats::rust_style_ffi_note_animation_evaluation();
-        let computed = unsafe { &*computed };
-        assert!(!computed.preparation_key.is_null());
-        assert!(!computed.underlying_longhand_table.is_null());
-        assert!(!computed.overlay.is_null());
-        let preparation_key = unsafe { &*computed.preparation_key };
-        let current_keys = unsafe { std::slice::from_raw_parts(computed.current_keys, computed.current_key_count) };
-        let overlay = unsafe { &mut *computed.overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
-        let preparation = overlay
-            .animation_preparation
-            .as_ref()
-            .filter(|preparation| unsafe { preparation.key.matches_ffi(preparation_key) })
-            .cloned()
-            .unwrap_or_else(|| {
-                assert!(!computed.resolved_animation_storage.is_null());
-                assert!(!computed.computed_keyframe_storage.is_null());
-                let resolved = *unsafe {
-                    Box::from_raw(
-                        computed
-                            .resolved_animation_storage
-                            .cast::<ResolvedAnimationDeclarations>(),
-                    )
-                };
-                let computed_keyframe_values = unsafe {
-                    crate::css::style_compute::take_animation_keyframe_longhand_values(
-                        computed.computed_keyframe_storage,
-                    )
-                };
-                assert_eq!(computed_keyframe_values.len(), resolved.properties.len());
-                let keyframes_by_value = resolved
-                    .value_plans
-                    .iter()
-                    .map(|plan| {
-                        plan.property_indices
-                            .iter()
-                            .map(|&property_index| {
-                                let property = &resolved.properties[property_index];
-                                let keyframe = &resolved.keyframes[property.keyframe_index];
-                                FfiAnimationKeyframeValue {
-                                    key: keyframe.key,
-                                    value: computed_keyframe_values[property_index].pointer(),
-                                    easing: keyframe.easing_descriptor(),
-                                    composite: keyframe.composite,
-                                }
-                            })
-                            .collect()
-                    })
-                    .collect();
-                std::rc::Rc::new(PreparedAnimationBatch {
-                    key: unsafe { AnimationPreparationKey::from_ffi(preparation_key) },
-                    resolved,
-                    _computed_keyframe_values: computed_keyframe_values,
-                    keyframes_by_value,
-                    context: computed.context,
-                })
-            });
-        if computed.cache_preparation {
-            overlay.animation_preparation = Some(preparation.clone());
-        } else {
-            overlay.animation_preparation = None;
-        }
-        let resolved = &preparation.resolved;
-        let mut context = preparation.context;
-        context.current_color = computed.context.current_color;
-        context.has_transform_reference_box = computed.context.has_transform_reference_box;
-        context.transform_reference_box_width = computed.context.transform_reference_box_width;
-        context.transform_reference_box_height = computed.context.transform_reference_box_height;
-        let underlying_longhand_table = unsafe {
-            &*computed
-                .underlying_longhand_table
-                .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
-        };
-
-        // https://www.w3.org/TR/web-animations-1/#effect-stacks
-        // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
-        //     next effect affecting the same property.
-        let mut custom_final_values = Vec::<(u32, RetainedStyleValueData)>::new();
-        let mut previous_values = Vec::<(u16, u32, *const StyleValueData)>::with_capacity(resolved.value_plans.len());
-        for (plan, keyframes) in resolved.value_plans.iter().zip(&preparation.keyframes_by_value) {
-            assert!(plan.effect_index < current_keys.len());
-            let (underlying, initial) = if plan.custom_name_id != 0 {
-                let custom_index = (plan.custom_name_id - 1) as usize;
-                assert!(custom_index < computed.custom_value_count);
-                (
-                    unsafe { *computed.custom_underlying_values.add(custom_index) },
-                    unsafe { *computed.custom_initial_values.add(custom_index) },
-                )
-            } else {
-                let underlying = underlying_longhand_table
-                    .get(plan.property_id)
-                    .expect("an animated longhand must have an underlying computed value");
-                (
-                    underlying.pointer(),
-                    crate::css::style_compute::initial_value_data(plan.property_id),
+    crate::css::ffi_stats::rust_style_ffi_note_animation_evaluation();
+    let computed = unsafe { &*computed };
+    assert!(!computed.preparation_key.is_null());
+    assert!(!computed.underlying_longhand_table.is_null());
+    assert!(!computed.overlay.is_null());
+    let preparation_key = unsafe { &*computed.preparation_key };
+    let current_keys = unsafe { std::slice::from_raw_parts(computed.current_keys, computed.current_key_count) };
+    let overlay = unsafe { &mut *computed.overlay.cast::<crate::css::animated_overlay::AnimatedOverlay>() };
+    let preparation = overlay
+        .animation_preparation
+        .as_ref()
+        .filter(|preparation| unsafe { preparation.key.matches_ffi(preparation_key) })
+        .cloned()
+        .unwrap_or_else(|| {
+            assert!(!computed.resolved_animation_storage.is_null());
+            assert!(!computed.computed_keyframe_storage.is_null());
+            let resolved = *unsafe {
+                Box::from_raw(
+                    computed
+                        .resolved_animation_storage
+                        .cast::<ResolvedAnimationDeclarations>(),
                 )
             };
-            let input = FfiAnimationValueInput {
-                property_id: plan.property_id,
-                custom_name_id: plan.custom_name_id,
-                result_of_transition: plan.result_of_transition,
-                underlying,
-                initial,
-                current_key: current_keys[plan.effect_index],
-                keyframes: keyframes.as_ptr(),
-                keyframe_count: keyframes.len(),
+            let computed_keyframe_values = unsafe {
+                crate::css::style_compute::take_animation_keyframe_longhand_values(computed.computed_keyframe_storage)
             };
-            let previous_value = previous_values
+            assert_eq!(computed_keyframe_values.len(), resolved.properties.len());
+            let keyframes_by_value = resolved
+                .value_plans
                 .iter()
-                .rev()
-                .find(|(property_id, custom_name_id, _)| {
-                    *property_id == input.property_id && *custom_name_id == input.custom_name_id
+                .map(|plan| {
+                    plan.property_indices
+                        .iter()
+                        .map(|&property_index| {
+                            let property = &resolved.properties[property_index];
+                            let keyframe = &resolved.keyframes[property.keyframe_index];
+                            FfiAnimationKeyframeValue {
+                                key: keyframe.key,
+                                value: computed_keyframe_values[property_index].pointer(),
+                                easing: keyframe.easing_descriptor(),
+                                composite: keyframe.composite,
+                            }
+                        })
+                        .collect()
                 })
-                .map(|(_, _, value)| unsafe { &**value });
-            let result = evaluate_animation_value(&context, &input, previous_value);
-            if !result.apply {
-                assert!(result.value.is_null());
-                continue;
-            }
-            if input.custom_name_id != 0 {
-                if !result.value.is_null() {
-                    previous_values.push((input.property_id, input.custom_name_id, result.value));
-                    custom_final_values.push((input.custom_name_id, unsafe {
-                        RetainedStyleValueData::from_retained_pointer(result.value)
-                    }));
-                }
-                continue;
-            }
+                .collect();
+            std::rc::Rc::new(PreparedAnimationBatch {
+                key: unsafe { AnimationPreparationKey::from_ffi(preparation_key) },
+                resolved,
+                _computed_keyframe_values: computed_keyframe_values,
+                keyframes_by_value,
+                context: computed.context,
+            })
+        });
+    if computed.cache_preparation {
+        overlay.animation_preparation = Some(preparation.clone());
+    } else {
+        overlay.animation_preparation = None;
+    }
+    let resolved = &preparation.resolved;
+    let mut context = preparation.context;
+    context.current_color = computed.context.current_color;
+    context.has_transform_reference_box = computed.context.has_transform_reference_box;
+    context.transform_reference_box_width = computed.context.transform_reference_box_width;
+    context.transform_reference_box_height = computed.context.transform_reference_box_height;
+    let underlying_longhand_table = unsafe {
+        &*computed
+            .underlying_longhand_table
+            .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
+    };
+
+    // https://www.w3.org/TR/web-animations-1/#effect-stacks
+    // NB: Inputs arrive in composite order. Keep each result as the underlying value for the
+    //     next effect affecting the same property.
+    let mut custom_final_values = Vec::<(u32, RetainedStyleValueData)>::new();
+    let mut previous_values = Vec::<(u16, u32, *const StyleValueData)>::with_capacity(resolved.value_plans.len());
+    for (plan, keyframes) in resolved.value_plans.iter().zip(&preparation.keyframes_by_value) {
+        assert!(plan.effect_index < current_keys.len());
+        let (underlying, initial) = if plan.custom_name_id != 0 {
+            let custom_index = (plan.custom_name_id - 1) as usize;
+            assert!(custom_index < computed.custom_value_count);
+            (
+                unsafe { *computed.custom_underlying_values.add(custom_index) },
+                unsafe { *computed.custom_initial_values.add(custom_index) },
+            )
+        } else {
+            let underlying = underlying_longhand_table
+                .get(plan.property_id)
+                .expect("an animated longhand must have an underlying computed value");
+            (
+                underlying.pointer(),
+                crate::css::style_compute::initial_value_data(plan.property_id),
+            )
+        };
+        let input = FfiAnimationValueInput {
+            property_id: plan.property_id,
+            custom_name_id: plan.custom_name_id,
+            result_of_transition: plan.result_of_transition,
+            underlying,
+            initial,
+            current_key: current_keys[plan.effect_index],
+            keyframes: keyframes.as_ptr(),
+            keyframe_count: keyframes.len(),
+        };
+        let previous_value = previous_values
+            .iter()
+            .rev()
+            .find(|(property_id, custom_name_id, _)| {
+                *property_id == input.property_id && *custom_name_id == input.custom_name_id
+            })
+            .map(|(_, _, value)| unsafe { &**value });
+        let result = evaluate_animation_value(&context, &input, previous_value);
+        if !result.apply {
+            assert!(result.value.is_null());
+            continue;
+        }
+        if input.custom_name_id != 0 {
             if !result.value.is_null() {
                 previous_values.push((input.property_id, input.custom_name_id, result.value));
-                let value = unsafe { RetainedStyleValueData::from_retained_pointer(result.value) };
-                overlay.set_owned(input.property_id, value, false, input.result_of_transition);
-            } else {
-                let value = RetainedStyleValueData::from_owned(StyleValueData::Keyword {
-                    keyword: crate::css::css_enums::keyword::HIDDEN,
+                custom_final_values.push((input.custom_name_id, unsafe {
+                    RetainedStyleValueData::from_retained_pointer(result.value)
+                }));
+            }
+            continue;
+        }
+        if !result.value.is_null() {
+            previous_values.push((input.property_id, input.custom_name_id, result.value));
+            let value = unsafe { RetainedStyleValueData::from_retained_pointer(result.value) };
+            overlay.set_owned(input.property_id, value, false, input.result_of_transition);
+        } else {
+            let value = RetainedStyleValueData::from_owned(StyleValueData::Keyword {
+                keyword: crate::css::css_enums::keyword::HIDDEN,
+            });
+            overlay.set_owned(
+                crate::css::property_metadata::property_id::VISIBILITY,
+                value,
+                false,
+                input.result_of_transition,
+            );
+        }
+    }
+    if !custom_final_values.is_empty() {
+        assert!(!computed.custom_results.is_null());
+        assert!(!computed.custom_result_count.is_null());
+        let mut final_by_name = std::collections::BTreeMap::<u32, RetainedStyleValueData>::new();
+        for (custom_name_id, value) in custom_final_values {
+            final_by_name.insert(custom_name_id, value);
+        }
+        let mut written = 0;
+        for (custom_name_id, value) in final_by_name {
+            assert!(written < computed.custom_value_count);
+            let pointer = value.pointer();
+            std::mem::forget(value);
+            unsafe {
+                computed.custom_results.add(written).write(FfiAnimatedCustomProperty {
+                    custom_name_id,
+                    value: pointer,
                 });
-                overlay.set_owned(
-                    crate::css::property_metadata::property_id::VISIBILITY,
-                    value,
-                    false,
-                    input.result_of_transition,
-                );
             }
+            written += 1;
         }
-        if !custom_final_values.is_empty() {
-            assert!(!computed.custom_results.is_null());
-            assert!(!computed.custom_result_count.is_null());
-            let mut final_by_name = std::collections::BTreeMap::<u32, RetainedStyleValueData>::new();
-            for (custom_name_id, value) in custom_final_values {
-                final_by_name.insert(custom_name_id, value);
-            }
-            let mut written = 0;
-            for (custom_name_id, value) in final_by_name {
-                assert!(written < computed.custom_value_count);
-                let pointer = value.pointer();
-                std::mem::forget(value);
-                unsafe {
-                    computed.custom_results.add(written).write(FfiAnimatedCustomProperty {
-                        custom_name_id,
-                        value: pointer,
-                    });
-                }
-                written += 1;
-            }
-            unsafe { computed.custom_result_count.write(written) };
-        }
-        resolved.value_plans.len()
-    })
+        unsafe { computed.custom_result_count.write(written) };
+    }
+    resolved.value_plans.len()
 }
 
 /// Attempt Rust-owned style value interpolation without consulting C++ or the DOM.
@@ -7396,15 +7387,13 @@ pub unsafe extern "C" fn rust_interpolate_scalar_style_value(
     to: *const StyleValueData,
     delta: f32,
 ) -> FfiAnimationValueResult {
-    crate::abort_on_panic(|| {
-        interpolate_value(
-            unsafe { context.as_ref() },
-            property_id,
-            unsafe { &*from },
-            unsafe { &*to },
-            delta,
-        )
-    })
+    interpolate_value(
+        unsafe { context.as_ref() },
+        property_id,
+        unsafe { &*from },
+        unsafe { &*to },
+        delta,
+    )
 }
 
 /// Test-only bridge for exercising Rust-owned style value composition without constructing an
@@ -7418,7 +7407,7 @@ pub unsafe extern "C" fn rust_test_composite_style_value(
     animated: *const StyleValueData,
     operation: FfiCompositeOperation,
 ) -> FfiAnimationValueResult {
-    crate::abort_on_panic(|| composite_scalar_value(unsafe { &*underlying }, unsafe { &*animated }, operation))
+    composite_scalar_value(unsafe { &*underlying }, unsafe { &*animated }, operation)
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/calc.rs
+++ b/Libraries/LibWeb/Rust/src/css/calc.rs
@@ -530,15 +530,13 @@ pub unsafe extern "C" fn rust_numeric_type_operate(
     second: *const FfiNumericType,
 ) -> FfiNumericType {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let first = unsafe { &*first }.to_calc();
-        let result = match operation {
-            FfiNumericTypeOperation::Add => first.added_to(&unsafe { &*second }.to_calc()),
-            FfiNumericTypeOperation::Multiply => first.multiplied_by(&unsafe { &*second }.to_calc()),
-            FfiNumericTypeOperation::Invert => Some(first.inverted()),
-        };
-        FfiNumericType::from_calc(result)
-    })
+    let first = unsafe { &*first }.to_calc();
+    let result = match operation {
+        FfiNumericTypeOperation::Add => first.added_to(&unsafe { &*second }.to_calc()),
+        FfiNumericTypeOperation::Multiply => first.multiplied_by(&unsafe { &*second }.to_calc()),
+        FfiNumericTypeOperation::Invert => Some(first.inverted()),
+    };
+    FfiNumericType::from_calc(result)
 }
 
 /// Tests a numeric type against one of the CSS numeric matching categories.
@@ -554,18 +552,16 @@ pub unsafe extern "C" fn rust_numeric_type_matches(
     percentages_resolve_as: u8,
 ) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let numeric_type = unsafe { &*numeric_type }.to_calc();
-        let resolve_as = resolve_as_for_value_type(has_percentages_resolve_as.then_some(percentages_resolve_as));
-        match match_kind {
-            FfiNumericTypeMatch::Dimension => numeric_type.matches_dimension(base_type as usize, resolve_as),
-            FfiNumericTypeMatch::Percentage => numeric_type.matches_percentage(),
-            FfiNumericTypeMatch::DimensionPercentage => {
-                numeric_type.matches_dimension_percentage(base_type as usize, resolve_as)
-            }
-            FfiNumericTypeMatch::Number => numeric_type.matches_number(resolve_as),
+    let numeric_type = unsafe { &*numeric_type }.to_calc();
+    let resolve_as = resolve_as_for_value_type(has_percentages_resolve_as.then_some(percentages_resolve_as));
+    match match_kind {
+        FfiNumericTypeMatch::Dimension => numeric_type.matches_dimension(base_type as usize, resolve_as),
+        FfiNumericTypeMatch::Percentage => numeric_type.matches_percentage(),
+        FfiNumericTypeMatch::DimensionPercentage => {
+            numeric_type.matches_dimension_percentage(base_type as usize, resolve_as)
         }
-    })
+        FfiNumericTypeMatch::Number => numeric_type.matches_number(resolve_as),
+    }
 }
 
 /// https://drafts.csswg.org/css-values-4/#round-func
@@ -1084,29 +1080,27 @@ unsafe fn children_from_raw(children: *const *const CalcNode, count: usize) -> V
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_calc_node_create_numeric_dimension(kind: u8, value: f64, unit: u8) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        let numeric = match kind {
-            0 => CalcNumericValue::Number {
-                value,
-                number_type: unit,
-            },
-            1 => CalcNumericValue::Angle { value, unit },
-            2 => CalcNumericValue::Flex { value, unit },
-            3 => CalcNumericValue::Frequency { value, unit },
-            4 => CalcNumericValue::Length { value, unit },
-            5 => CalcNumericValue::Percentage(value),
-            6 => CalcNumericValue::Resolution { value, unit },
-            7 => CalcNumericValue::Time { value, unit },
-            _ => unreachable!("invalid numeric dimension kind {kind}"),
-        };
-        handle(CalcNode::Numeric(numeric))
-    })
+    let numeric = match kind {
+        0 => CalcNumericValue::Number {
+            value,
+            number_type: unit,
+        },
+        1 => CalcNumericValue::Angle { value, unit },
+        2 => CalcNumericValue::Flex { value, unit },
+        3 => CalcNumericValue::Frequency { value, unit },
+        4 => CalcNumericValue::Length { value, unit },
+        5 => CalcNumericValue::Percentage(value),
+        6 => CalcNumericValue::Resolution { value, unit },
+        7 => CalcNumericValue::Time { value, unit },
+        _ => unreachable!("invalid numeric dimension kind {kind}"),
+    };
+    handle(CalcNode::Numeric(numeric))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_calc_node_create_channel_keyword(channel: u8) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| handle(CalcNode::ChannelKeyword(channel)))
+    handle(CalcNode::ChannelKeyword(channel))
 }
 
 /// Creates a variadic node: kind selects sum (0), product (1), min (2),
@@ -1121,18 +1115,16 @@ pub unsafe extern "C" fn rust_calc_node_create_variadic(
     count: usize,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        let children = unsafe { children_from_raw(children, count) };
-        let node = match kind {
-            0 => CalcNode::Sum(children),
-            1 => CalcNode::Product(children),
-            2 => CalcNode::Min(children),
-            3 => CalcNode::Max(children),
-            4 => CalcNode::Hypot(children),
-            _ => unreachable!("invalid variadic calc node kind {kind}"),
-        };
-        handle(node)
-    })
+    let children = unsafe { children_from_raw(children, count) };
+    let node = match kind {
+        0 => CalcNode::Sum(children),
+        1 => CalcNode::Product(children),
+        2 => CalcNode::Min(children),
+        3 => CalcNode::Max(children),
+        4 => CalcNode::Hypot(children),
+        _ => unreachable!("invalid variadic calc node kind {kind}"),
+    };
+    handle(node)
 }
 
 /// Creates a single-child node: kind selects negate (0), invert (1), abs (2),
@@ -1144,25 +1136,23 @@ pub unsafe extern "C" fn rust_calc_node_create_variadic(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_node_create_unary(kind: u8, child: *const CalcNode) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        let child = unsafe { Arc::from_raw(child) };
-        let node = match kind {
-            0 => CalcNode::Negate(child),
-            1 => CalcNode::Invert(child),
-            2 => CalcNode::Abs(child),
-            3 => CalcNode::Sign(child),
-            4 => CalcNode::Sin(child),
-            5 => CalcNode::Cos(child),
-            6 => CalcNode::Tan(child),
-            7 => CalcNode::Asin(child),
-            8 => CalcNode::Acos(child),
-            9 => CalcNode::Atan(child),
-            10 => CalcNode::Sqrt(child),
-            11 => CalcNode::Exp(child),
-            _ => unreachable!("invalid unary calc node kind {kind}"),
-        };
-        handle(node)
-    })
+    let child = unsafe { Arc::from_raw(child) };
+    let node = match kind {
+        0 => CalcNode::Negate(child),
+        1 => CalcNode::Invert(child),
+        2 => CalcNode::Abs(child),
+        3 => CalcNode::Sign(child),
+        4 => CalcNode::Sin(child),
+        5 => CalcNode::Cos(child),
+        6 => CalcNode::Tan(child),
+        7 => CalcNode::Asin(child),
+        8 => CalcNode::Acos(child),
+        9 => CalcNode::Atan(child),
+        10 => CalcNode::Sqrt(child),
+        11 => CalcNode::Exp(child),
+        _ => unreachable!("invalid unary calc node kind {kind}"),
+    };
+    handle(node)
 }
 
 /// Creates a two-child node: kind selects atan2 (0), pow (1), log (2),
@@ -1177,31 +1167,29 @@ pub unsafe extern "C" fn rust_calc_node_create_binary(
     second: *const CalcNode,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        let first = unsafe { Arc::from_raw(first) };
-        let second = unsafe { Arc::from_raw(second) };
-        let node = match kind {
-            0 => CalcNode::Atan2 { y: first, x: second },
-            1 => CalcNode::Pow {
-                base: first,
-                exponent: second,
-            },
-            2 => CalcNode::Log {
-                value: first,
-                base: second,
-            },
-            3 => CalcNode::Mod {
-                value: first,
-                modulus: second,
-            },
-            4 => CalcNode::Rem {
-                value: first,
-                divisor: second,
-            },
-            _ => unreachable!("invalid binary calc node kind {kind}"),
-        };
-        handle(node)
-    })
+    let first = unsafe { Arc::from_raw(first) };
+    let second = unsafe { Arc::from_raw(second) };
+    let node = match kind {
+        0 => CalcNode::Atan2 { y: first, x: second },
+        1 => CalcNode::Pow {
+            base: first,
+            exponent: second,
+        },
+        2 => CalcNode::Log {
+            value: first,
+            base: second,
+        },
+        3 => CalcNode::Mod {
+            value: first,
+            modulus: second,
+        },
+        4 => CalcNode::Rem {
+            value: first,
+            divisor: second,
+        },
+        _ => unreachable!("invalid binary calc node kind {kind}"),
+    };
+    handle(node)
 }
 
 /// # Safety
@@ -1213,12 +1201,10 @@ pub unsafe extern "C" fn rust_calc_node_create_clamp(
     max: *const CalcNode,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        handle(CalcNode::Clamp {
-            min: unsafe { Arc::from_raw(min) },
-            center: unsafe { Arc::from_raw(center) },
-            max: unsafe { Arc::from_raw(max) },
-        })
+    handle(CalcNode::Clamp {
+        min: unsafe { Arc::from_raw(min) },
+        center: unsafe { Arc::from_raw(center) },
+        max: unsafe { Arc::from_raw(max) },
     })
 }
 
@@ -1232,13 +1218,11 @@ pub unsafe extern "C" fn rust_calc_node_create_progress(
     to: *const CalcNode,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        handle(CalcNode::Progress {
-            no_clamp,
-            progress: unsafe { Arc::from_raw(progress) },
-            from: unsafe { Arc::from_raw(from) },
-            to: unsafe { Arc::from_raw(to) },
-        })
+    handle(CalcNode::Progress {
+        no_clamp,
+        progress: unsafe { Arc::from_raw(progress) },
+        from: unsafe { Arc::from_raw(from) },
+        to: unsafe { Arc::from_raw(to) },
     })
 }
 
@@ -1251,12 +1235,10 @@ pub unsafe extern "C" fn rust_calc_node_create_round(
     interval: *const CalcNode,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        handle(CalcNode::Round {
-            strategy,
-            value: unsafe { Arc::from_raw(value) },
-            interval: unsafe { Arc::from_raw(interval) },
-        })
+    handle(CalcNode::Round {
+        strategy,
+        value: unsafe { Arc::from_raw(value) },
+        interval: unsafe { Arc::from_raw(interval) },
     })
 }
 
@@ -1271,17 +1253,15 @@ pub unsafe extern "C" fn rust_calc_node_create_random(
     sharing: *const std::ffi::c_void,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        handle(CalcNode::Random {
-            min: unsafe { Arc::from_raw(min) },
-            max: unsafe { Arc::from_raw(max) },
-            step: if step.is_null() {
-                None
-            } else {
-                Some(unsafe { Arc::from_raw(step) })
-            },
-            sharing: unsafe { RetainedStyleValueData::from_retained_pointer(sharing.cast()) },
-        })
+    handle(CalcNode::Random {
+        min: unsafe { Arc::from_raw(min) },
+        max: unsafe { Arc::from_raw(max) },
+        step: if step.is_null() {
+            None
+        } else {
+            Some(unsafe { Arc::from_raw(step) })
+        },
+        sharing: unsafe { RetainedStyleValueData::from_retained_pointer(sharing.cast()) },
     })
 }
 
@@ -1293,11 +1273,9 @@ pub unsafe extern "C" fn rust_calc_node_create_non_math_function(
     numeric_type: *const FfiNumericType,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeBuildEntry);
-    crate::abort_on_panic(|| {
-        handle(CalcNode::NonMathFunction {
-            value: unsafe { RetainedStyleValueData::from_retained_pointer(value.cast()) },
-            numeric_type: unsafe { &*numeric_type }.to_calc(),
-        })
+    handle(CalcNode::NonMathFunction {
+        value: unsafe { RetainedStyleValueData::from_retained_pointer(value.cast()) },
+        numeric_type: unsafe { &*numeric_type }.to_calc(),
     })
 }
 
@@ -1306,7 +1284,7 @@ pub unsafe extern "C" fn rust_calc_node_create_non_math_function(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_node_release(node: *const CalcNode) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeRetainReleaseEntry);
-    crate::abort_on_panic(|| drop(unsafe { Arc::from_raw(node) }));
+    drop(unsafe { Arc::from_raw(node) });
 }
 
 /// Retains an additional strong reference to a calculation node, so the C++
@@ -1317,7 +1295,7 @@ pub unsafe extern "C" fn rust_calc_node_release(node: *const CalcNode) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_node_retain(node: *const CalcNode) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeRetainReleaseEntry);
-    crate::abort_on_panic(|| unsafe { Arc::increment_strong_count(node) });
+    unsafe { Arc::increment_strong_count(node) };
 }
 
 /// https://drafts.csswg.org/css-values-4/#determine-the-type-of-a-calculation
@@ -1335,11 +1313,9 @@ pub unsafe extern "C" fn rust_calc_node_determine_type(
     resolve_as_base: u8,
 ) -> FfiNumericType {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeQueryEntry);
-    crate::abort_on_panic(|| {
-        let resolve_as = resolve_as_from_fields(has_percentages_resolve_as, resolve_as_is_number, resolve_as_base);
-        let percentage_leaf_type = percentage_leaf_type_for(resolve_as);
-        FfiNumericType::from_calc(unsafe { &*node }.numeric_type(&percentage_leaf_type))
-    })
+    let resolve_as = resolve_as_from_fields(has_percentages_resolve_as, resolve_as_is_number, resolve_as_base);
+    let percentage_leaf_type = percentage_leaf_type_for(resolve_as);
+    FfiNumericType::from_calc(unsafe { &*node }.numeric_type(&percentage_leaf_type))
 }
 
 /// Whether any leaf of the calculation is a percentage.
@@ -1349,7 +1325,7 @@ pub unsafe extern "C" fn rust_calc_node_determine_type(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_node_contains_percentage(node: *const CalcNode) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeQueryEntry);
-    crate::abort_on_panic(|| unsafe { &*node }.contains_percentage())
+    unsafe { &*node }.contains_percentage()
 }
 
 /// What percentages resolve against in the surrounding context.
@@ -2760,39 +2736,37 @@ pub unsafe extern "C" fn rust_calc_external_resolutions(
     basis_unit: u8,
 ) -> FfiCalcExternalResolutions {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let mut resolutions = Vec::new();
-        let root = unsafe { &*root };
-        collect_external_resolutions(root, &mut resolutions);
-        if basis_kind == 3
-            && root.contains_percentage()
-            && crate::css::style_compute::LENGTH_UNIT_NAMES[basis_unit as usize].starts_with("cq")
-        {
-            resolutions.push(FfiCalcExternalResolution {
-                kind: FfiCalcExternalResolutionKind::Length,
-                source: std::ptr::null(),
-                input_value: basis_value,
-                unit_or_channel: basis_unit,
-                has_number: false,
-                number: 0.0,
-                resolved_node: std::ptr::null(),
-                resolved_style_value: std::ptr::null(),
-            });
-        }
-        let storage = Box::new(CalcExternalResolutionStorage {
-            resolutions: resolutions.into_boxed_slice(),
+    let mut resolutions = Vec::new();
+    let root = unsafe { &*root };
+    collect_external_resolutions(root, &mut resolutions);
+    if basis_kind == 3
+        && root.contains_percentage()
+        && crate::css::style_compute::LENGTH_UNIT_NAMES[basis_unit as usize].starts_with("cq")
+    {
+        resolutions.push(FfiCalcExternalResolution {
+            kind: FfiCalcExternalResolutionKind::Length,
+            source: std::ptr::null(),
+            input_value: basis_value,
+            unit_or_channel: basis_unit,
+            has_number: false,
+            number: 0.0,
+            resolved_node: std::ptr::null(),
+            resolved_style_value: std::ptr::null(),
         });
-        let result = FfiCalcExternalResolutions {
-            resolutions: storage.resolutions.as_ptr().cast_mut(),
-            resolution_count: storage.resolutions.len(),
-            storage: std::ptr::null_mut(),
-        };
-        let storage = Box::into_raw(storage);
-        FfiCalcExternalResolutions {
-            storage: storage.cast(),
-            ..result
-        }
-    })
+    }
+    let storage = Box::new(CalcExternalResolutionStorage {
+        resolutions: resolutions.into_boxed_slice(),
+    });
+    let result = FfiCalcExternalResolutions {
+        resolutions: storage.resolutions.as_ptr().cast_mut(),
+        resolution_count: storage.resolutions.len(),
+        storage: std::ptr::null_mut(),
+    };
+    let storage = Box::into_raw(storage);
+    FfiCalcExternalResolutions {
+        storage: storage.cast(),
+        ..result
+    }
 }
 
 /// Returns the borrowed calculation-tree root stored in calculated style value
@@ -2802,14 +2776,12 @@ pub unsafe extern "C" fn rust_calc_external_resolutions(
 /// `calculated` must point at live Calculated style value data.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_root_from_calculated(calculated: *const std::ffi::c_void) -> *const CalcNode {
-    crate::abort_on_panic(|| {
-        let crate::css::style_value::StyleValueData::Calculated { rust_calculation, .. } =
-            (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
-        else {
-            unreachable!("rust_calc_root_from_calculated requires calculated value data");
-        };
-        rust_calculation.node()
-    })
+    let crate::css::style_value::StyleValueData::Calculated { rust_calculation, .. } =
+        (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
+    else {
+        unreachable!("rust_calc_root_from_calculated requires calculated value data");
+    };
+    rust_calculation.node()
 }
 
 /// # Safety
@@ -3484,47 +3456,45 @@ pub unsafe extern "C" fn rust_calc_resolve(
 ) -> FfiResolvedCalc {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
     use crate::css::style_value::StyleValueData;
-    crate::abort_on_panic(|| {
-        let StyleValueData::Calculated {
-            rust_calculation,
-            has_percentages_resolve_as,
-            resolve_as_is_number,
-            resolve_as_base,
-            resolve_numbers_as_integers,
-            accepted_ranges,
-            ..
-        } = (unsafe { &*(calculated as *const StyleValueData) })
-        else {
-            unreachable!("rust_calc_resolve requires calculated value data");
-        };
-        let context = unsafe { &*context };
-        let root = rust_calculation.node_arc();
+    let StyleValueData::Calculated {
+        rust_calculation,
+        has_percentages_resolve_as,
+        resolve_as_is_number,
+        resolve_as_base,
+        resolve_numbers_as_integers,
+        accepted_ranges,
+        ..
+    } = (unsafe { &*(calculated as *const StyleValueData) })
+    else {
+        unreachable!("rust_calc_resolve requires calculated value data");
+    };
+    let context = unsafe { &*context };
+    let root = rust_calculation.node_arc();
 
-        // The percentage leaf type and resolve-as target from the creation-time fields.
-        let resolve_as = resolve_as_from_fields(*has_percentages_resolve_as, *resolve_as_is_number, *resolve_as_base);
-        with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
-            // The calculation tree is again simplified at used value time.
-            let simplified = root.simplify(evaluation_context, callbacks);
-            match resolve_simplified_calculation(
-                &simplified,
-                evaluation_context,
-                resolve_as,
-                *resolve_numbers_as_integers,
-                accepted_ranges.as_slice(),
-                apply_censoring_and_clamping,
-            ) {
-                Some((value, numeric_type)) => FfiResolvedCalc {
-                    resolved: true,
-                    value,
-                    numeric_type: FfiNumericType::from_calc(numeric_type),
-                },
-                None => FfiResolvedCalc {
-                    resolved: false,
-                    value: 0.0,
-                    numeric_type: FfiNumericType::from_calc(None),
-                },
-            }
-        })
+    // The percentage leaf type and resolve-as target from the creation-time fields.
+    let resolve_as = resolve_as_from_fields(*has_percentages_resolve_as, *resolve_as_is_number, *resolve_as_base);
+    with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
+        // The calculation tree is again simplified at used value time.
+        let simplified = root.simplify(evaluation_context, callbacks);
+        match resolve_simplified_calculation(
+            &simplified,
+            evaluation_context,
+            resolve_as,
+            *resolve_numbers_as_integers,
+            accepted_ranges.as_slice(),
+            apply_censoring_and_clamping,
+        ) {
+            Some((value, numeric_type)) => FfiResolvedCalc {
+                resolved: true,
+                value,
+                numeric_type: FfiNumericType::from_calc(numeric_type),
+            },
+            None => FfiResolvedCalc {
+                resolved: false,
+                value: 0.0,
+                numeric_type: FfiNumericType::from_calc(None),
+            },
+        }
     })
 }
 
@@ -4550,18 +4520,15 @@ impl CalcNode {
 pub unsafe extern "C" fn rust_calc_equals(first: *const std::ffi::c_void, second: *const std::ffi::c_void) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
     use crate::css::style_value::StyleValueData;
-    crate::abort_on_panic(|| {
-        let tree_of = |data: *const std::ffi::c_void| {
-            let StyleValueData::Calculated { rust_calculation, .. } = (unsafe { &*(data as *const StyleValueData) })
-            else {
-                unreachable!("rust_calc_equals requires calculated value data");
-            };
-            rust_calculation.node_arc()
+    let tree_of = |data: *const std::ffi::c_void| {
+        let StyleValueData::Calculated { rust_calculation, .. } = (unsafe { &*(data as *const StyleValueData) }) else {
+            unreachable!("rust_calc_equals requires calculated value data");
         };
-        let first_tree = tree_of(first);
-        let second_tree = tree_of(second);
-        first_tree.structurally_equals(&second_tree)
-    })
+        rust_calculation.node_arc()
+    };
+    let first_tree = tree_of(first);
+    let second_tree = tree_of(second);
+    first_tree.structurally_equals(&second_tree)
 }
 
 /// Whether a calculated style value contains an anchor() function.
@@ -4571,14 +4538,12 @@ pub unsafe extern "C" fn rust_calc_equals(first: *const std::ffi::c_void, second
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_contains_anchor(calculated: *const std::ffi::c_void) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let crate::css::style_value::StyleValueData::Calculated { rust_calculation, .. } =
-            (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
-        else {
-            unreachable!("rust_calc_contains_anchor requires calculated value data");
-        };
-        rust_calculation.node().contains_anchor_function()
-    })
+    let crate::css::style_value::StyleValueData::Calculated { rust_calculation, .. } =
+        (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
+    else {
+        unreachable!("rust_calc_contains_anchor requires calculated value data");
+    };
+    rust_calculation.node().contains_anchor_function()
 }
 
 /// The node kind codes exposed to C++ in a stable documented order.
@@ -4702,57 +4667,55 @@ fn append_reification_node(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_describe_for_typed_om(calculated: *const std::ffi::c_void) -> FfiCalcReification {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let crate::css::style_value::StyleValueData::Calculated {
-            rust_calculation,
-            has_percentages_resolve_as,
-            resolve_as_is_number,
-            resolve_as_base,
-            ..
-        } = (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
-        else {
-            unreachable!("rust_calc_describe_for_typed_om requires calculated value data");
-        };
-        let percentage_leaf_type = percentage_leaf_type_for(resolve_as_from_fields(
-            *has_percentages_resolve_as,
-            *resolve_as_is_number,
-            *resolve_as_base,
-        ));
-        let mut nodes = Vec::new();
-        let mut children = Vec::new();
-        if append_reification_node(
-            rust_calculation.node(),
-            &percentage_leaf_type,
-            &mut nodes,
-            &mut children,
-        )
-        .is_none()
-        {
-            return FfiCalcReification {
-                nodes: std::ptr::null(),
-                node_count: 0,
-                children: std::ptr::null(),
-                child_count: 0,
-                storage: std::ptr::null_mut(),
-            };
-        }
-        let storage = Box::new(CalcReificationStorage {
-            nodes: nodes.into_boxed_slice(),
-            children: children.into_boxed_slice(),
-        });
-        let result = FfiCalcReification {
-            nodes: storage.nodes.as_ptr(),
-            node_count: storage.nodes.len(),
-            children: storage.children.as_ptr(),
-            child_count: storage.children.len(),
+    let crate::css::style_value::StyleValueData::Calculated {
+        rust_calculation,
+        has_percentages_resolve_as,
+        resolve_as_is_number,
+        resolve_as_base,
+        ..
+    } = (unsafe { &*(calculated as *const crate::css::style_value::StyleValueData) })
+    else {
+        unreachable!("rust_calc_describe_for_typed_om requires calculated value data");
+    };
+    let percentage_leaf_type = percentage_leaf_type_for(resolve_as_from_fields(
+        *has_percentages_resolve_as,
+        *resolve_as_is_number,
+        *resolve_as_base,
+    ));
+    let mut nodes = Vec::new();
+    let mut children = Vec::new();
+    if append_reification_node(
+        rust_calculation.node(),
+        &percentage_leaf_type,
+        &mut nodes,
+        &mut children,
+    )
+    .is_none()
+    {
+        return FfiCalcReification {
+            nodes: std::ptr::null(),
+            node_count: 0,
+            children: std::ptr::null(),
+            child_count: 0,
             storage: std::ptr::null_mut(),
         };
-        let storage = Box::into_raw(storage);
-        FfiCalcReification {
-            storage: storage.cast(),
-            ..result
-        }
-    })
+    }
+    let storage = Box::new(CalcReificationStorage {
+        nodes: nodes.into_boxed_slice(),
+        children: children.into_boxed_slice(),
+    });
+    let result = FfiCalcReification {
+        nodes: storage.nodes.as_ptr(),
+        node_count: storage.nodes.len(),
+        children: storage.children.as_ptr(),
+        child_count: storage.children.len(),
+        storage: std::ptr::null_mut(),
+    };
+    let storage = Box::into_raw(storage);
+    FfiCalcReification {
+        storage: storage.cast(),
+        ..result
+    }
 }
 
 /// # Safety
@@ -4773,11 +4736,11 @@ pub unsafe extern "C" fn rust_calc_reification_release(storage: *mut std::ffi::c
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_calc_node_style_value(node: *const CalcNode) -> *const std::ffi::c_void {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcNodeQueryEntry);
-    crate::abort_on_panic(|| match unsafe { &*node } {
+    match unsafe { &*node } {
         CalcNode::Random { sharing, .. } => sharing.data() as *const _ as *const _,
         CalcNode::NonMathFunction { value, .. } => value.data() as *const _ as *const _,
         _ => std::ptr::null(),
-    })
+    }
 }
 
 /// Simplifies a free-standing calculation tree: the css-values-4 algorithm
@@ -4799,14 +4762,12 @@ pub unsafe extern "C" fn rust_calc_simplify_tree(
     resolve_as_base: u8,
 ) -> *const CalcNode {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
-    crate::abort_on_panic(|| {
-        let context = unsafe { &*context };
-        unsafe { Arc::increment_strong_count(root) };
-        let root = unsafe { Arc::from_raw(root) };
-        let resolve_as = resolve_as_from_fields(has_percentages_resolve_as, resolve_as_is_number, resolve_as_base);
-        with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
-            Arc::into_raw(root.simplify(evaluation_context, callbacks))
-        })
+    let context = unsafe { &*context };
+    unsafe { Arc::increment_strong_count(root) };
+    let root = unsafe { Arc::from_raw(root) };
+    let resolve_as = resolve_as_from_fields(has_percentages_resolve_as, resolve_as_is_number, resolve_as_base);
+    with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
+        Arc::into_raw(root.simplify(evaluation_context, callbacks))
     })
 }
 
@@ -4837,52 +4798,50 @@ pub unsafe extern "C" fn rust_calc_absolutize(
 ) -> FfiAbsolutizedCalc {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CalcOperationEntry);
     use crate::css::style_value::StyleValueData;
-    crate::abort_on_panic(|| {
-        let StyleValueData::Calculated {
-            rust_calculation,
-            has_percentages_resolve_as,
-            resolve_as_is_number,
-            resolve_as_base,
-            resolve_numbers_as_integers,
-            accepted_ranges,
-            ..
-        } = (unsafe { &*(calculated as *const StyleValueData) })
-        else {
-            unreachable!("rust_calc_absolutize requires calculated value data");
-        };
-        let context = unsafe { &*context };
-        let root = rust_calculation.node_arc();
+    let StyleValueData::Calculated {
+        rust_calculation,
+        has_percentages_resolve_as,
+        resolve_as_is_number,
+        resolve_as_base,
+        resolve_numbers_as_integers,
+        accepted_ranges,
+        ..
+    } = (unsafe { &*(calculated as *const StyleValueData) })
+    else {
+        unreachable!("rust_calc_absolutize requires calculated value data");
+    };
+    let context = unsafe { &*context };
+    let root = rust_calculation.node_arc();
 
-        let resolve_as = resolve_as_from_fields(*has_percentages_resolve_as, *resolve_as_is_number, *resolve_as_base);
-        with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
-            let simplified = root.simplify(evaluation_context, callbacks);
+    let resolve_as = resolve_as_from_fields(*has_percentages_resolve_as, *resolve_as_is_number, *resolve_as_base);
+    with_ffi_evaluation(resolve_as, context, |evaluation_context, callbacks| {
+        let simplified = root.simplify(evaluation_context, callbacks);
 
-            if let Some(percentage) = percentage_dimension_mix(&simplified, evaluation_context) {
-                return FfiAbsolutizedCalc {
-                    is_percentage: true,
-                    percentage_value: percentage,
-                    collapsed: std::ptr::null(),
-                    simplified: std::ptr::null(),
-                };
-            }
+        if let Some(percentage) = percentage_dimension_mix(&simplified, evaluation_context) {
+            return FfiAbsolutizedCalc {
+                is_percentage: true,
+                percentage_value: percentage,
+                collapsed: std::ptr::null(),
+                simplified: std::ptr::null(),
+            };
+        }
 
-            if let Some(collapsed) =
-                collapse_absolutized_calculation(&simplified, *resolve_numbers_as_integers, accepted_ranges.as_slice())
-            {
-                return FfiAbsolutizedCalc {
-                    is_percentage: false,
-                    percentage_value: 0.0,
-                    collapsed: Arc::into_raw(Arc::new(collapsed)).cast(),
-                    simplified: std::ptr::null(),
-                };
-            }
-
-            FfiAbsolutizedCalc {
+        if let Some(collapsed) =
+            collapse_absolutized_calculation(&simplified, *resolve_numbers_as_integers, accepted_ranges.as_slice())
+        {
+            return FfiAbsolutizedCalc {
                 is_percentage: false,
                 percentage_value: 0.0,
-                collapsed: std::ptr::null(),
-                simplified: Arc::into_raw(simplified),
-            }
-        })
+                collapsed: Arc::into_raw(Arc::new(collapsed)).cast(),
+                simplified: std::ptr::null(),
+            };
+        }
+
+        FfiAbsolutizedCalc {
+            is_percentage: false,
+            percentage_value: 0.0,
+            collapsed: std::ptr::null(),
+            simplified: Arc::into_raw(simplified),
+        }
     })
 }

--- a/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/cascaded_properties.rs
@@ -19,7 +19,6 @@ use std::ffi::c_void;
 use std::hash::BuildHasherDefault;
 use std::hash::Hasher;
 
-use crate::abort_on_panic;
 use crate::css::custom_properties::CustomPropertyStore;
 use crate::css::ffi_support::FfiUtf16View;
 use crate::css::parser::query_parser::FfiMediaEnvironment;
@@ -448,16 +447,14 @@ impl CascadedPropertyStore {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_cascaded_properties_create() -> *mut CascadedPropertyStore {
-    abort_on_panic(|| {
-        // A store lives exactly as long as the computation of one element's style, and a style pass
-        // builds one per element. Recycling the emptied ones keeps the arena's capacity and the
-        // map's buckets, so only the first few elements of a pass allocate at all. The store itself
-        // is still created and destroyed as C++ asks, so nothing about its lifetime changes.
-        let store = STORE_POOL
-            .with_borrow_mut(Vec::pop)
-            .unwrap_or_else(CascadedPropertyStore::new);
-        Box::into_raw(Box::new(store))
-    })
+    // A store lives exactly as long as the computation of one element's style, and a style pass
+    // builds one per element. Recycling the emptied ones keeps the arena's capacity and the
+    // map's buckets, so only the first few elements of a pass allocate at all. The store itself
+    // is still created and destroyed as C++ asks, so nothing about its lifetime changes.
+    let store = STORE_POOL
+        .with_borrow_mut(Vec::pop)
+        .unwrap_or_else(CascadedPropertyStore::new);
+    Box::into_raw(Box::new(store))
 }
 
 thread_local! {
@@ -473,15 +470,13 @@ const STORE_POOL_CAPACITY: usize = 4;
 /// destroyed yet; no references into the store may outlive this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_cascaded_properties_destroy(store: *mut CascadedPropertyStore) {
-    abort_on_panic(|| {
-        let mut store = unsafe { Box::from_raw(store) };
-        STORE_POOL.with_borrow_mut(|pool| {
-            if pool.len() >= STORE_POOL_CAPACITY {
-                return;
-            }
-            store.reset();
-            pool.push(*store);
-        });
+    let mut store = unsafe { Box::from_raw(store) };
+    STORE_POOL.with_borrow_mut(|pool| {
+        if pool.len() >= STORE_POOL_CAPACITY {
+            return;
+        }
+        store.reset();
+        pool.push(*store);
     });
 }
 
@@ -495,10 +490,10 @@ pub unsafe extern "C" fn rust_cascaded_properties_property(
     property_id: u16,
 ) -> *const c_void {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| match unsafe { &*store }.last_entry(property_id) {
+    match unsafe { &*store }.last_entry(property_id) {
         Some(entry) => entry.value.pointer().cast(),
         None => std::ptr::null(),
-    })
+    }
 }
 
 /// Returns the winning declaration's source slot, or -1 when the property has no cascaded value.
@@ -511,10 +506,10 @@ pub unsafe extern "C" fn rust_cascaded_properties_source_slot(
     property_id: u16,
 ) -> i64 {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| match unsafe { &*store }.last_entry(property_id) {
+    match unsafe { &*store }.last_entry(property_id) {
         Some(entry) => entry.source_slot as i64,
         None => -1,
-    })
+    }
 }
 
 /// Returns whether the winning declaration's original C++ facade carried
@@ -528,11 +523,9 @@ pub unsafe extern "C" fn rust_cascaded_properties_has_style_sheet_context(
     property_id: u16,
 ) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadedStoreQueryEntry);
-    abort_on_panic(|| {
-        unsafe { &*store }
-            .last_entry(property_id)
-            .is_some_and(|entry| entry.has_style_sheet_context)
-    })
+    unsafe { &*store }
+        .last_entry(property_id)
+        .is_some_and(|entry| entry.has_style_sheet_context)
 }
 
 pub const CASCADED_ENVIRONMENT_NEEDS_DOCUMENT_BASE_URL: u8 = 1 << 0;
@@ -1793,83 +1786,80 @@ pub unsafe extern "C" fn rust_resolve_unresolved_style_values(
     finalizer_context: *mut c_void,
     finalize_component: Option<unsafe extern "C" fn(*mut c_void, *const u32, usize, *mut FfiResolvedStyleValue)>,
 ) -> FfiCustomPropertyResolutionStats {
-    crate::abort_on_panic(|| {
-        let resolution_context = unsafe { *resolution_context };
-        let inputs = if input_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(inputs, input_count) }
-        };
-        let outputs = if input_count == 0 {
-            &mut []
-        } else {
-            unsafe { std::slice::from_raw_parts_mut(outputs, input_count) }
-        };
-        let mut resolution_environment = unsafe {
-            crate::css::custom_properties::prepare_var_resolution_environment(
-                resolution_context.attributes,
-                resolution_context.attribute_count,
-                resolution_context.custom_functions,
-                resolution_context.custom_function_count,
-                resolution_context.custom_function_scope_identity,
-            )
-        };
-        let (components, cycle_participants, use_final_custom_properties) = if finalize_component.is_some() {
-            custom_property_components(inputs)
-        } else {
-            ((0..input_count as u32).map(|index| vec![index]).collect(), 0, false)
-        };
-        let mut final_custom_properties = HashMap::new();
-        for mut component in components {
-            component.sort_unstable();
-            for &member in &component {
-                let input = &inputs[member as usize];
-                if !input.resolve_substitutions {
-                    outputs[member as usize].data = unsafe {
-                        crate::css::style_value::retain_style_value(input.data.cast::<StyleValueData>()).cast()
-                    };
-                    continue;
-                }
-                let mut member_context = resolution_context;
-                member_context.root_custom_property_name = input.root_custom_property_name;
-                let resolved = resolve_cascade_value(
-                    &member_context,
-                    resolution_environment.as_mut(),
-                    0,
-                    input.property_id,
-                    input.data,
-                    false,
-                    use_final_custom_properties.then_some(&final_custom_properties),
+    let resolution_context = unsafe { *resolution_context };
+    let inputs = if input_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(inputs, input_count) }
+    };
+    let outputs = if input_count == 0 {
+        &mut []
+    } else {
+        unsafe { std::slice::from_raw_parts_mut(outputs, input_count) }
+    };
+    let mut resolution_environment = unsafe {
+        crate::css::custom_properties::prepare_var_resolution_environment(
+            resolution_context.attributes,
+            resolution_context.attribute_count,
+            resolution_context.custom_functions,
+            resolution_context.custom_function_count,
+            resolution_context.custom_function_scope_identity,
+        )
+    };
+    let (components, cycle_participants, use_final_custom_properties) = if finalize_component.is_some() {
+        custom_property_components(inputs)
+    } else {
+        ((0..input_count as u32).map(|index| vec![index]).collect(), 0, false)
+    };
+    let mut final_custom_properties = HashMap::new();
+    for mut component in components {
+        component.sort_unstable();
+        for &member in &component {
+            let input = &inputs[member as usize];
+            if !input.resolve_substitutions {
+                outputs[member as usize].data =
+                    unsafe { crate::css::style_value::retain_style_value(input.data.cast::<StyleValueData>()).cast() };
+                continue;
+            }
+            let mut member_context = resolution_context;
+            member_context.root_custom_property_name = input.root_custom_property_name;
+            let resolved = resolve_cascade_value(
+                &member_context,
+                resolution_environment.as_mut(),
+                0,
+                input.property_id,
+                input.data,
+                false,
+                use_final_custom_properties.then_some(&final_custom_properties),
+            );
+            outputs[member as usize].data = resolved.value.pointer().cast();
+            std::mem::forget(resolved.value);
+        }
+        if let Some(finalize_component) = finalize_component {
+            unsafe {
+                finalize_component(
+                    finalizer_context,
+                    component.as_ptr(),
+                    component.len(),
+                    outputs.as_mut_ptr(),
                 );
-                outputs[member as usize].data = resolved.value.pointer().cast();
-                std::mem::forget(resolved.value);
-            }
-            if let Some(finalize_component) = finalize_component {
-                unsafe {
-                    finalize_component(
-                        finalizer_context,
-                        component.as_ptr(),
-                        component.len(),
-                        outputs.as_mut_ptr(),
-                    );
-                };
-                for &member in &component {
-                    let name = unsafe { inputs[member as usize].root_custom_property_name.to_utf16() }
-                        .expect("custom-property resolution input name");
-                    final_custom_properties.insert(name, outputs[member as usize].data);
-                }
+            };
+            for &member in &component {
+                let name = unsafe { inputs[member as usize].root_custom_property_name.to_utf16() }
+                    .expect("custom-property resolution input name");
+                final_custom_properties.insert(name, outputs[member as usize].data);
             }
         }
-        FfiCustomPropertyResolutionStats {
-            final_value_hits: resolution_environment
-                .as_ref()
-                .map_or(0, |environment| environment.final_value_hits()),
-            final_value_misses: resolution_environment
-                .as_ref()
-                .map_or(0, |environment| environment.final_value_misses()),
-            cycle_participants,
-        }
-    })
+    }
+    FfiCustomPropertyResolutionStats {
+        final_value_hits: resolution_environment
+            .as_ref()
+            .map_or(0, |environment| environment.final_value_hits()),
+        final_value_misses: resolution_environment
+            .as_ref()
+            .map_or(0, |environment| environment.final_value_misses()),
+        cycle_participants,
+    }
 }
 
 /// Runs the longhand cascade for one element in css-cascade-5 origin order
@@ -1902,129 +1892,126 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
     resolution_context: *const FfiCascadeResolutionContext,
 ) -> FfiCascadeResult {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CascadeBulkEntry);
-    abort_on_panic(|| {
-        let store = unsafe { &mut *store };
-        let blocks = if block_count == 0 {
+    let store = unsafe { &mut *store };
+    let blocks = if block_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(blocks, block_count) }
+    };
+    let resolution_context = unsafe { &*resolution_context };
+
+    let (custom_properties_apply, custom_properties, mut unadopted_custom_property_store) = cascade_custom_properties(
+        blocks,
+        author_context_count,
+        pseudo_element,
+        resolution_context.custom_property_store,
+    );
+    let mut resolution_context = *resolution_context;
+    if custom_properties_apply {
+        resolution_context.custom_property_store = unsafe {
+            (resolution_context
+                .install_custom_properties
+                .expect("missing custom property installer"))(
+                resolution_context.callback_context,
+                custom_properties.as_ptr(),
+                custom_properties.len(),
+                &raw mut unadopted_custom_property_store,
+            )
+        };
+    }
+    if !unadopted_custom_property_store.is_null() {
+        drop(unsafe { std::sync::Arc::from_raw(unadopted_custom_property_store.cast::<CustomPropertyStore>()) });
+    }
+
+    let mut resolution_environment = None;
+
+    let application_order = cascade_application_order(blocks, author_context_count);
+    let has_pseudo_element = pseudo_element != NO_PSEUDO_ELEMENT;
+    let block_layer_names: Vec<Option<RetainedUtf16FlyString>> = blocks
+        .iter()
+        .map(|block| {
+            block
+                .has_layer_name
+                .then(|| unsafe { RetainedUtf16FlyString::from_leaked_raw(block.layer_name_raw) })
+        })
+        .collect();
+
+    let mut source_slot_assignments: Vec<FfiSourceSlotAssignment> = Vec::new();
+    let mut apply = |block_index: usize, important: bool, use_layer_name: bool| {
+        let block = &blocks[block_index];
+        let declarations = if block.declaration_count == 0 {
             &[]
         } else {
-            unsafe { std::slice::from_raw_parts(blocks, block_count) }
+            unsafe { std::slice::from_raw_parts(block.declarations, block.declaration_count) }
         };
-        let resolution_context = unsafe { &*resolution_context };
-
-        let (custom_properties_apply, custom_properties, mut unadopted_custom_property_store) =
-            cascade_custom_properties(
-                blocks,
-                author_context_count,
-                pseudo_element,
-                resolution_context.custom_property_store,
-            );
-        let mut resolution_context = *resolution_context;
-        if custom_properties_apply {
-            resolution_context.custom_property_store = unsafe {
-                (resolution_context
-                    .install_custom_properties
-                    .expect("missing custom property installer"))(
-                    resolution_context.callback_context,
-                    custom_properties.as_ptr(),
-                    custom_properties.len(),
-                    &raw mut unadopted_custom_property_store,
-                )
-            };
-        }
-        if !unadopted_custom_property_store.is_null() {
-            drop(unsafe { std::sync::Arc::from_raw(unadopted_custom_property_store.cast::<CustomPropertyStore>()) });
-        }
-
-        let mut resolution_environment = None;
-
-        let application_order = cascade_application_order(blocks, author_context_count);
-        let has_pseudo_element = pseudo_element != NO_PSEUDO_ELEMENT;
-        let block_layer_names: Vec<Option<RetainedUtf16FlyString>> = blocks
-            .iter()
-            .map(|block| {
-                block
-                    .has_layer_name
-                    .then(|| unsafe { RetainedUtf16FlyString::from_leaked_raw(block.layer_name_raw) })
-            })
-            .collect();
-
-        let mut source_slot_assignments: Vec<FfiSourceSlotAssignment> = Vec::new();
-        let mut apply = |block_index: usize, important: bool, use_layer_name: bool| {
-            let block = &blocks[block_index];
-            let declarations = if block.declaration_count == 0 {
-                &[]
+        let is_property_disallowed = |property_id: u16| -> bool {
+            if block.bypass_pseudo_element_property_whitelist || !has_pseudo_element {
+                return false;
+            }
+            !crate::css::property_metadata::pseudo_element_supports_property(pseudo_element, property_id)
+        };
+        apply_declaration_block(
+            store,
+            declarations,
+            important,
+            block.origin,
+            if use_layer_name {
+                block_layer_names[block_index].as_ref()
             } else {
-                unsafe { std::slice::from_raw_parts(block.declarations, block.declaration_count) }
-            };
-            let is_property_disallowed = |property_id: u16| -> bool {
-                if block.bypass_pseudo_element_property_whitelist || !has_pseudo_element {
-                    return false;
-                }
-                !crate::css::property_metadata::pseudo_element_supports_property(pseudo_element, property_id)
-            };
-            apply_declaration_block(
-                store,
-                declarations,
-                important,
-                block.origin,
-                if use_layer_name {
-                    block_layer_names[block_index].as_ref()
-                } else {
-                    None
-                },
-                block.source_shadow_root_identity,
-                unset_data,
-                &is_property_disallowed,
-                &mut |style_engine_rule_id, property_id, unresolved_data, has_style_sheet_context| {
-                    let resolution_environment = resolution_environment.get_or_insert_with(|| unsafe {
-                        crate::css::custom_properties::prepare_var_resolution_environment(
-                            resolution_context.attributes,
-                            resolution_context.attribute_count,
-                            resolution_context.custom_functions,
-                            resolution_context.custom_function_count,
-                            resolution_context.custom_function_scope_identity,
-                        )
-                    });
-                    resolve_cascade_value(
-                        &resolution_context,
-                        resolution_environment.as_mut(),
-                        style_engine_rule_id,
-                        property_id,
-                        unresolved_data,
-                        has_style_sheet_context,
-                        None,
+                None
+            },
+            block.source_shadow_root_identity,
+            unset_data,
+            &is_property_disallowed,
+            &mut |style_engine_rule_id, property_id, unresolved_data, has_style_sheet_context| {
+                let resolution_environment = resolution_environment.get_or_insert_with(|| unsafe {
+                    crate::css::custom_properties::prepare_var_resolution_environment(
+                        resolution_context.attributes,
+                        resolution_context.attribute_count,
+                        resolution_context.custom_functions,
+                        resolution_context.custom_function_count,
+                        resolution_context.custom_function_scope_identity,
                     )
-                },
-                block.style_engine_rule_id,
-                |slot| {
-                    source_slot_assignments.push(FfiSourceSlotAssignment {
-                        slot,
-                        source_id: block.source_id,
-                    });
-                },
-            );
+                });
+                resolve_cascade_value(
+                    &resolution_context,
+                    resolution_environment.as_mut(),
+                    style_engine_rule_id,
+                    property_id,
+                    unresolved_data,
+                    has_style_sheet_context,
+                    None,
+                )
+            },
+            block.style_engine_rule_id,
+            |slot| {
+                source_slot_assignments.push(FfiSourceSlotAssignment {
+                    slot,
+                    source_id: block.source_id,
+                });
+            },
+        );
+    };
+
+    for &(block_index, important, use_layer_name) in &application_order {
+        apply(block_index, important, use_layer_name);
+    }
+
+    if source_slot_assignments.is_empty() {
+        return FfiCascadeResult {
+            source_slot_assignments: std::ptr::null(),
+            source_slot_assignment_count: 0,
+            storage: std::ptr::null_mut(),
         };
-
-        for &(block_index, important, use_layer_name) in &application_order {
-            apply(block_index, important, use_layer_name);
-        }
-
-        if source_slot_assignments.is_empty() {
-            return FfiCascadeResult {
-                source_slot_assignments: std::ptr::null(),
-                source_slot_assignment_count: 0,
-                storage: std::ptr::null_mut(),
-            };
-        }
-        let source_slot_assignments = source_slot_assignments.into_boxed_slice();
-        let source_slot_assignment_count = source_slot_assignments.len();
-        let storage = Box::into_raw(source_slot_assignments);
-        FfiCascadeResult {
-            source_slot_assignments: storage.cast::<FfiSourceSlotAssignment>(),
-            source_slot_assignment_count,
-            storage: storage.cast(),
-        }
-    })
+    }
+    let source_slot_assignments = source_slot_assignments.into_boxed_slice();
+    let source_slot_assignment_count = source_slot_assignments.len();
+    let storage = Box::into_raw(source_slot_assignments);
+    FfiCascadeResult {
+        source_slot_assignments: storage.cast::<FfiSourceSlotAssignment>(),
+        source_slot_assignment_count,
+        storage: storage.cast(),
+    }
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/css/color_interpolation.rs
+++ b/Libraries/LibWeb/Rust/src/css/color_interpolation.rs
@@ -383,30 +383,28 @@ pub unsafe extern "C" fn rust_interpolate_color(
     delta: f32,
     alpha_multiplier: f32,
 ) -> *const StyleValueData {
-    crate::abort_on_panic(|| {
-        let (Some(from), Some(to), Some(method)) = (unsafe { from.as_ref() }, unsafe { to.as_ref() }, unsafe {
-            color_interpolation_method.as_ref()
-        }) else {
-            return std::ptr::null();
-        };
-        let StyleValueData::ColorInterpolationMethod {
-            is_polar,
-            color_space,
-            hue_interpolation_method,
-        } = method
-        else {
-            return std::ptr::null();
-        };
-        interpolate(
-            from,
-            to,
-            *is_polar,
-            *color_space,
-            *hue_interpolation_method,
-            delta,
-            alpha_multiplier,
-        )
-        .map(|result| Arc::into_raw(Arc::new(result)))
-        .unwrap_or(std::ptr::null())
-    })
+    let (Some(from), Some(to), Some(method)) = (unsafe { from.as_ref() }, unsafe { to.as_ref() }, unsafe {
+        color_interpolation_method.as_ref()
+    }) else {
+        return std::ptr::null();
+    };
+    let StyleValueData::ColorInterpolationMethod {
+        is_polar,
+        color_space,
+        hue_interpolation_method,
+    } = method
+    else {
+        return std::ptr::null();
+    };
+    interpolate(
+        from,
+        to,
+        *is_polar,
+        *color_space,
+        *hue_interpolation_method,
+        delta,
+        alpha_multiplier,
+    )
+    .map(|result| Arc::into_raw(Arc::new(result)))
+    .unwrap_or(std::ptr::null())
 }

--- a/Libraries/LibWeb/Rust/src/css/color_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/css/color_resolution.rs
@@ -2197,21 +2197,19 @@ pub unsafe extern "C" fn rust_style_value_to_color(
     input: *const FfiColorResolutionInput,
 ) -> FfiResolvedColorValue {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueQueryEntry);
-    crate::abort_on_panic(|| {
-        let value = unsafe { &*value.cast::<crate::css::style_value::StyleValueData>() };
-        let input = unsafe { &*input };
-        let channels = relative_color_context_from_ffi(input);
-        // SAFETY: The caller warrants the input's pointers outlive the call.
-        let resolution_input = unsafe { resolution_input_from_ffi(input, &channels) };
-        match to_color(value, &resolution_input) {
-            Some(color) => FfiResolvedColorValue {
-                resolved: true,
-                rgba: [color.r, color.g, color.b, color.a],
-            },
-            None => FfiResolvedColorValue {
-                resolved: false,
-                rgba: [0; 4],
-            },
-        }
-    })
+    let value = unsafe { &*value.cast::<crate::css::style_value::StyleValueData>() };
+    let input = unsafe { &*input };
+    let channels = relative_color_context_from_ffi(input);
+    // SAFETY: The caller warrants the input's pointers outlive the call.
+    let resolution_input = unsafe { resolution_input_from_ffi(input, &channels) };
+    match to_color(value, &resolution_input) {
+        Some(color) => FfiResolvedColorValue {
+            resolved: true,
+            rgba: [color.r, color.g, color.b, color.a],
+        },
+        None => FfiResolvedColorValue {
+            resolved: false,
+            rgba: [0; 4],
+        },
+    }
 }

--- a/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_longhand_table.rs
@@ -25,7 +25,6 @@
 use std::ffi::c_void;
 use std::sync::Arc;
 
-use crate::abort_on_panic;
 use crate::css::animated_overlay::AnimatedOverlay;
 use crate::css::animated_overlay::overlay_wins;
 use crate::css::property_metadata::{
@@ -669,7 +668,7 @@ impl ComputedLonghandTable {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_computed_longhand_table_create() -> *mut ComputedLonghandTable {
-    abort_on_panic(|| Arc::into_raw(Arc::new(ComputedLonghandTable::new())).cast_mut())
+    Arc::into_raw(Arc::new(ComputedLonghandTable::new())).cast_mut()
 }
 
 /// Takes one additional strong reference to a frozen table.
@@ -681,11 +680,9 @@ pub extern "C" fn rust_computed_longhand_table_create() -> *mut ComputedLonghand
 pub unsafe extern "C" fn rust_computed_longhand_table_retain(
     table: *const ComputedLonghandTable,
 ) -> *const ComputedLonghandTable {
-    abort_on_panic(|| {
-        debug_assert!(unsafe { &*table }.frozen, "only frozen tables are shared");
-        unsafe { Arc::increment_strong_count(table) };
-        table
-    })
+    debug_assert!(unsafe { &*table }.frozen, "only frozen tables are shared");
+    unsafe { Arc::increment_strong_count(table) };
+    table
 }
 
 /// Releases one strong reference.
@@ -695,7 +692,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_retain(
 /// no references into the table may outlive the final release.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_computed_longhand_table_release(table: *mut ComputedLonghandTable) {
-    abort_on_panic(|| unsafe { Arc::decrement_strong_count(table.cast_const()) });
+    unsafe { Arc::decrement_strong_count(table.cast_const()) };
 }
 
 /// Creates a frozen copy of `table` with every inherited longhand value taken
@@ -708,12 +705,10 @@ pub unsafe extern "C" fn rust_computed_longhand_table_create_with_inherited_valu
     table: *const ComputedLonghandTable,
     inherited_source: *const ComputedLonghandTable,
 ) -> *mut ComputedLonghandTable {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(
-            unsafe { &*table }.with_inherited_values_from(unsafe { &*inherited_source }),
-        ))
-        .cast_mut()
-    })
+    Arc::into_raw(Arc::new(
+        unsafe { &*table }.with_inherited_values_from(unsafe { &*inherited_source }),
+    ))
+    .cast_mut()
 }
 
 /// Stores one computed longhand, retaining `data`. `source_slot` is the
@@ -731,12 +726,10 @@ pub unsafe extern "C" fn rust_computed_longhand_table_set(
     data: *const c_void,
     source_slot: i64,
 ) {
-    abort_on_panic(|| {
-        let value = unsafe {
-            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(data.cast()))
-        };
-        unsafe { &mut *table }.set(property_id, value, source_slot);
-    });
+    let value = unsafe {
+        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(data.cast()))
+    };
+    unsafe { &mut *table }.set(property_id, value, source_slot);
 }
 
 /// Replaces the table's contents with `source`'s, for the C++ builder that
@@ -750,7 +743,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_copy_from(
     table: *mut ComputedLonghandTable,
     source: *const ComputedLonghandTable,
 ) {
-    abort_on_panic(|| unsafe { &mut *table }.copy_from(unsafe { &*source }));
+    unsafe { &mut *table }.copy_from(unsafe { &*source });
 }
 
 /// Replaces the table's values with a complete borrowed value span, retaining
@@ -767,10 +760,8 @@ pub unsafe extern "C" fn rust_computed_longhand_table_copy_from_values(
     values: *const *const c_void,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        let values = unsafe { std::slice::from_raw_parts(values, count) };
-        unsafe { &mut *table }.copy_from_values(values);
-    });
+    let values = unsafe { std::slice::from_raw_parts(values, count) };
+    unsafe { &mut *table }.copy_from_values(values);
 }
 
 /// Returns the table's value span: one borrowed data pointer per longhand,
@@ -783,11 +774,9 @@ pub unsafe extern "C" fn rust_computed_longhand_table_copy_from_values(
 pub unsafe extern "C" fn rust_computed_longhand_table_values(
     table: *const ComputedLonghandTable,
 ) -> *const *const c_void {
-    abort_on_panic(|| {
-        let table = unsafe { &*table };
-        debug_assert!(table.frozen, "only frozen tables hand out their value span");
-        table.value_view.as_ptr()
-    })
+    let table = unsafe { &*table };
+    debug_assert!(table.frozen, "only frozen tables hand out their value span");
+    table.value_view.as_ptr()
 }
 
 /// Whether two frozen tables have equal values and publication metadata.
@@ -799,7 +788,7 @@ pub unsafe extern "C" fn rust_computed_longhand_tables_equal_for_publication(
     first: *const ComputedLonghandTable,
     second: *const ComputedLonghandTable,
 ) -> bool {
-    abort_on_panic(|| unsafe { &*first }.publication_equals(unsafe { &*second }))
+    unsafe { &*first }.publication_equals(unsafe { &*second })
 }
 
 /// Makes the table immutable; every later store aborts. Only a frozen table
@@ -809,7 +798,7 @@ pub unsafe extern "C" fn rust_computed_longhand_tables_equal_for_publication(
 /// `table` must be a valid, uniquely owned table.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_computed_longhand_table_freeze(table: *mut ComputedLonghandTable) {
-    abort_on_panic(|| unsafe { &mut *table }.freeze());
+    unsafe { &mut *table }.freeze();
 }
 
 /// Returns the retained raw cascaded font-size data, or null when none won.
@@ -820,7 +809,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_freeze(table: *mut Compute
 pub unsafe extern "C" fn rust_computed_longhand_table_raw_cascaded_font_size(
     table: *const ComputedLonghandTable,
 ) -> *const c_void {
-    abort_on_panic(|| unsafe { &*table }.raw_cascaded_font_size())
+    unsafe { &*table }.raw_cascaded_font_size()
 }
 
 /// Replaces the retained raw cascaded font-size data.
@@ -833,12 +822,10 @@ pub unsafe extern "C" fn rust_computed_longhand_table_set_raw_cascaded_font_size
     table: *mut ComputedLonghandTable,
     data: *const c_void,
 ) {
-    abort_on_panic(|| {
-        let value = (!data.is_null()).then(|| unsafe {
-            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(data.cast()))
-        });
-        unsafe { &mut *table }.set_raw_cascaded_font_size(value);
+    let value = (!data.is_null()).then(|| unsafe {
+        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(data.cast()))
     });
+    unsafe { &mut *table }.set_raw_cascaded_font_size(value);
 }
 
 /// Returns the longhand's recorded cascade source slot, or -1 when its value
@@ -851,10 +838,10 @@ pub unsafe extern "C" fn rust_computed_longhand_table_source_slot(
     table: *const ComputedLonghandTable,
     property_id: u16,
 ) -> i64 {
-    abort_on_panic(|| match unsafe { &*table }.source_slot(property_id) {
+    match unsafe { &*table }.source_slot(property_id) {
         Some(slot) => i64::from(slot),
         None => -1,
-    })
+    }
 }
 
 /// Marks a longhand's stored value `!important` (or not).
@@ -867,7 +854,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_set_important(
     property_id: u16,
     important: bool,
 ) {
-    abort_on_panic(|| unsafe { &mut *table }.set_important(property_id, important));
+    unsafe { &mut *table }.set_important(property_id, important);
 }
 
 /// Marks a longhand's computed value as taken by inheritance (or not).
@@ -880,7 +867,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_set_inherited(
     property_id: u16,
     inherited: bool,
 ) {
-    abort_on_panic(|| unsafe { &mut *table }.set_inherited(property_id, inherited));
+    unsafe { &mut *table }.set_inherited(property_id, inherited);
 }
 
 /// # Safety
@@ -890,7 +877,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_is_important(
     table: *const ComputedLonghandTable,
     property_id: u16,
 ) -> bool {
-    abort_on_panic(|| unsafe { &*table }.is_important(property_id))
+    unsafe { &*table }.is_important(property_id)
 }
 
 /// # Safety
@@ -900,7 +887,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_is_inherited(
     table: *const ComputedLonghandTable,
     property_id: u16,
 ) -> bool {
-    abort_on_panic(|| unsafe { &*table }.is_inherited(property_id))
+    unsafe { &*table }.is_inherited(property_id)
 }
 
 /// The importance bitmap, in the C++ `FixedBitmap` byte layout. The pointer
@@ -912,7 +899,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_is_inherited(
 pub unsafe extern "C" fn rust_computed_longhand_table_importance_bits(
     table: *const ComputedLonghandTable,
 ) -> *const u8 {
-    abort_on_panic(|| unsafe { &*table }.important_bits.as_ptr())
+    unsafe { &*table }.important_bits.as_ptr()
 }
 
 /// The inheritance bitmap, in the C++ `FixedBitmap` byte layout.
@@ -923,7 +910,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_importance_bits(
 pub unsafe extern "C" fn rust_computed_longhand_table_inheritance_bits(
     table: *const ComputedLonghandTable,
 ) -> *const u8 {
-    abort_on_panic(|| unsafe { &*table }.inherited_bits.as_ptr())
+    unsafe { &*table }.inherited_bits.as_ptr()
 }
 
 /// Replaces the whole importance and inheritance bitmaps, for the builder
@@ -940,13 +927,11 @@ pub unsafe extern "C" fn rust_computed_longhand_table_load_flag_bitmaps(
     inheritance: *const u8,
     inheritance_count: usize,
 ) {
-    abort_on_panic(|| {
-        let table = unsafe { &mut *table };
-        table.load_flag_bitmaps(
-            unsafe { std::slice::from_raw_parts(importance, importance_count) },
-            unsafe { std::slice::from_raw_parts(inheritance, inheritance_count) },
-        );
-    });
+    let table = unsafe { &mut *table };
+    table.load_flag_bitmaps(
+        unsafe { std::slice::from_raw_parts(importance, importance_count) },
+        unsafe { std::slice::from_raw_parts(inheritance, inheritance_count) },
+    );
 }
 
 /// Resets the state a fresh drive must not inherit from the style its table
@@ -957,7 +942,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_load_flag_bitmaps(
 /// `table` must be a valid, unfrozen, uniquely owned table.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_computed_longhand_table_clear_seeded_state(table: *mut ComputedLonghandTable) {
-    abort_on_panic(|| unsafe { &mut *table }.clear_seeded_state());
+    unsafe { &mut *table }.clear_seeded_state();
 }
 
 /// Records (or replaces) a longhand's inheritance-dependent specified value,
@@ -972,12 +957,10 @@ pub unsafe extern "C" fn rust_computed_longhand_table_add_inheritance_dependent_
     property_id: u16,
     value: *const c_void,
 ) {
-    abort_on_panic(|| {
-        let value = unsafe {
-            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
-        };
-        unsafe { &mut *table }.add_inheritance_dependent_value(property_id, value);
-    });
+    let value = unsafe {
+        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(value.cast()))
+    };
+    unsafe { &mut *table }.add_inheritance_dependent_value(property_id, value);
 }
 
 /// # Safety
@@ -987,7 +970,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_remove_inheritance_depende
     table: *mut ComputedLonghandTable,
     property_id: u16,
 ) {
-    abort_on_panic(|| unsafe { &mut *table }.remove_inheritance_dependent_value(property_id));
+    unsafe { &mut *table }.remove_inheritance_dependent_value(property_id);
 }
 
 /// Returns the non-longhand computation state stored alongside the table.
@@ -999,7 +982,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_remove_inheritance_depende
 pub unsafe extern "C" fn rust_computed_longhand_table_metadata(
     table: *mut ComputedLonghandTable,
 ) -> *mut FfiComputedStyleMetadata {
-    abort_on_panic(|| &raw mut unsafe { &mut *table }.metadata)
+    &raw mut unsafe { &mut *table }.metadata
 }
 
 /// The recorded inheritance-dependent specified values as a borrowed span.
@@ -1013,11 +996,9 @@ pub unsafe extern "C" fn rust_computed_longhand_table_inheritance_dependent_valu
     table: *const ComputedLonghandTable,
     out_count: *mut usize,
 ) -> *const FfiTableInheritanceDependentValue {
-    abort_on_panic(|| {
-        let table = unsafe { &*table };
-        unsafe { *out_count = table.inheritance_dependent_view.len() };
-        table.inheritance_dependent_view.as_ptr()
-    })
+    let table = unsafe { &*table };
+    unsafe { *out_count = table.inheritance_dependent_view.len() };
+    table.inheritance_dependent_view.as_ptr()
 }
 
 /// The effective value for one longhand: the animated overlay under the
@@ -1034,7 +1015,7 @@ pub unsafe extern "C" fn rust_computed_longhand_table_effective_value(
     property_id: u16,
     with_animations: bool,
 ) -> FfiEffectiveLonghandValue {
-    abort_on_panic(|| unsafe { &*table }.effective_value(unsafe { overlay.as_ref() }, property_id, with_animations))
+    unsafe { &*table }.effective_value(unsafe { overlay.as_ref() }, property_id, with_animations)
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -1440,7 +1440,7 @@ pub unsafe extern "C" fn rust_style_group_registry_register(
     count: usize,
     out_default_payloads: *mut *const c_void,
 ) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         let tables: Box<[StyleGroupVTable]> = std::slice::from_raw_parts(vtables, count).into();
         let mut defaults = Vec::with_capacity(count);
         for (index, table) in tables.iter().enumerate() {
@@ -1465,7 +1465,7 @@ pub unsafe extern "C" fn rust_style_group_registry_register(
                 .is_ok(),
             "style group registry registered twice"
         );
-    });
+    };
 }
 
 /// Allocates a new payload for `group_index` with a reference count of one,
@@ -1476,12 +1476,12 @@ pub unsafe extern "C" fn rust_style_group_registry_register(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_group_clone(group_index: usize, source: *const c_void) -> *mut c_void {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleGroupCloneEntry);
-    abort_on_panic(|| unsafe {
+    unsafe {
         let table = vtable(group_index);
         let payload = allocate_payload(table, 1);
         copy_construct(table, payload, source);
         payload
-    })
+    }
 }
 
 /// Retains one reference to each style-group payload in `payloads`.
@@ -1491,14 +1491,14 @@ pub unsafe extern "C" fn rust_style_group_clone(group_index: usize, source: *con
 /// order.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_groups_retain(payloads: *const *const c_void, group_count: usize) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         assert!(!payloads.is_null(), "style group payload array is null");
         for group_index in 0..group_count {
             let payload = *payloads.add(group_index);
             assert!(!payload.is_null(), "style group payload is null");
             retain_group_payload(group_index, payload);
         }
-    });
+    };
 }
 
 /// Releases one reference to each style-group payload in `payloads`.
@@ -1508,14 +1508,14 @@ pub unsafe extern "C" fn rust_style_groups_retain(payloads: *const *const c_void
 /// order, each with an outstanding reference.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_groups_release(payloads: *const *const c_void, group_count: usize) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         assert!(!payloads.is_null(), "style group payload array is null");
         for group_index in 0..group_count {
             let payload = *payloads.add(group_index);
             assert!(!payload.is_null(), "style group payload is null");
             release_group_payload(group_index, payload);
         }
-    });
+    };
 }
 
 /// Destroys and deallocates a payload whose reference count has reached zero.
@@ -1526,13 +1526,13 @@ pub unsafe extern "C" fn rust_style_groups_release(payloads: *const *const c_voi
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_group_free(group_index: usize, payload: *mut c_void) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleGroupFreeEntry);
-    abort_on_panic(|| unsafe {
+    unsafe {
         let table = vtable(group_index);
         debug_assert!(refcount_of(payload, payload_align(table)).load(Ordering::Relaxed) == 0);
         destruct(table, payload);
         let allocation = (payload as *mut u8).sub(header_size(payload_align(table)));
         dealloc(allocation, allocation_layout(table));
-    });
+    };
 }
 
 pub(crate) fn release_group_payload(group_index: usize, payload: *const c_void) {
@@ -1567,7 +1567,7 @@ pub unsafe extern "C" fn rust_style_group_payloads_equal(
     a: *const c_void,
     b: *const c_void,
 ) -> bool {
-    abort_on_panic(|| style_group_payloads_equal(group_index, a, b))
+    style_group_payloads_equal(group_index, a, b)
 }
 
 /// One field of a style group the generic builder can populate or check: a
@@ -1723,37 +1723,35 @@ pub unsafe extern "C" fn rust_style_group_register_field_descriptors(
     descriptors: *const FfiGroupFieldDescriptor,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        let slice = unsafe { std::slice::from_raw_parts(descriptors, count) };
-        let copied: Box<[FfiGroupFieldDescriptor]> = slice
-            .iter()
-            .map(|descriptor| FfiGroupFieldDescriptor { ..*descriptor })
-            .collect();
-        let group_count = copied
-            .iter()
-            .map(|descriptor| descriptor.group_index as usize + 1)
-            .max()
-            .unwrap_or(0);
-        let mut group_ranges = vec![0..0; group_count];
-        for (index, descriptor) in copied.iter().enumerate() {
-            let range = &mut group_ranges[descriptor.group_index as usize];
-            if range.start == range.end {
-                *range = index..index + 1;
-            } else {
-                assert_eq!(range.end, index, "a group's field descriptors must be contiguous");
-                range.end += 1;
-            }
+    let slice = unsafe { std::slice::from_raw_parts(descriptors, count) };
+    let copied: Box<[FfiGroupFieldDescriptor]> = slice
+        .iter()
+        .map(|descriptor| FfiGroupFieldDescriptor { ..*descriptor })
+        .collect();
+    let group_count = copied
+        .iter()
+        .map(|descriptor| descriptor.group_index as usize + 1)
+        .max()
+        .unwrap_or(0);
+    let mut group_ranges = vec![0..0; group_count];
+    for (index, descriptor) in copied.iter().enumerate() {
+        let range = &mut group_ranges[descriptor.group_index as usize];
+        if range.start == range.end {
+            *range = index..index + 1;
+        } else {
+            assert_eq!(range.end, index, "a group's field descriptors must be contiguous");
+            range.end += 1;
         }
-        assert!(
-            FIELD_DESCRIPTORS
-                .set(FieldDescriptors {
-                    entries: copied,
-                    group_ranges: group_ranges.into_boxed_slice(),
-                })
-                .is_ok(),
-            "field descriptors installed twice"
-        );
-    });
+    }
+    assert!(
+        FIELD_DESCRIPTORS
+            .set(FieldDescriptors {
+                entries: copied,
+                group_ranges: group_ranges.into_boxed_slice(),
+            })
+            .is_ok(),
+        "field descriptors installed twice"
+    );
 }
 
 /// Installs the dependency closure from longhand winners to computed style groups.
@@ -1767,20 +1765,18 @@ pub unsafe extern "C" fn rust_style_group_register_property_dependency_masks(
     output_masks: *const u32,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        let masks = unsafe { std::slice::from_raw_parts(masks, count) };
-        let output_masks = unsafe { std::slice::from_raw_parts(output_masks, count) };
-        assert!(
-            PROPERTY_DEPENDENCY_MASKS
-                .set(PropertyDependencyMasks {
-                    first_property,
-                    masks: masks.into(),
-                    output_masks: output_masks.into(),
-                })
-                .is_ok(),
-            "property dependency masks installed twice"
-        );
-    });
+    let masks = unsafe { std::slice::from_raw_parts(masks, count) };
+    let output_masks = unsafe { std::slice::from_raw_parts(output_masks, count) };
+    assert!(
+        PROPERTY_DEPENDENCY_MASKS
+            .set(PropertyDependencyMasks {
+                first_property,
+                masks: masks.into(),
+                output_masks: output_masks.into(),
+            })
+            .is_ok(),
+        "property dependency masks installed twice"
+    );
 }
 
 /// One decoded write into a scratch payload.
@@ -2086,7 +2082,7 @@ pub unsafe extern "C" fn rust_build_style_group(
     count: usize,
     parent_payload: *const c_void,
 ) -> *const c_void {
-    abort_on_panic(|| {
+    let build_or_reuse_group_payload = || {
         let descriptors = registered_group_field_descriptors(group_index)?;
         if descriptors.len() != count {
             return None;
@@ -2127,8 +2123,8 @@ pub unsafe extern "C" fn rust_build_style_group(
             return Some(default_payload);
         }
         Some(scratch as *const c_void)
-    })
-    .unwrap_or(std::ptr::null())
+    };
+    build_or_reuse_group_payload().unwrap_or(std::ptr::null())
 }
 
 /// Shares one group's immortal default payload - or the parent payload when
@@ -2214,45 +2210,41 @@ pub unsafe extern "C" fn rust_build_inherited_box_group(
 ) -> *const c_void {
     use crate::css::style_value::StyleValueData;
 
-    abort_on_panic(|| {
-        let keyword_code = |data: *const c_void, map: fn(u16) -> Option<u8>| -> u8 {
-            match unsafe { (data as *const StyleValueData).as_ref() } {
-                Some(StyleValueData::Keyword { keyword }) => {
-                    map(*keyword).expect("computed keyword has a supported value")
-                }
-                _ => panic!("computed inherited box value is not a keyword"),
-            }
-        };
-        let built = InheritedBoxValues {
-            visibility: keyword_code(visibility, crate::css::style_compute::keyword_to_visibility),
-            direction: keyword_code(direction, crate::css::style_compute::keyword_to_direction),
-            writing_mode: keyword_code(writing_mode, crate::css::style_compute::keyword_to_writing_mode),
-            content_visibility: keyword_code(
-                content_visibility,
-                crate::css::style_compute::keyword_to_content_visibility,
-            ),
-            image_rendering: keyword_code(image_rendering, crate::css::style_compute::keyword_to_image_rendering),
-        };
-
-        if !parent_payload.is_null() {
-            // SAFETY: The caller guarantees a valid inherited box payload.
-            if built == unsafe { *(parent_payload as *const InheritedBoxValues) } {
-                retain_group_payload(group_index, parent_payload);
-                return parent_payload;
-            }
+    let keyword_code = |data: *const c_void, map: fn(u16) -> Option<u8>| -> u8 {
+        match unsafe { (data as *const StyleValueData).as_ref() } {
+            Some(StyleValueData::Keyword { keyword }) => map(*keyword).expect("computed keyword has a supported value"),
+            _ => panic!("computed inherited box value is not a keyword"),
         }
+    };
+    let built = InheritedBoxValues {
+        visibility: keyword_code(visibility, crate::css::style_compute::keyword_to_visibility),
+        direction: keyword_code(direction, crate::css::style_compute::keyword_to_direction),
+        writing_mode: keyword_code(writing_mode, crate::css::style_compute::keyword_to_writing_mode),
+        content_visibility: keyword_code(
+            content_visibility,
+            crate::css::style_compute::keyword_to_content_visibility,
+        ),
+        image_rendering: keyword_code(image_rendering, crate::css::style_compute::keyword_to_image_rendering),
+    };
 
-        let default_payload = default_group_payload(group_index);
-        // SAFETY: The default payload is a valid inherited box payload.
-        if built == unsafe { *(default_payload as *const InheritedBoxValues) } {
-            return default_payload;
+    if !parent_payload.is_null() {
+        // SAFETY: The caller guarantees a valid inherited box payload.
+        if built == unsafe { *(parent_payload as *const InheritedBoxValues) } {
+            retain_group_payload(group_index, parent_payload);
+            return parent_payload;
         }
+    }
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        // SAFETY: The payload was allocated for this group's layout.
-        unsafe { *(payload as *mut InheritedBoxValues) = built };
-        payload as *const c_void
-    })
+    let default_payload = default_group_payload(group_index);
+    // SAFETY: The default payload is a valid inherited box payload.
+    if built == unsafe { *(default_payload as *const InheritedBoxValues) } {
+        return default_payload;
+    }
+
+    let payload = allocate_payload(vtable(group_index), 1);
+    // SAFETY: The payload was allocated for this group's layout.
+    unsafe { *(payload as *mut InheritedBoxValues) = built };
+    payload as *const c_void
 }
 
 impl ComputedSize {
@@ -3123,7 +3115,7 @@ pub unsafe extern "C" fn rust_build_alignment_group(
 ) -> *const c_void {
     use crate::css::style_value::StyleValueData;
 
-    abort_on_panic(|| {
+    let build_or_reuse_group_payload = || {
         let keyword_code = |data: *const c_void, map: fn(u16) -> Option<u8>| -> Option<u8> {
             match unsafe { data.cast::<StyleValueData>().as_ref() } {
                 Some(StyleValueData::Keyword { keyword }) => map(*keyword),
@@ -3159,8 +3151,8 @@ pub unsafe extern "C" fn rust_build_alignment_group(
         let payload = allocate_payload(vtable(group_index), 1);
         unsafe { payload.cast::<AlignmentValues>().write(built) };
         Some(payload.cast_const())
-    })
-    .unwrap_or(std::ptr::null())
+    };
+    build_or_reuse_group_payload().unwrap_or(std::ptr::null())
 }
 
 /// Interns a complete non-inherited SVG geometry and painting group.
@@ -3212,40 +3204,38 @@ pub unsafe extern "C" fn rust_build_text_reset_group(
     white_space_trim_discard_inner: bool,
     parent_payload: *const c_void,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let lines = if text_decoration_line_count == 0 {
-            &[]
+    let lines = if text_decoration_line_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(text_decoration_lines, text_decoration_line_count) }
+    };
+    let built = TextResetValues {
+        text_decoration_lines: RetainedTextDecorationLineList::from_vec(lines.to_vec()),
+        text_decoration_thickness_kind,
+        text_decoration_thickness: if text_decoration_thickness_kind == 2 {
+            ComputedStyleValueHandle::retained(text_decoration_thickness.cast())
         } else {
-            unsafe { std::slice::from_raw_parts(text_decoration_lines, text_decoration_line_count) }
-        };
-        let built = TextResetValues {
-            text_decoration_lines: RetainedTextDecorationLineList::from_vec(lines.to_vec()),
-            text_decoration_thickness_kind,
-            text_decoration_thickness: if text_decoration_thickness_kind == 2 {
-                ComputedStyleValueHandle::retained(text_decoration_thickness.cast())
-            } else {
-                ComputedStyleValueHandle::empty()
-            },
-            text_decoration_style,
-            text_decoration_color,
-            white_space_trim_discard_before,
-            white_space_trim_discard_after,
-            white_space_trim_discard_inner,
-        };
+            ComputedStyleValueHandle::empty()
+        },
+        text_decoration_style,
+        text_decoration_color,
+        white_space_trim_discard_before,
+        white_space_trim_discard_after,
+        white_space_trim_discard_inner,
+    };
 
-        if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<TextResetValues>() }) {
-            retain_group_payload(group_index, parent_payload);
-            return parent_payload;
-        }
-        let default_payload = default_group_payload(group_index);
-        if built.eq(unsafe { &*default_payload.cast::<TextResetValues>() }) {
-            return default_payload;
-        }
+    if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<TextResetValues>() }) {
+        retain_group_payload(group_index, parent_payload);
+        return parent_payload;
+    }
+    let default_payload = default_group_payload(group_index);
+    if built.eq(unsafe { &*default_payload.cast::<TextResetValues>() }) {
+        return default_payload;
+    }
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        unsafe { payload.cast::<TextResetValues>().write(built) };
-        payload.cast_const()
-    })
+    let payload = allocate_payload(vtable(group_index), 1);
+    unsafe { payload.cast::<TextResetValues>().write(built) };
+    payload.cast_const()
 }
 
 /// # Safety
@@ -3257,14 +3247,12 @@ pub unsafe extern "C" fn rust_text_reset_set_decoration_lines(
     lines: *const u8,
     line_count: usize,
 ) {
-    abort_on_panic(|| {
-        let lines = if line_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(lines, line_count) }
-        };
-        unsafe { (*target).text_decoration_lines = RetainedTextDecorationLineList::from_vec(lines.to_vec()) };
-    });
+    let lines = if line_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(lines, line_count) }
+    };
+    unsafe { (*target).text_decoration_lines = RetainedTextDecorationLineList::from_vec(lines.to_vec()) };
 }
 
 /// # Safety
@@ -3276,14 +3264,14 @@ pub unsafe extern "C" fn rust_text_reset_set_decoration_thickness(
     kind: u8,
     value: *const c_void,
 ) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         (*target).text_decoration_thickness_kind = kind;
         (*target).text_decoration_thickness = if kind == 2 {
             ComputedStyleValueHandle { pointer: value }
         } else {
             ComputedStyleValueHandle::empty()
         };
-    });
+    };
 }
 
 /// Builds the complete surround group from the physical inset, margin, and
@@ -3314,7 +3302,7 @@ pub unsafe extern "C" fn rust_build_surround_group(
 ) -> *const c_void {
     use crate::css::style_value::StyleValueData;
 
-    abort_on_panic(|| {
+    let build_or_reuse_group_payload = || {
         let anchor = |data: *const c_void| {
             let data = data.cast::<StyleValueData>();
             if matches!(unsafe { data.as_ref() }, Some(StyleValueData::Anchor { .. })) {
@@ -3371,8 +3359,8 @@ pub unsafe extern "C" fn rust_build_surround_group(
         let payload = allocate_payload(vtable(group_index), 1);
         unsafe { payload.cast::<SurroundValues>().write(built) };
         Some(payload.cast_const())
-    })
-    .unwrap_or(std::ptr::null())
+    };
+    build_or_reuse_group_payload().unwrap_or(std::ptr::null())
 }
 
 /// Replaces the position-anchor style value retained for Rust layout.
@@ -3382,7 +3370,7 @@ pub unsafe extern "C" fn rust_build_surround_group(
 /// transfer one leaked fly-string reference when nonzero.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_surround_set_position_anchor(target: *mut SurroundValues, name_raw: usize) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         (*target).position_anchor = if name_raw == 0 {
             ComputedStyleValueHandle::empty()
         } else {
@@ -3390,7 +3378,7 @@ pub unsafe extern "C" fn rust_surround_set_position_anchor(target: *mut Surround
                 pointer: crate::css::style_value::rust_style_value_create_custom_ident(name_raw).cast(),
             }
         };
-    });
+    };
 }
 
 /// Replaces the position-anchor value in a uniquely owned anchor payload.
@@ -3404,10 +3392,10 @@ pub unsafe extern "C" fn rust_anchor_set_position_anchor(
     position_anchor_type: u8,
     name_raw: usize,
 ) {
-    abort_on_panic(|| unsafe {
+    unsafe {
         (*target).position_anchor_type = position_anchor_type;
         (*target).position_anchor_name = RetainedUtf16FlyString::from_leaked_raw(name_raw);
-    });
+    };
 }
 
 /// Builds the box group from a fully materialized payload value. C++ resolves
@@ -3430,22 +3418,20 @@ pub unsafe extern "C" fn rust_build_box_group(
     values: *const BoxValues,
     parent_payload: *const c_void,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let built = unsafe { values.read() };
+    let built = unsafe { values.read() };
 
-        if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<BoxValues>() }) {
-            retain_group_payload(group_index, parent_payload);
-            return parent_payload;
-        }
-        let default_payload = default_group_payload(group_index);
-        if built.eq(unsafe { &*default_payload.cast::<BoxValues>() }) {
-            return default_payload;
-        }
+    if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<BoxValues>() }) {
+        retain_group_payload(group_index, parent_payload);
+        return parent_payload;
+    }
+    let default_payload = default_group_payload(group_index);
+    if built.eq(unsafe { &*default_payload.cast::<BoxValues>() }) {
+        return default_payload;
+    }
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        unsafe { payload.cast::<BoxValues>().write(built) };
-        payload.cast_const()
-    })
+    let payload = allocate_payload(vtable(group_index), 1);
+    unsafe { payload.cast::<BoxValues>().write(built) };
+    payload.cast_const()
 }
 
 /// # Safety
@@ -3458,22 +3444,20 @@ pub unsafe extern "C" fn rust_build_grid_group(
     values: *const GridValues,
     parent_payload: *const c_void,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let built = unsafe { values.read() };
+    let built = unsafe { values.read() };
 
-        if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<GridValues>() }) {
-            retain_group_payload(group_index, parent_payload);
-            return parent_payload;
-        }
-        let default_payload = default_group_payload(group_index);
-        if built.eq(unsafe { &*default_payload.cast::<GridValues>() }) {
-            return default_payload;
-        }
+    if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<GridValues>() }) {
+        retain_group_payload(group_index, parent_payload);
+        return parent_payload;
+    }
+    let default_payload = default_group_payload(group_index);
+    if built.eq(unsafe { &*default_payload.cast::<GridValues>() }) {
+        return default_payload;
+    }
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        unsafe { payload.cast::<GridValues>().write(built) };
-        payload.cast_const()
-    })
+    let payload = allocate_payload(vtable(group_index), 1);
+    unsafe { payload.cast::<GridValues>().write(built) };
+    payload.cast_const()
 }
 
 /// # Safety
@@ -3481,37 +3465,35 @@ pub unsafe extern "C" fn rust_build_grid_group(
 /// group value.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_grid_values_copy_placements(source: *const GridValues, target: *mut GridValues) {
-    abort_on_panic(|| {
-        // SAFETY: The caller passes a valid source payload and a uniquely
-        // owned target value.
-        let (source, target) = unsafe { (&*source, &mut *target) };
-        let mut remapped = |placement: ComputedGridPlacement| {
-            let mut remap_index = |index: u32| {
-                if index == GRID_NO_INDEX {
-                    return GRID_NO_INDEX;
-                }
-                target.intern_name(&source.names.as_slice()[index as usize])
-            };
-            ComputedGridPlacement {
-                name_index: remap_index(placement.name_index),
-                implicit_start_name_index: remap_index(placement.implicit_start_name_index),
-                implicit_end_name_index: remap_index(placement.implicit_end_name_index),
-                ..placement
+    // SAFETY: The caller passes a valid source payload and a uniquely
+    // owned target value.
+    let (source, target) = unsafe { (&*source, &mut *target) };
+    let mut remapped = |placement: ComputedGridPlacement| {
+        let mut remap_index = |index: u32| {
+            if index == GRID_NO_INDEX {
+                return GRID_NO_INDEX;
             }
+            target.intern_name(&source.names.as_slice()[index as usize])
         };
-        let column_start = remapped(source.column_start);
-        let column_end = remapped(source.column_end);
-        let row_start = remapped(source.row_start);
-        let row_end = remapped(source.row_end);
-        target.column_start = column_start;
-        target.column_end = column_end;
-        target.row_start = row_start;
-        target.row_end = row_end;
-        target.grid_column_start_style_value = source.grid_column_start_style_value.clone();
-        target.grid_column_end_style_value = source.grid_column_end_style_value.clone();
-        target.grid_row_start_style_value = source.grid_row_start_style_value.clone();
-        target.grid_row_end_style_value = source.grid_row_end_style_value.clone();
-    });
+        ComputedGridPlacement {
+            name_index: remap_index(placement.name_index),
+            implicit_start_name_index: remap_index(placement.implicit_start_name_index),
+            implicit_end_name_index: remap_index(placement.implicit_end_name_index),
+            ..placement
+        }
+    };
+    let column_start = remapped(source.column_start);
+    let column_end = remapped(source.column_end);
+    let row_start = remapped(source.row_start);
+    let row_end = remapped(source.row_end);
+    target.column_start = column_start;
+    target.column_end = column_end;
+    target.row_start = row_start;
+    target.row_end = row_end;
+    target.grid_column_start_style_value = source.grid_column_start_style_value.clone();
+    target.grid_column_end_style_value = source.grid_column_end_style_value.clone();
+    target.grid_row_start_style_value = source.grid_row_start_style_value.clone();
+    target.grid_row_end_style_value = source.grid_row_end_style_value.clone();
 }
 
 /// # Safety
@@ -3521,61 +3503,57 @@ pub unsafe extern "C" fn rust_grid_values_placements_equal(
     source: *const GridValues,
     target: *const GridValues,
 ) -> bool {
-    abort_on_panic(|| {
-        // SAFETY: The caller passes valid payloads and only reads them.
-        let (source, target) = unsafe { (&*source, &*target) };
-        let name_raw = |grid: &GridValues, index: u32| {
-            if index == GRID_NO_INDEX {
-                return 0;
-            }
-            grid.names.as_slice()[index as usize].raw()
-        };
-        // Name indices are payload-local, so a placement compares as its index-neutralized
-        // shape plus the raw names those indices resolve to; a field added to
-        // ComputedGridPlacement flows into the comparison through the struct update.
-        let comparable_placement = |grid: &GridValues, placement: &ComputedGridPlacement| {
-            (
-                ComputedGridPlacement {
-                    name_index: GRID_NO_INDEX,
-                    implicit_start_name_index: GRID_NO_INDEX,
-                    implicit_end_name_index: GRID_NO_INDEX,
-                    ..*placement
-                },
-                name_raw(grid, placement.name_index),
-                name_raw(grid, placement.implicit_start_name_index),
-                name_raw(grid, placement.implicit_end_name_index),
-            )
-        };
-        let placements_equal = |ours: &ComputedGridPlacement, theirs: &ComputedGridPlacement| {
-            comparable_placement(source, ours) == comparable_placement(target, theirs)
-        };
-        placements_equal(&source.column_start, &target.column_start)
-            && placements_equal(&source.column_end, &target.column_end)
-            && placements_equal(&source.row_start, &target.row_start)
-            && placements_equal(&source.row_end, &target.row_end)
-            && source.grid_column_start_style_value == target.grid_column_start_style_value
-            && source.grid_column_end_style_value == target.grid_column_end_style_value
-            && source.grid_row_start_style_value == target.grid_row_start_style_value
-            && source.grid_row_end_style_value == target.grid_row_end_style_value
-    })
+    // SAFETY: The caller passes valid payloads and only reads them.
+    let (source, target) = unsafe { (&*source, &*target) };
+    let name_raw = |grid: &GridValues, index: u32| {
+        if index == GRID_NO_INDEX {
+            return 0;
+        }
+        grid.names.as_slice()[index as usize].raw()
+    };
+    // Name indices are payload-local, so a placement compares as its index-neutralized
+    // shape plus the raw names those indices resolve to; a field added to
+    // ComputedGridPlacement flows into the comparison through the struct update.
+    let comparable_placement = |grid: &GridValues, placement: &ComputedGridPlacement| {
+        (
+            ComputedGridPlacement {
+                name_index: GRID_NO_INDEX,
+                implicit_start_name_index: GRID_NO_INDEX,
+                implicit_end_name_index: GRID_NO_INDEX,
+                ..*placement
+            },
+            name_raw(grid, placement.name_index),
+            name_raw(grid, placement.implicit_start_name_index),
+            name_raw(grid, placement.implicit_end_name_index),
+        )
+    };
+    let placements_equal = |ours: &ComputedGridPlacement, theirs: &ComputedGridPlacement| {
+        comparable_placement(source, ours) == comparable_placement(target, theirs)
+    };
+    placements_equal(&source.column_start, &target.column_start)
+        && placements_equal(&source.column_end, &target.column_end)
+        && placements_equal(&source.row_start, &target.row_start)
+        && placements_equal(&source.row_end, &target.row_end)
+        && source.grid_column_start_style_value == target.grid_column_start_style_value
+        && source.grid_column_end_style_value == target.grid_column_end_style_value
+        && source.grid_row_start_style_value == target.grid_row_start_style_value
+        && source.grid_row_end_style_value == target.grid_row_end_style_value
 }
 
 /// # Safety
 /// `target` must be a uniquely owned grid group value.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_grid_values_reset_placements_to_auto(target: *mut GridValues) {
-    abort_on_panic(|| {
-        // SAFETY: The caller passes a uniquely owned target value.
-        let target = unsafe { &mut *target };
-        target.column_start = AUTO_GRID_PLACEMENT;
-        target.column_end = AUTO_GRID_PLACEMENT;
-        target.row_start = AUTO_GRID_PLACEMENT;
-        target.row_end = AUTO_GRID_PLACEMENT;
-        target.grid_column_start_style_value = ComputedStyleValueHandle::empty();
-        target.grid_column_end_style_value = ComputedStyleValueHandle::empty();
-        target.grid_row_start_style_value = ComputedStyleValueHandle::empty();
-        target.grid_row_end_style_value = ComputedStyleValueHandle::empty();
-    });
+    // SAFETY: The caller passes a uniquely owned target value.
+    let target = unsafe { &mut *target };
+    target.column_start = AUTO_GRID_PLACEMENT;
+    target.column_end = AUTO_GRID_PLACEMENT;
+    target.row_start = AUTO_GRID_PLACEMENT;
+    target.row_end = AUTO_GRID_PLACEMENT;
+    target.grid_column_start_style_value = ComputedStyleValueHandle::empty();
+    target.grid_column_end_style_value = ComputedStyleValueHandle::empty();
+    target.grid_row_start_style_value = ComputedStyleValueHandle::empty();
+    target.grid_row_end_style_value = ComputedStyleValueHandle::empty();
 }
 
 /// Builds the complete sizing group from its six computed values. Accepted
@@ -3597,30 +3575,28 @@ pub unsafe extern "C" fn rust_build_sizing_group(
     max_height: *const c_void,
     parent_payload: *const c_void,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let built = SizingValues {
-            width: ComputedSize::from_data(width),
-            min_width: ComputedSize::from_data(min_width),
-            max_width: ComputedSize::from_data(max_width),
-            height: ComputedSize::from_data(height),
-            min_height: ComputedSize::from_data(min_height),
-            max_height: ComputedSize::from_data(max_height),
-        };
+    let built = SizingValues {
+        width: ComputedSize::from_data(width),
+        min_width: ComputedSize::from_data(min_width),
+        max_width: ComputedSize::from_data(max_width),
+        height: ComputedSize::from_data(height),
+        min_height: ComputedSize::from_data(min_height),
+        max_height: ComputedSize::from_data(max_height),
+    };
 
-        if !parent_payload.is_null() && built.eq(unsafe { &*(parent_payload as *const SizingValues) }) {
-            retain_group_payload(group_index, parent_payload);
-            return parent_payload;
-        }
+    if !parent_payload.is_null() && built.eq(unsafe { &*(parent_payload as *const SizingValues) }) {
+        retain_group_payload(group_index, parent_payload);
+        return parent_payload;
+    }
 
-        let default_payload = default_group_payload(group_index);
-        if built.eq(unsafe { &*(default_payload as *const SizingValues) }) {
-            return default_payload;
-        }
+    let default_payload = default_group_payload(group_index);
+    if built.eq(unsafe { &*(default_payload as *const SizingValues) }) {
+        return default_payload;
+    }
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        unsafe { (payload as *mut SizingValues).write(built) };
-        payload
-    })
+    let payload = allocate_payload(vtable(group_index), 1);
+    unsafe { (payload as *mut SizingValues).write(built) };
+    payload
 }
 
 /// Builds an inherited table group payload from the computed values, with the
@@ -3641,54 +3617,50 @@ pub unsafe extern "C" fn rust_build_inherited_table_group(
 ) -> *const c_void {
     use crate::css::style_value::StyleValueData;
 
-    abort_on_panic(|| {
-        let keyword_code = |data: *const c_void, map: fn(u16) -> Option<u8>| -> u8 {
-            match unsafe { (data as *const StyleValueData).as_ref() } {
-                Some(StyleValueData::Keyword { keyword }) => {
-                    map(*keyword).expect("computed keyword has a supported value")
-                }
-                _ => panic!("computed inherited table value is not a keyword"),
-            }
-        };
-        let spacing_component = |data: &StyleValueData| -> i32 {
-            match data {
-                StyleValueData::Length { value, unit } if *unit == crate::css::style_compute::px_length_unit() => {
-                    crate::css::css_pixels::CssPixels::nearest_value_for(*value).raw_value()
-                }
-                _ => panic!("computed border-spacing component is not an absolute pixel length"),
-            }
-        };
-        let components = match unsafe { (border_spacing as *const StyleValueData).as_ref() } {
-            Some(StyleValueData::ValueList { values, .. }) if values.as_slice().len() == 2 => values.as_slice(),
-            _ => panic!("computed border-spacing is not a pair"),
-        };
-        let built = InheritedTableValues {
-            border_collapse: keyword_code(border_collapse, crate::css::style_compute::keyword_to_border_collapse),
-            caption_side: keyword_code(caption_side, crate::css::style_compute::keyword_to_caption_side),
-            empty_cells: keyword_code(empty_cells, crate::css::style_compute::keyword_to_empty_cells),
-            border_spacing_horizontal: spacing_component(components[0].data()),
-            border_spacing_vertical: spacing_component(components[1].data()),
-        };
-
-        if !parent_payload.is_null() {
-            // SAFETY: The caller guarantees a valid inherited table payload.
-            if built == unsafe { *(parent_payload as *const InheritedTableValues) } {
-                retain_group_payload(group_index, parent_payload);
-                return parent_payload;
-            }
+    let keyword_code = |data: *const c_void, map: fn(u16) -> Option<u8>| -> u8 {
+        match unsafe { (data as *const StyleValueData).as_ref() } {
+            Some(StyleValueData::Keyword { keyword }) => map(*keyword).expect("computed keyword has a supported value"),
+            _ => panic!("computed inherited table value is not a keyword"),
         }
-
-        let default_payload = default_group_payload(group_index);
-        // SAFETY: The default payload is a valid inherited table payload.
-        if built == unsafe { *(default_payload as *const InheritedTableValues) } {
-            return default_payload;
+    };
+    let spacing_component = |data: &StyleValueData| -> i32 {
+        match data {
+            StyleValueData::Length { value, unit } if *unit == crate::css::style_compute::px_length_unit() => {
+                crate::css::css_pixels::CssPixels::nearest_value_for(*value).raw_value()
+            }
+            _ => panic!("computed border-spacing component is not an absolute pixel length"),
         }
+    };
+    let components = match unsafe { (border_spacing as *const StyleValueData).as_ref() } {
+        Some(StyleValueData::ValueList { values, .. }) if values.as_slice().len() == 2 => values.as_slice(),
+        _ => panic!("computed border-spacing is not a pair"),
+    };
+    let built = InheritedTableValues {
+        border_collapse: keyword_code(border_collapse, crate::css::style_compute::keyword_to_border_collapse),
+        caption_side: keyword_code(caption_side, crate::css::style_compute::keyword_to_caption_side),
+        empty_cells: keyword_code(empty_cells, crate::css::style_compute::keyword_to_empty_cells),
+        border_spacing_horizontal: spacing_component(components[0].data()),
+        border_spacing_vertical: spacing_component(components[1].data()),
+    };
 
-        let payload = allocate_payload(vtable(group_index), 1);
-        // SAFETY: The payload was allocated for this group's layout.
-        unsafe { *(payload as *mut InheritedTableValues) = built };
-        payload as *const c_void
-    })
+    if !parent_payload.is_null() {
+        // SAFETY: The caller guarantees a valid inherited table payload.
+        if built == unsafe { *(parent_payload as *const InheritedTableValues) } {
+            retain_group_payload(group_index, parent_payload);
+            return parent_payload;
+        }
+    }
+
+    let default_payload = default_group_payload(group_index);
+    // SAFETY: The default payload is a valid inherited table payload.
+    if built == unsafe { *(default_payload as *const InheritedTableValues) } {
+        return default_payload;
+    }
+
+    let payload = allocate_payload(vtable(group_index), 1);
+    // SAFETY: The payload was allocated for this group's layout.
+    unsafe { *(payload as *mut InheritedTableValues) = built };
+    payload as *const c_void
 }
 
 /// Layout of the inherited table style value group.

--- a/Libraries/LibWeb/Rust/src/css/css_pixels.rs
+++ b/Libraries/LibWeb/Rust/src/css/css_pixels.rs
@@ -580,24 +580,22 @@ mod tests {
 /// FFI hooks for the C++ parity test.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_css_pixels_multiply(left_raw: i32, right_raw: i32) -> i32 {
-    crate::abort_on_panic(|| (CssPixels::from_raw(left_raw) * CssPixels::from_raw(right_raw)).raw_value())
+    (CssPixels::from_raw(left_raw) * CssPixels::from_raw(right_raw)).raw_value()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_css_pixels_divide_as_fraction(numerator_raw: i32, denominator_raw: i32) -> i32 {
-    crate::abort_on_panic(|| {
-        CssPixels::from_raw(numerator_raw)
-            .div_as_fraction(CssPixels::from_raw(denominator_raw))
-            .raw_value()
-    })
+    CssPixels::from_raw(numerator_raw)
+        .div_as_fraction(CssPixels::from_raw(denominator_raw))
+        .raw_value()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_css_pixels_nearest_value_for(value: f64) -> i32 {
-    crate::abort_on_panic(|| CssPixels::nearest_value_for(value).raw_value())
+    CssPixels::nearest_value_for(value).raw_value()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_css_pixels_scaled(raw: i32, factor: f64) -> i32 {
-    crate::abort_on_panic(|| CssPixels::from_raw(raw).scaled(factor).raw_value())
+    CssPixels::from_raw(raw).scaled(factor).raw_value()
 }

--- a/Libraries/LibWeb/Rust/src/css/css_tokenizer.rs
+++ b/Libraries/LibWeb/Rust/src/css/css_tokenizer.rs
@@ -83,15 +83,13 @@ pub unsafe extern "C" fn rust_css_tokenize_for_syntax_highlighting(
     callback: unsafe extern "C" fn(ctx: *mut c_void, token: *const CssSyntaxToken),
 ) {
     unsafe {
-        crate::abort_on_panic(|| {
-            let Some(input) = TokenizerInput::from_raw_parts(ascii_input, utf16_input, input_len) else {
-                return;
-            };
+        let Some(input) = TokenizerInput::from_raw_parts(ascii_input, utf16_input, input_len) else {
+            return;
+        };
 
-            tokenize(input, |token, _| {
-                let ffi_token = token.as_syntax_ffi();
-                callback(ctx, &raw const ffi_token);
-            });
+        tokenize(input, |token, _| {
+            let ffi_token = token.as_syntax_ffi();
+            callback(ctx, &raw const ffi_token);
         });
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/custom_properties.rs
+++ b/Libraries/LibWeb/Rust/src/css/custom_properties.rs
@@ -12,7 +12,6 @@ use std::collections::HashSet;
 use std::ffi::c_void;
 use std::sync::Arc;
 
-use crate::abort_on_panic;
 use crate::css::css_tokenizer::OwnedToken;
 use crate::css::css_tokenizer::OwnedTokenKind;
 use crate::css::css_tokenizer::TokenizerInput;
@@ -2710,15 +2709,13 @@ mod tests {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_custom_property_registry_create() -> *mut c_void {
-    abort_on_panic(|| {
-        Box::into_raw(Box::new(CustomPropertyRegistry {
-            registrations: HashMap::new(),
-            document_url: Vec::new(),
-            document_base_url: Vec::new(),
-            intern_utf16_fly_string: None,
-        }))
-        .cast()
-    })
+    Box::into_raw(Box::new(CustomPropertyRegistry {
+        registrations: HashMap::new(),
+        document_url: Vec::new(),
+        document_base_url: Vec::new(),
+        intern_utf16_fly_string: None,
+    }))
+    .cast()
 }
 
 /// Replaces the effective registered custom-property names for one document.
@@ -2733,49 +2730,47 @@ pub unsafe extern "C" fn rust_custom_property_registry_update(
     registrations: *const FfiCustomPropertyRegistration,
     registration_count: usize,
 ) {
-    abort_on_panic(|| {
-        let Some(context) = (unsafe { context.as_ref() }) else {
-            return;
-        };
-        let registrations = if registration_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(registrations, registration_count) }
-        };
-        let registry = unsafe { &mut *registry.cast::<CustomPropertyRegistry>() };
-        registry.document_url = unsafe { crate::bytes_from_raw(context.document_url, context.document_url_length) }
+    let Some(context) = (unsafe { context.as_ref() }) else {
+        return;
+    };
+    let registrations = if registration_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(registrations, registration_count) }
+    };
+    let registry = unsafe { &mut *registry.cast::<CustomPropertyRegistry>() };
+    registry.document_url = unsafe { crate::bytes_from_raw(context.document_url, context.document_url_length) }
+        .unwrap_or_default()
+        .to_vec();
+    registry.document_base_url =
+        unsafe { crate::bytes_from_raw(context.document_base_url, context.document_base_url_length) }
             .unwrap_or_default()
             .to_vec();
-        registry.document_base_url =
-            unsafe { crate::bytes_from_raw(context.document_base_url, context.document_base_url_length) }
-                .unwrap_or_default()
-                .to_vec();
-        registry.intern_utf16_fly_string = context.intern_utf16_fly_string;
-        registry.registrations.clear();
-        registry.registrations.reserve(registrations.len());
-        for registration in registrations {
-            let name = unsafe { registration.name.to_utf16() }.expect("invalid registered custom property name");
-            let initial_source = if registration.has_initial_value {
-                Some(
-                    unsafe { registration.initial_value.to_utf16() }
-                        .expect("invalid registered custom property initial value"),
-                )
-            } else {
-                None
-            };
-            let Some(syntax) = (unsafe { clone_syntax_handle(registration.syntax) }) else {
-                continue;
-            };
-            registry.registrations.insert(
-                name,
-                RegisteredCustomProperty {
-                    syntax,
-                    inherits: registration.inherits,
-                    initial_source,
-                },
-            );
-        }
-    });
+    registry.intern_utf16_fly_string = context.intern_utf16_fly_string;
+    registry.registrations.clear();
+    registry.registrations.reserve(registrations.len());
+    for registration in registrations {
+        let name = unsafe { registration.name.to_utf16() }.expect("invalid registered custom property name");
+        let initial_source = if registration.has_initial_value {
+            Some(
+                unsafe { registration.initial_value.to_utf16() }
+                    .expect("invalid registered custom property initial value"),
+            )
+        } else {
+            None
+        };
+        let Some(syntax) = (unsafe { clone_syntax_handle(registration.syntax) }) else {
+            continue;
+        };
+        registry.registrations.insert(
+            name,
+            RegisteredCustomProperty {
+                syntax,
+                inherits: registration.inherits,
+                initial_source,
+            },
+        );
+    }
 }
 
 /// # Safety
@@ -2783,7 +2778,7 @@ pub unsafe extern "C" fn rust_custom_property_registry_update(
 /// already been destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_custom_property_registry_destroy(registry: *mut c_void) {
-    abort_on_panic(|| drop(unsafe { Box::from_raw(registry.cast::<CustomPropertyRegistry>()) }));
+    drop(unsafe { Box::from_raw(registry.cast::<CustomPropertyRegistry>()) });
 }
 
 /// Creates one Rust store node. Each entry transfers a leaked fly-string reference and a
@@ -2802,54 +2797,52 @@ pub unsafe extern "C" fn rust_custom_property_store_create(
     inheritance_parent: *const c_void,
 ) -> *const c_void {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
-    abort_on_panic(|| {
-        let entries = if entry_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(entries, entry_count) }
-        };
-        assert!(declared_count <= entries.len());
-        let parent = if parent.is_null() {
-            None
-        } else {
-            let parent = parent.cast::<CustomPropertyStore>();
-            unsafe { Arc::increment_strong_count(parent) };
-            Some(unsafe { Arc::from_raw(parent) })
-        };
-        let inheritance_parent = if inheritance_parent.is_null() {
-            None
-        } else {
-            let inheritance_parent = inheritance_parent.cast::<CustomPropertyStore>();
-            unsafe { Arc::increment_strong_count(inheritance_parent) };
-            Some(unsafe { Arc::from_raw(inheritance_parent) })
-        };
-        let mut own_names = HashMap::with_capacity(entries.len());
-        let own_values = entries
-            .iter()
-            .map(|entry| {
-                let name = unsafe { entry.name.to_utf16() }.expect("invalid custom property name");
-                own_names.insert(name.clone(), entry.name_raw);
-                (
-                    entry.name_raw,
-                    CustomPropertyEntry {
-                        _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
-                        name,
-                        value: unsafe { RetainedStyleValueData::from_retained_pointer(entry.data.cast()) },
-                        important: entry.important,
-                    },
-                )
-            })
-            .collect();
-        Arc::into_raw(Arc::new(CustomPropertyStore {
-            own_values,
-            declared_names: entries[..declared_count].iter().map(|entry| entry.name_raw).collect(),
-            own_names,
-            ancestor_count: parent.as_ref().map_or(0, |parent| parent.ancestor_count + 1),
-            parent,
-            inheritance_parent,
-        }))
-        .cast()
-    })
+    let entries = if entry_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(entries, entry_count) }
+    };
+    assert!(declared_count <= entries.len());
+    let parent = if parent.is_null() {
+        None
+    } else {
+        let parent = parent.cast::<CustomPropertyStore>();
+        unsafe { Arc::increment_strong_count(parent) };
+        Some(unsafe { Arc::from_raw(parent) })
+    };
+    let inheritance_parent = if inheritance_parent.is_null() {
+        None
+    } else {
+        let inheritance_parent = inheritance_parent.cast::<CustomPropertyStore>();
+        unsafe { Arc::increment_strong_count(inheritance_parent) };
+        Some(unsafe { Arc::from_raw(inheritance_parent) })
+    };
+    let mut own_names = HashMap::with_capacity(entries.len());
+    let own_values = entries
+        .iter()
+        .map(|entry| {
+            let name = unsafe { entry.name.to_utf16() }.expect("invalid custom property name");
+            own_names.insert(name.clone(), entry.name_raw);
+            (
+                entry.name_raw,
+                CustomPropertyEntry {
+                    _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
+                    name,
+                    value: unsafe { RetainedStyleValueData::from_retained_pointer(entry.data.cast()) },
+                    important: entry.important,
+                },
+            )
+        })
+        .collect();
+    Arc::into_raw(Arc::new(CustomPropertyStore {
+        own_values,
+        declared_names: entries[..declared_count].iter().map(|entry| entry.name_raw).collect(),
+        own_names,
+        ancestor_count: parent.as_ref().map_or(0, |parent| parent.ancestor_count + 1),
+        parent,
+        inheritance_parent,
+    }))
+    .cast()
 }
 
 /// Creates a store holding an element's animated custom property values on top of the element's
@@ -2866,53 +2859,51 @@ pub unsafe extern "C" fn rust_custom_property_store_create_animation_overlay(
     base: *const c_void,
 ) -> *const c_void {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
-    abort_on_panic(|| {
-        let entries = if entry_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(entries, entry_count) }
-        };
-        let base = if base.is_null() {
-            None
-        } else {
-            let base = base.cast::<CustomPropertyStore>();
-            Some(unsafe { &*base })
-        };
-        let (mut own_values, mut own_names, parent, inheritance_parent, ancestor_count) = match base {
-            Some(base) => (
-                base.own_values.clone(),
-                base.own_names.clone(),
-                base.parent.clone(),
-                base.inheritance_parent.clone(),
-                base.ancestor_count,
-            ),
-            None => (HashMap::new(), HashMap::new(), None, None, 0),
-        };
-        let mut declared_names = Vec::with_capacity(entries.len());
-        for entry in entries {
-            let name = unsafe { entry.name.to_utf16() }.expect("invalid custom property name");
-            declared_names.push(entry.name_raw);
-            own_names.insert(name.clone(), entry.name_raw);
-            own_values.insert(
-                entry.name_raw,
-                CustomPropertyEntry {
-                    _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
-                    name,
-                    value: unsafe { RetainedStyleValueData::from_retained_pointer(entry.data.cast()) },
-                    important: entry.important,
-                },
-            );
-        }
-        Arc::into_raw(Arc::new(CustomPropertyStore {
-            own_values,
-            declared_names,
-            own_names,
-            ancestor_count,
-            parent,
-            inheritance_parent,
-        }))
-        .cast()
-    })
+    let entries = if entry_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(entries, entry_count) }
+    };
+    let base = if base.is_null() {
+        None
+    } else {
+        let base = base.cast::<CustomPropertyStore>();
+        Some(unsafe { &*base })
+    };
+    let (mut own_values, mut own_names, parent, inheritance_parent, ancestor_count) = match base {
+        Some(base) => (
+            base.own_values.clone(),
+            base.own_names.clone(),
+            base.parent.clone(),
+            base.inheritance_parent.clone(),
+            base.ancestor_count,
+        ),
+        None => (HashMap::new(), HashMap::new(), None, None, 0),
+    };
+    let mut declared_names = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let name = unsafe { entry.name.to_utf16() }.expect("invalid custom property name");
+        declared_names.push(entry.name_raw);
+        own_names.insert(name.clone(), entry.name_raw);
+        own_values.insert(
+            entry.name_raw,
+            CustomPropertyEntry {
+                _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
+                name,
+                value: unsafe { RetainedStyleValueData::from_retained_pointer(entry.data.cast()) },
+                important: entry.important,
+            },
+        );
+    }
+    Arc::into_raw(Arc::new(CustomPropertyStore {
+        own_values,
+        declared_names,
+        own_names,
+        ancestor_count,
+        parent,
+        inheritance_parent,
+    }))
+    .cast()
 }
 
 /// Releases one store reference returned by `rust_custom_property_store_create`.
@@ -2923,7 +2914,7 @@ pub unsafe extern "C" fn rust_custom_property_store_create_animation_overlay(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_custom_property_store_destroy(store: *const c_void) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
-    abort_on_panic(|| drop(unsafe { Arc::from_raw(store.cast::<CustomPropertyStore>()) }));
+    drop(unsafe { Arc::from_raw(store.cast::<CustomPropertyStore>()) });
 }
 
 #[repr(C)]
@@ -2946,30 +2937,28 @@ pub unsafe extern "C" fn rust_custom_property_store_get(
     name_raw: usize,
 ) -> FfiCustomPropertyStoreValue {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::CustomPropertyStoreQueryEntry);
-    abort_on_panic(|| {
-        let store = unsafe { &*store.cast::<CustomPropertyStore>() };
-        let Some(entry) = store.get(name_raw) else {
-            return FfiCustomPropertyStoreValue {
-                found: false,
-                important: false,
-                data: std::ptr::null(),
-                token_source_ascii: std::ptr::null(),
-                token_source_utf16: std::ptr::null(),
-                token_source_length: 0,
-            };
+    let store = unsafe { &*store.cast::<CustomPropertyStore>() };
+    let Some(entry) = store.get(name_raw) else {
+        return FfiCustomPropertyStoreValue {
+            found: false,
+            important: false,
+            data: std::ptr::null(),
+            token_source_ascii: std::ptr::null(),
+            token_source_utf16: std::ptr::null(),
+            token_source_length: 0,
         };
-        let token_source = entry.value.data().unresolved_token_source().unwrap_or_default();
-        let (token_source_ascii, token_source_utf16) = match token_source {
-            TokenizerInput::Ascii(units) => (units.as_ptr(), std::ptr::null()),
-            TokenizerInput::Utf16(units) => (std::ptr::null(), units.as_ptr()),
-        };
-        FfiCustomPropertyStoreValue {
-            found: true,
-            important: entry.important,
-            data: entry.value.data() as *const StyleValueData as *const c_void,
-            token_source_ascii,
-            token_source_utf16,
-            token_source_length: token_source.len(),
-        }
-    })
+    };
+    let token_source = entry.value.data().unresolved_token_source().unwrap_or_default();
+    let (token_source_ascii, token_source_utf16) = match token_source {
+        TokenizerInput::Ascii(units) => (units.as_ptr(), std::ptr::null()),
+        TokenizerInput::Utf16(units) => (std::ptr::null(), units.as_ptr()),
+    };
+    FfiCustomPropertyStoreValue {
+        found: true,
+        important: entry.important,
+        data: entry.value.data() as *const StyleValueData as *const c_void,
+        token_source_ascii,
+        token_source_utf16,
+        token_source_length: token_source.len(),
+    }
 }

--- a/Libraries/LibWeb/Rust/src/css/parser/descriptor_parser.rs
+++ b/Libraries/LibWeb/Rust/src/css/parser/descriptor_parser.rs
@@ -516,27 +516,25 @@ pub unsafe extern "C" fn rust_parse_css_descriptor(
     name: FfiUtf16View,
     source: FfiUtf16View,
 ) -> *const c_void {
-    crate::abort_on_panic(|| {
-        let Some(context) = (unsafe { context.as_ref() }) else {
-            return std::ptr::null();
-        };
-        let Some(name) = (unsafe { name.units() }) else {
-            return std::ptr::null();
-        };
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null();
-        };
-        let Ok(values) = consume_a_list_of_component_values(tokenize_for_parser(source)) else {
-            return std::ptr::null();
-        };
-        let mut name_units = Vec::with_capacity(name.len());
-        name.append_to(&mut name_units);
-        let mut source_units = Vec::with_capacity(source.len());
-        source.append_to(&mut source_units);
-        parse_descriptor(context, at_rule, &name_units, &values, &source_units)
-            .map(|descriptor| Arc::into_raw(descriptor.value).cast::<c_void>())
-            .unwrap_or(std::ptr::null())
-    })
+    let Some(context) = (unsafe { context.as_ref() }) else {
+        return std::ptr::null();
+    };
+    let Some(name) = (unsafe { name.units() }) else {
+        return std::ptr::null();
+    };
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null();
+    };
+    let Ok(values) = consume_a_list_of_component_values(tokenize_for_parser(source)) else {
+        return std::ptr::null();
+    };
+    let mut name_units = Vec::with_capacity(name.len());
+    name.append_to(&mut name_units);
+    let mut source_units = Vec::with_capacity(source.len());
+    source.append_to(&mut source_units);
+    parse_descriptor(context, at_rule, &name_units, &values, &source_units)
+        .map(|descriptor| Arc::into_raw(descriptor.value).cast::<c_void>())
+        .unwrap_or(std::ptr::null())
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/parser/query_parser.rs
+++ b/Libraries/LibWeb/Rust/src/css/parser/query_parser.rs
@@ -2622,25 +2622,23 @@ pub unsafe extern "C" fn rust_parse_sizes_attribute(
     media_environment: *const FfiMediaEnvironment,
     img_auto_width: *const f64,
 ) -> *const c_void {
-    crate::abort_on_panic(|| {
-        crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::SizesAttributeParseEntry);
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null();
-        };
-        let Some(context) = (unsafe { context.as_ref() }) else {
-            return std::ptr::null();
-        };
-        let media_environment =
-            unsafe { media_environment.as_ref() }.and_then(|environment| unsafe { ffi_media_environment(environment) });
-        let img_auto_width = unsafe { img_auto_width.as_ref() }.copied();
-        Arc::into_raw(Arc::new(parse_sizes_attribute(
-            context,
-            source,
-            media_environment,
-            img_auto_width,
-        )))
-        .cast()
-    })
+    crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::SizesAttributeParseEntry);
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null();
+    };
+    let Some(context) = (unsafe { context.as_ref() }) else {
+        return std::ptr::null();
+    };
+    let media_environment =
+        unsafe { media_environment.as_ref() }.and_then(|environment| unsafe { ffi_media_environment(environment) });
+    let img_auto_width = unsafe { img_auto_width.as_ref() }.copied();
+    Arc::into_raw(Arc::new(parse_sizes_attribute(
+        context,
+        source,
+        media_environment,
+        img_auto_width,
+    )))
+    .cast()
 }
 
 pub(crate) unsafe fn declared_namespaces_from_context(context: &ParseContext) -> Option<Vec<TokenizerInput<'_>>> {
@@ -2667,21 +2665,19 @@ pub unsafe extern "C" fn rust_visit_media_query_list(
     context: *mut c_void,
     visit: VisitQueryHandle,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return false;
-        };
-        let Some(queries) = parse_media_query_list(source, &resolve_query_feature) else {
-            return false;
-        };
-        for query in queries {
-            let handle = Arc::new(FfiQueryHandle {
-                tree: QueryTree::MediaQuery(query),
-            });
-            unsafe { visit(context, Arc::as_ptr(&handle)) };
-        }
-        true
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return false;
+    };
+    let Some(queries) = parse_media_query_list(source, &resolve_query_feature) else {
+        return false;
+    };
+    for query in queries {
+        let handle = Arc::new(FfiQueryHandle {
+            tree: QueryTree::MediaQuery(query),
+        });
+        unsafe { visit(context, Arc::as_ptr(&handle)) };
+    }
+    true
 }
 
 #[allow(clippy::arc_with_non_send_sync)]
@@ -2698,38 +2694,34 @@ pub unsafe extern "C" fn rust_parse_supports_condition(
     source: FfiUtf16View,
     context: *const ParseContext,
 ) -> *const FfiQueryHandle {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null();
-        };
-        let Some(context) = (unsafe { context.as_ref() }) else {
-            return std::ptr::null();
-        };
-        let Some(declared_namespaces) = (unsafe { declared_namespaces_from_context(context) }) else {
-            return std::ptr::null();
-        };
-        let Some(expression) = parse_supports_condition(source, &|kind, value| {
-            supports_feature_matches(context, &declared_namespaces, kind, value)
-        }) else {
-            return std::ptr::null();
-        };
-        create_expression_handle(expression, QueryKind::Supports)
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null();
+    };
+    let Some(context) = (unsafe { context.as_ref() }) else {
+        return std::ptr::null();
+    };
+    let Some(declared_namespaces) = (unsafe { declared_namespaces_from_context(context) }) else {
+        return std::ptr::null();
+    };
+    let Some(expression) = parse_supports_condition(source, &|kind, value| {
+        supports_feature_matches(context, &declared_namespaces, kind, value)
+    }) else {
+        return std::ptr::null();
+    };
+    create_expression_handle(expression, QueryKind::Supports)
 }
 
 /// # Safety
 /// The source pointers must identify readable storage for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_style_query(source: FfiUtf16View) -> *const FfiQueryHandle {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null();
-        };
-        let Some(expression) = parse_style_query_from_source(source, &resolve_query_feature) else {
-            return std::ptr::null();
-        };
-        create_expression_handle(expression, QueryKind::Style)
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null();
+    };
+    let Some(expression) = parse_style_query_from_source(source, &resolve_query_feature) else {
+        return std::ptr::null();
+    };
+    create_expression_handle(expression, QueryKind::Style)
 }
 
 /// Adds one strong reference to a borrowed query handle.
@@ -2738,12 +2730,10 @@ pub unsafe extern "C" fn rust_parse_style_query(source: FfiUtf16View) -> *const 
 /// `handle` must be null or point to a live query handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn css_query_ref(handle: *const FfiQueryHandle) -> *const FfiQueryHandle {
-    crate::abort_on_panic(|| {
-        if !handle.is_null() {
-            unsafe { Arc::increment_strong_count(handle) };
-        }
-        handle
-    })
+    if !handle.is_null() {
+        unsafe { Arc::increment_strong_count(handle) };
+    }
+    handle
 }
 
 /// Releases one strong reference to a query handle.
@@ -2752,21 +2742,17 @@ pub unsafe extern "C" fn css_query_ref(handle: *const FfiQueryHandle) -> *const 
 /// `handle` must be null or own one strong reference to a live query handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn css_query_unref(handle: *const FfiQueryHandle) {
-    crate::abort_on_panic(|| {
-        if !handle.is_null() {
-            unsafe { Arc::decrement_strong_count(handle) };
-        }
-    });
+    if !handle.is_null() {
+        unsafe { Arc::decrement_strong_count(handle) };
+    }
 }
 
 #[unsafe(no_mangle)]
 #[allow(clippy::arc_with_non_send_sync)]
 pub extern "C" fn css_query_create_not_all() -> *const FfiQueryHandle {
-    crate::abort_on_panic(|| {
-        Arc::into_raw(Arc::new(FfiQueryHandle {
-            tree: QueryTree::MediaQuery(invalid_media_query()),
-        }))
-    })
+    Arc::into_raw(Arc::new(FfiQueryHandle {
+        tree: QueryTree::MediaQuery(invalid_media_query()),
+    }))
 }
 
 /// Serializes a retained media query without changing its UTF-16 representation.
@@ -2780,17 +2766,15 @@ pub unsafe extern "C" fn css_query_serialize_media_query(
     context: *mut c_void,
     visit: VisitQuerySerialization,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return false;
-        };
-        let QueryTree::MediaQuery(query) = &handle.tree else {
-            return false;
-        };
-        let serialized = serialize_media_query(query);
-        unsafe { visit(context, serialized.as_ptr(), serialized.len()) };
-        true
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return false;
+    };
+    let QueryTree::MediaQuery(query) = &handle.tree else {
+        return false;
+    };
+    let serialized = serialize_media_query(query);
+    unsafe { visit(context, serialized.as_ptr(), serialized.len()) };
+    true
 }
 
 /// Evaluates a retained media query against an immutable feature snapshot.
@@ -2803,18 +2787,16 @@ pub unsafe extern "C" fn css_query_evaluate_media(
     handle: *const FfiQueryHandle,
     environment: FfiMediaEnvironment,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return false;
-        };
-        let QueryTree::MediaQuery(query) = &handle.tree else {
-            return false;
-        };
-        let Some((values, length_context)) = (unsafe { ffi_media_environment(&environment) }) else {
-            return false;
-        };
-        evaluate_media_query(query, values, length_context) == MatchResult::True
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return false;
+    };
+    let QueryTree::MediaQuery(query) = &handle.tree else {
+        return false;
+    };
+    let Some((values, length_context)) = (unsafe { ffi_media_environment(&environment) }) else {
+        return false;
+    };
+    evaluate_media_query(query, values, length_context) == MatchResult::True
 }
 
 /// Evaluates a retained standalone media condition against an immutable feature snapshot.
@@ -2828,22 +2810,20 @@ pub unsafe extern "C" fn css_query_evaluate_media_condition(
     handle: *const FfiQueryHandle,
     environment: FfiMediaEnvironment,
 ) -> u8 {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return 3;
-        };
-        let QueryTree::Expression {
-            expression,
-            kind: QueryKind::Media,
-        } = &handle.tree
-        else {
-            return 3;
-        };
-        let Some((values, length_context)) = (unsafe { ffi_media_environment(&environment) }) else {
-            return MatchResult::False as u8;
-        };
-        evaluate_media_expression(expression, values, length_context) as u8
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return 3;
+    };
+    let QueryTree::Expression {
+        expression,
+        kind: QueryKind::Media,
+    } = &handle.tree
+    else {
+        return 3;
+    };
+    let Some((values, length_context)) = (unsafe { ffi_media_environment(&environment) }) else {
+        return MatchResult::False as u8;
+    };
+    evaluate_media_expression(expression, values, length_context) as u8
 }
 
 /// Evaluates a retained supports condition whose feature results were captured while parsing.
@@ -2853,19 +2833,17 @@ pub unsafe extern "C" fn css_query_evaluate_media_condition(
 /// `handle` must point to a live supports-expression handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn css_query_evaluate_supports(handle: *const FfiQueryHandle) -> u8 {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return 3;
-        };
-        let QueryTree::Expression {
-            expression,
-            kind: QueryKind::Supports,
-        } = &handle.tree
-        else {
-            return 3;
-        };
-        evaluate_supports_expression(expression) as u8
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return 3;
+    };
+    let QueryTree::Expression {
+        expression,
+        kind: QueryKind::Supports,
+    } = &handle.tree
+    else {
+        return 3;
+    };
+    evaluate_supports_expression(expression) as u8
 }
 
 /// Returns the query-container capabilities needed by a retained container condition.
@@ -2874,19 +2852,17 @@ pub unsafe extern "C" fn css_query_evaluate_supports(handle: *const FfiQueryHand
 /// `handle` must point to a live container-expression handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn css_query_container_requirements(handle: *const FfiQueryHandle) -> u8 {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return CONTAINER_QUERY_HAS_UNKNOWN_FEATURE;
-        };
-        let QueryTree::Expression {
-            expression,
-            kind: QueryKind::Size,
-        } = &handle.tree
-        else {
-            return CONTAINER_QUERY_HAS_UNKNOWN_FEATURE;
-        };
-        container_requirements(expression)
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return CONTAINER_QUERY_HAS_UNKNOWN_FEATURE;
+    };
+    let QueryTree::Expression {
+        expression,
+        kind: QueryKind::Size,
+    } = &handle.tree
+    else {
+        return CONTAINER_QUERY_HAS_UNKNOWN_FEATURE;
+    };
+    container_requirements(expression)
 }
 
 /// Evaluates a retained container condition against immutable size facts and style callbacks.
@@ -2896,27 +2872,25 @@ pub unsafe extern "C" fn css_query_container_requirements(handle: *const FfiQuer
 /// `facts` must remain valid for the duration of this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn css_query_evaluate_container(handle: *const FfiQueryHandle, facts: FfiContainerFacts) -> u8 {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return MatchResult::Unknown as u8;
-        };
-        let QueryTree::Expression { expression, kind } = &handle.tree else {
-            return MatchResult::Unknown as u8;
-        };
-        if !matches!(kind, QueryKind::Size | QueryKind::Style) {
-            return MatchResult::Unknown as u8;
-        }
-        if !facts.container_available {
-            return MatchResult::Unknown as u8;
-        }
-        let length_context = unsafe {
-            facts
-                .length_resolution_context
-                .cast::<FfiLengthResolutionContext>()
-                .as_ref()
-        };
-        evaluate_container_expression(expression, &facts, length_context) as u8
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return MatchResult::Unknown as u8;
+    };
+    let QueryTree::Expression { expression, kind } = &handle.tree else {
+        return MatchResult::Unknown as u8;
+    };
+    if !matches!(kind, QueryKind::Size | QueryKind::Style) {
+        return MatchResult::Unknown as u8;
+    }
+    if !facts.container_available {
+        return MatchResult::Unknown as u8;
+    }
+    let length_context = unsafe {
+        facts
+            .length_resolution_context
+            .cast::<FfiLengthResolutionContext>()
+            .as_ref()
+    };
+    evaluate_container_expression(expression, &facts, length_context) as u8
 }
 
 /// Serializes a retained query condition without changing its UTF-16 representation.
@@ -2930,19 +2904,17 @@ pub unsafe extern "C" fn css_query_serialize_condition(
     context: *mut c_void,
     visit: VisitQuerySerialization,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(handle) = (unsafe { handle.as_ref() }) else {
-            return false;
-        };
-        let QueryTree::Expression { expression, kind } = &handle.tree else {
-            return false;
-        };
-        let mut sink = TextSink::new();
-        serialize_expression(&mut sink, expression, *kind);
-        let serialized = sink.into_utf16();
-        unsafe { visit(context, serialized.as_ptr(), serialized.len()) };
-        true
-    })
+    let Some(handle) = (unsafe { handle.as_ref() }) else {
+        return false;
+    };
+    let QueryTree::Expression { expression, kind } = &handle.tree else {
+        return false;
+    };
+    let mut sink = TextSink::new();
+    serialize_expression(&mut sink, expression, *kind);
+    let serialized = sink.into_utf16();
+    unsafe { visit(context, serialized.as_ptr(), serialized.len()) };
+    true
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/parser/syntax.rs
+++ b/Libraries/LibWeb/Rust/src/css/parser/syntax.rs
@@ -435,38 +435,34 @@ pub(crate) fn parse_with_syntax(context: &ParseContext, source: &[u16], syntax: 
 /// `source` must remain readable for `source_length` UTF-16 code units during this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_syntax(source: FfiUtf16View, limit_ident_to_custom_ident: bool) -> *const c_void {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.to_utf16() }) else {
-            return std::ptr::null();
-        };
-        let Some(syntax) = parse_syntax(&source, limit_ident_to_custom_ident) else {
-            return std::ptr::null();
-        };
-        Arc::into_raw(Arc::new(syntax)).cast()
-    })
+    let Some(source) = (unsafe { source.to_utf16() }) else {
+        return std::ptr::null();
+    };
+    let Some(syntax) = parse_syntax(&source, limit_ident_to_custom_ident) else {
+        return std::ptr::null();
+    };
+    Arc::into_raw(Arc::new(syntax)).cast()
 }
 
 /// Returns an owned universal-syntax handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_syntax_create_universal() -> *const c_void {
-    crate::abort_on_panic(|| Arc::into_raw(Arc::new(SyntaxNode::Universal)).cast())
+    Arc::into_raw(Arc::new(SyntaxNode::Universal)).cast()
 }
 
 /// # Safety
 /// `syntax` must be a live parsed-syntax handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_retain(syntax: *const c_void) -> *const c_void {
-    crate::abort_on_panic(|| {
-        unsafe { Arc::increment_strong_count(syntax.cast::<SyntaxNode>()) };
-        syntax
-    })
+    unsafe { Arc::increment_strong_count(syntax.cast::<SyntaxNode>()) };
+    syntax
 }
 
 /// # Safety
 /// `syntax` must be a live parsed-syntax handle whose strong count is released exactly once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_release(syntax: *const c_void) {
-    crate::abort_on_panic(|| unsafe { Arc::decrement_strong_count(syntax.cast::<SyntaxNode>()) });
+    unsafe { Arc::decrement_strong_count(syntax.cast::<SyntaxNode>()) };
 }
 
 /// # Safety
@@ -479,25 +475,23 @@ pub(crate) unsafe fn clone_syntax_handle(syntax: *const c_void) -> Option<Syntax
 /// `syntax` must be a live parsed-syntax handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_is_universal(syntax: *const c_void) -> bool {
-    crate::abort_on_panic(|| matches!(unsafe { &*syntax.cast::<SyntaxNode>() }, SyntaxNode::Universal))
+    matches!(unsafe { &*syntax.cast::<SyntaxNode>() }, SyntaxNode::Universal)
 }
 
 /// # Safety
 /// `syntax` must be a live parsed-syntax handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_is_single_component(syntax: *const c_void) -> bool {
-    crate::abort_on_panic(|| is_single_syntax_component(unsafe { &*syntax.cast::<SyntaxNode>() }))
+    is_single_syntax_component(unsafe { &*syntax.cast::<SyntaxNode>() })
 }
 
 /// # Safety
 /// `left` and `right` must be live parsed-syntax handles.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_equals(left: *const c_void, right: *const c_void) -> bool {
-    crate::abort_on_panic(|| {
-        let left = unsafe { &*left.cast::<SyntaxNode>() };
-        let right = unsafe { &*right.cast::<SyntaxNode>() };
-        left == right
-    })
+    let left = unsafe { &*left.cast::<SyntaxNode>() };
+    let right = unsafe { &*right.cast::<SyntaxNode>() };
+    left == right
 }
 
 /// Serializes a syntax handle into an owned native `AK::Utf16String`.
@@ -506,11 +500,9 @@ pub unsafe extern "C" fn rust_syntax_equals(left: *const c_void, right: *const c
 /// `syntax` must be a live parsed-syntax handle. The returned raw string must be adopted by C++.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_syntax_serialize(syntax: *const c_void) -> usize {
-    crate::abort_on_panic(|| {
-        let mut sink = TextSink::new();
-        serialize_syntax(unsafe { &*syntax.cast::<SyntaxNode>() }, &mut sink);
-        crate::css::serialize::sink_into_ffi(sink).raw
-    })
+    let mut sink = TextSink::new();
+    serialize_syntax(unsafe { &*syntax.cast::<SyntaxNode>() }, &mut sink);
+    crate::css::serialize::sink_into_ffi(sink).raw
 }
 
 /// Parses a CSS value against a registered syntax and returns one strong style-value handle.
@@ -524,22 +516,20 @@ pub unsafe extern "C" fn rust_parse_with_syntax(
     syntax: *const c_void,
     out_status: *mut FfiParseStatus,
 ) -> *const c_void {
-    crate::abort_on_panic(|| {
-        if context.is_null() || syntax.is_null() || out_status.is_null() {
-            return std::ptr::null();
-        }
-        let Some(source) = (unsafe { source.to_utf16() }) else {
-            unsafe { *out_status = FfiParseStatus::Invalid };
-            return std::ptr::null();
-        };
-        let Some(parsed) = parse_with_syntax(unsafe { &*context }, &source, unsafe { &*syntax.cast::<SyntaxNode>() })
-        else {
-            unsafe { *out_status = FfiParseStatus::Invalid };
-            return std::ptr::null();
-        };
-        unsafe { *out_status = FfiParseStatus::Parsed };
-        Arc::into_raw(Arc::new(parsed)).cast()
-    })
+    if context.is_null() || syntax.is_null() || out_status.is_null() {
+        return std::ptr::null();
+    }
+    let Some(source) = (unsafe { source.to_utf16() }) else {
+        unsafe { *out_status = FfiParseStatus::Invalid };
+        return std::ptr::null();
+    };
+    let Some(parsed) = parse_with_syntax(unsafe { &*context }, &source, unsafe { &*syntax.cast::<SyntaxNode>() })
+    else {
+        unsafe { *out_status = FfiParseStatus::Invalid };
+        return std::ptr::null();
+    };
+    unsafe { *out_status = FfiParseStatus::Parsed };
+    Arc::into_raw(Arc::new(parsed)).cast()
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/parser/syntax_parser.rs
+++ b/Libraries/LibWeb/Rust/src/css/parser/syntax_parser.rs
@@ -3357,17 +3357,15 @@ pub unsafe extern "C" fn rust_parse_css_stylesheet_syntax(
     source: FfiUtf16View,
     parse_context: *const ParseContext,
 ) -> *mut FfiSyntaxParse {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null_mut();
-        };
-        let (mut parser, diagnostics) = Parser::from_source(source, Vec::new());
-        let mut parse = FfiSyntaxParse::new(parse_context, false);
-        parse.diagnostics = diagnostics;
-        let rules = parser.consume_stylesheet_contents();
-        parse.append_roots(&rules);
-        Box::into_raw(Box::new(parse))
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null_mut();
+    };
+    let (mut parser, diagnostics) = Parser::from_source(source, Vec::new());
+    let mut parse = FfiSyntaxParse::new(parse_context, false);
+    parse.diagnostics = diagnostics;
+    let rules = parser.consume_stylesheet_contents();
+    parse.append_roots(&rules);
+    Box::into_raw(Box::new(parse))
 }
 
 /// Parses exactly one CSS rule into a Rust-owned arena.
@@ -3382,36 +3380,34 @@ pub unsafe extern "C" fn rust_parse_css_rule_syntax(
     nested: bool,
     parse_context: *const ParseContext,
 ) -> *mut FfiSyntaxParse {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(contexts) = (unsafe { crate::bytes_from_raw(contexts, context_count) }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(contexts) = contexts
-            .iter()
-            .copied()
-            .map(|context| {
-                if context > RuleContext::Margin as u8 {
-                    return None;
-                }
-                // SAFETY: RuleContext has contiguous repr(u8) discriminants and the value was range-checked.
-                Some(unsafe { std::mem::transmute::<u8, RuleContext>(context) })
-            })
-            .collect::<Option<Vec<_>>>()
-        else {
-            return std::ptr::null_mut();
-        };
-        let (parser, diagnostics) = Parser::from_source(source, contexts);
-        let mut parse = FfiSyntaxParse::new(parse_context, false);
-        parse.diagnostics = diagnostics;
-        let rule = parse_rule_from_tokens(parser.tokens, parser.rule_context, nested);
-        if let Some(rule) = rule {
-            parse.append_roots(std::slice::from_ref(&rule));
-        }
-        Box::into_raw(Box::new(parse))
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(contexts) = (unsafe { crate::bytes_from_raw(contexts, context_count) }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(contexts) = contexts
+        .iter()
+        .copied()
+        .map(|context| {
+            if context > RuleContext::Margin as u8 {
+                return None;
+            }
+            // SAFETY: RuleContext has contiguous repr(u8) discriminants and the value was range-checked.
+            Some(unsafe { std::mem::transmute::<u8, RuleContext>(context) })
+        })
+        .collect::<Option<Vec<_>>>()
+    else {
+        return std::ptr::null_mut();
+    };
+    let (parser, diagnostics) = Parser::from_source(source, contexts);
+    let mut parse = FfiSyntaxParse::new(parse_context, false);
+    parse.diagnostics = diagnostics;
+    let rule = parse_rule_from_tokens(parser.tokens, parser.rule_context, nested);
+    if let Some(rule) = rule {
+        parse.append_roots(std::slice::from_ref(&rule));
+    }
+    Box::into_raw(Box::new(parse))
 }
 
 /// Parses a keyframe selector list into a Rust-owned syntax arena.
@@ -3423,27 +3419,25 @@ pub unsafe extern "C" fn rust_parse_css_keyframe_selectors_syntax(
     source: FfiUtf16View,
     parse_context: *const ParseContext,
 ) -> *mut FfiSyntaxParse {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null_mut();
-        };
-        let tokens = tokenize_for_parser(source);
-        let diagnostics = token_diagnostics(&tokens);
-        let prelude = consume_a_list_of_component_values(tokens).unwrap_or_default();
-        let mut parse = FfiSyntaxParse::new(parse_context, false);
-        parse.diagnostics = diagnostics;
-        parse.append_roots(&[Rule::Qualified(QualifiedRule {
-            prelude,
-            prelude_is_selector: false,
-            prelude_is_relative: false,
-            valid_in_context: true,
-            outer_rule_name: None,
-            declarations: Vec::new(),
-            children: Vec::new(),
-            source_position: None,
-        })]);
-        Box::into_raw(Box::new(parse))
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null_mut();
+    };
+    let tokens = tokenize_for_parser(source);
+    let diagnostics = token_diagnostics(&tokens);
+    let prelude = consume_a_list_of_component_values(tokens).unwrap_or_default();
+    let mut parse = FfiSyntaxParse::new(parse_context, false);
+    parse.diagnostics = diagnostics;
+    parse.append_roots(&[Rule::Qualified(QualifiedRule {
+        prelude,
+        prelude_is_selector: false,
+        prelude_is_relative: false,
+        valid_in_context: true,
+        outer_rule_name: None,
+        declarations: Vec::new(),
+        children: Vec::new(),
+        source_position: None,
+    })]);
+    Box::into_raw(Box::new(parse))
 }
 
 /// Parses a CSS page selector list into a Rust-owned arena.
@@ -3452,15 +3446,13 @@ pub unsafe extern "C" fn rust_parse_css_keyframe_selectors_syntax(
 /// `source` must remain readable for this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_page_selector_list(source: FfiUtf16View) -> *mut FfiPageSelectorList {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(selectors) = parse_page_selector_list(source) else {
-            return std::ptr::null_mut();
-        };
-        Box::into_raw(Box::new(FfiPageSelectorList::new(selectors)))
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(selectors) = parse_page_selector_list(source) else {
+        return std::ptr::null_mut();
+    };
+    Box::into_raw(Box::new(FfiPageSelectorList::new(selectors)))
 }
 
 /// Returns borrowed arena slices which remain live until `rust_page_selector_list_free`.
@@ -3469,18 +3461,16 @@ pub unsafe extern "C" fn rust_parse_page_selector_list(source: FfiUtf16View) -> 
 /// `list` must be a live handle returned by `rust_parse_page_selector_list`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_page_selector_list_data(list: *const FfiPageSelectorList) -> FfiPageSelectorListData {
-    crate::abort_on_panic(|| unsafe { &*list }.data())
+    unsafe { &*list }.data()
 }
 
 /// # Safety
 /// `list` must be null or a live page-selector-list handle and must only be freed once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_page_selector_list_free(list: *mut FfiPageSelectorList) {
-    crate::abort_on_panic(|| {
-        if !list.is_null() {
-            drop(unsafe { Box::from_raw(list) });
-        }
-    });
+    if !list.is_null() {
+        drop(unsafe { Box::from_raw(list) });
+    }
 }
 
 /// Parses block contents into a Rust-owned arena.
@@ -3495,34 +3485,32 @@ pub unsafe extern "C" fn rust_parse_css_block_syntax(
     parse_context: *const ParseContext,
     preserve_property_source_text: bool,
 ) -> *mut FfiSyntaxParse {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(contexts) = (unsafe { crate::bytes_from_raw(contexts, context_count) }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(contexts) = contexts
-            .iter()
-            .copied()
-            .map(|context| {
-                if context > RuleContext::Margin as u8 {
-                    return None;
-                }
-                // SAFETY: RuleContext has contiguous repr(u8) discriminants and the value was range-checked.
-                Some(unsafe { std::mem::transmute::<u8, RuleContext>(context) })
-            })
-            .collect::<Option<Vec<_>>>()
-        else {
-            return std::ptr::null_mut();
-        };
-        let (mut parser, diagnostics) = Parser::from_source(source, contexts);
-        let mut parse = FfiSyntaxParse::new(parse_context, preserve_property_source_text);
-        parse.diagnostics = diagnostics;
-        let items = parser.consume_block_contents();
-        parse.append_root_items(&items);
-        Box::into_raw(Box::new(parse))
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(contexts) = (unsafe { crate::bytes_from_raw(contexts, context_count) }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(contexts) = contexts
+        .iter()
+        .copied()
+        .map(|context| {
+            if context > RuleContext::Margin as u8 {
+                return None;
+            }
+            // SAFETY: RuleContext has contiguous repr(u8) discriminants and the value was range-checked.
+            Some(unsafe { std::mem::transmute::<u8, RuleContext>(context) })
+        })
+        .collect::<Option<Vec<_>>>()
+    else {
+        return std::ptr::null_mut();
+    };
+    let (mut parser, diagnostics) = Parser::from_source(source, contexts);
+    let mut parse = FfiSyntaxParse::new(parse_context, preserve_property_source_text);
+    parse.diagnostics = diagnostics;
+    let items = parser.consume_block_contents();
+    parse.append_root_items(&items);
+    Box::into_raw(Box::new(parse))
 }
 
 /// Returns borrowed arena slices which remain live until `rust_css_syntax_parse_free`.
@@ -3531,18 +3519,16 @@ pub unsafe extern "C" fn rust_parse_css_block_syntax(
 /// `parse` must be a live handle returned by a Rust syntax parse function.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_css_syntax_parse_data(parse: *const FfiSyntaxParse) -> FfiSyntaxParseData {
-    crate::abort_on_panic(|| unsafe { &*parse }.data())
+    unsafe { &*parse }.data()
 }
 
 /// # Safety
 /// `parse` must be null or a live syntax parse handle and must only be freed once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_css_syntax_parse_free(parse: *mut FfiSyntaxParse) {
-    crate::abort_on_panic(|| {
-        if !parse.is_null() {
-            drop(unsafe { Box::from_raw(parse) });
-        }
-    });
+    if !parse.is_null() {
+        drop(unsafe { Box::from_raw(parse) });
+    }
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/parser/value_parser.rs
+++ b/Libraries/LibWeb/Rust/src/css/parser/value_parser.rs
@@ -5582,67 +5582,58 @@ pub unsafe extern "C" fn rust_parse_css_value(
     source: FfiUtf16View,
     out_status: *mut FfiParseStatus,
 ) -> *const c_void {
-    crate::abort_on_panic(|| {
-        let invalid_ffi_result = || {
-            if !out_status.is_null() {
-                unsafe { *out_status = FfiParseStatus::NotHandled };
+    let invalid_ffi_result = || {
+        if !out_status.is_null() {
+            unsafe { *out_status = FfiParseStatus::NotHandled };
+        }
+        std::ptr::null()
+    };
+
+    if context.is_null() || out_status.is_null() {
+        return invalid_ffi_result();
+    }
+    let Some(source) = (unsafe { source.units() }) else {
+        return invalid_ffi_result();
+    };
+    let mut source_utf16 = Vec::with_capacity(source.len());
+    source.append_to(&mut source_utf16);
+    let context = unsafe { &*context };
+    let outcome = match component_values_from_source(source) {
+        Ok(values) => {
+            let mut substitution_presence = SubstitutionFunctionsPresence::default();
+            if collect_arbitrary_substitution_function_presence(&values, &mut substitution_presence).is_err() {
+                ParseOutcome::Invalid
+            } else if property_id == property_id::CUSTOM || substitution_presence.has_any() {
+                match consume_a_list_of_component_values(tokenize_for_parser(source_utf16.as_slice())) {
+                    Ok(values) => parse_css_value_with_utf16_source(context, property_id, &values, &source_utf16),
+                    Err(()) => ParseOutcome::NotHandled,
+                }
+            } else {
+                parse_css_value_after_substitution_scan(context, property_id, &values, &[], &[], substitution_presence)
+            }
+        }
+        Err(()) => ParseOutcome::NotHandled,
+    };
+    match outcome {
+        ParseOutcome::Parsed(value) => {
+            unsafe {
+                *out_status = FfiParseStatus::Parsed;
+            }
+            Arc::into_raw(value).cast()
+        }
+        ParseOutcome::Invalid => {
+            unsafe {
+                *out_status = FfiParseStatus::Invalid;
             }
             std::ptr::null()
-        };
-
-        if context.is_null() || out_status.is_null() {
-            return invalid_ffi_result();
         }
-        let Some(source) = (unsafe { source.units() }) else {
-            return invalid_ffi_result();
-        };
-        let mut source_utf16 = Vec::with_capacity(source.len());
-        source.append_to(&mut source_utf16);
-        let context = unsafe { &*context };
-        let outcome = match component_values_from_source(source) {
-            Ok(values) => {
-                let mut substitution_presence = SubstitutionFunctionsPresence::default();
-                if collect_arbitrary_substitution_function_presence(&values, &mut substitution_presence).is_err() {
-                    ParseOutcome::Invalid
-                } else if property_id == property_id::CUSTOM || substitution_presence.has_any() {
-                    match consume_a_list_of_component_values(tokenize_for_parser(source_utf16.as_slice())) {
-                        Ok(values) => parse_css_value_with_utf16_source(context, property_id, &values, &source_utf16),
-                        Err(()) => ParseOutcome::NotHandled,
-                    }
-                } else {
-                    parse_css_value_after_substitution_scan(
-                        context,
-                        property_id,
-                        &values,
-                        &[],
-                        &[],
-                        substitution_presence,
-                    )
-                }
+        ParseOutcome::NotHandled => {
+            unsafe {
+                *out_status = FfiParseStatus::NotHandled;
             }
-            Err(()) => ParseOutcome::NotHandled,
-        };
-        match outcome {
-            ParseOutcome::Parsed(value) => {
-                unsafe {
-                    *out_status = FfiParseStatus::Parsed;
-                }
-                Arc::into_raw(value).cast()
-            }
-            ParseOutcome::Invalid => {
-                unsafe {
-                    *out_status = FfiParseStatus::Invalid;
-                }
-                std::ptr::null()
-            }
-            ParseOutcome::NotHandled => {
-                unsafe {
-                    *out_status = FfiParseStatus::NotHandled;
-                }
-                std::ptr::null()
-            }
+            std::ptr::null()
         }
-    })
+    }
 }
 
 /// Returns a substitution-function presence bitmap for CSS source.
@@ -5655,22 +5646,20 @@ pub unsafe extern "C" fn rust_collect_arbitrary_substitution_function_presence_f
     source: FfiUtf16View,
     out_presence: *mut u8,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        if out_presence.is_null() {
-            return false;
-        }
-        let Some(source) = (unsafe { source.units() }) else {
-            return false;
-        };
-        let Ok(values) = component_values_from_source(source) else {
-            return false;
-        };
-        let Some(presence) = substitution_function_presence_bits(&values) else {
-            return false;
-        };
-        unsafe { *out_presence = presence };
-        true
-    })
+    if out_presence.is_null() {
+        return false;
+    }
+    let Some(source) = (unsafe { source.units() }) else {
+        return false;
+    };
+    let Ok(values) = component_values_from_source(source) else {
+        return false;
+    };
+    let Some(presence) = substitution_function_presence_bits(&values) else {
+        return false;
+    };
+    unsafe { *out_presence = presence };
+    true
 }
 
 type VisitMarginComponent = unsafe extern "C" fn(*mut c_void, u8, f64, *const u16, usize);
@@ -5685,37 +5674,35 @@ pub unsafe extern "C" fn rust_visit_margin_components(
     context: *mut c_void,
     visit: VisitMarginComponent,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return false;
-        };
-        let Ok(values) = component_values_from_source(source) else {
-            return false;
-        };
-        let values = values.iter().filter(|value| !value.is_whitespace()).collect::<Vec<_>>();
-        if values.len() > 4
-            || values.iter().any(|value| {
-                !matches!(
-                    value.kind,
-                    ComponentKind::Token(ParserTokenKind::Dimension { .. } | ParserTokenKind::Percentage { .. })
-                )
-            })
-        {
-            return false;
+    let Some(source) = (unsafe { source.units() }) else {
+        return false;
+    };
+    let Ok(values) = component_values_from_source(source) else {
+        return false;
+    };
+    let values = values.iter().filter(|value| !value.is_whitespace()).collect::<Vec<_>>();
+    if values.len() > 4
+        || values.iter().any(|value| {
+            !matches!(
+                value.kind,
+                ComponentKind::Token(ParserTokenKind::Dimension { .. } | ParserTokenKind::Percentage { .. })
+            )
+        })
+    {
+        return false;
+    }
+    for value in values {
+        match &value.kind {
+            ComponentKind::Token(ParserTokenKind::Dimension { value, unit, .. }) => unsafe {
+                visit(context, 0, *value, unit.as_ptr(), unit.len());
+            },
+            ComponentKind::Token(ParserTokenKind::Percentage { value, .. }) => unsafe {
+                visit(context, 1, *value, std::ptr::null(), 0);
+            },
+            _ => unreachable!(),
         }
-        for value in values {
-            match &value.kind {
-                ComponentKind::Token(ParserTokenKind::Dimension { value, unit, .. }) => unsafe {
-                    visit(context, 0, *value, unit.as_ptr(), unit.len());
-                },
-                ComponentKind::Token(ParserTokenKind::Percentage { value, .. }) => unsafe {
-                    visit(context, 1, *value, std::ptr::null(), 0);
-                },
-                _ => unreachable!(),
-            }
-        }
-        true
-    })
+    }
+    true
 }
 
 fn parse_css_primitive_values(
@@ -5829,27 +5816,25 @@ pub unsafe extern "C" fn rust_parse_entire_css_primitive_from_source(
     range_min: f64,
     range_max: f64,
 ) -> *const c_void {
-    crate::abort_on_panic(|| {
-        if context.is_null() {
-            return std::ptr::null();
-        }
-        let Some(source) = (unsafe { source.units() }) else {
-            return std::ptr::null();
-        };
-        let Ok(values) = component_values_from_source(source) else {
-            return std::ptr::null();
-        };
-        let Some((parsed, consumed)) =
-            parse_css_primitive_values(unsafe { &*context }, value_type, &values, range_min, range_max)
-        else {
-            return std::ptr::null();
-        };
-        if values[consumed..].iter().all(ComponentValue::is_whitespace) {
-            Arc::into_raw(Arc::new(parsed)).cast()
-        } else {
-            std::ptr::null()
-        }
-    })
+    if context.is_null() {
+        return std::ptr::null();
+    }
+    let Some(source) = (unsafe { source.units() }) else {
+        return std::ptr::null();
+    };
+    let Ok(values) = component_values_from_source(source) else {
+        return std::ptr::null();
+    };
+    let Some((parsed, consumed)) =
+        parse_css_primitive_values(unsafe { &*context }, value_type, &values, range_min, range_max)
+    else {
+        return std::ptr::null();
+    };
+    if values[consumed..].iter().all(ComponentValue::is_whitespace) {
+        Arc::into_raw(Arc::new(parsed)).cast()
+    } else {
+        std::ptr::null()
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -5868,42 +5853,38 @@ pub struct FfiSimpleColor {
 /// The source view must contain exactly one valid pointer when non-empty.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_simple_color(source: FfiUtf16View) -> FfiSimpleColor {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return FfiSimpleColor::default();
-        };
-        let Some([red, green, blue, alpha]) = parse_simple_color(source) else {
-            return FfiSimpleColor::default();
-        };
-        FfiSimpleColor {
-            success: true,
-            red,
-            green,
-            blue,
-            alpha,
-        }
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return FfiSimpleColor::default();
+    };
+    let Some([red, green, blue, alpha]) = parse_simple_color(source) else {
+        return FfiSimpleColor::default();
+    };
+    FfiSimpleColor {
+        success: true,
+        red,
+        green,
+        blue,
+        alpha,
+    }
 }
 
 /// # Safety
 /// The source view must contain exactly one valid pointer when non-empty.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_is_valid_animation_name_custom_ident(source: FfiUtf16View) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(source) = (unsafe { source.units() }) else {
-            return false;
-        };
-        is_valid_custom_ident_matching(
-            |expected| {
-                source.len() == expected.len()
-                    && expected.iter().enumerate().all(|(index, &expected)| {
-                        u8::try_from(source.code_unit_at(index))
-                            .is_ok_and(|code_unit| code_unit.eq_ignore_ascii_case(&expected))
-                    })
-            },
-            &["none"],
-        )
-    })
+    let Some(source) = (unsafe { source.units() }) else {
+        return false;
+    };
+    is_valid_custom_ident_matching(
+        |expected| {
+            source.len() == expected.len()
+                && expected.iter().enumerate().all(|(index, &expected)| {
+                    u8::try_from(source.code_unit_at(index))
+                        .is_ok_and(|code_unit| code_unit.eq_ignore_ascii_case(&expected))
+                })
+        },
+        &["none"],
+    )
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/selector.rs
@@ -7,7 +7,6 @@
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::abort_on_panic;
 use crate::css::ffi_support::ascii_lowercase;
 use crate::css::retained_fly_string::RetainedUtf16FlyString;
 
@@ -665,26 +664,22 @@ pub fn is_ascii_case_insensitive_html_attribute(name: &[u16]) -> bool {
 /// `selector` must be an owned selector handle that has not already been destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_destroy(selector: *mut RustSelector) {
-    abort_on_panic(|| {
-        if !selector.is_null() {
-            // SAFETY: The caller guarantees that this is an owned handle returned by
-            // a selector-producing FFI function and that it has not already been destroyed.
-            drop(unsafe { Box::from_raw(selector) });
-        }
-    });
+    if !selector.is_null() {
+        // SAFETY: The caller guarantees that this is an owned handle returned by
+        // a selector-producing FFI function and that it has not already been destroyed.
+        drop(unsafe { Box::from_raw(selector) });
+    }
 }
 
 /// # Safety
 /// `selector` must point to a live selector handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_target_pseudo_element(selector: *const RustSelector) -> u8 {
-    abort_on_panic(|| {
-        assert!(!selector.is_null());
-        // SAFETY: The caller guarantees that `selector` points to a live selector handle.
-        unsafe { &(*selector).selector }
-            .target_pseudo_element
-            .map_or(u8::MAX, |pseudo_element| pseudo_element as u8)
-    })
+    assert!(!selector.is_null());
+    // SAFETY: The caller guarantees that `selector` points to a live selector handle.
+    unsafe { &(*selector).selector }
+        .target_pseudo_element
+        .map_or(u8::MAX, |pseudo_element| pseudo_element as u8)
 }
 
 /// Returns the selector's specificity in the packed representation used by the DevTools protocol.
@@ -693,11 +688,9 @@ pub unsafe extern "C" fn rust_selector_target_pseudo_element(selector: *const Ru
 /// `selector` must point to a live selector handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_specificity(selector: *const RustSelector) -> u32 {
-    abort_on_panic(|| {
-        assert!(!selector.is_null());
-        // SAFETY: The caller guarantees that the selector handle remains valid for this call.
-        unsafe { &(*selector).selector }.specificity().packed()
-    })
+    assert!(!selector.is_null());
+    // SAFETY: The caller guarantees that the selector handle remains valid for this call.
+    unsafe { &(*selector).selector }.specificity().packed()
 }
 
 fn can_simple_selector_use_fast_matches(simple_selector: &SimpleSelector) -> bool {

--- a/Libraries/LibWeb/Rust/src/css/selector_operations.rs
+++ b/Libraries/LibWeb/Rust/src/css/selector_operations.rs
@@ -199,10 +199,8 @@ fn supports_simple_dom_matching(selector: &CompiledSelector) -> bool {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_supports_simple_dom_matching(selector: *const RustSelector) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            supports_simple_dom_matching((*selector).compiled())
-        })
+        assert!(!selector.is_null());
+        supports_simple_dom_matching((*selector).compiled())
     }
 }
 
@@ -229,10 +227,8 @@ fn matches_every_element(selector: &CompiledSelector) -> bool {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_matches_every_element(selector: *const RustSelector) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            matches_every_element((*selector).compiled())
-        })
+        assert!(!selector.is_null());
+        matches_every_element((*selector).compiled())
     }
 }
 
@@ -268,10 +264,8 @@ unsafe fn replacement(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_contains_nesting(selector: *const RustSelector) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            contains_nesting((*selector).compiled())
-        })
+        assert!(!selector.is_null());
+        contains_nesting((*selector).compiled())
     }
 }
 
@@ -280,10 +274,8 @@ pub unsafe extern "C" fn rust_selector_contains_nesting(selector: *const RustSel
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_contains_pseudo_class(selector: *const RustSelector, value: u8) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            contains_pseudo_class((*selector).compiled(), pseudo_class_from_ffi(value))
-        })
+        assert!(!selector.is_null());
+        contains_pseudo_class((*selector).compiled(), pseudo_class_from_ffi(value))
     }
 }
 
@@ -292,10 +284,8 @@ pub unsafe extern "C" fn rust_selector_contains_pseudo_class(selector: *const Ru
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_contains_named_namespace(selector: *const RustSelector) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            contains_named_namespace((*selector).compiled())
-        })
+        assert!(!selector.is_null());
+        contains_named_namespace((*selector).compiled())
     }
 }
 
@@ -321,74 +311,72 @@ pub unsafe extern "C" fn rust_selector_matches_simple_dom(
     fold_id_and_classes: bool,
 ) -> u8 {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            let compounds = &(*selector).compiled().compound_selectors;
-            if !supports_simple_dom_matching((*selector).compiled()) {
+        assert!(!selector.is_null());
+        let compounds = &(*selector).compiled().compound_selectors;
+        if !supports_simple_dom_matching((*selector).compiled()) {
+            return u8::MAX;
+        }
+        let compound = &compounds[0];
+        let classes = if class_count == 0 {
+            &[][..]
+        } else {
+            if classes.is_null() {
                 return u8::MAX;
             }
-            let compound = &compounds[0];
-            let classes = if class_count == 0 {
-                &[][..]
-            } else {
-                if classes.is_null() {
-                    return u8::MAX;
-                }
-                std::slice::from_raw_parts(classes, class_count)
-            };
-            let lowercase_classes = if !fold_id_and_classes || class_count == 0 {
-                &[][..]
-            } else {
-                if lowercase_classes.is_null() {
-                    return u8::MAX;
-                }
-                std::slice::from_raw_parts(lowercase_classes, class_count)
-            };
-            for simple in &compound.simple_selectors {
-                let matches = match simple {
-                    SimpleSelector::Universal(name)
-                        if matches!(
-                            name.namespace_type,
-                            super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
-                        ) =>
-                    {
-                        true
-                    }
-                    SimpleSelector::TagName(name)
-                        if matches!(
-                            name.namespace_type,
-                            super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
-                        ) =>
-                    {
-                        if fold_tag_name {
-                            name.interned_lowercase_name_identity() == Some(lowercase_tag_name)
-                        } else {
-                            name.interned_name_identity() == Some(tag_name)
-                        }
-                    }
-                    SimpleSelector::Id(name) => {
-                        if fold_id_and_classes {
-                            name.interned_lowercase_name_identity() == Some(lowercase_id)
-                        } else {
-                            name.interned_name_identity() == Some(id)
-                        }
-                    }
-                    SimpleSelector::Class(name) => {
-                        let (expected, candidates) = if fold_id_and_classes {
-                            (name.interned_lowercase_name_identity(), lowercase_classes)
-                        } else {
-                            (name.interned_name_identity(), classes)
-                        };
-                        expected.is_some_and(|expected| candidates.contains(&expected))
-                    }
-                    _ => unreachable!(),
-                };
-                if !matches {
-                    return 0;
-                }
+            std::slice::from_raw_parts(classes, class_count)
+        };
+        let lowercase_classes = if !fold_id_and_classes || class_count == 0 {
+            &[][..]
+        } else {
+            if lowercase_classes.is_null() {
+                return u8::MAX;
             }
-            1
-        })
+            std::slice::from_raw_parts(lowercase_classes, class_count)
+        };
+        for simple in &compound.simple_selectors {
+            let matches = match simple {
+                SimpleSelector::Universal(name)
+                    if matches!(
+                        name.namespace_type,
+                        super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
+                    ) =>
+                {
+                    true
+                }
+                SimpleSelector::TagName(name)
+                    if matches!(
+                        name.namespace_type,
+                        super::selector::NamespaceType::Any | super::selector::NamespaceType::Default
+                    ) =>
+                {
+                    if fold_tag_name {
+                        name.interned_lowercase_name_identity() == Some(lowercase_tag_name)
+                    } else {
+                        name.interned_name_identity() == Some(tag_name)
+                    }
+                }
+                SimpleSelector::Id(name) => {
+                    if fold_id_and_classes {
+                        name.interned_lowercase_name_identity() == Some(lowercase_id)
+                    } else {
+                        name.interned_name_identity() == Some(id)
+                    }
+                }
+                SimpleSelector::Class(name) => {
+                    let (expected, candidates) = if fold_id_and_classes {
+                        (name.interned_lowercase_name_identity(), lowercase_classes)
+                    } else {
+                        (name.interned_name_identity(), classes)
+                    };
+                    expected.is_some_and(|expected| candidates.contains(&expected))
+                }
+                _ => unreachable!(),
+            };
+            if !matches {
+                return 0;
+            }
+        }
+        1
     }
 }
 
@@ -397,14 +385,12 @@ pub unsafe extern "C" fn rust_selector_matches_simple_dom(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_first_combinator(selector: *const RustSelector) -> Combinator {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            (*selector)
-                .compiled()
-                .compound_selectors
-                .first()
-                .map_or(Combinator::None, |compound| compound.combinator)
-        })
+        assert!(!selector.is_null());
+        (*selector)
+            .compiled()
+            .compound_selectors
+            .first()
+            .map_or(Combinator::None, |compound| compound.combinator)
     }
 }
 
@@ -413,16 +399,14 @@ pub unsafe extern "C" fn rust_selector_first_combinator(selector: *const RustSel
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_with_first_combinator_none(selector: *const RustSelector) -> *mut RustSelector {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            let mut compounds = (*selector).compiled().compound_selectors.clone();
-            if let Some(first) = compounds.first_mut() {
-                first.combinator = Combinator::None;
-            }
-            Box::into_raw(Box::new(RustSelector {
-                selector: CompiledSelector::new(compounds),
-            }))
-        })
+        assert!(!selector.is_null());
+        let mut compounds = (*selector).compiled().compound_selectors.clone();
+        if let Some(first) = compounds.first_mut() {
+            first.combinator = Combinator::None;
+        }
+        Box::into_raw(Box::new(RustSelector {
+            selector: CompiledSelector::new(compounds),
+        }))
     }
 }
 
@@ -431,12 +415,10 @@ pub unsafe extern "C" fn rust_selector_with_first_combinator_none(selector: *con
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_relative_to_nesting(selector: *const RustSelector) -> *mut RustSelector {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            Box::into_raw(Box::new(RustSelector {
-                selector: relative_to((*selector).compiled(), SimpleSelector::Nesting),
-            }))
-        })
+        assert!(!selector.is_null());
+        Box::into_raw(Box::new(RustSelector {
+            selector: relative_to((*selector).compiled(), SimpleSelector::Nesting),
+        }))
     }
 }
 
@@ -451,13 +433,11 @@ pub unsafe extern "C" fn rust_selector_relative_to_scope(
     count: usize,
 ) -> *mut RustSelector {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            let parent = replacement(use_parent_selectors, parents, count);
-            Box::into_raw(Box::new(RustSelector {
-                selector: relative_to((*selector).compiled(), parent),
-            }))
-        })
+        assert!(!selector.is_null());
+        let parent = replacement(use_parent_selectors, parents, count);
+        Box::into_raw(Box::new(RustSelector {
+            selector: relative_to((*selector).compiled(), parent),
+        }))
     }
 }
 
@@ -472,13 +452,11 @@ pub unsafe extern "C" fn rust_selector_absolutize(
     count: usize,
 ) -> *mut RustSelector {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            let replacement = replacement(use_parent_selectors, parents, count);
-            absolutize((*selector).compiled(), &replacement)
-                .map(|selector| Box::into_raw(Box::new(RustSelector { selector })))
-                .unwrap_or(std::ptr::null_mut())
-        })
+        assert!(!selector.is_null());
+        let replacement = replacement(use_parent_selectors, parents, count);
+        absolutize((*selector).compiled(), &replacement)
+            .map(|selector| Box::into_raw(Box::new(RustSelector { selector })))
+            .unwrap_or(std::ptr::null_mut())
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/css/selector_parser.rs
+++ b/Libraries/LibWeb/Rust/src/css/selector_parser.rs
@@ -1275,45 +1275,43 @@ pub unsafe extern "C" fn rust_selector_parse(
     is_forgiving: bool,
 ) -> *mut RustParsedSelectorList {
     unsafe {
-        crate::abort_on_panic(|| {
-            let Some(input) = input.units() else {
-                return std::ptr::null_mut();
-            };
-            let namespace_views = if namespace_count == 0 {
-                &[]
+        let Some(input) = input.units() else {
+            return std::ptr::null_mut();
+        };
+        let namespace_views = if namespace_count == 0 {
+            &[]
+        } else {
+            assert!(!namespaces.is_null());
+            std::slice::from_raw_parts(namespaces, namespace_count)
+        };
+        let namespace_storage = namespace_views
+            .iter()
+            .map(|namespace| {
+                if namespace.length == 0 {
+                    TokenizerInput::Utf16(&[])
+                } else {
+                    assert!(!namespace.data.is_null());
+                    TokenizerInput::Utf16(std::slice::from_raw_parts(namespace.data, namespace.length))
+                }
+            })
+            .collect::<Vec<_>>();
+        let Ok(selectors) = parse_selector_list(
+            input,
+            &namespace_storage,
+            if is_relative {
+                SelectorType::Relative
             } else {
-                assert!(!namespaces.is_null());
-                std::slice::from_raw_parts(namespaces, namespace_count)
-            };
-            let namespace_storage = namespace_views
-                .iter()
-                .map(|namespace| {
-                    if namespace.length == 0 {
-                        TokenizerInput::Utf16(&[])
-                    } else {
-                        assert!(!namespace.data.is_null());
-                        TokenizerInput::Utf16(std::slice::from_raw_parts(namespace.data, namespace.length))
-                    }
-                })
-                .collect::<Vec<_>>();
-            let Ok(selectors) = parse_selector_list(
-                input,
-                &namespace_storage,
-                if is_relative {
-                    SelectorType::Relative
-                } else {
-                    SelectorType::Standalone
-                },
-                if is_forgiving {
-                    SelectorParsingMode::Forgiving
-                } else {
-                    SelectorParsingMode::Standard
-                },
-            ) else {
-                return std::ptr::null_mut();
-            };
-            Box::into_raw(Box::new(RustParsedSelectorList::new(selectors)))
-        })
+                SelectorType::Standalone
+            },
+            if is_forgiving {
+                SelectorParsingMode::Forgiving
+            } else {
+                SelectorParsingMode::Standard
+            },
+        ) else {
+            return std::ptr::null_mut();
+        };
+        Box::into_raw(Box::new(RustParsedSelectorList::new(selectors)))
     }
 }
 
@@ -1330,24 +1328,22 @@ pub struct FfiParsedPseudoElement {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_parse_pseudo_element(input: FfiUtf16View) -> FfiParsedPseudoElement {
     unsafe {
-        crate::abort_on_panic(|| {
-            let Some(input) = input.units() else {
-                return FfiParsedPseudoElement {
-                    selector: std::ptr::null_mut(),
-                    pseudo_element: u8::MAX,
-                };
+        let Some(input) = input.units() else {
+            return FfiParsedPseudoElement {
+                selector: std::ptr::null_mut(),
+                pseudo_element: u8::MAX,
             };
-            let Ok((selector, pseudo_element)) = parse_pseudo_element_selector(input) else {
-                return FfiParsedPseudoElement {
-                    selector: std::ptr::null_mut(),
-                    pseudo_element: u8::MAX,
-                };
+        };
+        let Ok((selector, pseudo_element)) = parse_pseudo_element_selector(input) else {
+            return FfiParsedPseudoElement {
+                selector: std::ptr::null_mut(),
+                pseudo_element: u8::MAX,
             };
-            FfiParsedPseudoElement {
-                selector: Box::into_raw(Box::new(RustSelector { selector })),
-                pseudo_element: pseudo_element as u8,
-            }
-        })
+        };
+        FfiParsedPseudoElement {
+            selector: Box::into_raw(Box::new(RustSelector { selector })),
+            pseudo_element: pseudo_element as u8,
+        }
     }
 }
 
@@ -1356,11 +1352,9 @@ pub unsafe extern "C" fn rust_selector_parse_pseudo_element(input: FfiUtf16View)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parsed_selector_list_destroy(list: *mut RustParsedSelectorList) {
     unsafe {
-        crate::abort_on_panic(|| {
-            if !list.is_null() {
-                drop(Box::from_raw(list));
-            }
-        });
+        if !list.is_null() {
+            drop(Box::from_raw(list));
+        }
     }
 }
 
@@ -1368,7 +1362,7 @@ pub unsafe extern "C" fn rust_parsed_selector_list_destroy(list: *mut RustParsed
 /// `list` must point to a live parsed selector list.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parsed_selector_list_length(list: *const RustParsedSelectorList) -> usize {
-    unsafe { crate::abort_on_panic(|| (&*list).selectors.len()) }
+    unsafe { (&*list).selectors.len() }
 }
 
 /// # Safety
@@ -1380,11 +1374,9 @@ pub unsafe extern "C" fn rust_parsed_selector_list_selector(
     index: usize,
 ) -> *mut RustSelector {
     unsafe {
-        crate::abort_on_panic(|| {
-            Box::into_raw(Box::new(RustSelector {
-                selector: (&(*list).selectors)[index].clone(),
-            }))
-        })
+        Box::into_raw(Box::new(RustSelector {
+            selector: (&(*list).selectors)[index].clone(),
+        }))
     }
 }
 
@@ -1392,7 +1384,7 @@ pub unsafe extern "C" fn rust_parsed_selector_list_selector(
 /// `list` must point to a live parsed selector list.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parsed_selector_list_interned_name_count(list: *const RustParsedSelectorList) -> usize {
-    unsafe { crate::abort_on_panic(|| (&*list).interned_names.len()) }
+    unsafe { (&*list).interned_names.len() }
 }
 
 /// # Safety
@@ -1403,13 +1395,11 @@ pub unsafe extern "C" fn rust_parsed_selector_list_interned_name(
     index: usize,
 ) -> FfiStringView {
     unsafe {
-        crate::abort_on_panic(|| {
-            let name = &(&(*list).interned_names)[index];
-            FfiStringView {
-                data: name.as_ptr(),
-                length: name.len(),
-            }
-        })
+        let name = &(&(*list).interned_names)[index];
+        FfiStringView {
+            data: name.as_ptr(),
+            length: name.len(),
+        }
     }
 }
 
@@ -1425,22 +1415,20 @@ pub unsafe extern "C" fn rust_parsed_selector_list_bind_interned_names(
     name_count: usize,
 ) {
     unsafe {
-        crate::abort_on_panic(|| {
-            let list = &mut *list;
-            assert_eq!(name_count, list.interned_names.len());
-            let leaked_name_raws = if name_count == 0 {
-                &[]
-            } else {
-                assert!(!leaked_name_raws.is_null());
-                std::slice::from_raw_parts(leaked_name_raws, name_count)
-            };
-            let retained_names = leaked_name_raws
-                .iter()
-                .map(|&raw| RetainedUtf16FlyString::from_leaked_raw(raw))
-                .collect::<Vec<_>>();
-            for selector in &mut list.selectors {
-                bind_interned_names_in_selector(selector, &list.interned_names, &retained_names);
-            }
-        });
+        let list = &mut *list;
+        assert_eq!(name_count, list.interned_names.len());
+        let leaked_name_raws = if name_count == 0 {
+            &[]
+        } else {
+            assert!(!leaked_name_raws.is_null());
+            std::slice::from_raw_parts(leaked_name_raws, name_count)
+        };
+        let retained_names = leaked_name_raws
+            .iter()
+            .map(|&raw| RetainedUtf16FlyString::from_leaked_raw(raw))
+            .collect::<Vec<_>>();
+        for selector in &mut list.selectors {
+            bind_interned_names_in_selector(selector, &list.interned_names, &retained_names);
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/selector_serialization.rs
+++ b/Libraries/LibWeb/Rust/src/css/selector_serialization.rs
@@ -302,42 +302,40 @@ pub unsafe extern "C" fn rust_selector_serialize(
     prefix_count: usize,
 ) -> FfiSelectorSerializedText {
     unsafe {
-        crate::abort_on_panic(|| {
-            assert!(!selector.is_null());
-            let prefix_views = if prefix_count == 0 {
-                &[]
-            } else {
-                assert!(!prefixes_mapping_to_default.is_null());
-                std::slice::from_raw_parts(prefixes_mapping_to_default, prefix_count)
-            };
-            let prefixes = prefix_views
-                .iter()
-                .map(|prefix| {
-                    if prefix.length == 0 {
-                        &[][..]
-                    } else {
-                        assert!(!prefix.data.is_null());
-                        std::slice::from_raw_parts(prefix.data, prefix.length)
-                    }
-                })
-                .collect::<Vec<_>>();
-            let context = NamespaceContext {
-                has_default_namespace,
-                prefixes_mapping_to_default: &prefixes,
-            };
-            let mut sink = TextSink::new();
-            serialize_selector(&mut sink, (*selector).compiled(), &context);
-            let storage = Box::new(sink.into_utf16());
-            let result = FfiSelectorSerializedText {
-                data: storage.as_ptr(),
-                length: storage.len(),
-                storage: std::ptr::null_mut(),
-            };
-            FfiSelectorSerializedText {
-                storage: Box::into_raw(storage).cast(),
-                ..result
-            }
-        })
+        assert!(!selector.is_null());
+        let prefix_views = if prefix_count == 0 {
+            &[]
+        } else {
+            assert!(!prefixes_mapping_to_default.is_null());
+            std::slice::from_raw_parts(prefixes_mapping_to_default, prefix_count)
+        };
+        let prefixes = prefix_views
+            .iter()
+            .map(|prefix| {
+                if prefix.length == 0 {
+                    &[][..]
+                } else {
+                    assert!(!prefix.data.is_null());
+                    std::slice::from_raw_parts(prefix.data, prefix.length)
+                }
+            })
+            .collect::<Vec<_>>();
+        let context = NamespaceContext {
+            has_default_namespace,
+            prefixes_mapping_to_default: &prefixes,
+        };
+        let mut sink = TextSink::new();
+        serialize_selector(&mut sink, (*selector).compiled(), &context);
+        let storage = Box::new(sink.into_utf16());
+        let result = FfiSelectorSerializedText {
+            data: storage.as_ptr(),
+            length: storage.len(),
+            storage: std::ptr::null_mut(),
+        };
+        FfiSelectorSerializedText {
+            storage: Box::into_raw(storage).cast(),
+            ..result
+        }
     }
 }
 
@@ -346,10 +344,8 @@ pub unsafe extern "C" fn rust_selector_serialize(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_serialized_text_release(storage: *mut c_void) {
     unsafe {
-        crate::abort_on_panic(|| {
-            if !storage.is_null() {
-                drop(Box::from_raw(storage.cast::<Vec<u16>>()));
-            }
-        });
+        if !storage.is_null() {
+            drop(Box::from_raw(storage.cast::<Vec<u16>>()));
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/css/serialize.rs
@@ -3601,14 +3601,12 @@ pub(crate) fn sink_into_ffi(sink: TextSink) -> FfiSerializedText {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_serialize(value: *const c_void, mode: u8) -> FfiSerializedText {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueSerializeEntry);
-    crate::abort_on_panic(|| {
-        let value = unsafe { &*value.cast::<StyleValueData>() };
-        let mut sink = TextSink::new();
-        if !serialize_style_value(&mut sink, value, SerializationMode::from_ffi(mode)) {
-            return FfiSerializedText::unported();
-        }
-        sink_into_ffi(sink)
-    })
+    let value = unsafe { &*value.cast::<StyleValueData>() };
+    let mut sink = TextSink::new();
+    if !serialize_style_value(&mut sink, value, SerializationMode::from_ffi(mode)) {
+        return FfiSerializedText::unported();
+    }
+    sink_into_ffi(sink)
 }
 
 /// Serializes the retained component values of an unresolved style value. Mode 0 is normalized
@@ -3622,21 +3620,19 @@ pub unsafe extern "C" fn rust_unresolved_style_value_serialize_components(
     value: *const c_void,
     mode: u8,
 ) -> FfiSerializedText {
-    crate::abort_on_panic(|| {
-        let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
-            unreachable!("component serialization requires an unresolved style value");
-        };
-        let mode = match mode {
-            0 => ComponentSerializationMode::Normalized,
-            1 => ComponentSerializationMode::PreserveNumericSource,
-            2 => ComponentSerializationMode::Retokenize,
-            _ => unreachable!("unknown component serialization mode"),
-        };
-        let serialized = serialize_component_values_to_utf16(components.as_slice(), mode);
-        let mut sink = TextSink::new();
-        serialized.into_iter().for_each(|unit| sink.push_code_unit(unit));
-        sink_into_ffi(sink)
-    })
+    let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
+        unreachable!("component serialization requires an unresolved style value");
+    };
+    let mode = match mode {
+        0 => ComponentSerializationMode::Normalized,
+        1 => ComponentSerializationMode::PreserveNumericSource,
+        2 => ComponentSerializationMode::Retokenize,
+        _ => unreachable!("unknown component serialization mode"),
+    };
+    let serialized = serialize_component_values_to_utf16(components.as_slice(), mode);
+    let mut sink = TextSink::new();
+    serialized.into_iter().for_each(|unit| sink.push_code_unit(unit));
+    sink_into_ffi(sink)
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/css/style/bridge.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/bridge.rs
@@ -919,21 +919,19 @@ impl StyleEngine {
 /// Creates one document's style engine.
 #[unsafe(no_mangle)]
 pub extern "C" fn style_engine_create(device_class: FfiDeviceClass) -> *mut c_void {
-    abort_on_panic(|| {
-        let device_class = device_class.decode();
-        let mut engine = Box::new(StyleEngine::new(device_class));
-        engine.begin_recording(device_class);
-        engine.record_boundary_call(EventKind::SetComputedGroupDependencyMasks, |payload| {
-            let mapping = crate::css::computed_values::property_dependency_masks_snapshot();
-            payload.write_bool(mapping.is_some());
-            if let Some((first_property, masks, output_masks)) = mapping {
-                payload.write_u16(first_property);
-                payload.write_u32_slice(masks);
-                payload.write_u32_slice(output_masks);
-            }
-        });
-        Box::into_raw(engine).cast()
-    })
+    let device_class = device_class.decode();
+    let mut engine = Box::new(StyleEngine::new(device_class));
+    engine.begin_recording(device_class);
+    engine.record_boundary_call(EventKind::SetComputedGroupDependencyMasks, |payload| {
+        let mapping = crate::css::computed_values::property_dependency_masks_snapshot();
+        payload.write_bool(mapping.is_some());
+        if let Some((first_property, masks, output_masks)) = mapping {
+            payload.write_u16(first_property);
+            payload.write_u32_slice(masks);
+            payload.write_u32_slice(output_masks);
+        }
+    });
+    Box::into_raw(engine).cast()
 }
 
 /// Installs the C++ ownership callbacks used by live process-global raw atoms.
@@ -957,13 +955,11 @@ pub unsafe extern "C" fn style_engine_install_font_resolver(
     retain: unsafe extern "C" fn(*const c_void),
     release: unsafe extern "C" fn(*const c_void),
 ) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        assert!(engine.font_resolver.is_none(), "font resolver is installed once");
-        engine.font_resolver = Some(super::font_resolution::FontResolver::new(
-            context, resolve, retain, release,
-        ));
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    assert!(engine.font_resolver.is_none(), "font resolver is installed once");
+    engine.font_resolver = Some(super::font_resolution::FontResolver::new(
+        context, resolve, retain, release,
+    ));
 }
 
 /// Creates a replay engine whose atom keys are opaque capture tokens rather than live fly strings.
@@ -977,10 +973,8 @@ pub fn style_engine_create_for_replay(device_class: FfiDeviceClass) -> *mut c_vo
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_use_recording_memory_policy(engine: *mut c_void) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.memory.enable_recording_policy();
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.memory.enable_recording_policy();
 }
 
 /// Accounts C++ substitution-cache capacity against this document's acceleration budget.
@@ -989,10 +983,8 @@ pub unsafe extern "C" fn style_engine_use_recording_memory_policy(engine: *mut c
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_resize_parsed_substitution_cache(engine: *mut c_void, bytes: u64) -> bool {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.resize_parsed_substitution_cache(bytes)
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.resize_parsed_substitution_cache(bytes)
 }
 
 #[unsafe(no_mangle)]
@@ -1004,26 +996,22 @@ pub extern "C" fn style_engine_verification_gate_bits() -> u8 {
 /// `engine` must be a pointer returned by `style_engine_create` and not yet destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_destroy(engine: *mut c_void) {
-    abort_on_panic(|| {
-        let mut engine = unsafe { Box::from_raw(engine.cast::<StyleEngine>()) };
-        engine.end_recording();
-    });
+    let mut engine = unsafe { Box::from_raw(engine.cast::<StyleEngine>()) };
+    engine.end_recording();
 }
 
 /// # Safety
 /// `engine` must be live, and `out` must point at `count` writable `u32` values.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_allocate_style_nodes(engine: *mut c_void, out: *mut u32, count: usize) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let out = if count == 0 {
-            &mut []
-        } else {
-            unsafe { std::slice::from_raw_parts_mut(out, count) }
-        };
-        engine.allocate_style_nodes(out);
-        engine.record_boundary_call(EventKind::AllocateStyleNodes, |payload| payload.write_u32_slice(out));
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let out = if count == 0 {
+        &mut []
+    } else {
+        unsafe { std::slice::from_raw_parts_mut(out, count) }
+    };
+    engine.allocate_style_nodes(out);
+    engine.record_boundary_call(EventKind::AllocateStyleNodes, |payload| payload.write_u32_slice(out));
 }
 
 /// Returns the live element descendants whose inheritance path begins at `root` in the flat tree.
@@ -1033,22 +1021,20 @@ pub unsafe extern "C" fn style_engine_allocate_style_nodes(engine: *mut c_void, 
 /// `style_engine_*` entry point or an explicit discard of the flat-tree descendants.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_flat_tree_descendants(engine: *mut c_void, root: u32) -> FfiStyleNodeSlice {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_style_node_query();
-        let Some(root) = StyleNodeID::from_raw(root) else {
-            return FfiStyleNodeSlice::default();
-        };
-        let mut descendants = Vec::new();
-        engine.for_each_flat_tree_descendant(root, |node| {
-            descendants.push(node.raw());
-        });
-        engine.record_boundary_call(EventKind::ForEachFlatTreeDescendant, |payload| {
-            payload.write_u32(root.raw());
-            payload.write_u32_slice(&descendants);
-        });
-        engine.install_ffi_style_node_query(descendants)
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_style_node_query();
+    let Some(root) = StyleNodeID::from_raw(root) else {
+        return FfiStyleNodeSlice::default();
+    };
+    let mut descendants = Vec::new();
+    engine.for_each_flat_tree_descendant(root, |node| {
+        descendants.push(node.raw());
+    });
+    engine.record_boundary_call(EventKind::ForEachFlatTreeDescendant, |payload| {
+        payload.write_u32(root.raw());
+        payload.write_u32_slice(&descendants);
+    });
+    engine.install_ffi_style_node_query(descendants)
 }
 
 /// Discards the borrowed flat-tree descendant slice.
@@ -1057,10 +1043,8 @@ pub unsafe extern "C" fn style_engine_flat_tree_descendants(engine: *mut c_void,
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_discard_flat_tree_descendants(engine: *mut c_void) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_style_node_query();
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_style_node_query();
 }
 
 /// Returns the owner nodes whose element or pseudo style depends on viewport metrics.
@@ -1070,12 +1054,10 @@ pub unsafe extern "C" fn style_engine_discard_flat_tree_descendants(engine: *mut
 /// explicit discard.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_viewport_dependent_nodes(engine: *mut c_void) -> FfiStyleNodeSlice {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_style_node_query();
-        let nodes = engine.computed_group_sets.viewport_dependent_nodes();
-        engine.install_ffi_style_node_query(nodes)
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_style_node_query();
+    let nodes = engine.computed_group_sets.viewport_dependent_nodes();
+    engine.install_ffi_style_node_query(nodes)
 }
 
 /// Discards the borrowed viewport-dependent node slice.
@@ -1084,10 +1066,8 @@ pub unsafe extern "C" fn style_engine_viewport_dependent_nodes(engine: *mut c_vo
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_discard_viewport_dependent_nodes(engine: *mut c_void) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_style_node_query();
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_style_node_query();
 }
 
 /// Applies one flat style input transaction.
@@ -1097,44 +1077,42 @@ pub unsafe extern "C" fn style_engine_discard_viewport_dependent_nodes(engine: *
 /// records for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_apply_transaction(engine: *mut c_void, transaction: &FfiStyleInputTransaction) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        // SAFETY: the caller vouches that each pointer covers its stated count for this call.
-        let tree = unsafe { borrow(transaction.tree_deltas, transaction.tree_delta_count) };
-        let arrivals = unsafe { borrow(transaction.element_arrivals, transaction.element_arrival_count) };
-        let arrival_custom_state_atoms = unsafe {
-            borrow(
-                transaction.arrival_custom_state_atoms,
-                transaction.arrival_custom_state_atom_count,
-            )
-        };
-        let features = unsafe { borrow(transaction.local_feature_deltas, transaction.local_feature_delta_count) };
-        let states = unsafe { borrow(transaction.state_deltas, transaction.state_delta_count) };
-        let declarations = unsafe {
-            borrow(
-                transaction.element_declaration_deltas,
-                transaction.element_declaration_delta_count,
-            )
-        };
-        let element_style_inputs =
-            unsafe { borrow(transaction.element_style_inputs, transaction.element_style_input_count) };
-        engine.apply_transaction_batch(
-            tree,
-            (arrivals, arrival_custom_state_atoms),
-            features,
-            states,
-            declarations,
-            element_style_inputs,
-        );
-        engine.record_boundary_call(EventKind::ApplyTransaction, |payload| {
-            write_recording_tree_deltas(tree, payload);
-            payload.write_raw_slice(arrivals);
-            payload.write_u32_slice(arrival_custom_state_atoms);
-            payload.write_raw_slice(features);
-            write_recording_state_deltas(states, payload);
-            payload.write_raw_slice(declarations);
-            write_recording_element_style_inputs(element_style_inputs, payload);
-        });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    // SAFETY: the caller vouches that each pointer covers its stated count for this call.
+    let tree = unsafe { borrow(transaction.tree_deltas, transaction.tree_delta_count) };
+    let arrivals = unsafe { borrow(transaction.element_arrivals, transaction.element_arrival_count) };
+    let arrival_custom_state_atoms = unsafe {
+        borrow(
+            transaction.arrival_custom_state_atoms,
+            transaction.arrival_custom_state_atom_count,
+        )
+    };
+    let features = unsafe { borrow(transaction.local_feature_deltas, transaction.local_feature_delta_count) };
+    let states = unsafe { borrow(transaction.state_deltas, transaction.state_delta_count) };
+    let declarations = unsafe {
+        borrow(
+            transaction.element_declaration_deltas,
+            transaction.element_declaration_delta_count,
+        )
+    };
+    let element_style_inputs =
+        unsafe { borrow(transaction.element_style_inputs, transaction.element_style_input_count) };
+    engine.apply_transaction_batch(
+        tree,
+        (arrivals, arrival_custom_state_atoms),
+        features,
+        states,
+        declarations,
+        element_style_inputs,
+    );
+    engine.record_boundary_call(EventKind::ApplyTransaction, |payload| {
+        write_recording_tree_deltas(tree, payload);
+        payload.write_raw_slice(arrivals);
+        payload.write_u32_slice(arrival_custom_state_atoms);
+        payload.write_raw_slice(features);
+        write_recording_state_deltas(states, payload);
+        payload.write_raw_slice(declarations);
+        write_recording_element_style_inputs(element_style_inputs, payload);
     });
 }
 
@@ -1227,53 +1205,50 @@ pub unsafe extern "C" fn style_engine_add_style_rule(
     scope_level_implicit_roots: *const u32,
     scope_level_count: usize,
 ) -> u32 {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        if sheet == 0 || count == 0 {
-            engine.record_boundary_call(EventKind::AddStyleRule, |payload| {
-                payload.write_u32(sheet);
-                payload.write_u32(before_rule);
-                payload.write_u32(0);
-            });
-            return 0;
-        }
-        let compiled = unsafe { borrow_selectors(selectors, count) };
-        if compiled.is_empty() {
-            engine.record_boundary_call(EventKind::AddStyleRule, |payload| {
-                payload.write_u32(sheet);
-                payload.write_u32(before_rule);
-                payload.write_u32(0);
-            });
-            return 0;
-        }
-        let scope = unsafe { borrow_selectors(scope_roots, scope_root_count) };
-        let limits = unsafe { borrow_selectors(scope_limits, scope_limit_count) };
-        let levels =
-            unsafe { borrow_scope_levels(scope_level_root_counts, scope_level_limit_counts, scope_level_count) };
-        let implicit_roots = unsafe { borrow_implicit_scope_roots(scope_level_implicit_roots, scope_level_count) };
-        let before = match before_rule {
-            0 => None,
-            id => Some(RuleID(id - 1)),
-        };
-        let namespaces =
-            unsafe { borrow_namespace_scope(default_namespace, namespace_prefixes, namespace_uris, namespace_count) };
-        let scope = ScopeChain {
-            roots: &scope,
-            limits: &limits,
-            levels: &levels,
-            implicit_roots: &implicit_roots,
-        };
-        let rule = engine.add_style_rule_in_scope(SheetID(sheet - 1), before, &compiled, namespaces, &scope);
-        let result = rule.0 + 1;
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    if sheet == 0 || count == 0 {
         engine.record_boundary_call(EventKind::AddStyleRule, |payload| {
             payload.write_u32(sheet);
             payload.write_u32(before_rule);
-            payload.write_u32(result);
-            write_recording_atom_mappings(engine, payload);
-            super::selector::replay::write(engine.selector_program_for_rule(rule), payload);
+            payload.write_u32(0);
         });
-        result
-    })
+        return 0;
+    }
+    let compiled = unsafe { borrow_selectors(selectors, count) };
+    if compiled.is_empty() {
+        engine.record_boundary_call(EventKind::AddStyleRule, |payload| {
+            payload.write_u32(sheet);
+            payload.write_u32(before_rule);
+            payload.write_u32(0);
+        });
+        return 0;
+    }
+    let scope = unsafe { borrow_selectors(scope_roots, scope_root_count) };
+    let limits = unsafe { borrow_selectors(scope_limits, scope_limit_count) };
+    let levels = unsafe { borrow_scope_levels(scope_level_root_counts, scope_level_limit_counts, scope_level_count) };
+    let implicit_roots = unsafe { borrow_implicit_scope_roots(scope_level_implicit_roots, scope_level_count) };
+    let before = match before_rule {
+        0 => None,
+        id => Some(RuleID(id - 1)),
+    };
+    let namespaces =
+        unsafe { borrow_namespace_scope(default_namespace, namespace_prefixes, namespace_uris, namespace_count) };
+    let scope = ScopeChain {
+        roots: &scope,
+        limits: &limits,
+        levels: &levels,
+        implicit_roots: &implicit_roots,
+    };
+    let rule = engine.add_style_rule_in_scope(SheetID(sheet - 1), before, &compiled, namespaces, &scope);
+    let result = rule.0 + 1;
+    engine.record_boundary_call(EventKind::AddStyleRule, |payload| {
+        payload.write_u32(sheet);
+        payload.write_u32(before_rule);
+        payload.write_u32(result);
+        write_recording_atom_mappings(engine, payload);
+        super::selector::replay::write(engine.selector_program_for_rule(rule), payload);
+    });
+    result
 }
 
 /// Installs one already compiled semantic selector program.
@@ -1372,34 +1347,31 @@ pub unsafe extern "C" fn style_engine_replace_style_rule_selectors(
     scope_level_implicit_roots: *const u32,
     scope_level_count: usize,
 ) {
-    abort_on_panic(|| {
-        if rule == 0 || count == 0 {
-            return;
-        }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let compiled = unsafe { borrow_selectors(selectors, count) };
-        if compiled.is_empty() {
-            return;
-        }
-        let scope = unsafe { borrow_selectors(scope_roots, scope_root_count) };
-        let limits = unsafe { borrow_selectors(scope_limits, scope_limit_count) };
-        let levels =
-            unsafe { borrow_scope_levels(scope_level_root_counts, scope_level_limit_counts, scope_level_count) };
-        let implicit_roots = unsafe { borrow_implicit_scope_roots(scope_level_implicit_roots, scope_level_count) };
-        let namespaces =
-            unsafe { borrow_namespace_scope(default_namespace, namespace_prefixes, namespace_uris, namespace_count) };
-        let scope = ScopeChain {
-            roots: &scope,
-            limits: &limits,
-            levels: &levels,
-            implicit_roots: &implicit_roots,
-        };
-        engine.replace_style_rule_selectors(RuleID(rule - 1), &compiled, namespaces, &scope);
-        engine.record_boundary_call(EventKind::ReplaceStyleRuleSelectors, |payload| {
-            payload.write_u32(rule);
-            write_recording_atom_mappings(engine, payload);
-            super::selector::replay::write(engine.selector_program_for_rule(RuleID(rule - 1)), payload);
-        });
+    if rule == 0 || count == 0 {
+        return;
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let compiled = unsafe { borrow_selectors(selectors, count) };
+    if compiled.is_empty() {
+        return;
+    }
+    let scope = unsafe { borrow_selectors(scope_roots, scope_root_count) };
+    let limits = unsafe { borrow_selectors(scope_limits, scope_limit_count) };
+    let levels = unsafe { borrow_scope_levels(scope_level_root_counts, scope_level_limit_counts, scope_level_count) };
+    let implicit_roots = unsafe { borrow_implicit_scope_roots(scope_level_implicit_roots, scope_level_count) };
+    let namespaces =
+        unsafe { borrow_namespace_scope(default_namespace, namespace_prefixes, namespace_uris, namespace_count) };
+    let scope = ScopeChain {
+        roots: &scope,
+        limits: &limits,
+        levels: &levels,
+        implicit_roots: &implicit_roots,
+    };
+    engine.replace_style_rule_selectors(RuleID(rule - 1), &compiled, namespaces, &scope);
+    engine.record_boundary_call(EventKind::ReplaceStyleRuleSelectors, |payload| {
+        payload.write_u32(rule);
+        write_recording_atom_mappings(engine, payload);
+        super::selector::replay::write(engine.selector_program_for_rule(RuleID(rule - 1)), payload);
     });
 }
 /// Records the shadow parts an element exposes and which host each name reaches.
@@ -1414,32 +1386,30 @@ pub unsafe extern "C" fn style_engine_set_element_parts(
     hosts: *const u32,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return;
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let pairs: Vec<(StyleAtomID, StyleNodeID)> = match count == 0 || names.is_null() || hosts.is_null() {
-            true => Vec::new(),
-            false => {
-                let names = unsafe { std::slice::from_raw_parts(names, count) };
-                let hosts = unsafe { std::slice::from_raw_parts(hosts, count) };
-                names
-                    .iter()
-                    .zip(hosts.iter())
-                    .filter_map(|(name, host)| StyleNodeID::from_raw(*host).map(|host| (StyleAtomID(*name), host)))
-                    .collect()
-            }
-        };
-        engine.set_element_parts(node, &pairs);
-        engine.record_boundary_call(EventKind::SetElementParts, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_length(pairs.len());
-            for (name, host) in &pairs {
-                payload.write_u32(name.0);
-                payload.write_u32(host.raw());
-            }
-        });
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return;
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let pairs: Vec<(StyleAtomID, StyleNodeID)> = match count == 0 || names.is_null() || hosts.is_null() {
+        true => Vec::new(),
+        false => {
+            let names = unsafe { std::slice::from_raw_parts(names, count) };
+            let hosts = unsafe { std::slice::from_raw_parts(hosts, count) };
+            names
+                .iter()
+                .zip(hosts.iter())
+                .filter_map(|(name, host)| StyleNodeID::from_raw(*host).map(|host| (StyleAtomID(*name), host)))
+                .collect()
+        }
+    };
+    engine.set_element_parts(node, &pairs);
+    engine.record_boundary_call(EventKind::SetElementParts, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_length(pairs.len());
+        for (name, host) in &pairs {
+            payload.write_u32(name.0);
+            payload.write_u32(host.raw());
+        }
     });
 }
 /// Records the element's resolved language, as its primary subtag atom.
@@ -1454,25 +1424,23 @@ pub unsafe extern "C" fn style_engine_set_element_language(
     text: *const u16,
     text_length: usize,
 ) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let text = match language != 0 && !text.is_null() {
-            true => unsafe { std::slice::from_raw_parts(text, text_length) },
-            false => &[],
-        };
-        if language != 0 && !text.is_empty() {
-            // A range is not a name, so `:lang()` compares against the tag itself. It is recorded
-            // once per language rather than once per element.
-            engine.set_element_language_text(StyleAtomID(language), text);
-        }
-        if let Some(node) = StyleNodeID::from_raw(node) {
-            engine.set_element_language(node, StyleAtomID(language));
-        }
-        engine.record_boundary_call(EventKind::SetElementLanguage, |payload| {
-            payload.write_u32(node);
-            payload.write_u32(language);
-            payload.write_u16_slice(text);
-        });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let text = match language != 0 && !text.is_null() {
+        true => unsafe { std::slice::from_raw_parts(text, text_length) },
+        false => &[],
+    };
+    if language != 0 && !text.is_empty() {
+        // A range is not a name, so `:lang()` compares against the tag itself. It is recorded
+        // once per language rather than once per element.
+        engine.set_element_language_text(StyleAtomID(language), text);
+    }
+    if let Some(node) = StyleNodeID::from_raw(node) {
+        engine.set_element_language(node, StyleAtomID(language));
+    }
+    engine.record_boundary_call(EventKind::SetElementLanguage, |payload| {
+        payload.write_u32(node);
+        payload.write_u32(language);
+        payload.write_u16_slice(text);
     });
 }
 
@@ -1531,40 +1499,36 @@ pub unsafe extern "C" fn style_engine_compile_selector_query(
     selectors: *const *const c_void,
     count: usize,
 ) -> *mut c_void {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let selectors = unsafe { borrow_selectors(selectors, count) };
-        let program = engine.compile_selector_query(&selectors);
-        let mut atoms = HashSet::default();
-        program.collect_atoms(&mut atoms);
-        let atoms = engine.atoms.pin(atoms);
-        engine.record_boundary_call(EventKind::SelectorQueryAtomMappings, |payload| {
-            write_recording_atom_mappings(engine, payload);
-        });
-        let bytes = program
-            .capacity_bytes()
-            .saturating_add(std::mem::size_of::<SelectorQuery>() as u64);
-        let mut memory = MemoryLease::new(MemoryCategory::SelectorQuery);
-        memory.resize_required_to(&mut engine.memory, bytes);
-        Box::into_raw(Box::new(SelectorQuery {
-            program,
-            cache: SelectorQueryCache::default(),
-            _atoms: atoms,
-            _memory: memory,
-        }))
-        .cast()
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let selectors = unsafe { borrow_selectors(selectors, count) };
+    let program = engine.compile_selector_query(&selectors);
+    let mut atoms = HashSet::default();
+    program.collect_atoms(&mut atoms);
+    let atoms = engine.atoms.pin(atoms);
+    engine.record_boundary_call(EventKind::SelectorQueryAtomMappings, |payload| {
+        write_recording_atom_mappings(engine, payload);
+    });
+    let bytes = program
+        .capacity_bytes()
+        .saturating_add(std::mem::size_of::<SelectorQuery>() as u64);
+    let mut memory = MemoryLease::new(MemoryCategory::SelectorQuery);
+    memory.resize_required_to(&mut engine.memory, bytes);
+    Box::into_raw(Box::new(SelectorQuery {
+        program,
+        cache: SelectorQueryCache::default(),
+        _atoms: atoms,
+        _memory: memory,
+    }))
+    .cast()
 }
 
 /// # Safety
 /// `query` must have been returned by `style_engine_compile_selector_query` and not yet destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_destroy_selector_query(query: *mut c_void) {
-    abort_on_panic(|| {
-        if !query.is_null() {
-            drop(unsafe { Box::from_raw(query.cast::<SelectorQuery>()) });
-        }
-    });
+    if !query.is_null() {
+        drop(unsafe { Box::from_raw(query.cast::<SelectorQuery>()) });
+    }
 }
 /// Matches one resident element against an ad-hoc selector list.
 ///
@@ -1618,38 +1582,36 @@ pub unsafe extern "C" fn style_engine_selector_query_all(
     matches: *mut u32,
     capacity: usize,
 ) -> usize {
-    abort_on_panic(|| {
-        let Some(root) = StyleNodeID::from_raw(root) else {
-            return usize::MAX;
-        };
-        if query.is_null() || (capacity != 0 && matches.is_null()) {
-            return usize::MAX;
+    let Some(root) = StyleNodeID::from_raw(root) else {
+        return usize::MAX;
+    };
+    if query.is_null() || (capacity != 0 && matches.is_null()) {
+        return usize::MAX;
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let query = unsafe { &mut *query.cast::<SelectorQuery>() };
+    let result = engine.selector_query_all(
+        &query.program,
+        &mut query.cache,
+        SelectorQueryContext {
+            root,
+            include_root,
+            scope_root: StyleNodeID::from_raw(scope_root),
+            shadow_root: StyleNodeID::from_raw(shadow_root),
+            has_document_root,
+        },
+    );
+    let query_bytes = query.capacity_bytes();
+    query._memory.resize_required_to(&mut engine.memory, query_bytes);
+    let Ok(result) = result else {
+        return usize::MAX;
+    };
+    if result.len() <= capacity {
+        for (index, node) in result.iter().enumerate() {
+            unsafe { matches.add(index).write(node.raw()) };
         }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let query = unsafe { &mut *query.cast::<SelectorQuery>() };
-        let result = engine.selector_query_all(
-            &query.program,
-            &mut query.cache,
-            SelectorQueryContext {
-                root,
-                include_root,
-                scope_root: StyleNodeID::from_raw(scope_root),
-                shadow_root: StyleNodeID::from_raw(shadow_root),
-                has_document_root,
-            },
-        );
-        let query_bytes = query.capacity_bytes();
-        query._memory.resize_required_to(&mut engine.memory, query_bytes);
-        let Ok(result) = result else {
-            return usize::MAX;
-        };
-        if result.len() <= capacity {
-            for (index, node) in result.iter().enumerate() {
-                unsafe { matches.add(index).write(node.raw()) };
-            }
-        }
-        result.len()
-    })
+    }
+    result.len()
 }
 
 /// # Safety
@@ -1666,33 +1628,31 @@ pub unsafe extern "C" fn style_engine_selector_query_first(
     has_document_root: bool,
     matched: *mut u32,
 ) -> bool {
-    abort_on_panic(|| {
-        let Some(root) = StyleNodeID::from_raw(root) else {
-            return false;
-        };
-        if query.is_null() || matched.is_null() {
-            return false;
-        }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let query = unsafe { &mut *query.cast::<SelectorQuery>() };
-        let result = engine.selector_query_first(
-            &query.program,
-            SelectorQueryContext {
-                root,
-                include_root,
-                scope_root: StyleNodeID::from_raw(scope_root),
-                shadow_root: StyleNodeID::from_raw(shadow_root),
-                has_document_root,
-            },
-        );
-        let query_bytes = query.capacity_bytes();
-        query._memory.resize_required_to(&mut engine.memory, query_bytes);
-        let Ok(result) = result else {
-            return false;
-        };
-        unsafe { matched.write(result.map_or(0, |node| node.raw())) };
-        true
-    })
+    let Some(root) = StyleNodeID::from_raw(root) else {
+        return false;
+    };
+    if query.is_null() || matched.is_null() {
+        return false;
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let query = unsafe { &mut *query.cast::<SelectorQuery>() };
+    let result = engine.selector_query_first(
+        &query.program,
+        SelectorQueryContext {
+            root,
+            include_root,
+            scope_root: StyleNodeID::from_raw(scope_root),
+            shadow_root: StyleNodeID::from_raw(shadow_root),
+            has_document_root,
+        },
+    );
+    let query_bytes = query.capacity_bytes();
+    query._memory.resize_required_to(&mut engine.memory, query_bytes);
+    let Ok(result) = result else {
+        return false;
+    };
+    unsafe { matched.write(result.map_or(0, |node| node.raw())) };
+    true
 }
 
 unsafe fn selector_query_matches_impl(
@@ -1821,47 +1781,45 @@ pub unsafe extern "C" fn style_engine_consume_published_match_answer(
     out: *mut FfiRuleMatch,
     capacity: usize,
 ) -> usize {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return usize::MAX;
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let result = engine
-            .consume_published_match_answer_with(
-                node,
-                capacity,
-                |index, node, rule, semantic_declaration, pseudo_element, scope_host, scope_proximity| unsafe {
-                    *out.add(index) = FfiRuleMatch {
-                        node: node.raw(),
-                        rule: rule.0 + 1,
-                        semantic_declaration: semantic_declaration.0,
-                        pseudo_element: pseudo_element.map_or(u32::MAX, |target| u32::from(target.kind.0)),
-                        scope_host,
-                        scope_proximity,
-                    };
-                },
-            )
-            .unwrap_or(usize::MAX);
-        engine.record_boundary_call(EventKind::ConsumePublishedMatchAnswer, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_u64(u64::try_from(capacity).expect("match capacity exceeds u64"));
-            payload.write_u64(u64::try_from(result).expect("match count exceeds u64"));
-            let written = result != usize::MAX && result <= capacity;
-            payload.write_bool(written);
-            if written {
-                let matches = unsafe { std::slice::from_raw_parts(out, result) };
-                payload.write_length(matches.len());
-                for entry in matches {
-                    payload.write_u32(entry.node);
-                    payload.write_u32(entry.rule);
-                    payload.write_u32(entry.pseudo_element);
-                    payload.write_u32(entry.scope_host);
-                    payload.write_u32(entry.scope_proximity);
-                }
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return usize::MAX;
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let result = engine
+        .consume_published_match_answer_with(
+            node,
+            capacity,
+            |index, node, rule, semantic_declaration, pseudo_element, scope_host, scope_proximity| unsafe {
+                *out.add(index) = FfiRuleMatch {
+                    node: node.raw(),
+                    rule: rule.0 + 1,
+                    semantic_declaration: semantic_declaration.0,
+                    pseudo_element: pseudo_element.map_or(u32::MAX, |target| u32::from(target.kind.0)),
+                    scope_host,
+                    scope_proximity,
+                };
+            },
+        )
+        .unwrap_or(usize::MAX);
+    engine.record_boundary_call(EventKind::ConsumePublishedMatchAnswer, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_u64(u64::try_from(capacity).expect("match capacity exceeds u64"));
+        payload.write_u64(u64::try_from(result).expect("match count exceeds u64"));
+        let written = result != usize::MAX && result <= capacity;
+        payload.write_bool(written);
+        if written {
+            let matches = unsafe { std::slice::from_raw_parts(out, result) };
+            payload.write_length(matches.len());
+            for entry in matches {
+                payload.write_u32(entry.node);
+                payload.write_u32(entry.rule);
+                payload.write_u32(entry.pseudo_element);
+                payload.write_u32(entry.scope_host);
+                payload.write_u32(entry.scope_proximity);
             }
-        });
-        result
-    })
+        }
+    });
+    result
 }
 /// Matches one element and writes its matches, in cascade order, into `out`.
 ///
@@ -1881,40 +1839,38 @@ pub unsafe extern "C" fn style_engine_match_element(
     capacity: usize,
     compact_for_cascade: bool,
 ) -> usize {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return usize::MAX;
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let result = match compact_for_cascade {
-            true => engine.match_element_for_cascade(node),
-            false => engine.match_element(node),
-        };
-        let Ok(matches) = result else {
-            return usize::MAX;
-        };
-        let result = unsafe { write_rule_matches(engine, &matches, out, capacity) };
-        engine.record_boundary_call(EventKind::MatchElement, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_u64(u64::try_from(capacity).expect("match capacity exceeds u64"));
-            payload.write_bool(compact_for_cascade);
-            payload.write_u64(u64::try_from(result).expect("match count exceeds u64"));
-            let written = result != usize::MAX && result <= capacity;
-            payload.write_bool(written);
-            if written {
-                let matches = unsafe { std::slice::from_raw_parts(out, result) };
-                payload.write_length(matches.len());
-                for entry in matches {
-                    payload.write_u32(entry.node);
-                    payload.write_u32(entry.rule);
-                    payload.write_u32(entry.pseudo_element);
-                    payload.write_u32(entry.scope_host);
-                    payload.write_u32(entry.scope_proximity);
-                }
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return usize::MAX;
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let result = match compact_for_cascade {
+        true => engine.match_element_for_cascade(node),
+        false => engine.match_element(node),
+    };
+    let Ok(matches) = result else {
+        return usize::MAX;
+    };
+    let result = unsafe { write_rule_matches(engine, &matches, out, capacity) };
+    engine.record_boundary_call(EventKind::MatchElement, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_u64(u64::try_from(capacity).expect("match capacity exceeds u64"));
+        payload.write_bool(compact_for_cascade);
+        payload.write_u64(u64::try_from(result).expect("match count exceeds u64"));
+        let written = result != usize::MAX && result <= capacity;
+        payload.write_bool(written);
+        if written {
+            let matches = unsafe { std::slice::from_raw_parts(out, result) };
+            payload.write_length(matches.len());
+            for entry in matches {
+                payload.write_u32(entry.node);
+                payload.write_u32(entry.rule);
+                payload.write_u32(entry.pseudo_element);
+                payload.write_u32(entry.scope_host);
+                payload.write_u32(entry.scope_proximity);
             }
-        });
-        result
-    })
+        }
+    });
+    result
 }
 /// Records which longhand properties one of an element's own declarations covers.
 ///
@@ -1934,58 +1890,56 @@ pub unsafe extern "C" fn style_engine_set_element_declared_properties(
     count: usize,
     declarations_are_complete: bool,
 ) {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return;
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let declared: Vec<DeclaredProperty> = match count == 0 {
-            true => Vec::new(),
-            false => {
-                if properties.is_null()
-                    || important.is_null()
-                    || operators.is_null()
-                    || values.is_null()
-                    || original_values.is_null()
-                {
-                    return;
-                }
-                let properties = unsafe { std::slice::from_raw_parts(properties, count) };
-                let important = unsafe { std::slice::from_raw_parts(important, count) };
-                let operators = unsafe { std::slice::from_raw_parts(operators, count) };
-                let values = unsafe { std::slice::from_raw_parts(values, count) };
-                let original_values = unsafe { std::slice::from_raw_parts(original_values, count) };
-                properties
-                    .iter()
-                    .copied()
-                    .zip(important.iter().copied())
-                    .zip(operators.iter().copied())
-                    .zip(values.iter().copied().zip(original_values.iter().copied()))
-                    .map(|(((property, important), operator), (value, original_value))| {
-                        let specified_value = unsafe { engine.intern_specified_value(value.cast()) };
-                        unsafe { engine.alias_specified_value(original_value.cast(), specified_value) };
-                        DeclaredProperty {
-                            property,
-                            important,
-                            operator: operator.decode(),
-                            value: specified_value,
-                        }
-                    })
-                    .collect()
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return;
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let declared: Vec<DeclaredProperty> = match count == 0 {
+        true => Vec::new(),
+        false => {
+            if properties.is_null()
+                || important.is_null()
+                || operators.is_null()
+                || values.is_null()
+                || original_values.is_null()
+            {
+                return;
             }
-        };
-        engine.set_element_declared_properties(
-            node,
-            decode_element_declaration_kind(kind),
-            &declared,
-            declarations_are_complete,
-        );
-        engine.record_boundary_call(EventKind::SetElementDeclaredProperties, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_u8(kind as u8);
-            payload.write_bool(declarations_are_complete);
-            write_declared_properties(&declared, payload);
-        });
+            let properties = unsafe { std::slice::from_raw_parts(properties, count) };
+            let important = unsafe { std::slice::from_raw_parts(important, count) };
+            let operators = unsafe { std::slice::from_raw_parts(operators, count) };
+            let values = unsafe { std::slice::from_raw_parts(values, count) };
+            let original_values = unsafe { std::slice::from_raw_parts(original_values, count) };
+            properties
+                .iter()
+                .copied()
+                .zip(important.iter().copied())
+                .zip(operators.iter().copied())
+                .zip(values.iter().copied().zip(original_values.iter().copied()))
+                .map(|(((property, important), operator), (value, original_value))| {
+                    let specified_value = unsafe { engine.intern_specified_value(value.cast()) };
+                    unsafe { engine.alias_specified_value(original_value.cast(), specified_value) };
+                    DeclaredProperty {
+                        property,
+                        important,
+                        operator: operator.decode(),
+                        value: specified_value,
+                    }
+                })
+                .collect()
+        }
+    };
+    engine.set_element_declared_properties(
+        node,
+        decode_element_declaration_kind(kind),
+        &declared,
+        declarations_are_complete,
+    );
+    engine.record_boundary_call(EventKind::SetElementDeclaredProperties, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_u8(kind as u8);
+        payload.write_bool(declarations_are_complete);
+        write_declared_properties(&declared, payload);
     });
 }
 
@@ -1999,53 +1953,51 @@ pub unsafe extern "C" fn style_engine_publish_exact_cascade_state(
     store: *const c_void,
     inherited_style_groups: u8,
 ) -> FfiExactCascadePublication {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return FfiExactCascadePublication::missing();
-        };
-        if store.is_null() {
-            return FfiExactCascadePublication::missing();
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return FfiExactCascadePublication::missing();
+    };
+    if store.is_null() {
+        return FfiExactCascadePublication::missing();
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let generation_snapshot =
+        engine.exact_cascade_generation_snapshot(super::computed::ComputedStyleTarget::new(node, pseudo_kind));
+    let (publication, winners, had_previous) = engine.publish_exact_cascade_state(
+        super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+        unsafe { &*store.cast::<crate::css::cascaded_properties::CascadedPropertyStore>() },
+        inherited_style_groups,
+    );
+    engine.record_boundary_call(EventKind::PublishExactCascadeState, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_u8(pseudo_kind);
+        payload.write_u8(inherited_style_groups);
+        payload.write_u64(generation_snapshot.0);
+        payload.write_bool(generation_snapshot.1.is_some());
+        if let Some(generation) = generation_snapshot.1 {
+            payload.write_u64(generation);
         }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let generation_snapshot =
-            engine.exact_cascade_generation_snapshot(super::computed::ComputedStyleTarget::new(node, pseudo_kind));
-        let (publication, winners, had_previous) = engine.publish_exact_cascade_state(
-            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
-            unsafe { &*store.cast::<crate::css::cascaded_properties::CascadedPropertyStore>() },
-            inherited_style_groups,
-        );
-        engine.record_boundary_call(EventKind::PublishExactCascadeState, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_u8(pseudo_kind);
-            payload.write_u8(inherited_style_groups);
-            payload.write_u64(generation_snapshot.0);
-            payload.write_bool(generation_snapshot.1.is_some());
-            if let Some(generation) = generation_snapshot.1 {
-                payload.write_u64(generation);
-            }
-            payload.write_length(winners.len());
-            for (property, winner) in winners {
-                payload.write_u16(property);
-                payload.write_u64(winner.value.0);
-                payload.write_u8(match winner.operator {
-                    CascadeOperator::Declared => 0,
-                    CascadeOperator::Inherit => 1,
-                    CascadeOperator::Initial => 2,
-                    CascadeOperator::Unset => 3,
-                    CascadeOperator::Revert => 4,
-                    CascadeOperator::RevertLayer => 5,
-                });
-                payload.write_u32(winner.animation_relevance);
-            }
-            write_exact_cascade_publication(publication, payload);
-            // NB: Whether a previous cascade state was retained decides the publication's group
-            //     mask, and retention differs legitimately between the recording session and a
-            //     replay (memory pressure evicts). Record it so replay can compare accordingly;
-            //     older captures simply end before this byte.
-            payload.write_bool(had_previous);
-        });
-        publication
-    })
+        payload.write_length(winners.len());
+        for (property, winner) in winners {
+            payload.write_u16(property);
+            payload.write_u64(winner.value.0);
+            payload.write_u8(match winner.operator {
+                CascadeOperator::Declared => 0,
+                CascadeOperator::Inherit => 1,
+                CascadeOperator::Initial => 2,
+                CascadeOperator::Unset => 3,
+                CascadeOperator::Revert => 4,
+                CascadeOperator::RevertLayer => 5,
+            });
+            payload.write_u32(winner.animation_relevance);
+        }
+        write_exact_cascade_publication(publication, payload);
+        // NB: Whether a previous cascade state was retained decides the publication's group
+        //     mask, and retention differs legitimately between the recording session and a
+        //     replay (memory pressure evicts). Record it so replay can compare accordingly;
+        //     older captures simply end before this byte.
+        payload.write_bool(had_previous);
+    });
+    publication
 }
 
 /// Seed the ordinary cascade store from a complete retained winner relation.
@@ -2063,35 +2015,33 @@ pub unsafe extern "C" fn style_engine_materialize_retained_cascade_state(
     blocks: *const c_void,
     block_count: usize,
 ) -> FfiSourceSlotAssignmentView {
-    abort_on_panic(|| {
-        if engine.is_null() {
-            return FfiSourceSlotAssignmentView::default();
+    if engine.is_null() {
+        return FfiSourceSlotAssignmentView::default();
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_retained_cascade_assignments();
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return FfiSourceSlotAssignmentView::default();
+    };
+    if store.is_null() {
+        return FfiSourceSlotAssignmentView::default();
+    }
+    let blocks = if block_count == 0 {
+        &[]
+    } else {
+        unsafe {
+            std::slice::from_raw_parts(
+                blocks.cast::<crate::css::cascaded_properties::FfiCascadeBlock>(),
+                block_count,
+            )
         }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_retained_cascade_assignments();
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return FfiSourceSlotAssignmentView::default();
-        };
-        if store.is_null() {
-            return FfiSourceSlotAssignmentView::default();
-        }
-        let blocks = if block_count == 0 {
-            &[]
-        } else {
-            unsafe {
-                std::slice::from_raw_parts(
-                    blocks.cast::<crate::css::cascaded_properties::FfiCascadeBlock>(),
-                    block_count,
-                )
-            }
-        };
-        let assignments = engine.materialize_retained_cascade_state(
-            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
-            unsafe { &mut *store.cast::<crate::css::cascaded_properties::CascadedPropertyStore>() },
-            blocks,
-        );
-        engine.install_ffi_retained_cascade_assignments(assignments)
-    })
+    };
+    let assignments = engine.materialize_retained_cascade_state(
+        super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+        unsafe { &mut *store.cast::<crate::css::cascaded_properties::CascadedPropertyStore>() },
+        blocks,
+    );
+    engine.install_ffi_retained_cascade_assignments(assignments)
 }
 
 /// Discards the borrowed retained cascade source-slot assignments.
@@ -2100,10 +2050,8 @@ pub unsafe extern "C" fn style_engine_materialize_retained_cascade_state(
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_discard_retained_cascade_assignments(engine: *mut c_void) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.clear_ffi_retained_cascade_assignments();
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.clear_ffi_retained_cascade_assignments();
 }
 
 #[cfg(feature = "style-recording")]
@@ -2205,147 +2153,145 @@ pub unsafe extern "C" fn style_engine_publish_computed_groups(
     animation_overlay_payload_count: usize,
     longhand_table: *const c_void,
 ) -> FfiStyleRecordDelta {
-    abort_on_panic(|| {
-        if count != 0 && payloads.is_null() {
-            return FfiStyleRecordDelta::default();
+    if count != 0 && payloads.is_null() {
+        return FfiStyleRecordDelta::default();
+    }
+    let payloads = match count {
+        0 => &[],
+        _ => unsafe { std::slice::from_raw_parts(payloads, count) },
+    };
+    if animation_overlay_payload_count != 0 && animation_overlay_payloads.is_null() {
+        return FfiStyleRecordDelta::default();
+    }
+    let animation_overlay_payloads = match animation_overlay_payload_count {
+        0 => &[],
+        _ => unsafe { std::slice::from_raw_parts(animation_overlay_payloads, animation_overlay_payload_count) },
+    };
+    let longhand_table = unsafe {
+        longhand_table
+            .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
+            .as_ref()
+    };
+    let raw_cascaded_font_size = longhand_table.map_or(std::ptr::null(), |table| table.raw_cascaded_font_size());
+    assert!(longhand_table.is_some() || (node == 0 && pseudo_kind == u8::MAX));
+    let pseudo_element_styles = longhand_table.map_or(0, |table| table.pseudo_element_styles());
+    let inherited_group_swap_eligible = longhand_table.is_some_and(|table| {
+        inherited_group_swap_candidate && table.property_inheritance_is_standard() && !table.display_is_list_item()
+    });
+    let holds_image_values = crate::css::computed_values::style_group_payloads_hold_image_values(payloads)
+        || crate::css::computed_values::style_group_payloads_hold_image_values(animation_overlay_payloads);
+    let dependency_flags = longhand_table.map_or(0, |table| table.publication_dependency_flags())
+        | (u8::from(inherited_group_swap_eligible) * super::computed::INHERITED_GROUP_SWAP_ELIGIBLE)
+        | (u8::from(holds_image_values) * super::computed::HOLDS_IMAGE_VALUES);
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    if animation_overlay_identity != 0 && animated_overlay.is_null() {
+        return FfiStyleRecordDelta::default();
+    }
+    let metadata_input = super::computed::ComputedMetadataInput {
+        pseudo_element_styles,
+        dependency_flags,
+        counter_style_environment_identity,
+        animation_overlay_identity,
+        animated_overlay: animated_overlay.cast(),
+        animation_overlay_payloads,
+        longhand_table: longhand_table.map_or(std::ptr::null(), std::ptr::from_ref),
+    };
+    let publication = if let Some(node) = StyleNodeID::from_raw(node) {
+        engine.publish_computed_groups(
+            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+            payloads,
+            inherited_group_count,
+            custom_property_environment,
+            metadata_input,
+        )
+    } else {
+        engine.intern_computed_groups(
+            payloads,
+            inherited_group_count,
+            custom_property_environment,
+            metadata_input,
+        )
+    };
+    let result = FfiStyleRecordDelta {
+        old_style_record: publication
+            .previous_style_record_identity
+            .map_or(0, super::computed::FinalStyleRecordID::raw),
+        new_style_record: publication.style_record_identity.raw(),
+    };
+    engine.record_boundary_call(EventKind::PublishComputedGroups, |payload| {
+        let pointer_token = |pointer: *const c_void| match pointer.is_null() {
+            true => 0,
+            false => engine
+                .recording_pointer_token(pointer as usize)
+                .expect("an enabled recorder must tokenize the pointer"),
+        };
+        payload.write_u32(node);
+        payload.write_u8(pseudo_kind);
+        let groups = engine
+            .recording_computed_group_identities(result.new_style_record)
+            .expect("a published style record must retain its computed groups");
+        let retained_bytes = engine
+            .recording_computed_group_retained_bytes(result.new_style_record)
+            .expect("a published style record must retain its computed group sizes");
+        assert_eq!(groups.len(), retained_bytes.len());
+        payload.write_length(groups.len());
+        for (identity, retained_bytes) in groups.into_iter().zip(retained_bytes) {
+            payload.write_u32(identity);
+            payload.write_u64(retained_bytes);
         }
-        let payloads = match count {
-            0 => &[],
-            _ => unsafe { std::slice::from_raw_parts(payloads, count) },
-        };
-        if animation_overlay_payload_count != 0 && animation_overlay_payloads.is_null() {
-            return FfiStyleRecordDelta::default();
+        payload.write_length(inherited_group_count);
+        payload.write_u64(custom_property_environment);
+        payload.write_u64(pseudo_element_styles);
+        payload.write_u8(dependency_flags);
+        payload.write_u64(counter_style_environment_identity);
+        payload.write_u64(animation_overlay_identity);
+        payload.write_u64(u64::from(!animated_overlay.is_null()));
+        payload.write_length(animation_overlay_payloads.len());
+        for &pointer in animation_overlay_payloads {
+            payload.write_u64(pointer_token(pointer));
         }
-        let animation_overlay_payloads = match animation_overlay_payload_count {
-            0 => &[],
-            _ => unsafe { std::slice::from_raw_parts(animation_overlay_payloads, animation_overlay_payload_count) },
-        };
-        let longhand_table = unsafe {
-            longhand_table
-                .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
-                .as_ref()
-        };
-        let raw_cascaded_font_size = longhand_table.map_or(std::ptr::null(), |table| table.raw_cascaded_font_size());
-        assert!(longhand_table.is_some() || (node == 0 && pseudo_kind == u8::MAX));
-        let pseudo_element_styles = longhand_table.map_or(0, |table| table.pseudo_element_styles());
-        let inherited_group_swap_eligible = longhand_table.is_some_and(|table| {
-            inherited_group_swap_candidate && table.property_inheritance_is_standard() && !table.display_is_list_item()
+        payload.write_bytes(longhand_table.map_or(&[], |table| table.importance_bits()));
+        payload.write_bytes(longhand_table.map_or(&[], |table| table.inheritance_bits()));
+        payload.write_length(longhand_table.map_or(0, |table| table.inheritance_dependent_values().count()));
+        for (property, value) in longhand_table
+            .into_iter()
+            .flat_map(crate::css::computed_longhand_table::ComputedLonghandTable::inheritance_dependent_values)
+        {
+            payload.write_u16(property);
+            payload.write_u64(pointer_token(value));
+            payload.write_u8(crate::css::style_value::style_value_dependency_flags(value.cast()));
+        }
+        payload.write_u64(pointer_token(raw_cascaded_font_size));
+        payload.write_u8(match raw_cascaded_font_size.is_null() {
+            true => 0,
+            false => crate::css::style_value::style_value_dependency_flags(raw_cascaded_font_size.cast()),
         });
-        let holds_image_values = crate::css::computed_values::style_group_payloads_hold_image_values(payloads)
-            || crate::css::computed_values::style_group_payloads_hold_image_values(animation_overlay_payloads);
-        let dependency_flags = longhand_table.map_or(0, |table| table.publication_dependency_flags())
-            | (u8::from(inherited_group_swap_eligible) * super::computed::INHERITED_GROUP_SWAP_ELIGIBLE)
-            | (u8::from(holds_image_values) * super::computed::HOLDS_IMAGE_VALUES);
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        if animation_overlay_identity != 0 && animated_overlay.is_null() {
-            return FfiStyleRecordDelta::default();
-        }
-        let metadata_input = super::computed::ComputedMetadataInput {
-            pseudo_element_styles,
-            dependency_flags,
-            counter_style_environment_identity,
-            animation_overlay_identity,
-            animated_overlay: animated_overlay.cast(),
-            animation_overlay_payloads,
-            longhand_table: longhand_table.map_or(std::ptr::null(), std::ptr::from_ref),
-        };
-        let publication = if let Some(node) = StyleNodeID::from_raw(node) {
-            engine.publish_computed_groups(
-                super::computed::ComputedStyleTarget::new(node, pseudo_kind),
-                payloads,
-                inherited_group_count,
-                custom_property_environment,
-                metadata_input,
-            )
-        } else {
-            engine.intern_computed_groups(
-                payloads,
-                inherited_group_count,
-                custom_property_environment,
-                metadata_input,
-            )
-        };
-        let result = FfiStyleRecordDelta {
-            old_style_record: publication
-                .previous_style_record_identity
-                .map_or(0, super::computed::FinalStyleRecordID::raw),
-            new_style_record: publication.style_record_identity.raw(),
-        };
-        engine.record_boundary_call(EventKind::PublishComputedGroups, |payload| {
-            let pointer_token = |pointer: *const c_void| match pointer.is_null() {
-                true => 0,
-                false => engine
-                    .recording_pointer_token(pointer as usize)
-                    .expect("an enabled recorder must tokenize the pointer"),
-            };
-            payload.write_u32(node);
-            payload.write_u8(pseudo_kind);
-            let groups = engine
-                .recording_computed_group_identities(result.new_style_record)
-                .expect("a published style record must retain its computed groups");
-            let retained_bytes = engine
-                .recording_computed_group_retained_bytes(result.new_style_record)
-                .expect("a published style record must retain its computed group sizes");
-            assert_eq!(groups.len(), retained_bytes.len());
-            payload.write_length(groups.len());
-            for (identity, retained_bytes) in groups.into_iter().zip(retained_bytes) {
-                payload.write_u32(identity);
-                payload.write_u64(retained_bytes);
-            }
-            payload.write_length(inherited_group_count);
-            payload.write_u64(custom_property_environment);
-            payload.write_u64(pseudo_element_styles);
-            payload.write_u8(dependency_flags);
-            payload.write_u64(counter_style_environment_identity);
-            payload.write_u64(animation_overlay_identity);
-            payload.write_u64(u64::from(!animated_overlay.is_null()));
-            payload.write_length(animation_overlay_payloads.len());
-            for &pointer in animation_overlay_payloads {
-                payload.write_u64(pointer_token(pointer));
-            }
-            payload.write_bytes(longhand_table.map_or(&[], |table| table.importance_bits()));
-            payload.write_bytes(longhand_table.map_or(&[], |table| table.inheritance_bits()));
-            payload.write_length(longhand_table.map_or(0, |table| table.inheritance_dependent_values().count()));
-            for (property, value) in longhand_table
-                .into_iter()
-                .flat_map(crate::css::computed_longhand_table::ComputedLonghandTable::inheritance_dependent_values)
-            {
-                payload.write_u16(property);
-                payload.write_u64(pointer_token(value));
-                payload.write_u8(crate::css::style_value::style_value_dependency_flags(value.cast()));
-            }
-            payload.write_u64(pointer_token(raw_cascaded_font_size));
-            payload.write_u8(match raw_cascaded_font_size.is_null() {
-                true => 0,
-                false => crate::css::style_value::style_value_dependency_flags(raw_cascaded_font_size.cast()),
-            });
-            payload.write_bool(longhand_table.is_some());
-            if longhand_table.is_some() {
-                let (identity, canonical_values) = engine
-                    .recording_computed_longhand_table(result.new_style_record)
-                    .expect("a published style record must retain its longhand table");
-                payload.write_u32(identity);
-                let record_definition = engine.recording_first_response(2, u64::from(identity));
-                payload.write_bool(record_definition);
-                if record_definition {
-                    let stored_values = canonical_values
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, value)| !value.is_null())
-                        .collect::<Vec<_>>();
-                    payload.write_length(stored_values.len());
-                    for (index, &value) in stored_values {
-                        payload.write_u16(crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID + index as u16);
-                        payload.write_u64(pointer_token(value));
-                        payload.write_u8(crate::css::style_value::style_value_dependency_flags(value.cast()));
-                    }
+        payload.write_bool(longhand_table.is_some());
+        if longhand_table.is_some() {
+            let (identity, canonical_values) = engine
+                .recording_computed_longhand_table(result.new_style_record)
+                .expect("a published style record must retain its longhand table");
+            payload.write_u32(identity);
+            let record_definition = engine.recording_first_response(2, u64::from(identity));
+            payload.write_bool(record_definition);
+            if record_definition {
+                let stored_values = canonical_values
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, value)| !value.is_null())
+                    .collect::<Vec<_>>();
+                payload.write_length(stored_values.len());
+                for (index, &value) in stored_values {
+                    payload.write_u16(crate::css::property_metadata::FIRST_LONGHAND_PROPERTY_ID + index as u16);
+                    payload.write_u64(pointer_token(value));
+                    payload.write_u8(crate::css::style_value::style_value_dependency_flags(value.cast()));
                 }
             }
-            payload.write_u64(result.old_style_record);
-            payload.write_u64(result.new_style_record);
-        });
-        result
-    })
+        }
+        payload.write_u64(result.old_style_record);
+        payload.write_u64(result.new_style_record);
+    });
+    result
 }
 
 /// Replaces only the animation overlay on an already-published target. Recording falls back to
@@ -2365,34 +2311,32 @@ pub unsafe extern "C" fn style_engine_publish_animation_overlay(
     payloads: *const *const c_void,
     payload_count: usize,
 ) -> FfiStyleRecordDelta {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return FfiStyleRecordDelta::default();
-        };
-        if animation_overlay_identity != 0 && animated_overlay.is_null() {
-            return FfiStyleRecordDelta::default();
-        }
-        if payload_count != 0 && payloads.is_null() {
-            return FfiStyleRecordDelta::default();
-        }
-        let payloads = match payload_count {
-            0 => &[],
-            _ => unsafe { std::slice::from_raw_parts(payloads, payload_count) },
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let Some(publication) = engine.publish_animation_overlay_impl(
-            super::computed::ComputedStyleTarget::new(node, pseudo_kind),
-            animation_overlay_identity,
-            animated_overlay.cast(),
-            payloads,
-        ) else {
-            return FfiStyleRecordDelta::default();
-        };
-        FfiStyleRecordDelta {
-            old_style_record: publication.previous_style_record.raw(),
-            new_style_record: publication.style_record.raw(),
-        }
-    })
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return FfiStyleRecordDelta::default();
+    };
+    if animation_overlay_identity != 0 && animated_overlay.is_null() {
+        return FfiStyleRecordDelta::default();
+    }
+    if payload_count != 0 && payloads.is_null() {
+        return FfiStyleRecordDelta::default();
+    }
+    let payloads = match payload_count {
+        0 => &[],
+        _ => unsafe { std::slice::from_raw_parts(payloads, payload_count) },
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let Some(publication) = engine.publish_animation_overlay_impl(
+        super::computed::ComputedStyleTarget::new(node, pseudo_kind),
+        animation_overlay_identity,
+        animated_overlay.cast(),
+        payloads,
+    ) else {
+        return FfiStyleRecordDelta::default();
+    };
+    FfiStyleRecordDelta {
+        old_style_record: publication.previous_style_record.raw(),
+        new_style_record: publication.style_record.raw(),
+    }
 }
 
 /// Assigns an already-interned base style record to one element or pseudo-element.
@@ -2410,31 +2354,29 @@ pub unsafe extern "C" fn style_engine_assign_shared_style_record(
     inherited_group_count: usize,
     inherited_group_swap_eligible: bool,
 ) -> FfiStyleRecordDelta {
-    abort_on_panic(|| {
-        if engine.is_null() || node == 0 || style_record == 0 {
-            return FfiStyleRecordDelta::default();
-        }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        if engine.recording_id().is_some() {
-            return FfiStyleRecordDelta::default();
-        }
-        let target = super::computed::ComputedStyleTarget::new(
-            StyleNodeID::from_raw(node).expect("a nonzero node must be a style node"),
-            pseudo_kind,
-        );
-        let publication = engine.assign_shared_style_record(
-            target,
-            style_record,
-            inherited_group_count,
-            inherited_group_swap_eligible,
-        );
-        FfiStyleRecordDelta {
-            old_style_record: publication
-                .previous_style_record_identity
-                .map_or(0, super::computed::FinalStyleRecordID::raw),
-            new_style_record: publication.style_record_identity.raw(),
-        }
-    })
+    if engine.is_null() || node == 0 || style_record == 0 {
+        return FfiStyleRecordDelta::default();
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    if engine.recording_id().is_some() {
+        return FfiStyleRecordDelta::default();
+    }
+    let target = super::computed::ComputedStyleTarget::new(
+        StyleNodeID::from_raw(node).expect("a nonzero node must be a style node"),
+        pseudo_kind,
+    );
+    let publication = engine.assign_shared_style_record(
+        target,
+        style_record,
+        inherited_group_count,
+        inherited_group_swap_eligible,
+    );
+    FfiStyleRecordDelta {
+        old_style_record: publication
+            .previous_style_record_identity
+            .map_or(0, super::computed::FinalStyleRecordID::raw),
+        new_style_record: publication.style_record_identity.raw(),
+    }
 }
 
 /// Returns the StyleEngine-owned group payload array for a base or live animation-overlay record.
@@ -2443,45 +2385,43 @@ pub unsafe extern "C" fn style_engine_assign_shared_style_record(
 /// `engine` must be live for this call and for every read through the returned pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_style_record_payloads(engine: *const c_void, style_record: u64) -> *const c_void {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        let payloads = engine.style_record_payloads(style_record);
-        let result = payloads.map_or(std::ptr::null(), |payloads| payloads.as_ptr().cast());
-        let record_response = engine.recording_first_response(0, style_record);
-        if !record_response {
-            return result;
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    let payloads = engine.style_record_payloads(style_record);
+    let result = payloads.map_or(std::ptr::null(), |payloads| payloads.as_ptr().cast());
+    let record_response = engine.recording_first_response(0, style_record);
+    if !record_response {
+        return result;
+    }
+    engine.record_boundary_call(EventKind::StyleRecordPayloads, |payload| {
+        payload.write_u64(style_record);
+        payload.write_bool(record_response);
+        payload.write_bool(payloads.is_some());
+        let Some(style_payloads) = payloads else {
+            return;
+        };
+        let semantic_payloads = if style_record & (1 << 63) != 0 {
+            style_payloads
+                .iter()
+                .map(|&pointer| {
+                    engine
+                        .recording_pointer_token(pointer as usize)
+                        .expect("an enabled recorder must tokenize the pointer")
+                })
+                .collect::<Vec<_>>()
+        } else {
+            engine
+                .recording_computed_group_identities(style_record)
+                .expect("a base style record must retain its computed groups")
+                .into_iter()
+                .map(|identity| u64::from(identity) + 1)
+                .collect()
+        };
+        payload.write_length(semantic_payloads.len());
+        for semantic_payload in semantic_payloads {
+            payload.write_u64(semantic_payload);
         }
-        engine.record_boundary_call(EventKind::StyleRecordPayloads, |payload| {
-            payload.write_u64(style_record);
-            payload.write_bool(record_response);
-            payload.write_bool(payloads.is_some());
-            let Some(style_payloads) = payloads else {
-                return;
-            };
-            let semantic_payloads = if style_record & (1 << 63) != 0 {
-                style_payloads
-                    .iter()
-                    .map(|&pointer| {
-                        engine
-                            .recording_pointer_token(pointer as usize)
-                            .expect("an enabled recorder must tokenize the pointer")
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                engine
-                    .recording_computed_group_identities(style_record)
-                    .expect("a base style record must retain its computed groups")
-                    .into_iter()
-                    .map(|identity| u64::from(identity) + 1)
-                    .collect()
-            };
-            payload.write_length(semantic_payloads.len());
-            for semantic_payload in semantic_payloads {
-                payload.write_u64(semantic_payload);
-            }
-        });
-        result
-    })
+    });
+    result
 }
 
 /// Returns the dependency flags of one final style record without accessing its group payloads.
@@ -2490,10 +2430,8 @@ pub unsafe extern "C" fn style_engine_style_record_payloads(engine: *const c_voi
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_style_record_dependency_flags(engine: *const c_void, style_record: u64) -> u8 {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        engine.style_record_dependency_flags(style_record).unwrap_or(0)
-    })
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    engine.style_record_dependency_flags(style_record).unwrap_or(0)
 }
 
 /// Computes the property-dependent damage between two final style records.
@@ -2508,15 +2446,13 @@ pub unsafe extern "C" fn style_engine_compare_style_records(
     font_lists_equal: bool,
     element_folds_transform_into_layout: bool,
 ) -> u32 {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.compare_style_records(
-            old_style_record,
-            new_style_record,
-            font_lists_equal,
-            element_folds_transform_into_layout,
-        )
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.compare_style_records(
+        old_style_record,
+        new_style_record,
+        font_lists_equal,
+        element_folds_transform_into_layout,
+    )
 }
 
 /// Returns whether a candidate animation overlay changes any effective value in a style record.
@@ -2530,10 +2466,8 @@ pub unsafe extern "C" fn style_engine_animation_overlay_changed(
     old_style_record: u64,
     animated_overlay: *const c_void,
 ) -> bool {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        engine.animation_overlay_changed(old_style_record, animated_overlay.cast())
-    })
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    engine.animation_overlay_changed(old_style_record, animated_overlay.cast())
 }
 
 /// Computes property-dependent damage for the sparse changed values in an animation overlay.
@@ -2550,11 +2484,9 @@ pub unsafe extern "C" fn style_engine_compare_animation_overlay(
     payload_count: usize,
     is_document_element: bool,
 ) -> FfiAnimationInvalidation {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        let payloads = unsafe { std::slice::from_raw_parts(payloads, payload_count) };
-        engine.compare_animation_overlay(old_style_record, animated_overlay.cast(), payloads, is_document_element)
-    })
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    let payloads = unsafe { std::slice::from_raw_parts(payloads, payload_count) };
+    engine.compare_animation_overlay(old_style_record, animated_overlay.cast(), payloads, is_document_element)
 }
 
 /// Returns a synchronous borrowed view of a base or live animation-overlay record.
@@ -2566,101 +2498,98 @@ pub unsafe extern "C" fn style_engine_style_record_view(
     engine: *const c_void,
     style_record: u64,
 ) -> FfiStyleRecordView {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        let view = engine.style_record_view(style_record);
-        let result = match &view {
-            None => FfiStyleRecordView::missing(),
-            Some(view) => FfiStyleRecordView {
-                payloads: view.payloads.as_ptr(),
-                base_payloads: view.base_payloads.as_ptr(),
-                longhand_table: view.longhand_table.cast(),
-                animated_overlay: view.animated_overlay.cast(),
-                payload_count: view.payloads.len(),
-                pseudo_element_styles: view.pseudo_element_styles,
-                counter_style_environment_identity: view.counter_style_environment_identity,
-                animation_overlay_identity: view.animation_overlay_identity,
-                dependency_flags: view.dependency_flags,
-                present: true,
-            },
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    let view = engine.style_record_view(style_record);
+    let result = match &view {
+        None => FfiStyleRecordView::missing(),
+        Some(view) => FfiStyleRecordView {
+            payloads: view.payloads.as_ptr(),
+            base_payloads: view.base_payloads.as_ptr(),
+            longhand_table: view.longhand_table.cast(),
+            animated_overlay: view.animated_overlay.cast(),
+            payload_count: view.payloads.len(),
+            pseudo_element_styles: view.pseudo_element_styles,
+            counter_style_environment_identity: view.counter_style_environment_identity,
+            animation_overlay_identity: view.animation_overlay_identity,
+            dependency_flags: view.dependency_flags,
+            present: true,
+        },
+    };
+    let record_response = engine.recording_first_response(1, style_record);
+    if !record_response {
+        return result;
+    }
+    engine.record_boundary_call(EventKind::StyleRecordView, |payload| {
+        payload.write_u64(style_record);
+        payload.write_bool(record_response);
+        payload.write_bool(result.present);
+        let Some(view) = view else {
+            return;
         };
-        let record_response = engine.recording_first_response(1, style_record);
-        if !record_response {
-            return result;
-        }
-        engine.record_boundary_call(EventKind::StyleRecordView, |payload| {
-            payload.write_u64(style_record);
-            payload.write_bool(record_response);
-            payload.write_bool(result.present);
-            let Some(view) = view else {
-                return;
-            };
-            let base_payloads = engine
-                .recording_computed_group_identities(style_record)
-                .expect("a style record view must retain its base computed groups")
-                .into_iter()
-                .map(|identity| u64::from(identity) + 1)
-                .collect::<Vec<_>>();
-            let style_payloads = match view.animation_overlay_identity {
-                0 => base_payloads.clone(),
-                _ => view
-                    .payloads
-                    .iter()
-                    .map(|&pointer| {
-                        engine
-                            .recording_pointer_token(pointer as usize)
-                            .expect("an enabled recorder must tokenize the pointer")
-                    })
-                    .collect(),
-            };
-            payload.write_length(style_payloads.len());
-            for pointer in style_payloads {
-                payload.write_u64(pointer);
-            }
-            payload.write_length(base_payloads.len());
-            for pointer in base_payloads {
-                payload.write_u64(pointer);
-            }
-            let longhand_table = unsafe { view.longhand_table.as_ref() };
-            payload.write_bytes(longhand_table.map_or(&[], |table| table.importance_bits()));
-            payload.write_bytes(longhand_table.map_or(&[], |table| table.inheritance_bits()));
-            payload.write_length(longhand_table.map_or(0, |table| table.inheritance_dependent_values().count()));
-            for (property, value) in longhand_table
-                .into_iter()
-                .flat_map(crate::css::computed_longhand_table::ComputedLonghandTable::inheritance_dependent_values)
-            {
-                payload.write_u16(property);
-                payload.write_u64(
+        let base_payloads = engine
+            .recording_computed_group_identities(style_record)
+            .expect("a style record view must retain its base computed groups")
+            .into_iter()
+            .map(|identity| u64::from(identity) + 1)
+            .collect::<Vec<_>>();
+        let style_payloads = match view.animation_overlay_identity {
+            0 => base_payloads.clone(),
+            _ => view
+                .payloads
+                .iter()
+                .map(|&pointer| {
                     engine
-                        .recording_pointer_token(value as usize)
-                        .expect("an enabled recorder must tokenize the pointer"),
-                );
-            }
-            let raw_cascaded_font_size =
-                longhand_table.map_or(std::ptr::null(), |table| table.raw_cascaded_font_size());
-            payload.write_u64(match raw_cascaded_font_size.is_null() {
+                        .recording_pointer_token(pointer as usize)
+                        .expect("an enabled recorder must tokenize the pointer")
+                })
+                .collect(),
+        };
+        payload.write_length(style_payloads.len());
+        for pointer in style_payloads {
+            payload.write_u64(pointer);
+        }
+        payload.write_length(base_payloads.len());
+        for pointer in base_payloads {
+            payload.write_u64(pointer);
+        }
+        let longhand_table = unsafe { view.longhand_table.as_ref() };
+        payload.write_bytes(longhand_table.map_or(&[], |table| table.importance_bits()));
+        payload.write_bytes(longhand_table.map_or(&[], |table| table.inheritance_bits()));
+        payload.write_length(longhand_table.map_or(0, |table| table.inheritance_dependent_values().count()));
+        for (property, value) in longhand_table
+            .into_iter()
+            .flat_map(crate::css::computed_longhand_table::ComputedLonghandTable::inheritance_dependent_values)
+        {
+            payload.write_u16(property);
+            payload.write_u64(
+                engine
+                    .recording_pointer_token(value as usize)
+                    .expect("an enabled recorder must tokenize the pointer"),
+            );
+        }
+        let raw_cascaded_font_size = longhand_table.map_or(std::ptr::null(), |table| table.raw_cascaded_font_size());
+        payload.write_u64(match raw_cascaded_font_size.is_null() {
+            true => 0,
+            false => engine
+                .recording_pointer_token(raw_cascaded_font_size as usize)
+                .expect("an enabled recorder must tokenize the pointer"),
+        });
+        payload.write_u64(u64::from(!view.animated_overlay.is_null()));
+        payload.write_u64(view.pseudo_element_styles);
+        payload.write_u64(view.counter_style_environment_identity);
+        payload.write_u64(view.animation_overlay_identity);
+        payload.write_u8(view.dependency_flags);
+        payload.write_length(view.longhand_values.len());
+        for &value in view.longhand_values {
+            payload.write_u64(match value.is_null() {
                 true => 0,
                 false => engine
-                    .recording_pointer_token(raw_cascaded_font_size as usize)
+                    .recording_pointer_token(value as usize)
                     .expect("an enabled recorder must tokenize the pointer"),
             });
-            payload.write_u64(u64::from(!view.animated_overlay.is_null()));
-            payload.write_u64(view.pseudo_element_styles);
-            payload.write_u64(view.counter_style_environment_identity);
-            payload.write_u64(view.animation_overlay_identity);
-            payload.write_u8(view.dependency_flags);
-            payload.write_length(view.longhand_values.len());
-            for &value in view.longhand_values {
-                payload.write_u64(match value.is_null() {
-                    true => 0,
-                    false => engine
-                        .recording_pointer_token(value as usize)
-                        .expect("an enabled recorder must tokenize the pointer"),
-                });
-            }
-        });
-        result
-    })
+        }
+    });
+    result
 }
 /// Removes the retained computed-input assignment for one pseudo-element kind.
 ///
@@ -2672,25 +2601,23 @@ pub unsafe extern "C" fn style_engine_remove_computed_pseudo(
     node: u32,
     pseudo_kind: u8,
 ) -> FfiStyleRecordDelta {
-    abort_on_panic(|| {
-        let Some(node) = StyleNodeID::from_raw(node) else {
-            return FfiStyleRecordDelta::default();
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let result = FfiStyleRecordDelta {
-            old_style_record: engine
-                .remove_computed_pseudo(node, pseudo_kind)
-                .map_or(0, super::computed::FinalStyleRecordID::raw),
-            new_style_record: 0,
-        };
-        engine.record_boundary_call(EventKind::RemoveComputedPseudo, |payload| {
-            payload.write_u32(node.raw());
-            payload.write_u8(pseudo_kind);
-            payload.write_u64(result.old_style_record);
-            payload.write_u64(result.new_style_record);
-        });
-        result
-    })
+    let Some(node) = StyleNodeID::from_raw(node) else {
+        return FfiStyleRecordDelta::default();
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let result = FfiStyleRecordDelta {
+        old_style_record: engine
+            .remove_computed_pseudo(node, pseudo_kind)
+            .map_or(0, super::computed::FinalStyleRecordID::raw),
+        new_style_record: 0,
+    };
+    engine.record_boundary_call(EventKind::RemoveComputedPseudo, |payload| {
+        payload.write_u32(node.raw());
+        payload.write_u8(pseudo_kind);
+        payload.write_u64(result.old_style_record);
+        payload.write_u64(result.new_style_record);
+    });
+    result
 }
 /// Records which longhand properties a rule declares. All four arrays are parallel.
 ///
@@ -2709,52 +2636,50 @@ pub unsafe extern "C" fn style_engine_set_rule_declared_properties(
     count: usize,
     declarations_are_complete: bool,
 ) {
-    abort_on_panic(|| {
-        if rule == 0 {
-            return;
-        }
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let declared: Vec<DeclaredProperty> = match count == 0 {
-            true => Vec::new(),
-            false => {
-                if properties.is_null()
-                    || important.is_null()
-                    || operators.is_null()
-                    || values.is_null()
-                    || original_values.is_null()
-                {
-                    return;
-                }
-                let properties = unsafe { std::slice::from_raw_parts(properties, count) };
-                let important = unsafe { std::slice::from_raw_parts(important, count) };
-                let operators = unsafe { std::slice::from_raw_parts(operators, count) };
-                let values = unsafe { std::slice::from_raw_parts(values, count) };
-                let original_values = unsafe { std::slice::from_raw_parts(original_values, count) };
-                properties
-                    .iter()
-                    .copied()
-                    .zip(important.iter().copied())
-                    .zip(operators.iter().copied())
-                    .zip(values.iter().copied().zip(original_values.iter().copied()))
-                    .map(|(((property, important), operator), (value, original_value))| {
-                        let value = unsafe { engine.intern_specified_value(value.cast()) };
-                        unsafe { engine.alias_specified_value(original_value.cast(), value) };
-                        DeclaredProperty {
-                            property,
-                            important,
-                            operator: operator.decode(),
-                            value,
-                        }
-                    })
-                    .collect()
+    if rule == 0 {
+        return;
+    }
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let declared: Vec<DeclaredProperty> = match count == 0 {
+        true => Vec::new(),
+        false => {
+            if properties.is_null()
+                || important.is_null()
+                || operators.is_null()
+                || values.is_null()
+                || original_values.is_null()
+            {
+                return;
             }
-        };
-        engine.set_rule_declared_properties_with_operators(RuleID(rule - 1), &declared, declarations_are_complete);
-        engine.record_boundary_call(EventKind::SetRuleDeclaredProperties, |payload| {
-            payload.write_u32(rule);
-            payload.write_bool(declarations_are_complete);
-            write_declared_properties(&declared, payload);
-        });
+            let properties = unsafe { std::slice::from_raw_parts(properties, count) };
+            let important = unsafe { std::slice::from_raw_parts(important, count) };
+            let operators = unsafe { std::slice::from_raw_parts(operators, count) };
+            let values = unsafe { std::slice::from_raw_parts(values, count) };
+            let original_values = unsafe { std::slice::from_raw_parts(original_values, count) };
+            properties
+                .iter()
+                .copied()
+                .zip(important.iter().copied())
+                .zip(operators.iter().copied())
+                .zip(values.iter().copied().zip(original_values.iter().copied()))
+                .map(|(((property, important), operator), (value, original_value))| {
+                    let value = unsafe { engine.intern_specified_value(value.cast()) };
+                    unsafe { engine.alias_specified_value(original_value.cast(), value) };
+                    DeclaredProperty {
+                        property,
+                        important,
+                        operator: operator.decode(),
+                        value,
+                    }
+                })
+                .collect()
+        }
+    };
+    engine.set_rule_declared_properties_with_operators(RuleID(rule - 1), &declared, declarations_are_complete);
+    engine.record_boundary_call(EventKind::SetRuleDeclaredProperties, |payload| {
+        payload.write_u32(rule);
+        payload.write_bool(declarations_are_complete);
+        write_declared_properties(&declared, payload);
     });
 }
 /// Interns one name identity and returns its document-local atom.
@@ -2766,16 +2691,14 @@ pub unsafe extern "C" fn style_engine_set_rule_declared_properties(
 /// `engine` must be live.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn style_engine_intern_atom(engine: *mut c_void, raw: usize) -> u32 {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        let result = engine.intern_atom(raw).0;
-        let token = engine.recording_atom_pointer_token(raw);
-        engine.record_boundary_call(EventKind::InternAtom, |payload| {
-            payload.write_u64(token.expect("an enabled recorder must tokenize the pointer"));
-            payload.write_u32(result);
-        });
-        result
-    })
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    let result = engine.intern_atom(raw).0;
+    let token = engine.recording_atom_pointer_token(raw);
+    engine.record_boundary_call(EventKind::InternAtom, |payload| {
+        payload.write_u64(token.expect("an enabled recorder must tokenize the pointer"));
+        payload.write_u32(result);
+    });
+    result
 }
 
 /// Takes the pending style transaction and returns its versioned semantic match answers.
@@ -2789,66 +2712,64 @@ pub unsafe extern "C" fn style_engine_take_style_transaction(
     root: u32,
     computation_inputs: FfiDocumentStyleComputationInputs,
 ) -> FfiStyleTransactionView {
-    abort_on_panic(|| {
-        let Some(root) = StyleNodeID::from_raw(root) else {
-            return FfiStyleTransactionView::default();
-        };
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        engine.document_style_computation_inputs = Some(computation_inputs);
-        engine.clear_ffi_style_transaction_output();
-        let mut output = FfiStyleTransactionOutput::default();
-        output.scoped = engine.take_style_transaction(root, |transaction_version, program_version, answers| {
-            assert!(
-                output.answers.is_empty(),
-                "a style transaction emitted more than one batch"
-            );
-            output.transaction_version = transaction_version.0;
-            output.program_version = program_version.0;
-            output.answers.extend_from_slice(answers);
+    let Some(root) = StyleNodeID::from_raw(root) else {
+        return FfiStyleTransactionView::default();
+    };
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    engine.document_style_computation_inputs = Some(computation_inputs);
+    engine.clear_ffi_style_transaction_output();
+    let mut output = FfiStyleTransactionOutput::default();
+    output.scoped = engine.take_style_transaction(root, |transaction_version, program_version, answers| {
+        assert!(
+            output.answers.is_empty(),
+            "a style transaction emitted more than one batch"
+        );
+        output.transaction_version = transaction_version.0;
+        output.program_version = program_version.0;
+        output.answers.extend_from_slice(answers);
+    });
+    output.reclaimed_style_atoms = std::mem::take(&mut engine.reclaimed_style_atoms)
+        .into_iter()
+        .map(|reclaimed| FfiReclaimedStyleAtom {
+            raw: reclaimed.raw,
+            atom: reclaimed.atom.0,
+        })
+        .collect();
+    output.style_atoms_swept = std::mem::take(&mut engine.style_atoms_swept);
+    if engine.recording_id().is_some() {
+        engine.record_boundary_call(EventKind::StyleDeltaBatch, |payload| {
+            payload.write_u32(root.raw());
+            payload.write_u64(computation_inputs.viewport_width.to_bits());
+            payload.write_u64(computation_inputs.viewport_height.to_bits());
+            payload.write_u64(computation_inputs.root_font_size.to_bits());
+            payload.write_u64(computation_inputs.root_font_x_height.to_bits());
+            payload.write_u64(computation_inputs.root_font_cap_height.to_bits());
+            payload.write_u64(computation_inputs.root_font_zero_advance.to_bits());
+            payload.write_u64(computation_inputs.root_line_height.to_bits());
+            payload.write_bool(computation_inputs.root_font_metrics_depend_on_viewport_metrics);
+            payload.write_i32(computation_inputs.initial_font_size_raw);
+            payload.write_i32(computation_inputs.default_font_size_raw);
+            payload.write_u64(computation_inputs.device_pixels_per_css_pixel.to_bits());
+            payload.write_u64(computation_inputs.font_environment_generation);
+            let mut outputs = super::record_replay::PayloadWriter::default();
+            write_style_transaction_outputs(&output, &mut outputs);
+            payload.write_bytes(outputs.as_bytes());
+            payload.write_u64(outputs.stable_digest());
         });
-        output.reclaimed_style_atoms = std::mem::take(&mut engine.reclaimed_style_atoms)
-            .into_iter()
-            .map(|reclaimed| FfiReclaimedStyleAtom {
-                raw: reclaimed.raw,
-                atom: reclaimed.atom.0,
-            })
-            .collect();
-        output.style_atoms_swept = std::mem::take(&mut engine.style_atoms_swept);
-        if engine.recording_id().is_some() {
-            engine.record_boundary_call(EventKind::StyleDeltaBatch, |payload| {
-                payload.write_u32(root.raw());
-                payload.write_u64(computation_inputs.viewport_width.to_bits());
-                payload.write_u64(computation_inputs.viewport_height.to_bits());
-                payload.write_u64(computation_inputs.root_font_size.to_bits());
-                payload.write_u64(computation_inputs.root_font_x_height.to_bits());
-                payload.write_u64(computation_inputs.root_font_cap_height.to_bits());
-                payload.write_u64(computation_inputs.root_font_zero_advance.to_bits());
-                payload.write_u64(computation_inputs.root_line_height.to_bits());
-                payload.write_bool(computation_inputs.root_font_metrics_depend_on_viewport_metrics);
-                payload.write_i32(computation_inputs.initial_font_size_raw);
-                payload.write_i32(computation_inputs.default_font_size_raw);
-                payload.write_u64(computation_inputs.device_pixels_per_css_pixel.to_bits());
-                payload.write_u64(computation_inputs.font_environment_generation);
-                let mut outputs = super::record_replay::PayloadWriter::default();
-                write_style_transaction_outputs(&output, &mut outputs);
-                payload.write_bytes(outputs.as_bytes());
-                payload.write_u64(outputs.stable_digest());
-            });
-            engine.forget_recording_atom_mappings(output.reclaimed_style_atoms.iter().map(|reclaimed| reclaimed.atom));
-        }
-        engine.install_ffi_style_transaction_output(output);
-        let output = &engine.ffi_style_transaction_output;
-        FfiStyleTransactionView {
-            transaction_version: output.transaction_version,
-            program_version: output.program_version,
-            answers: output.answers.as_ptr(),
-            count: output.answers.len(),
-            reclaimed_style_atoms: output.reclaimed_style_atoms.as_ptr(),
-            reclaimed_style_atom_count: output.reclaimed_style_atoms.len(),
-            scoped: output.scoped,
-            style_atoms_swept: output.style_atoms_swept,
-        }
-    })
+        engine.forget_recording_atom_mappings(output.reclaimed_style_atoms.iter().map(|reclaimed| reclaimed.atom));
+    }
+    engine.install_ffi_style_transaction_output(output);
+    let output = &engine.ffi_style_transaction_output;
+    FfiStyleTransactionView {
+        transaction_version: output.transaction_version,
+        program_version: output.program_version,
+        answers: output.answers.as_ptr(),
+        count: output.answers.len(),
+        reclaimed_style_atoms: output.reclaimed_style_atoms.as_ptr(),
+        reclaimed_style_atom_count: output.reclaimed_style_atoms.len(),
+        scoped: output.scoped,
+        style_atoms_swept: output.style_atoms_swept,
+    }
 }
 
 /// Orders a completed reaction batch for direct application in C++.
@@ -2861,18 +2782,16 @@ pub unsafe extern "C" fn style_engine_sort_style_deltas_for_direct_application(
     deltas: *mut FfiStyleDelta,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        if count == 0 {
-            return;
-        }
-        assert!(!deltas.is_null(), "a non-empty delta span must have storage");
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        let deltas = unsafe { std::slice::from_raw_parts_mut(deltas, count) };
-        deltas.sort_unstable_by(|first, second| {
-            let first = StyleNodeID::from_raw(first.style_node).expect("a style delta must name an element");
-            let second = StyleNodeID::from_raw(second.style_node).expect("a style delta must name an element");
-            engine.tree.compare_style_reaction_order(first, second)
-        });
+    if count == 0 {
+        return;
+    }
+    assert!(!deltas.is_null(), "a non-empty delta span must have storage");
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    let deltas = unsafe { std::slice::from_raw_parts_mut(deltas, count) };
+    deltas.sort_unstable_by(|first, second| {
+        let first = StyleNodeID::from_raw(first.style_node).expect("a style delta must name an element");
+        let second = StyleNodeID::from_raw(second.style_node).expect("a style delta must name an element");
+        engine.tree.compare_style_reaction_order(first, second)
     });
 }
 
@@ -2886,17 +2805,15 @@ pub unsafe extern "C" fn style_engine_set_replay_reclaimed_style_atoms(
     atoms: *const u32,
     count: usize,
 ) {
-    abort_on_panic(|| {
-        let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
-        assert!(engine.replay_reclaimed_style_atoms.is_none());
-        let atoms = if count == 0 {
-            &[]
-        } else {
-            assert!(!atoms.is_null());
-            unsafe { std::slice::from_raw_parts(atoms, count) }
-        };
-        engine.replay_reclaimed_style_atoms = Some(atoms.iter().copied().map(StyleAtomID).collect());
-    });
+    let engine = unsafe { &mut *engine.cast::<StyleEngine>() };
+    assert!(engine.replay_reclaimed_style_atoms.is_none());
+    let atoms = if count == 0 {
+        &[]
+    } else {
+        assert!(!atoms.is_null());
+        unsafe { std::slice::from_raw_parts(atoms, count) }
+    };
+    engine.replay_reclaimed_style_atoms = Some(atoms.iter().copied().map(StyleAtomID).collect());
 }
 /// Reads one counter by index, returning its stable name and writing its value and name length, or
 /// null once the index is past the end. C++ enumerates the counters this way rather than
@@ -2911,26 +2828,24 @@ pub unsafe extern "C" fn style_engine_counter(
     out_value: *mut u64,
     out_name_length: *mut usize,
 ) -> *const u8 {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        let result = engine.counters().iter().nth(index);
-        engine.record_boundary_call(EventKind::Counter, |payload| {
-            payload.write_u64(u64::try_from(index).expect("counter index exceeds u64"));
-            payload.write_bool(result.is_some());
-            if let Some((name, value)) = result {
-                payload.write_bytes(name.as_bytes());
-                payload.write_u64(value);
-            }
-        });
-        let Some((name, value)) = result else {
-            return std::ptr::null();
-        };
-        unsafe {
-            *out_value = value;
-            *out_name_length = name.len();
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    let result = engine.counters().iter().nth(index);
+    engine.record_boundary_call(EventKind::Counter, |payload| {
+        payload.write_u64(u64::try_from(index).expect("counter index exceeds u64"));
+        payload.write_bool(result.is_some());
+        if let Some((name, value)) = result {
+            payload.write_bytes(name.as_bytes());
+            payload.write_u64(value);
         }
-        name.as_ptr()
-    })
+    });
+    let Some((name, value)) = result else {
+        return std::ptr::null();
+    };
+    unsafe {
+        *out_value = value;
+        *out_name_length = name.len();
+    }
+    name.as_ptr()
 }
 
 /// Records a benchmark phase marker when capture is enabled.
@@ -2945,20 +2860,18 @@ pub unsafe extern "C" fn style_engine_record_benchmark_marker(
     length: usize,
     is_ascii: bool,
 ) {
-    abort_on_panic(|| {
-        let engine = unsafe { &*engine.cast::<StyleEngine>() };
-        if engine.recording_id().is_none() {
-            return;
-        }
-        let name = match is_ascii {
-            true => unsafe { borrow(name.cast::<u8>(), length) }
-                .iter()
-                .map(|&code_unit| u16::from(code_unit))
-                .collect::<Vec<_>>(),
-            false => unsafe { borrow(name.cast::<u16>(), length) }.to_vec(),
-        };
-        engine.record_boundary_call(EventKind::BenchmarkMarker, |payload| payload.write_u16_slice(&name));
-    });
+    let engine = unsafe { &*engine.cast::<StyleEngine>() };
+    if engine.recording_id().is_none() {
+        return;
+    }
+    let name = match is_ascii {
+        true => unsafe { borrow(name.cast::<u8>(), length) }
+            .iter()
+            .map(|&code_unit| u16::from(code_unit))
+            .collect::<Vec<_>>(),
+        false => unsafe { borrow(name.cast::<u16>(), length) }.to_vec(),
+    };
+    engine.record_boundary_call(EventKind::BenchmarkMarker, |payload| payload.write_u16_slice(&name));
 }
 
 unsafe fn borrow<'a, T>(pointer: *const T, count: usize) -> &'a [T] {

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn rust_absolutize_length(
     context: *const FfiLengthResolutionContext,
 ) -> FfiAbsolutizedLength {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| absolutize_length(value, unit as usize, unsafe { &*context }))
+    absolutize_length(value, unit as usize, unsafe { &*context })
 }
 
 /// Result of computing a property that resolves to a number.
@@ -558,10 +558,8 @@ fn compute_font_width(value: &StyleValueData) -> FfiComputedNumber {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_compute_font_width(absolutized_value: *const c_void) -> FfiComputedNumber {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_font_width(value)
-    })
+    let value = unsafe { &*(absolutized_value as *const StyleValueData) };
+    compute_font_width(value)
 }
 
 /// An <absolute-size> keyword refers to an entry in a table of font sizes computed and kept by
@@ -710,16 +708,14 @@ pub unsafe extern "C" fn rust_compute_font_size(
     default_font_size_raw: i32,
 ) -> FfiComputedNumber {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_font_size(
-            value,
-            computed_math_depth,
-            CssPixels::from_raw(inherited_font_size_raw),
-            inherited_math_depth,
-            CssPixels::from_raw(default_font_size_raw),
-        )
-    })
+    let value = unsafe { &*(absolutized_value as *const StyleValueData) };
+    compute_font_size(
+        value,
+        computed_math_depth,
+        CssPixels::from_raw(inherited_font_size_raw),
+        inherited_math_depth,
+        CssPixels::from_raw(default_font_size_raw),
+    )
 }
 
 /// Why a monospace font-size recascade batch stopped.
@@ -884,32 +880,30 @@ pub unsafe extern "C" fn rust_recascade_font_size_batch(
     length_resolution_context: *const FfiLengthResolutionContext,
 ) -> FfiFontSizeRecascadeBatch {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let style_engine = unsafe { &*style_engine.cast::<crate::css::style::StyleEngine>() };
-        let style_records = if style_record_count == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(style_records, style_record_count) }
-        };
-        recascade_font_size_batch(
-            style_records.len(),
-            |index| {
-                let style_record = style_records[index];
-                if style_record == 0 {
-                    return std::ptr::null();
-                }
-                style_engine
-                    .style_record_view(style_record)
-                    .and_then(|view| unsafe { view.longhand_table.as_ref() })
-                    .map_or(std::ptr::null(), ComputedLonghandTable::raw_cascaded_font_size)
-            },
-            start_index,
-            current_size_raw,
-            current_depends_on_viewport_metrics,
-            default_size_raw,
-            length_resolution_context,
-        )
-    })
+    let style_engine = unsafe { &*style_engine.cast::<crate::css::style::StyleEngine>() };
+    let style_records = if style_record_count == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(style_records, style_record_count) }
+    };
+    recascade_font_size_batch(
+        style_records.len(),
+        |index| {
+            let style_record = style_records[index];
+            if style_record == 0 {
+                return std::ptr::null();
+            }
+            style_engine
+                .style_record_view(style_record)
+                .and_then(|view| unsafe { view.longhand_table.as_ref() })
+                .map_or(std::ptr::null(), ComputedLonghandTable::raw_cascaded_font_size)
+        },
+        start_index,
+        current_size_raw,
+        current_depends_on_viewport_metrics,
+        default_size_raw,
+        length_resolution_context,
+    )
 }
 
 /// Some pseudo-elements are generated regardless of CSS rules, so their
@@ -918,15 +912,13 @@ pub unsafe extern "C" fn rust_recascade_font_size_batch(
 pub extern "C" fn rust_pseudo_element_has_implicit_style(pseudo_element: u8) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     use crate::css::selector::PseudoElementType;
-    abort_on_panic(|| {
-        matches!(
-            crate::css::selector::pseudo_element_type_from_code(pseudo_element),
-            PseudoElementType::DetailsContent
-                | PseudoElementType::FileSelectorButton
-                | PseudoElementType::Marker
-                | PseudoElementType::Placeholder
-        )
-    })
+    matches!(
+        crate::css::selector::pseudo_element_type_from_code(pseudo_element),
+        PseudoElementType::DetailsContent
+            | PseudoElementType::FileSelectorButton
+            | PseudoElementType::Marker
+            | PseudoElementType::Placeholder
+    )
 }
 
 /// Whether style computation for a pseudo-element bails because no
@@ -941,27 +933,25 @@ pub extern "C" fn rust_pseudo_element_has_implicit_style(pseudo_element: u8) -> 
 pub unsafe extern "C" fn rust_pseudo_element_content_bails(content_value: *const c_void, pseudo_element: u8) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     use crate::css::selector::PseudoElementType;
-    abort_on_panic(|| {
-        let content_is_normal = if content_value.is_null() {
-            // NOTE: `normal` is the initial value, so the absence of a value is treated as `normal`.
-            true
-        } else {
-            match unsafe { &*(content_value as *const StyleValueData) } {
-                StyleValueData::Keyword { keyword } => {
-                    if *keyword == keyword::NONE {
-                        return true;
-                    }
-                    *keyword == keyword::NORMAL
+    let content_is_normal = if content_value.is_null() {
+        // NOTE: `normal` is the initial value, so the absence of a value is treated as `normal`.
+        true
+    } else {
+        match unsafe { &*(content_value as *const StyleValueData) } {
+            StyleValueData::Keyword { keyword } => {
+                if *keyword == keyword::NONE {
+                    return true;
                 }
-                _ => false,
+                *keyword == keyword::NORMAL
             }
-        };
-        content_is_normal
-            && matches!(
-                crate::css::selector::pseudo_element_type_from_code(pseudo_element),
-                PseudoElementType::Before | PseudoElementType::After
-            )
-    })
+            _ => false,
+        }
+    };
+    content_is_normal
+        && matches!(
+            crate::css::selector::pseudo_element_type_from_code(pseudo_element),
+            PseudoElementType::Before | PseudoElementType::After
+        )
 }
 
 /// https://drafts.css-houdini.org/css-properties-values-api/#computationally-independent
@@ -1860,10 +1850,8 @@ pub(crate) fn collect_unfixed_random_sharings_in_value(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_is_computationally_independent(data: *const c_void) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueQueryEntry);
-    abort_on_panic(|| {
-        value_is_computationally_independent(unsafe { &*(data as *const StyleValueData) })
-            .expect("computational independence requested for an unsupported value")
-    })
+    value_is_computationally_independent(unsafe { &*(data as *const StyleValueData) })
+        .expect("computational independence requested for an unsupported value")
 }
 
 // The computed value of the math-depth value is determined as follows:
@@ -2182,20 +2170,18 @@ pub struct FfiFontStyleComputation {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_compute_font_style(absolutized_value: *const c_void) -> FfiFontStyleComputation {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        if let StyleValueData::Keyword { keyword } = (unsafe { &*(absolutized_value as *const StyleValueData) })
-            && let Some(font_style_keyword) = keyword_to_font_style_keyword(*keyword)
-        {
-            return FfiFontStyleComputation {
-                is_keyword: true,
-                font_style_keyword,
-            };
-        }
-        FfiFontStyleComputation {
-            is_keyword: false,
-            font_style_keyword: 0,
-        }
-    })
+    if let StyleValueData::Keyword { keyword } = (unsafe { &*(absolutized_value as *const StyleValueData) })
+        && let Some(font_style_keyword) = keyword_to_font_style_keyword(*keyword)
+    {
+        return FfiFontStyleComputation {
+            is_keyword: true,
+            font_style_keyword,
+        };
+    }
+    FfiFontStyleComputation {
+        is_keyword: false,
+        font_style_keyword: 0,
+    }
 }
 
 fn compute_letter_or_word_spacing_value(absolutized_value: &StyleValueData) -> FfiComputedNumber {
@@ -2411,33 +2397,31 @@ static INITIAL_VALUE_TABLE: std::sync::OnceLock<InitialValueTable> = std::sync::
 /// `entries` must point at `length` transferred strong references.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_metadata_set_initial_value_table(entries: *const *const c_void, length: usize) {
-    abort_on_panic(|| {
-        let values: Vec<_> = unsafe { std::slice::from_raw_parts(entries, length) }
-            .iter()
-            .map(|entry| unsafe {
-                crate::css::style_value::RetainedStyleValueData::from_retained_pointer(
-                    (*entry).cast::<crate::css::style_value::StyleValueData>(),
-                )
+    let values: Vec<_> = unsafe { std::slice::from_raw_parts(entries, length) }
+        .iter()
+        .map(|entry| unsafe {
+            crate::css::style_value::RetainedStyleValueData::from_retained_pointer(
+                (*entry).cast::<crate::css::style_value::StyleValueData>(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        length,
+        crate::css::property_metadata::NUMBER_OF_LONGHAND_PROPERTIES,
+        "initial value table has one entry per longhand"
+    );
+    assert!(
+        INITIAL_VALUE_TABLE
+            .set(InitialValueTable {
+                dependencies: values
+                    .iter()
+                    .map(|value| external_value_dependencies(value.data()))
+                    .collect(),
+                values,
             })
-            .collect();
-        assert_eq!(
-            length,
-            crate::css::property_metadata::NUMBER_OF_LONGHAND_PROPERTIES,
-            "initial value table has one entry per longhand"
-        );
-        assert!(
-            INITIAL_VALUE_TABLE
-                .set(InitialValueTable {
-                    dependencies: values
-                        .iter()
-                        .map(|value| external_value_dependencies(value.data()))
-                        .collect(),
-                    values,
-                })
-                .is_ok(),
-            "initial value table installed twice"
-        );
-    });
+            .is_ok(),
+        "initial value table installed twice"
+    );
 }
 
 /// Returns the initial value data of a longhand property.
@@ -2456,7 +2440,7 @@ fn initial_value_dependencies(property_id: u16) -> ExternalValueDependencies {
 /// FFI accessor for the parity test on the C++ side.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_metadata_initial_value(property_id: u16) -> *const c_void {
-    abort_on_panic(|| initial_value_data(property_id).cast())
+    initial_value_data(property_id).cast()
 }
 
 /// Whether a keyword resolves as a color during computed-value processing.
@@ -4932,155 +4916,151 @@ fn effective_display(table: &ComputedLonghandTable, overlay: Option<&AnimatedOve
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_compute_properties(input: *const FfiComputePropertiesInput) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
-    abort_on_panic(|| {
-        let input = unsafe { &*input };
-        let style_engine = unsafe { &*input.style_engine.cast::<crate::css::style::StyleEngine>() };
-        let previous_style = (input.previous_style_record != 0).then(|| {
-            style_engine
-                .style_record_view(input.previous_style_record)
-                .expect("the previous style record must remain live during computation")
-        });
-        let previous_longhand_values = previous_style.as_ref().map(|view| view.longhand_values);
-        let mut selected_transition_properties = previous_style
-            .as_ref()
-            .and_then(|view| unsafe { view.longhand_table.as_ref() })
-            .map(active_transition_properties)
-            .unwrap_or_default();
-        let has_retained_transition_candidates = !selected_transition_properties.is_empty();
-        if input.selected_transition_property_count != 0 {
-            selected_transition_properties.extend_from_slice(unsafe {
-                std::slice::from_raw_parts(
-                    input.selected_transition_properties,
-                    input.selected_transition_property_count,
-                )
-            });
-        }
-        let retained_selection = if input.use_retained_style_computation_selection {
-            crate::css::style::tree::StyleNodeID::from_raw(input.style_node)
-                .and_then(|node| style_engine.pending_style_computation_selection(node, input.pseudo_kind))
-        } else {
-            None
-        };
-        let plan = crate::css::cascaded_properties::StyleComputationPlanInput {
-            initial_computed_group_mask: input.initial_computed_group_mask,
-            all_computed_groups: input.all_computed_groups,
-            previous_longhand_values,
-            retained_selection,
-            selected_transition_properties: &selected_transition_properties,
-            has_retained_transition_candidates,
-            has_relevant_animations: input.has_relevant_animations,
-            has_css_defined_animations: input.has_css_defined_animations,
-        };
-        let requirements = unsafe {
-            crate::css::cascaded_properties::collect_style_computation_requirements(input.store, Some(&plan))
-        };
-        let parent_snapshot = if input.inheritance_parent_style_record != 0 {
-            Some(parent_snapshot_for_style_record(
-                style_engine,
-                input.inheritance_parent_style_record,
-                None,
-            ))
-        } else {
-            None
-        };
-        let mut drive_input = std::mem::MaybeUninit::<FfiLonghandDriveInput>::uninit();
-        let rebuilds_over_previous_properties = requirements.computed_group_mask != input.all_computed_groups
-            || requirements.has_computed_property_selection;
-        let longhand_table = if rebuilds_over_previous_properties {
-            let previous_style = previous_style
-                .as_ref()
-                .expect("a partial style drive must have a previous style record");
-            previous_style.longhand_table_for_partial_drive()
-        } else {
-            ComputedLonghandTable::new()
-        };
-        unsafe {
-            (input.prepare_longhand_drive)(
-                input.callback_context,
-                &raw const requirements,
-                longhand_table.into_raw_shared().cast_mut(),
-                parent_snapshot
-                    .as_ref()
-                    .is_some_and(ParentSnapshot::has_animated_values),
-                drive_input.as_mut_ptr(),
-            );
-        }
-        let drive_input = unsafe { drive_input.assume_init() };
-        let parent_text_align_input_is_animated = parent_snapshot.as_ref().is_some_and(|snapshot| {
-            snapshot.has_animated_property(property_id::TEXT_ALIGN)
-                || snapshot.has_animated_property(property_id::DIRECTION)
-        });
-        let (mut result, mut finalization_line_height_metrics) =
-            unsafe { compute_longhands(&drive_input, parent_snapshot.as_ref()) };
-        if !input.stop_after_longhand_drive {
-            result.transitions = build_computed_transition_list(unsafe { &*drive_input.longhand_table });
-            result.animations = build_computed_animation_list(unsafe { &*drive_input.longhand_table });
-        }
-        let mut animated_overlay = drive_input.animated_overlay;
-        let mut animation_values_applied =
-            unsafe { animated_overlay.as_ref() }.is_some_and(|overlay| !overlay.is_empty());
-        unsafe { (input.finish_longhand_drive)(input.callback_context, &raw const result) };
-        unsafe { destroy_style_computation_result(&result) };
-        unsafe { crate::css::cascaded_properties::destroy_style_computation_requirements(requirements.storage) };
-        if input.stop_after_longhand_drive {
-            unsafe { (input.finish_properties)(input.callback_context, false) };
-            unsafe { &mut *drive_input.longhand_table }.freeze();
-            return;
-        }
-
-        unsafe { (input.process_animation_definitions)(input.callback_context) };
-        let has_animations = unsafe { (input.prepare_animations)(input.callback_context) };
-        if animation_values_applied || has_animations {
-            let invalidated = unsafe { restore_post_compute_values(&mut *drive_input.longhand_table, false) };
-            unsafe { (input.did_mutate_post_compute)(input.callback_context, invalidated) };
-        }
-        if has_animations {
-            animated_overlay = unsafe {
-                (input.apply_animations)(
-                    input.callback_context,
-                    (&*drive_input.environment).box_type_input.check_input_line_height,
-                    &raw mut finalization_line_height_metrics,
-                )
-            };
-            animation_values_applied = true;
-        }
-
-        if parent_text_align_input_is_animated && !animation_values_applied {
-            let invalidated = unsafe { restore_post_compute_values(&mut *drive_input.longhand_table, true) };
-            unsafe { (input.did_mutate_post_compute)(input.callback_context, invalidated) };
-        }
-        let finalization_mode = if animation_values_applied {
-            Some(FfiStyleFinalizationMode::All)
-        } else if parent_text_align_input_is_animated {
-            Some(FfiStyleFinalizationMode::TextAlign)
-        } else {
-            None
-        };
-        if let Some(mode) = finalization_mode {
-            let environment = unsafe { &*drive_input.environment };
-            let finalization = finalize_computed_style(
-                mode,
-                environment.box_type_input,
-                environment.is_th_element,
-                parent_snapshot.as_ref(),
-                unsafe { &mut *drive_input.longhand_table },
-                unsafe { animated_overlay.as_mut() },
-                Some(&finalization_line_height_metrics),
-            );
-            unsafe { (input.did_mutate_post_compute)(input.callback_context, finalization.invalidated_longhands) };
-        }
-        let parent_style_in_display_none_subtree = parent_snapshot
-            .as_ref()
-            .is_some_and(|snapshot| snapshot.in_display_none_subtree);
-        let display_is_none = effective_display(unsafe { &*drive_input.longhand_table }, unsafe {
-            animated_overlay.as_ref()
-        })
-        .is_none();
-        unsafe { &mut *drive_input.longhand_table }
-            .set_in_display_none_subtree(parent_style_in_display_none_subtree || display_is_none);
-        unsafe { (input.finish_properties)(input.callback_context, parent_style_in_display_none_subtree) };
-        unsafe { &mut *drive_input.longhand_table }.freeze();
+    let input = unsafe { &*input };
+    let style_engine = unsafe { &*input.style_engine.cast::<crate::css::style::StyleEngine>() };
+    let previous_style = (input.previous_style_record != 0).then(|| {
+        style_engine
+            .style_record_view(input.previous_style_record)
+            .expect("the previous style record must remain live during computation")
     });
+    let previous_longhand_values = previous_style.as_ref().map(|view| view.longhand_values);
+    let mut selected_transition_properties = previous_style
+        .as_ref()
+        .and_then(|view| unsafe { view.longhand_table.as_ref() })
+        .map(active_transition_properties)
+        .unwrap_or_default();
+    let has_retained_transition_candidates = !selected_transition_properties.is_empty();
+    if input.selected_transition_property_count != 0 {
+        selected_transition_properties.extend_from_slice(unsafe {
+            std::slice::from_raw_parts(
+                input.selected_transition_properties,
+                input.selected_transition_property_count,
+            )
+        });
+    }
+    let retained_selection = if input.use_retained_style_computation_selection {
+        crate::css::style::tree::StyleNodeID::from_raw(input.style_node)
+            .and_then(|node| style_engine.pending_style_computation_selection(node, input.pseudo_kind))
+    } else {
+        None
+    };
+    let plan = crate::css::cascaded_properties::StyleComputationPlanInput {
+        initial_computed_group_mask: input.initial_computed_group_mask,
+        all_computed_groups: input.all_computed_groups,
+        previous_longhand_values,
+        retained_selection,
+        selected_transition_properties: &selected_transition_properties,
+        has_retained_transition_candidates,
+        has_relevant_animations: input.has_relevant_animations,
+        has_css_defined_animations: input.has_css_defined_animations,
+    };
+    let requirements =
+        unsafe { crate::css::cascaded_properties::collect_style_computation_requirements(input.store, Some(&plan)) };
+    let parent_snapshot = if input.inheritance_parent_style_record != 0 {
+        Some(parent_snapshot_for_style_record(
+            style_engine,
+            input.inheritance_parent_style_record,
+            None,
+        ))
+    } else {
+        None
+    };
+    let mut drive_input = std::mem::MaybeUninit::<FfiLonghandDriveInput>::uninit();
+    let rebuilds_over_previous_properties =
+        requirements.computed_group_mask != input.all_computed_groups || requirements.has_computed_property_selection;
+    let longhand_table = if rebuilds_over_previous_properties {
+        let previous_style = previous_style
+            .as_ref()
+            .expect("a partial style drive must have a previous style record");
+        previous_style.longhand_table_for_partial_drive()
+    } else {
+        ComputedLonghandTable::new()
+    };
+    unsafe {
+        (input.prepare_longhand_drive)(
+            input.callback_context,
+            &raw const requirements,
+            longhand_table.into_raw_shared().cast_mut(),
+            parent_snapshot
+                .as_ref()
+                .is_some_and(ParentSnapshot::has_animated_values),
+            drive_input.as_mut_ptr(),
+        );
+    }
+    let drive_input = unsafe { drive_input.assume_init() };
+    let parent_text_align_input_is_animated = parent_snapshot.as_ref().is_some_and(|snapshot| {
+        snapshot.has_animated_property(property_id::TEXT_ALIGN)
+            || snapshot.has_animated_property(property_id::DIRECTION)
+    });
+    let (mut result, mut finalization_line_height_metrics) =
+        unsafe { compute_longhands(&drive_input, parent_snapshot.as_ref()) };
+    if !input.stop_after_longhand_drive {
+        result.transitions = build_computed_transition_list(unsafe { &*drive_input.longhand_table });
+        result.animations = build_computed_animation_list(unsafe { &*drive_input.longhand_table });
+    }
+    let mut animated_overlay = drive_input.animated_overlay;
+    let mut animation_values_applied = unsafe { animated_overlay.as_ref() }.is_some_and(|overlay| !overlay.is_empty());
+    unsafe { (input.finish_longhand_drive)(input.callback_context, &raw const result) };
+    unsafe { destroy_style_computation_result(&result) };
+    unsafe { crate::css::cascaded_properties::destroy_style_computation_requirements(requirements.storage) };
+    if input.stop_after_longhand_drive {
+        unsafe { (input.finish_properties)(input.callback_context, false) };
+        unsafe { &mut *drive_input.longhand_table }.freeze();
+        return;
+    }
+
+    unsafe { (input.process_animation_definitions)(input.callback_context) };
+    let has_animations = unsafe { (input.prepare_animations)(input.callback_context) };
+    if animation_values_applied || has_animations {
+        let invalidated = unsafe { restore_post_compute_values(&mut *drive_input.longhand_table, false) };
+        unsafe { (input.did_mutate_post_compute)(input.callback_context, invalidated) };
+    }
+    if has_animations {
+        animated_overlay = unsafe {
+            (input.apply_animations)(
+                input.callback_context,
+                (&*drive_input.environment).box_type_input.check_input_line_height,
+                &raw mut finalization_line_height_metrics,
+            )
+        };
+        animation_values_applied = true;
+    }
+
+    if parent_text_align_input_is_animated && !animation_values_applied {
+        let invalidated = unsafe { restore_post_compute_values(&mut *drive_input.longhand_table, true) };
+        unsafe { (input.did_mutate_post_compute)(input.callback_context, invalidated) };
+    }
+    let finalization_mode = if animation_values_applied {
+        Some(FfiStyleFinalizationMode::All)
+    } else if parent_text_align_input_is_animated {
+        Some(FfiStyleFinalizationMode::TextAlign)
+    } else {
+        None
+    };
+    if let Some(mode) = finalization_mode {
+        let environment = unsafe { &*drive_input.environment };
+        let finalization = finalize_computed_style(
+            mode,
+            environment.box_type_input,
+            environment.is_th_element,
+            parent_snapshot.as_ref(),
+            unsafe { &mut *drive_input.longhand_table },
+            unsafe { animated_overlay.as_mut() },
+            Some(&finalization_line_height_metrics),
+        );
+        unsafe { (input.did_mutate_post_compute)(input.callback_context, finalization.invalidated_longhands) };
+    }
+    let parent_style_in_display_none_subtree = parent_snapshot
+        .as_ref()
+        .is_some_and(|snapshot| snapshot.in_display_none_subtree);
+    let display_is_none = effective_display(unsafe { &*drive_input.longhand_table }, unsafe {
+        animated_overlay.as_ref()
+    })
+    .is_none();
+    unsafe { &mut *drive_input.longhand_table }
+        .set_in_display_none_subtree(parent_style_in_display_none_subtree || display_is_none);
+    unsafe { (input.finish_properties)(input.callback_context, parent_style_in_display_none_subtree) };
+    unsafe { &mut *drive_input.longhand_table }.freeze();
 }
 
 /// Creates the complete initial document longhand table. Unlike a normal
@@ -5095,112 +5075,110 @@ pub unsafe extern "C" fn rust_create_document_longhand_table(
     input: *const FfiDocumentLonghandInput,
 ) -> *mut ComputedLonghandTable {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
-    abort_on_panic(|| {
-        let input = unsafe { &*input };
-        let mut longhand_table = ComputedLonghandTable::new();
-        let store = CascadedPropertyStore::new();
-        let environment = FfiStyleComputationEnvironment {
-            box_type_input: FfiBoxTypeTransformationInput {
-                display: FfiDisplay::inline(),
-                position: keyword::STATIC,
-                float_value: keyword::NONE,
-                is_br_element: false,
-                is_document_element: false,
-                is_mathml_element: false,
-                is_mathml_mtable: false,
-                is_mathml_mtr: false,
-                is_mathml_mtd: false,
-                has_parent_display: false,
-                parent_display: FfiDisplay::block(),
-                is_wbr_element: false,
-                disallow_display_contents: false,
-                rewrite_inline_flow: false,
-                is_button_element: false,
-                force_line_height_normal: false,
-                check_input_line_height: false,
-                hide_audio_without_controls: false,
-                is_table_element: false,
-                force_position_static: false,
-                force_symbol_display_inline: false,
-            },
-            color_scheme_input: input.color_scheme_input,
-            is_th_element: false,
-            has_new_font_size: false,
-            has_tree_counting_context: false,
-            sibling_count: 0,
-            sibling_index: 0,
-            random_base_values: std::ptr::null(),
-            random_base_value_count: 0,
-            document_base_url: std::ptr::null(),
-            document_base_url_length: 0,
-            style_sheet_resource_contexts: std::ptr::null(),
-            style_sheet_resource_context_count: 0,
-            device_pixels_per_css_pixel: input.device_pixels_per_css_pixel,
-            initial_font_size_raw: input.initial_font_size_raw,
-            default_font_size_raw: input.default_font_size_raw,
+    let input = unsafe { &*input };
+    let mut longhand_table = ComputedLonghandTable::new();
+    let store = CascadedPropertyStore::new();
+    let environment = FfiStyleComputationEnvironment {
+        box_type_input: FfiBoxTypeTransformationInput {
+            display: FfiDisplay::inline(),
+            position: keyword::STATIC,
+            float_value: keyword::NONE,
+            is_br_element: false,
+            is_document_element: false,
+            is_mathml_element: false,
+            is_mathml_mtable: false,
+            is_mathml_mtr: false,
+            is_mathml_mtd: false,
+            has_parent_display: false,
+            parent_display: FfiDisplay::block(),
+            is_wbr_element: false,
+            disallow_display_contents: false,
+            rewrite_inline_flow: false,
+            is_button_element: false,
+            force_line_height_normal: false,
+            check_input_line_height: false,
+            hide_audio_without_controls: false,
+            is_table_element: false,
+            force_position_static: false,
+            force_symbol_display_inline: false,
+        },
+        color_scheme_input: input.color_scheme_input,
+        is_th_element: false,
+        has_new_font_size: false,
+        has_tree_counting_context: false,
+        sibling_count: 0,
+        sibling_index: 0,
+        random_base_values: std::ptr::null(),
+        random_base_value_count: 0,
+        document_base_url: std::ptr::null(),
+        document_base_url_length: 0,
+        style_sheet_resource_contexts: std::ptr::null(),
+        style_sheet_resource_context_count: 0,
+        device_pixels_per_css_pixel: input.device_pixels_per_css_pixel,
+        initial_font_size_raw: input.initial_font_size_raw,
+        default_font_size_raw: input.default_font_size_raw,
+    };
+    let mut results = empty_longhand_driver_results();
+    let mut effective_color_scheme = -1;
+    for phase in [
+        LONGHAND_DRIVE_PHASE_FONT,
+        LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
+        LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
+        LONGHAND_DRIVE_PHASE_REMAINING,
+    ] {
+        let length_resolution_context = if phase == LONGHAND_DRIVE_PHASE_COLOR_SCHEME {
+            std::ptr::null()
+        } else {
+            &raw const input.length_resolution_context
         };
-        let mut results = empty_longhand_driver_results();
-        let mut effective_color_scheme = -1;
-        for phase in [
-            LONGHAND_DRIVE_PHASE_FONT,
-            LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
-            LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
-            LONGHAND_DRIVE_PHASE_REMAINING,
-        ] {
-            let length_resolution_context = if phase == LONGHAND_DRIVE_PHASE_COLOR_SCHEME {
-                std::ptr::null()
-            } else {
-                &raw const input.length_resolution_context
-            };
-            unsafe {
-                drive_property_computation(
-                    &raw mut longhand_table,
-                    std::ptr::null_mut(),
-                    &raw const store,
-                    None,
-                    &raw const environment,
-                    u32::MAX,
-                    std::ptr::null(),
-                    phase,
-                    length_resolution_context,
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    &raw mut results,
-                    &mut effective_color_scheme,
-                    true,
-                );
-            }
+        unsafe {
+            drive_property_computation(
+                &raw mut longhand_table,
+                std::ptr::null_mut(),
+                &raw const store,
+                None,
+                &raw const environment,
+                u32::MAX,
+                std::ptr::null(),
+                phase,
+                length_resolution_context,
+                std::ptr::null(),
+                std::ptr::null(),
+                &raw mut results,
+                &mut effective_color_scheme,
+                true,
+            );
         }
-        longhand_table.merge_dependency_flags(
-            results.depends_on_viewport_metrics,
-            results.font_metrics_depend_on_viewport_metrics,
-        );
-        longhand_table.set(
-            property_id::WIDTH,
-            retained_new(StyleValueData::Length {
-                value: input.viewport_width,
-                unit: px_length_unit(),
-            }),
-            -1,
-        );
-        longhand_table.set(
-            property_id::HEIGHT,
-            retained_new(StyleValueData::Length {
-                value: input.viewport_height,
-                unit: px_length_unit(),
-            }),
-            -1,
-        );
-        longhand_table.set(
-            property_id::DISPLAY,
-            retained_new(StyleValueData::Display {
-                raw: FfiDisplay::block().encoded(),
-            }),
-            -1,
-        );
-        longhand_table.freeze();
-        longhand_table.into_raw_shared().cast_mut()
-    })
+    }
+    longhand_table.merge_dependency_flags(
+        results.depends_on_viewport_metrics,
+        results.font_metrics_depend_on_viewport_metrics,
+    );
+    longhand_table.set(
+        property_id::WIDTH,
+        retained_new(StyleValueData::Length {
+            value: input.viewport_width,
+            unit: px_length_unit(),
+        }),
+        -1,
+    );
+    longhand_table.set(
+        property_id::HEIGHT,
+        retained_new(StyleValueData::Length {
+            value: input.viewport_height,
+            unit: px_length_unit(),
+        }),
+        -1,
+    );
+    longhand_table.set(
+        property_id::DISPLAY,
+        retained_new(StyleValueData::Display {
+            raw: FfiDisplay::block().encoded(),
+        }),
+        -1,
+    );
+    longhand_table.freeze();
+    longhand_table.into_raw_shared().cast_mut()
 }
 
 /// Computes every selected keyframe longhand through the Rust longhand driver.
@@ -5218,226 +5196,224 @@ pub unsafe extern "C" fn rust_compute_animation_keyframe_longhands(
 ) -> FfiAnimationKeyframeLonghandResult {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::LonghandDriverEntry);
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::AnimationKeyframeLonghandEntry);
-    abort_on_panic(|| {
-        use crate::css::property_metadata::{
-            FIRST_LONGHAND_PROPERTY_ID, LAST_LONGHAND_PROPERTY_ID, NUMBER_OF_LONGHAND_PROPERTIES,
-        };
+    use crate::css::property_metadata::{
+        FIRST_LONGHAND_PROPERTY_ID, LAST_LONGHAND_PROPERTY_ID, NUMBER_OF_LONGHAND_PROPERTIES,
+    };
 
-        let input = unsafe { &*input };
-        let properties = if input.property_count == 0 {
-            &[][..]
-        } else {
-            unsafe {
-                std::slice::from_raw_parts(
-                    input
-                        .resolved_properties
-                        .cast::<crate::css::animation::FfiResolvedAnimationProperty>(),
-                    input.property_count,
-                )
-            }
+    let input = unsafe { &*input };
+    let properties = if input.property_count == 0 {
+        &[][..]
+    } else {
+        unsafe {
+            std::slice::from_raw_parts(
+                input
+                    .resolved_properties
+                    .cast::<crate::css::animation::FfiResolvedAnimationProperty>(),
+                input.property_count,
+            )
+        }
+    };
+    if properties.is_empty() {
+        return FfiAnimationKeyframeLonghandResult {
+            value_count: 0,
+            depends_on_viewport_metrics: false,
+            font_metrics_depend_on_viewport_metrics: false,
+            storage: std::ptr::null_mut(),
         };
-        if properties.is_empty() {
-            return FfiAnimationKeyframeLonghandResult {
-                value_count: 0,
-                depends_on_viewport_metrics: false,
-                font_metrics_depend_on_viewport_metrics: false,
-                storage: std::ptr::null_mut(),
+    }
+    assert!(!input.underlying_longhand_table.is_null());
+    assert!(!input.environment.is_null());
+    assert!(!input.font_length_resolution_context.is_null());
+    assert!(!input.line_height_length_resolution_context.is_null());
+    assert!(!input.remaining_length_resolution_context.is_null());
+    let underlying_longhand_table = unsafe { &*input.underlying_longhand_table };
+    let parent_snapshot = if input.inheritance_parent_style_record == 0 {
+        None
+    } else {
+        let style_engine = unsafe { &*input.style_engine.cast::<crate::css::style::StyleEngine>() };
+        Some(keyframe_parent_snapshot_for_style_record(
+            style_engine,
+            input.inheritance_parent_style_record,
+        ))
+    };
+    let mut longhands_by_keyframe = std::collections::BTreeMap::<usize, Vec<usize>>::new();
+    for (index, property) in properties.iter().enumerate() {
+        if property.custom_name_id != 0 {
+            continue;
+        }
+        assert!((FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&property.physical_property_id));
+        assert!(!property.value.is_null());
+        longhands_by_keyframe
+            .entry(property.keyframe_index)
+            .or_default()
+            .push(index);
+    }
+
+    const LONGHAND_WORD_COUNT: usize = NUMBER_OF_LONGHAND_PROPERTIES.div_ceil(64);
+    let mut values = std::iter::repeat_with(|| None)
+        .take(properties.len())
+        .collect::<Vec<_>>();
+    for (index, property) in properties.iter().enumerate() {
+        if property.custom_name_id == 0 {
+            continue;
+        }
+        assert!(!input.custom_property_values.is_null());
+        let value = unsafe { *input.custom_property_values.add(index) };
+        assert!(!value.is_null());
+        values[index] = Some(unsafe {
+            crate::css::style_value::RetainedStyleValueData::from_retained_pointer(
+                crate::css::style_value::retain_style_value(value.cast()),
+            )
+        });
+    }
+    let mut depends_on_viewport_metrics = false;
+    let mut font_metrics_depend_on_viewport_metrics = false;
+    for indices in longhands_by_keyframe.values() {
+        // The keyframe drive reads only the selected longhands and the coordination inputs
+        // seeded below. Starting from the underlying table would retain and release every
+        // unrelated longhand for every keyframe on every animation sample.
+        let mut table = ComputedLonghandTable::new();
+        // Background lists coordinate against the underlying background-image layer count
+        // when background-image is not selected by this keyframe.
+        if let Some(value) = underlying_longhand_table.get(property_id::BACKGROUND_IMAGE) {
+            table.set(property_id::BACKGROUND_IMAGE, value.clone_retained(), -1);
+        }
+        let mut store = CascadedPropertyStore::new();
+        for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
+            if !is_required_driver_input(property_id) {
+                continue;
+            }
+            if let Some(value) = underlying_longhand_table.get(property_id) {
+                store.seed_retained_property(property_id, value.clone_retained(), false, false);
+            }
+        }
+        let mut selected_longhands = [0; LONGHAND_WORD_COUNT];
+        let mut style_sheet_resource_contexts = Vec::new();
+        for &index in indices {
+            use crate::css::animation::FfiAnimationSpecifiedValueSource;
+
+            let property = &properties[index];
+            let value = match property.value_source {
+                FfiAnimationSpecifiedValueSource::Value => unsafe {
+                    RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                        property.value.cast(),
+                    ))
+                },
+                FfiAnimationSpecifiedValueSource::Initial => unsafe {
+                    RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                        initial_value_data(property.source_longhand_id).cast(),
+                    ))
+                },
+                FfiAnimationSpecifiedValueSource::Underlying => underlying_longhand_table
+                    .get(property.source_longhand_id)
+                    .expect("an animated longhand must have an underlying value")
+                    .clone_retained(),
+                FfiAnimationSpecifiedValueSource::Inherited => {
+                    let inherited = parent_snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.value(property.source_longhand_id));
+                    let inherited =
+                        inherited.unwrap_or_else(|| unsafe { &*initial_value_data(property.source_longhand_id) });
+                    unsafe {
+                        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
+                            std::ptr::from_ref(inherited).cast(),
+                        ))
+                    }
+                }
             };
-        }
-        assert!(!input.underlying_longhand_table.is_null());
-        assert!(!input.environment.is_null());
-        assert!(!input.font_length_resolution_context.is_null());
-        assert!(!input.line_height_length_resolution_context.is_null());
-        assert!(!input.remaining_length_resolution_context.is_null());
-        let underlying_longhand_table = unsafe { &*input.underlying_longhand_table };
-        let parent_snapshot = if input.inheritance_parent_style_record == 0 {
-            None
-        } else {
-            let style_engine = unsafe { &*input.style_engine.cast::<crate::css::style::StyleEngine>() };
-            Some(keyframe_parent_snapshot_for_style_record(
-                style_engine,
-                input.inheritance_parent_style_record,
-            ))
-        };
-        let mut longhands_by_keyframe = std::collections::BTreeMap::<usize, Vec<usize>>::new();
-        for (index, property) in properties.iter().enumerate() {
-            if property.custom_name_id != 0 {
+            if property.is_transition {
+                values[index] = Some(value);
                 continue;
             }
-            assert!((FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID).contains(&property.physical_property_id));
-            assert!(!property.value.is_null());
-            longhands_by_keyframe
-                .entry(property.keyframe_index)
-                .or_default()
-                .push(index);
-        }
-
-        const LONGHAND_WORD_COUNT: usize = NUMBER_OF_LONGHAND_PROPERTIES.div_ceil(64);
-        let mut values = std::iter::repeat_with(|| None)
-            .take(properties.len())
-            .collect::<Vec<_>>();
-        for (index, property) in properties.iter().enumerate() {
-            if property.custom_name_id == 0 {
-                continue;
-            }
-            assert!(!input.custom_property_values.is_null());
-            let value = unsafe { *input.custom_property_values.add(index) };
-            assert!(!value.is_null());
-            values[index] = Some(unsafe {
-                crate::css::style_value::RetainedStyleValueData::from_retained_pointer(
-                    crate::css::style_value::retain_style_value(value.cast()),
-                )
-            });
-        }
-        let mut depends_on_viewport_metrics = false;
-        let mut font_metrics_depend_on_viewport_metrics = false;
-        for indices in longhands_by_keyframe.values() {
-            // The keyframe drive reads only the selected longhands and the coordination inputs
-            // seeded below. Starting from the underlying table would retain and release every
-            // unrelated longhand for every keyframe on every animation sample.
-            let mut table = ComputedLonghandTable::new();
-            // Background lists coordinate against the underlying background-image layer count
-            // when background-image is not selected by this keyframe.
-            if let Some(value) = underlying_longhand_table.get(property_id::BACKGROUND_IMAGE) {
-                table.set(property_id::BACKGROUND_IMAGE, value.clone_retained(), -1);
-            }
-            let mut store = CascadedPropertyStore::new();
-            for property_id in FIRST_LONGHAND_PROPERTY_ID..=LAST_LONGHAND_PROPERTY_ID {
-                if !is_required_driver_input(property_id) {
-                    continue;
-                }
-                if let Some(value) = underlying_longhand_table.get(property_id) {
-                    store.seed_retained_property(property_id, value.clone_retained(), false, false);
-                }
-            }
-            let mut selected_longhands = [0; LONGHAND_WORD_COUNT];
-            let mut style_sheet_resource_contexts = Vec::new();
-            for &index in indices {
-                use crate::css::animation::FfiAnimationSpecifiedValueSource;
-
-                let property = &properties[index];
-                let value = match property.value_source {
-                    FfiAnimationSpecifiedValueSource::Value => unsafe {
-                        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
-                            property.value.cast(),
-                        ))
-                    },
-                    FfiAnimationSpecifiedValueSource::Initial => unsafe {
-                        RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
-                            initial_value_data(property.source_longhand_id).cast(),
-                        ))
-                    },
-                    FfiAnimationSpecifiedValueSource::Underlying => underlying_longhand_table
-                        .get(property.source_longhand_id)
-                        .expect("an animated longhand must have an underlying value")
-                        .clone_retained(),
-                    FfiAnimationSpecifiedValueSource::Inherited => {
-                        let inherited = parent_snapshot
-                            .as_ref()
-                            .and_then(|snapshot| snapshot.value(property.source_longhand_id));
-                        let inherited =
-                            inherited.unwrap_or_else(|| unsafe { &*initial_value_data(property.source_longhand_id) });
-                        unsafe {
-                            RetainedStyleValueData::from_retained_pointer(crate::css::style_value::retain_style_value(
-                                std::ptr::from_ref(inherited).cast(),
-                            ))
-                        }
+            let style_sheet_resource_context =
+                if matches!(property.value_source, FfiAnimationSpecifiedValueSource::Value) {
+                    FfiStyleSheetResourceContext {
+                        base_url: property.style_sheet_resource_context.base_url,
+                        base_url_length: property.style_sheet_resource_context.base_url_length,
+                        has_value: property.style_sheet_resource_context.has_value,
+                        origin_clean: property.style_sheet_resource_context.origin_clean,
                     }
+                } else {
+                    FfiStyleSheetResourceContext::empty()
                 };
-                if property.is_transition {
-                    values[index] = Some(value);
-                    continue;
+            let has_style_sheet_context = style_sheet_resource_context.has_value;
+            let source_slot =
+                store.seed_retained_property(property.physical_property_id, value, false, has_style_sheet_context);
+            if has_style_sheet_context {
+                let source_slot = source_slot as usize;
+                if style_sheet_resource_contexts.len() <= source_slot {
+                    style_sheet_resource_contexts.resize(source_slot + 1, FfiStyleSheetResourceContext::empty());
                 }
-                let style_sheet_resource_context =
-                    if matches!(property.value_source, FfiAnimationSpecifiedValueSource::Value) {
-                        FfiStyleSheetResourceContext {
-                            base_url: property.style_sheet_resource_context.base_url,
-                            base_url_length: property.style_sheet_resource_context.base_url_length,
-                            has_value: property.style_sheet_resource_context.has_value,
-                            origin_clean: property.style_sheet_resource_context.origin_clean,
-                        }
-                    } else {
-                        FfiStyleSheetResourceContext::empty()
-                    };
-                let has_style_sheet_context = style_sheet_resource_context.has_value;
-                let source_slot =
-                    store.seed_retained_property(property.physical_property_id, value, false, has_style_sheet_context);
-                if has_style_sheet_context {
-                    let source_slot = source_slot as usize;
-                    if style_sheet_resource_contexts.len() <= source_slot {
-                        style_sheet_resource_contexts.resize(source_slot + 1, FfiStyleSheetResourceContext::empty());
-                    }
-                    style_sheet_resource_contexts[source_slot] = style_sheet_resource_context;
-                }
-                set_longhand_bit(&mut selected_longhands, property.physical_property_id);
+                style_sheet_resource_contexts[source_slot] = style_sheet_resource_context;
             }
-            if selected_longhands.iter().all(|word| *word == 0) {
+            set_longhand_bit(&mut selected_longhands, property.physical_property_id);
+        }
+        if selected_longhands.iter().all(|word| *word == 0) {
+            continue;
+        }
+        let mut environment = unsafe { *input.environment };
+        environment.style_sheet_resource_contexts = style_sheet_resource_contexts.as_ptr();
+        environment.style_sheet_resource_context_count = style_sheet_resource_contexts.len();
+
+        let mut results = empty_longhand_driver_results();
+        let mut effective_color_scheme = -1;
+        for phase in [
+            LONGHAND_DRIVE_PHASE_FONT,
+            LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
+            LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
+            LONGHAND_DRIVE_PHASE_REMAINING,
+        ] {
+            let length_resolution_context = match phase {
+                LONGHAND_DRIVE_PHASE_FONT => input.font_length_resolution_context,
+                LONGHAND_DRIVE_PHASE_LINE_HEIGHT => input.line_height_length_resolution_context,
+                LONGHAND_DRIVE_PHASE_COLOR_SCHEME => std::ptr::null(),
+                LONGHAND_DRIVE_PHASE_REMAINING => input.remaining_length_resolution_context,
+                _ => unreachable!(),
+            };
+            unsafe {
+                drive_property_computation(
+                    &raw mut table,
+                    std::ptr::null_mut(),
+                    &raw const store,
+                    parent_snapshot.as_ref(),
+                    &raw const environment,
+                    u32::MAX,
+                    selected_longhands.as_ptr(),
+                    phase,
+                    length_resolution_context,
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    &raw mut results,
+                    &mut effective_color_scheme,
+                    false,
+                );
+            }
+        }
+        depends_on_viewport_metrics |= results.depends_on_viewport_metrics;
+        font_metrics_depend_on_viewport_metrics |= results.font_metrics_depend_on_viewport_metrics;
+        for &index in indices {
+            if properties[index].is_transition {
                 continue;
             }
-            let mut environment = unsafe { *input.environment };
-            environment.style_sheet_resource_contexts = style_sheet_resource_contexts.as_ptr();
-            environment.style_sheet_resource_context_count = style_sheet_resource_contexts.len();
-
-            let mut results = empty_longhand_driver_results();
-            let mut effective_color_scheme = -1;
-            for phase in [
-                LONGHAND_DRIVE_PHASE_FONT,
-                LONGHAND_DRIVE_PHASE_LINE_HEIGHT,
-                LONGHAND_DRIVE_PHASE_COLOR_SCHEME,
-                LONGHAND_DRIVE_PHASE_REMAINING,
-            ] {
-                let length_resolution_context = match phase {
-                    LONGHAND_DRIVE_PHASE_FONT => input.font_length_resolution_context,
-                    LONGHAND_DRIVE_PHASE_LINE_HEIGHT => input.line_height_length_resolution_context,
-                    LONGHAND_DRIVE_PHASE_COLOR_SCHEME => std::ptr::null(),
-                    LONGHAND_DRIVE_PHASE_REMAINING => input.remaining_length_resolution_context,
-                    _ => unreachable!(),
-                };
-                unsafe {
-                    drive_property_computation(
-                        &raw mut table,
-                        std::ptr::null_mut(),
-                        &raw const store,
-                        parent_snapshot.as_ref(),
-                        &raw const environment,
-                        u32::MAX,
-                        selected_longhands.as_ptr(),
-                        phase,
-                        length_resolution_context,
-                        std::ptr::null(),
-                        std::ptr::null(),
-                        &raw mut results,
-                        &mut effective_color_scheme,
-                        false,
-                    );
-                }
-            }
-            depends_on_viewport_metrics |= results.depends_on_viewport_metrics;
-            font_metrics_depend_on_viewport_metrics |= results.font_metrics_depend_on_viewport_metrics;
-            for &index in indices {
-                if properties[index].is_transition {
-                    continue;
-                }
-                let value = table
-                    .get(properties[index].physical_property_id)
-                    .expect("the keyframe longhand drive must store every selected property");
-                values[index] = Some(value.clone_retained());
-            }
+            let value = table
+                .get(properties[index].physical_property_id)
+                .expect("the keyframe longhand drive must store every selected property");
+            values[index] = Some(value.clone_retained());
         }
+    }
 
-        let values = Box::new(
-            values
-                .into_iter()
-                .map(|value| value.expect("the keyframe longhand drive must produce every requested value"))
-                .collect::<Vec<_>>(),
-        );
-        FfiAnimationKeyframeLonghandResult {
-            value_count: values.len(),
-            depends_on_viewport_metrics,
-            font_metrics_depend_on_viewport_metrics,
-            storage: Box::into_raw(values).cast(),
-        }
-    })
+    let values = Box::new(
+        values
+            .into_iter()
+            .map(|value| value.expect("the keyframe longhand drive must produce every requested value"))
+            .collect::<Vec<_>>(),
+    );
+    FfiAnimationKeyframeLonghandResult {
+        value_count: values.len(),
+        depends_on_viewport_metrics,
+        font_metrics_depend_on_viewport_metrics,
+        storage: Box::into_raw(values).cast(),
+    }
 }
 
 /// # Safety
@@ -5698,23 +5674,21 @@ pub unsafe extern "C" fn rust_expand_property_shorthands(
     data: *const c_void,
 ) -> FfiShorthandExpansion {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::ShorthandExpansionEntry);
-    abort_on_panic(|| {
-        let expansion = Box::new(expand_shorthands(property_id, data));
-        let properties = expansion.properties.as_ptr();
-        let count = expansion.properties.len();
-        FfiShorthandExpansion {
-            properties,
-            count,
-            storage: Box::into_raw(expansion).cast(),
-        }
-    })
+    let expansion = Box::new(expand_shorthands(property_id, data));
+    let properties = expansion.properties.as_ptr();
+    let count = expansion.properties.len();
+    FfiShorthandExpansion {
+        properties,
+        count,
+        storage: Box::into_raw(expansion).cast(),
+    }
 }
 
 /// # Safety
 /// `storage` must be a live pointer returned by `rust_expand_property_shorthands`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_shorthand_expansion_destroy(storage: *mut c_void) {
-    abort_on_panic(|| drop(unsafe { Box::from_raw(storage.cast::<ShorthandExpansion>()) }));
+    drop(unsafe { Box::from_raw(storage.cast::<ShorthandExpansion>()) });
 }
 
 pub(crate) fn display_is_none(raw: u32) -> bool {
@@ -6130,14 +6104,12 @@ pub unsafe extern "C" fn rust_resolve_effective_color_scheme(
     value: *const c_void,
     input: *const FfiEffectiveColorSchemeInput,
 ) -> u8 {
-    abort_on_panic(|| {
-        let StyleValueData::ColorScheme { scheme_codes, .. } = (unsafe { &*(value as *const StyleValueData) }) else {
-            unreachable!("computed color-scheme must have color-scheme data");
-        };
-        let input = unsafe { &*input };
-        resolve_effective_color_scheme(scheme_codes.as_slice(), input.preferred_color_scheme, unsafe {
-            input.document_supported_schemes()
-        })
+    let StyleValueData::ColorScheme { scheme_codes, .. } = (unsafe { &*(value as *const StyleValueData) }) else {
+        unreachable!("computed color-scheme must have color-scheme data");
+    };
+    let input = unsafe { &*input };
+    resolve_effective_color_scheme(scheme_codes.as_slice(), input.preferred_color_scheme, unsafe {
+        input.document_supported_schemes()
     })
 }
 
@@ -6564,22 +6536,20 @@ pub unsafe extern "C" fn rust_finalize_style(
     input_line_height_metrics: *const FfiInputLineHeightMetrics,
 ) -> FfiStyleFinalization {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let input = unsafe { &*input };
-        if let Some(longhand_table) = unsafe { longhand_table.as_mut() } {
-            finalize_computed_style(
-                input.mode,
-                input.box_type,
-                input.is_th_element,
-                None,
-                longhand_table,
-                unsafe { animated_overlay.as_mut() },
-                unsafe { input_line_height_metrics.as_ref() },
-            )
-        } else {
-            finalize_style(input, None, None, None)
-        }
-    })
+    let input = unsafe { &*input };
+    if let Some(longhand_table) = unsafe { longhand_table.as_mut() } {
+        finalize_computed_style(
+            input.mode,
+            input.box_type,
+            input.is_th_element,
+            None,
+            longhand_table,
+            unsafe { animated_overlay.as_mut() },
+            unsafe { input_line_height_metrics.as_ref() },
+        )
+    } else {
+        finalize_style(input, None, None, None)
+    }
 }
 
 /// Computes the font-weight property from its absolutized value.
@@ -6592,10 +6562,8 @@ pub unsafe extern "C" fn rust_compute_font_weight(
     inherited_font_weight: f64,
 ) -> FfiComputedNumber {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let value = unsafe { &*(absolutized_value as *const StyleValueData) };
-        compute_font_weight(value, inherited_font_weight)
-    })
+    let value = unsafe { &*(absolutized_value as *const StyleValueData) };
+    compute_font_weight(value, inherited_font_weight)
 }
 
 // The standalone cargo test binary has no C++ side, so release callbacks are

--- a/Libraries/LibWeb/Rust/src/css/style_value.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_value.rs
@@ -23,7 +23,6 @@ use std::cell::RefCell;
 #[cfg(any(test, feature = "style-replay"))]
 use std::collections::HashMap;
 
-use crate::abort_on_panic;
 use crate::css::css_enums::keyword_from_ascii_case_insensitive;
 use crate::css::css_tokenizer::{ParserSource, ParserTokenKind, SourcePosition, TokenizerInput};
 use crate::css::parser::component_value::{ComponentKind, ComponentSerializationMode, ComponentValue};
@@ -277,13 +276,11 @@ pub unsafe extern "C" fn rust_unresolved_style_value_visit_reification(
     context: *mut c_void,
     visit: unsafe extern "C" fn(*mut c_void, u8, *const u16, usize, bool),
 ) {
-    abort_on_panic(|| {
-        let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
-            unreachable!("reification requires an unresolved style value");
-        };
-        let segments = reify_unresolved_segments(components.as_slice());
-        visit_reified_unresolved_segments(&segments, context, visit);
-    });
+    let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
+        unreachable!("reification requires an unresolved style value");
+    };
+    let segments = reify_unresolved_segments(components.as_slice());
+    visit_reified_unresolved_segments(&segments, context, visit);
 }
 
 /// Visits literal custom-property references and reports whether every reference name was
@@ -297,12 +294,10 @@ pub unsafe extern "C" fn rust_unresolved_style_value_visit_custom_property_refer
     context: *mut c_void,
     visit: unsafe extern "C" fn(*mut c_void, *const u16, usize),
 ) -> bool {
-    abort_on_panic(|| {
-        let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
-            unreachable!("reference scanning requires an unresolved style value");
-        };
-        scan_custom_property_references(components.as_slice(), context, visit)
-    })
+    let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
+        unreachable!("reference scanning requires an unresolved style value");
+    };
+    scan_custom_property_references(components.as_slice(), context, visit)
 }
 
 /// Reports whether any component of an unresolved style value is a CSS-wide keyword identifier.
@@ -311,12 +306,10 @@ pub unsafe extern "C" fn rust_unresolved_style_value_visit_custom_property_refer
 /// `value` must point at live unresolved style value data.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_unresolved_style_value_contains_css_wide_keyword(value: *const c_void) -> bool {
-    abort_on_panic(|| {
-        let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
-            unreachable!("keyword scanning requires an unresolved style value");
-        };
-        contains_css_wide_keyword(components.as_slice())
-    })
+    let StyleValueData::Unresolved { components, .. } = (unsafe { &*value.cast::<StyleValueData>() }) else {
+        unreachable!("keyword scanning requires an unresolved style value");
+    };
+    contains_css_wide_keyword(components.as_slice())
 }
 
 #[cfg(test)]
@@ -2300,37 +2293,35 @@ pub unsafe extern "C" fn rust_style_value_copy_computed_font_families(
     output: *mut FfiComputedFontFamilyEntry,
     capacity: usize,
 ) -> usize {
-    abort_on_panic(|| {
-        let StyleValueData::ValueList { values, .. } = (unsafe { &*(value as *const StyleValueData) }) else {
-            unreachable!("computed font-family must be a value list");
+    let StyleValueData::ValueList { values, .. } = (unsafe { &*(value as *const StyleValueData) }) else {
+        unreachable!("computed font-family must be a value list");
+    };
+    if output.is_null() {
+        return values.as_slice().len();
+    }
+    assert!(capacity >= values.as_slice().len());
+    for (index, value) in values.as_slice().iter().enumerate() {
+        let entry = match value.data() {
+            StyleValueData::Keyword { keyword } => FfiComputedFontFamilyEntry {
+                kind: COMPUTED_FONT_FAMILY_GENERIC,
+                keyword: *keyword,
+                string_raw: 0,
+            },
+            StyleValueData::CustomIdent { custom_ident } => FfiComputedFontFamilyEntry {
+                kind: COMPUTED_FONT_FAMILY_CUSTOM_IDENT,
+                keyword: 0,
+                string_raw: custom_ident.raw(),
+            },
+            StyleValueData::String { string, .. } => FfiComputedFontFamilyEntry {
+                kind: COMPUTED_FONT_FAMILY_STRING,
+                keyword: 0,
+                string_raw: string.raw(),
+            },
+            _ => unreachable!("computed font-family entry must be a generic or named family"),
         };
-        if output.is_null() {
-            return values.as_slice().len();
-        }
-        assert!(capacity >= values.as_slice().len());
-        for (index, value) in values.as_slice().iter().enumerate() {
-            let entry = match value.data() {
-                StyleValueData::Keyword { keyword } => FfiComputedFontFamilyEntry {
-                    kind: COMPUTED_FONT_FAMILY_GENERIC,
-                    keyword: *keyword,
-                    string_raw: 0,
-                },
-                StyleValueData::CustomIdent { custom_ident } => FfiComputedFontFamilyEntry {
-                    kind: COMPUTED_FONT_FAMILY_CUSTOM_IDENT,
-                    keyword: 0,
-                    string_raw: custom_ident.raw(),
-                },
-                StyleValueData::String { string, .. } => FfiComputedFontFamilyEntry {
-                    kind: COMPUTED_FONT_FAMILY_STRING,
-                    keyword: 0,
-                    string_raw: string.raw(),
-                },
-                _ => unreachable!("computed font-family entry must be a generic or named family"),
-            };
-            unsafe { output.add(index).write(entry) };
-        }
-        values.as_slice().len()
-    })
+        unsafe { output.add(index).write(entry) };
+    }
+    values.as_slice().len()
 }
 
 /// Reads the primitive payload of a computed absolute length.
@@ -2339,10 +2330,10 @@ pub unsafe extern "C" fn rust_style_value_copy_computed_font_families(
 /// `value` must point at live Length StyleValueData.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_computed_length_value(value: *const c_void) -> f64 {
-    abort_on_panic(|| match unsafe { &*(value as *const StyleValueData) } {
+    match unsafe { &*(value as *const StyleValueData) } {
         StyleValueData::Length { value, .. } => *value,
         _ => unreachable!("computed value must be a length"),
-    })
+    }
 }
 
 /// Reads the primitive payload of a computed number.
@@ -2351,10 +2342,10 @@ pub unsafe extern "C" fn rust_style_value_computed_length_value(value: *const c_
 /// `value` must point at live Number StyleValueData.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_computed_number(value: *const c_void) -> f64 {
-    abort_on_panic(|| match unsafe { &*(value as *const StyleValueData) } {
+    match unsafe { &*(value as *const StyleValueData) } {
         StyleValueData::Number { value } => *value,
         _ => unreachable!("computed value must be a number"),
-    })
+    }
 }
 
 /// Reads the primitive payload of a computed percentage.
@@ -2363,10 +2354,10 @@ pub unsafe extern "C" fn rust_style_value_computed_number(value: *const c_void) 
 /// `value` must point at live Percentage StyleValueData.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_computed_percentage(value: *const c_void) -> f64 {
-    abort_on_panic(|| match unsafe { &*(value as *const StyleValueData) } {
+    match unsafe { &*(value as *const StyleValueData) } {
         StyleValueData::Percentage { value } => *value,
         _ => unreachable!("computed value must be a percentage"),
-    })
+    }
 }
 
 impl StyleValueData {
@@ -3041,52 +3032,52 @@ impl StyleValueData {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_keyword(keyword: u16) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Keyword { keyword })))
+    Arc::into_raw(Arc::new(StyleValueData::Keyword { keyword }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_number(value: f64) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Number { value })))
+    Arc::into_raw(Arc::new(StyleValueData::Number { value }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_integer(value: i32) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Integer { value })))
+    Arc::into_raw(Arc::new(StyleValueData::Integer { value }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_angle(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Angle { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Angle { value, unit }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_flex(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Flex { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Flex { value, unit }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_frequency(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Frequency { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Frequency { value, unit }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_length(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Length { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Length { value, unit }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_percentage(value: f64) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Percentage { value })))
+    Arc::into_raw(Arc::new(StyleValueData::Percentage { value }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_resolution(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Resolution { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Resolution { value, unit }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_time(value: f64, unit: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Time { value, unit })))
+    Arc::into_raw(Arc::new(StyleValueData::Time { value, unit }))
 }
 
 /// Takes ownership of one strong reference to each of the numerator and denominator.
@@ -3095,12 +3086,10 @@ pub unsafe extern "C" fn rust_style_value_create_ratio(
     numerator: *const StyleValueData,
     denominator: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Ratio {
-            numerator: unsafe { RetainedStyleValueData::from_retained_pointer(numerator) },
-            denominator: unsafe { RetainedStyleValueData::from_retained_pointer(denominator) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Ratio {
+        numerator: unsafe { RetainedStyleValueData::from_retained_pointer(numerator) },
+        denominator: unsafe { RetainedStyleValueData::from_retained_pointer(denominator) },
+    }))
 }
 
 #[unsafe(no_mangle)]
@@ -3108,22 +3097,18 @@ pub extern "C" fn rust_style_value_create_unicode_range(
     min_code_point: u32,
     max_code_point: u32,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::UnicodeRange {
-            min_code_point,
-            max_code_point,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::UnicodeRange {
+        min_code_point,
+        max_code_point,
+    }))
 }
 
 /// Takes ownership of one strong reference to the value.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_create_opacity_value(value: *const StyleValueData) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::OpacityValue {
-            value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::OpacityValue {
+        value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the offset data if it is non-null.
@@ -3133,28 +3118,26 @@ pub unsafe extern "C" fn rust_style_value_create_edge(
     edge: u8,
     offset: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Edge {
-            has_edge,
-            edge,
-            offset: unsafe { RetainedStyleValueData::from_retained_optional_pointer(offset) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Edge {
+        has_edge,
+        edge,
+        offset: unsafe { RetainedStyleValueData::from_retained_optional_pointer(offset) },
+    }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_guaranteed_invalid() -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::GuaranteedInvalid)))
+    Arc::into_raw(Arc::new(StyleValueData::GuaranteedInvalid))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_empty_optional() -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::EmptyOptional)))
+    Arc::into_raw(Arc::new(StyleValueData::EmptyOptional))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_grid_auto_flow(row: bool, dense: bool) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::GridAutoFlow { row, dense })))
+    Arc::into_raw(Arc::new(StyleValueData::GridAutoFlow { row, dense }))
 }
 
 #[unsafe(no_mangle)]
@@ -3162,7 +3145,7 @@ pub extern "C" fn rust_style_value_create_text_underline_position(
     horizontal: u8,
     vertical: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::TextUnderlinePosition { horizontal, vertical })))
+    Arc::into_raw(Arc::new(StyleValueData::TextUnderlinePosition { horizontal, vertical }))
 }
 
 /// Takes ownership of one strong reference to the color.
@@ -3173,16 +3156,14 @@ pub unsafe extern "C" fn rust_style_value_create_contrast_color(
     color_syntax: u8,
     color: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ContrastColor {
-            color_base: ColorBase {
-                has_color_type,
-                color_type,
-                color_syntax,
-            },
-            color: unsafe { RetainedStyleValueData::from_retained_pointer(color) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ContrastColor {
+        color_base: ColorBase {
+            has_color_type,
+            color_type,
+            color_syntax,
+        },
+        color: unsafe { RetainedStyleValueData::from_retained_pointer(color) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the parameter data.
@@ -3190,11 +3171,9 @@ pub unsafe extern "C" fn rust_style_value_create_contrast_color(
 pub unsafe extern "C" fn rust_style_value_create_superellipse(
     parameter: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Superellipse {
-            parameter: unsafe { RetainedStyleValueData::from_retained_pointer(parameter) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Superellipse {
+        parameter: unsafe { RetainedStyleValueData::from_retained_pointer(parameter) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the original shorthand value.
@@ -3202,13 +3181,9 @@ pub unsafe extern "C" fn rust_style_value_create_superellipse(
 pub unsafe extern "C" fn rust_style_value_create_pending_substitution(
     original_shorthand_value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::PendingSubstitution {
-            original_shorthand_value: unsafe {
-                RetainedStyleValueData::from_retained_pointer(original_shorthand_value)
-            },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::PendingSubstitution {
+        original_shorthand_value: unsafe { RetainedStyleValueData::from_retained_pointer(original_shorthand_value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each color.
@@ -3217,12 +3192,10 @@ pub unsafe extern "C" fn rust_style_value_create_scrollbar_color(
     thumb_color: *const StyleValueData,
     track_color: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ScrollbarColor {
-            thumb_color: unsafe { RetainedStyleValueData::from_retained_pointer(thumb_color) },
-            track_color: unsafe { RetainedStyleValueData::from_retained_pointer(track_color) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ScrollbarColor {
+        thumb_color: unsafe { RetainedStyleValueData::from_retained_pointer(thumb_color) },
+        track_color: unsafe { RetainedStyleValueData::from_retained_pointer(track_color) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each edge data allocation.
@@ -3233,14 +3206,12 @@ pub unsafe extern "C" fn rust_style_value_create_rect(
     bottom: *const StyleValueData,
     left: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Rect {
-            top: unsafe { RetainedStyleValueData::from_retained_pointer(top) },
-            right: unsafe { RetainedStyleValueData::from_retained_pointer(right) },
-            bottom: unsafe { RetainedStyleValueData::from_retained_pointer(bottom) },
-            left: unsafe { RetainedStyleValueData::from_retained_pointer(left) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Rect {
+        top: unsafe { RetainedStyleValueData::from_retained_pointer(top) },
+        right: unsafe { RetainedStyleValueData::from_retained_pointer(right) },
+        bottom: unsafe { RetainedStyleValueData::from_retained_pointer(bottom) },
+        left: unsafe { RetainedStyleValueData::from_retained_pointer(left) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the filter's value.
@@ -3250,13 +3221,11 @@ pub unsafe extern "C" fn rust_style_value_create_filter(
     color_operation: u8,
     value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Filter {
-            kind,
-            color_operation,
-            value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Filter {
+        kind,
+        color_operation,
+        value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each radius data allocation.
@@ -3266,13 +3235,11 @@ pub unsafe extern "C" fn rust_style_value_create_border_radius(
     horizontal_radius: *const StyleValueData,
     vertical_radius: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::BorderRadius {
-            is_elliptical,
-            horizontal_radius: unsafe { RetainedStyleValueData::from_retained_pointer(horizontal_radius) },
-            vertical_radius: unsafe { RetainedStyleValueData::from_retained_pointer(vertical_radius) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::BorderRadius {
+        is_elliptical,
+        horizontal_radius: unsafe { RetainedStyleValueData::from_retained_pointer(horizontal_radius) },
+        vertical_radius: unsafe { RetainedStyleValueData::from_retained_pointer(vertical_radius) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each corner radius data allocation.
@@ -3283,14 +3250,12 @@ pub unsafe extern "C" fn rust_style_value_create_border_radius_rect(
     bottom_right: *const StyleValueData,
     bottom_left: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::BorderRadiusRect {
-            top_left: unsafe { RetainedStyleValueData::from_retained_pointer(top_left) },
-            top_right: unsafe { RetainedStyleValueData::from_retained_pointer(top_right) },
-            bottom_right: unsafe { RetainedStyleValueData::from_retained_pointer(bottom_right) },
-            bottom_left: unsafe { RetainedStyleValueData::from_retained_pointer(bottom_left) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::BorderRadiusRect {
+        top_left: unsafe { RetainedStyleValueData::from_retained_pointer(top_left) },
+        top_right: unsafe { RetainedStyleValueData::from_retained_pointer(top_right) },
+        bottom_right: unsafe { RetainedStyleValueData::from_retained_pointer(bottom_right) },
+        bottom_left: unsafe { RetainedStyleValueData::from_retained_pointer(bottom_left) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the string.
@@ -3299,22 +3264,18 @@ pub extern "C" fn rust_style_value_create_string(
     string: usize,
     is_valid_animation_name_custom_ident: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::String {
-            string: unsafe { RetainedUtf16FlyString::from_leaked_raw(string) },
-            is_valid_animation_name_custom_ident,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::String {
+        string: unsafe { RetainedUtf16FlyString::from_leaked_raw(string) },
+        is_valid_animation_name_custom_ident,
+    }))
 }
 
 /// Takes ownership of one leaked reference to the string.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_custom_ident(custom_ident: usize) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::CustomIdent {
-            custom_ident: unsafe { RetainedUtf16FlyString::from_leaked_raw(custom_ident) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::CustomIdent {
+        custom_ident: unsafe { RetainedUtf16FlyString::from_leaked_raw(custom_ident) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the name and one strong reference to the value data.
@@ -3323,12 +3284,10 @@ pub unsafe extern "C" fn rust_style_value_create_function(
     name: usize,
     value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Function {
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-            value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Function {
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+        value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the tag and one strong reference to the value data.
@@ -3339,14 +3298,12 @@ pub unsafe extern "C" fn rust_style_value_create_open_type_tagged(
     packed_tag: u32,
     value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::OpenTypeTagged {
-            mode,
-            tag: unsafe { RetainedUtf16FlyString::from_leaked_raw(tag) },
-            packed_tag,
-            value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::OpenTypeTagged {
+        mode,
+        tag: unsafe { RetainedUtf16FlyString::from_leaked_raw(tag) },
+        packed_tag,
+        value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the angle value data if it is non-null.
@@ -3355,12 +3312,10 @@ pub unsafe extern "C" fn rust_style_value_create_font_style(
     font_style: u8,
     angle_value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::FontStyle {
-            font_style,
-            angle_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(angle_value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::FontStyle {
+        font_style,
+        angle_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(angle_value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the length-percentage.
@@ -3370,13 +3325,11 @@ pub unsafe extern "C" fn rust_style_value_create_text_indent(
     hanging: bool,
     each_line: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::TextIndent {
-            length_percentage: unsafe { RetainedStyleValueData::from_retained_pointer(length_percentage) },
-            hanging,
-            each_line,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::TextIndent {
+        length_percentage: unsafe { RetainedStyleValueData::from_retained_pointer(length_percentage) },
+        hanging,
+        each_line,
+    }))
 }
 
 /// Takes ownership of one strong reference to the offset data.
@@ -3386,13 +3339,11 @@ pub unsafe extern "C" fn rust_style_value_create_overflow_clip_margin(
     visual_box: u8,
     offset: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::OverflowClipMargin {
-            has_visual_box,
-            visual_box,
-            offset: unsafe { RetainedStyleValueData::from_retained_pointer(offset) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::OverflowClipMargin {
+        has_visual_box,
+        visual_box,
+        offset: unsafe { RetainedStyleValueData::from_retained_pointer(offset) },
+    }))
 }
 
 #[unsafe(no_mangle)]
@@ -3400,12 +3351,10 @@ pub extern "C" fn rust_style_value_create_tree_counting_function(
     function: u8,
     computed_type: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::TreeCountingFunction {
-            function,
-            computed_type,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::TreeCountingFunction {
+        function,
+        computed_type,
+    }))
 }
 
 /// Takes ownership of one strong reference to each size.
@@ -3414,17 +3363,15 @@ pub unsafe extern "C" fn rust_style_value_create_background_size(
     size_x: *const StyleValueData,
     size_y: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::BackgroundSize {
-            size_x: unsafe { RetainedStyleValueData::from_retained_pointer(size_x) },
-            size_y: unsafe { RetainedStyleValueData::from_retained_pointer(size_y) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::BackgroundSize {
+        size_x: unsafe { RetainedStyleValueData::from_retained_pointer(size_x) },
+        size_y: unsafe { RetainedStyleValueData::from_retained_pointer(size_y) },
+    }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_repeat_style(repeat_x: u8, repeat_y: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::RepeatStyle { repeat_x, repeat_y })))
+    Arc::into_raw(Arc::new(StyleValueData::RepeatStyle { repeat_x, repeat_y }))
 }
 
 /// Takes ownership of one strong reference to each offset data allocation.
@@ -3436,15 +3383,13 @@ pub unsafe extern "C" fn rust_style_value_create_border_image_slice(
     left: *const StyleValueData,
     fill: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::BorderImageSlice {
-            top: unsafe { RetainedStyleValueData::from_retained_pointer(top) },
-            right: unsafe { RetainedStyleValueData::from_retained_pointer(right) },
-            bottom: unsafe { RetainedStyleValueData::from_retained_pointer(bottom) },
-            left: unsafe { RetainedStyleValueData::from_retained_pointer(left) },
-            fill,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::BorderImageSlice {
+        top: unsafe { RetainedStyleValueData::from_retained_pointer(top) },
+        right: unsafe { RetainedStyleValueData::from_retained_pointer(right) },
+        bottom: unsafe { RetainedStyleValueData::from_retained_pointer(bottom) },
+        left: unsafe { RetainedStyleValueData::from_retained_pointer(left) },
+        fill,
+    }))
 }
 
 /// Takes ownership of one leaked reference to the anchor name (0 when absent) and one strong
@@ -3457,15 +3402,13 @@ pub unsafe extern "C" fn rust_style_value_create_anchor_size(
     anchor_size: u8,
     fallback_value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::AnchorSize {
-            has_anchor_name,
-            anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
-            has_anchor_size,
-            anchor_size,
-            fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::AnchorSize {
+        has_anchor_name,
+        anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
+        has_anchor_size,
+        anchor_size,
+        fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the anchor name (0 when absent), one strong
@@ -3477,14 +3420,12 @@ pub unsafe extern "C" fn rust_style_value_create_anchor(
     anchor_side: *const StyleValueData,
     fallback_value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Anchor {
-            has_anchor_name,
-            anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
-            anchor_side: unsafe { RetainedStyleValueData::from_retained_pointer(anchor_side) },
-            fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Anchor {
+        has_anchor_name,
+        anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
+        anchor_side: unsafe { RetainedStyleValueData::from_retained_pointer(anchor_side) },
+        fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each edge data allocation.
@@ -3493,12 +3434,10 @@ pub unsafe extern "C" fn rust_style_value_create_position(
     edge_x: *const StyleValueData,
     edge_y: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Position {
-            edge_x: unsafe { RetainedStyleValueData::from_retained_pointer(edge_x) },
-            edge_y: unsafe { RetainedStyleValueData::from_retained_pointer(edge_y) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Position {
+        edge_x: unsafe { RetainedStyleValueData::from_retained_pointer(edge_x) },
+        edge_y: unsafe { RetainedStyleValueData::from_retained_pointer(edge_y) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null style value.
@@ -3512,17 +3451,15 @@ pub unsafe extern "C" fn rust_style_value_create_shadow(
     spread_distance: *const StyleValueData,
     placement: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Shadow {
-            shadow_type,
-            color: unsafe { RetainedStyleValueData::from_retained_optional_pointer(color) },
-            offset_x: unsafe { RetainedStyleValueData::from_retained_pointer(offset_x) },
-            offset_y: unsafe { RetainedStyleValueData::from_retained_pointer(offset_y) },
-            blur_radius: unsafe { RetainedStyleValueData::from_retained_optional_pointer(blur_radius) },
-            spread_distance: unsafe { RetainedStyleValueData::from_retained_optional_pointer(spread_distance) },
-            placement,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Shadow {
+        shadow_type,
+        color: unsafe { RetainedStyleValueData::from_retained_optional_pointer(color) },
+        offset_x: unsafe { RetainedStyleValueData::from_retained_pointer(offset_x) },
+        offset_y: unsafe { RetainedStyleValueData::from_retained_pointer(offset_y) },
+        blur_radius: unsafe { RetainedStyleValueData::from_retained_optional_pointer(blur_radius) },
+        spread_distance: unsafe { RetainedStyleValueData::from_retained_optional_pointer(spread_distance) },
+        placement,
+    }))
 }
 
 /// Takes ownership of one strong reference to the content list and, when non-null, the
@@ -3532,12 +3469,10 @@ pub unsafe extern "C" fn rust_style_value_create_content(
     content: *const StyleValueData,
     alt_text: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Content {
-            content: unsafe { RetainedStyleValueData::from_retained_pointer(content) },
-            alt_text: unsafe { RetainedStyleValueData::from_retained_optional_pointer(alt_text) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Content {
+        content: unsafe { RetainedStyleValueData::from_retained_pointer(content) },
+        alt_text: unsafe { RetainedStyleValueData::from_retained_optional_pointer(alt_text) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to each string and one strong reference to the
@@ -3549,14 +3484,12 @@ pub unsafe extern "C" fn rust_style_value_create_counter(
     counter_style: *const StyleValueData,
     join_string: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Counter {
-            function,
-            counter_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(counter_name) },
-            counter_style: unsafe { RetainedStyleValueData::from_retained_pointer(counter_style) },
-            join_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(join_string) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Counter {
+        function,
+        counter_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(counter_name) },
+        counter_style: unsafe { RetainedStyleValueData::from_retained_pointer(counter_style) },
+        join_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(join_string) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each color.
@@ -3568,17 +3501,15 @@ pub unsafe extern "C" fn rust_style_value_create_light_dark(
     light: *const StyleValueData,
     dark: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::LightDark {
-            color_base: ColorBase {
-                has_color_type,
-                color_type,
-                color_syntax,
-            },
-            light: unsafe { RetainedStyleValueData::from_retained_pointer(light) },
-            dark: unsafe { RetainedStyleValueData::from_retained_pointer(dark) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::LightDark {
+        color_base: ColorBase {
+            has_color_type,
+            color_type,
+            color_syntax,
+        },
+        light: unsafe { RetainedStyleValueData::from_retained_pointer(light) },
+        dark: unsafe { RetainedStyleValueData::from_retained_pointer(dark) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the fixed value and one leaked reference to the
@@ -3591,20 +3522,18 @@ pub unsafe extern "C" fn rust_style_value_create_random_value_sharing(
     name: usize,
     element_shared: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::RandomValueSharing {
-            fixed_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fixed_value) },
-            is_auto,
-            has_name,
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-            element_shared,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::RandomValueSharing {
+        fixed_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fixed_value) },
+        is_auto,
+        has_name,
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+        element_shared,
+    }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_scrollbar_gutter(value: u8) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::ScrollbarGutter { value })))
+    Arc::into_raw(Arc::new(StyleValueData::ScrollbarGutter { value }))
 }
 
 #[unsafe(no_mangle)]
@@ -3613,13 +3542,11 @@ pub extern "C" fn rust_style_value_create_color_interpolation_method(
     color_space: u8,
     hue_interpolation_method: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ColorInterpolationMethod {
-            is_polar,
-            color_space,
-            hue_interpolation_method,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ColorInterpolationMethod {
+        is_polar,
+        color_space,
+        hue_interpolation_method,
+    }))
 }
 
 /// Takes ownership of one strong reference to each of the `length` values.
@@ -3630,13 +3557,11 @@ pub unsafe extern "C" fn rust_style_value_create_value_list(
     separator: u8,
     collapsible: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ValueList {
-            values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, length) },
-            separator,
-            collapsible,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ValueList {
+        values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, length) },
+        separator,
+        collapsible,
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value.
@@ -3645,11 +3570,9 @@ pub unsafe extern "C" fn rust_style_value_create_tuple(
     values: *const *const StyleValueData,
     length: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Tuple {
-            values: unsafe { RetainedStyleValueDataList::from_retained_optional_pointers(values, length) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Tuple {
+        values: unsafe { RetainedStyleValueDataList::from_retained_optional_pointers(values, length) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each value.
@@ -3660,13 +3583,11 @@ pub unsafe extern "C" fn rust_style_value_create_transformation(
     values: *const *const StyleValueData,
     length: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Transformation {
-            property,
-            transform_function,
-            values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, length) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Transformation {
+        property,
+        transform_function,
+        values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, length) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each value; the property ids are copied.
@@ -3678,18 +3599,16 @@ pub unsafe extern "C" fn rust_style_value_create_shorthand(
     values: *const *const StyleValueData,
     value_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Shorthand {
-            shorthand_property,
-            sub_properties: unsafe { RetainedPropertyIdList::from_raw(sub_properties, sub_property_count) },
-            values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, value_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Shorthand {
+        shorthand_property,
+        sub_properties: unsafe { RetainedPropertyIdList::from_raw(sub_properties, sub_property_count) },
+        values: unsafe { RetainedStyleValueDataList::from_retained_pointers(values, value_count) },
+    }))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_style_value_create_display(raw: u32) -> *const StyleValueData {
-    abort_on_panic(|| Arc::into_raw(Arc::new(StyleValueData::Display { raw })))
+    Arc::into_raw(Arc::new(StyleValueData::Display { raw }))
 }
 
 /// Takes ownership of one strong reference to each non-null component value.
@@ -3703,17 +3622,15 @@ pub unsafe extern "C" fn rust_style_value_create_radial_size(
     extent_1: u8,
     value_1: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::RadialSize {
-            component_count,
-            is_extent_0,
-            extent_0,
-            value_0: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value_0) },
-            is_extent_1,
-            extent_1,
-            value_1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value_1) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::RadialSize {
+        component_count,
+        is_extent_0,
+        extent_0,
+        value_0: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value_0) },
+        is_extent_1,
+        extent_1,
+        value_1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value_1) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the URL string and to each modifier's retained
@@ -3727,13 +3644,11 @@ pub unsafe extern "C" fn rust_style_value_create_url(
     modifiers: *const RetainedRequestUrlModifier,
     modifier_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Url {
-            url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
-            url_type,
-            modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(modifiers, modifier_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Url {
+        url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
+        url_type,
+        modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(modifiers, modifier_count) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the local name if local, or one leaked reference
@@ -3753,18 +3668,16 @@ pub unsafe extern "C" fn rust_style_value_create_font_source(
     tech: *const u8,
     tech_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::FontSource {
-            is_local,
-            local_name: unsafe { RetainedStyleValueData::from_retained_optional_pointer(local_name) },
-            url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
-            url_type,
-            url_modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(url_modifiers, url_modifier_count) },
-            has_format,
-            format: unsafe { RetainedUtf16FlyString::from_leaked_raw(format) },
-            tech: unsafe { RetainedByteList::from_raw(tech, tech_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::FontSource {
+        is_local,
+        local_name: unsafe { RetainedStyleValueData::from_retained_optional_pointer(local_name) },
+        url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
+        url_type,
+        url_modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(url_modifiers, url_modifier_count) },
+        has_format,
+        format: unsafe { RetainedUtf16FlyString::from_leaked_raw(format) },
+        tech: unsafe { RetainedByteList::from_raw(tech, tech_count) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to each scheme name.
@@ -3775,13 +3688,11 @@ pub unsafe extern "C" fn rust_style_value_create_color_scheme(
     scheme_count: usize,
     only: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ColorScheme {
-            schemes: unsafe { RetainedUtf16FlyStringList::from_raw(schemes, scheme_count) },
-            scheme_codes: unsafe { RetainedByteList::from_raw(scheme_codes, scheme_count) },
-            only,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ColorScheme {
+        schemes: unsafe { RetainedUtf16FlyStringList::from_raw(schemes, scheme_count) },
+        scheme_codes: unsafe { RetainedByteList::from_raw(scheme_codes, scheme_count) },
+        only,
+    }))
 }
 
 /// Creates an unresolved value from borrowed token source. Rust derives the source and comparison
@@ -3807,72 +3718,70 @@ pub unsafe extern "C" fn rust_style_value_create_unresolved_from_source(
     contains_attr_tainted_values: bool,
     parsed_value: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        let token_source = unsafe {
-            TokenizerInput::from_raw_parts(token_source_ascii_units, token_source_code_units, token_source_length)
+    let token_source = unsafe {
+        TokenizerInput::from_raw_parts(token_source_ascii_units, token_source_code_units, token_source_length)
+    }
+    .unwrap_or_default();
+    let components = crate::css::parser::component_value::consume_a_list_of_component_values(
+        crate::css::css_tokenizer::tokenize_for_parser(token_source),
+    )
+    .unwrap_or_default();
+    let normalized = crate::css::serialize::serialize_component_values_to_utf16(
+        &components,
+        crate::css::parser::component_value::ComponentSerializationMode::Normalized,
+    );
+    let (source_text, value_comparison_text) = if has_original_source_text {
+        let original_source_text = unsafe {
+            TokenizerInput::from_raw_parts(
+                original_source_text_ascii_units,
+                original_source_text_code_units,
+                original_source_text_length,
+            )
         }
         .unwrap_or_default();
-        let components = crate::css::parser::component_value::consume_a_list_of_component_values(
-            crate::css::css_tokenizer::tokenize_for_parser(token_source),
+        let mut source_text = Vec::with_capacity(original_source_text.len());
+        original_source_text.append_to(&mut source_text);
+        (
+            crate::css::serialize::trim_ascii_whitespace(&source_text).to_vec(),
+            crate::css::serialize::trim_ascii_whitespace(&normalized).to_vec(),
         )
-        .unwrap_or_default();
-        let normalized = crate::css::serialize::serialize_component_values_to_utf16(
-            &components,
-            crate::css::parser::component_value::ComponentSerializationMode::Normalized,
-        );
-        let (source_text, value_comparison_text) = if has_original_source_text {
-            let original_source_text = unsafe {
-                TokenizerInput::from_raw_parts(
-                    original_source_text_ascii_units,
-                    original_source_text_code_units,
-                    original_source_text_length,
-                )
-            }
-            .unwrap_or_default();
-            let mut source_text = Vec::with_capacity(original_source_text.len());
-            original_source_text.append_to(&mut source_text);
-            (
-                crate::css::serialize::trim_ascii_whitespace(&source_text).to_vec(),
-                crate::css::serialize::trim_ascii_whitespace(&normalized).to_vec(),
-            )
-        } else {
-            let source_text = match source_text_mode {
-                0 | 1 => crate::css::serialize::serialize_component_values_to_utf16(
-                    &components,
-                    crate::css::parser::component_value::ComponentSerializationMode::PreserveNumericSource,
-                ),
-                2 => crate::css::serialize::original_component_values_source(&components)
-                    .unwrap_or_else(|| normalized.clone()),
-                _ => unreachable!("unknown unresolved source text mode"),
-            };
-            let source_text = if source_text_mode == 0 {
-                crate::css::serialize::trim_ascii_whitespace(&source_text)
-            } else if source_text_mode == 1 {
-                crate::css::serialize::trim_ascii_whitespace_start(&source_text)
-            } else {
-                &source_text
-            };
-            (source_text.to_vec(), Vec::new())
+    } else {
+        let source_text = match source_text_mode {
+            0 | 1 => crate::css::serialize::serialize_component_values_to_utf16(
+                &components,
+                crate::css::parser::component_value::ComponentSerializationMode::PreserveNumericSource,
+            ),
+            2 => crate::css::serialize::original_component_values_source(&components)
+                .unwrap_or_else(|| normalized.clone()),
+            _ => unreachable!("unknown unresolved source text mode"),
         };
-        let component_source = if value_comparison_text.is_empty() {
+        let source_text = if source_text_mode == 0 {
+            crate::css::serialize::trim_ascii_whitespace(&source_text)
+        } else if source_text_mode == 1 {
+            crate::css::serialize::trim_ascii_whitespace_start(&source_text)
+        } else {
             &source_text
-        } else {
-            &value_comparison_text
         };
-        Arc::into_raw(Arc::new(StyleValueData::Unresolved {
-            components: RetainedComponentValueList::from_source(component_source),
-            source_text: RetainedReadableString::from_utf16(&source_text),
-            value_comparison_text: RetainedReadableString::from_utf16(&value_comparison_text),
-            presence_attr,
-            presence_dashed_function,
-            presence_env,
-            presence_if,
-            presence_inherit,
-            presence_var,
-            contains_attr_tainted_values,
-            parsed_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(parsed_value) },
-        }))
-    })
+        (source_text.to_vec(), Vec::new())
+    };
+    let component_source = if value_comparison_text.is_empty() {
+        &source_text
+    } else {
+        &value_comparison_text
+    };
+    Arc::into_raw(Arc::new(StyleValueData::Unresolved {
+        components: RetainedComponentValueList::from_source(component_source),
+        source_text: RetainedReadableString::from_utf16(&source_text),
+        value_comparison_text: RetainedReadableString::from_utf16(&value_comparison_text),
+        presence_attr,
+        presence_dashed_function,
+        presence_env,
+        presence_if,
+        presence_inherit,
+        presence_var,
+        contains_attr_tainted_values,
+        parsed_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(parsed_value) },
+    }))
 }
 
 /// Takes ownership of the definitions' retained strings and values.
@@ -3881,11 +3790,9 @@ pub unsafe extern "C" fn rust_style_value_create_counter_definitions(
     definitions: *const RetainedCounterDefinition,
     length: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::CounterDefinitions {
-            counter_definitions: unsafe { RetainedCounterDefinitionList::from_raw(definitions, length) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::CounterDefinitions {
+        counter_definitions: unsafe { RetainedCounterDefinitionList::from_raw(definitions, length) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the value and one leaked reference to the name
@@ -3899,16 +3806,14 @@ pub unsafe extern "C" fn rust_style_value_create_grid_track_placement(
     implicit_start_name: usize,
     implicit_end_name: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::GridTrackPlacement {
-            kind,
-            value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value) },
-            has_name,
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-            implicit_start_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(implicit_start_name) },
-            implicit_end_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(implicit_end_name) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::GridTrackPlacement {
+        kind,
+        value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value) },
+        has_name,
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+        implicit_start_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(implicit_start_name) },
+        implicit_end_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(implicit_end_name) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the first symbol and one leaked reference to the
@@ -3920,14 +3825,12 @@ pub unsafe extern "C" fn rust_style_value_create_counter_style_system(
     first_symbol: *const StyleValueData,
     name: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::CounterStyleSystem {
-            kind,
-            system,
-            first_symbol: unsafe { RetainedStyleValueData::from_retained_optional_pointer(first_symbol) },
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::CounterStyleSystem {
+        kind,
+        system,
+        first_symbol: unsafe { RetainedStyleValueData::from_retained_optional_pointer(first_symbol) },
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the name (0 when this is a symbols() function)
@@ -3940,14 +3843,12 @@ pub unsafe extern "C" fn rust_style_value_create_counter_style(
     symbols: *const usize,
     symbol_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::CounterStyle {
-            is_symbols,
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-            symbols_type,
-            symbols: unsafe { RetainedUtf16FlyStringList::from_raw(symbols, symbol_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::CounterStyle {
+        is_symbols,
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+        symbols_type,
+        symbols: unsafe { RetainedUtf16FlyStringList::from_raw(symbols, symbol_count) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the image and to each non-null coordinate.
@@ -3957,13 +3858,11 @@ pub unsafe extern "C" fn rust_style_value_create_cursor(
     x: *const StyleValueData,
     y: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Cursor {
-            image: unsafe { RetainedStyleValueData::from_retained_pointer(image) },
-            x: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x) },
-            y: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Cursor {
+        image: unsafe { RetainedStyleValueData::from_retained_pointer(image) },
+        x: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x) },
+        y: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value and one leaked reference to
@@ -3981,22 +3880,20 @@ pub unsafe extern "C" fn rust_style_value_create_color_function(
     name: usize,
     origin_color: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ColorFunction {
-            color_base: ColorBase {
-                has_color_type,
-                color_type,
-                color_syntax,
-            },
-            channel_0: unsafe { RetainedStyleValueData::from_retained_pointer(channel_0) },
-            channel_1: unsafe { RetainedStyleValueData::from_retained_pointer(channel_1) },
-            channel_2: unsafe { RetainedStyleValueData::from_retained_pointer(channel_2) },
-            alpha: unsafe { RetainedStyleValueData::from_retained_optional_pointer(alpha) },
-            has_name,
-            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
-            origin_color: unsafe { RetainedStyleValueData::from_retained_optional_pointer(origin_color) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ColorFunction {
+        color_base: ColorBase {
+            has_color_type,
+            color_type,
+            color_syntax,
+        },
+        channel_0: unsafe { RetainedStyleValueData::from_retained_pointer(channel_0) },
+        channel_1: unsafe { RetainedStyleValueData::from_retained_pointer(channel_1) },
+        channel_2: unsafe { RetainedStyleValueData::from_retained_pointer(channel_2) },
+        alpha: unsafe { RetainedStyleValueData::from_retained_optional_pointer(alpha) },
+        has_name,
+        name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
+        origin_color: unsafe { RetainedStyleValueData::from_retained_optional_pointer(origin_color) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value.
@@ -4011,22 +3908,20 @@ pub unsafe extern "C" fn rust_style_value_create_color_mix(
     second_color: *const StyleValueData,
     second_percentage: *const StyleValueData,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ColorMix {
-            color_base: ColorBase {
-                has_color_type,
-                color_type,
-                color_syntax,
-            },
-            color_interpolation_method: unsafe {
-                RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
-            },
-            first_color: unsafe { RetainedStyleValueData::from_retained_pointer(first_color) },
-            first_percentage: unsafe { RetainedStyleValueData::from_retained_optional_pointer(first_percentage) },
-            second_color: unsafe { RetainedStyleValueData::from_retained_pointer(second_color) },
-            second_percentage: unsafe { RetainedStyleValueData::from_retained_optional_pointer(second_percentage) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ColorMix {
+        color_base: ColorBase {
+            has_color_type,
+            color_type,
+            color_syntax,
+        },
+        color_interpolation_method: unsafe {
+            RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
+        },
+        first_color: unsafe { RetainedStyleValueData::from_retained_pointer(first_color) },
+        first_percentage: unsafe { RetainedStyleValueData::from_retained_optional_pointer(first_percentage) },
+        second_color: unsafe { RetainedStyleValueData::from_retained_pointer(second_color) },
+        second_percentage: unsafe { RetainedStyleValueData::from_retained_optional_pointer(second_percentage) },
+    }))
 }
 
 /// Takes ownership of the options' retained values and strings.
@@ -4035,11 +3930,9 @@ pub unsafe extern "C" fn rust_style_value_create_image_set(
     options: *const RetainedImageSetOption,
     length: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ImageSet {
-            options: unsafe { RetainedImageSetOptionList::from_raw(options, length) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ImageSet {
+        options: unsafe { RetainedImageSetOptionList::from_raw(options, length) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value and of the stops' retained
@@ -4056,20 +3949,18 @@ pub unsafe extern "C" fn rust_style_value_create_linear_gradient(
     color_interpolation_method: *const StyleValueData,
     color_syntax: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::LinearGradient {
-            has_direction_value,
-            direction_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(direction_value) },
-            side_or_corner,
-            color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
-            gradient_type,
-            repeating,
-            color_interpolation_method: unsafe {
-                RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
-            },
-            color_syntax,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::LinearGradient {
+        has_direction_value,
+        direction_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(direction_value) },
+        side_or_corner,
+        color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
+        gradient_type,
+        repeating,
+        color_interpolation_method: unsafe {
+            RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
+        },
+        color_syntax,
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value and of the stops' retained
@@ -4084,18 +3975,16 @@ pub unsafe extern "C" fn rust_style_value_create_conic_gradient(
     color_interpolation_method: *const StyleValueData,
     color_syntax: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::ConicGradient {
-            from_angle: unsafe { RetainedStyleValueData::from_retained_optional_pointer(from_angle) },
-            position: unsafe { RetainedStyleValueData::from_retained_pointer(position) },
-            color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
-            repeating,
-            color_interpolation_method: unsafe {
-                RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
-            },
-            color_syntax,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::ConicGradient {
+        from_angle: unsafe { RetainedStyleValueData::from_retained_optional_pointer(from_angle) },
+        position: unsafe { RetainedStyleValueData::from_retained_pointer(position) },
+        color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
+        repeating,
+        color_interpolation_method: unsafe {
+            RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
+        },
+        color_syntax,
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value and of the stops' retained
@@ -4111,19 +4000,17 @@ pub unsafe extern "C" fn rust_style_value_create_radial_gradient(
     color_interpolation_method: *const StyleValueData,
     color_syntax: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::RadialGradient {
-            ending_shape,
-            size: unsafe { RetainedStyleValueData::from_retained_pointer(size) },
-            position: unsafe { RetainedStyleValueData::from_retained_pointer(position) },
-            color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
-            repeating,
-            color_interpolation_method: unsafe {
-                RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
-            },
-            color_syntax,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::RadialGradient {
+        ending_shape,
+        size: unsafe { RetainedStyleValueData::from_retained_pointer(size) },
+        position: unsafe { RetainedStyleValueData::from_retained_pointer(position) },
+        color_stop_list: unsafe { RetainedColorStopList::from_raw(stops, stop_count) },
+        repeating,
+        color_interpolation_method: unsafe {
+            RetainedStyleValueData::from_retained_optional_pointer(color_interpolation_method)
+        },
+        color_syntax,
+    }))
 }
 
 /// Takes ownership of the areas' retained names.
@@ -4134,13 +4021,11 @@ pub unsafe extern "C" fn rust_style_value_create_grid_template_area(
     row_count: usize,
     column_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::GridTemplateArea {
-            grid_areas: unsafe { RetainedGridAreaList::from_raw(areas, area_count) },
-            row_count,
-            column_count,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::GridTemplateArea {
+        grid_areas: unsafe { RetainedGridAreaList::from_raw(areas, area_count) },
+        row_count,
+        column_count,
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value and of the stops' retained
@@ -4157,18 +4042,16 @@ pub unsafe extern "C" fn rust_style_value_create_easing(
     number_of_intervals: *const StyleValueData,
     step_position: u8,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Easing {
-            kind,
-            linear_stops: unsafe { RetainedLinearEasingStopList::from_raw(linear_stops, linear_stop_count) },
-            x1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x1) },
-            y1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y1) },
-            x2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x2) },
-            y2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y2) },
-            number_of_intervals: unsafe { RetainedStyleValueData::from_retained_optional_pointer(number_of_intervals) },
-            step_position,
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Easing {
+        kind,
+        linear_stops: unsafe { RetainedLinearEasingStopList::from_raw(linear_stops, linear_stop_count) },
+        x1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x1) },
+        y1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y1) },
+        x2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(x2) },
+        y2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(y2) },
+        number_of_intervals: unsafe { RetainedStyleValueData::from_retained_optional_pointer(number_of_intervals) },
+        step_position,
+    }))
 }
 
 /// Takes ownership of the entries' retained values and names, recursively.
@@ -4179,13 +4062,11 @@ pub unsafe extern "C" fn rust_style_value_create_grid_track_size_list(
     entries: *const GridTrackEntryInput,
     entry_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::GridTrackSizeList {
-            is_subgrid,
-            preserve_line_name_sets,
-            entries: unsafe { RetainedGridTrackEntryList::from_raw(entries, entry_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::GridTrackSizeList {
+        is_subgrid,
+        preserve_line_name_sets,
+        entries: unsafe { RetainedGridTrackEntryList::from_raw(entries, entry_count) },
+    }))
 }
 
 /// Takes ownership of one strong reference to each non-null value, of the points' retained
@@ -4203,19 +4084,17 @@ pub unsafe extern "C" fn rust_style_value_create_basic_shape(
     point_count: usize,
     path_string: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::BasicShape {
-            kind,
-            v0: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v0) },
-            v1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v1) },
-            v2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v2) },
-            v3: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v3) },
-            v4: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v4) },
-            fill_rule,
-            points: unsafe { RetainedShapePointList::from_raw(points, point_count) },
-            path_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(path_string) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::BasicShape {
+        kind,
+        v0: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v0) },
+        v1: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v1) },
+        v2: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v2) },
+        v3: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v3) },
+        v4: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v4) },
+        fill_rule,
+        points: unsafe { RetainedShapePointList::from_raw(points, point_count) },
+        path_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(path_string) },
+    }))
 }
 
 /// Takes ownership of one strong reference to the calculation node; the byte blob and ranges
@@ -4232,18 +4111,16 @@ pub unsafe extern "C" fn rust_style_value_create_calculated(
     accepted_ranges: *const RetainedNumericRangeByType,
     accepted_range_count: usize,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Calculated {
-            rust_calculation: unsafe { crate::css::calc::CalcNodeHandle::from_raw(rust_calculation) },
-            resolve_as_is_number,
-            resolve_as_base,
-            resolved_type,
-            has_percentages_resolve_as,
-            percentages_resolve_as,
-            resolve_numbers_as_integers,
-            accepted_ranges: unsafe { RetainedNumericRangeList::from_raw(accepted_ranges, accepted_range_count) },
-        }))
-    })
+    Arc::into_raw(Arc::new(StyleValueData::Calculated {
+        rust_calculation: unsafe { crate::css::calc::CalcNodeHandle::from_raw(rust_calculation) },
+        resolve_as_is_number,
+        resolve_as_base,
+        resolved_type,
+        has_percentages_resolve_as,
+        percentages_resolve_as,
+        resolve_numbers_as_integers,
+        accepted_ranges: unsafe { RetainedNumericRangeList::from_raw(accepted_ranges, accepted_range_count) },
+    }))
 }
 
 /// Takes ownership of one leaked reference to the URL string and each modifier string.
@@ -4263,22 +4140,20 @@ pub unsafe extern "C" fn rust_style_value_create_image(
     parent_style_sheet_origin_clean: bool,
     should_absolutize_url_for_computed_value: bool,
 ) -> *const StyleValueData {
-    abort_on_panic(|| {
-        Arc::into_raw(Arc::new(StyleValueData::Image {
-            url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
-            url_type,
-            url_modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(url_modifiers, url_modifier_count) },
-            resource_context: ImageResourceContext {
-                base_url: unsafe {
-                    RetainedString::from_raw(resource_base_url, resource_base_url_bytes, resource_base_url_length)
-                },
-                has_base_url: has_resource_base_url,
-                has_parent_style_sheet_origin_clean,
-                parent_style_sheet_origin_clean,
-                should_absolutize_url_for_computed_value,
+    Arc::into_raw(Arc::new(StyleValueData::Image {
+        url: unsafe { RetainedString::from_raw(url, url_bytes, url_length) },
+        url_type,
+        url_modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(url_modifiers, url_modifier_count) },
+        resource_context: ImageResourceContext {
+            base_url: unsafe {
+                RetainedString::from_raw(resource_base_url, resource_base_url_bytes, resource_base_url_length)
             },
-        }))
-    })
+            has_base_url: has_resource_base_url,
+            has_parent_style_sheet_origin_clean,
+            parent_style_sheet_origin_clean,
+            should_absolutize_url_for_computed_value,
+        },
+    }))
 }
 
 pub(crate) unsafe fn release_style_value(value: *const StyleValueData) {
@@ -4298,7 +4173,7 @@ pub(crate) unsafe fn release_style_value(value: *const StyleValueData) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_release(value: *const StyleValueData) {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueDestroyEntry);
-    abort_on_panic(|| unsafe { release_style_value(value) });
+    unsafe { release_style_value(value) };
 }
 
 /// Whether two shared style values hold the same value.
@@ -4311,20 +4186,17 @@ pub unsafe extern "C" fn rust_style_value_release(value: *const StyleValueData) 
 /// `first` and `second` must be null or point at live `StyleValueData` allocated by this module.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_equals(first: *const StyleValueData, second: *const StyleValueData) -> bool {
-    abort_on_panic(|| {
-        if std::ptr::eq(first, second) {
-            return true;
-        }
-        if first.is_null() || second.is_null() {
-            return false;
-        }
-        // Replay pointers are opaque identity tokens rather than readable StyleValueData.
-        if replay_style_value_dependency_flags(first).is_some() || replay_style_value_dependency_flags(second).is_some()
-        {
-            return false;
-        }
-        unsafe { *first == *second }
-    })
+    if std::ptr::eq(first, second) {
+        return true;
+    }
+    if first.is_null() || second.is_null() {
+        return false;
+    }
+    // Replay pointers are opaque identity tokens rather than readable StyleValueData.
+    if replay_style_value_dependency_flags(first).is_some() || replay_style_value_dependency_flags(second).is_some() {
+        return false;
+    }
+    unsafe { *first == *second }
 }
 
 /// Retains one reference to a shared style value allocation.
@@ -4343,7 +4215,7 @@ pub(crate) unsafe fn retain_style_value(value: *const StyleValueData) -> *const 
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_retain(value: *const StyleValueData) -> *const StyleValueData {
-    abort_on_panic(|| unsafe { retain_style_value(value) })
+    unsafe { retain_style_value(value) }
 }
 
 #[cfg(test)]
@@ -4483,5 +4355,5 @@ pub(crate) fn retained_value_may_depend_on_font_metrics(value: &RetainedStyleVal
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_depends_on_current_color(data: *const c_void) -> bool {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StyleValueQueryEntry);
-    crate::abort_on_panic(|| value_depends_on_current_color(unsafe { &*(data as *const StyleValueData) }))
+    value_depends_on_current_color(unsafe { &*(data as *const StyleValueData) })
 }

--- a/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
+++ b/Libraries/LibWeb/Rust/src/css/table_group_builder.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 use std::ffi::c_void;
 
-use crate::abort_on_panic;
 use crate::css::animated_overlay::AnimatedOverlay;
 use crate::css::calc::{resolve_calculated_flex_without_context, resolve_calculated_integer_without_context};
 use crate::css::color_resolution::{
@@ -3284,120 +3283,110 @@ pub unsafe extern "C" fn rust_build_group_payloads_from_table(
     out_payloads: *mut *const c_void,
     group_count: usize,
 ) {
-    abort_on_panic(|| {
-        assert_eq!(
-            group_count,
-            group_index::COUNT,
-            "the C++ StyleGroupIndex numbering drifted from the table builder's mirror"
-        );
-        let table = unsafe { &*table };
-        let inputs = unsafe { &*inputs };
-        let parents = unsafe { std::slice::from_raw_parts(parent_payloads, group_count) };
-        let out = unsafe { std::slice::from_raw_parts_mut(out_payloads, group_count) };
-        let values = EffectiveValues {
-            table,
-            animated_overlay: unsafe { inputs.animated_overlay.as_ref() },
-        };
-        let color_input = unsafe { &*inputs.color_input.cast::<FfiColorResolutionInput>() };
-        let channels = relative_color_context_from_ffi(color_input);
-        // SAFETY: The caller keeps the input's pointers live across the call.
-        let input = unsafe { resolution_input_from_ffi(color_input, &channels) };
+    assert_eq!(
+        group_count,
+        group_index::COUNT,
+        "the C++ StyleGroupIndex numbering drifted from the table builder's mirror"
+    );
+    let table = unsafe { &*table };
+    let inputs = unsafe { &*inputs };
+    let parents = unsafe { std::slice::from_raw_parts(parent_payloads, group_count) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out_payloads, group_count) };
+    let values = EffectiveValues {
+        table,
+        animated_overlay: unsafe { inputs.animated_overlay.as_ref() },
+    };
+    let color_input = unsafe { &*inputs.color_input.cast::<FfiColorResolutionInput>() };
+    let channels = relative_color_context_from_ffi(color_input);
+    // SAFETY: The caller keeps the input's pointers live across the call.
+    let input = unsafe { resolution_input_from_ffi(color_input, &channels) };
 
-        for group in 0..group_count {
-            out[group] = std::ptr::null();
-            if (groups_to_apply >> group) & 1 == 0 {
-                continue;
-            }
-            let parent_payload = parents[group];
-            // SAFETY: Gathered pointers name live table or override data and
-            // the caller warrants the parent payloads.
-            let payload = unsafe {
-                match group {
-                    group_index::FONT => build_font_group(
-                        &values,
-                        inputs
-                            .font
-                            .as_ref()
-                            .expect("an applied font group has platform font inputs"),
-                        parent_payload,
-                    ),
-                    group_index::BOX => {
-                        build_box_group(&values, inputs.box_display_before_transformation_raw, parent_payload)
-                    }
-                    group_index::INHERITED_TABLE => rust_build_inherited_table_group(
-                        group,
-                        values.pointer(property_id::BORDER_COLLAPSE),
-                        values.pointer(property_id::CAPTION_SIDE),
-                        values.pointer(property_id::EMPTY_CELLS),
-                        values.pointer(property_id::BORDER_SPACING),
-                        parent_payload,
-                    ),
-                    group_index::INHERITED_BOX => rust_build_inherited_box_group(
-                        group,
-                        values.pointer(property_id::VISIBILITY),
-                        values.pointer(property_id::DIRECTION),
-                        values.pointer(property_id::WRITING_MODE),
-                        values.pointer(property_id::CONTENT_VISIBILITY),
-                        values.pointer(property_id::IMAGE_RENDERING),
-                        parent_payload,
-                    ),
-                    group_index::SIZING => rust_build_sizing_group(
-                        group,
-                        values.pointer(property_id::WIDTH),
-                        values.pointer(property_id::MIN_WIDTH),
-                        values.pointer(property_id::MAX_WIDTH),
-                        values.pointer(property_id::HEIGHT),
-                        values.pointer(property_id::MIN_HEIGHT),
-                        values.pointer(property_id::MAX_HEIGHT),
-                        parent_payload,
-                    ),
-                    group_index::SURROUND => build_surround_group(&values, parent_payload),
-                    group_index::ANIMATION => {
-                        build_animation_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::ANCHOR => {
-                        build_anchor_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::TEXT_RESET => build_text_reset_group(&values, &input, parent_payload),
-                    group_index::ALIGNMENT => build_alignment_group(&values, parent_payload),
-                    group_index::SVG_RESET => build_svg_reset_group(&values, &input, parent_payload),
-                    group_index::GRID => build_grid_group(&values, parent_payload),
-                    group_index::TRANSFORM => {
-                        build_transform_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::EFFECTS => {
-                        build_effects_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::INHERITED_UI => {
-                        build_inherited_ui_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::INHERITED_TEXT => {
-                        build_inherited_text_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::MISC_RESET => {
-                        build_misc_reset_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::INHERITED_SVG => {
-                        build_inherited_svg_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::INHERITED_LIST => {
-                        build_inherited_list_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::CONTENT => {
-                        build_content_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::BACKGROUND => {
-                        build_background_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    group_index::MASK => build_mask_group(&values, &input, inputs.used_color_scheme, parent_payload),
-                    group_index::BORDER => {
-                        build_border_group(&values, &input, inputs.used_color_scheme, parent_payload)
-                    }
-                    _ => build_generic_group(group, &values, &input, inputs.used_color_scheme, parent_payload),
-                }
-            };
-            assert!(!payload.is_null(), "computed group build returned null");
-            out[group] = payload;
+    for group in 0..group_count {
+        out[group] = std::ptr::null();
+        if (groups_to_apply >> group) & 1 == 0 {
+            continue;
         }
-    });
+        let parent_payload = parents[group];
+        // SAFETY: Gathered pointers name live table or override data and
+        // the caller warrants the parent payloads.
+        let payload = unsafe {
+            match group {
+                group_index::FONT => build_font_group(
+                    &values,
+                    inputs
+                        .font
+                        .as_ref()
+                        .expect("an applied font group has platform font inputs"),
+                    parent_payload,
+                ),
+                group_index::BOX => {
+                    build_box_group(&values, inputs.box_display_before_transformation_raw, parent_payload)
+                }
+                group_index::INHERITED_TABLE => rust_build_inherited_table_group(
+                    group,
+                    values.pointer(property_id::BORDER_COLLAPSE),
+                    values.pointer(property_id::CAPTION_SIDE),
+                    values.pointer(property_id::EMPTY_CELLS),
+                    values.pointer(property_id::BORDER_SPACING),
+                    parent_payload,
+                ),
+                group_index::INHERITED_BOX => rust_build_inherited_box_group(
+                    group,
+                    values.pointer(property_id::VISIBILITY),
+                    values.pointer(property_id::DIRECTION),
+                    values.pointer(property_id::WRITING_MODE),
+                    values.pointer(property_id::CONTENT_VISIBILITY),
+                    values.pointer(property_id::IMAGE_RENDERING),
+                    parent_payload,
+                ),
+                group_index::SIZING => rust_build_sizing_group(
+                    group,
+                    values.pointer(property_id::WIDTH),
+                    values.pointer(property_id::MIN_WIDTH),
+                    values.pointer(property_id::MAX_WIDTH),
+                    values.pointer(property_id::HEIGHT),
+                    values.pointer(property_id::MIN_HEIGHT),
+                    values.pointer(property_id::MAX_HEIGHT),
+                    parent_payload,
+                ),
+                group_index::SURROUND => build_surround_group(&values, parent_payload),
+                group_index::ANIMATION => {
+                    build_animation_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::ANCHOR => build_anchor_group(&values, &input, inputs.used_color_scheme, parent_payload),
+                group_index::TEXT_RESET => build_text_reset_group(&values, &input, parent_payload),
+                group_index::ALIGNMENT => build_alignment_group(&values, parent_payload),
+                group_index::SVG_RESET => build_svg_reset_group(&values, &input, parent_payload),
+                group_index::GRID => build_grid_group(&values, parent_payload),
+                group_index::TRANSFORM => {
+                    build_transform_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::EFFECTS => build_effects_group(&values, &input, inputs.used_color_scheme, parent_payload),
+                group_index::INHERITED_UI => {
+                    build_inherited_ui_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::INHERITED_TEXT => {
+                    build_inherited_text_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::MISC_RESET => {
+                    build_misc_reset_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::INHERITED_SVG => {
+                    build_inherited_svg_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::INHERITED_LIST => {
+                    build_inherited_list_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::CONTENT => build_content_group(&values, &input, inputs.used_color_scheme, parent_payload),
+                group_index::BACKGROUND => {
+                    build_background_group(&values, &input, inputs.used_color_scheme, parent_payload)
+                }
+                group_index::MASK => build_mask_group(&values, &input, inputs.used_color_scheme, parent_payload),
+                group_index::BORDER => build_border_group(&values, &input, inputs.used_color_scheme, parent_payload),
+                _ => build_generic_group(group, &values, &input, inputs.used_color_scheme, parent_payload),
+            }
+        };
+        assert!(!payload.is_null(), "computed group build returned null");
+        out[group] = payload;
+    }
 }

--- a/Libraries/LibWeb/Rust/src/css/transition.rs
+++ b/Libraries/LibWeb/Rust/src/css/transition.rs
@@ -343,60 +343,58 @@ pub unsafe extern "C" fn rust_decide_transitions(
     input: *mut FfiTransitionInput,
     actions: *mut FfiTransitionAction,
 ) {
-    crate::abort_on_panic(|| {
-        crate::css::ffi_stats::rust_style_ffi_note_transition_decision();
-        let input = unsafe { &mut *input };
-        let properties = if input.property_count == 0 {
-            &mut []
-        } else {
-            unsafe { std::slice::from_raw_parts_mut(input.properties, input.property_count) }
-        };
-        if properties.is_empty() {
-            return;
-        }
-        let style_engine = unsafe { style_engine.cast::<crate::css::style::StyleEngine>().as_ref() };
-        let before_style_view = style_engine
-            .expect("transition decisions require a style engine")
-            .style_record_view(before_style_record)
-            .expect("the transition baseline style record must remain live");
-        let before_style = {
-            let style = &before_style_view;
-            (
-                unsafe {
-                    style
-                        .longhand_table
-                        .as_ref()
-                        .expect("a transition baseline style record must carry a longhand table")
-                },
-                unsafe { style.animated_overlay.as_ref() },
-            )
-        };
-        let after_table = unsafe {
-            after_longhand_table
-                .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
-                .as_ref()
-        };
-        let after_overlay = unsafe {
-            after_animated_overlay
-                .cast::<crate::css::animated_overlay::AnimatedOverlay>()
-                .as_ref()
-        };
-        for (index, property) in properties.iter_mut().enumerate() {
-            let values_originate_from_current_color = prepare_transition_values(
-                before_style,
-                after_table.expect("transition decisions require an after-change table"),
-                after_overlay,
-                property,
-            );
+    crate::css::ffi_stats::rust_style_ffi_note_transition_decision();
+    let input = unsafe { &mut *input };
+    let properties = if input.property_count == 0 {
+        &mut []
+    } else {
+        unsafe { std::slice::from_raw_parts_mut(input.properties, input.property_count) }
+    };
+    if properties.is_empty() {
+        return;
+    }
+    let style_engine = unsafe { style_engine.cast::<crate::css::style::StyleEngine>().as_ref() };
+    let before_style_view = style_engine
+        .expect("transition decisions require a style engine")
+        .style_record_view(before_style_record)
+        .expect("the transition baseline style record must remain live");
+    let before_style = {
+        let style = &before_style_view;
+        (
             unsafe {
-                actions.add(index).write(decide_transition(
-                    &input.context,
-                    property,
-                    values_originate_from_current_color,
-                ));
-            };
-        }
-    });
+                style
+                    .longhand_table
+                    .as_ref()
+                    .expect("a transition baseline style record must carry a longhand table")
+            },
+            unsafe { style.animated_overlay.as_ref() },
+        )
+    };
+    let after_table = unsafe {
+        after_longhand_table
+            .cast::<crate::css::computed_longhand_table::ComputedLonghandTable>()
+            .as_ref()
+    };
+    let after_overlay = unsafe {
+        after_animated_overlay
+            .cast::<crate::css::animated_overlay::AnimatedOverlay>()
+            .as_ref()
+    };
+    for (index, property) in properties.iter_mut().enumerate() {
+        let values_originate_from_current_color = prepare_transition_values(
+            before_style,
+            after_table.expect("transition decisions require an after-change table"),
+            after_overlay,
+            property,
+        );
+        unsafe {
+            actions.add(index).write(decide_transition(
+                &input.context,
+                property,
+                values_originate_from_current_color,
+            ));
+        };
+    }
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/encoding_detection.rs
+++ b/Libraries/LibWeb/Rust/src/encoding_detection.rs
@@ -38,41 +38,39 @@ pub unsafe extern "C" fn rust_detect_encoding(
     out_encoding_name_len: *mut usize,
 ) -> bool {
     unsafe {
-        crate::abort_on_panic(|| {
-            let Some(input_slice) = crate::bytes_from_raw(input, input_len) else {
-                return false;
-            };
+        let Some(input_slice) = crate::bytes_from_raw(input, input_len) else {
+            return false;
+        };
 
-            let tld_slice = if tld.is_null() || tld_len == 0 {
-                None
-            } else {
-                Some(std::slice::from_raw_parts(tld, tld_len))
-            };
+        let tld_slice = if tld.is_null() || tld_len == 0 {
+            None
+        } else {
+            Some(std::slice::from_raw_parts(tld, tld_len))
+        };
 
-            // Web browsers must use `Iso2022JpDetection::Deny` and `Utf8Detection::Deny` to
-            // prevent charset confusion attacks. See the chardetng documentation for details.
-            // Japanese pages using ISO-2022-JP will have declared it in a <meta> tag, which
-            // is detected in step 5 (prescan) before this step is reached.
-            // We always call `guess()` even for pure-ASCII input because chardetng still
-            // tracks ESC sequences (ISO-2022-JP uses 7-bit escapes) and returns the
-            // correct locale-based fallback (windows-1252 for generic TLD) with
-            // `Utf8Detection::Deny` when no distinctive non-ASCII encoding evidence is found.
-            let mut detector = EncodingDetector::new(Iso2022JpDetection::Deny);
-            // Pass last=false because the caller may only be providing a sniff-bytes prefix
-            // of a longer stream. chardetng docs: "If you want to perform detection on just
-            // the prefix of a longer stream, do not pass last=true."
-            detector.feed(input_slice, false);
+        // Web browsers must use `Iso2022JpDetection::Deny` and `Utf8Detection::Deny` to
+        // prevent charset confusion attacks. See the chardetng documentation for details.
+        // Japanese pages using ISO-2022-JP will have declared it in a <meta> tag, which
+        // is detected in step 5 (prescan) before this step is reached.
+        // We always call `guess()` even for pure-ASCII input because chardetng still
+        // tracks ESC sequences (ISO-2022-JP uses 7-bit escapes) and returns the
+        // correct locale-based fallback (windows-1252 for generic TLD) with
+        // `Utf8Detection::Deny` when no distinctive non-ASCII encoding evidence is found.
+        let mut detector = EncodingDetector::new(Iso2022JpDetection::Deny);
+        // Pass last=false because the caller may only be providing a sniff-bytes prefix
+        // of a longer stream. chardetng docs: "If you want to perform detection on just
+        // the prefix of a longer stream, do not pass last=true."
+        detector.feed(input_slice, false);
 
-            let utf8_detection = if allow_utf8 {
-                Utf8Detection::Allow
-            } else {
-                Utf8Detection::Deny
-            };
-            let encoding = detector.guess(tld_slice, utf8_detection);
-            let name = encoding.name().as_bytes();
-            *out_encoding_name = name.as_ptr();
-            *out_encoding_name_len = name.len();
-            true
-        })
+        let utf8_detection = if allow_utf8 {
+            Utf8Detection::Allow
+        } else {
+            Utf8Detection::Deny
+        };
+        let encoding = detector.guess(tld_slice, utf8_detection);
+        let name = encoding.name().as_bytes();
+        *out_encoding_name = name.as_ptr();
+        *out_encoding_name_len = name.len();
+        true
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/commit.rs
+++ b/Libraries/LibWeb/Rust/src/layout/commit.rs
@@ -46,7 +46,7 @@ fn commit_subtree(
         debug_assert!(
             fragment.computed_svg_path.is_some()
                 || !matches!(
-                    callbacks.node_data(node).kind,
+                    callbacks.node_data(node).kind.get(),
                     NodeKind::SVGGeometryBox | NodeKind::SVGTextBox | NodeKind::SVGTextPathBox
                 ),
             "committed path-like fragment carries no computed SVG path"

--- a/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fc_run_cache.rs
@@ -438,8 +438,8 @@ fn collect_fragment_tree_fonts(links: &[FragmentLink], fonts: &mut Vec<*const c_
 fn run_root_validity(callbacks: &FfiLayoutFcCallbacks, box_: Node) -> FcRunCacheValidity {
     let data = NodeFacts::new(callbacks, box_).data();
     FcRunCacheValidity {
-        slot_generation: data.slot_generation,
-        fragment_cache_epoch: data.fragment_cache_epoch,
+        slot_generation: data.slot_generation.get(),
+        fragment_cache_epoch: data.fragment_cache_epoch.get(),
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -928,9 +928,7 @@ impl FfiLayoutFcCallbacks {
     }
 
     pub(crate) fn node_data(&self, node: Node) -> &NodeData {
-        // SAFETY: Entry points guarantee that the arena remains live, and
-        // data() validates the slot generation.
-        unsafe { &*self.arena().data(node) }
+        self.arena().data(node)
     }
 
     pub(crate) fn text_content(&self, node: Node) -> &'static crate::layout::layout_node_arena::TextContent {
@@ -971,24 +969,25 @@ impl FfiLayoutFcCallbacks {
 
     pub(crate) fn can_skip_is_anonymous_text_run(&self, node: Node) -> bool {
         let data = self.node_data(node);
-        if !node_facts::has_flag(data, NodeFlag::Anonymous) || data.generated_for != 0 {
+        if !node_facts::has_flag(data, NodeFlag::Anonymous) || data.generated_for.get() != 0 {
             return false;
         }
 
-        let mut child = data.first_child;
+        let mut child = data.first_child.get();
         while !child.is_invalid() {
             let data = self.node_data(child);
-            if !node_facts::kind_is_text(data.kind) || !self.text_content(child).untransformed_text_is_ascii_whitespace
+            if !node_facts::kind_is_text(data.kind.get())
+                || !self.text_content(child).untransformed_text_is_ascii_whitespace
             {
                 return false;
             }
-            child = data.next_sibling;
+            child = data.next_sibling.get();
         }
         true
     }
 
     pub(crate) fn shell(&self, node: Node) -> *mut c_void {
-        let shell = self.node_data(node).shell;
+        let shell = self.node_data(node).shell.get();
         assert!(!shell.is_null());
         shell
     }
@@ -1004,8 +1003,7 @@ impl FfiLayoutFcCallbacks {
 
     pub(crate) fn saved_abspos_layout_inputs(&self, node: Node) -> Option<abspos_inputs::AbsposLayoutInputs> {
         let data = self.arena().data(node);
-        // SAFETY: node_data_pointer() returns a live arena slot.
-        assert!(unsafe { node_facts::kind_is_box((*data).kind) });
+        assert!(node_facts::kind_is_box(data.kind.get()));
         self.arena().saved_abspos_layout_inputs(data)
     }
 
@@ -1019,14 +1017,13 @@ impl FfiLayoutFcCallbacks {
 
     #[inline]
     pub(crate) fn has_committed_fragment_link(&self, node: Node) -> bool {
-        self.node_data(node).flags & NodeFlag::HasCommittedFragmentLink as u32 != 0
+        self.node_data(node).flags.get() & NodeFlag::HasCommittedFragmentLink as u32 != 0
     }
 
     pub(crate) fn set_saved_abspos_layout_inputs(&self, node: Node, inputs: Option<abspos_inputs::AbsposLayoutInputs>) {
         let data = self.arena().data(node);
         // Match prepare_node's former as_if<Box>() guard.
-        // SAFETY: node_data_pointer() returns a live arena slot.
-        if !unsafe { node_facts::kind_is_box((*data).kind) } {
+        if !node_facts::kind_is_box(data.kind.get()) {
             return;
         }
         self.arena().set_saved_abspos_layout_inputs(data, inputs);
@@ -1034,27 +1031,27 @@ impl FfiLayoutFcCallbacks {
 
     #[inline]
     pub(crate) fn parent(&self, node: Node) -> Node {
-        self.node_data(node).parent
+        self.node_data(node).parent.get()
     }
 
     #[inline]
     pub(crate) fn first_child(&self, node: Node) -> Node {
-        self.node_data(node).first_child
+        self.node_data(node).first_child.get()
     }
 
     #[inline]
     pub(crate) fn next_sibling(&self, node: Node) -> Node {
-        self.node_data(node).next_sibling
+        self.node_data(node).next_sibling.get()
     }
 
     #[inline]
     pub(crate) fn containing_block(&self, node: Node) -> Node {
-        self.node_data(node).containing_block
+        self.node_data(node).containing_block.get()
     }
 
     #[inline]
     pub(crate) fn inline_containing_block(&self, node: Node) -> Node {
-        self.node_data(node).inline_containing_block
+        self.node_data(node).inline_containing_block.get()
     }
 
     pub(crate) fn is_ancestor(&self, ancestor: Node, mut node: Node) -> bool {
@@ -1062,16 +1059,16 @@ impl FfiLayoutFcCallbacks {
             if node == ancestor {
                 return true;
             }
-            node = self.node_data(node).parent;
+            node = self.node_data(node).parent.get();
         }
         false
     }
 
     pub(crate) fn non_anonymous_containing_block(&self, node: Node) -> Node {
-        let mut containing_block = self.node_data(node).containing_block;
+        let mut containing_block = self.node_data(node).containing_block.get();
         assert!(!containing_block.is_invalid());
-        while self.node_data(containing_block).flags & NodeFlag::Anonymous as u32 != 0 {
-            containing_block = self.node_data(containing_block).containing_block;
+        while self.node_data(containing_block).flags.get() & NodeFlag::Anonymous as u32 != 0 {
+            containing_block = self.node_data(containing_block).containing_block.get();
             assert!(!containing_block.is_invalid());
         }
         containing_block
@@ -1133,10 +1130,10 @@ pub(crate) fn formatting_context_type_created_by_node_data(
     style: Option<ComputedValuesView<'_>>,
     parent_style: Option<ComputedValuesView<'_>>,
 ) -> Option<FfiFormattingContextType> {
-    if data.kind == crate::layout::node_data::NodeKind::SVGSVGBox {
+    if data.kind.get() == crate::layout::node_data::NodeKind::SVGSVGBox {
         return Some(FfiFormattingContextType::Svg);
     }
-    let is_replaced_box = node_facts::kind_is_replaced_box(data.kind);
+    let is_replaced_box = node_facts::kind_is_replaced_box(data.kind.get());
     let can_have_children = node_facts::node_can_have_children(data);
     if is_replaced_box && can_have_children {
         return Some(FfiFormattingContextType::ReplacedWithChildren);
@@ -1153,7 +1150,7 @@ pub(crate) fn formatting_context_type_created_by_node_data(
             display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
         })
     {
-        return Some(if node_facts::kind_is_block_container(data.kind) {
+        return Some(if node_facts::kind_is_block_container(data.kind.get()) {
             FfiFormattingContextType::Block
         } else {
             FfiFormattingContextType::InternalReplaced
@@ -1212,13 +1209,12 @@ pub extern "C" fn rust_layout_formatting_context_type_for_box(facts: FfiFormatti
     // SAFETY: The C++ caller borrows the box's arena for this synchronous
     // classification.
     let arena = unsafe { LayoutNodeArena::from_handle(facts.arena) };
-    // SAFETY: The caller supplies the live box's arena slot.
-    let data = unsafe { &*arena.data(facts.node) };
+    let data = arena.data(facts.node);
     let style = arena
         .style_payloads(facts.node)
         .map(|payloads| ComputedValuesView::new(&payloads.groups));
-    let parent_style = (!data.parent.is_invalid())
-        .then(|| arena.style_payloads(data.parent))
+    let parent_style = (!data.parent.get().is_invalid())
+        .then(|| arena.style_payloads(data.parent.get()))
         .flatten()
         .map(|payloads| ComputedValuesView::new(&payloads.groups));
     formatting_context_type_created_by_node_data(data, style, parent_style)

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1209,23 +1209,21 @@ pub struct FfiFormattingContextArenaFacts {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_layout_formatting_context_type_for_box(facts: FfiFormattingContextArenaFacts) -> u8 {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller borrows the box's arena for this synchronous
-        // classification.
-        let arena = unsafe { LayoutNodeArena::from_handle(facts.arena) };
-        // SAFETY: The caller supplies the live box's arena slot.
-        let data = unsafe { &*arena.data(facts.node) };
-        let style = arena
-            .style_payloads(facts.node)
-            .map(|payloads| ComputedValuesView::new(&payloads.groups));
-        let parent_style = (!data.parent.is_invalid())
-            .then(|| arena.style_payloads(data.parent))
-            .flatten()
-            .map(|payloads| ComputedValuesView::new(&payloads.groups));
-        formatting_context_type_created_by_node_data(data, style, parent_style)
-            .map(|type_| type_ as u8)
-            .unwrap_or(NO_FORMATTING_CONTEXT)
-    })
+    // SAFETY: The C++ caller borrows the box's arena for this synchronous
+    // classification.
+    let arena = unsafe { LayoutNodeArena::from_handle(facts.arena) };
+    // SAFETY: The caller supplies the live box's arena slot.
+    let data = unsafe { &*arena.data(facts.node) };
+    let style = arena
+        .style_payloads(facts.node)
+        .map(|payloads| ComputedValuesView::new(&payloads.groups));
+    let parent_style = (!data.parent.is_invalid())
+        .then(|| arena.style_payloads(data.parent))
+        .flatten()
+        .map(|payloads| ComputedValuesView::new(&payloads.groups));
+    formatting_context_type_created_by_node_data(data, style, parent_style)
+        .map(|type_| type_ as u8)
+        .unwrap_or(NO_FORMATTING_CONTEXT)
 }
 
 fn create_formatting_context_implementation<'pass>(
@@ -2187,82 +2185,80 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
     callbacks: *const FfiLayoutFcCallbacks,
     sink: *const commit::FfiCommitSink,
 ) {
-    abort_on_panic(|| {
-        assert!(!root.is_invalid());
-        assert!(!callbacks.is_null());
-        assert!(!sink.is_null());
-        // SAFETY: The C++ pass host keeps both callback tables live for this
-        // synchronous entry.
-        let callbacks = unsafe { *callbacks };
-        let sink = unsafe { &*sink };
-        let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
-        let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
+    assert!(!root.is_invalid());
+    assert!(!callbacks.is_null());
+    assert!(!sink.is_null());
+    // SAFETY: The C++ pass host keeps both callback tables live for this
+    // synchronous entry.
+    let callbacks = unsafe { *callbacks };
+    let sink = unsafe { &*sink };
+    let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
+    let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
 
-        let root_constraints = ContainingBlockConstraints {
-            percentage_basis_inline_size: Some(viewport_inline_size),
-            percentage_basis_block_size: Some(viewport_block_size),
-            ..ContainingBlockConstraints::default()
-        };
-        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
-        let viewport_used = entry_records.create_used_values(&callbacks, root, root_constraints);
-        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
-        let entry_run = FormattingContextRun {
-            purpose: LayoutPurpose::Commit,
-            records: entry_records.clone(),
-            box_: root,
-            layout_mode: LayoutMode::Normal,
-            callbacks,
-            should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
-            fragments: Some(entry_fragments.clone()),
-            previous_line_data: None,
-        };
+    let root_constraints = ContainingBlockConstraints {
+        percentage_basis_inline_size: Some(viewport_inline_size),
+        percentage_basis_block_size: Some(viewport_block_size),
+        ..ContainingBlockConstraints::default()
+    };
+    let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
+    let viewport_used = entry_records.create_used_values(&callbacks, root, root_constraints);
+    let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
+    let entry_run = FormattingContextRun {
+        purpose: LayoutPurpose::Commit,
+        records: entry_records.clone(),
+        box_: root,
+        layout_mode: LayoutMode::Normal,
+        callbacks,
+        should_collect_devtools_layout_data,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+        fragments: Some(entry_fragments.clone()),
+        previous_line_data: None,
+    };
 
-        let mut root_for_layout = root;
-        let mut root_for_layout_used = viewport_used.clone();
-        let first_child = callbacks.first_child(root);
-        if !first_child.is_invalid() && NodeFacts::new(&callbacks, first_child).is_svg_svg_box() {
-            viewport_used.set_content_inline_size(viewport_inline_size);
-            viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&entry_run, root, FfiCssPixelPoint::default(), None);
-            root_for_layout_used = entry_records.create_used_values(&callbacks, first_child, root_constraints);
-            root_for_layout = first_child;
-        }
-        let input = LayoutInput::new(
-            AvailableSpace {
-                inline_size: AvailableSize::definite(viewport_inline_size),
-                block_size: AvailableSize::definite(viewport_block_size),
-            },
-            ContainingBlockConstraints::default(),
-            ParticipationInParentFormattingContext::Root,
-        )
-        .with_forced_sizes(viewport_inline_size, viewport_block_size);
-        let fc_type = independent_formatting_context_type(root_for_layout, &callbacks);
-        run_formatting_context(
-            LayoutPurpose::Commit,
-            Some(&entry_fragments),
-            &root_for_layout_used,
-            root_for_layout,
-            None,
-            fc_type,
-            LayoutMode::Normal,
-            should_collect_devtools_layout_data,
-            callbacks,
-            input,
-            None,
-            None,
-        );
-        place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default(), None);
-        drain_and_commit_entry_pass(
-            &entry_records,
-            &entry_fragments,
-            &callbacks,
-            should_collect_devtools_layout_data,
-            root,
-            sink,
-        );
-        callbacks.arena().sweep_stale_fc_run_cache_entries();
-    });
+    let mut root_for_layout = root;
+    let mut root_for_layout_used = viewport_used.clone();
+    let first_child = callbacks.first_child(root);
+    if !first_child.is_invalid() && NodeFacts::new(&callbacks, first_child).is_svg_svg_box() {
+        viewport_used.set_content_inline_size(viewport_inline_size);
+        viewport_used.set_content_block_size(viewport_block_size);
+        place_child(&entry_run, root, FfiCssPixelPoint::default(), None);
+        root_for_layout_used = entry_records.create_used_values(&callbacks, first_child, root_constraints);
+        root_for_layout = first_child;
+    }
+    let input = LayoutInput::new(
+        AvailableSpace {
+            inline_size: AvailableSize::definite(viewport_inline_size),
+            block_size: AvailableSize::definite(viewport_block_size),
+        },
+        ContainingBlockConstraints::default(),
+        ParticipationInParentFormattingContext::Root,
+    )
+    .with_forced_sizes(viewport_inline_size, viewport_block_size);
+    let fc_type = independent_formatting_context_type(root_for_layout, &callbacks);
+    run_formatting_context(
+        LayoutPurpose::Commit,
+        Some(&entry_fragments),
+        &root_for_layout_used,
+        root_for_layout,
+        None,
+        fc_type,
+        LayoutMode::Normal,
+        should_collect_devtools_layout_data,
+        callbacks,
+        input,
+        None,
+        None,
+    );
+    place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default(), None);
+    drain_and_commit_entry_pass(
+        &entry_records,
+        &entry_fragments,
+        &callbacks,
+        should_collect_devtools_layout_data,
+        root,
+        sink,
+    );
+    callbacks.arena().sweep_stale_fc_run_cache_entries();
 }
 
 fn drain_and_commit_entry_pass(
@@ -2299,86 +2295,84 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
     callbacks: *const FfiLayoutFcCallbacks,
     sink: *const commit::FfiCommitSink,
 ) {
-    abort_on_panic(|| {
-        assert!(!root.is_invalid());
-        assert!(!callbacks.is_null());
-        assert!(!sink.is_null());
-        // SAFETY: The C++ pass host keeps both callback tables live for this
-        // synchronous entry.
-        let callbacks = unsafe { *callbacks };
-        let sink = unsafe { &*sink };
+    assert!(!root.is_invalid());
+    assert!(!callbacks.is_null());
+    assert!(!sink.is_null());
+    // SAFETY: The C++ pass host keeps both callback tables live for this
+    // synchronous entry.
+    let callbacks = unsafe { *callbacks };
+    let sink = unsafe { &*sink };
 
-        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
-        let root_used = used_values::used_values_from_committed_fragment_link(&callbacks, root)
-            .expect("partial relayout root must have committed geometry");
-        entry_records.register(root, root_used.clone());
-        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
-        let entry_run = FormattingContextRun {
-            purpose: LayoutPurpose::Commit,
-            records: entry_records.clone(),
-            box_: root,
-            layout_mode: LayoutMode::Normal,
-            callbacks,
-            should_collect_devtools_layout_data: false,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
-            fragments: Some(entry_fragments.clone()),
-            previous_line_data: None,
+    let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, root));
+    let root_used = used_values::used_values_from_committed_fragment_link(&callbacks, root)
+        .expect("partial relayout root must have committed geometry");
+    entry_records.register(root, root_used.clone());
+    let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(root));
+    let entry_run = FormattingContextRun {
+        purpose: LayoutPurpose::Commit,
+        records: entry_records.clone(),
+        box_: root,
+        layout_mode: LayoutMode::Normal,
+        callbacks,
+        should_collect_devtools_layout_data: false,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+        fragments: Some(entry_fragments.clone()),
+        previous_line_data: None,
+    };
+    if !viewport.is_invalid() && viewport != root {
+        let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
+        let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
+        let viewport_constraints = ContainingBlockConstraints {
+            percentage_basis_inline_size: Some(viewport_inline_size),
+            percentage_basis_block_size: Some(viewport_block_size),
+            ..ContainingBlockConstraints::default()
         };
-        if !viewport.is_invalid() && viewport != root {
-            let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
-            let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
-            let viewport_constraints = ContainingBlockConstraints {
-                percentage_basis_inline_size: Some(viewport_inline_size),
-                percentage_basis_block_size: Some(viewport_block_size),
-                ..ContainingBlockConstraints::default()
-            };
-            let viewport_used = entry_records.create_used_values(&callbacks, viewport, viewport_constraints);
-            viewport_used.set_content_inline_size(viewport_inline_size);
-            viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&entry_run, viewport, FfiCssPixelPoint::default(), None);
-        }
-        let input = LayoutInput::new(
-            AvailableSpace {
-                inline_size: AvailableSize::definite(root_used.content_inline_size.get()),
-                block_size: AvailableSize::definite(root_used.content_block_size.get()),
-            },
-            // The subtree root has definite sizes in both axes, so boxes
-            // below it do not need inherited percentage constraints.
-            ContainingBlockConstraints::default(),
-            ParticipationInParentFormattingContext::Root,
-        );
+        let viewport_used = entry_records.create_used_values(&callbacks, viewport, viewport_constraints);
+        viewport_used.set_content_inline_size(viewport_inline_size);
+        viewport_used.set_content_block_size(viewport_block_size);
+        place_child(&entry_run, viewport, FfiCssPixelPoint::default(), None);
+    }
+    let input = LayoutInput::new(
+        AvailableSpace {
+            inline_size: AvailableSize::definite(root_used.content_inline_size.get()),
+            block_size: AvailableSize::definite(root_used.content_block_size.get()),
+        },
+        // The subtree root has definite sizes in both axes, so boxes
+        // below it do not need inherited percentage constraints.
+        ContainingBlockConstraints::default(),
+        ParticipationInParentFormattingContext::Root,
+    );
 
-        let facts = NodeFacts::new(&callbacks, root);
-        let fc_type = formatting_context_type_created_by_box(facts)
-            .expect("partial relayout root must establish an independent formatting context");
-        run_formatting_context(
-            LayoutPurpose::Commit,
-            Some(&entry_fragments),
-            &root_used,
-            root,
-            None,
-            fc_type,
-            LayoutMode::Normal,
-            false,
-            callbacks,
-            input,
-            None,
-            None,
-        );
-        entry_fragments.normalize_arrivals_for_placement(root);
-        entry_fragments.build_fragment_for_placed_box(
-            &callbacks,
-            root,
-            None,
-            &root_used,
-            false,
-            None,
-            root_used.content_offset.get(),
-            None,
-        );
-        drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, root, sink);
-        callbacks.arena().sweep_stale_fc_run_cache_entries();
-    });
+    let facts = NodeFacts::new(&callbacks, root);
+    let fc_type = formatting_context_type_created_by_box(facts)
+        .expect("partial relayout root must establish an independent formatting context");
+    run_formatting_context(
+        LayoutPurpose::Commit,
+        Some(&entry_fragments),
+        &root_used,
+        root,
+        None,
+        fc_type,
+        LayoutMode::Normal,
+        false,
+        callbacks,
+        input,
+        None,
+        None,
+    );
+    entry_fragments.normalize_arrivals_for_placement(root);
+    entry_fragments.build_fragment_for_placed_box(
+        &callbacks,
+        root,
+        None,
+        &root_used,
+        false,
+        None,
+        root_used.content_offset.get(),
+        None,
+    );
+    drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, root, sink);
+    callbacks.arena().sweep_stale_fc_run_cache_entries();
 }
 
 /// # Safety
@@ -2390,33 +2384,31 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
     callbacks: *const FfiLayoutFcCallbacks,
     sink: *const commit::FfiCommitSink,
 ) {
-    abort_on_panic(|| {
-        assert!(!box_.is_invalid());
-        assert!(!callbacks.is_null());
-        assert!(!sink.is_null());
-        // SAFETY: The C++ pass host keeps both callback tables live for this
-        // synchronous entry.
-        let callbacks = unsafe { *callbacks };
-        let sink = unsafe { &*sink };
-        let containing_block = callbacks.containing_block(box_);
-        assert!(!containing_block.is_invalid());
-        let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(
-            containing_block,
-        ));
-        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, containing_block));
-        let run = FormattingContextRun {
-            purpose: LayoutPurpose::Commit,
-            records: entry_records.clone(),
-            box_: containing_block,
-            layout_mode: LayoutMode::Normal,
-            callbacks,
-            should_collect_devtools_layout_data: false,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
-            fragments: Some(entry_fragments.clone()),
-            previous_line_data: None,
-        };
-        abspos_engine::AbsposEngine::for_run(&run).replay(&run, box_);
-        drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, box_, sink);
-        callbacks.arena().sweep_stale_fc_run_cache_entries();
-    });
+    assert!(!box_.is_invalid());
+    assert!(!callbacks.is_null());
+    assert!(!sink.is_null());
+    // SAFETY: The C++ pass host keeps both callback tables live for this
+    // synchronous entry.
+    let callbacks = unsafe { *callbacks };
+    let sink = unsafe { &*sink };
+    let containing_block = callbacks.containing_block(box_);
+    assert!(!containing_block.is_invalid());
+    let entry_fragments = std::rc::Rc::new(fragment_tree::RunFragmentBuilder::new_entry_accumulator(
+        containing_block,
+    ));
+    let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(callbacks.arena, containing_block));
+    let run = FormattingContextRun {
+        purpose: LayoutPurpose::Commit,
+        records: entry_records.clone(),
+        box_: containing_block,
+        layout_mode: LayoutMode::Normal,
+        callbacks,
+        should_collect_devtools_layout_data: false,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+        fragments: Some(entry_fragments.clone()),
+        previous_line_data: None,
+    };
+    abspos_engine::AbsposEngine::for_run(&run).replay(&run, box_);
+    drain_and_commit_entry_pass(&entry_records, &entry_fragments, &callbacks, false, box_, sink);
+    callbacks.arena().sweep_stale_fc_run_cache_entries();
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -15,7 +15,8 @@ use crate::css::style::fast_hash::FastMap as HashMap;
 use crate::layout::CssPixels;
 use crate::layout::FfiReplacedContentFacts;
 use crate::layout::node_data::{
-    FfiNodeConstructionFacts, FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId,
+    FfiNodeConstructionFacts, FfiNodeLink, FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind,
+    NodeSlotId,
 };
 use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
@@ -2086,6 +2087,40 @@ impl LayoutNodeArena {
         unsafe { (*self.data(id)).shell }
     }
 
+    pub(crate) fn node_link_shell(&self, id: NodeSlotId, link: FfiNodeLink) -> *mut c_void {
+        let data = self.data(id);
+        // SAFETY: data() validated that id names a live slot, and the links are plain values.
+        let linked = unsafe {
+            match link {
+                FfiNodeLink::Parent => (&raw const (*data).parent).read(),
+                FfiNodeLink::FirstChild => (&raw const (*data).first_child).read(),
+                FfiNodeLink::LastChild => (&raw const (*data).last_child).read(),
+                FfiNodeLink::PreviousSibling => (&raw const (*data).previous_sibling).read(),
+                FfiNodeLink::NextSibling => (&raw const (*data).next_sibling).read(),
+            }
+        };
+        if linked.is_invalid() {
+            return std::ptr::null_mut();
+        }
+        self.node_shell(linked)
+    }
+
+    pub(crate) fn node_containing_block_shell_if_live(&self, id: NodeSlotId) -> *mut c_void {
+        // SAFETY: data() validated that id names a live slot.
+        let containing_block = unsafe { (&raw const (*self.data(id)).containing_block).read() };
+        self.shell_if_live(containing_block)
+    }
+
+    pub(crate) fn node_flags(&self, id: NodeSlotId) -> u32 {
+        // SAFETY: data() validated that id names a live slot.
+        unsafe { (&raw const (*self.data(id)).flags).read() }
+    }
+
+    pub(crate) fn node_generated_for(&self, id: NodeSlotId) -> u8 {
+        // SAFETY: data() validated that id names a live slot.
+        unsafe { (&raw const (*self.data(id)).generated_for).read() }
+    }
+
     pub(crate) fn node_shell(&self, id: NodeSlotId) -> *mut c_void {
         // SAFETY: data() validated that id names a live slot.
         unsafe { (&raw const (*self.data(id)).shell).read() }
@@ -2336,6 +2371,37 @@ pub unsafe extern "C" fn layout_arena_recompute_containing_blocks(
 pub unsafe extern "C" fn layout_arena_node_shell_if_live(arena: *mut c_void, id: NodeSlotId) -> *mut c_void {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     unsafe { LayoutNodeArena::from_handle(arena) }.shell_if_live(id)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_link_shell(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    link: FfiNodeLink,
+) -> *mut c_void {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_link_shell(id, link)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_containing_block_shell_if_live(
+    arena: *mut c_void,
+    id: NodeSlotId,
+) -> *mut c_void {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_containing_block_shell_if_live(id)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_flags(arena: *mut c_void, id: NodeSlotId) -> u32 {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_flags(id)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_generated_for(arena: *mut c_void, id: NodeSlotId) -> u8 {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_generated_for(id)
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -621,21 +621,15 @@ impl LayoutNodeArena {
         NodeAllocation {
             slot: NodeSlotId::new(index, generation),
             data: self.data_mut(index),
-            generation: u32::from(generation),
         }
     }
 
-    pub(crate) fn free(&mut self, id: NodeSlotId, generation: u32) -> FreedSlot {
+    pub(crate) fn free(&mut self, id: NodeSlotId) -> FreedSlot {
         self.assert_owner_thread();
 
         assert!(!id.is_invalid(), "invalid layout node arena slot ID");
         let index = id.slot_index();
         let id_generation = id.generation();
-        assert_eq!(
-            u32::from(id_generation),
-            generation,
-            "layout node arena slot ID and allocation generation disagree"
-        );
         self.mark_descendant_subtree_caches_dirty_from_layout_node(id);
         let detached_children = self.unlink_children_for_free(id);
         let should_reuse = {
@@ -2144,7 +2138,6 @@ impl LayoutNodeArena {
 pub struct NodeAllocation {
     pub slot: NodeSlotId,
     pub data: *mut NodeData,
-    pub generation: u32,
 }
 
 #[unsafe(no_mangle)]
@@ -2171,13 +2164,13 @@ pub unsafe extern "C" fn layout_arena_allocate(arena: *mut c_void) -> NodeAlloca
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, generation: u32) {
+pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId) {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
     let freed = {
         let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-        arena.free(id, generation)
+        arena.free(id)
     };
     freed.detached_children.release_all();
     if let Some(reset) = freed.paintable_row_reset {
@@ -2584,12 +2577,9 @@ mod tests {
             (*first_data).table_column_span = 42;
             assert_eq!((*arena.data(first.slot)).table_column_span, 42);
         }
-        arena.free(first.slot, first.generation).detached_children.release_all();
+        arena.free(first.slot).detached_children.release_all();
         for allocation in allocations {
-            arena
-                .free(allocation.slot, allocation.generation)
-                .detached_children
-                .release_all();
+            arena.free(allocation.slot).detached_children.release_all();
         }
     }
 
@@ -2599,26 +2589,20 @@ mod tests {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate();
         assert_eq!(allocation.data as usize % 64, 0);
-        arena
-            .free(allocation.slot, allocation.generation)
-            .detached_children
-            .release_all();
+        arena.free(allocation.slot).detached_children.release_all();
     }
 
     #[test]
     fn freed_slots_are_reused_with_a_new_generation() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate();
-        arena.free(first.slot, first.generation).detached_children.release_all();
+        arena.free(first.slot).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
-        assert_ne!(second.generation, first.generation);
-        arena
-            .free(second.slot, second.generation)
-            .detached_children
-            .release_all();
+        assert_ne!(second.slot.generation(), first.slot.generation());
+        arena.free(second.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2635,10 +2619,7 @@ mod tests {
         assert_ne!(flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
-        arena
-            .free(anchor.slot, anchor.generation)
-            .detached_children
-            .release_all();
+        arena.free(anchor.slot).detached_children.release_all();
         assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
 
         let anchor_slot_reoccupant = arena.allocate();
@@ -2657,10 +2638,7 @@ mod tests {
         assert_eq!(cleared_flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(cleared_flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
-        arena
-            .free(positioned.slot, positioned.generation)
-            .detached_children
-            .release_all();
+        arena.free(positioned.slot).detached_children.release_all();
         let positioned_slot_reoccupant = arena.allocate();
         assert_eq!(
             positioned_slot_reoccupant.slot.slot_index(),
@@ -2668,20 +2646,14 @@ mod tests {
         );
         arena.set_default_scroll_shift(positioned_slot_reoccupant.slot, anchor_slot_reoccupant.slot, true, true);
         arena
-            .free(positioned_slot_reoccupant.slot, positioned_slot_reoccupant.generation)
+            .free(positioned_slot_reoccupant.slot)
             .detached_children
             .release_all();
         let next_reoccupant = arena.allocate();
         assert!(arena.default_scroll_shift_anchor(next_reoccupant.slot).is_invalid());
 
-        arena
-            .free(next_reoccupant.slot, next_reoccupant.generation)
-            .detached_children
-            .release_all();
-        arena
-            .free(anchor_slot_reoccupant.slot, anchor_slot_reoccupant.generation)
-            .detached_children
-            .release_all();
+        arena.free(next_reoccupant.slot).detached_children.release_all();
+        arena.free(anchor_slot_reoccupant.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2708,27 +2680,21 @@ mod tests {
             assert_eq!((*detached.data).flags & update_flags, update_flags);
         }
         arena.remove_child(root.slot, child.slot);
-        arena.free(root.slot, root.generation).detached_children.release_all();
-        arena.free(child.slot, child.generation).detached_children.release_all();
-        arena
-            .free(detached.slot, detached.generation)
-            .detached_children
-            .release_all();
+        arena.free(root.slot).detached_children.release_all();
+        arena.free(child.slot).detached_children.release_all();
+        arena.free(detached.slot).detached_children.release_all();
     }
 
     #[test]
     fn stale_slot_ids_do_not_resolve_to_a_new_occupant() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate();
-        arena.free(first.slot, first.generation).detached_children.release_all();
+        arena.free(first.slot).detached_children.release_all();
         let second = arena.allocate();
 
         let stale_read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| arena.data(first.slot)));
         assert!(stale_read.is_err());
-        arena
-            .free(second.slot, second.generation)
-            .detached_children
-            .release_all();
+        arena.free(second.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2748,10 +2714,7 @@ mod tests {
         }
 
         assert!(arena.committed_fragment_link(allocation.data).is_none());
-        arena
-            .free(allocation.slot, allocation.generation)
-            .detached_children
-            .release_all();
+        arena.free(allocation.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2774,8 +2737,8 @@ mod tests {
             .committed_fragment_link(new.data)
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
-        arena.free(old.slot, old.generation).detached_children.release_all();
-        arena.free(new.slot, new.generation).detached_children.release_all();
+        arena.free(old.slot).detached_children.release_all();
+        arena.free(new.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2854,7 +2817,7 @@ mod tests {
             false
         }));
         assert_eq!(dependency_computations.get(), 2);
-        arena.free(first.slot, first.generation).detached_children.release_all();
+        arena.free(first.slot).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
@@ -2873,10 +2836,7 @@ mod tests {
             ),
             None
         );
-        arena
-            .free(second.slot, second.generation)
-            .detached_children
-            .release_all();
+        arena.free(second.slot).detached_children.release_all();
     }
 
     #[test]
@@ -2976,10 +2936,7 @@ mod tests {
             arena.intrinsic_block_size_cache_get(data, max_content, key_at_another_inline_size_with_inline_basis(400)),
             None
         );
-        arena
-            .free(allocation.slot, allocation.generation)
-            .detached_children
-            .release_all();
+        arena.free(allocation.slot).detached_children.release_all();
     }
 
     #[test]
@@ -3027,16 +2984,13 @@ mod tests {
 
         first_data.intrinsic_cache_epoch += 1;
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
-        arena.free(first.slot, first.generation).detached_children.release_all();
+        arena.free(first.slot).detached_children.release_all();
 
         let second = arena.allocate();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         // SAFETY: The second allocation is live and reuses the first allocation's slot.
         let second_data = unsafe { &*second.data };
         assert_eq!(arena.table_cell_measurement_cache_get(second_data, key), None);
-        arena
-            .free(second.slot, second.generation)
-            .detached_children
-            .release_all();
+        arena.free(second.slot).detached_children.release_all();
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -524,7 +524,7 @@ impl LayoutNodeArena {
     /// Drops one node's cached intrinsic sizes outright, for the wrap of its epoch:
     /// entries are stamped with the epoch they were measured under, so a stamp reused
     /// after a full lap would match a pre-wrap entry.
-    pub(crate) fn drop_intrinsic_size_cache(&self, data: *const NodeData) {
+    pub(crate) fn drop_intrinsic_size_cache(&self, data: &NodeData) {
         let (index, _) = self.slot_for_data(data);
         if let Some(slot) = self.intrinsic_size_caches.borrow_mut().get_mut(index as usize) {
             *slot = IntrinsicSizeCacheSlot::default();
@@ -533,14 +533,8 @@ impl LayoutNodeArena {
 
     pub(crate) fn reset_cached_intrinsic_sizes(&self, node: NodeSlotId) {
         let data = self.data(node);
-        // SAFETY: data() validated that node names a live slot, and layout
-        // serializes mutation on the arena's owner thread.
-        let bumped_epoch = unsafe {
-            let epoch = &raw mut (*data).intrinsic_cache_epoch;
-            let bumped = epoch.read().wrapping_add(1);
-            epoch.write(bumped);
-            bumped
-        };
+        let bumped_epoch = data.intrinsic_cache_epoch.get().wrapping_add(1);
+        data.intrinsic_cache_epoch.set(bumped_epoch);
         if bumped_epoch == 0 {
             self.drop_intrinsic_size_cache(data);
         }
@@ -562,9 +556,7 @@ impl LayoutNodeArena {
                 return false;
             }
             let id = NodeSlotId::new(slot, metadata.generation);
-            // SAFETY: The slot is occupied at the matching generation, so the
-            // pointer addresses a live NodeData.
-            unsafe { (*self.data(id)).fragment_cache_epoch == validity.fragment_cache_epoch }
+            self.data(id).fragment_cache_epoch.get() == validity.fragment_cache_epoch
         });
     }
 
@@ -577,25 +569,23 @@ impl LayoutNodeArena {
     pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeSlotId {
         let slot = self.allocate_slot();
         let data = self.data_mut(slot.slot_index());
-        data.kind = construction_facts.kind;
-        data.shell = construction_facts.shell;
-        data.flags = super::node_facts::construction_flags(&construction_facts);
+        data.kind.set(construction_facts.kind);
+        data.shell.set(construction_facts.shell);
+        data.flags
+            .set(super::node_facts::construction_flags(&construction_facts));
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
         slot
     }
 
     #[cfg(test)]
     pub(crate) fn allocate_for_test(&mut self) -> NodeAllocation {
-        let slot = self.allocate_slot();
         NodeAllocation {
-            slot,
-            data: self.data_mut(slot.slot_index()),
+            slot: self.allocate_slot(),
         }
     }
 
     pub(crate) fn enroll_node_for_replaced_content_facts_sync_if_eligible(&self, node: NodeSlotId) {
-        // SAFETY: data() validated that node names a live slot.
-        let data = unsafe { &*self.data(node) };
+        let data = self.data(node);
         if !super::node_facts::node_may_have_replaced_content_facts_including_size_containment(data) {
             return;
         }
@@ -650,7 +640,7 @@ impl LayoutNodeArena {
             .expect("retired layout node arena slot was reused");
         metadata.occupied = true;
         let generation = metadata.generation;
-        self.data_mut(index).slot_generation = generation;
+        self.data_mut(index).slot_generation.set(generation);
 
         NodeSlotId::new(index, generation)
     }
@@ -712,11 +702,11 @@ impl LayoutNodeArena {
         self.raw_table_column_spans.remove(&id);
         let data = self.data_mut(index);
         debug_assert!(
-            data.parent.is_invalid()
-                && data.first_child.is_invalid()
-                && data.last_child.is_invalid()
-                && data.previous_sibling.is_invalid()
-                && data.next_sibling.is_invalid(),
+            data.parent.get().is_invalid()
+                && data.first_child.get().is_invalid()
+                && data.last_child.get().is_invalid()
+                && data.previous_sibling.get().is_invalid()
+                && data.next_sibling.get().is_invalid(),
             "layout node arena freed a slot that is still linked into a tree"
         );
         *data = NodeData::default();
@@ -736,22 +726,15 @@ impl LayoutNodeArena {
 
     fn unlink_children_for_free(&self, id: NodeSlotId) -> DetachedShells {
         let data = self.data(id);
-        // SAFETY: data() validated that id names a live slot, and the links are plain values.
-        let (parent, previous_sibling, next_sibling) = unsafe {
-            (
-                (&raw const (*data).parent).read(),
-                (&raw const (*data).previous_sibling).read(),
-                (&raw const (*data).next_sibling).read(),
-            )
-        };
+        let (parent, previous_sibling, next_sibling) =
+            { (data.parent.get(), data.previous_sibling.get(), data.next_sibling.get()) };
         assert!(
             parent.is_invalid() && previous_sibling.is_invalid() && next_sibling.is_invalid(),
             "layout node arena freed a slot that is still linked under a parent"
         );
         let mut detached_children = DetachedShells::default();
         loop {
-            // SAFETY: As above; unlink_child only rewrites link fields of live slots.
-            let child = unsafe { (&raw const (*data).first_child).read() };
+            let child = data.first_child.get();
             if child.is_invalid() {
                 break;
             }
@@ -762,19 +745,16 @@ impl LayoutNodeArena {
         detached_children
     }
 
-    pub(crate) fn data(&self, id: NodeSlotId) -> *mut NodeData {
+    pub(crate) fn data(&self, id: NodeSlotId) -> &NodeData {
         assert!(!id.is_invalid(), "invalid layout node arena slot ID");
         let index = id.slot_index() as usize;
         let chunk = self
             .chunks
             .get(index / SLOTS_PER_CHUNK)
             .expect("invalid layout node arena slot ID");
-        let data = (&raw const chunk.slots[index % SLOTS_PER_CHUNK]).cast_mut();
-        // SAFETY: The chunk bounds check above established that data addresses
-        // an initialized NodeData slot.
-        let generation = unsafe { (&raw const (*data).slot_generation).read() };
+        let data = &chunk.slots[index % SLOTS_PER_CHUNK];
         assert_eq!(
-            generation,
+            data.slot_generation.get(),
             id.generation(),
             "layout node arena read a stale or unused slot"
         );
@@ -784,34 +764,26 @@ impl LayoutNodeArena {
     pub(crate) fn set_node_generated_for(&self, id: NodeSlotId, generated_for: u8) {
         self.assert_owner_thread();
         let data = self.data(id);
-        // SAFETY: data() validated that id names a live slot, and layout
-        // serializes mutation on the arena's owner thread.
-        unsafe { (&raw mut (*data).generated_for).write(generated_for) };
+        data.generated_for.set(generated_for);
     }
 
     pub(crate) fn set_node_style_payloads(&self, id: NodeSlotId, payloads: *const c_void) {
         self.assert_owner_thread();
         let data = self.data(id);
-        // SAFETY: As above.
-        unsafe { (&raw mut (*data).style).write(payloads) };
+        data.style.set(payloads);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(id);
     }
 
     pub(crate) fn set_node_flag(&self, id: NodeSlotId, flag: NodeFlag, value: bool) {
         self.assert_owner_thread();
         let data = self.data(id);
-        // SAFETY: data() validated that id names a live slot, and layout
-        // serializes mutation on the arena's owner thread.
-        unsafe {
-            let flags = &raw mut (*data).flags;
-            let mut updated = flags.read();
-            if value {
-                updated |= flag as u32;
-            } else {
-                updated &= !(flag as u32);
-            }
-            flags.write(updated);
+        let mut updated = data.flags.get();
+        if value {
+            updated |= flag as u32;
+        } else {
+            updated &= !(flag as u32);
         }
+        data.flags.set(updated);
     }
 
     pub(crate) fn for_each_node_in_layout_subtree_in_pre_order(
@@ -823,15 +795,8 @@ impl LayoutNodeArena {
         loop {
             callback(current);
             let data = self.data(current);
-            // SAFETY: data() validated that current names a live slot, and the topology is
-            // stable during this call.
-            let (parent, first_child, next_sibling) = unsafe {
-                (
-                    (&raw const (*data).parent).read(),
-                    (&raw const (*data).first_child).read(),
-                    (&raw const (*data).next_sibling).read(),
-                )
-            };
+            let (parent, first_child, next_sibling) =
+                { (data.parent.get(), data.first_child.get(), data.next_sibling.get()) };
 
             if !first_child.is_invalid() {
                 current = first_child;
@@ -847,15 +812,13 @@ impl LayoutNodeArena {
 
             current = parent;
             while current != root {
-                // SAFETY: Parent links from a live subtree node name live slots in the same tree.
                 let data = self.data(current);
-                let next_sibling = unsafe { (&raw const (*data).next_sibling).read() };
+                let next_sibling = data.next_sibling.get();
                 if !next_sibling.is_invalid() {
                     current = next_sibling;
                     break;
                 }
-                // SAFETY: data() validated current and the topology is stable during this call.
-                current = unsafe { (&raw const (*data).parent).read() };
+                current = data.parent.get();
             }
             if current == root {
                 break;
@@ -868,31 +831,22 @@ impl LayoutNodeArena {
         let flags_to_clear = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
         self.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
             let data = self.data(node);
-            // SAFETY: data() validated that node names a live slot, and layout tree mutation
-            // is serialized on the arena's owner thread.
-            unsafe {
-                let flags = &raw mut (*data).flags;
-                flags.write(flags.read() & !flags_to_clear);
-            }
+            data.flags.set(data.flags.get() & !flags_to_clear);
         });
     }
 
     fn node_is_capable_of_forming_a_containing_block(&self, id: NodeSlotId) -> bool {
-        // SAFETY: data() validated that id names a live slot.
-        let data = unsafe { &*self.data(id) };
+        let data = self.data(id);
         super::node_facts::node_forms_containing_block_for_children(data, self.node_style_if_live(id))
     }
 
     fn nearest_ancestor_capable_of_forming_a_containing_block(&self, node: NodeSlotId) -> NodeSlotId {
-        // SAFETY: Callers pass a node validated by the subtree walk, and parent
-        // links from a live tree node name live slots.
-        let mut ancestor = unsafe { (&raw const (*self.data(node)).parent).read() };
+        let mut ancestor = self.data(node).parent.get();
         while !ancestor.is_invalid() {
             if self.node_is_capable_of_forming_a_containing_block(ancestor) {
                 return ancestor;
             }
-            // SAFETY: As above.
-            ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            ancestor = self.data(ancestor).parent.get();
         }
         NodeSlotId::INVALID
     }
@@ -907,16 +861,12 @@ impl LayoutNodeArena {
 
         let data = self.data(node);
         // Reset the inline containing block - we'll set it below if applicable.
-        // SAFETY: data() validated that node names a live slot, and layout
-        // serializes arena mutation on the owner thread.
-        unsafe { (&raw mut (*data).inline_containing_block).write(NodeSlotId::INVALID) };
+        data.inline_containing_block.set(NodeSlotId::INVALID);
 
-        // SAFETY: As above.
-        let kind = unsafe { (&raw const (*data).kind).read() };
+        let kind = data.kind.get();
         if super::node_facts::kind_is_text(kind) {
             let containing_block = self.nearest_ancestor_capable_of_forming_a_containing_block(node);
-            // SAFETY: As above.
-            unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+            data.containing_block.set(containing_block);
             return;
         }
 
@@ -926,24 +876,20 @@ impl LayoutNodeArena {
 
         // https://drafts.csswg.org/css-position-3/#absolute-cb
         if position == positioning::ABSOLUTE {
-            // SAFETY: As above; parent links from a live tree name live slots.
-            let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+            let mut ancestor = data.parent.get();
             while !ancestor.is_invalid() && !establishes_positioning_containing_blocks(self, ancestor).0 {
-                // SAFETY: As above.
-                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+                ancestor = self.data(ancestor).parent.get();
             }
-            // SAFETY: As above.
-            unsafe { (&raw mut (*data).containing_block).write(ancestor) };
+            data.containing_block.set(ancestor);
             if !ancestor.is_invalid() {
                 // SAFETY: Both slots are live; the callback only reads DOM ancestry
                 // and per-node facts through the shells and does not mutate the tree.
                 let inline_containing_block = unsafe {
-                    let node_shell = (&raw const (*data).shell).read();
-                    let ancestor_shell = (&raw const (*self.data(ancestor)).shell).read();
+                    let node_shell = data.shell.get();
+                    let ancestor_shell = self.data(ancestor).shell.get();
                     inline_cb_lookup(node_shell, ancestor_shell)
                 };
-                // SAFETY: As above.
-                unsafe { (&raw mut (*data).inline_containing_block).write(inline_containing_block) };
+                data.inline_containing_block.set(inline_containing_block);
             }
             return;
         }
@@ -954,12 +900,10 @@ impl LayoutNodeArena {
             // containing block, with the bounds of the containing block determined identically to the absolute positioning
             // containing block.
             let mut last_visited = node;
-            // SAFETY: As above.
-            let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+            let mut ancestor = data.parent.get();
             while !ancestor.is_invalid() && !establishes_positioning_containing_blocks(self, ancestor).1 {
                 last_visited = ancestor;
-                // SAFETY: As above.
-                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+                ancestor = self.data(ancestor).parent.get();
             }
             // If no ancestor establishes one, the box's fixed positioning containing block is the initial fixed containing
             // block:
@@ -969,20 +913,17 @@ impl LayoutNodeArena {
             //   page. (They are fixed with respect to the page box only, and are not affected by being seen through a
             //   viewport; as in the case of print preview, for example.)
             let containing_block = if ancestor.is_invalid() { last_visited } else { ancestor };
-            // SAFETY: As above.
-            unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+            data.containing_block.set(containing_block);
             return;
         }
 
         let containing_block = self.nearest_ancestor_capable_of_forming_a_containing_block(node);
-        // SAFETY: As above.
-        unsafe { (&raw mut (*data).containing_block).write(containing_block) };
+        data.containing_block.set(containing_block);
     }
 
     fn derive_abspos_escape_flags_for_node(&self, node: NodeSlotId) {
         let data = self.data(node);
-        // SAFETY: data() validated that node names a live slot.
-        let kind = unsafe { (&raw const (*data).kind).read() };
+        let kind = data.kind.get();
         if !super::node_facts::kind_is_box(kind) {
             return;
         }
@@ -993,17 +934,14 @@ impl LayoutNodeArena {
         {
             return;
         }
-        // SAFETY: As above; parent links from a live tree name live slots.
-        let containing_block = unsafe { (&raw const (*data).containing_block).read() };
-        let mut ancestor = unsafe { (&raw const (*data).parent).read() };
+        let containing_block = data.containing_block.get();
+        let mut ancestor = data.parent.get();
         while !ancestor.is_invalid() && ancestor != containing_block {
-            // SAFETY: As above.
-            let ancestor_kind = unsafe { (&raw const (*self.data(ancestor)).kind).read() };
+            let ancestor_kind = self.data(ancestor).kind.get();
             if super::node_facts::kind_is_box(ancestor_kind) {
                 self.set_node_flag(ancestor, NodeFlag::AbsposDescendantEscapes, true);
             }
-            // SAFETY: As above.
-            ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            ancestor = self.data(ancestor).parent.get();
         }
     }
 
@@ -1026,9 +964,8 @@ impl LayoutNodeArena {
         });
     }
 
-    fn slot_for_data(&self, data: *const NodeData) -> (u32, SlotMetadata) {
-        assert!(!data.is_null(), "layout node arena data pointer is null");
-        let data_address = data as usize;
+    fn slot_for_data(&self, data: &NodeData) -> (u32, SlotMetadata) {
+        let data_address = std::ptr::from_ref(data) as usize;
         let slot_size = size_of::<NodeData>();
 
         let address_index = self
@@ -1051,9 +988,7 @@ impl LayoutNodeArena {
         let index = u32::try_from(index).expect("layout node arena slot index overflowed");
         let metadata = *self.metadata(index);
         assert!(metadata.occupied, "layout node arena access for an unused slot");
-        // SAFETY: The range and alignment checks established that data points
-        // to the indexed NodeData slot.
-        let generation = unsafe { (&raw const (*data).slot_generation).read() };
+        let generation = data.slot_generation.get();
         assert_eq!(
             generation, metadata.generation,
             "layout node arena access used a stale slot"
@@ -1083,9 +1018,7 @@ impl LayoutNodeArena {
     fn last_descendant_in_pre_order(&self, node: NodeSlotId) -> NodeSlotId {
         let mut current = node;
         loop {
-            // SAFETY: data() validated that current names a live slot, and child links only
-            // name live slots.
-            let last_child = unsafe { (&raw const (*self.data(current)).last_child).read() };
+            let last_child = self.data(current).last_child.get();
             if last_child.is_invalid() {
                 return current;
             }
@@ -1097,14 +1030,7 @@ impl LayoutNodeArena {
         let mut current = node;
         loop {
             let data = self.data(current);
-            // SAFETY: data() validated that current names a live slot, and the topology links
-            // only name live slots.
-            let (parent, next_sibling) = unsafe {
-                (
-                    (&raw const (*data).parent).read(),
-                    (&raw const (*data).next_sibling).read(),
-                )
-            };
+            let (parent, next_sibling) = { (data.parent.get(), data.next_sibling.get()) };
             if !next_sibling.is_invalid() {
                 return self.node_pre_order_label(next_sibling);
             }
@@ -1117,14 +1043,7 @@ impl LayoutNodeArena {
 
     fn assign_pre_order_labels_to_inserted_subtree(&self, parent: NodeSlotId, child: NodeSlotId) {
         let child_data = self.data(child);
-        // SAFETY: data() validated that child names a live slot, and insert_child wrote its
-        // sibling links before this call.
-        let (previous_sibling, next_sibling) = unsafe {
-            (
-                (&raw const (*child_data).previous_sibling).read(),
-                (&raw const (*child_data).next_sibling).read(),
-            )
-        };
+        let (previous_sibling, next_sibling) = { (child_data.previous_sibling.get(), child_data.next_sibling.get()) };
         let lower = if previous_sibling.is_invalid() {
             self.node_pre_order_label(parent)
         } else {
@@ -1157,9 +1076,7 @@ impl LayoutNodeArena {
         }
         let mut ancestor = parent;
         loop {
-            // SAFETY: data() validated that ancestor names a live slot, and parent links only
-            // name live slots.
-            let ancestor_parent = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            let ancestor_parent = self.data(ancestor).parent.get();
             if ancestor_parent.is_invalid() {
                 self.set_node_pre_order_label(ancestor, 0);
                 let spread_succeeded = self.spread_pre_order_labels_evenly_over_descendants(ancestor, 0, u64::MAX);
@@ -1204,9 +1121,7 @@ impl LayoutNodeArena {
     #[cfg(debug_assertions)]
     fn nodes_share_a_layout_tree_root(&self, node: NodeSlotId, other: NodeSlotId) -> bool {
         let root_of = |mut slot: NodeSlotId| loop {
-            // SAFETY: data() validates the live generation, and parent links only name live
-            // slots in this arena.
-            let parent = unsafe { (&raw const (*self.data(slot)).parent).read() };
+            let parent = self.data(slot).parent.get();
             if parent.is_invalid() {
                 return slot;
             }
@@ -1216,8 +1131,8 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn is_before(&self, node: &NodeData, other: &NodeData) -> bool {
-        let (node_index, node_metadata) = self.slot_for_data(std::ptr::from_ref(node));
-        let (other_index, other_metadata) = self.slot_for_data(std::ptr::from_ref(other));
+        let (node_index, node_metadata) = self.slot_for_data(node);
+        let (other_index, other_metadata) = self.slot_for_data(other);
         let node = NodeSlotId::new(node_index, node_metadata.generation);
         let other = NodeSlotId::new(other_index, other_metadata.generation);
         assert_ne!(node, other, "a layout node cannot precede itself");
@@ -1243,10 +1158,10 @@ impl LayoutNodeArena {
             "block size cache kind must use the block axis"
         );
 
-        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let (index, metadata) = self.slot_for_data(data);
         let caches = self.intrinsic_size_caches.borrow();
         let slot = caches.get(index as usize)?;
-        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch.get() {
             return None;
         }
         let map = slot
@@ -1258,16 +1173,16 @@ impl LayoutNodeArena {
     }
 
     fn with_intrinsic_size_maps_mut(&self, data: &NodeData, callback: impl FnOnce(&mut IntrinsicSizeMaps)) {
-        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let (index, metadata) = self.slot_for_data(data);
         let mut caches = self.intrinsic_size_caches.borrow_mut();
         if caches.len() <= index as usize {
             caches.resize_with(index as usize + 1, IntrinsicSizeCacheSlot::default);
         }
         let slot = &mut caches[index as usize];
-        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch.get() {
             *slot = IntrinsicSizeCacheSlot {
                 generation: metadata.generation,
-                epoch: data.intrinsic_cache_epoch,
+                epoch: data.intrinsic_cache_epoch.get(),
                 sizes: Some(Box::default()),
             };
         }
@@ -1303,10 +1218,10 @@ impl LayoutNodeArena {
             "inline measurement cache kind must use the inline axis"
         );
 
-        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let (index, metadata) = self.slot_for_data(data);
         let caches = self.intrinsic_size_caches.borrow();
         let slot = caches.get(index as usize)?;
-        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch.get() {
             return None;
         }
         let map = slot
@@ -1322,12 +1237,12 @@ impl LayoutNodeArena {
         data: &NodeData,
         compute: impl FnOnce() -> bool,
     ) -> bool {
-        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let (index, metadata) = self.slot_for_data(data);
         {
             let caches = self.intrinsic_size_caches.borrow();
             if let Some(slot) = caches.get(index as usize)
                 && slot.generation == metadata.generation
-                && slot.epoch == data.intrinsic_cache_epoch
+                && slot.epoch == data.intrinsic_cache_epoch.get()
                 && let Some(value) = slot
                     .sizes
                     .as_ref()
@@ -1364,10 +1279,10 @@ impl LayoutNodeArena {
         data: &NodeData,
         key: TableCellMeasurementKey,
     ) -> Option<TableCellMeasurement> {
-        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let (index, metadata) = self.slot_for_data(data);
         let caches = self.intrinsic_size_caches.borrow();
         let slot = caches.get(index as usize)?;
-        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch.get() {
             return None;
         }
         slot.sizes.as_ref()?.table_cell_measurements.get(&key).copied()
@@ -1401,7 +1316,7 @@ impl LayoutNodeArena {
         self.intrinsic_measurements.get()
     }
 
-    pub(crate) fn saved_abspos_layout_inputs(&self, data: *const NodeData) -> Option<AbsposLayoutInputs> {
+    pub(crate) fn saved_abspos_layout_inputs(&self, data: &NodeData) -> Option<AbsposLayoutInputs> {
         let (index, metadata) = self.slot_for_data(data);
         let slots = self.saved_abspos_layout_inputs.borrow();
         let inputs = slots
@@ -1409,9 +1324,7 @@ impl LayoutNodeArena {
             .filter(|slot| slot.generation == metadata.generation)
             .and_then(|slot| slot.inputs.as_deref().copied());
 
-        // SAFETY: slot_for_data() established that data points to a live slot
-        // in this arena.
-        let flags = unsafe { (&raw const (*data).flags).read() };
+        let flags = data.flags.get();
         assert_eq!(
             flags & NodeFlag::HasSavedAbsposLayoutInputs as u32 != 0,
             inputs.is_some(),
@@ -1430,7 +1343,7 @@ impl LayoutNodeArena {
         inputs
     }
 
-    pub(crate) fn set_saved_abspos_layout_inputs(&self, data: *mut NodeData, inputs: Option<AbsposLayoutInputs>) {
+    pub(crate) fn set_saved_abspos_layout_inputs(&self, data: &NodeData, inputs: Option<AbsposLayoutInputs>) {
         let (index, metadata) = self.slot_for_data(data);
         let mut slots = self.saved_abspos_layout_inputs.borrow_mut();
         if slots.len() <= index as usize {
@@ -1456,23 +1369,17 @@ impl LayoutNodeArena {
         let saved_abspos_flags = NodeFlag::HasSavedAbsposLayoutInputs as u32
             | NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32
             | NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
-        // SAFETY: slot_for_data() established that data points to a live slot
-        // in this arena, and layout/tree building serialize mutation on the
-        // arena's owner thread.
-        unsafe {
-            let flags = &raw mut (*data).flags;
-            let mut value = flags.read() & !saved_abspos_flags;
-            if let Some(inputs) = inputs {
-                value |= NodeFlag::HasSavedAbsposLayoutInputs as u32;
-                if inputs.containing_block_info.derives_from_own_computed_values {
-                    value |= NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32;
-                }
-                if inputs.static_position_rect.alignment_derives_from_own_computed_values {
-                    value |= NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
-                }
+        let mut value = data.flags.get() & !saved_abspos_flags;
+        if let Some(inputs) = inputs {
+            value |= NodeFlag::HasSavedAbsposLayoutInputs as u32;
+            if inputs.containing_block_info.derives_from_own_computed_values {
+                value |= NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32;
             }
-            flags.write(value);
+            if inputs.static_position_rect.alignment_derives_from_own_computed_values {
+                value |= NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
+            }
         }
+        data.flags.set(value);
     }
 
     pub(crate) fn set_default_scroll_shift(
@@ -1531,15 +1438,13 @@ impl LayoutNodeArena {
         self.any_default_scroll_shift_anchor_ever_stored.get()
     }
 
-    pub(crate) fn committed_fragment_link(&self, data: *const NodeData) -> Option<super::fragment_tree::FragmentLink> {
+    pub(crate) fn committed_fragment_link(&self, data: &NodeData) -> Option<super::fragment_tree::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
         let link = self
             .paintable_rows
             .committed_fragment_link_cloned(index, metadata.generation);
 
-        // SAFETY: slot_for_data() established that data points to a live slot
-        // in this arena.
-        let flags = unsafe { (&raw const (*data).flags).read() };
+        let flags = data.flags.get();
         assert_eq!(
             flags & NodeFlag::HasCommittedFragmentLink as u32 != 0,
             link.is_some(),
@@ -1548,41 +1453,28 @@ impl LayoutNodeArena {
         link
     }
 
-    pub(crate) fn set_committed_fragment_link(&self, data: *mut NodeData, link: super::fragment_tree::FragmentLink) {
+    pub(crate) fn set_committed_fragment_link(&self, data: &NodeData, link: super::fragment_tree::FragmentLink) {
         let (index, metadata) = self.slot_for_data(data);
         self.paintable_rows
             .set_committed_fragment_link(index, metadata.generation, link);
 
-        // SAFETY: slot_for_data() established that data points to a live slot
-        // in this arena, and layout/tree building serialize mutation on the
-        // arena's owner thread.
-        unsafe {
-            let flags = &raw mut (*data).flags;
-            flags.write(flags.read() | NodeFlag::HasCommittedFragmentLink as u32);
-        }
+        data.flags
+            .set(data.flags.get() | NodeFlag::HasCommittedFragmentLink as u32);
     }
 
-    pub(crate) fn take_committed_fragment_link(
-        &self,
-        data: *mut NodeData,
-    ) -> Option<super::fragment_tree::FragmentLink> {
+    pub(crate) fn take_committed_fragment_link(&self, data: &NodeData) -> Option<super::fragment_tree::FragmentLink> {
         let (index, metadata) = self.slot_for_data(data);
         let link = self
             .paintable_rows
             .take_committed_fragment_link(index, metadata.generation);
 
-        // SAFETY: slot_for_data() established that data points to a live slot
-        // in this arena, and layout/tree building serialize mutation on the
-        // owner thread.
-        unsafe {
-            let flags = &raw mut (*data).flags;
-            assert_eq!(
-                flags.read() & NodeFlag::HasCommittedFragmentLink as u32 != 0,
-                link.is_some(),
-                "committed fragment link presence flag disagrees with the arena side table"
-            );
-            flags.write(flags.read() & !(NodeFlag::HasCommittedFragmentLink as u32));
-        }
+        assert_eq!(
+            data.flags.get() & NodeFlag::HasCommittedFragmentLink as u32 != 0,
+            link.is_some(),
+            "committed fragment link presence flag disagrees with the arena side table"
+        );
+        data.flags
+            .set(data.flags.get() & !(NodeFlag::HasCommittedFragmentLink as u32));
         link
     }
 
@@ -1692,9 +1584,7 @@ impl LayoutNodeArena {
     /// is only replaced between passes, so the array stays valid for as long
     /// as the node occupies its arena slot.
     pub(crate) fn style_payloads(&self, id: NodeSlotId) -> Option<&FfiStylePayloads> {
-        // SAFETY: data() generation-checks the slot and returns an
-        // initialized NodeData.
-        let style = unsafe { (&raw const (*self.data(id)).style).read() };
+        let style = self.data(id).style.get();
         // SAFETY: A non-null style pointer addresses the container's group
         // pointer array, which FfiStylePayloads mirrors exactly.
         (!style.is_null()).then(|| unsafe { &*style.cast::<FfiStylePayloads>() })
@@ -1818,15 +1708,11 @@ impl LayoutNodeArena {
             if invalidation == AncestorInvalidation::StructuralChange {
                 self.fc_run_cache_store.note_inline_layout_damage(node);
             }
-            // SAFETY: data() validated that node names a live slot, mutation is serialized on
-            // the owner thread, and no reference into the slot is held across this write.
-            let (kind, parent) = unsafe {
-                if epochs_enabled {
-                    let epoch = &raw mut (*data).fragment_cache_epoch;
-                    epoch.write(epoch.read().wrapping_add(1));
-                }
-                ((&raw const (*data).kind).read(), (&raw const (*data).parent).read())
-            };
+            if epochs_enabled {
+                data.fragment_cache_epoch
+                    .set(data.fragment_cache_epoch.get().wrapping_add(1));
+            }
+            let (kind, parent) = (data.kind.get(), data.parent.get());
             if super::node_facts::kind_is_box(kind) {
                 paintable_rows.clear_cached_overflow_data(node);
             }
@@ -1848,79 +1734,61 @@ impl LayoutNodeArena {
         let parent_data = self.data(parent);
         let child_data = self.data(child);
 
-        // SAFETY (for every raw access below): data() validated that the slot IDs name live
-        // nodes, and layout tree mutation is serialized on the arena's owner thread.
-        unsafe {
-            let child_parent = (&raw const (*child_data).parent).read();
-            let child_previous_sibling = (&raw const (*child_data).previous_sibling).read();
-            let child_next_sibling = (&raw const (*child_data).next_sibling).read();
-            assert!(
-                child_parent.is_invalid(),
-                "inserted layout node is still linked to a parent"
-            );
-            assert!(
-                child_previous_sibling.is_invalid(),
-                "inserted layout node is still linked to a previous sibling"
-            );
-            assert!(
-                child_next_sibling.is_invalid(),
-                "inserted layout node is still linked to a next sibling"
-            );
-            debug_assert_eq!(
-                (&raw const (*parent_data).first_child).read().is_invalid(),
-                (&raw const (*parent_data).last_child).read().is_invalid(),
-                "layout node child list endpoints disagree"
-            );
-        }
+        let child_parent = child_data.parent.get();
+        let child_previous_sibling = child_data.previous_sibling.get();
+        let child_next_sibling = child_data.next_sibling.get();
+        assert!(
+            child_parent.is_invalid(),
+            "inserted layout node is still linked to a parent"
+        );
+        assert!(
+            child_previous_sibling.is_invalid(),
+            "inserted layout node is still linked to a previous sibling"
+        );
+        assert!(
+            child_next_sibling.is_invalid(),
+            "inserted layout node is still linked to a next sibling"
+        );
+        debug_assert_eq!(
+            parent_data.first_child.get().is_invalid(),
+            parent_data.last_child.get().is_invalid(),
+            "layout node child list endpoints disagree"
+        );
 
         #[cfg(debug_assertions)]
         {
             let mut ancestor = parent;
             while !ancestor.is_invalid() {
                 assert_ne!(ancestor, child, "layout node insertion would create a cycle");
-                // SAFETY: data() validated that ancestor names a live slot, and parent links
-                // only name live slots.
-                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+                ancestor = self.data(ancestor).parent.get();
             }
         }
 
-        let before_data = if before.is_invalid() {
-            std::ptr::null_mut()
+        let previous = if before.is_invalid() {
+            parent_data.last_child.get()
         } else {
             assert_ne!(before, child, "a layout node cannot be inserted before itself");
-            self.data(before)
-        };
-        let previous = if before_data.is_null() {
-            // SAFETY: parent_data addresses a live node validated above.
-            unsafe { (&raw const (*parent_data).last_child).read() }
-        } else {
-            // SAFETY: data() validated that before names a live node.
-            unsafe {
-                let before_parent = (&raw const (*before_data).parent).read();
-                assert_eq!(
-                    before_parent, parent,
-                    "insertion reference is not a child of the parent"
-                );
-                (&raw const (*before_data).previous_sibling).read()
-            }
+            let before_data = self.data(before);
+            assert_eq!(
+                before_data.parent.get(),
+                parent,
+                "insertion reference is not a child of the parent"
+            );
+            before_data.previous_sibling.get()
         };
 
-        // SAFETY: Every written slot was validated live above (previous comes from a validated
-        // sibling or child-list link), and mutation is serialized on the owner thread.
-        unsafe {
-            (&raw mut (*child_data).parent).write(parent);
-            (&raw mut (*child_data).previous_sibling).write(previous);
-            (&raw mut (*child_data).next_sibling).write(before);
-            if previous.is_invalid() {
-                (&raw mut (*parent_data).first_child).write(child);
-            } else {
-                (&raw mut (*self.data(previous)).next_sibling).write(child);
-            }
-            if before_data.is_null() {
-                (&raw mut (*parent_data).last_child).write(child);
-            } else {
-                (&raw mut (*before_data).previous_sibling).write(child);
-            }
+        child_data.parent.set(parent);
+        child_data.previous_sibling.set(previous);
+        child_data.next_sibling.set(before);
+        if previous.is_invalid() {
+            parent_data.first_child.set(child);
+        } else {
+            self.data(previous).next_sibling.set(child);
+        }
+        if before.is_invalid() {
+            parent_data.last_child.set(child);
+        } else {
+            self.data(before).previous_sibling.set(child);
         }
 
         self.assign_pre_order_labels_to_inserted_subtree(parent, child);
@@ -1938,47 +1806,42 @@ impl LayoutNodeArena {
         let parent_data = self.data(parent);
         let child_data = self.data(child);
 
-        // SAFETY (for every raw access below): data() validated that the slot IDs name live
-        // nodes, sibling and child-list links only name live slots, and layout tree mutation
-        // is serialized on the arena's owner thread.
-        unsafe {
-            let child_parent = (&raw const (*child_data).parent).read();
-            assert_eq!(child_parent, parent, "removed layout node is not a child of the parent");
-            let previous = (&raw const (*child_data).previous_sibling).read();
-            let next = (&raw const (*child_data).next_sibling).read();
+        let child_parent = child_data.parent.get();
+        assert_eq!(child_parent, parent, "removed layout node is not a child of the parent");
+        let previous = child_data.previous_sibling.get();
+        let next = child_data.next_sibling.get();
 
-            if previous.is_invalid() {
-                let first_child = (&raw const (*parent_data).first_child).read();
-                assert_eq!(first_child, child, "layout node child list lost its first child");
-                (&raw mut (*parent_data).first_child).write(next);
-            } else {
-                let previous_data = self.data(previous);
-                let previous_next_sibling = (&raw const (*previous_data).next_sibling).read();
-                assert_eq!(
-                    previous_next_sibling, child,
-                    "layout node sibling chain is inconsistent"
-                );
-                (&raw mut (*previous_data).next_sibling).write(next);
-            }
-
-            if next.is_invalid() {
-                let last_child = (&raw const (*parent_data).last_child).read();
-                assert_eq!(last_child, child, "layout node child list lost its last child");
-                (&raw mut (*parent_data).last_child).write(previous);
-            } else {
-                let next_data = self.data(next);
-                let next_previous_sibling = (&raw const (*next_data).previous_sibling).read();
-                assert_eq!(
-                    next_previous_sibling, child,
-                    "layout node sibling chain is inconsistent"
-                );
-                (&raw mut (*next_data).previous_sibling).write(previous);
-            }
-
-            (&raw mut (*child_data).parent).write(NodeSlotId::INVALID);
-            (&raw mut (*child_data).previous_sibling).write(NodeSlotId::INVALID);
-            (&raw mut (*child_data).next_sibling).write(NodeSlotId::INVALID);
+        if previous.is_invalid() {
+            let first_child = parent_data.first_child.get();
+            assert_eq!(first_child, child, "layout node child list lost its first child");
+            parent_data.first_child.set(next);
+        } else {
+            let previous_data = self.data(previous);
+            let previous_next_sibling = previous_data.next_sibling.get();
+            assert_eq!(
+                previous_next_sibling, child,
+                "layout node sibling chain is inconsistent"
+            );
+            previous_data.next_sibling.set(next);
         }
+
+        if next.is_invalid() {
+            let last_child = parent_data.last_child.get();
+            assert_eq!(last_child, child, "layout node child list lost its last child");
+            parent_data.last_child.set(previous);
+        } else {
+            let next_data = self.data(next);
+            let next_previous_sibling = next_data.previous_sibling.get();
+            assert_eq!(
+                next_previous_sibling, child,
+                "layout node sibling chain is inconsistent"
+            );
+            next_data.previous_sibling.set(previous);
+        }
+
+        child_data.parent.set(NodeSlotId::INVALID);
+        child_data.previous_sibling.set(NodeSlotId::INVALID);
+        child_data.next_sibling.set(NodeSlotId::INVALID);
     }
 
     pub(crate) fn paint_state(&self) -> &RefCell<crate::painting::paint_state::PaintState> {
@@ -1989,32 +1852,28 @@ impl LayoutNodeArena {
         if self.shell_if_live(id).is_null() {
             return 0;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        unsafe { (*self.data(id)).flags }
+        self.data(id).flags.get()
     }
 
     pub(crate) fn node_is_generated_for_pseudo_element(&self, id: NodeSlotId) -> bool {
         if self.shell_if_live(id).is_null() {
             return false;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        unsafe { (*self.data(id)).generated_for != 0 }
+        self.data(id).generated_for.get() != 0
     }
 
     pub(crate) fn node_kind_if_live(&self, id: NodeSlotId) -> Option<NodeKind> {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        Some(unsafe { (*self.data(id)).kind })
+        Some(self.data(id).kind.get())
     }
 
     pub(crate) fn node_parent_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        let parent = unsafe { (*self.data(id)).parent };
+        let parent = self.data(id).parent.get();
         (!parent.is_invalid()).then_some(parent)
     }
 
@@ -2022,8 +1881,7 @@ impl LayoutNodeArena {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        let child = unsafe { (*self.data(id)).first_child };
+        let child = self.data(id).first_child.get();
         (!child.is_invalid()).then_some(child)
     }
 
@@ -2031,8 +1889,7 @@ impl LayoutNodeArena {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        let sibling = unsafe { (*self.data(id)).next_sibling };
+        let sibling = self.data(id).next_sibling.get();
         (!sibling.is_invalid()).then_some(sibling)
     }
 
@@ -2040,8 +1897,7 @@ impl LayoutNodeArena {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        Some(unsafe { &*self.data(id) })
+        Some(self.data(id))
     }
 
     pub(crate) fn node_is_out_of_flow_if_live(&self, id: NodeSlotId) -> bool {
@@ -2053,8 +1909,7 @@ impl LayoutNodeArena {
         if self.shell_if_live(id).is_null() {
             return None;
         }
-        // SAFETY: shell_if_live established a live slot of this generation.
-        let block = unsafe { (*self.data(id)).containing_block };
+        let block = self.data(id).containing_block.get();
         (!block.is_invalid()).then_some(block)
     }
 
@@ -2084,20 +1939,18 @@ impl LayoutNodeArena {
         if !self.slot_is_live(id) {
             return std::ptr::null_mut();
         }
-        // SAFETY: The metadata check established a live slot of this generation.
-        unsafe { (*self.data(id)).shell }
+        self.data(id).shell.get()
     }
 
     pub(crate) fn node_link_shell(&self, id: NodeSlotId, link: FfiNodeLink) -> *mut c_void {
         let data = self.data(id);
-        // SAFETY: data() validated that id names a live slot, and the links are plain values.
-        let linked = unsafe {
+        let linked = {
             match link {
-                FfiNodeLink::Parent => (&raw const (*data).parent).read(),
-                FfiNodeLink::FirstChild => (&raw const (*data).first_child).read(),
-                FfiNodeLink::LastChild => (&raw const (*data).last_child).read(),
-                FfiNodeLink::PreviousSibling => (&raw const (*data).previous_sibling).read(),
-                FfiNodeLink::NextSibling => (&raw const (*data).next_sibling).read(),
+                FfiNodeLink::Parent => data.parent.get(),
+                FfiNodeLink::FirstChild => data.first_child.get(),
+                FfiNodeLink::LastChild => data.last_child.get(),
+                FfiNodeLink::PreviousSibling => data.previous_sibling.get(),
+                FfiNodeLink::NextSibling => data.next_sibling.get(),
             }
         };
         if linked.is_invalid() {
@@ -2107,24 +1960,20 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_containing_block_shell_if_live(&self, id: NodeSlotId) -> *mut c_void {
-        // SAFETY: data() validated that id names a live slot.
-        let containing_block = unsafe { (&raw const (*self.data(id)).containing_block).read() };
+        let containing_block = self.data(id).containing_block.get();
         self.shell_if_live(containing_block)
     }
 
     pub(crate) fn node_flags(&self, id: NodeSlotId) -> u32 {
-        // SAFETY: data() validated that id names a live slot.
-        unsafe { (&raw const (*self.data(id)).flags).read() }
+        self.data(id).flags.get()
     }
 
     pub(crate) fn node_generated_for(&self, id: NodeSlotId) -> u8 {
-        // SAFETY: data() validated that id names a live slot.
-        unsafe { (&raw const (*self.data(id)).generated_for).read() }
+        self.data(id).generated_for.get()
     }
 
     pub(crate) fn node_shell(&self, id: NodeSlotId) -> *mut c_void {
-        // SAFETY: data() validated that id names a live slot.
-        unsafe { (&raw const (*self.data(id)).shell).read() }
+        self.data(id).shell.get()
     }
 
     pub(crate) fn dom_offset_for_rendered_text_offset(
@@ -2218,7 +2067,6 @@ impl LayoutNodeArena {
 #[derive(Clone, Copy)]
 pub(crate) struct NodeAllocation {
     pub(crate) slot: NodeSlotId,
-    pub(crate) data: *mut NodeData,
 }
 
 #[unsafe(no_mangle)]
@@ -2559,7 +2407,7 @@ pub unsafe extern "C" fn layout_arena_sync_enrolled_content_for_layout(
             continue;
         }
         // SAFETY: shell_if_live established a live slot of this generation.
-        let parent = unsafe { (&raw const (*(&*arena.cast::<LayoutNodeArena>()).data(node)).parent).read() };
+        let parent = unsafe { &*arena.cast::<LayoutNodeArena>() }.data(node).parent.get();
         if parent.is_invalid() {
             still_detached_text_nodes.push(node);
             continue;
@@ -2620,16 +2468,9 @@ pub unsafe extern "C" fn layout_arena_set_table_spans(
     // serializes all access on the document thread.
     let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
     let data = arena.data(id);
-    // SAFETY: data() validated that id names a live slot, and layout
-    // serializes mutation on the arena's owner thread.
-    let effective_spans_changed = unsafe {
-        let stored_column_span = &raw mut (*data).table_column_span;
-        let stored_row_span = &raw mut (*data).table_row_span;
-        let changed = stored_column_span.read() != column_span || stored_row_span.read() != row_span;
-        stored_column_span.write(column_span);
-        stored_row_span.write(row_span);
-        changed
-    };
+    let effective_spans_changed = data.table_column_span.get() != column_span || data.table_row_span.get() != row_span;
+    data.table_column_span.set(column_span);
+    data.table_row_span.set(row_span);
     let previous_raw_column_span = arena.set_raw_table_column_span(id, raw_column_span);
     effective_spans_changed || previous_raw_column_span != raw_column_span
 }
@@ -2691,20 +2532,16 @@ mod tests {
     fn node_data_addresses_remain_stable_when_chunks_are_added() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate_for_test();
-        let first_data = first.data;
+        let first_data_address = std::ptr::from_ref(arena.data(first.slot)) as usize;
 
         let mut allocations = Vec::new();
         for _ in 0..SLOTS_PER_CHUNK * 2 {
             allocations.push(arena.allocate_for_test());
         }
 
-        assert_eq!(first_data, arena.data(first.slot));
-        // SAFETY: The first allocation is still live, and the comparison above
-        // confirms that its pointer still addresses the arena slot.
-        unsafe {
-            (*first_data).table_column_span = 42;
-            assert_eq!((*arena.data(first.slot)).table_column_span, 42);
-        }
+        assert_eq!(first_data_address, std::ptr::from_ref(arena.data(first.slot)) as usize);
+        arena.data(first.slot).table_column_span.set(42);
+        assert_eq!(arena.data(first.slot).table_column_span.get(), 42);
         arena.free(first.slot).detached_children.release_all();
         for allocation in allocations {
             arena.free(allocation.slot).detached_children.release_all();
@@ -2716,7 +2553,7 @@ mod tests {
         assert_eq!(align_of::<Chunk>() % 64, 0);
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
-        assert_eq!(allocation.data as usize % 64, 0);
+        assert_eq!(std::ptr::from_ref(arena.data(allocation.slot)) as usize % 64, 0);
         arena.free(allocation.slot).detached_children.release_all();
     }
 
@@ -2742,8 +2579,7 @@ mod tests {
         arena.set_default_scroll_shift(positioned.slot, anchor.slot, true, false);
         assert!(arena.may_have_default_scroll_shift_anchor());
         assert_eq!(arena.default_scroll_shift_anchor(positioned.slot), anchor.slot);
-        // SAFETY: The allocation remains live and the arena keeps its address stable.
-        let flags = unsafe { (*positioned.data).flags };
+        let flags = arena.data(positioned.slot).flags.get();
         assert_ne!(flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
@@ -2761,8 +2597,7 @@ mod tests {
         );
         arena.set_default_scroll_shift(positioned.slot, NodeSlotId::INVALID, false, false);
         assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
-        // SAFETY: The allocation remains live and the arena keeps its address stable.
-        let cleared_flags = unsafe { (*positioned.data).flags };
+        let cleared_flags = arena.data(positioned.slot).flags.get();
         assert_eq!(cleared_flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(cleared_flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
@@ -2792,21 +2627,24 @@ mod tests {
         let detached = arena.allocate_for_test();
         arena.insert_child(root.slot, child.slot, NodeSlotId::INVALID);
         let update_flags = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
-        // SAFETY: All three allocations remain live for the duration of the test.
-        unsafe {
-            (*root.data).flags |= update_flags;
-            (*child.data).flags |= update_flags;
-            (*detached.data).flags |= update_flags;
-        }
+        arena
+            .data(root.slot)
+            .flags
+            .set(arena.data(root.slot).flags.get() | (update_flags));
+        arena
+            .data(child.slot)
+            .flags
+            .set(arena.data(child.slot).flags.get() | (update_flags));
+        arena
+            .data(detached.slot)
+            .flags
+            .set(arena.data(detached.slot).flags.get() | (update_flags));
 
         arena.reset_layout_update_flags_in_subtree(root.slot);
 
-        // SAFETY: The allocations remain live and the arena keeps their addresses stable.
-        unsafe {
-            assert_eq!((*root.data).flags & update_flags, 0);
-            assert_eq!((*child.data).flags & update_flags, 0);
-            assert_eq!((*detached.data).flags & update_flags, update_flags);
-        }
+        assert_eq!(arena.data(root.slot).flags.get() & update_flags, 0);
+        assert_eq!(arena.data(child.slot).flags.get() & update_flags, 0);
+        assert_eq!(arena.data(detached.slot).flags.get() & update_flags, update_flags);
         arena.remove_child(root.slot, child.slot);
         arena.free(root.slot).detached_children.release_all();
         arena.free(child.slot).detached_children.release_all();
@@ -2829,8 +2667,8 @@ mod tests {
     fn clearing_a_committed_box_evicts_its_fragment_link() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
-        arena.set_committed_fragment_link(allocation.data, test_fragment_link(allocation.slot));
-        assert!(arena.committed_fragment_link(allocation.data).is_some());
+        arena.set_committed_fragment_link(arena.data(allocation.slot), test_fragment_link(allocation.slot));
+        assert!(arena.committed_fragment_link(arena.data(allocation.slot)).is_some());
 
         // SAFETY: arena is a live handle on this thread, and allocation names
         // a live slot in it.
@@ -2841,7 +2679,7 @@ mod tests {
             );
         }
 
-        assert!(arena.committed_fragment_link(allocation.data).is_none());
+        assert!(arena.committed_fragment_link(arena.data(allocation.slot)).is_none());
         arena.free(allocation.slot).detached_children.release_all();
     }
 
@@ -2852,17 +2690,17 @@ mod tests {
         let new = arena.allocate_for_test();
         let link = test_fragment_link(old.slot);
         let retained_fragment = link.fragment.clone();
-        arena.set_committed_fragment_link(old.data, link);
+        arena.set_committed_fragment_link(arena.data(old.slot), link);
 
         let moved = arena
-            .take_committed_fragment_link(old.data)
+            .take_committed_fragment_link(arena.data(old.slot))
             .expect("old slot must retain its committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
-        arena.set_committed_fragment_link(new.data, moved);
+        arena.set_committed_fragment_link(arena.data(new.slot), moved);
 
-        assert!(arena.committed_fragment_link(old.data).is_none());
+        assert!(arena.committed_fragment_link(arena.data(old.slot)).is_none());
         let moved = arena
-            .committed_fragment_link(new.data)
+            .committed_fragment_link(arena.data(new.slot))
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
         arena.free(old.slot).detached_children.release_all();
@@ -2899,8 +2737,7 @@ mod tests {
         };
         let dependency_computations = Cell::new(0);
 
-        // SAFETY: The allocation remains live until it is explicitly freed below.
-        let first_data = unsafe { &mut *first.data };
+        let first_data = arena.data(first.slot);
         arena.intrinsic_block_size_cache_put(first_data, IntrinsicSizeCacheKind::MinContentBlock, key, value);
         arena.intrinsic_inline_size_measurement_cache_put(
             first_data,
@@ -2927,7 +2764,9 @@ mod tests {
         assert!(arena.intrinsic_inline_size_depends_on_block_size(first_data, || false));
         assert_eq!(dependency_computations.get(), 1);
 
-        first_data.intrinsic_cache_epoch += 1;
+        first_data
+            .intrinsic_cache_epoch
+            .set(first_data.intrinsic_cache_epoch.get() + 1);
         assert_eq!(
             arena.intrinsic_block_size_cache_get(first_data, IntrinsicSizeCacheKind::MinContentBlock, key),
             None
@@ -2950,8 +2789,7 @@ mod tests {
         let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
-        // SAFETY: The second allocation is live and reuses the first allocation's slot.
-        let second_data = unsafe { &*second.data };
+        let second_data = &*arena.data(second.slot);
         assert_eq!(
             arena.intrinsic_block_size_cache_get(second_data, IntrinsicSizeCacheKind::MinContentBlock, key),
             None
@@ -2971,8 +2809,7 @@ mod tests {
     fn intrinsic_size_cache_answers_masked_probes_only_from_independent_measurements() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
-        // SAFETY: The allocation remains live until it is explicitly freed below.
-        let data = unsafe { &mut *allocation.data };
+        let data = arena.data(allocation.slot);
         let key_with_basis = |basis: i32| IntrinsicSizeCacheKey {
             measured_at_inline_size: Some(CssPixels::from_raw(64)),
             percentage_basis_block_size: Some(CssPixels::from_raw(basis)),
@@ -3094,8 +2931,7 @@ mod tests {
             },
         };
 
-        // SAFETY: The allocation remains live until it is explicitly freed below.
-        let first_data = unsafe { &mut *first.data };
+        let first_data = arena.data(first.slot);
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
         arena.table_cell_measurement_cache_put(first_data, key, value);
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), Some(value));
@@ -3110,14 +2946,15 @@ mod tests {
             None
         );
 
-        first_data.intrinsic_cache_epoch += 1;
+        first_data
+            .intrinsic_cache_epoch
+            .set(first_data.intrinsic_cache_epoch.get() + 1);
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
         arena.free(first.slot).detached_children.release_all();
 
         let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
-        // SAFETY: The second allocation is live and reuses the first allocation's slot.
-        let second_data = unsafe { &*second.data };
+        let second_data = &*arena.data(second.slot);
         assert_eq!(arena.table_cell_measurement_cache_get(second_data, key), None);
         arena.free(second.slot).detached_children.release_all();
     }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -574,19 +574,23 @@ impl LayoutNodeArena {
 
     // Freshly created chunks are default-initialized and free() resets slots on release, so
     // allocate() always hands out clean NodeData without writing it again.
-    pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeAllocation {
-        let allocation = self.allocate_slot();
-        let data = self.data_mut(allocation.slot.slot_index());
+    pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeSlotId {
+        let slot = self.allocate_slot();
+        let data = self.data_mut(slot.slot_index());
         data.kind = construction_facts.kind;
         data.shell = construction_facts.shell;
         data.flags = super::node_facts::construction_flags(&construction_facts);
-        self.enroll_node_for_replaced_content_facts_sync_if_eligible(allocation.slot);
-        allocation
+        self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
+        slot
     }
 
     #[cfg(test)]
     pub(crate) fn allocate_for_test(&mut self) -> NodeAllocation {
-        self.allocate_slot()
+        let slot = self.allocate_slot();
+        NodeAllocation {
+            slot,
+            data: self.data_mut(slot.slot_index()),
+        }
     }
 
     pub(crate) fn enroll_node_for_replaced_content_facts_sync_if_eligible(&self, node: NodeSlotId) {
@@ -601,7 +605,7 @@ impl LayoutNodeArena {
         }
     }
 
-    fn allocate_slot(&mut self) -> NodeAllocation {
+    fn allocate_slot(&mut self) -> NodeSlotId {
         self.assert_owner_thread();
 
         let index = if let Some(index) = self.free_list.pop() {
@@ -648,10 +652,7 @@ impl LayoutNodeArena {
         let generation = metadata.generation;
         self.data_mut(index).slot_generation = generation;
 
-        NodeAllocation {
-            slot: NodeSlotId::new(index, generation),
-            data: self.data_mut(index),
-        }
+        NodeSlotId::new(index, generation)
     }
 
     pub(crate) fn free(&mut self, id: NodeSlotId) -> FreedSlot {
@@ -2213,11 +2214,11 @@ impl LayoutNodeArena {
     }
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy)]
-#[repr(C)]
-pub struct NodeAllocation {
-    pub slot: NodeSlotId,
-    pub data: *mut NodeData,
+pub(crate) struct NodeAllocation {
+    pub(crate) slot: NodeSlotId,
+    pub(crate) data: *mut NodeData,
 }
 
 #[unsafe(no_mangle)]
@@ -2239,7 +2240,7 @@ pub unsafe extern "C" fn layout_arena_destroy(arena: *mut c_void) {
 pub unsafe extern "C" fn layout_arena_allocate(
     arena: *mut c_void,
     construction_facts: FfiNodeConstructionFacts,
-) -> NodeAllocation {
+) -> NodeSlotId {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
@@ -2323,16 +2324,6 @@ pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
     unsafe { &*arena.cast::<LayoutNodeArena>() }.pre_order_relabel_count()
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `id` must
-/// name a live node in this arena.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_node_data(arena: *mut c_void, id: NodeSlotId) -> *mut NodeData {
-    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-    unsafe { LayoutNodeArena::from_handle(arena) }.data(id)
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -11,7 +11,6 @@ use super::geometry::AvailableSize;
 use super::geometry::AvailableSpace;
 use super::used_values::SizeConstraint;
 use super::used_values::UsedValues;
-use crate::abort_on_panic;
 use crate::css::style::fast_hash::FastMap as HashMap;
 use crate::layout::CssPixels;
 use crate::layout::FfiReplacedContentFacts;
@@ -2150,68 +2149,58 @@ pub struct NodeAllocation {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn layout_arena_create() -> *mut c_void {
-    abort_on_panic(|| Box::into_raw(Box::new(LayoutNodeArena::new())).cast())
+    Box::into_raw(Box::new(LayoutNodeArena::new())).cast()
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_destroy(arena: *mut c_void) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The handle came from layout_arena_create and ownership is
-        // transferred back exactly once by the C++ RAII wrapper.
-        let arena = unsafe { Box::from_raw(arena.cast::<LayoutNodeArena>()) };
-        arena.assert_owner_thread();
-        assert_eq!(arena.live_count, 0, "layout node arena destroyed with live slots");
-    });
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The handle came from layout_arena_create and ownership is
+    // transferred back exactly once by the C++ RAII wrapper.
+    let arena = unsafe { Box::from_raw(arena.cast::<LayoutNodeArena>()) };
+    arena.assert_owner_thread();
+    assert_eq!(arena.live_count, 0, "layout node arena destroyed with live slots");
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_allocate(arena: *mut c_void) -> NodeAllocation {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate()
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate()
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, generation: u32) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        let freed = {
-            let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-            arena.free(id, generation)
-        };
-        freed.detached_children.release_all();
-        if let Some(reset) = freed.paintable_row_reset {
-            reset.invoke_callback();
-        }
-    });
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    let freed = {
+        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
+        arena.free(id, generation)
+    };
+    freed.detached_children.release_all();
+    if let Some(reset) = freed.paintable_row_reset {
+        reset.invoke_callback();
+    }
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_fc_run_cache_hit_count(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }
-            .fc_run_cache_store()
-            .hit_count()
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .fc_run_cache_store()
+        .hit_count()
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_table_cell_measurement_cache_miss_count(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }.table_cell_measurement_cache_miss_count()
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.table_cell_measurement_cache_miss_count()
 }
 
 /// # Safety
@@ -2219,12 +2208,10 @@ pub unsafe extern "C" fn layout_arena_table_cell_measurement_cache_miss_count(ar
 /// The arena must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_intrinsic_measurement_count(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }.intrinsic_measurement_count()
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.intrinsic_measurement_count()
 }
 
 /// # Safety
@@ -2232,25 +2219,23 @@ pub unsafe extern "C" fn layout_arena_intrinsic_measurement_count(arena: *mut c_
 /// The arena must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_pre_order_label_violation_count(arena: *mut c_void, root: NodeSlotId) -> u64 {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        let arena = unsafe { &*arena.cast::<LayoutNodeArena>() };
-        if arena.shell_if_live(root).is_null() {
-            return 0;
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    let arena = unsafe { &*arena.cast::<LayoutNodeArena>() };
+    if arena.shell_if_live(root).is_null() {
+        return 0;
+    }
+    let mut violation_count = 0u64;
+    let mut previous_label: Option<u64> = None;
+    arena.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
+        let label = arena.node_pre_order_label(node);
+        if previous_label.is_some_and(|previous| label <= previous) {
+            violation_count += 1;
         }
-        let mut violation_count = 0u64;
-        let mut previous_label: Option<u64> = None;
-        arena.for_each_node_in_layout_subtree_in_pre_order(root, |node| {
-            let label = arena.node_pre_order_label(node);
-            if previous_label.is_some_and(|previous| label <= previous) {
-                violation_count += 1;
-            }
-            previous_label = Some(label);
-        });
-        violation_count
-    })
+        previous_label = Some(label);
+    });
+    violation_count
 }
 
 /// # Safety
@@ -2258,12 +2243,10 @@ pub unsafe extern "C" fn layout_arena_pre_order_label_violation_count(arena: *mu
 /// The arena must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }.pre_order_relabel_count()
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.pre_order_relabel_count()
 }
 
 /// # Safety
@@ -2272,10 +2255,8 @@ pub unsafe extern "C" fn layout_arena_pre_order_relabel_count(arena: *mut c_void
 /// name a live node in this arena.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_data(arena: *mut c_void, id: NodeSlotId) -> *mut NodeData {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.data(id)
-    })
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.data(id)
 }
 
 /// # Safety
@@ -2284,10 +2265,8 @@ pub unsafe extern "C" fn layout_arena_node_data(arena: *mut c_void, id: NodeSlot
 /// name the root of a live subtree in this arena.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_reset_layout_update_flags_in_subtree(arena: *mut c_void, root: NodeSlotId) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.reset_layout_update_flags_in_subtree(root);
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.reset_layout_update_flags_in_subtree(root);
 }
 
 /// # Safety
@@ -2304,10 +2283,8 @@ pub unsafe extern "C" fn layout_arena_recompute_containing_blocks(
     root: NodeSlotId,
     inline_cb_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.recompute_containing_blocks_in_subtree(root, inline_cb_lookup);
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.recompute_containing_blocks_in_subtree(root, inline_cb_lookup);
 }
 
 /// # Safety
@@ -2316,10 +2293,8 @@ pub unsafe extern "C" fn layout_arena_recompute_containing_blocks(
 /// invalid or stale; null is returned in that case.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_shell_if_live(arena: *mut c_void, id: NodeSlotId) -> *mut c_void {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.shell_if_live(id)
-    })
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.shell_if_live(id)
 }
 
 /// # Safety
@@ -2329,18 +2304,16 @@ pub unsafe extern "C" fn layout_arena_node_shell_if_live(arena: *mut c_void, id:
 /// Unless the caller holds its own reference, the node may be destroyed before this returns.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_detach_node_for_destruction(arena: *mut c_void, node: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call; the borrow
-        // ends before the release below re-enters the arena.
-        let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_from_parent(node);
-        match detached {
-            Some(detached) => {
-                detached.release();
-                true
-            }
-            None => false,
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call; the borrow
+    // ends before the release below re-enters the arena.
+    let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_from_parent(node);
+    match detached {
+        Some(detached) => {
+            detached.release();
+            true
         }
-    })
+        None => false,
+    }
 }
 
 /// # Safety
@@ -2352,10 +2325,8 @@ pub unsafe extern "C" fn layout_arena_bump_fragment_cache_epoch_of_self_and_ance
     arena: *mut c_void,
     node: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
 }
 
 #[unsafe(no_mangle)]
@@ -2370,34 +2341,32 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
     dom_start_offset: usize,
     rendered_text_has_edits: bool,
 ) -> bool {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        let text = if length_in_code_units == 0 {
-            Vec::new()
-        } else if !ascii_text.is_null() {
-            // SAFETY: The C++ caller passes the live ASCII storage of the
-            // node's rendered text for the duration of this synchronous call.
-            unsafe { std::slice::from_raw_parts(ascii_text, length_in_code_units) }
-                .iter()
-                .map(|unit| u16::from(*unit))
-                .collect()
-        } else {
-            assert!(!utf16_text.is_null(), "text content push carries no storage");
-            // SAFETY: The C++ caller passes the live UTF-16 storage of the
-            // node's rendered text for the duration of this synchronous call.
-            unsafe { std::slice::from_raw_parts(utf16_text, length_in_code_units) }.to_vec()
-        };
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_text_content(
-            id,
-            text,
-            untransformed_text_is_ascii_whitespace,
-            may_require_bidi_processing,
-            dom_start_offset,
-            rendered_text_has_edits,
-        )
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    let text = if length_in_code_units == 0 {
+        Vec::new()
+    } else if !ascii_text.is_null() {
+        // SAFETY: The C++ caller passes the live ASCII storage of the
+        // node's rendered text for the duration of this synchronous call.
+        unsafe { std::slice::from_raw_parts(ascii_text, length_in_code_units) }
+            .iter()
+            .map(|unit| u16::from(*unit))
+            .collect()
+    } else {
+        assert!(!utf16_text.is_null(), "text content push carries no storage");
+        // SAFETY: The C++ caller passes the live UTF-16 storage of the
+        // node's rendered text for the duration of this synchronous call.
+        unsafe { std::slice::from_raw_parts(utf16_text, length_in_code_units) }.to_vec()
+    };
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_text_content(
+        id,
+        text,
+        untransformed_text_is_ascii_whitespace,
+        may_require_bidi_processing,
+        dom_start_offset,
+        rendered_text_has_edits,
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -2406,25 +2375,21 @@ pub unsafe extern "C" fn layout_arena_set_replaced_content_facts(
     id: NodeSlotId,
     facts: FfiReplacedContentFacts,
 ) -> bool {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(id, facts)
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(id, facts)
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_enroll_text_node_for_content_sync(arena: *mut c_void, node: NodeSlotId) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }
-            .text_nodes_enrolled_for_content_sync
-            .borrow_mut()
-            .push(node);
-    });
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .text_nodes_enrolled_for_content_sync
+        .borrow_mut()
+        .push(node);
 }
 
 /// # Safety
@@ -2436,14 +2401,12 @@ pub unsafe extern "C" fn layout_arena_enroll_node_for_replaced_content_facts_syn
     arena: *mut c_void,
     node: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: As above.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }
-            .nodes_enrolled_for_replaced_content_facts_sync
-            .borrow_mut()
-            .push(node);
-    });
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .nodes_enrolled_for_replaced_content_facts_sync
+        .borrow_mut()
+        .push(node);
 }
 
 /// # Safety
@@ -2457,68 +2420,66 @@ pub unsafe extern "C" fn layout_arena_sync_enrolled_content_for_layout(
     sync_text_content: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     build_replaced_content_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiReplacedContentFacts),
 ) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY (for every derive below): the C++ wrapper keeps the arena alive for this call
-        // and serializes all access on the document thread; no shared borrow outlives a callback.
-        let enrolled_text_nodes = std::mem::take(
-            &mut *unsafe { &*arena.cast::<LayoutNodeArena>() }
-                .text_nodes_enrolled_for_content_sync
-                .borrow_mut(),
-        );
-        // A node that is alive but detached keeps its enrollment: it cannot
-        // resolve style-dependent text without a parent, and it may be reinserted
-        // by a later tree update without another enrollment trigger.
-        let mut still_detached_text_nodes = Vec::new();
-        for node in enrolled_text_nodes {
-            let shell = unsafe { &*arena.cast::<LayoutNodeArena>() }.shell_if_live(node);
-            if shell.is_null() {
-                continue;
-            }
-            // SAFETY: shell_if_live established a live slot of this generation.
-            let parent = unsafe { (&raw const (*(&*arena.cast::<LayoutNodeArena>()).data(node)).parent).read() };
-            if parent.is_invalid() {
-                still_detached_text_nodes.push(node);
-                continue;
-            }
-            // Changed rendered text invalidates cached formatting-context runs regardless of
-            // which channel produced the change, including sources with no invalidation of
-            // their own (e.g. lang-keyed locale-sensitive casing).
-            // SAFETY: The callback receives a live shell.
-            if unsafe { sync_text_content(context, shell) } {
-                unsafe { &*arena.cast::<LayoutNodeArena>() }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
-            }
-        }
-        unsafe { &*arena.cast::<LayoutNodeArena>() }
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY (for every derive below): the C++ wrapper keeps the arena alive for this call
+    // and serializes all access on the document thread; no shared borrow outlives a callback.
+    let enrolled_text_nodes = std::mem::take(
+        &mut *unsafe { &*arena.cast::<LayoutNodeArena>() }
             .text_nodes_enrolled_for_content_sync
-            .borrow_mut()
-            .extend(still_detached_text_nodes);
-
-        let enrolled_replaced_nodes = unsafe { &*arena.cast::<LayoutNodeArena>() }
-            .nodes_enrolled_for_replaced_content_facts_sync
-            .borrow()
-            .clone();
-        let mut live_replaced_nodes = Vec::with_capacity(enrolled_replaced_nodes.len());
-        for node in enrolled_replaced_nodes {
-            let shell = unsafe { &*arena.cast::<LayoutNodeArena>() }.shell_if_live(node);
-            if shell.is_null() {
-                continue;
-            }
-            live_replaced_nodes.push(node);
-            let mut facts = FfiReplacedContentFacts::default();
-            // SAFETY: The callback receives a live shell and a valid out-pointer.
-            unsafe { build_replaced_content_facts(context, shell, &raw mut facts) };
-            // Changed facts invalidate cached formatting-context runs regardless of which
-            // channel produced the change, including sources with no invalidation of their own.
-            // SAFETY: As above; the shared borrows ended with their statements.
-            if unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(node, facts) {
-                unsafe { &*arena.cast::<LayoutNodeArena>() }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
-            }
+            .borrow_mut(),
+    );
+    // A node that is alive but detached keeps its enrollment: it cannot
+    // resolve style-dependent text without a parent, and it may be reinserted
+    // by a later tree update without another enrollment trigger.
+    let mut still_detached_text_nodes = Vec::new();
+    for node in enrolled_text_nodes {
+        let shell = unsafe { &*arena.cast::<LayoutNodeArena>() }.shell_if_live(node);
+        if shell.is_null() {
+            continue;
         }
-        *unsafe { &*arena.cast::<LayoutNodeArena>() }
-            .nodes_enrolled_for_replaced_content_facts_sync
-            .borrow_mut() = live_replaced_nodes;
-    });
+        // SAFETY: shell_if_live established a live slot of this generation.
+        let parent = unsafe { (&raw const (*(&*arena.cast::<LayoutNodeArena>()).data(node)).parent).read() };
+        if parent.is_invalid() {
+            still_detached_text_nodes.push(node);
+            continue;
+        }
+        // Changed rendered text invalidates cached formatting-context runs regardless of
+        // which channel produced the change, including sources with no invalidation of
+        // their own (e.g. lang-keyed locale-sensitive casing).
+        // SAFETY: The callback receives a live shell.
+        if unsafe { sync_text_content(context, shell) } {
+            unsafe { &*arena.cast::<LayoutNodeArena>() }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
+        }
+    }
+    unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .text_nodes_enrolled_for_content_sync
+        .borrow_mut()
+        .extend(still_detached_text_nodes);
+
+    let enrolled_replaced_nodes = unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .nodes_enrolled_for_replaced_content_facts_sync
+        .borrow()
+        .clone();
+    let mut live_replaced_nodes = Vec::with_capacity(enrolled_replaced_nodes.len());
+    for node in enrolled_replaced_nodes {
+        let shell = unsafe { &*arena.cast::<LayoutNodeArena>() }.shell_if_live(node);
+        if shell.is_null() {
+            continue;
+        }
+        live_replaced_nodes.push(node);
+        let mut facts = FfiReplacedContentFacts::default();
+        // SAFETY: The callback receives a live shell and a valid out-pointer.
+        unsafe { build_replaced_content_facts(context, shell, &raw mut facts) };
+        // Changed facts invalidate cached formatting-context runs regardless of which
+        // channel produced the change, including sources with no invalidation of their own.
+        // SAFETY: As above; the shared borrows ended with their statements.
+        if unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(node, facts) {
+            unsafe { &*arena.cast::<LayoutNodeArena>() }.bump_fragment_cache_epoch_of_self_and_ancestors(node);
+        }
+    }
+    *unsafe { &*arena.cast::<LayoutNodeArena>() }
+        .nodes_enrolled_for_replaced_content_facts_sync
+        .borrow_mut() = live_replaced_nodes;
 }
 
 /// # Safety
@@ -2533,25 +2494,23 @@ pub unsafe extern "C" fn layout_arena_set_table_spans(
     row_span: u16,
     raw_column_span: u32,
 ) -> bool {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ wrapper keeps the arena alive for this call and
-        // serializes all access on the document thread.
-        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-        let data = arena.data(id);
-        // SAFETY: data() validated that id names a live slot, and layout
-        // serializes mutation on the arena's owner thread.
-        let effective_spans_changed = unsafe {
-            let stored_column_span = &raw mut (*data).table_column_span;
-            let stored_row_span = &raw mut (*data).table_row_span;
-            let changed = stored_column_span.read() != column_span || stored_row_span.read() != row_span;
-            stored_column_span.write(column_span);
-            stored_row_span.write(row_span);
-            changed
-        };
-        let previous_raw_column_span = arena.set_raw_table_column_span(id, raw_column_span);
-        effective_spans_changed || previous_raw_column_span != raw_column_span
-    })
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
+    let data = arena.data(id);
+    // SAFETY: data() validated that id names a live slot, and layout
+    // serializes mutation on the arena's owner thread.
+    let effective_spans_changed = unsafe {
+        let stored_column_span = &raw mut (*data).table_column_span;
+        let stored_row_span = &raw mut (*data).table_row_span;
+        let changed = stored_column_span.read() != column_span || stored_row_span.read() != row_span;
+        stored_column_span.write(column_span);
+        stored_row_span.write(row_span);
+        changed
+    };
+    let previous_raw_column_span = arena.set_raw_table_column_span(id, raw_column_span);
+    effective_spans_changed || previous_raw_column_span != raw_column_span
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -14,7 +14,9 @@ use super::used_values::UsedValues;
 use crate::css::style::fast_hash::FastMap as HashMap;
 use crate::layout::CssPixels;
 use crate::layout::FfiReplacedContentFacts;
-use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId};
+use crate::layout::node_data::{
+    FfiNodeConstructionFacts, FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind, NodeSlotId,
+};
 use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
 use std::cell::RefCell;
@@ -571,7 +573,34 @@ impl LayoutNodeArena {
 
     // Freshly created chunks are default-initialized and free() resets slots on release, so
     // allocate() always hands out clean NodeData without writing it again.
-    pub(crate) fn allocate(&mut self) -> NodeAllocation {
+    pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeAllocation {
+        let allocation = self.allocate_slot();
+        let data = self.data_mut(allocation.slot.slot_index());
+        data.kind = construction_facts.kind;
+        data.shell = construction_facts.shell;
+        data.flags = super::node_facts::construction_flags(&construction_facts);
+        self.enroll_node_for_replaced_content_facts_sync_if_eligible(allocation.slot);
+        allocation
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allocate_for_test(&mut self) -> NodeAllocation {
+        self.allocate_slot()
+    }
+
+    pub(crate) fn enroll_node_for_replaced_content_facts_sync_if_eligible(&self, node: NodeSlotId) {
+        // SAFETY: data() validated that node names a live slot.
+        let data = unsafe { &*self.data(node) };
+        if !super::node_facts::node_may_have_replaced_content_facts_including_size_containment(data) {
+            return;
+        }
+        let mut enrolled_nodes = self.nodes_enrolled_for_replaced_content_facts_sync.borrow_mut();
+        if !enrolled_nodes.contains(&node) {
+            enrolled_nodes.push(node);
+        }
+    }
+
+    fn allocate_slot(&mut self) -> NodeAllocation {
         self.assert_owner_thread();
 
         let index = if let Some(index) = self.free_list.pop() {
@@ -2156,11 +2185,14 @@ pub unsafe extern "C" fn layout_arena_destroy(arena: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_allocate(arena: *mut c_void) -> NodeAllocation {
+pub unsafe extern "C" fn layout_arena_allocate(
+    arena: *mut c_void,
+    construction_facts: FfiNodeConstructionFacts,
+) -> NodeAllocation {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
-    unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate()
+    unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate(construction_facts)
 }
 
 #[unsafe(no_mangle)]
@@ -2390,16 +2422,13 @@ pub unsafe extern "C" fn layout_arena_enroll_text_node_for_content_sync(arena: *
 /// The arena must remain valid for the duration of the call, and `node` must name a live node
 /// in this arena.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_enroll_node_for_replaced_content_facts_sync(
+pub unsafe extern "C" fn layout_arena_enroll_node_for_replaced_content_facts_sync_if_eligible(
     arena: *mut c_void,
     node: NodeSlotId,
 ) {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: As above.
-    unsafe { &*arena.cast::<LayoutNodeArena>() }
-        .nodes_enrolled_for_replaced_content_facts_sync
-        .borrow_mut()
-        .push(node);
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.enroll_node_for_replaced_content_facts_sync_if_eligible(node);
 }
 
 /// # Safety
@@ -2562,12 +2591,12 @@ mod tests {
     #[test]
     fn node_data_addresses_remain_stable_when_chunks_are_added() {
         let mut arena = LayoutNodeArena::new();
-        let first = arena.allocate();
+        let first = arena.allocate_for_test();
         let first_data = first.data;
 
         let mut allocations = Vec::new();
         for _ in 0..SLOTS_PER_CHUNK * 2 {
-            allocations.push(arena.allocate());
+            allocations.push(arena.allocate_for_test());
         }
 
         assert_eq!(first_data, arena.data(first.slot));
@@ -2587,7 +2616,7 @@ mod tests {
     fn node_data_slots_are_cache_line_aligned() {
         assert_eq!(align_of::<Chunk>() % 64, 0);
         let mut arena = LayoutNodeArena::new();
-        let allocation = arena.allocate();
+        let allocation = arena.allocate_for_test();
         assert_eq!(allocation.data as usize % 64, 0);
         arena.free(allocation.slot).detached_children.release_all();
     }
@@ -2595,10 +2624,10 @@ mod tests {
     #[test]
     fn freed_slots_are_reused_with_a_new_generation() {
         let mut arena = LayoutNodeArena::new();
-        let first = arena.allocate();
+        let first = arena.allocate_for_test();
         arena.free(first.slot).detached_children.release_all();
 
-        let second = arena.allocate();
+        let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
         assert_ne!(second.slot.generation(), first.slot.generation());
@@ -2608,8 +2637,8 @@ mod tests {
     #[test]
     fn default_scroll_shift_anchors_behave_like_weak_references() {
         let mut arena = LayoutNodeArena::new();
-        let positioned = arena.allocate();
-        let anchor = arena.allocate();
+        let positioned = arena.allocate_for_test();
+        let anchor = arena.allocate_for_test();
 
         arena.set_default_scroll_shift(positioned.slot, anchor.slot, true, false);
         assert!(arena.may_have_default_scroll_shift_anchor());
@@ -2622,7 +2651,7 @@ mod tests {
         arena.free(anchor.slot).detached_children.release_all();
         assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
 
-        let anchor_slot_reoccupant = arena.allocate();
+        let anchor_slot_reoccupant = arena.allocate_for_test();
         assert_eq!(anchor_slot_reoccupant.slot.slot_index(), anchor.slot.slot_index());
         assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
 
@@ -2639,7 +2668,7 @@ mod tests {
         assert_eq!(cleared_flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
         arena.free(positioned.slot).detached_children.release_all();
-        let positioned_slot_reoccupant = arena.allocate();
+        let positioned_slot_reoccupant = arena.allocate_for_test();
         assert_eq!(
             positioned_slot_reoccupant.slot.slot_index(),
             positioned.slot.slot_index()
@@ -2649,7 +2678,7 @@ mod tests {
             .free(positioned_slot_reoccupant.slot)
             .detached_children
             .release_all();
-        let next_reoccupant = arena.allocate();
+        let next_reoccupant = arena.allocate_for_test();
         assert!(arena.default_scroll_shift_anchor(next_reoccupant.slot).is_invalid());
 
         arena.free(next_reoccupant.slot).detached_children.release_all();
@@ -2659,9 +2688,9 @@ mod tests {
     #[test]
     fn layout_update_flags_are_reset_only_in_the_requested_subtree() {
         let mut arena = LayoutNodeArena::new();
-        let root = arena.allocate();
-        let child = arena.allocate();
-        let detached = arena.allocate();
+        let root = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
+        let detached = arena.allocate_for_test();
         arena.insert_child(root.slot, child.slot, NodeSlotId::INVALID);
         let update_flags = NodeFlag::NeedsLayoutUpdate as u32 | NodeFlag::NeedsOwnGeometryUpdate as u32;
         // SAFETY: All three allocations remain live for the duration of the test.
@@ -2688,9 +2717,9 @@ mod tests {
     #[test]
     fn stale_slot_ids_do_not_resolve_to_a_new_occupant() {
         let mut arena = LayoutNodeArena::new();
-        let first = arena.allocate();
+        let first = arena.allocate_for_test();
         arena.free(first.slot).detached_children.release_all();
-        let second = arena.allocate();
+        let second = arena.allocate_for_test();
 
         let stale_read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| arena.data(first.slot)));
         assert!(stale_read.is_err());
@@ -2700,7 +2729,7 @@ mod tests {
     #[test]
     fn clearing_a_committed_box_evicts_its_fragment_link() {
         let mut arena = LayoutNodeArena::new();
-        let allocation = arena.allocate();
+        let allocation = arena.allocate_for_test();
         arena.set_committed_fragment_link(allocation.data, test_fragment_link(allocation.slot));
         assert!(arena.committed_fragment_link(allocation.data).is_some());
 
@@ -2720,8 +2749,8 @@ mod tests {
     #[test]
     fn committed_fragment_links_move_between_slots() {
         let mut arena = LayoutNodeArena::new();
-        let old = arena.allocate();
-        let new = arena.allocate();
+        let old = arena.allocate_for_test();
+        let new = arena.allocate_for_test();
         let link = test_fragment_link(old.slot);
         let retained_fragment = link.fragment.clone();
         arena.set_committed_fragment_link(old.data, link);
@@ -2744,7 +2773,7 @@ mod tests {
     #[test]
     fn intrinsic_size_cache_validates_epoch_and_generation() {
         let mut arena = LayoutNodeArena::new();
-        let first = arena.allocate();
+        let first = arena.allocate_for_test();
         let key = IntrinsicSizeCacheKey {
             measured_at_inline_size: Some(CssPixels::from_raw(64)),
             ..Default::default()
@@ -2819,7 +2848,7 @@ mod tests {
         assert_eq!(dependency_computations.get(), 2);
         arena.free(first.slot).detached_children.release_all();
 
-        let second = arena.allocate();
+        let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
         // SAFETY: The second allocation is live and reuses the first allocation's slot.
@@ -2842,7 +2871,7 @@ mod tests {
     #[test]
     fn intrinsic_size_cache_answers_masked_probes_only_from_independent_measurements() {
         let mut arena = LayoutNodeArena::new();
-        let allocation = arena.allocate();
+        let allocation = arena.allocate_for_test();
         // SAFETY: The allocation remains live until it is explicitly freed below.
         let data = unsafe { &mut *allocation.data };
         let key_with_basis = |basis: i32| IntrinsicSizeCacheKey {
@@ -2942,7 +2971,7 @@ mod tests {
     #[test]
     fn table_cell_measurements_follow_the_intrinsic_cache_epoch() {
         let mut arena = LayoutNodeArena::new();
-        let first = arena.allocate();
+        let first = arena.allocate_for_test();
         let key = TableCellMeasurementKey {
             layout_mode: crate::layout::layout_node_arena::LayoutMode::Normal,
             available_space: crate::layout::layout_node_arena::AvailableSpace {
@@ -2986,7 +3015,7 @@ mod tests {
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
         arena.free(first.slot).detached_children.release_all();
 
-        let second = arena.allocate();
+        let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         // SAFETY: The second allocation is live and reuses the first allocation's slot.
         let second_data = unsafe { &*second.data };

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -779,6 +779,22 @@ impl LayoutNodeArena {
         data
     }
 
+    pub(crate) fn set_node_generated_for(&self, id: NodeSlotId, generated_for: u8) {
+        self.assert_owner_thread();
+        let data = self.data(id);
+        // SAFETY: data() validated that id names a live slot, and layout
+        // serializes mutation on the arena's owner thread.
+        unsafe { (&raw mut (*data).generated_for).write(generated_for) };
+    }
+
+    pub(crate) fn set_node_style_payloads(&self, id: NodeSlotId, payloads: *const c_void) {
+        self.assert_owner_thread();
+        let data = self.data(id);
+        // SAFETY: As above.
+        unsafe { (&raw mut (*data).style).write(payloads) };
+        self.enroll_node_for_replaced_content_facts_sync_if_eligible(id);
+    }
+
     pub(crate) fn set_node_flag(&self, id: NodeSlotId, flag: NodeFlag, value: bool) {
         self.assert_owner_thread();
         let data = self.data(id);
@@ -2404,6 +2420,32 @@ pub unsafe extern "C" fn layout_arena_set_replaced_content_facts(
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
     unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(id, facts)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_node_flag(arena: *mut c_void, id: NodeSlotId, flag: NodeFlag, value: bool) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_flag(id, flag, value);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_node_generated_for(arena: *mut c_void, id: NodeSlotId, generated_for: u8) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_generated_for(id, generated_for);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_node_style_payloads(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    payloads: *const c_void,
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_style_payloads(id, payloads);
 }
 
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-pub(crate) use crate::abort_on_panic;
 pub(crate) use crate::css::computed_value_types::*;
 pub(crate) use crate::css::computed_value_views::*;
 pub(crate) use crate::css::css_enums::*;

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -49,6 +49,7 @@ use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKind;
 pub(crate) use crate::layout::layout_node_arena::{LayoutNodeArena, RenderedTextBoundary};
 use crate::layout::layout_node_arena::{TableCellMeasurement, TableCellMeasurementKey};
+pub use crate::layout::node_data::FfiNodeConstructionFacts;
 pub use crate::layout::node_data::FfiReplacedContentFacts;
 pub use crate::layout::node_data::FfiStylePayloads;
 use crate::layout::node_data::NodeData;

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -171,6 +171,16 @@ pub enum NodeFlag {
     IsDocumentElement = 1 << 30,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum FfiNodeLink {
+    Parent,
+    FirstChild,
+    LastChild,
+    PreviousSibling,
+    NextSibling,
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiNodeConstructionFacts {

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::layout::CssPixels;
+use std::cell::Cell;
 use std::ffi::c_void;
 
 pub const INVALID_NODE_SLOT_INDEX: u32 = u32::MAX;
@@ -198,51 +199,51 @@ pub struct FfiNodeConstructionFacts {
 
 #[repr(C)]
 pub(crate) struct NodeData {
-    pub parent: NodeSlotId,
-    pub first_child: NodeSlotId,
-    pub last_child: NodeSlotId,
-    pub previous_sibling: NodeSlotId,
-    pub next_sibling: NodeSlotId,
-    pub containing_block: NodeSlotId,
-    pub inline_containing_block: NodeSlotId,
-    pub kind: NodeKind,
-    pub generated_for: u8,
-    pub intrinsic_cache_epoch: u16,
-    pub flags: u32,
+    pub parent: Cell<NodeSlotId>,
+    pub first_child: Cell<NodeSlotId>,
+    pub last_child: Cell<NodeSlotId>,
+    pub previous_sibling: Cell<NodeSlotId>,
+    pub next_sibling: Cell<NodeSlotId>,
+    pub containing_block: Cell<NodeSlotId>,
+    pub inline_containing_block: Cell<NodeSlotId>,
+    pub kind: Cell<NodeKind>,
+    pub generated_for: Cell<u8>,
+    pub intrinsic_cache_epoch: Cell<u16>,
+    pub flags: Cell<u32>,
     /// Advanced on every layout invalidation that reaches this node or its
     /// subtree, with no propagation boundary: unlike the intrinsic epoch,
     /// changes inside absolutely positioned and SVG descendants must reach
     /// every ancestor, because their fragments live in ancestor run trees.
     /// Wide enough that wrapping between a cache store and the next probe
     /// is unreachable.
-    pub fragment_cache_epoch: u32,
-    pub slot_generation: u8,
-    pub table_column_span: u16,
-    pub table_row_span: u16,
-    pub style: *const c_void,
-    pub shell: *mut c_void,
+    pub fragment_cache_epoch: Cell<u32>,
+    pub slot_generation: Cell<u8>,
+    pub table_column_span: Cell<u16>,
+    pub table_row_span: Cell<u16>,
+    pub style: Cell<*const c_void>,
+    pub shell: Cell<*mut c_void>,
 }
 
 impl Default for NodeData {
     fn default() -> Self {
         Self {
-            parent: NodeSlotId::INVALID,
-            first_child: NodeSlotId::INVALID,
-            last_child: NodeSlotId::INVALID,
-            previous_sibling: NodeSlotId::INVALID,
-            next_sibling: NodeSlotId::INVALID,
-            containing_block: NodeSlotId::INVALID,
-            inline_containing_block: NodeSlotId::INVALID,
-            kind: NodeKind::Unset,
-            generated_for: 0,
-            intrinsic_cache_epoch: 0,
-            flags: 0,
-            slot_generation: 0,
-            table_column_span: 1,
-            table_row_span: 1,
-            fragment_cache_epoch: 0,
-            style: std::ptr::null(),
-            shell: std::ptr::null_mut(),
+            parent: Cell::new(NodeSlotId::INVALID),
+            first_child: Cell::new(NodeSlotId::INVALID),
+            last_child: Cell::new(NodeSlotId::INVALID),
+            previous_sibling: Cell::new(NodeSlotId::INVALID),
+            next_sibling: Cell::new(NodeSlotId::INVALID),
+            containing_block: Cell::new(NodeSlotId::INVALID),
+            inline_containing_block: Cell::new(NodeSlotId::INVALID),
+            kind: Cell::new(NodeKind::Unset),
+            generated_for: Cell::new(0),
+            intrinsic_cache_epoch: Cell::new(0),
+            flags: Cell::new(0),
+            slot_generation: Cell::new(0),
+            table_column_span: Cell::new(1),
+            table_row_span: Cell::new(1),
+            fragment_cache_epoch: Cell::new(0),
+            style: Cell::new(std::ptr::null()),
+            shell: Cell::new(std::ptr::null_mut()),
         }
     }
 }
@@ -254,7 +255,7 @@ mod tests {
     #[test]
     fn node_kind_has_a_stable_default_and_byte_width() {
         assert_eq!(std::mem::size_of::<NodeKind>(), 1);
-        assert_eq!(NodeData::default().kind, NodeKind::Unset);
+        assert_eq!(NodeData::default().kind.get(), NodeKind::Unset);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -171,6 +171,21 @@ pub enum NodeFlag {
     IsDocumentElement = 1 << 30,
 }
 
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiNodeConstructionFacts {
+    pub kind: NodeKind,
+    pub shell: *mut c_void,
+    pub is_anonymous: bool,
+    pub is_html_input_element: bool,
+    pub is_html_html_element: bool,
+    pub is_document_element: bool,
+    pub is_in_user_agent_shadow_tree: bool,
+    pub uses_button_layout: bool,
+    pub is_editing_host: bool,
+    pub is_body: bool,
+}
+
 #[repr(C)]
 pub struct NodeData {
     pub parent: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -197,7 +197,7 @@ pub struct FfiNodeConstructionFacts {
 }
 
 #[repr(C)]
-pub struct NodeData {
+pub(crate) struct NodeData {
     pub parent: NodeSlotId,
     pub first_child: NodeSlotId,
     pub last_child: NodeSlotId,

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -189,6 +189,28 @@ pub(crate) fn node_creates_block_formatting_context(
     parent_style.is_some_and(|parent| parent.display().is_flex_inside() || parent.display().is_grid_inside())
 }
 
+pub(crate) fn construction_flags(facts: &FfiNodeConstructionFacts) -> u32 {
+    let has_style = facts.kind != NodeKind::Node && !kind_is_text(facts.kind);
+    // Some native controls use a generic box so they can host their internal shadow tree, but
+    // remain replaced elements for CSS box generation and inline layout.
+    let is_replaced_element = kind_is_replaced_box(facts.kind) || facts.is_html_input_element;
+    [
+        (NodeFlag::Anonymous, facts.is_anonymous),
+        (NodeFlag::HasStyle, has_style),
+        (NodeFlag::IsReplacedElement, is_replaced_element),
+        (NodeFlag::IsHtmlInputElement, facts.is_html_input_element),
+        (NodeFlag::IsHtmlHtmlElement, facts.is_html_html_element),
+        (NodeFlag::IsDocumentElement, facts.is_document_element),
+        (NodeFlag::IsInUserAgentShadowTree, facts.is_in_user_agent_shadow_tree),
+        (NodeFlag::UsesButtonLayout, facts.uses_button_layout),
+        (NodeFlag::IsEditingHost, facts.is_editing_host),
+        (NodeFlag::IsBody, facts.is_body),
+    ]
+    .into_iter()
+    .filter(|(_, is_set)| *is_set)
+    .fold(0, |flags, (flag, _)| flags | flag as u32)
+}
+
 pub(crate) fn has_flag(data: &NodeData, flag: NodeFlag) -> bool {
     data.flags & flag as u32 != 0
 }

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -7,9 +7,9 @@
 use super::*;
 
 pub(crate) fn node_may_have_replaced_content_facts(data: &NodeData) -> bool {
-    kind_is_replaced_box(data.kind)
+    kind_is_replaced_box(data.kind.get())
         || matches!(
-            data.kind,
+            data.kind.get(),
             NodeKind::RangeInputBox | NodeKind::TextAreaBox | NodeKind::TextInputBox
         )
         || has_flag(data, NodeFlag::IsHtmlInputElement)
@@ -22,7 +22,7 @@ pub(crate) fn node_may_have_replaced_content_facts_including_size_containment(da
     if node_may_have_replaced_content_facts(data) {
         return true;
     }
-    if !kind_is_box(data.kind) {
+    if !kind_is_box(data.kind.get()) {
         return false;
     }
     let Some(style) = node_style_view(data) else {
@@ -34,12 +34,12 @@ pub(crate) fn node_may_have_replaced_content_facts_including_size_containment(da
 /// The node's own computed style, read off the style container the node data points at. Callers inside a layout pass go
 /// through the pass callbacks instead; this is for the node-data entry points the C++ side calls directly.
 pub(crate) fn node_style_view(data: &NodeData) -> Option<ComputedValuesView<'_>> {
-    if data.style.is_null() {
+    if data.style.get().is_null() {
         return None;
     }
     // SAFETY: A non-null style pointer addresses the container's group
     // pointer array, which FfiStylePayloads mirrors exactly.
-    let payloads = unsafe { &*data.style.cast::<crate::layout::FfiStylePayloads>() };
+    let payloads = unsafe { &*data.style.get().cast::<crate::layout::FfiStylePayloads>() };
     Some(ComputedValuesView::new(&payloads.groups))
 }
 
@@ -82,7 +82,7 @@ pub(crate) fn node_display(style: Option<ComputedValuesView<'_>>) -> crate::css:
 }
 
 pub(crate) fn node_can_have_children(data: &NodeData) -> bool {
-    match data.kind {
+    match data.kind.get() {
         NodeKind::BreakNode => false,
         NodeKind::AudioBox | NodeKind::VideoBox => has_flag(data, NodeFlag::ReplacedBoxCanHaveChildren),
         NodeKind::SVGSVGBox => true,
@@ -96,7 +96,7 @@ pub(crate) fn node_can_have_children(data: &NodeData) -> bool {
 /// has to ask it too: the boxes inside such a box are laid out against it, not against the block container of the
 /// context the walk started in.
 pub(crate) fn node_forms_containing_block_for_children(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
-    if kind_is_block_container(data.kind) && !node_is_fragmented_inline(data, style) {
+    if kind_is_block_container(data.kind.get()) && !node_is_fragmented_inline(data, style) {
         return true;
     }
     if let Some(style) = style {
@@ -105,7 +105,7 @@ pub(crate) fn node_forms_containing_block_for_children(data: &NodeData, style: O
             return true;
         }
     }
-    kind_is_replaced_box(data.kind) && node_can_have_children(data)
+    kind_is_replaced_box(data.kind.get()) && node_can_have_children(data)
 }
 
 /// https://drafts.csswg.org/css-display/#atomic-inline
@@ -116,7 +116,7 @@ pub(crate) fn node_forms_containing_block_for_children(data: &NodeData, style: O
 /// <fieldset> get a block container box whatever their computed display says.
 pub(crate) fn node_is_atomic_inline(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
     has_flag(data, NodeFlag::IsReplacedElement)
-        || data.kind == NodeKind::ListItemMarkerBox
+        || data.kind.get() == NodeKind::ListItemMarkerBox
         || style.is_some_and(|style| {
             let display = style.display();
             display.is_inline_outside()
@@ -125,8 +125,8 @@ pub(crate) fn node_is_atomic_inline(data: &NodeData, style: Option<ComputedValue
 }
 
 pub(crate) fn node_is_fragmented_inline(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
-    data.kind == NodeKind::InlineNode
-        || (data.kind == NodeKind::ListItemBox
+    data.kind.get() == NodeKind::InlineNode
+        || (data.kind.get() == NodeKind::ListItemBox
             && style.is_some_and(|style| {
                 let display = style.display();
                 display.is_inline_outside() && display.is_flow_inside()
@@ -134,9 +134,9 @@ pub(crate) fn node_is_fragmented_inline(data: &NodeData, style: Option<ComputedV
 }
 
 pub(crate) fn node_has_auto_content_box_size(data: &NodeData) -> bool {
-    (kind_is_replaced_box(data.kind) && data.kind != NodeKind::AudioBox)
+    (kind_is_replaced_box(data.kind.get()) && data.kind.get() != NodeKind::AudioBox)
         || matches!(
-            data.kind,
+            data.kind.get(),
             NodeKind::RangeInputBox | NodeKind::TextAreaBox | NodeKind::TextInputBox
         )
 }
@@ -151,10 +151,10 @@ pub(crate) fn node_creates_block_formatting_context(
     style: Option<ComputedValuesView<'_>>,
     parent_style: Option<ComputedValuesView<'_>>,
 ) -> bool {
-    if kind_is_replaced_box(data.kind) {
+    if kind_is_replaced_box(data.kind.get()) {
         return false;
     }
-    if data.kind == NodeKind::SVGForeignObjectBox {
+    if data.kind.get() == NodeKind::SVGForeignObjectBox {
         return true;
     }
     if let Some(style) = style {
@@ -178,10 +178,10 @@ pub(crate) fn node_creates_block_formatting_context(
         }
     }
     if has_flag(data, NodeFlag::IsHtmlHtmlElement)
-        || data.kind == NodeKind::FieldSetBox
+        || data.kind.get() == NodeKind::FieldSetBox
         // https://drafts.csswg.org/css-lists-3/#list-style-position-outside
         // "If the list item is a block container: the marker box is a block container"
-        || data.kind == NodeKind::ListItemMarkerBox
+        || data.kind.get() == NodeKind::ListItemMarkerBox
         || has_flag(data, NodeFlag::UsesButtonLayout)
     {
         return true;
@@ -212,7 +212,7 @@ pub(crate) fn construction_flags(facts: &FfiNodeConstructionFacts) -> u32 {
 }
 
 pub(crate) fn has_flag(data: &NodeData, flag: NodeFlag) -> bool {
-    data.flags & flag as u32 != 0
+    data.flags.get() & flag as u32 != 0
 }
 
 pub(crate) fn kind_is_text(kind: NodeKind) -> bool {
@@ -315,7 +315,8 @@ impl<'pass> NodeFacts<'pass> {
         // SAFETY: A non-null style pointer addresses the container's group
         // pointer array, which FfiStylePayloads mirrors exactly. The node's
         // ComputedValues keep the container alive for the layout pass.
-        let style_payloads = (!data.style.is_null()).then(|| unsafe { &*data.style.cast::<FfiStylePayloads>() });
+        let style_payloads =
+            (!data.style.get().is_null()).then(|| unsafe { &*data.style.get().cast::<FfiStylePayloads>() });
         Self {
             callbacks,
             node,
@@ -329,7 +330,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     fn parent_data(&self) -> Option<&'pass NodeData> {
-        let parent = self.data().parent;
+        let parent = self.data().parent.get();
         (!parent.is_invalid()).then(|| self.callbacks.node_data(parent))
     }
 
@@ -346,7 +347,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(super) fn parent_computed_values_view_if_styled(&self) -> Option<ComputedValuesView<'pass>> {
-        let parent = self.data().parent;
+        let parent = self.data().parent.get();
         if parent.is_invalid() {
             return None;
         }
@@ -372,35 +373,35 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_text_node(&self) -> bool {
-        kind_is_text(self.data().kind)
+        kind_is_text(self.data().kind.get())
     }
 
     pub(crate) fn is_break_node(&self) -> bool {
-        self.data().kind == NodeKind::BreakNode
+        self.data().kind.get() == NodeKind::BreakNode
     }
 
     pub(crate) fn is_box(&self) -> bool {
-        kind_is_box(self.data().kind)
+        kind_is_box(self.data().kind.get())
     }
 
     pub(crate) fn is_block_container(&self) -> bool {
-        kind_is_block_container(self.data().kind)
+        kind_is_block_container(self.data().kind.get())
     }
 
     pub(crate) fn is_replaced_box(&self) -> bool {
-        kind_is_replaced_box(self.data().kind)
+        kind_is_replaced_box(self.data().kind.get())
     }
 
     pub(crate) fn is_native_form_control_box(&self) -> bool {
         matches!(
-            self.data().kind,
+            self.data().kind.get(),
             NodeKind::RangeInputBox | NodeKind::TextAreaBox | NodeKind::TextInputBox
         )
     }
 
     pub(crate) fn is_replaced_box_with_children(&self) -> bool {
         let data = self.data();
-        kind_is_replaced_box(data.kind) && node_can_have_children(data)
+        kind_is_replaced_box(data.kind.get()) && node_can_have_children(data)
     }
 
     pub(crate) fn is_floating(&self) -> bool {
@@ -428,7 +429,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_inline(&self) -> bool {
-        kind_is_text(self.data().kind)
+        kind_is_text(self.data().kind.get())
             || self
                 .computed_values_view_if_styled()
                 .is_some_and(|style| style.display().is_inline_outside())
@@ -440,7 +441,7 @@ impl<'pass> NodeFacts<'pass> {
 
     pub(crate) fn has_box_model_metrics(&self) -> bool {
         !matches!(
-            self.data().kind,
+            self.data().kind.get(),
             NodeKind::Unset
                 | NodeKind::Node
                 | NodeKind::NodeWithStyle
@@ -486,35 +487,37 @@ impl<'pass> NodeFacts<'pass> {
         if display.is_internal_table() || display.is_table_caption() {
             return false;
         }
-        if parent.kind == NodeKind::SVGForeignObjectBox {
+        if parent.kind.get() == NodeKind::SVGForeignObjectBox {
             return false;
         }
-        if kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGForeignObjectBox {
+        if kind_is_svg_box(data.kind.get()) || data.kind.get() == NodeKind::SVGForeignObjectBox {
             return false;
         }
-        if data.kind == NodeKind::SVGSVGBox && (kind_is_svg_box(parent.kind) || parent.kind == NodeKind::SVGSVGBox) {
+        if data.kind.get() == NodeKind::SVGSVGBox
+            && (kind_is_svg_box(parent.kind.get()) || parent.kind.get() == NodeKind::SVGSVGBox)
+        {
             return false;
         }
-        if kind_is_replaced_box(parent.kind) && node_can_have_children(parent) {
+        if kind_is_replaced_box(parent.kind.get()) && node_can_have_children(parent) {
             return false;
         }
         true
     }
 
     pub(crate) fn is_list_item_marker_box(&self) -> bool {
-        self.data().kind == NodeKind::ListItemMarkerBox
+        self.data().kind.get() == NodeKind::ListItemMarkerBox
     }
 
     pub(crate) fn is_list_item_box(&self) -> bool {
-        self.data().kind == NodeKind::ListItemBox
+        self.data().kind.get() == NodeKind::ListItemBox
     }
 
     pub(crate) fn is_svg_mask_box(&self) -> bool {
-        self.data().kind == NodeKind::SVGMaskBox
+        self.data().kind.get() == NodeKind::SVGMaskBox
     }
 
     pub(crate) fn is_svg_clip_box(&self) -> bool {
-        self.data().kind == NodeKind::SVGClipBox
+        self.data().kind.get() == NodeKind::SVGClipBox
     }
 
     pub(crate) fn is_flow_layout_participant(&self) -> bool {
@@ -539,7 +542,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_generated_for_pseudo_element(&self) -> bool {
-        self.data().generated_for != 0
+        self.data().generated_for.get() != 0
     }
 
     pub(crate) fn children_are_inline(&self) -> bool {
@@ -588,7 +591,7 @@ impl<'pass> NodeFacts<'pass> {
 
     pub(crate) fn vertical_align_applies(&self) -> bool {
         let data = self.data();
-        kind_is_box(data.kind) && !has_flag(data, NodeFlag::IsFlexItem) && !has_flag(data, NodeFlag::IsGridItem)
+        kind_is_box(data.kind.get()) && !has_flag(data, NodeFlag::IsFlexItem) && !has_flag(data, NodeFlag::IsGridItem)
     }
 
     pub(crate) fn is_html_input_element(&self) -> bool {
@@ -596,23 +599,23 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_fieldset_box(&self) -> bool {
-        self.data().kind == NodeKind::FieldSetBox
+        self.data().kind.get() == NodeKind::FieldSetBox
     }
 
     pub(crate) fn rendered_legend(&self) -> Node {
         let data = self.data();
-        if data.kind != NodeKind::FieldSetBox {
+        if data.kind.get() != NodeKind::FieldSetBox {
             return Node::INVALID;
         }
-        let mut child = data.first_child;
+        let mut child = data.first_child.get();
         while !child.is_invalid() {
             let child_data = self.callbacks.node_data(child);
-            if child_data.kind == NodeKind::LegendBox
+            if child_data.kind.get() == NodeKind::LegendBox
                 && !node_is_out_of_flow(child_data, self.callbacks.computed_values_view_if_styled(child))
             {
                 return child;
             }
-            child = child_data.next_sibling;
+            child = child_data.next_sibling.get();
         }
         Node::INVALID
     }
@@ -624,30 +627,30 @@ impl<'pass> NodeFacts<'pass> {
         // Outside markers are direct children. Inside markers participate in
         // an inline run and can therefore move below anonymous block wrappers.
         // Walk those wrappers, but not nested authored or generated list items.
-        let mut candidate = self.data().first_child;
+        let mut candidate = self.data().first_child.get();
         while !candidate.is_invalid() {
             let data = self.callbacks.node_data(candidate);
-            if data.kind == NodeKind::ListItemMarkerBox {
+            if data.kind.get() == NodeKind::ListItemMarkerBox {
                 return candidate;
             }
-            if data.kind == NodeKind::BlockContainer
+            if data.kind.get() == NodeKind::BlockContainer
                 && has_flag(data, NodeFlag::Anonymous)
-                && data.generated_for == 0
-                && !data.first_child.is_invalid()
+                && data.generated_for.get() == 0
+                && !data.first_child.get().is_invalid()
             {
-                candidate = data.first_child;
+                candidate = data.first_child.get();
                 continue;
             }
             let mut current_data = data;
             loop {
-                if !current_data.next_sibling.is_invalid() {
-                    candidate = current_data.next_sibling;
+                if !current_data.next_sibling.get().is_invalid() {
+                    candidate = current_data.next_sibling.get();
                     break;
                 }
-                if current_data.parent == self.node {
+                if current_data.parent.get() == self.node {
                     return Node::INVALID;
                 }
-                current_data = self.callbacks.node_data(current_data.parent);
+                current_data = self.callbacks.node_data(current_data.parent.get());
             }
         }
         Node::INVALID
@@ -739,22 +742,22 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_scroll_container(&self) -> bool {
-        kind_and_style_make_scroll_container(self.data().kind, self.computed_values_view_if_styled())
+        kind_and_style_make_scroll_container(self.data().kind.get(), self.computed_values_view_if_styled())
     }
 
     pub(crate) fn display(&self) -> crate::layout::FfiDisplay {
-        if self.data().style.is_null() {
+        if self.data().style.get().is_null() {
             return crate::layout::FfiDisplay::block();
         }
         self.style().display()
     }
 
     pub(crate) fn is_svg_box(&self) -> bool {
-        kind_is_svg_box(self.data().kind)
+        kind_is_svg_box(self.data().kind.get())
     }
 
     pub(crate) fn is_svg_svg_box(&self) -> bool {
-        self.data().kind == NodeKind::SVGSVGBox
+        self.data().kind.get() == NodeKind::SVGSVGBox
     }
 
     pub(crate) fn is_table_box(&self) -> bool {
@@ -762,7 +765,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_table_wrapper(&self) -> bool {
-        self.data().kind == NodeKind::TableWrapper
+        self.data().kind.get() == NodeKind::TableWrapper
     }
 
     pub(crate) fn is_table_row_group(&self) -> bool {
@@ -802,7 +805,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_viewport(&self) -> bool {
-        self.data().kind == NodeKind::Viewport
+        self.data().kind.get() == NodeKind::Viewport
     }
 
     pub(crate) fn document_in_quirks_mode(&self) -> bool {
@@ -825,10 +828,11 @@ impl<'pass> NodeFacts<'pass> {
 #[cfg(test)]
 mod node_facts_tests {
     use crate::layout::node_data::{NodeData, NodeFlag, NodeKind};
+    use std::cell::Cell;
 
     fn data_with_kind(kind: NodeKind) -> NodeData {
         NodeData {
-            kind,
+            kind: Cell::new(kind),
             ..NodeData::default()
         }
     }
@@ -849,11 +853,11 @@ mod node_facts_tests {
         assert!(super::node_can_have_children(&data_with_kind(NodeKind::InlineNode)));
         assert!(super::node_can_have_children(&data_with_kind(NodeKind::TextNode)));
 
-        let mut media = data_with_kind(NodeKind::AudioBox);
+        let media = data_with_kind(NodeKind::AudioBox);
         assert!(!super::node_can_have_children(&media));
-        media.flags = NodeFlag::ReplacedBoxCanHaveChildren as u32;
+        media.flags.set(NodeFlag::ReplacedBoxCanHaveChildren as u32);
         assert!(super::node_can_have_children(&media));
-        media.kind = NodeKind::VideoBox;
+        media.kind.set(NodeKind::VideoBox);
         assert!(super::node_can_have_children(&media));
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::abort_on_panic;
 use crate::layout::LayoutNodeArena;
 use crate::layout::formatting_context::{FfiFormattingContextType, formatting_context_type_created_by_node_data};
 use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
@@ -458,10 +457,8 @@ impl LayoutNodeArena {
 /// in this arena.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_is_partial_relayout_boundary(arena: *mut c_void, node: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.node_is_partial_relayout_boundary(node)
-    })
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_is_partial_relayout_boundary(node)
 }
 
 /// # Safety
@@ -469,10 +466,8 @@ pub unsafe extern "C" fn layout_arena_node_is_partial_relayout_boundary(arena: *
 /// The arena must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_has_partial_relayout_boundary_roots(arena: *mut c_void) -> bool {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.has_partial_relayout_boundary_roots()
-    })
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.has_partial_relayout_boundary_roots()
 }
 
 /// # Safety
@@ -485,14 +480,12 @@ pub unsafe extern "C" fn layout_arena_take_partial_relayout_boundary_roots(
     context: *mut c_void,
     push_root: unsafe extern "C" fn(*mut c_void, NodeSlotId),
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-        for root in arena.take_partial_relayout_boundary_roots() {
-            // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
-            unsafe { push_root(context, root) };
-        }
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    for root in arena.take_partial_relayout_boundary_roots() {
+        // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
+        unsafe { push_root(context, root) };
+    }
 }
 
 /// # Safety
@@ -510,32 +503,30 @@ pub unsafe extern "C" fn layout_arena_collect_partial_relayout_roots(
     context: *mut c_void,
     push_root: unsafe extern "C" fn(*mut c_void, NodeSlotId),
 ) -> bool {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena and both slot arrays alive for this call.
-        let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-        let registered = if registered_root_count == 0 {
-            &[]
-        } else {
-            // SAFETY: A nonzero count implies a valid array of that length.
-            unsafe { std::slice::from_raw_parts(registered_root_slots, registered_root_count) }
-        };
-        let rebuilt = if rebuilt_subtree_root_count == 0 {
-            &[]
-        } else {
-            // SAFETY: A nonzero count implies a valid array of that length.
-            unsafe { std::slice::from_raw_parts(rebuilt_subtree_root_slots, rebuilt_subtree_root_count) }
-        };
-        match arena.collect_partial_relayout_roots(registered, rebuilt) {
-            Some(roots) => {
-                for root in roots {
-                    // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
-                    unsafe { push_root(context, root) };
-                }
-                true
+    // SAFETY: The C++ caller keeps the arena and both slot arrays alive for this call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    let registered = if registered_root_count == 0 {
+        &[]
+    } else {
+        // SAFETY: A nonzero count implies a valid array of that length.
+        unsafe { std::slice::from_raw_parts(registered_root_slots, registered_root_count) }
+    };
+    let rebuilt = if rebuilt_subtree_root_count == 0 {
+        &[]
+    } else {
+        // SAFETY: A nonzero count implies a valid array of that length.
+        unsafe { std::slice::from_raw_parts(rebuilt_subtree_root_slots, rebuilt_subtree_root_count) }
+    };
+    match arena.collect_partial_relayout_roots(registered, rebuilt) {
+        Some(roots) => {
+            for root in roots {
+                // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
+                unsafe { push_root(context, root) };
             }
-            None => false,
+            true
         }
-    })
+        None => false,
+    }
 }
 
 /// # Safety
@@ -547,10 +538,8 @@ pub unsafe extern "C" fn layout_arena_reset_cached_intrinsic_sizes_of_self_and_a
     arena: *mut c_void,
     node: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.reset_cached_intrinsic_sizes_of_self_and_ancestors(node);
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.reset_cached_intrinsic_sizes_of_self_and_ancestors(node);
 }
 
 /// # Safety
@@ -563,11 +552,9 @@ pub unsafe extern "C" fn layout_arena_classify_layout_tree_update(
     node: NodeSlotId,
     reason_is_structural_boundary_self_rebuild: bool,
 ) -> FfiLayoutTreeUpdateClassification {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }
-            .classify_layout_tree_update(node, reason_is_structural_boundary_self_rebuild)
-    })
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }
+        .classify_layout_tree_update(node, reason_is_structural_boundary_self_rebuild)
 }
 
 /// # Safety
@@ -580,10 +567,8 @@ pub unsafe extern "C" fn layout_arena_set_needs_layout_update(
     node: NodeSlotId,
     propagate_through_ancestors: bool,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe { LayoutNodeArena::from_handle(arena) }.set_needs_layout_update(node, propagate_through_ancestors);
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.set_needs_layout_update(node, propagate_through_ancestors);
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -588,10 +588,7 @@ mod tests {
     }
 
     fn free_node(arena: &mut LayoutNodeArena, allocation: &NodeAllocation) {
-        arena
-            .free(allocation.slot, allocation.generation)
-            .detached_children
-            .release_all();
+        arena.free(allocation.slot).detached_children.release_all();
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -577,7 +577,7 @@ mod tests {
     use crate::layout::node_data::{NodeFlag, NodeKind, NodeSlotId};
 
     fn allocate_box_with_a_dummy_shell(arena: &mut LayoutNodeArena) -> NodeAllocation {
-        let allocation = arena.allocate();
+        let allocation = arena.allocate_for_test();
         // SAFETY: allocate() returned this live slot's data pointer. The dummy shell
         // pointer is only ever compared against null, never dereferenced.
         unsafe {
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn a_box_without_a_committed_row_or_splice_derivable_ancestors_is_not_a_boundary() {
         let mut arena = LayoutNodeArena::new();
-        let allocation = arena.allocate();
+        let allocation = arena.allocate_for_test();
         // SAFETY: allocate() returned this live slot's data pointer.
         unsafe {
             (*allocation.data).kind = NodeKind::Box;

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -30,9 +30,7 @@ impl LayoutNodeArena {
         reason_is_structural_boundary_self_rebuild: bool,
     ) -> FfiLayoutTreeUpdateClassification {
         let data = self.data(node);
-        // SAFETY: data() generation-checks every slot this classification visits; the raw
-        // reads never overlap a write.
-        let (kind, parent) = unsafe { ((&raw const (*data).kind).read(), (&raw const (*data).parent).read()) };
+        let (kind, parent) = (data.kind.get(), data.parent.get());
 
         let marks_boundary_self_only = node_facts::kind_is_box(kind)
             && reason_is_structural_boundary_self_rebuild
@@ -43,13 +41,9 @@ impl LayoutNodeArena {
             let mut ancestor = parent;
             let mut ancestor_is_first = true;
             while !ancestor.is_invalid() {
-                // SAFETY: As above.
-                let (ancestor_flags, ancestor_parent) = unsafe {
+                let (ancestor_flags, ancestor_parent) = {
                     let ancestor_data = self.data(ancestor);
-                    (
-                        (&raw const (*ancestor_data).flags).read(),
-                        (&raw const (*ancestor_data).parent).read(),
-                    )
+                    (ancestor_data.flags.get(), ancestor_data.parent.get())
                 };
                 if ancestor_flags & NodeFlag::Anonymous as u32 == 0 {
                     if !ancestor_is_first {
@@ -71,25 +65,22 @@ impl LayoutNodeArena {
 
     fn commit_splice_position_is_derivable_from_layout_ancestors(&self, node: NodeSlotId) -> bool {
         let paintable_rows = self.paintable_rows();
-        // SAFETY: data() generation-checks every slot the walk visits.
-        let mut ancestor = unsafe { (*self.data(node)).parent };
+        let mut ancestor = self.data(node).parent.get();
         while !ancestor.is_invalid() {
             if paintable_rows.paintable_row_is_populated(ancestor) {
                 return true;
             }
-            // SAFETY: data() generation-checks every slot the walk visits.
-            let ancestor_data = unsafe { &*self.data(ancestor) };
+            let ancestor_data = self.data(ancestor);
             if !node_facts::node_is_fragmented_inline(ancestor_data, node_facts::node_style_view(ancestor_data)) {
                 return false;
             }
-            ancestor = ancestor_data.parent;
+            ancestor = ancestor_data.parent.get();
         }
         false
     }
 
     pub(crate) fn node_is_partial_relayout_boundary(&self, node: NodeSlotId) -> bool {
-        // SAFETY: The caller supplies a live slot; data() generation-checks it.
-        let data = unsafe { &*self.data(node) };
+        let data = self.data(node);
 
         // An absolutely or fixed positioned descendant whose containing block is outside this
         // box's subtree is laid out by a formatting context outside it, which makes subtree
@@ -113,7 +104,7 @@ impl LayoutNodeArena {
         // own user units, so a nested <svg> is just as reproducible from its own root as the
         // outermost one. An absolutely positioned SVG root's placement is not frozen, so it must
         // qualify through the saved-inputs replay path below instead.
-        if data.kind == NodeKind::SVGSVGBox && !style_is_absolutely_positioned {
+        if data.kind.get() == NodeKind::SVGSVGBox && !style_is_absolutely_positioned {
             return node_facts::has_flag(data, NodeFlag::HasCommittedFragmentLink);
         }
 
@@ -140,8 +131,8 @@ impl LayoutNodeArena {
         //       not disqualify a boundary: replay re-solves the boundary's own size, and a resized
         //       boundary triggers ancestor scrollable overflow recomputation after commit.
 
-        let parent_style = (!data.parent.is_invalid())
-            .then(|| self.style_payloads(data.parent))
+        let parent_style = (!data.parent.get().is_invalid())
+            .then(|| self.style_payloads(data.parent.get()))
             .flatten()
             .map(|payloads| crate::css::computed_value_views::ComputedValuesView::new(&payloads.groups));
         matches!(
@@ -156,8 +147,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn register_partial_relayout_boundary_root(&self, node: NodeSlotId) {
-        // SAFETY: The caller supplies a live slot; data() generation-checks it.
-        let kind = unsafe { (*self.data(node)).kind };
+        let kind = self.data(node).kind.get();
         assert!(node_facts::kind_is_box(kind));
         let mut roots = self.partial_relayout_boundary_roots.borrow_mut();
         roots.retain(|candidate| !self.shell_if_live(*candidate).is_null());
@@ -179,19 +169,17 @@ impl LayoutNodeArena {
     }
 
     fn nearest_inclusive_partial_relayout_boundary(&self, node: NodeSlotId) -> Option<NodeSlotId> {
-        // SAFETY: data() generation-checks every slot the walk visits.
-        let (node_kind, mut ancestor) = unsafe {
+        let (node_kind, mut ancestor) = {
             let data = self.data(node);
-            ((&raw const (*data).kind).read(), (&raw const (*data).parent).read())
+            (data.kind.get(), data.parent.get())
         };
         if node_facts::kind_is_box(node_kind) && self.node_is_partial_relayout_boundary(node) {
             return Some(node);
         }
         while !ancestor.is_invalid() {
-            // SAFETY: As above.
-            let (ancestor_kind, ancestor_parent) = unsafe {
+            let (ancestor_kind, ancestor_parent) = {
                 let data = self.data(ancestor);
-                ((&raw const (*data).kind).read(), (&raw const (*data).parent).read())
+                (data.kind.get(), data.parent.get())
             };
             if node_facts::kind_is_box(ancestor_kind) && self.node_is_partial_relayout_boundary(ancestor) {
                 return Some(ancestor);
@@ -220,8 +208,7 @@ impl LayoutNodeArena {
 
             // A replaced box applies the saved-inputs validity check unconditionally: the change
             // that drove the replacement cannot be classified anymore.
-            // SAFETY: Collected boundaries name live slots; data() generation-checks them.
-            let boundary_data = unsafe { &*self.data(boundary) };
+            let boundary_data = self.data(boundary);
             let saved_inputs_may_be_style_stale =
                 node_facts::has_flag(boundary_data, NodeFlag::NeedsOwnGeometryUpdate) || boundary_box_was_replaced;
             let boundary_is_absolutely_positioned =
@@ -246,8 +233,7 @@ impl LayoutNodeArena {
             if self.shell_if_live(slot).is_null() {
                 continue;
             }
-            // SAFETY: shell_if_live established a live slot of this generation.
-            let parent = unsafe { (&raw const (*self.data(slot)).parent).read() };
+            let parent = self.data(slot).parent.get();
             if parent.is_invalid() {
                 continue;
             }
@@ -268,14 +254,12 @@ impl LayoutNodeArena {
 
         // A root nested inside another root is relaid out as part of the ancestor's subtree.
         partial_relayout_roots.retain(|&root| {
-            // SAFETY: Collected roots name live slots; data() generation-checks every slot
-            // the walk visits.
-            let mut ancestor = unsafe { (&raw const (*self.data(root)).parent).read() };
+            let mut ancestor = self.data(root).parent.get();
             while !ancestor.is_invalid() {
                 if collected_boundaries.contains(&ancestor) {
                     return false;
                 }
-                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+                ancestor = self.data(ancestor).parent.get();
             }
             true
         });
@@ -287,10 +271,9 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_can_replay_saved_abspos_layout_inputs_after_style_change(&self, node: NodeSlotId) -> bool {
-        // SAFETY: The caller supplies a live slot; data() generation-checks it.
-        let data = unsafe { &*self.data(node) };
+        let data = self.data(node);
 
-        if data.containing_block.is_invalid() || !self.slot_is_live(data.containing_block) {
+        if data.containing_block.get().is_invalid() || !self.slot_is_live(data.containing_block.get()) {
             return false;
         }
 
@@ -314,8 +297,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn reset_cached_intrinsic_sizes_of_self_and_ancestors(&self, node: NodeSlotId) {
-        // SAFETY: data() generation-checks the slot; the raw read ends before the epoch write.
-        let node_kind = unsafe { (&raw const (*self.data(node)).kind).read() };
+        let node_kind = self.data(node).kind.get();
         if node_facts::kind_is_box(node_kind) {
             self.reset_cached_intrinsic_sizes(node);
         }
@@ -328,18 +310,10 @@ impl LayoutNodeArena {
     // SVG root elements have intrinsic sizes determined solely by their own attributes
     // (width, height, viewBox), not by their children, so the same logic applies.
     fn reset_cached_intrinsic_sizes_of_ancestors(&self, node: NodeSlotId) {
-        // SAFETY: data() generation-checks every slot the walk visits; the raw reads
-        // end before the epoch write for the same node.
-        let mut ancestor = unsafe { (&raw const (*self.data(node)).parent).read() };
+        let mut ancestor = self.data(node).parent.get();
         while !ancestor.is_invalid() {
             let ancestor_data = self.data(ancestor);
-            // SAFETY: As above.
-            let (ancestor_kind, ancestor_parent) = unsafe {
-                (
-                    (&raw const (*ancestor_data).kind).read(),
-                    (&raw const (*ancestor_data).parent).read(),
-                )
-            };
+            let (ancestor_kind, ancestor_parent) = { (ancestor_data.kind.get(), ancestor_data.parent.get()) };
             if node_facts::kind_is_box(ancestor_kind) {
                 self.reset_cached_intrinsic_sizes(ancestor);
                 let ancestor_is_absolutely_positioned = self
@@ -359,13 +333,12 @@ impl LayoutNodeArena {
         self.bump_fragment_cache_epoch_of_self_and_ancestors(node);
 
         let data = self.data(node);
-        // SAFETY: data() generation-checks the slot; the raw reads end before any write.
-        let (node_was_already_dirty, node_is_box, first_child, parent) = unsafe {
+        let (node_was_already_dirty, node_is_box, first_child, parent) = {
             (
-                (&raw const (*data).flags).read() & NodeFlag::NeedsLayoutUpdate as u32 != 0,
-                node_facts::kind_is_box((&raw const (*data).kind).read()),
-                (&raw const (*data).first_child).read(),
-                (&raw const (*data).parent).read(),
+                data.flags.get() & NodeFlag::NeedsLayoutUpdate as u32 != 0,
+                node_facts::kind_is_box(data.kind.get()),
+                data.first_child.get(),
+                data.parent.get(),
             )
         };
 
@@ -396,22 +369,18 @@ impl LayoutNodeArena {
         let mut child = first_child;
         while !child.is_invalid() {
             let child_data = self.data(child);
-            // SAFETY: data() generation-checks every slot the walk visits; the raw reads
-            // end before the flag and epoch writes for the same child.
-            let (child_kind, child_is_anonymous, next_sibling) = unsafe {
+            let (child_kind, child_is_anonymous, next_sibling) = {
                 (
-                    (&raw const (*child_data).kind).read(),
-                    (&raw const (*child_data).flags).read() & NodeFlag::Anonymous as u32 != 0,
-                    (&raw const (*child_data).next_sibling).read(),
+                    child_data.kind.get(),
+                    child_data.flags.get() & NodeFlag::Anonymous as u32 != 0,
+                    child_data.next_sibling.get(),
                 )
             };
             if node_facts::kind_is_box(child_kind) && child_is_anonymous && child_kind != NodeKind::TableWrapper {
                 if fragment_cache_epochs_enabled {
-                    // SAFETY: As above; layout serializes mutation on the arena's owner thread.
-                    unsafe {
-                        let epoch = &raw mut (*child_data).fragment_cache_epoch;
-                        epoch.write(epoch.read().wrapping_add(1));
-                    }
+                    child_data
+                        .fragment_cache_epoch
+                        .set(child_data.fragment_cache_epoch.get().wrapping_add(1));
                 }
                 self.set_node_flag(child, NodeFlag::NeedsLayoutUpdate, true);
                 self.reset_cached_intrinsic_sizes(child);
@@ -427,13 +396,11 @@ impl LayoutNodeArena {
         let mut ancestor = parent;
         while !ancestor.is_invalid() {
             let ancestor_data = self.data(ancestor);
-            // SAFETY: data() generation-checks every slot the walk visits; the raw reads
-            // end before the flag write for the same ancestor.
-            let (ancestor_kind, ancestor_is_dirty, ancestor_parent) = unsafe {
+            let (ancestor_kind, ancestor_is_dirty, ancestor_parent) = {
                 (
-                    (&raw const (*ancestor_data).kind).read(),
-                    (&raw const (*ancestor_data).flags).read() & NodeFlag::NeedsLayoutUpdate as u32 != 0,
-                    (&raw const (*ancestor_data).parent).read(),
+                    ancestor_data.kind.get(),
+                    ancestor_data.flags.get() & NodeFlag::NeedsLayoutUpdate as u32 != 0,
+                    ancestor_data.parent.get(),
                 )
             };
             if ancestor_is_dirty {
@@ -578,12 +545,8 @@ mod tests {
 
     fn allocate_box_with_a_dummy_shell(arena: &mut LayoutNodeArena) -> NodeAllocation {
         let allocation = arena.allocate_for_test();
-        // SAFETY: allocate() returned this live slot's data pointer. The dummy shell
-        // pointer is only ever compared against null, never dereferenced.
-        unsafe {
-            (*allocation.data).kind = NodeKind::Box;
-            (*allocation.data).shell = allocation.data.cast();
-        }
+        arena.data(allocation.slot).kind.set(NodeKind::Box);
+        arena.data(allocation.slot).shell.set(std::ptr::dangling_mut());
         allocation
     }
 
@@ -595,10 +558,7 @@ mod tests {
     fn a_box_without_a_committed_row_or_splice_derivable_ancestors_is_not_a_boundary() {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
-        // SAFETY: allocate() returned this live slot's data pointer.
-        unsafe {
-            (*allocation.data).kind = NodeKind::Box;
-        }
+        arena.data(allocation.slot).kind.set(NodeKind::Box);
         assert!(!arena.node_is_partial_relayout_boundary(allocation.slot));
         free_node(&mut arena, &allocation);
     }
@@ -643,14 +603,12 @@ mod tests {
         free_node(&mut arena, &second);
     }
 
-    fn node_is_dirty(allocation: &NodeAllocation) -> bool {
-        // SAFETY: The allocation is still live, so its data pointer addresses the arena slot.
-        unsafe { (*allocation.data).flags & NodeFlag::NeedsLayoutUpdate as u32 != 0 }
+    fn node_is_dirty(arena: &LayoutNodeArena, allocation: &NodeAllocation) -> bool {
+        arena.data(allocation.slot).flags.get() & NodeFlag::NeedsLayoutUpdate as u32 != 0
     }
 
-    fn intrinsic_cache_epoch(allocation: &NodeAllocation) -> u16 {
-        // SAFETY: The allocation is still live, so its data pointer addresses the arena slot.
-        unsafe { (*allocation.data).intrinsic_cache_epoch }
+    fn intrinsic_cache_epoch(arena: &LayoutNodeArena, allocation: &NodeAllocation) -> u16 {
+        arena.data(allocation.slot).intrinsic_cache_epoch.get()
     }
 
     #[test]
@@ -662,10 +620,10 @@ mod tests {
 
         arena.set_needs_layout_update(child.slot, true);
 
-        assert!(node_is_dirty(&child));
-        assert!(node_is_dirty(&parent));
-        assert_eq!(intrinsic_cache_epoch(&child), 1);
-        assert_eq!(intrinsic_cache_epoch(&parent), 1);
+        assert!(node_is_dirty(&arena, &child));
+        assert!(node_is_dirty(&arena, &parent));
+        assert_eq!(intrinsic_cache_epoch(&arena, &child), 1);
+        assert_eq!(intrinsic_cache_epoch(&arena, &parent), 1);
         free_node(&mut arena, &parent);
     }
 
@@ -681,8 +639,8 @@ mod tests {
 
         arena.set_needs_layout_update(child.slot, true);
 
-        assert!(node_is_dirty(&child));
-        assert!(!node_is_dirty(&grandparent));
+        assert!(node_is_dirty(&arena, &child));
+        assert!(!node_is_dirty(&arena, &grandparent));
         free_node(&mut arena, &grandparent);
     }
 
@@ -696,8 +654,8 @@ mod tests {
 
         arena.set_needs_layout_update(child.slot, true);
 
-        assert!(!node_is_dirty(&parent));
-        assert_eq!(intrinsic_cache_epoch(&parent), 0);
+        assert!(!node_is_dirty(&arena, &parent));
+        assert_eq!(intrinsic_cache_epoch(&arena, &parent), 0);
         free_node(&mut arena, &parent);
     }
 
@@ -708,22 +666,28 @@ mod tests {
         let anonymous_child = allocate_box_with_a_dummy_shell(&mut arena);
         let anonymous_table_wrapper_child = allocate_box_with_a_dummy_shell(&mut arena);
         let named_child = allocate_box_with_a_dummy_shell(&mut arena);
-        // SAFETY: allocate() returned these live slots' data pointers.
-        unsafe {
-            (*anonymous_child.data).flags |= NodeFlag::Anonymous as u32;
-            (*anonymous_table_wrapper_child.data).flags |= NodeFlag::Anonymous as u32;
-            (*anonymous_table_wrapper_child.data).kind = NodeKind::TableWrapper;
-        }
+        arena
+            .data(anonymous_child.slot)
+            .flags
+            .set(arena.data(anonymous_child.slot).flags.get() | (NodeFlag::Anonymous as u32));
+        arena
+            .data(anonymous_table_wrapper_child.slot)
+            .flags
+            .set(arena.data(anonymous_table_wrapper_child.slot).flags.get() | (NodeFlag::Anonymous as u32));
+        arena
+            .data(anonymous_table_wrapper_child.slot)
+            .kind
+            .set(NodeKind::TableWrapper);
         arena.insert_child(parent.slot, anonymous_child.slot, NodeSlotId::INVALID);
         arena.insert_child(parent.slot, anonymous_table_wrapper_child.slot, NodeSlotId::INVALID);
         arena.insert_child(parent.slot, named_child.slot, NodeSlotId::INVALID);
 
         arena.set_needs_layout_update(parent.slot, true);
 
-        assert!(node_is_dirty(&parent));
-        assert!(node_is_dirty(&anonymous_child));
-        assert!(!node_is_dirty(&anonymous_table_wrapper_child));
-        assert!(!node_is_dirty(&named_child));
+        assert!(node_is_dirty(&arena, &parent));
+        assert!(node_is_dirty(&arena, &anonymous_child));
+        assert!(!node_is_dirty(&arena, &anonymous_table_wrapper_child));
+        assert!(!node_is_dirty(&arena, &named_child));
         free_node(&mut arena, &parent);
     }
 
@@ -752,10 +716,10 @@ mod tests {
         let grandparent = allocate_box_with_a_dummy_shell(&mut arena);
         let anonymous_parent = allocate_box_with_a_dummy_shell(&mut arena);
         let child = allocate_box_with_a_dummy_shell(&mut arena);
-        // SAFETY: allocate() returned this live slot's data pointer.
-        unsafe {
-            (*anonymous_parent.data).flags |= NodeFlag::Anonymous as u32;
-        }
+        arena
+            .data(anonymous_parent.slot)
+            .flags
+            .set(arena.data(anonymous_parent.slot).flags.get() | (NodeFlag::Anonymous as u32));
         arena.insert_child(grandparent.slot, anonymous_parent.slot, NodeSlotId::INVALID);
         arena.insert_child(anonymous_parent.slot, child.slot, NodeSlotId::INVALID);
 
@@ -787,8 +751,8 @@ mod tests {
 
         arena.set_needs_layout_update(child.slot, false);
 
-        assert!(node_is_dirty(&child));
-        assert!(!node_is_dirty(&parent));
+        assert!(node_is_dirty(&arena, &child));
+        assert!(!node_is_dirty(&arena, &parent));
         assert_eq!(arena.take_partial_relayout_boundary_roots(), vec![child.slot]);
         free_node(&mut arena, &parent);
     }

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -425,19 +425,19 @@ impl SvgFormattingContext {
     }
 
     fn first_child(&self, node: Node) -> Node {
-        self.callbacks.node_data(node).first_child
+        self.callbacks.node_data(node).first_child.get()
     }
 
     fn next_sibling(&self, node: Node) -> Node {
-        self.callbacks.node_data(node).next_sibling
+        self.callbacks.node_data(node).next_sibling.get()
     }
 
     fn parent(&self, node: Node) -> Node {
-        self.callbacks.node_data(node).parent
+        self.callbacks.node_data(node).parent.get()
     }
 
     fn node_kind(&self, node: Node) -> NodeKind {
-        self.callbacks.node_data(node).kind
+        self.callbacks.node_data(node).kind.get()
     }
 
     fn svg_facts(&self, node: Node) -> FfiSvgElementFacts {

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -670,7 +670,7 @@ fn matching_children<T: TableTree>(tree: &T, parent: Node, predicate: impl Fn(Ff
     let mut result = Vec::new();
     let mut child = tree.first_child(parent);
     while !child.is_invalid() {
-        if node_facts::kind_is_box(tree.node_data(child).kind) && predicate(tree.display(child)) {
+        if node_facts::kind_is_box(tree.node_data(child).kind.get()) && predicate(tree.display(child)) {
             result.push(child);
         }
         child = tree.next_sibling(child);
@@ -689,7 +689,7 @@ fn count_columns_in_subtree<T: TableTree>(tree: &T, root: Node) -> usize {
             child = tree.next_sibling(child);
         }
         for child in children.into_iter().rev() {
-            if node_facts::kind_is_box(tree.node_data(child).kind) && tree.display(child).is_table_column() {
+            if node_facts::kind_is_box(tree.node_data(child).kind.get()) && tree.display(child).is_table_column() {
                 count = count.saturating_add(tree.table_column_span(child));
             }
             stack.push(child);
@@ -765,7 +765,7 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
 
     let mut child = tree.first_child(table);
     while !child.is_invalid() {
-        let child_is_box = node_facts::kind_is_box(tree.node_data(child).kind);
+        let child_is_box = node_facts::kind_is_box(tree.node_data(child).kind.get());
         let child_display = tree.display(child);
         if child_is_box
             && (child_display.is_table_row_group()
@@ -824,11 +824,11 @@ pub(crate) trait TableTree {
     fn display(&self, node: Node) -> FfiDisplay;
 
     fn table_column_span(&self, node: Node) -> usize {
-        self.node_data(node).table_column_span as usize
+        self.node_data(node).table_column_span.get() as usize
     }
 
     fn table_row_span(&self, node: Node) -> usize {
-        self.node_data(node).table_row_span as usize
+        self.node_data(node).table_row_span.get() as usize
     }
 
     fn row_is_collapsed(&self, _row: Node, _row_group: Option<Node>) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -355,12 +355,12 @@ pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
     }
 
     // SAFETY: The arena and layout node remain live throughout the ancestor walk.
-    let mut ancestor = unsafe { &*(*arena).data(layout_node) }.parent;
+    let mut ancestor = unsafe { &*arena }.data(layout_node).parent.get();
     while !ancestor.is_invalid() {
         // SAFETY: `ancestor` is a live layout node with a live shell.
-        let data = unsafe { &*(*arena).data(ancestor) };
-        let shell = data.shell;
-        let parent = data.parent;
+        let data = unsafe { &*arena }.data(ancestor);
+        let shell = data.shell.get();
+        let parent = data.parent.get();
         let dom_node = unsafe { (callbacks.layout_dom_node)(shell) };
         // SAFETY: Both DOM pointers remain live throughout cleanup.
         if !dom_node.is_null()
@@ -390,14 +390,14 @@ fn topmost_layout_node_of_top_layer_placement(arena: *mut LayoutNodeArena, layou
     let mut direct_viewport_child_candidate = layout_node;
     loop {
         // SAFETY: The caller guarantees a live arena, and parent links only name live slots.
-        let parent = unsafe { &*(*arena).data(direct_viewport_child_candidate) }.parent;
+        let parent = unsafe { &*arena }.data(direct_viewport_child_candidate).parent.get();
         if parent.is_invalid() {
             return NodeSlotId::INVALID;
         }
         // SAFETY: `parent` is a live layout node.
-        let parent_data = unsafe { &*(*arena).data(parent) };
+        let parent_data = unsafe { &*arena }.data(parent);
         if !node_has_flag(parent_data, NodeFlag::Anonymous) {
-            return if parent_data.kind == NodeKind::Viewport {
+            return if parent_data.kind.get() == NodeKind::Viewport {
                 direct_viewport_child_candidate
             } else {
                 NodeSlotId::INVALID
@@ -433,8 +433,7 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
         } else {
             topmost
         };
-        // SAFETY: The chosen layout subtree and its shell remain live throughout detachment.
-        let shell = unsafe { (*(*arena).data(layout_node_to_detach)).shell };
+        let shell = unsafe { &*arena }.data(layout_node_to_detach).shell.get();
         // SAFETY: The C++ detach preparation walks the still-linked subtree; the arena borrow
         // ends before the release below re-enters it.
         unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
@@ -1024,7 +1023,7 @@ unsafe fn update_principal_node_descendants(
             let can_have_children = node_facts::node_can_have_children(layout_node_data);
             (
                 can_have_children,
-                node_facts::kind_is_replaced_box(layout_node_data.kind) && can_have_children,
+                node_facts::kind_is_replaced_box(layout_node_data.kind.get()) && can_have_children,
             )
         };
         let prior_quote_nesting_level = state.quote_nesting_level;
@@ -1254,7 +1253,7 @@ unsafe fn update_principal_node_descendants(
                 && !context.has_svg_root
             {
                 state.ancestor_stack.push(layout_node);
-                if layout_host.data(layout_node).kind == NodeKind::ListItemBox {
+                if layout_host.data(layout_node).kind.get() == NodeKind::ListItemBox {
                     let placed = create_pseudo_element(
                         host,
                         state,
@@ -1275,7 +1274,7 @@ unsafe fn update_principal_node_descendants(
                 assert!(state.ancestor_stack.pop().is_some());
 
                 // SAFETY: The layout node's shell and its associated DOM node remain live throughout the call.
-                if node_kind_is_block_container(layout_host.data(layout_node).kind)
+                if node_kind_is_block_container(layout_host.data(layout_node).kind.get())
                     && unsafe { (host.callbacks.layout_node_has_first_letter_style)(layout_host.shell(layout_node)) }
                 {
                     let target = find_first_letter_in_block(host, layout_node);
@@ -1553,7 +1552,7 @@ fn update_principal_node_after_entry(
             is_element: entry_facts.is_element,
             rendered_in_top_layer: entry_facts.rendered_in_top_layer,
         };
-        let layout_node_is_svg_box = node_kind_is_svg_box(host.layout().data(layout_node).kind);
+        let layout_node_is_svg_box = node_kind_is_svg_box(host.layout().data(layout_node).kind.get());
         let prior_layout_top_layer = context.layout_top_layer;
         let placement =
             principal_box_placement_decision(placement_facts, layout_node_is_svg_box, prior_layout_top_layer);
@@ -1636,14 +1635,14 @@ fn update_principal_node_after_entry(
                 let arena = layout_host.arena();
                 let old_data = arena.data(old_layout_node);
                 let new_data = arena.data(layout_node);
-                // SAFETY: data() returned pointers to live slots.
-                if unsafe { node_kind_is_box((*old_data).kind) && node_kind_is_box((*new_data).kind) }
+                if node_kind_is_box(old_data.kind.get())
+                    && node_kind_is_box(new_data.kind.get())
                     && let Some(inputs) = arena.saved_abspos_layout_inputs(old_data)
                 {
                     arena.set_saved_abspos_layout_inputs(new_data, Some(inputs));
                 }
-                // SAFETY: data() returned pointers to live slots.
-                if unsafe { node_kind_is_box((*old_data).kind) && node_kind_is_box((*new_data).kind) }
+                if node_kind_is_box(old_data.kind.get())
+                    && node_kind_is_box(new_data.kind.get())
                     && let Some(link) = arena.take_committed_fragment_link(old_data)
                 {
                     arena.set_committed_fragment_link(new_data, link);
@@ -2053,7 +2052,7 @@ fn create_pseudo_element_with_frame(
     {
         // SAFETY: The originating element remains live and owns a list item box.
         let list_item_box = unsafe { (host.callbacks.element_layout_node)(element) };
-        assert_eq!(layout_host.data(list_item_box).kind, NodeKind::ListItemBox);
+        assert_eq!(layout_host.data(list_item_box).kind.get(), NodeKind::ListItemBox);
         let first_child = layout_host.first_child(list_item_box);
         layout_host.attach_child(list_item_box, unplaced_box.take().expect("the marker box"), first_child);
     }
@@ -2071,7 +2070,7 @@ fn create_pseudo_element_with_frame(
     let initial_quote_nesting_level = state.quote_nesting_level;
     // SAFETY: The frame and element remain live throughout configuration.
     unsafe { (callbacks.configure_layout_node)(frame, element, pseudo_element) };
-    let layout_node_kind = layout_host.data(layout_node).kind;
+    let layout_node_kind = layout_host.data(layout_node).kind.get();
     let is_outside_marker = layout_node_kind == NodeKind::ListItemMarkerBox && !facts.marker_position_is_inside;
     if let Some(insertion_mode) = insertion_mode
         && !is_outside_marker
@@ -2292,7 +2291,7 @@ struct TreeBuilderHost<'a> {
 }
 
 fn node_has_flag(data: &NodeData, flag: NodeFlag) -> bool {
-    data.flags & flag as u32 != 0
+    data.flags.get() & flag as u32 != 0
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -2407,8 +2406,7 @@ pub extern "C" fn layout_node_kind_is_svg_graphics_box(kind: NodeKind) -> bool {
 pub unsafe extern "C" fn layout_arena_node_is_atomic_inline(arena: *mut c_void, id: NodeSlotId) -> bool {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-    // SAFETY: data() validated that id names a live slot.
-    let data = unsafe { &*arena.data(id) };
+    let data = arena.data(id);
     node_facts::node_is_atomic_inline(data, node_facts::node_style_view(data))
 }
 
@@ -2416,17 +2414,16 @@ pub unsafe extern "C" fn layout_arena_node_is_atomic_inline(arena: *mut c_void, 
 pub unsafe extern "C" fn layout_arena_node_is_fragmented_inline(arena: *mut c_void, id: NodeSlotId) -> bool {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-    // SAFETY: data() validated that id names a live slot.
-    let data = unsafe { &*arena.data(id) };
+    let data = arena.data(id);
     node_facts::node_is_fragmented_inline(data, node_facts::node_style_view(data))
 }
 
 fn node_is_generated_for_pseudo_element(data: &NodeData) -> bool {
-    data.generated_for != 0
+    data.generated_for.get() != 0
 }
 
 fn node_is_inline_outside(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
-    node_kind_is_text(host.data(node).kind)
+    node_kind_is_text(host.data(node).kind.get())
         || host
             .style(node)
             .is_some_and(|style| style.display().is_inline_outside())
@@ -2454,7 +2451,7 @@ impl TreeBuilderHost<'_> {
         assert!(!node.is_invalid());
         // SAFETY: Entry points guarantee that the arena remains live, and callers only retain the reference until the
         // next mutation callback.
-        unsafe { &*(*self.arena).data(node) }
+        unsafe { &*self.arena }.data(node)
     }
 
     fn style(&self, node: LayoutNode) -> Option<ComputedValuesView<'_>> {
@@ -2475,7 +2472,7 @@ impl TreeBuilderHost<'_> {
     }
 
     fn shell(&self, node: LayoutNode) -> *mut c_void {
-        let shell = self.data(node).shell;
+        let shell = self.data(node).shell.get();
         assert!(!shell.is_null());
         shell
     }
@@ -2508,23 +2505,23 @@ impl TreeBuilderHost<'_> {
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
-        self.data(node).parent
+        self.data(node).parent.get()
     }
 
     fn first_child(&self, node: LayoutNode) -> LayoutNode {
-        self.data(node).first_child
+        self.data(node).first_child.get()
     }
 
     fn next_sibling(&self, node: LayoutNode) -> LayoutNode {
-        self.data(node).next_sibling
+        self.data(node).next_sibling.get()
     }
 
     fn previous_sibling(&self, node: LayoutNode) -> LayoutNode {
-        self.data(node).previous_sibling
+        self.data(node).previous_sibling.get()
     }
 
     fn last_child(&self, node: LayoutNode) -> LayoutNode {
-        self.data(node).last_child
+        self.data(node).last_child.get()
     }
 
     fn for_each_in_inclusive_subtree(
@@ -2704,13 +2701,13 @@ fn last_child_creating_anonymous_wrapper_if_needed(host: &TreeBuilderHost<'_>, p
 // block-level boxes must be either all block-level or all inline-level.
 fn insertion_parent_for_inline_node(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
     let data = host.data(parent);
-    if matches!(data.kind, NodeKind::FieldSetBox | NodeKind::SVGForeignObjectBox) {
+    if matches!(data.kind.get(), NodeKind::FieldSetBox | NodeKind::SVGForeignObjectBox) {
         return last_child_creating_anonymous_wrapper_if_needed(host, parent);
     }
 
     // SVG layout ignores the inline/block distinction, and an anonymous wrapper would only hide
     // the child from SVGFormattingContext (e.g. a shape with a foreignObject sibling).
-    if node_kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGSVGBox {
+    if node_kind_is_svg_box(data.kind.get()) || data.kind.get() == NodeKind::SVGSVGBox {
         return parent;
     }
 
@@ -2735,7 +2732,7 @@ fn nearest_rebuildable_container(host: &TreeBuilderHost<'_>, node: LayoutNode) -
     let mut container = node;
     loop {
         let data = host.data(container);
-        if !node_has_flag(data, NodeFlag::Anonymous) && data.kind != NodeKind::InlineNode {
+        if !node_has_flag(data, NodeFlag::Anonymous) && data.kind.get() != NodeKind::InlineNode {
             return container;
         }
         container = host.parent(container);
@@ -2766,13 +2763,13 @@ fn insertion_parent_for_block_node(
 
     // SVG layout ignores the inline/block distinction; wrapping existing inline-level siblings
     // (e.g. shapes next to a foreignObject) would only hide them from SVGFormattingContext.
-    if node_kind_is_svg_box(parent_data.kind) || parent_data.kind == NodeKind::SVGSVGBox {
+    if node_kind_is_svg_box(parent_data.kind.get()) || parent_data.kind.get() == NodeKind::SVGSVGBox {
         return parent;
     }
 
     // Make sure we're not inserting into an inline node, since those do not support block nodes.
     let mut new_parent = parent;
-    while layout.data(new_parent).kind == NodeKind::InlineNode {
+    while layout.data(new_parent).kind.get() == NodeKind::InlineNode {
         new_parent = layout.parent(new_parent);
         assert!(!new_parent.is_invalid());
     }
@@ -2867,8 +2864,8 @@ fn insert_child_in_dom_order(
     let (parent_is_empty_anonymous_wrapper, wrapper_parent) = {
         let data = layout.data(parent);
         (
-            node_has_flag(data, NodeFlag::Anonymous) && data.first_child.is_invalid(),
-            data.parent,
+            node_has_flag(data, NodeFlag::Anonymous) && data.first_child.get().is_invalid(),
+            data.parent.get(),
         )
     };
     if parent_is_empty_anonymous_wrapper && !wrapper_parent.is_invalid() {
@@ -2916,7 +2913,7 @@ fn insert_child_in_dom_order(
 
     let mut layout_child = layout.first_child(parent);
     while !layout_child.is_invalid() {
-        if layout.data(layout_child).generated_for == GENERATED_FOR_AFTER {
+        if layout.data(layout_child).generated_for.get() == GENERATED_FOR_AFTER {
             layout.attach_child(parent, child, layout_child);
             return;
         }
@@ -3141,7 +3138,7 @@ fn create_first_letter_boxes(host: &DomTreeBuilderHost<'_>, element: *mut c_void
 }
 
 fn is_marker_content(data: &NodeData) -> bool {
-    data.kind == NodeKind::ListItemMarkerBox || data.generated_for == GENERATED_FOR_MARKER
+    data.kind.get() == NodeKind::ListItemMarkerBox || data.generated_for.get() == GENERATED_FOR_MARKER
 }
 
 // https://drafts.csswg.org/css-pseudo-4/#first-letter-application
@@ -3161,7 +3158,7 @@ fn find_first_letter_in_block(host: &DomTreeBuilderHost<'_>, block: LayoutNode) 
             if is_marker_content(data) || node_is_out_of_flow(&layout_host, node) {
                 return TraversalDecision::SkipChildrenAndContinue;
             }
-            if node_kind_is_text(data.kind) {
+            if node_kind_is_text(data.kind.get()) {
                 result = find_first_letter_in_layout_text(&layout_host, node);
                 return if result.found {
                     TraversalDecision::Break
@@ -3187,7 +3184,7 @@ fn find_first_letter_in_block(host: &DomTreeBuilderHost<'_>, block: LayoutNode) 
             child = layout_host.next_sibling(child);
             continue;
         }
-        if !node_kind_is_block_container(data.kind) {
+        if !node_kind_is_block_container(data.kind.get()) {
             break;
         }
         // Stop descending if this child block defines its own ::first-letter: the child will style the first letter
@@ -3251,7 +3248,7 @@ fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Layou
 fn rendered_legend(host: &TreeBuilderHost<'_>, fieldset: LayoutNode) -> LayoutNode {
     let mut child = host.first_child(fieldset);
     while !child.is_invalid() {
-        if host.data(child).kind == NodeKind::LegendBox && !node_is_out_of_flow(host, child) {
+        if host.data(child).kind.get() == NodeKind::LegendBox && !node_is_out_of_flow(host, child) {
             return child;
         }
         child = host.next_sibling(child);
@@ -3266,7 +3263,7 @@ fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Lay
     // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain
     // the content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the
     // rendered legend, if there is one.
-    if host.data(layout_node).kind == NodeKind::FieldSetBox {
+    if host.data(layout_node).kind.get() == NodeKind::FieldSetBox {
         let legend = rendered_legend(host, layout_node);
         if legend.is_invalid() {
             return;
@@ -3349,20 +3346,20 @@ fn is_tabular_container(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
 
 fn is_ignorable_whitespace(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     let data = host.data(node);
-    if node_kind_is_text(data.kind)
+    if node_kind_is_text(data.kind.get())
         && unsafe { (host.callbacks.text_is_ascii_whitespace)(host.callbacks.context, host.shell(node)) }
     {
         return true;
     }
 
     if node_has_flag(data, NodeFlag::Anonymous)
-        && node_kind_is_block_container(data.kind)
+        && node_kind_is_block_container(data.kind.get())
         && node_has_flag(data, NodeFlag::ChildrenAreInline)
     {
         let mut contains_only_whitespace = true;
         host.for_each_in_inclusive_subtree(node, |descendant| {
             let descendant_data = host.data(descendant);
-            if node_kind_is_text(descendant_data.kind) {
+            if node_kind_is_text(descendant_data.kind.get()) {
                 if !unsafe { (host.callbacks.text_is_ascii_whitespace)(host.callbacks.context, host.shell(descendant)) }
                 {
                     contains_only_whitespace = false;
@@ -3428,7 +3425,7 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         let data = host.data(node);
 
         // 1. Children of a table-column.
-        if node_kind_is_box(data.kind) && host.display(node).is_table_column() {
+        if node_kind_is_box(data.kind.get()) && host.display(node).is_table_column() {
             host.set_children_are_inline(node, false);
             let mut child = host.first_child(node);
             while !child.is_invalid() {
@@ -3438,7 +3435,7 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         }
 
         // 2. Children of a table-column-group which are not a table-column.
-        if node_kind_is_box(data.kind) && host.display(node).is_table_column_group() {
+        if node_kind_is_box(data.kind.get()) && host.display(node).is_table_column_group() {
             host.set_children_are_inline(node, false);
             let mut child = host.first_child(node);
             while !child.is_invalid() {
@@ -3457,7 +3454,7 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         //    - they are the first and/or last child of a tabular container
         //    - whose immediate sibling, if any, is a table-non-root box
         let parent = host.parent(node);
-        if node_kind_is_box(data.kind)
+        if node_kind_is_box(data.kind.get())
             && !parent.is_invalid()
             && is_tabular_container(host, parent)
             && !node_has_flag(host.data(parent), NodeFlag::Anonymous)
@@ -3477,12 +3474,12 @@ fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode)
     // 2. Generate missing child wrappers:
     host.for_each_in_inclusive_subtree(root, |parent| {
         let data = host.data(parent);
-        if !node_kind_is_box(data.kind) {
+        if !node_kind_is_box(data.kind.get()) {
             return TraversalDecision::Continue;
         }
         // AD-HOC: SVG layout derives box types from the element, so display values must not introduce anonymous boxes
         //         inside SVG content.
-        if node_kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGSVGBox {
+        if node_kind_is_svg_box(data.kind.get()) || data.kind.get() == NodeKind::SVGSVGBox {
             return TraversalDecision::Continue;
         }
 
@@ -3534,8 +3531,8 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
             let data = host.data(parent);
             (
                 node_has_flag(data, NodeFlag::HasStyle),
-                node_kind_is_box(data.kind),
-                data.kind,
+                node_kind_is_box(data.kind.get()),
+                data.kind.get(),
             )
         };
         let current_display = host.display(parent);
@@ -3619,7 +3616,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         if is_box && current_display.is_table_inside() {
             let wrap_parent = host.parent(parent);
             let wrap_parent_is_svg_content = !wrap_parent.is_invalid() && {
-                let wrap_parent_kind = host.data(wrap_parent).kind;
+                let wrap_parent_kind = host.data(wrap_parent).kind.get();
                 node_kind_is_svg_box(wrap_parent_kind) || wrap_parent_kind == NodeKind::SVGSVGBox
             };
             if !wrap_parent_is_svg_content {
@@ -3634,7 +3631,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         let nearest_sibling = host.next_sibling(table_root);
         let parent = host.parent(table_root);
         assert!(!parent.is_invalid());
-        if host.data(parent).kind != NodeKind::TableWrapper {
+        if host.data(parent).kind.get() != NodeKind::TableWrapper {
             // SAFETY: `table_root` is a live table box.
             let wrapper = host.created(unsafe {
                 (host.callbacks.create_table_wrapper)(host.callbacks.context, host.shell(table_root))
@@ -3670,7 +3667,10 @@ fn remove_missing_table_cells(host: &TreeBuilderHost<'_>, table_root: LayoutNode
     let mut cells = Vec::new();
     host.for_each_in_inclusive_subtree(table_root, |node| {
         let data = host.data(node);
-        if node != table_root && node_kind_is_box(data.kind) && display_for_table_fixup(host, node).is_table_inside() {
+        if node != table_root
+            && node_kind_is_box(data.kind.get())
+            && display_for_table_fixup(host, node).is_table_inside()
+        {
             return TraversalDecision::SkipChildrenAndContinue;
         }
         if node_has_flag(data, NodeFlag::IsMissingTableCell) {
@@ -3726,7 +3726,7 @@ fn table_fixup_scope_for_rebuilt_subtree(host: &TreeBuilderHost<'_>, root: Layou
     let parent_display = display_for_table_fixup(host, parent);
     let parent_requires_table_children = is_tabular_container(host, parent) || parent_display.is_table_column_group();
     let root_data = host.data(root);
-    if node_kind_is_text(root_data.kind) || !node_has_flag(root_data, NodeFlag::HasStyle) {
+    if node_kind_is_text(root_data.kind.get()) || !node_has_flag(root_data, NodeFlag::HasStyle) {
         let mut ancestor = parent;
         while !ancestor.is_invalid() {
             let ancestor_data = host.data(ancestor);

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -2417,12 +2417,6 @@ pub unsafe extern "C" fn layout_node_data_is_fragmented_inline(data: *const Node
     node_facts::node_is_fragmented_inline(data, node_facts::node_style_view(data))
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_node_data_may_have_replaced_content_facts(data: *const NodeData) -> bool {
-    // SAFETY: The C++ caller passes the node's live arena slot.
-    node_facts::node_may_have_replaced_content_facts_including_size_containment(unsafe { &*data })
-}
-
 fn node_is_generated_for_pseudo_element(data: &NodeData) -> bool {
     data.generated_for != 0
 }

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -2404,16 +2404,20 @@ pub extern "C" fn layout_node_kind_is_svg_graphics_box(kind: NodeKind) -> bool {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_node_data_is_atomic_inline(data: *const NodeData) -> bool {
-    // SAFETY: The C++ caller passes the node's live arena slot.
-    let data = unsafe { &*data };
+pub unsafe extern "C" fn layout_arena_node_is_atomic_inline(arena: *mut c_void, id: NodeSlotId) -> bool {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    // SAFETY: data() validated that id names a live slot.
+    let data = unsafe { &*arena.data(id) };
     node_facts::node_is_atomic_inline(data, node_facts::node_style_view(data))
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_node_data_is_fragmented_inline(data: *const NodeData) -> bool {
-    // SAFETY: The C++ caller passes the node's live arena slot.
-    let data = unsafe { &*data };
+pub unsafe extern "C" fn layout_arena_node_is_fragmented_inline(arena: *mut c_void, id: NodeSlotId) -> bool {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    // SAFETY: data() validated that id names a live slot.
+    let data = unsafe { &*arena.data(id) };
     node_facts::node_is_fragmented_inline(data, node_facts::node_style_view(data))
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -344,35 +344,33 @@ pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
     layout_node: NodeSlotId,
     cleared_subtree_root: *mut c_void,
 ) -> bool {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!arena.is_null());
-        assert!(!layout_node.is_invalid());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let callbacks = unsafe { &*callbacks };
-        let arena = arena.cast::<LayoutNodeArena>();
-        if cleared_subtree_root.is_null() {
-            return true;
-        }
+    assert!(!callbacks.is_null());
+    assert!(!arena.is_null());
+    assert!(!layout_node.is_invalid());
+    // SAFETY: Guaranteed by the entry point's contract.
+    let callbacks = unsafe { &*callbacks };
+    let arena = arena.cast::<LayoutNodeArena>();
+    if cleared_subtree_root.is_null() {
+        return true;
+    }
 
-        // SAFETY: The arena and layout node remain live throughout the ancestor walk.
-        let mut ancestor = unsafe { &*(*arena).data(layout_node) }.parent;
-        while !ancestor.is_invalid() {
-            // SAFETY: `ancestor` is a live layout node with a live shell.
-            let data = unsafe { &*(*arena).data(ancestor) };
-            let shell = data.shell;
-            let parent = data.parent;
-            let dom_node = unsafe { (callbacks.layout_dom_node)(shell) };
-            // SAFETY: Both DOM pointers remain live throughout cleanup.
-            if !dom_node.is_null()
-                && unsafe { (callbacks.dom_is_shadow_including_inclusive_descendant)(dom_node, cleared_subtree_root) }
-            {
-                return false;
-            }
-            ancestor = parent;
+    // SAFETY: The arena and layout node remain live throughout the ancestor walk.
+    let mut ancestor = unsafe { &*(*arena).data(layout_node) }.parent;
+    while !ancestor.is_invalid() {
+        // SAFETY: `ancestor` is a live layout node with a live shell.
+        let data = unsafe { &*(*arena).data(ancestor) };
+        let shell = data.shell;
+        let parent = data.parent;
+        let dom_node = unsafe { (callbacks.layout_dom_node)(shell) };
+        // SAFETY: Both DOM pointers remain live throughout cleanup.
+        if !dom_node.is_null()
+            && unsafe { (callbacks.dom_is_shadow_including_inclusive_descendant)(dom_node, cleared_subtree_root) }
+        {
+            return false;
         }
-        true
-    })
+        ancestor = parent;
+    }
+    true
 }
 
 #[repr(C)]
@@ -420,46 +418,44 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
     arena: *mut c_void,
     element: *mut c_void,
 ) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!arena.is_null());
-        assert!(!element.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let callbacks = unsafe { &*callbacks };
-        let arena = arena.cast::<LayoutNodeArena>();
-        // SAFETY: The element remains live throughout the call.
-        let element_layout_node = unsafe { (callbacks.element_layout_node)(element) };
-        if !element_layout_node.is_invalid() {
-            let topmost = topmost_layout_node_of_top_layer_placement(arena, element_layout_node);
-            let layout_node_to_detach = if topmost.is_invalid() {
-                element_layout_node
-            } else {
-                topmost
-            };
-            // SAFETY: The chosen layout subtree and its shell remain live throughout detachment.
-            let shell = unsafe { (*(*arena).data(layout_node_to_detach)).shell };
-            // SAFETY: The C++ detach preparation walks the still-linked subtree; the arena borrow
-            // ends before the release below re-enters it.
-            unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
-            let detached = unsafe { &*arena }.detach_from_parent(layout_node_to_detach);
-            if let Some(detached) = detached {
-                detached.release();
-            }
+    assert!(!callbacks.is_null());
+    assert!(!arena.is_null());
+    assert!(!element.is_null());
+    // SAFETY: Guaranteed by the entry point's contract.
+    let callbacks = unsafe { &*callbacks };
+    let arena = arena.cast::<LayoutNodeArena>();
+    // SAFETY: The element remains live throughout the call.
+    let element_layout_node = unsafe { (callbacks.element_layout_node)(element) };
+    if !element_layout_node.is_invalid() {
+        let topmost = topmost_layout_node_of_top_layer_placement(arena, element_layout_node);
+        let layout_node_to_detach = if topmost.is_invalid() {
+            element_layout_node
+        } else {
+            topmost
+        };
+        // SAFETY: The chosen layout subtree and its shell remain live throughout detachment.
+        let shell = unsafe { (*(*arena).data(layout_node_to_detach)).shell };
+        // SAFETY: The C++ detach preparation walks the still-linked subtree; the arena borrow
+        // ends before the release below re-enters it.
+        unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
+        let detached = unsafe { &*arena }.detach_from_parent(layout_node_to_detach);
+        if let Some(detached) = detached {
+            detached.release();
         }
+    }
 
-        // SAFETY: The element remains live throughout subtree cleanup.
-        unsafe { (callbacks.clear_stale_subtree)(element) };
-        // SAFETY: The callback returns the element's adjusted HTMLSlotElement pointer, if any.
-        let slot_element = unsafe { (callbacks.slot_element)(element) };
-        if !slot_element.is_null() {
-            clear_stale_assigned_slottables(
-                slot_element,
-                |slot| unsafe { (callbacks.assigned_node_count)(slot) },
-                |slot, index| unsafe { (callbacks.assigned_node_at)(slot, index) },
-                |root| unsafe { (callbacks.clear_stale_subtree)(root) },
-            );
-        }
-    });
+    // SAFETY: The element remains live throughout subtree cleanup.
+    unsafe { (callbacks.clear_stale_subtree)(element) };
+    // SAFETY: The callback returns the element's adjusted HTMLSlotElement pointer, if any.
+    let slot_element = unsafe { (callbacks.slot_element)(element) };
+    if !slot_element.is_null() {
+        clear_stale_assigned_slottables(
+            slot_element,
+            |slot| unsafe { (callbacks.assigned_node_count)(slot) },
+            |slot, index| unsafe { (callbacks.assigned_node_at)(slot, index) },
+            |root| unsafe { (callbacks.clear_stale_subtree)(root) },
+        );
+    }
 }
 
 fn clear_stale_assigned_slottables(
@@ -1794,61 +1790,58 @@ pub unsafe extern "C" fn rust_build_layout_tree(
     arena: *mut c_void,
     document: *mut c_void,
 ) {
-    abort_on_panic(|| {
-        assert!(!document.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks, arena) };
-        let mut state = TreeBuilderState::default();
-        let mut context = TreeBuilderContext::default();
-        // SAFETY: All pointers remain live throughout the build.
-        let entry_facts =
-            unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, false) };
-        assert!(entry_facts.is_document);
+    assert!(!document.is_null());
+    // SAFETY: Guaranteed by the entry point's contract.
+    let host = unsafe { dom_tree_builder_host(callbacks, arena) };
+    let mut state = TreeBuilderState::default();
+    let mut context = TreeBuilderContext::default();
+    // SAFETY: All pointers remain live throughout the build.
+    let entry_facts = unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, false) };
+    assert!(entry_facts.is_document);
 
-        update_layout_tree(
-            &host,
-            &mut state,
-            document,
-            &mut context,
-            false,
-            FfiInsertionMode::Append,
-        );
+    update_layout_tree(
+        &host,
+        &mut state,
+        document,
+        &mut context,
+        false,
+        FfiInsertionMode::Append,
+    );
 
-        // NB: Called during layout tree construction.
-        // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
-        let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
-        if !document_layout_node.is_invalid() {
-            let layout_host = host.layout();
-            if entry_facts.document_needs_full_layout_tree_update
-                || !entry_facts.has_layout_node
-                || state.layout_tree_update_escaped_rebuild_roots
-            {
-                fixup_tables(&layout_host, document_layout_node);
-            } else {
-                fixup_tables_in_rebuilt_subtrees(
-                    &layout_host,
-                    &state.rebuilt_subtree_roots,
-                    &state.reused_child_list_update_roots,
-                    &state.additional_table_fixup_roots,
-                );
-            }
-        }
-
-        for &element in &state.layout_tree_rebuild_requests {
-            // SAFETY: The builder remains live, and the walk that could clear DOM update flags is complete.
-            unsafe { (host.callbacks.request_layout_tree_rebuild)(host.callbacks.builder, element) };
-        }
-
-        // SAFETY: The builder remains live and copies the reported shell pointers before returning.
-        unsafe {
-            (host.callbacks.report_rebuild_outcome)(
-                host.callbacks.builder,
-                state.rebuilt_subtree_root_shells.as_ptr(),
-                state.rebuilt_subtree_root_shells.len(),
-                state.layout_tree_update_escaped_rebuild_roots,
+    // NB: Called during layout tree construction.
+    // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
+    let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
+    if !document_layout_node.is_invalid() {
+        let layout_host = host.layout();
+        if entry_facts.document_needs_full_layout_tree_update
+            || !entry_facts.has_layout_node
+            || state.layout_tree_update_escaped_rebuild_roots
+        {
+            fixup_tables(&layout_host, document_layout_node);
+        } else {
+            fixup_tables_in_rebuilt_subtrees(
+                &layout_host,
+                &state.rebuilt_subtree_roots,
+                &state.reused_child_list_update_roots,
+                &state.additional_table_fixup_roots,
             );
         }
-    });
+    }
+
+    for &element in &state.layout_tree_rebuild_requests {
+        // SAFETY: The builder remains live, and the walk that could clear DOM update flags is complete.
+        unsafe { (host.callbacks.request_layout_tree_rebuild)(host.callbacks.builder, element) };
+    }
+
+    // SAFETY: The builder remains live and copies the reported shell pointers before returning.
+    unsafe {
+        (host.callbacks.report_rebuild_outcome)(
+            host.callbacks.builder,
+            state.rebuilt_subtree_root_shells.as_ptr(),
+            state.rebuilt_subtree_root_shells.len(),
+            state.layout_tree_update_escaped_rebuild_roots,
+        );
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -212,10 +212,7 @@ mod tests {
     }
 
     fn free(arena: &mut LayoutNodeArena, allocation: NodeAllocation) {
-        arena
-            .free(allocation.slot, allocation.generation)
-            .detached_children
-            .release_all();
+        arena.free(allocation.slot).detached_children.release_all();
     }
 
     #[test]
@@ -317,7 +314,7 @@ mod tests {
         arena.attach_child(root.slot, owned(a.slot), NodeSlotId::INVALID);
         arena.attach_child(root.slot, owned(b.slot), NodeSlotId::INVALID);
 
-        let freed = arena.free(root.slot, root.generation);
+        let freed = arena.free(root.slot);
         assert_eq!(freed.detached_children.len(), 2);
         assert!(links(&arena, a.slot).parent.is_invalid());
         assert!(links(&arena, b.slot).parent.is_invalid());
@@ -335,7 +332,7 @@ mod tests {
         let parent = arena.allocate();
         let child = arena.allocate();
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
-        let _ = arena.free(child.slot, child.generation);
+        let _ = arena.free(child.slot);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -218,8 +218,8 @@ mod tests {
     #[test]
     fn attaching_an_owned_child_and_detaching_it_round_trips_the_links() {
         let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate();
-        let child = arena.allocate();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
 
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
         assert_eq!(links(&arena, parent.slot).first_child, child.slot);
@@ -237,8 +237,8 @@ mod tests {
     #[test]
     fn detaching_from_the_parent_unlinks_an_attached_child_and_skips_a_root() {
         let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate();
-        let child = arena.allocate();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
 
         arena.detach_from_parent(child.slot).expect("attached child").release();
@@ -252,11 +252,11 @@ mod tests {
     #[test]
     fn replacing_a_child_keeps_the_sibling_position() {
         let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate();
-        let a = arena.allocate();
-        let b = arena.allocate();
-        let c = arena.allocate();
-        let d = arena.allocate();
+        let parent = arena.allocate_for_test();
+        let a = arena.allocate_for_test();
+        let b = arena.allocate_for_test();
+        let c = arena.allocate_for_test();
+        let d = arena.allocate_for_test();
         for child in [a.slot, b.slot, c.slot] {
             arena.attach_child(parent.slot, owned(child), NodeSlotId::INVALID);
         }
@@ -281,11 +281,11 @@ mod tests {
     #[test]
     fn moving_a_child_relinks_it_under_the_new_parent() {
         let mut arena = LayoutNodeArena::new();
-        let first_parent = arena.allocate();
-        let second_parent = arena.allocate();
-        let a = arena.allocate();
-        let b = arena.allocate();
-        let c = arena.allocate();
+        let first_parent = arena.allocate_for_test();
+        let second_parent = arena.allocate_for_test();
+        let a = arena.allocate_for_test();
+        let b = arena.allocate_for_test();
+        let c = arena.allocate_for_test();
         arena.attach_child(first_parent.slot, owned(a.slot), NodeSlotId::INVALID);
         arena.attach_child(first_parent.slot, owned(b.slot), NodeSlotId::INVALID);
         arena.attach_child(second_parent.slot, owned(c.slot), NodeSlotId::INVALID);
@@ -308,9 +308,9 @@ mod tests {
     #[test]
     fn freeing_a_node_unlinks_its_children_and_hands_back_their_references() {
         let mut arena = LayoutNodeArena::new();
-        let root = arena.allocate();
-        let a = arena.allocate();
-        let b = arena.allocate();
+        let root = arena.allocate_for_test();
+        let a = arena.allocate_for_test();
+        let b = arena.allocate_for_test();
         arena.attach_child(root.slot, owned(a.slot), NodeSlotId::INVALID);
         arena.attach_child(root.slot, owned(b.slot), NodeSlotId::INVALID);
 
@@ -329,8 +329,8 @@ mod tests {
     #[should_panic(expected = "still linked under a parent")]
     fn freeing_a_node_still_linked_under_a_parent_panics() {
         let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate();
-        let child = arena.allocate();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
         let _ = arena.free(child.slot);
     }
@@ -343,10 +343,10 @@ mod tests {
             return;
         }
         let mut arena = LayoutNodeArena::new();
-        let grandparent = arena.allocate();
-        let parent = arena.allocate();
-        let sibling = arena.allocate();
-        let child = arena.allocate();
+        let grandparent = arena.allocate_for_test();
+        let parent = arena.allocate_for_test();
+        let sibling = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
         arena.attach_child(grandparent.slot, owned(parent.slot), NodeSlotId::INVALID);
         arena.attach_child(grandparent.slot, owned(sibling.slot), NodeSlotId::INVALID);
         let grandparent_epoch = fragment_cache_epoch(&arena, grandparent.slot);
@@ -369,9 +369,9 @@ mod tests {
     #[test]
     fn a_structural_change_clears_the_overflow_validity_of_box_ancestors_only() {
         let mut arena = LayoutNodeArena::new();
-        let grandparent = arena.allocate();
-        let parent = arena.allocate();
-        let child = arena.allocate();
+        let grandparent = arena.allocate_for_test();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
         // SAFETY: The allocations stay live for the whole test.
         unsafe {
             (*grandparent.data).kind = NodeKind::BlockContainer;
@@ -411,8 +411,8 @@ mod tests {
     #[should_panic(expected = "without being released")]
     fn dropping_a_detached_shell_without_releasing_it_panics() {
         let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate();
-        let child = arena.allocate();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
         let _ = arena.detach_child(parent.slot, child.slot);
     }
@@ -422,7 +422,7 @@ mod tests {
     #[should_panic(expected = "leaked without being attached or released")]
     fn dropping_an_owned_layout_node_without_placing_it_panics() {
         let mut arena = LayoutNodeArena::new();
-        let node = arena.allocate();
+        let node = arena.allocate_for_test();
         // SAFETY: Test nodes have no shell, and the hooks skip null shells.
         let _ = unsafe { OwnedLayoutNode::adopt_created(node.slot) };
     }

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -120,13 +120,11 @@ impl Drop for OwnedLayoutNode {
 }
 
 fn parent_of(arena: &LayoutNodeArena, node: NodeSlotId) -> NodeSlotId {
-    // SAFETY: data() validated that node names a live slot; the link is a plain value.
-    unsafe { (&raw const (*arena.data(node)).parent).read() }
+    arena.data(node).parent.get()
 }
 
 fn next_sibling_of(arena: &LayoutNodeArena, node: NodeSlotId) -> NodeSlotId {
-    // SAFETY: data() validated that node names a live slot; the link is a plain value.
-    unsafe { (&raw const (*arena.data(node)).next_sibling).read() }
+    arena.data(node).next_sibling.get()
 }
 
 impl LayoutNodeArena {
@@ -190,20 +188,18 @@ mod tests {
     }
 
     fn links(arena: &LayoutNodeArena, node: NodeSlotId) -> Links {
-        // SAFETY: Every test keeps its allocations live while reading them.
-        let data = unsafe { &*arena.data(node) };
+        let data = arena.data(node);
         Links {
-            parent: data.parent,
-            first_child: data.first_child,
-            last_child: data.last_child,
-            previous_sibling: data.previous_sibling,
-            next_sibling: data.next_sibling,
+            parent: data.parent.get(),
+            first_child: data.first_child.get(),
+            last_child: data.last_child.get(),
+            previous_sibling: data.previous_sibling.get(),
+            next_sibling: data.next_sibling.get(),
         }
     }
 
     fn fragment_cache_epoch(arena: &LayoutNodeArena, node: NodeSlotId) -> u32 {
-        // SAFETY: Every test keeps its allocations live while reading them.
-        unsafe { (*arena.data(node)).fragment_cache_epoch }
+        arena.data(node).fragment_cache_epoch.get()
     }
 
     fn owned(slot: NodeSlotId) -> OwnedLayoutNode {
@@ -372,11 +368,8 @@ mod tests {
         let grandparent = arena.allocate_for_test();
         let parent = arena.allocate_for_test();
         let child = arena.allocate_for_test();
-        // SAFETY: The allocations stay live for the whole test.
-        unsafe {
-            (*grandparent.data).kind = NodeKind::BlockContainer;
-            (*parent.data).kind = NodeKind::InlineNode;
-        }
+        arena.data(grandparent.slot).kind.set(NodeKind::BlockContainer);
+        arena.data(parent.slot).kind.set(NodeKind::InlineNode);
         arena.attach_child(grandparent.slot, owned(parent.slot), NodeSlotId::INVALID);
         for node in [grandparent.slot, parent.slot] {
             arena.populate_paintable_row(node);

--- a/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
@@ -162,20 +162,18 @@ pub unsafe extern "C" fn painting_dump(
     display_list: *const c_void,
     callbacks: FfiPaintingDumpCallbacks,
 ) {
-    crate::abort_on_panic(|| {
-        assert!(!display_list.is_null());
-        let arena = unsafe { crate::painting::ffi::arena_from_handle(arena) };
-        let visual_context_tree = unsafe { crate::painting::ffi::tree_from_handle(visual_context_tree) };
-        let command_runs = unsafe { crate::painting::ffi::ffi_slice(command_runs, command_run_count) };
-        let owners = VisualContextNodeOwners::collect(arena, viewport);
-        let mut output = visual_context_tree.dump_nodes_reachable_from_runs(command_runs, |is_frame, index| {
-            let shell = arena.shell_if_live(owners.owner(is_frame, index)?);
-            (!shell.is_null()).then(|| callbacks.debug_description(shell))
-        });
-        output.push_str("\nDisplayList:\n");
-        dump_commands(&mut output, &callbacks, display_list, 0);
-        callbacks.append_text(&output);
+    assert!(!display_list.is_null());
+    let arena = unsafe { crate::painting::ffi::arena_from_handle(arena) };
+    let visual_context_tree = unsafe { crate::painting::ffi::tree_from_handle(visual_context_tree) };
+    let command_runs = unsafe { crate::painting::ffi::ffi_slice(command_runs, command_run_count) };
+    let owners = VisualContextNodeOwners::collect(arena, viewport);
+    let mut output = visual_context_tree.dump_nodes_reachable_from_runs(command_runs, |is_frame, index| {
+        let shell = arena.shell_if_live(owners.owner(is_frame, index)?);
+        (!shell.is_null()).then(|| callbacks.debug_description(shell))
     });
+    output.push_str("\nDisplayList:\n");
+    dump_commands(&mut output, &callbacks, display_list, 0);
+    callbacks.append_text(&output);
 }
 
 fn push_indent(output: &mut String, indent: usize) {

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::abort_on_panic;
 use crate::css::css_pixels::CssPixels;
 use crate::layout::LayoutNodeArena;
 use crate::layout::node_data::NodeSlotId;
@@ -109,18 +108,16 @@ pub unsafe extern "C" fn layout_arena_paintable_set_scrollbar_enlarged(
     direction: ScrollDirection,
     enlarged: bool,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let mut rows = arena.paintable_rows_mut();
-        if !rows.paintable_row_is_populated(slot) {
-            return;
-        }
-        let flag = match direction {
-            ScrollDirection::Horizontal => PaintableFlag::HorizontalScrollbarEnlarged,
-            ScrollDirection::Vertical => PaintableFlag::VerticalScrollbarEnlarged,
-        };
-        rows.paintable_data_mut(slot).set_flag(flag, enlarged);
-    });
+    let arena = unsafe { arena_from_handle_mut(arena) };
+    let mut rows = arena.paintable_rows_mut();
+    if !rows.paintable_row_is_populated(slot) {
+        return;
+    }
+    let flag = match direction {
+        ScrollDirection::Horizontal => PaintableFlag::HorizontalScrollbarEnlarged,
+        ScrollDirection::Vertical => PaintableFlag::VerticalScrollbarEnlarged,
+    };
+    rows.paintable_data_mut(slot).set_flag(flag, enlarged);
 }
 
 /// # Safety
@@ -131,14 +128,12 @@ pub unsafe extern "C" fn layout_arena_paintable_physical_resize_axes(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiPhysicalResizeAxes {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let axes = crate::painting::chrome_geometry::physical_resize_axes(&arena.paintable_rows(), slot);
-        FfiPhysicalResizeAxes {
-            horizontal: axes.horizontal,
-            vertical: axes.vertical,
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let axes = crate::painting::chrome_geometry::physical_resize_axes(&arena.paintable_rows(), slot);
+    FfiPhysicalResizeAxes {
+        horizontal: axes.horizontal,
+        vertical: axes.vertical,
+    }
 }
 
 /// # Safety
@@ -146,10 +141,8 @@ pub unsafe extern "C" fn layout_arena_paintable_physical_resize_axes(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_is_chrome_mirrored(arena: *mut c_void, slot: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::chrome_geometry::is_chrome_mirrored(&arena.paintable_rows(), slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::chrome_geometry::is_chrome_mirrored(&arena.paintable_rows(), slot)
 }
 
 /// # Safety
@@ -168,37 +161,35 @@ pub unsafe extern "C" fn layout_arena_paintable_compute_scrollbar_data(
     device_scroll_offset: f32,
     device_pixels_per_css_pixel: f64,
 ) -> FfiOptionalScrollbarData {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let data = crate::painting::chrome_geometry::ChromeGeometry {
-            arena: &paintable_rows,
-            metrics,
-            viewport_wheel_overflow_x: viewport_overflow_x,
-            viewport_wheel_overflow_y: viewport_overflow_y,
-        }
-        .compute_scrollbar_data(
-            slot,
-            direction,
-            enlarged,
-            has_device_scroll_offset.then_some(crate::painting::chrome_geometry::ScrollbarScrollState {
-                device_scroll_offset,
-                device_pixels_per_css_pixel,
-            }),
-        );
-        let Some(data) = data else {
-            return FfiOptionalScrollbarData::default();
-        };
-        FfiOptionalScrollbarData {
-            has_value: true,
-            value: FfiScrollbarData {
-                gutter_rect: data.gutter_rect.into(),
-                thumb_rect: data.thumb_rect.into(),
-                track_rect: data.track_rect.into(),
-                thumb_travel_to_scroll_ratio: data.thumb_travel_to_scroll_ratio.to_double(),
-            },
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let data = crate::painting::chrome_geometry::ChromeGeometry {
+        arena: &paintable_rows,
+        metrics,
+        viewport_wheel_overflow_x: viewport_overflow_x,
+        viewport_wheel_overflow_y: viewport_overflow_y,
+    }
+    .compute_scrollbar_data(
+        slot,
+        direction,
+        enlarged,
+        has_device_scroll_offset.then_some(crate::painting::chrome_geometry::ScrollbarScrollState {
+            device_scroll_offset,
+            device_pixels_per_css_pixel,
+        }),
+    );
+    let Some(data) = data else {
+        return FfiOptionalScrollbarData::default();
+    };
+    FfiOptionalScrollbarData {
+        has_value: true,
+        value: FfiScrollbarData {
+            gutter_rect: data.gutter_rect.into(),
+            thumb_rect: data.thumb_rect.into(),
+            track_rect: data.track_rect.into(),
+            thumb_travel_to_scroll_ratio: data.thumb_travel_to_scroll_ratio.to_double(),
+        },
+    }
 }
 
 /// # Safety
@@ -209,10 +200,8 @@ pub unsafe extern "C" fn layout_arena_paintable_minimum_scroll_offset(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelPoint {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::chrome_geometry::minimum_scroll_offset(&arena.paintable_rows(), slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::chrome_geometry::minimum_scroll_offset(&arena.paintable_rows(), slot).into()
 }
 
 /// # Safety
@@ -223,10 +212,8 @@ pub unsafe extern "C" fn layout_arena_paintable_maximum_scroll_offset(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelPoint {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::chrome_geometry::maximum_scroll_offset(&arena.paintable_rows(), slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::chrome_geometry::maximum_scroll_offset(&arena.paintable_rows(), slot).into()
 }
 
 /// # Safety
@@ -239,19 +226,17 @@ pub unsafe extern "C" fn layout_arena_paintable_wheel_scrollable_axes(
     viewport_overflow_x: u8,
     viewport_overflow_y: u8,
 ) -> FfiPhysicalResizeAxes {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let axes = crate::painting::chrome_geometry::wheel_scrollable_axes(
-            &arena.paintable_rows(),
-            slot,
-            viewport_overflow_x,
-            viewport_overflow_y,
-        );
-        FfiPhysicalResizeAxes {
-            horizontal: axes.horizontal,
-            vertical: axes.vertical,
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let axes = crate::painting::chrome_geometry::wheel_scrollable_axes(
+        &arena.paintable_rows(),
+        slot,
+        viewport_overflow_x,
+        viewport_overflow_y,
+    );
+    FfiPhysicalResizeAxes {
+        horizontal: axes.horizontal,
+        vertical: axes.vertical,
+    }
 }
 
 /// # Safety
@@ -263,10 +248,8 @@ pub unsafe extern "C" fn layout_arena_set_chrome_state_callback(
     context: *mut c_void,
     callback: unsafe extern "C" fn(*mut c_void, NodeSlotId, PaintableRowResetKind),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.set_chrome_state_callback(context, callback);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.set_chrome_state_callback(context, callback);
 }
 
 /// # Safety
@@ -274,10 +257,8 @@ pub unsafe extern "C" fn layout_arena_set_chrome_state_callback(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_clear_chrome_state_callback(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.clear_chrome_state_callback();
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.clear_chrome_state_callback();
 }
 
 /// # Safety
@@ -288,10 +269,8 @@ pub unsafe extern "C" fn layout_arena_node_establishes_an_absolute_positioning_c
     arena: *mut c_void,
     node: NodeSlotId,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::style_queries::establishes_positioning_containing_blocks(arena, node).0
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::style_queries::establishes_positioning_containing_blocks(arena, node).0
 }
 
 /// # Safety
@@ -302,10 +281,8 @@ pub unsafe extern "C" fn layout_arena_node_establishes_a_fixed_positioning_conta
     arena: *mut c_void,
     node: NodeSlotId,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::style_queries::establishes_positioning_containing_blocks(arena, node).1
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::style_queries::establishes_positioning_containing_blocks(arena, node).1
 }
 
 /// # Safety
@@ -313,13 +290,11 @@ pub unsafe extern "C" fn layout_arena_node_establishes_a_fixed_positioning_conta
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_has_css_transform(arena: *mut c_void, node: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let Some(style) = arena.node_style_if_live(node) else {
-            return false;
-        };
-        crate::painting::style_queries::has_css_transform(arena, node, style)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let Some(style) = arena.node_style_if_live(node) else {
+        return false;
+    };
+    crate::painting::style_queries::has_css_transform(arena, node, style)
 }
 
 /// # Safety
@@ -328,10 +303,8 @@ pub unsafe extern "C" fn layout_arena_node_has_css_transform(arena: *mut c_void,
 /// `node` must name a live node in this arena.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_schedule_scrollable_overflow_recalculation(arena: *mut c_void, node: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.schedule_scrollable_overflow_recalculation(node);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.schedule_scrollable_overflow_recalculation(node);
 }
 
 /// # Safety
@@ -339,10 +312,8 @@ pub unsafe extern "C" fn layout_arena_schedule_scrollable_overflow_recalculation
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_needs_full_scrollable_overflow_recalculation(arena: *mut c_void) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.needs_full_scrollable_overflow_recalculation.get()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.needs_full_scrollable_overflow_recalculation.get()
 }
 
 /// # Safety
@@ -350,10 +321,8 @@ pub unsafe extern "C" fn layout_arena_needs_full_scrollable_overflow_recalculati
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_set_needs_full_scrollable_overflow_recalculation(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.needs_full_scrollable_overflow_recalculation.set(true);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.needs_full_scrollable_overflow_recalculation.set(true);
 }
 
 /// # Safety
@@ -367,15 +336,13 @@ pub unsafe extern "C" fn layout_arena_take_scrollable_overflow_recalculation_sta
     context: *mut c_void,
     push_box: unsafe extern "C" fn(*mut c_void, NodeSlotId),
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let (boxes, needs_full_recalculation) = arena.take_scrollable_overflow_recalculation_state();
-        for slot in boxes {
-            // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
-            unsafe { push_box(context, slot) };
-        }
-        needs_full_recalculation
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let (boxes, needs_full_recalculation) = arena.take_scrollable_overflow_recalculation_state();
+    for slot in boxes {
+        // SAFETY: The C++ callback appends the slot id to a caller-owned collection.
+        unsafe { push_box(context, slot) };
+    }
+    needs_full_recalculation
 }
 
 /// # Safety
@@ -387,14 +354,12 @@ pub unsafe extern "C" fn layout_arena_invalidate_nearest_self_painting_inline_pa
     arena: *mut c_void,
     node: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if let Some(ancestor) =
-            crate::painting::fragment_ownership::nearest_self_painting_inline_box(&arena.paintable_rows(), node)
-        {
-            arena.invalidate_paint_cache(ancestor);
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    if let Some(ancestor) =
+        crate::painting::fragment_ownership::nearest_self_painting_inline_box(&arena.paintable_rows(), node)
+    {
+        arena.invalidate_paint_cache(ancestor);
+    }
 }
 
 /// # Safety
@@ -402,15 +367,13 @@ pub unsafe extern "C" fn layout_arena_invalidate_nearest_self_painting_inline_pa
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_supports_svg_masking(arena: *mut c_void, slot: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_rows().paintable_row_is_populated(slot) {
-            return false;
-        }
-        arena
-            .node_kind_if_live(slot)
-            .is_some_and(crate::painting::node_painting::supports_svg_masking)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_rows().paintable_row_is_populated(slot) {
+        return false;
+    }
+    arena
+        .node_kind_if_live(slot)
+        .is_some_and(crate::painting::node_painting::supports_svg_masking)
 }
 
 /// # Safety
@@ -418,14 +381,12 @@ pub unsafe extern "C" fn layout_arena_paintable_supports_svg_masking(arena: *mut
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: NodeSlotId) -> *const PaintableData {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return std::ptr::null();
-        }
-        paintable_rows.paintable_data_ptr(slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return std::ptr::null();
+    }
+    paintable_rows.paintable_data_ptr(slot)
 }
 
 /// # Safety
@@ -433,19 +394,17 @@ pub unsafe extern "C" fn layout_arena_paintable_row(arena: *mut c_void, slot: No
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_cleared_from_node(arena: *mut c_void, layout_node: NodeSlotId) {
-    abort_on_panic(|| {
-        let reset = {
-            let arena = unsafe { arena_from_handle(arena) };
-            arena.invalidate_paint_cache(layout_node);
-            arena.clear_committed_fragment_link(layout_node);
-            arena.prepare_paintable_row_cleared_reset(layout_node)
-        };
-        if let Some(reset) = reset {
-            reset.invoke_callback();
-            let arena = unsafe { arena_from_handle_mut(arena) };
-            arena.paintable_row_cleared(reset);
-        }
-    });
+    let reset = {
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.invalidate_paint_cache(layout_node);
+        arena.clear_committed_fragment_link(layout_node);
+        arena.prepare_paintable_row_cleared_reset(layout_node)
+    };
+    if let Some(reset) = reset {
+        reset.invoke_callback();
+        let arena = unsafe { arena_from_handle_mut(arena) };
+        arena.paintable_row_cleared(reset);
+    }
 }
 
 /// # Safety
@@ -456,10 +415,8 @@ pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> *mut c_void {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::hit_test::resolve::event_dispatch_shell_for_paintable(arena, slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::hit_test::resolve::event_dispatch_shell_for_paintable(arena, slot)
 }
 
 /// # Safety
@@ -467,13 +424,11 @@ pub unsafe extern "C" fn layout_arena_paintable_event_dispatch_node_shell(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_layout_node_shell(arena: *mut c_void, slot: NodeSlotId) -> *mut c_void {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return std::ptr::null_mut();
-        }
-        arena.shell_if_live(slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return std::ptr::null_mut();
+    }
+    arena.shell_if_live(slot)
 }
 
 /// # Safety
@@ -481,10 +436,8 @@ pub unsafe extern "C" fn layout_arena_paintable_layout_node_shell(arena: *mut c_
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_has_child_paintables(arena: *mut c_void, slot: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::paint_order::first_paint_child(&arena.paintable_rows(), slot).is_some()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::paint_order::first_paint_child(&arena.paintable_rows(), slot).is_some()
 }
 
 pub(crate) unsafe fn ffi_slice<'a, T>(data: *const T, length: usize) -> &'a [T] {
@@ -527,35 +480,33 @@ pub unsafe extern "C" fn display_list_compute_damage(
     viewport_rect: libgfx_rust::IntRect,
     out_damage_rect: *mut libgfx_rust::IntRect,
 ) -> bool {
-    abort_on_panic(|| {
-        let (old_tree, new_tree) = unsafe { (tree_from_handle(old_tree), tree_from_handle(new_tree)) };
-        // SAFETY: The caller guarantees the slices address the stated number of values.
-        let (old_command_bytes, old_scroll_offsets, new_command_bytes, new_scroll_offsets) = unsafe {
-            (
-                ffi_slice(old_command_bytes, old_command_bytes_length),
-                ffi_slice(old_scroll_offsets, old_scroll_offsets_len),
-                ffi_slice(new_command_bytes, new_command_bytes_length),
-                ffi_slice(new_scroll_offsets, new_scroll_offsets_len),
-            )
-        };
-        let damage = crate::painting::display_list::damage::compute_display_list_damage(
-            old_command_bytes,
-            old_tree,
-            old_scroll_offsets,
-            new_command_bytes,
-            new_tree,
-            new_scroll_offsets,
-            viewport_rect,
-        );
-        match damage {
-            Some(damage_rect) => {
-                // SAFETY: The caller guarantees `out_damage_rect` is writable.
-                unsafe { *out_damage_rect = damage_rect };
-                true
-            }
-            None => false,
+    let (old_tree, new_tree) = unsafe { (tree_from_handle(old_tree), tree_from_handle(new_tree)) };
+    // SAFETY: The caller guarantees the slices address the stated number of values.
+    let (old_command_bytes, old_scroll_offsets, new_command_bytes, new_scroll_offsets) = unsafe {
+        (
+            ffi_slice(old_command_bytes, old_command_bytes_length),
+            ffi_slice(old_scroll_offsets, old_scroll_offsets_len),
+            ffi_slice(new_command_bytes, new_command_bytes_length),
+            ffi_slice(new_scroll_offsets, new_scroll_offsets_len),
+        )
+    };
+    let damage = crate::painting::display_list::damage::compute_display_list_damage(
+        old_command_bytes,
+        old_tree,
+        old_scroll_offsets,
+        new_command_bytes,
+        new_tree,
+        new_scroll_offsets,
+        viewport_rect,
+    );
+    match damage {
+        Some(damage_rect) => {
+            // SAFETY: The caller guarantees `out_damage_rect` is writable.
+            unsafe { *out_damage_rect = damage_rect };
+            true
         }
-    })
+        None => false,
+    }
 }
 
 /// # Safety
@@ -573,19 +524,17 @@ pub unsafe extern "C" fn display_list_replay(
     scroll_offsets_len: usize,
     callbacks: *const crate::painting::host::FfiDisplayListReplayCallbacks,
 ) {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the slices address the stated number of values.
-        let (command_runs, scroll_offsets) = unsafe {
-            (
-                ffi_slice(command_runs, command_run_count),
-                ffi_slice(scroll_offsets, scroll_offsets_len),
-            )
-        };
-        // SAFETY: The caller guarantees `callbacks` is live for the call.
-        let mut painter = unsafe { *callbacks };
-        crate::painting::display_list::replay::replay_display_list(tree, command_runs, scroll_offsets, &mut painter);
-    });
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the slices address the stated number of values.
+    let (command_runs, scroll_offsets) = unsafe {
+        (
+            ffi_slice(command_runs, command_run_count),
+            ffi_slice(scroll_offsets, scroll_offsets_len),
+        )
+    };
+    // SAFETY: The caller guarantees `callbacks` is live for the call.
+    let mut painter = unsafe { *callbacks };
+    crate::painting::display_list::replay::replay_display_list(tree, command_runs, scroll_offsets, &mut painter);
 }
 
 /// # Safety
@@ -601,18 +550,16 @@ pub unsafe extern "C" fn layout_arena_selection_apply(
     range_start_offset: usize,
     range_end_offset: usize,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        if !arena.paintable_row_is_populated(viewport) {
-            return;
-        }
-        // SAFETY: The caller guarantees the entry span is valid for this synchronous call.
-        let entries = unsafe { ffi_slice(entries, entry_count) };
-        crate::painting::selection::apply(&mut arena.paintable_rows_mut(), viewport, entries);
-        arena.paint_state().borrow_mut().selection = Some(crate::painting::selection::SelectionRange {
-            start_offset: range_start_offset,
-            end_offset: range_end_offset,
-        });
+    let arena = unsafe { arena_from_handle_mut(arena) };
+    if !arena.paintable_row_is_populated(viewport) {
+        return;
+    }
+    // SAFETY: The caller guarantees the entry span is valid for this synchronous call.
+    let entries = unsafe { ffi_slice(entries, entry_count) };
+    crate::painting::selection::apply(&mut arena.paintable_rows_mut(), viewport, entries);
+    arena.paint_state().borrow_mut().selection = Some(crate::painting::selection::SelectionRange {
+        start_offset: range_start_offset,
+        end_offset: range_end_offset,
     });
 }
 
@@ -621,14 +568,12 @@ pub unsafe extern "C" fn layout_arena_selection_apply(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_selection_clear(arena: *mut c_void, viewport: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        if !arena.paintable_row_is_populated(viewport) {
-            return;
-        }
-        crate::painting::selection::clear(&mut arena.paintable_rows_mut(), viewport);
-        arena.paint_state().borrow_mut().selection = None;
-    });
+    let arena = unsafe { arena_from_handle_mut(arena) };
+    if !arena.paintable_row_is_populated(viewport) {
+        return;
+    }
+    crate::painting::selection::clear(&mut arena.paintable_rows_mut(), viewport);
+    arena.paint_state().borrow_mut().selection = None;
 }
 
 /// # Safety
@@ -636,13 +581,11 @@ pub unsafe extern "C" fn layout_arena_selection_clear(arena: *mut c_void, viewpo
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle_mut(arena) };
-        let mut paintable_rows = arena.paintable_rows_mut();
-        if paintable_rows.paintable_row_is_populated(slot) {
-            paintable_rows.paintable_data_mut(slot).overflow_measured_this_commit = false;
-        }
-    });
+    let arena = unsafe { arena_from_handle_mut(arena) };
+    let mut paintable_rows = arena.paintable_rows_mut();
+    if paintable_rows.paintable_row_is_populated(slot) {
+        paintable_rows.paintable_data_mut(slot).overflow_measured_this_commit = false;
+    }
 }
 
 /// # Safety
@@ -650,10 +593,8 @@ pub unsafe extern "C" fn layout_arena_paintable_clear_overflow_data(arena: *mut 
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_clear_cached_overflow_data(arena: *mut c_void, slot: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.paintable_rows().clear_cached_overflow_data(slot);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.paintable_rows().clear_cached_overflow_data(slot);
 }
 
 #[repr(C)]
@@ -672,12 +613,10 @@ pub unsafe extern "C" fn layout_arena_measure_scrollable_overflow(
     visual_context_callbacks: crate::painting::host::FfiVisualContextHostCallbacks,
     overflow_callbacks: crate::painting::host::FfiScrollableOverflowHostCallbacks,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
-        unsafe {
-            measure_scrollable_overflow_for_slot(arena, box_paintable, &visual_context_callbacks, &overflow_callbacks);
-        };
-    });
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe {
+        measure_scrollable_overflow_for_slot(arena, box_paintable, &visual_context_callbacks, &overflow_callbacks);
+    };
 }
 
 /// Whether a box is measured eagerly after a full commit rather than only when an ancestor's
@@ -745,233 +684,230 @@ pub unsafe extern "C" fn layout_arena_update_scrollable_overflow(
     scroll_offset_context: *mut c_void,
     clamp_scroll_offset_if_nonzero: unsafe extern "C" fn(*mut c_void, *mut c_void),
 ) -> FfiScrollableOverflowUpdateOutcome {
-    abort_on_panic(|| {
-        let no_recalculation = FfiScrollableOverflowUpdateOutcome {
-            performed_recalculation: false,
-            any_overflow_changed: false,
-            any_has_scrollable_overflow_flipped: false,
-        };
-        let (pending_boxes, needs_full_recalculation) = {
-            // SAFETY: The C++ caller keeps the arena alive for this synchronous call; every
-            // shared borrow below ends before the next exclusive re-derive.
-            let arena = unsafe { arena_from_handle(arena) };
-            arena.take_scrollable_overflow_recalculation_state()
-        };
-        if pending_boxes.is_empty() && !needs_full_recalculation {
-            return no_recalculation;
-        }
+    let no_recalculation = FfiScrollableOverflowUpdateOutcome {
+        performed_recalculation: false,
+        any_overflow_changed: false,
+        any_has_scrollable_overflow_flipped: false,
+    };
+    let (pending_boxes, needs_full_recalculation) = {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call; every
+        // shared borrow below ends before the next exclusive re-derive.
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.take_scrollable_overflow_recalculation_state()
+    };
+    if pending_boxes.is_empty() && !needs_full_recalculation {
+        return no_recalculation;
+    }
 
-        let row_is_populated = |slot: NodeSlotId| {
+    let row_is_populated = |slot: NodeSlotId| {
+        // SAFETY: As above.
+        unsafe { arena_from_handle(arena) }
+            .paintable_rows()
+            .paintable_row_is_populated(slot)
+    };
+    if !row_is_populated(viewport) {
+        return no_recalculation;
+    }
+
+    let measure_and_clamp = |slot: NodeSlotId| {
+        // SAFETY: As above; the callback receives a live shell and does not re-enter.
+        unsafe {
+            measure_scrollable_overflow_for_slot(arena, slot, &visual_context_callbacks, &overflow_callbacks);
+            let shell = arena_from_handle(arena).node_shell(slot);
+            clamp_scroll_offset_if_nonzero(scroll_offset_context, shell);
+        }
+    };
+
+    let performed = FfiScrollableOverflowUpdateOutcome {
+        performed_recalculation: true,
+        any_overflow_changed: false,
+        any_has_scrollable_overflow_flipped: false,
+    };
+    if handled_by_full_layout_commit {
+        assert!(needs_full_recalculation);
+        // A full-root commit reset every surviving row, including its overflow data and
+        // paint cache. There is therefore no old overflow to preserve or diff. Ordinary
+        // boxes are measured recursively when their overflow contributes to one of these
+        // roots, so they do not need separate eager measurement: only the viewport, scroll
+        // containers, and boxes holding a scroll offset are measured eagerly.
+        let mut eager_measurement_roots = Vec::new();
+        {
             // SAFETY: As above.
-            unsafe { arena_from_handle(arena) }
-                .paintable_rows()
-                .paintable_row_is_populated(slot)
-        };
-        if !row_is_populated(viewport) {
-            return no_recalculation;
-        }
-
-        let measure_and_clamp = |slot: NodeSlotId| {
-            // SAFETY: As above; the callback receives a live shell and does not re-enter.
-            unsafe {
-                measure_scrollable_overflow_for_slot(arena, slot, &visual_context_callbacks, &overflow_callbacks);
-                let shell = arena_from_handle(arena).node_shell(slot);
-                clamp_scroll_offset_if_nonzero(scroll_offset_context, shell);
-            }
-        };
-
-        let performed = FfiScrollableOverflowUpdateOutcome {
-            performed_recalculation: true,
-            any_overflow_changed: false,
-            any_has_scrollable_overflow_flipped: false,
-        };
-        if handled_by_full_layout_commit {
-            assert!(needs_full_recalculation);
-            // A full-root commit reset every surviving row, including its overflow data and
-            // paint cache. There is therefore no old overflow to preserve or diff. Ordinary
-            // boxes are measured recursively when their overflow contributes to one of these
-            // roots, so they do not need separate eager measurement: only the viewport, scroll
-            // containers, and boxes holding a scroll offset are measured eagerly.
-            let mut eager_measurement_roots = Vec::new();
-            {
-                // SAFETY: As above.
-                let arena = unsafe { arena_from_handle(arena) };
-                arena.for_each_node_in_layout_subtree_in_pre_order(viewport, |slot| {
-                    if !arena.paintable_rows().paintable_row_is_populated(slot) {
-                        return;
-                    }
-                    if slot == viewport || box_holds_scroll_state(arena, slot) {
-                        eager_measurement_roots.push(slot);
-                    }
-                });
-            }
-            for slot in eager_measurement_roots {
-                measure_and_clamp(slot);
-            }
-            return performed;
-        }
-
-        // For every box that will be re-measured, the overflow data it had before, so the diff
-        // below can tell what actually changed; an empty entry means the box's committed row was
-        // reset by a subtree layout commit and the old data is unknown.
-        let mut old_overflow_data_by_box: crate::css::style::fast_hash::FastMap<
-            NodeSlotId,
-            Option<crate::painting::paintable_data::FfiOverflowData>,
-        > = Default::default();
-        let overflow_snapshot = |slot: NodeSlotId| {
-            // SAFETY: As above; callers established a populated row.
             let arena = unsafe { arena_from_handle(arena) };
-            let paintable_rows = arena.paintable_rows();
-            let data = paintable_rows.paintable_data(slot);
-            data.overflow_measured_this_commit
-                .then_some(data.overflow_relative_to_padding_box)
-        };
-        let mut record_and_clear_overflow_data = |slot: NodeSlotId| {
-            if !row_is_populated(slot) {
-                return true;
-            }
-            if old_overflow_data_by_box.contains_key(&slot) {
-                return false;
-            }
-            old_overflow_data_by_box.insert(slot, overflow_snapshot(slot));
-            // SAFETY: As above; the row was just established as populated.
-            unsafe { arena_from_handle_mut(arena) }
-                .paintable_rows_mut()
-                .paintable_data_mut(slot)
-                .overflow_measured_this_commit = false;
-            true
-        };
-        let collect_box_subtree_slots = |root: NodeSlotId| {
-            let mut slots = Vec::new();
-            // SAFETY: As above; the traversal only reads tree links and kinds.
-            let arena = unsafe { arena_from_handle(arena) };
-            arena.for_each_node_in_layout_subtree_in_pre_order(root, |slot| {
-                if crate::layout::node_facts::kind_is_box(
-                    arena
-                        .node_kind_if_live(slot)
-                        .unwrap_or(crate::layout::node_data::NodeKind::Unset),
-                ) {
-                    slots.push(slot);
+            arena.for_each_node_in_layout_subtree_in_pre_order(viewport, |slot| {
+                if !arena.paintable_rows().paintable_row_is_populated(slot) {
+                    return;
+                }
+                if slot == viewport || box_holds_scroll_state(arena, slot) {
+                    eager_measurement_roots.push(slot);
                 }
             });
-            slots
-        };
-
-        if needs_full_recalculation {
-            for slot in collect_box_subtree_slots(viewport) {
-                record_and_clear_overflow_data(slot);
-            }
-            {
-                // SAFETY: As above.
-                let arena = unsafe { arena_from_handle(arena) };
-                let paintable_rows = arena.paintable_rows();
-                let mut paint_state = arena.paint_state().borrow_mut();
-                crate::painting::scrollable_overflow::refill_contained_boxes_index(
-                    &paintable_rows,
-                    viewport,
-                    &mut paint_state.scrollable_overflow_contained_boxes,
-                );
-            }
-        } else {
-            for &pending_slot in &pending_boxes {
-                // SAFETY: As above.
-                let pending_is_box = row_is_populated(pending_slot)
-                    && !unsafe { arena_from_handle(arena) }
-                        .shell_if_live(pending_slot)
-                        .is_null()
-                    && crate::layout::node_facts::kind_is_box(
-                        unsafe { arena_from_handle(arena) }
-                            .node_kind_if_live(pending_slot)
-                            .unwrap_or(crate::layout::node_data::NodeKind::Unset),
-                    );
-                if !pending_is_box {
-                    continue;
-                }
-                let was_reset_by_subtree_layout_commit = overflow_snapshot(pending_slot).is_none();
-                if was_reset_by_subtree_layout_commit {
-                    for slot in collect_box_subtree_slots(pending_slot) {
-                        record_and_clear_overflow_data(slot);
-                    }
-                }
-                // SAFETY: As above; containing-block links only name live slots.
-                let mut containing_block =
-                    unsafe { arena_from_handle(arena) }.node_containing_block_if_live(pending_slot);
-                while let Some(block) = containing_block {
-                    if row_is_populated(block) {
-                        // SAFETY: As above.
-                        unsafe { arena_from_handle(arena) }
-                            .paintable_rows()
-                            .clear_cached_overflow_data(block);
-                    }
-                    if !record_and_clear_overflow_data(block) {
-                        break;
-                    }
-                    // SAFETY: As above.
-                    containing_block = unsafe { arena_from_handle(arena) }.node_containing_block_if_live(block);
-                }
-            }
         }
-
-        if old_overflow_data_by_box.is_empty() {
-            return performed;
-        }
-
-        for (&slot, old_overflow_data) in &old_overflow_data_by_box {
-            if !row_is_populated(slot) {
-                continue;
-            }
-            // Boxes reset by a subtree commit have no previous overflow data. They will be
-            // measured recursively if an ancestor reaches them. Measuring each one here would
-            // repeatedly walk the same containing-block chains after a small subtree update.
-            if old_overflow_data.is_none() && slot != viewport {
-                // SAFETY: As above.
-                let arena = unsafe { arena_from_handle(arena) };
-                if !box_holds_scroll_state(arena, slot) {
-                    continue;
-                }
-            }
+        for slot in eager_measurement_roots {
             measure_and_clamp(slot);
         }
+        return performed;
+    }
 
-        let mut any_overflow_changed = false;
-        let mut any_has_scrollable_overflow_flipped = false;
-        for (&slot, old_overflow_data) in &old_overflow_data_by_box {
-            if !row_is_populated(slot) {
-                continue;
+    // For every box that will be re-measured, the overflow data it had before, so the diff
+    // below can tell what actually changed; an empty entry means the box's committed row was
+    // reset by a subtree layout commit and the old data is unknown.
+    let mut old_overflow_data_by_box: crate::css::style::fast_hash::FastMap<
+        NodeSlotId,
+        Option<crate::painting::paintable_data::FfiOverflowData>,
+    > = Default::default();
+    let overflow_snapshot = |slot: NodeSlotId| {
+        // SAFETY: As above; callers established a populated row.
+        let arena = unsafe { arena_from_handle(arena) };
+        let paintable_rows = arena.paintable_rows();
+        let data = paintable_rows.paintable_data(slot);
+        data.overflow_measured_this_commit
+            .then_some(data.overflow_relative_to_padding_box)
+    };
+    let mut record_and_clear_overflow_data = |slot: NodeSlotId| {
+        if !row_is_populated(slot) {
+            return true;
+        }
+        if old_overflow_data_by_box.contains_key(&slot) {
+            return false;
+        }
+        old_overflow_data_by_box.insert(slot, overflow_snapshot(slot));
+        // SAFETY: As above; the row was just established as populated.
+        unsafe { arena_from_handle_mut(arena) }
+            .paintable_rows_mut()
+            .paintable_data_mut(slot)
+            .overflow_measured_this_commit = false;
+        true
+    };
+    let collect_box_subtree_slots = |root: NodeSlotId| {
+        let mut slots = Vec::new();
+        // SAFETY: As above; the traversal only reads tree links and kinds.
+        let arena = unsafe { arena_from_handle(arena) };
+        arena.for_each_node_in_layout_subtree_in_pre_order(root, |slot| {
+            if crate::layout::node_facts::kind_is_box(
+                arena
+                    .node_kind_if_live(slot)
+                    .unwrap_or(crate::layout::node_data::NodeKind::Unset),
+            ) {
+                slots.push(slot);
             }
-            let Some(new_overflow_data) = overflow_snapshot(slot) else {
-                continue;
-            };
-            // A box with no prior overflow data was just created or reset by the layout commit,
-            // so its paint cache is already clean.
-            let Some(old_overflow_data) = old_overflow_data else {
-                continue;
-            };
-            // Boxes that merely moved do not register here; everything derived below is
-            // translation-invariant, and movement-driven repaint belongs to the layout commit.
-            let rect_changed = old_overflow_data.rect != new_overflow_data.rect;
-            let has_scrollable_overflow_flipped =
-                old_overflow_data.has_scrollable_overflow != new_overflow_data.has_scrollable_overflow;
-            if !rect_changed && !has_scrollable_overflow_flipped {
-                continue;
-            }
-            // Cached paint commands and hit-test items capture scrollbar geometry and
-            // per-direction scrollability derived from the overflow rect, so they cannot be
-            // reused once it changes. This must also run for the after-layout-commit path: a
-            // subtree relayout re-measures a surviving ancestor's overflow without resetting
-            // the ancestor's committed row.
+        });
+        slots
+    };
+
+    if needs_full_recalculation {
+        for slot in collect_box_subtree_slots(viewport) {
+            record_and_clear_overflow_data(slot);
+        }
+        {
             // SAFETY: As above.
-            unsafe { arena_from_handle(arena) }.invalidate_paint_cache(slot);
-            any_overflow_changed = true;
-            any_has_scrollable_overflow_flipped |= has_scrollable_overflow_flipped;
+            let arena = unsafe { arena_from_handle(arena) };
+            let paintable_rows = arena.paintable_rows();
+            let mut paint_state = arena.paint_state().borrow_mut();
+            crate::painting::scrollable_overflow::refill_contained_boxes_index(
+                &paintable_rows,
+                viewport,
+                &mut paint_state.scrollable_overflow_contained_boxes,
+            );
         }
+    } else {
+        for &pending_slot in &pending_boxes {
+            // SAFETY: As above.
+            let pending_is_box = row_is_populated(pending_slot)
+                && !unsafe { arena_from_handle(arena) }
+                    .shell_if_live(pending_slot)
+                    .is_null()
+                && crate::layout::node_facts::kind_is_box(
+                    unsafe { arena_from_handle(arena) }
+                        .node_kind_if_live(pending_slot)
+                        .unwrap_or(crate::layout::node_data::NodeKind::Unset),
+                );
+            if !pending_is_box {
+                continue;
+            }
+            let was_reset_by_subtree_layout_commit = overflow_snapshot(pending_slot).is_none();
+            if was_reset_by_subtree_layout_commit {
+                for slot in collect_box_subtree_slots(pending_slot) {
+                    record_and_clear_overflow_data(slot);
+                }
+            }
+            // SAFETY: As above; containing-block links only name live slots.
+            let mut containing_block = unsafe { arena_from_handle(arena) }.node_containing_block_if_live(pending_slot);
+            while let Some(block) = containing_block {
+                if row_is_populated(block) {
+                    // SAFETY: As above.
+                    unsafe { arena_from_handle(arena) }
+                        .paintable_rows()
+                        .clear_cached_overflow_data(block);
+                }
+                if !record_and_clear_overflow_data(block) {
+                    break;
+                }
+                // SAFETY: As above.
+                containing_block = unsafe { arena_from_handle(arena) }.node_containing_block_if_live(block);
+            }
+        }
+    }
 
-        FfiScrollableOverflowUpdateOutcome {
-            performed_recalculation: true,
-            any_overflow_changed,
-            any_has_scrollable_overflow_flipped,
+    if old_overflow_data_by_box.is_empty() {
+        return performed;
+    }
+
+    for (&slot, old_overflow_data) in &old_overflow_data_by_box {
+        if !row_is_populated(slot) {
+            continue;
         }
-    })
+        // Boxes reset by a subtree commit have no previous overflow data. They will be
+        // measured recursively if an ancestor reaches them. Measuring each one here would
+        // repeatedly walk the same containing-block chains after a small subtree update.
+        if old_overflow_data.is_none() && slot != viewport {
+            // SAFETY: As above.
+            let arena = unsafe { arena_from_handle(arena) };
+            if !box_holds_scroll_state(arena, slot) {
+                continue;
+            }
+        }
+        measure_and_clamp(slot);
+    }
+
+    let mut any_overflow_changed = false;
+    let mut any_has_scrollable_overflow_flipped = false;
+    for (&slot, old_overflow_data) in &old_overflow_data_by_box {
+        if !row_is_populated(slot) {
+            continue;
+        }
+        let Some(new_overflow_data) = overflow_snapshot(slot) else {
+            continue;
+        };
+        // A box with no prior overflow data was just created or reset by the layout commit,
+        // so its paint cache is already clean.
+        let Some(old_overflow_data) = old_overflow_data else {
+            continue;
+        };
+        // Boxes that merely moved do not register here; everything derived below is
+        // translation-invariant, and movement-driven repaint belongs to the layout commit.
+        let rect_changed = old_overflow_data.rect != new_overflow_data.rect;
+        let has_scrollable_overflow_flipped =
+            old_overflow_data.has_scrollable_overflow != new_overflow_data.has_scrollable_overflow;
+        if !rect_changed && !has_scrollable_overflow_flipped {
+            continue;
+        }
+        // Cached paint commands and hit-test items capture scrollbar geometry and
+        // per-direction scrollability derived from the overflow rect, so they cannot be
+        // reused once it changes. This must also run for the after-layout-commit path: a
+        // subtree relayout re-measures a surviving ancestor's overflow without resetting
+        // the ancestor's committed row.
+        // SAFETY: As above.
+        unsafe { arena_from_handle(arena) }.invalidate_paint_cache(slot);
+        any_overflow_changed = true;
+        any_has_scrollable_overflow_flipped |= has_scrollable_overflow_flipped;
+    }
+
+    FfiScrollableOverflowUpdateOutcome {
+        performed_recalculation: true,
+        any_overflow_changed,
+        any_has_scrollable_overflow_flipped,
+    }
 }
 
 #[repr(C)]
@@ -988,14 +924,12 @@ pub struct FfiBoxModelMetrics {
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_offset(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelPoint {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelPoint::default();
-        }
-        crate::painting::paintable_geometry::committed_offset(&paintable_rows, slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return FfiCssPixelPoint::default();
+    }
+    crate::painting::paintable_geometry::committed_offset(&paintable_rows, slot)
 }
 
 /// # Safety
@@ -1003,14 +937,12 @@ pub unsafe extern "C" fn layout_arena_paintable_offset(arena: *mut c_void, slot:
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_content_size(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelSize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelSize::default();
-        }
-        crate::painting::paintable_geometry::committed_content_size(&paintable_rows, slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return FfiCssPixelSize::default();
+    }
+    crate::painting::paintable_geometry::committed_content_size(&paintable_rows, slot)
 }
 
 /// # Safety
@@ -1021,14 +953,12 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_size(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelSize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelSize::default();
-        }
-        crate::painting::paintable_geometry::committed_svg_viewport_size(&paintable_rows, slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return FfiCssPixelSize::default();
+    }
+    crate::painting::paintable_geometry::committed_svg_viewport_size(&paintable_rows, slot)
 }
 
 #[repr(C)]
@@ -1045,18 +975,16 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_transform(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiOptionalAffineTransform {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let transform = if arena.paintable_row_is_populated(slot) {
-            crate::painting::paintable_geometry::committed_svg_viewport_transform(arena, slot)
-        } else {
-            None
-        };
-        FfiOptionalAffineTransform {
-            has_value: transform.is_some(),
-            transform: transform.unwrap_or_default(),
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let transform = if arena.paintable_row_is_populated(slot) {
+        crate::painting::paintable_geometry::committed_svg_viewport_transform(arena, slot)
+    } else {
+        None
+    };
+    FfiOptionalAffineTransform {
+        has_value: transform.is_some(),
+        transform: transform.unwrap_or_default(),
+    }
 }
 
 /// # Safety
@@ -1067,17 +995,15 @@ pub unsafe extern "C" fn layout_arena_paintable_transform_reference_box(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return FfiCssPixelRect::default();
-        }
-        let Some(style) = arena.node_style_if_live(slot) else {
-            return FfiCssPixelRect::default();
-        };
-        let paintable_rows = arena.paintable_rows();
-        crate::painting::visual_context::node_values::transform_reference_box(style, &paintable_rows, slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return FfiCssPixelRect::default();
+    }
+    let Some(style) = arena.node_style_if_live(slot) else {
+        return FfiCssPixelRect::default();
+    };
+    let paintable_rows = arena.paintable_rows();
+    crate::painting::visual_context::node_values::transform_reference_box(style, &paintable_rows, slot).into()
 }
 
 /// # Safety
@@ -1088,21 +1014,19 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_user_rect(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> used_values::OptionalCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return None.into();
-        }
-        let paintable_rows = arena.paintable_rows();
-        crate::painting::svg_viewport::nearest_svg_viewport_user_rect(&paintable_rows, slot)
-            .map(|rect| used_values::FfiCssPixelRect {
-                x: crate::css::css_pixels::CssPixels::nearest_value_for(rect.x as f64),
-                y: crate::css::css_pixels::CssPixels::nearest_value_for(rect.y as f64),
-                width: crate::css::css_pixels::CssPixels::nearest_value_for(rect.width as f64),
-                height: crate::css::css_pixels::CssPixels::nearest_value_for(rect.height as f64),
-            })
-            .into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return None.into();
+    }
+    let paintable_rows = arena.paintable_rows();
+    crate::painting::svg_viewport::nearest_svg_viewport_user_rect(&paintable_rows, slot)
+        .map(|rect| used_values::FfiCssPixelRect {
+            x: crate::css::css_pixels::CssPixels::nearest_value_for(rect.x as f64),
+            y: crate::css::css_pixels::CssPixels::nearest_value_for(rect.y as f64),
+            width: crate::css::css_pixels::CssPixels::nearest_value_for(rect.width as f64),
+            height: crate::css::css_pixels::CssPixels::nearest_value_for(rect.height as f64),
+        })
+        .into()
 }
 
 /// # Safety
@@ -1110,18 +1034,16 @@ pub unsafe extern "C" fn layout_arena_paintable_svg_viewport_user_rect(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_box_model(arena: *mut c_void, slot: NodeSlotId) -> FfiBoxModelMetrics {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return FfiBoxModelMetrics::default();
-        }
-        FfiBoxModelMetrics {
-            margin: crate::painting::paintable_geometry::committed_margin(arena, slot),
-            padding: crate::painting::paintable_geometry::committed_padding(arena, slot),
-            border: crate::painting::paintable_geometry::committed_border(arena, slot),
-            inset: crate::painting::paintable_geometry::committed_inset(arena, slot),
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return FfiBoxModelMetrics::default();
+    }
+    FfiBoxModelMetrics {
+        margin: crate::painting::paintable_geometry::committed_margin(arena, slot),
+        padding: crate::painting::paintable_geometry::committed_padding(arena, slot),
+        border: crate::painting::paintable_geometry::committed_border(arena, slot),
+        inset: crate::painting::paintable_geometry::committed_inset(arena, slot),
+    }
 }
 
 /// # Safety
@@ -1129,13 +1051,11 @@ pub unsafe extern "C" fn layout_arena_paintable_box_model(arena: *mut c_void, sl
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_is_positioned(arena: *mut c_void, slot: NodeSlotId) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return false;
-        }
-        crate::painting::style_queries::is_positioned(arena, slot)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return false;
+    }
+    crate::painting::style_queries::is_positioned(arena, slot)
 }
 
 /// # Safety
@@ -1143,10 +1063,8 @@ pub unsafe extern "C" fn layout_arena_paintable_is_positioned(arena: *mut c_void
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_absolute_rect(arena: *mut c_void, slot: NodeSlotId) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        crate::painting::paintable_geometry::absolute_rect_or_default(&arena.paintable_rows(), slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::paintable_geometry::absolute_rect_or_default(&arena.paintable_rows(), slot).into()
 }
 
 /// # Safety
@@ -1157,14 +1075,12 @@ pub unsafe extern "C" fn layout_arena_paintable_absolute_padding_box_rect(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelRect::default();
-        }
-        crate::painting::paintable_geometry::absolute_padding_box_rect(&paintable_rows, slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return FfiCssPixelRect::default();
+    }
+    crate::painting::paintable_geometry::absolute_padding_box_rect(&paintable_rows, slot).into()
 }
 
 /// # Safety
@@ -1175,14 +1091,12 @@ pub unsafe extern "C" fn layout_arena_paintable_absolute_border_box_rect(
     arena: *mut c_void,
     slot: NodeSlotId,
 ) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(slot) {
-            return FfiCssPixelRect::default();
-        }
-        crate::painting::paintable_geometry::absolute_border_box_rect(&paintable_rows, slot).into()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(slot) {
+        return FfiCssPixelRect::default();
+    }
+    crate::painting::paintable_geometry::absolute_border_box_rect(&paintable_rows, slot).into()
 }
 
 /// # Safety
@@ -1193,16 +1107,14 @@ pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxe
     arena: *mut c_void,
     root: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let mut paint_state = arena.paint_state().borrow_mut();
-        crate::painting::scrollable_overflow::refill_contained_boxes_index(
-            &paintable_rows,
-            root,
-            &mut paint_state.scrollable_overflow_contained_boxes,
-        );
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let mut paint_state = arena.paint_state().borrow_mut();
+    crate::painting::scrollable_overflow::refill_contained_boxes_index(
+        &paintable_rows,
+        root,
+        &mut paint_state.scrollable_overflow_contained_boxes,
+    );
 }
 
 /// # Safety
@@ -1210,14 +1122,12 @@ pub unsafe extern "C" fn layout_arena_rebuild_scrollable_overflow_contained_boxe
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_clear_scrollable_overflow_contained_boxes(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena
-            .paint_state()
-            .borrow_mut()
-            .scrollable_overflow_contained_boxes
-            .clear();
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena
+        .paint_state()
+        .borrow_mut()
+        .scrollable_overflow_contained_boxes
+        .clear();
 }
 
 /// # Safety
@@ -1228,18 +1138,16 @@ pub unsafe extern "C" fn layout_arena_physical_overflow_directions(
     arena: *mut c_void,
     paintable: NodeSlotId,
 ) -> FfiPhysicalOverflowDirections {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let directions = if arena.paintable_row_is_populated(paintable) {
-            crate::painting::scrollable_overflow::physical_overflow_directions(arena, paintable)
-        } else {
-            crate::painting::scrollable_overflow::PhysicalOverflowDirections::default()
-        };
-        FfiPhysicalOverflowDirections {
-            horizontal_axis_is_positive: directions.horizontal_axis_is_positive,
-            vertical_axis_is_positive: directions.vertical_axis_is_positive,
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let directions = if arena.paintable_row_is_populated(paintable) {
+        crate::painting::scrollable_overflow::physical_overflow_directions(arena, paintable)
+    } else {
+        crate::painting::scrollable_overflow::PhysicalOverflowDirections::default()
+    };
+    FfiPhysicalOverflowDirections {
+        horizontal_axis_is_positive: directions.horizontal_axis_is_positive,
+        vertical_axis_is_positive: directions.vertical_axis_is_positive,
+    }
 }
 
 /// # Safety
@@ -1251,22 +1159,18 @@ pub unsafe extern "C" fn layout_arena_visual_context_note_box_dirty(
     slot: NodeSlotId,
     kind: crate::painting::host::FfiVisualContextBoxDirtyKind,
 ) {
-    abort_on_panic(|| {
-        use crate::painting::host::FfiVisualContextBoxDirtyKind;
-        use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(slot) {
-            return;
-        }
-        let kind = match kind {
-            FfiVisualContextBoxDirtyKind::StyleValueChange => VisualContextBoxDirtyKind::StyleValueChange,
-            FfiVisualContextBoxDirtyKind::StyleStructuralChange => VisualContextBoxDirtyKind::StyleStructuralChange,
-            FfiVisualContextBoxDirtyKind::ScrollableOverflowFlipped => {
-                VisualContextBoxDirtyKind::ScrollableOverflowFlipped
-            }
-        };
-        arena.note_visual_context_box_dirty(slot, kind);
-    });
+    use crate::painting::host::FfiVisualContextBoxDirtyKind;
+    use crate::painting::visual_context::dirty::VisualContextBoxDirtyKind;
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(slot) {
+        return;
+    }
+    let kind = match kind {
+        FfiVisualContextBoxDirtyKind::StyleValueChange => VisualContextBoxDirtyKind::StyleValueChange,
+        FfiVisualContextBoxDirtyKind::StyleStructuralChange => VisualContextBoxDirtyKind::StyleStructuralChange,
+        FfiVisualContextBoxDirtyKind::ScrollableOverflowFlipped => VisualContextBoxDirtyKind::ScrollableOverflowFlipped,
+    };
+    arena.note_visual_context_box_dirty(slot, kind);
 }
 
 /// # Safety
@@ -1277,25 +1181,23 @@ pub unsafe extern "C" fn layout_arena_visual_context_request_full_rebuild(
     arena: *mut c_void,
     reason: crate::painting::host::FfiVisualContextGlobalRebuildReason,
 ) {
-    abort_on_panic(|| {
-        use crate::painting::host::FfiVisualContextGlobalRebuildReason;
-        use crate::painting::visual_context::dirty::VisualContextGlobalRebuildReason;
-        let arena = unsafe { arena_from_handle(arena) };
-        let reason = match reason {
-            FfiVisualContextGlobalRebuildReason::FirstBuild => VisualContextGlobalRebuildReason::FirstBuild,
-            FfiVisualContextGlobalRebuildReason::DocumentWideStructuralChange => {
-                VisualContextGlobalRebuildReason::DocumentWideStructuralChange
-            }
-            FfiVisualContextGlobalRebuildReason::FilterResourcesChanged => {
-                VisualContextGlobalRebuildReason::FilterResourcesChanged
-            }
-            FfiVisualContextGlobalRebuildReason::ForcedForTesting => VisualContextGlobalRebuildReason::ForcedForTesting,
-            FfiVisualContextGlobalRebuildReason::CanonicalDumpRequested => {
-                VisualContextGlobalRebuildReason::CanonicalDumpRequested
-            }
-        };
-        arena.request_full_visual_context_rebuild(reason);
-    });
+    use crate::painting::host::FfiVisualContextGlobalRebuildReason;
+    use crate::painting::visual_context::dirty::VisualContextGlobalRebuildReason;
+    let arena = unsafe { arena_from_handle(arena) };
+    let reason = match reason {
+        FfiVisualContextGlobalRebuildReason::FirstBuild => VisualContextGlobalRebuildReason::FirstBuild,
+        FfiVisualContextGlobalRebuildReason::DocumentWideStructuralChange => {
+            VisualContextGlobalRebuildReason::DocumentWideStructuralChange
+        }
+        FfiVisualContextGlobalRebuildReason::FilterResourcesChanged => {
+            VisualContextGlobalRebuildReason::FilterResourcesChanged
+        }
+        FfiVisualContextGlobalRebuildReason::ForcedForTesting => VisualContextGlobalRebuildReason::ForcedForTesting,
+        FfiVisualContextGlobalRebuildReason::CanonicalDumpRequested => {
+            VisualContextGlobalRebuildReason::CanonicalDumpRequested
+        }
+    };
+    arena.request_full_visual_context_rebuild(reason);
 }
 
 /// # Safety
@@ -1303,11 +1205,9 @@ pub unsafe extern "C" fn layout_arena_visual_context_request_full_rebuild(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_visual_context_pending_dirty_box_count(arena: *mut c_void) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state.visual_context.dirty_boxes.boxes.len()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state.visual_context.dirty_boxes.boxes.len()
 }
 
 /// # Safety
@@ -1324,22 +1224,20 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_animation_target_indices(
     context: *mut c_void,
     append: unsafe extern "C" fn(*mut c_void, u32),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let tree = unsafe { tree_from_handle(tree) };
-        arena.with_paintable_visual_context_node_handles(slot, |handles| {
-            let owned_indices: Vec<u32> = if targets_are_frames {
-                handles.frame_handles().map(|index| index.0).collect()
-            } else {
-                handles.spatial.iter().map(|index| index.0).collect()
-            };
-            for index in owned_indices {
-                if tree.visual_animation_target_is_valid(targets_are_frames, index) {
-                    // SAFETY: the host appends into its own storage synchronously.
-                    unsafe { append(context, index) };
-                }
+    let arena = unsafe { arena_from_handle(arena) };
+    let tree = unsafe { tree_from_handle(tree) };
+    arena.with_paintable_visual_context_node_handles(slot, |handles| {
+        let owned_indices: Vec<u32> = if targets_are_frames {
+            handles.frame_handles().map(|index| index.0).collect()
+        } else {
+            handles.spatial.iter().map(|index| index.0).collect()
+        };
+        for index in owned_indices {
+            if tree.visual_animation_target_is_valid(targets_are_frames, index) {
+                // SAFETY: the host appends into its own storage synchronously.
+                unsafe { append(context, index) };
             }
-        });
+        }
     });
 }
 
@@ -1352,13 +1250,11 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_context_node_count(
     slot: NodeSlotId,
     list: crate::painting::host::FfiVisualContextBoxNodeList,
 ) -> usize {
-    abort_on_panic(|| {
-        use crate::painting::host::FfiVisualContextBoxNodeList;
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.with_paintable_visual_context_node_handles(slot, |handles| match list {
-            FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.len(),
-            FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().count(),
-        })
+    use crate::painting::host::FfiVisualContextBoxNodeList;
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.with_paintable_visual_context_node_handles(slot, |handles| match list {
+        FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.len(),
+        FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().count(),
     })
 }
 
@@ -1374,18 +1270,16 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_context_copy_node_indices
     out: *mut u32,
     capacity: usize,
 ) {
-    abort_on_panic(|| {
-        use crate::painting::host::FfiVisualContextBoxNodeList;
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.with_paintable_visual_context_node_handles(slot, |handles| {
-            let indices: Vec<u32> = match list {
-                FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.iter().map(|index| index.0).collect(),
-                FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().map(|index| index.0).collect(),
-            };
-            assert!(indices.len() <= capacity);
-            // SAFETY: the caller warrants `capacity` writable indices behind `out`.
-            unsafe { std::ptr::copy_nonoverlapping(indices.as_ptr(), out, indices.len()) };
-        });
+    use crate::painting::host::FfiVisualContextBoxNodeList;
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.with_paintable_visual_context_node_handles(slot, |handles| {
+        let indices: Vec<u32> = match list {
+            FfiVisualContextBoxNodeList::SpatialNodes => handles.spatial.iter().map(|index| index.0).collect(),
+            FfiVisualContextBoxNodeList::FrameNodes => handles.frame_handles().map(|index| index.0).collect(),
+        };
+        assert!(indices.len() <= capacity);
+        // SAFETY: the caller warrants `capacity` writable indices behind `out`.
+        unsafe { std::ptr::copy_nonoverlapping(indices.as_ptr(), out, indices.len()) };
     });
 }
 
@@ -1503,132 +1397,130 @@ pub unsafe extern "C" fn layout_arena_update_accumulated_visual_contexts(
     viewport: NodeSlotId,
     callbacks: FfiVisualContextHostCallbacks,
 ) -> crate::painting::host::FfiVisualContextUpdateOutcome {
-    abort_on_panic(|| {
-        use crate::painting::visual_context::dirty::{
-            VisualContextBoxDirtyKind, VisualContextGlobalRebuildReason, VisualContextUpdateScope,
-        };
-        use crate::painting::visual_context::incremental::{
-            IncrementalUpdateResult, debug_assert_every_live_node_is_owned, update_visual_context_tree,
-        };
-        let arena_ref = unsafe { arena_from_handle(arena) };
-        if !arena_ref.paintable_row_is_populated(viewport) {
-            return crate::painting::host::FfiVisualContextUpdateOutcome::default();
-        }
-        let inputs = callbacks.tree_inputs();
-        let root_background_source = callbacks.root_background_source();
-        let mut state = std::mem::take(&mut arena_ref.paint_state().borrow_mut().visual_context);
-        state.release_quarantined_slots_while_no_handle_is_retained();
+    use crate::painting::visual_context::dirty::{
+        VisualContextBoxDirtyKind, VisualContextGlobalRebuildReason, VisualContextUpdateScope,
+    };
+    use crate::painting::visual_context::incremental::{
+        IncrementalUpdateResult, debug_assert_every_live_node_is_owned, update_visual_context_tree,
+    };
+    let arena_ref = unsafe { arena_from_handle(arena) };
+    if !arena_ref.paintable_row_is_populated(viewport) {
+        return crate::painting::host::FfiVisualContextUpdateOutcome::default();
+    }
+    let inputs = callbacks.tree_inputs();
+    let root_background_source = callbacks.root_background_source();
+    let mut state = std::mem::take(&mut arena_ref.paint_state().borrow_mut().visual_context);
+    state.release_quarantined_slots_while_no_handle_is_retained();
 
-        let mut reason = state.dirty_boxes.global_reason;
-        if state.tree.is_none() {
-            reason = reason.max(VisualContextGlobalRebuildReason::FirstBuild);
-        }
-        if state.last_tree_inputs.is_some_and(|last| {
-            last.device_pixels_per_css_pixel != inputs.device_pixels_per_css_pixel
-                || last.viewport_wheel_overflow_x != inputs.viewport_wheel_overflow_x
-                || last.viewport_wheel_overflow_y != inputs.viewport_wheel_overflow_y
-        }) {
-            reason = reason.max(VisualContextGlobalRebuildReason::TreeInputsChanged);
-        }
-        if arena_ref.may_have_default_scroll_shift_anchor() {
-            reason = reason.max(VisualContextGlobalRebuildReason::AnchorsRegistered);
-        }
-        if state.tree.as_deref().is_some_and(|tree| tree.should_compact()) {
-            reason = reason.max(VisualContextGlobalRebuildReason::Compaction);
-        }
-        if let Some(last_source) = state.last_root_background_source
-            && (last_source.use_body_background_properties != root_background_source.use_body_background_properties
-                || last_source.body_layout_node != root_background_source.body_layout_node)
-        {
-            for body in [last_source.body_layout_node, root_background_source.body_layout_node] {
-                if arena_ref.paintable_row_is_populated(body) {
-                    let pending_box_limit = arena_ref
-                        .paintable_row_count()
-                        .max(crate::painting::visual_context::dirty::MINIMUM_PENDING_DIRTY_BOX_LIMIT);
+    let mut reason = state.dirty_boxes.global_reason;
+    if state.tree.is_none() {
+        reason = reason.max(VisualContextGlobalRebuildReason::FirstBuild);
+    }
+    if state.last_tree_inputs.is_some_and(|last| {
+        last.device_pixels_per_css_pixel != inputs.device_pixels_per_css_pixel
+            || last.viewport_wheel_overflow_x != inputs.viewport_wheel_overflow_x
+            || last.viewport_wheel_overflow_y != inputs.viewport_wheel_overflow_y
+    }) {
+        reason = reason.max(VisualContextGlobalRebuildReason::TreeInputsChanged);
+    }
+    if arena_ref.may_have_default_scroll_shift_anchor() {
+        reason = reason.max(VisualContextGlobalRebuildReason::AnchorsRegistered);
+    }
+    if state.tree.as_deref().is_some_and(|tree| tree.should_compact()) {
+        reason = reason.max(VisualContextGlobalRebuildReason::Compaction);
+    }
+    if let Some(last_source) = state.last_root_background_source
+        && (last_source.use_body_background_properties != root_background_source.use_body_background_properties
+            || last_source.body_layout_node != root_background_source.body_layout_node)
+    {
+        for body in [last_source.body_layout_node, root_background_source.body_layout_node] {
+            if arena_ref.paintable_row_is_populated(body) {
+                let pending_box_limit = arena_ref
+                    .paintable_row_count()
+                    .max(crate::painting::visual_context::dirty::MINIMUM_PENDING_DIRTY_BOX_LIMIT);
+                state.dirty_boxes.note_box(
+                    body,
+                    VisualContextBoxDirtyKind::StyleStructuralChange,
+                    pending_box_limit,
+                );
+                if let Some(html) = crate::painting::paint_order::paint_parent(&arena_ref.paintable_rows(), body) {
                     state.dirty_boxes.note_box(
-                        body,
+                        html,
                         VisualContextBoxDirtyKind::StyleStructuralChange,
                         pending_box_limit,
                     );
-                    if let Some(html) = crate::painting::paint_order::paint_parent(&arena_ref.paintable_rows(), body) {
-                        state.dirty_boxes.note_box(
-                            html,
-                            VisualContextBoxDirtyKind::StyleStructuralChange,
-                            pending_box_limit,
-                        );
-                    }
                 }
             }
         }
+    }
 
-        loop {
-            let scope = VisualContextUpdateScope::for_reason(reason);
-            if scope == VisualContextUpdateScope::FreshTree {
-                break;
-            }
-            let result = {
-                let paintable_rows = arena_ref.paintable_rows();
-                update_visual_context_tree(
-                    &paintable_rows,
-                    &callbacks,
-                    viewport,
-                    inputs,
-                    root_background_source,
-                    scope,
-                    &mut state,
-                )
-            };
-            match result {
-                IncrementalUpdateResult::Applied(mut outcome) => {
-                    let arena_mut = unsafe { arena_from_handle_mut(arena) };
-                    apply_walk_assignments(arena_mut, viewport, &mut outcome, &mut state);
-                    arena_mut.resort_stacking_context_entries_flagged_for_resort();
-                    crate::painting::fragment_ownership::assign_fragment_ownership_for_pending_line_roots(arena_mut);
-                    let performed_full_build = scope == VisualContextUpdateScope::EveryBox;
-                    if performed_full_build {
-                        state.build_count += 1;
-                        state.last_full_build_reason = reason;
-                        debug_assert_every_live_node_is_owned(
-                            &arena_mut.paintable_rows(),
-                            state.tree.as_deref().expect("an applied walk keeps the tree"),
-                            viewport,
-                        );
-                    } else {
-                        state.incremental_update_count += 1;
-                    }
-                    let structural_epoch_changed = outcome.delta.structural_epoch_changed;
-                    let requires_display_list_recording = outcome.delta.requires_display_list_recording;
-                    state.dirty_boxes.clear();
-                    state.last_tree_inputs = Some(inputs);
-                    state.last_root_background_source = Some(root_background_source);
-                    let structural_epoch = state.structural_epoch();
-                    arena_mut.paint_state().borrow_mut().visual_context = state;
-                    return crate::painting::host::FfiVisualContextUpdateOutcome {
-                        performed_full_build,
-                        structural_epoch_changed,
-                        requires_display_list_recording,
-                        structural_epoch,
-                    };
-                }
-                IncrementalUpdateResult::NeedsFullBuild(fallback_reason) => {
-                    assert!(
-                        VisualContextUpdateScope::for_reason(fallback_reason) > scope,
-                        "a fallback widens the update scope"
+    loop {
+        let scope = VisualContextUpdateScope::for_reason(reason);
+        if scope == VisualContextUpdateScope::FreshTree {
+            break;
+        }
+        let result = {
+            let paintable_rows = arena_ref.paintable_rows();
+            update_visual_context_tree(
+                &paintable_rows,
+                &callbacks,
+                viewport,
+                inputs,
+                root_background_source,
+                scope,
+                &mut state,
+            )
+        };
+        match result {
+            IncrementalUpdateResult::Applied(mut outcome) => {
+                let arena_mut = unsafe { arena_from_handle_mut(arena) };
+                apply_walk_assignments(arena_mut, viewport, &mut outcome, &mut state);
+                arena_mut.resort_stacking_context_entries_flagged_for_resort();
+                crate::painting::fragment_ownership::assign_fragment_ownership_for_pending_line_roots(arena_mut);
+                let performed_full_build = scope == VisualContextUpdateScope::EveryBox;
+                if performed_full_build {
+                    state.build_count += 1;
+                    state.last_full_build_reason = reason;
+                    debug_assert_every_live_node_is_owned(
+                        &arena_mut.paintable_rows(),
+                        state.tree.as_deref().expect("an applied walk keeps the tree"),
+                        viewport,
                     );
-                    reason = fallback_reason;
+                } else {
+                    state.incremental_update_count += 1;
                 }
+                let structural_epoch_changed = outcome.delta.structural_epoch_changed;
+                let requires_display_list_recording = outcome.delta.requires_display_list_recording;
+                state.dirty_boxes.clear();
+                state.last_tree_inputs = Some(inputs);
+                state.last_root_background_source = Some(root_background_source);
+                let structural_epoch = state.structural_epoch();
+                arena_mut.paint_state().borrow_mut().visual_context = state;
+                return crate::painting::host::FfiVisualContextUpdateOutcome {
+                    performed_full_build,
+                    structural_epoch_changed,
+                    requires_display_list_recording,
+                    structural_epoch,
+                };
+            }
+            IncrementalUpdateResult::NeedsFullBuild(fallback_reason) => {
+                assert!(
+                    VisualContextUpdateScope::for_reason(fallback_reason) > scope,
+                    "a fallback widens the update scope"
+                );
+                reason = fallback_reason;
             }
         }
+    }
 
-        state.last_full_build_reason = reason;
-        let outcome =
-            fresh_visual_context_tree_build(arena, viewport, &callbacks, inputs, root_background_source, &mut state);
-        state.last_tree_inputs = Some(inputs);
-        state.last_root_background_source = Some(root_background_source);
-        let arena_ref = unsafe { arena_from_handle(arena) };
-        arena_ref.paint_state().borrow_mut().visual_context = state;
-        outcome
-    })
+    state.last_full_build_reason = reason;
+    let outcome =
+        fresh_visual_context_tree_build(arena, viewport, &callbacks, inputs, root_background_source, &mut state);
+    state.last_tree_inputs = Some(inputs);
+    state.last_root_background_source = Some(root_background_source);
+    let arena_ref = unsafe { arena_from_handle(arena) };
+    arena_ref.paint_state().borrow_mut().visual_context = state;
+    outcome
 }
 
 /// # Safety
@@ -1641,37 +1533,32 @@ pub unsafe extern "C" fn layout_arena_apply_css_transform_to_rect(
     callbacks: FfiVisualContextHostCallbacks,
     rect: FfiCssPixelRect,
 ) -> FfiCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let Some((transform, _is_invertible)) = crate::painting::visual_context::node_values::compute_transform(
-            &arena.paintable_rows(),
-            &callbacks,
-            node,
-            1.0,
-        ) else {
-            return rect;
-        };
-        let origin = transform.origin;
-        let mapped = transform
-            .matrix
-            .extract_2d_affine()
-            .map_rect(
-                libgfx_rust::FloatRect::new(
-                    rect.x.to_float(),
-                    rect.y.to_float(),
-                    rect.width.to_float(),
-                    rect.height.to_float(),
-                )
-                .translated(-origin.x, -origin.y),
+    let arena = unsafe { arena_from_handle(arena) };
+    let Some((transform, _is_invertible)) =
+        crate::painting::visual_context::node_values::compute_transform(&arena.paintable_rows(), &callbacks, node, 1.0)
+    else {
+        return rect;
+    };
+    let origin = transform.origin;
+    let mapped = transform
+        .matrix
+        .extract_2d_affine()
+        .map_rect(
+            libgfx_rust::FloatRect::new(
+                rect.x.to_float(),
+                rect.y.to_float(),
+                rect.width.to_float(),
+                rect.height.to_float(),
             )
-            .translated(origin.x, origin.y);
-        FfiCssPixelRect {
-            x: CssPixels::nearest_value_for_f32(mapped.x),
-            y: CssPixels::nearest_value_for_f32(mapped.y),
-            width: CssPixels::nearest_value_for_f32(mapped.width),
-            height: CssPixels::nearest_value_for_f32(mapped.height),
-        }
-    })
+            .translated(-origin.x, -origin.y),
+        )
+        .translated(origin.x, origin.y);
+    FfiCssPixelRect {
+        x: CssPixels::nearest_value_for_f32(mapped.x),
+        y: CssPixels::nearest_value_for_f32(mapped.y),
+        width: CssPixels::nearest_value_for_f32(mapped.width),
+        height: CssPixels::nearest_value_for_f32(mapped.height),
+    }
 }
 
 /// # Safety
@@ -1682,18 +1569,16 @@ pub unsafe extern "C" fn layout_arena_update_visual_viewport_transform(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let Some(tree) = &mut paint_state.visual_context.tree else {
-            return false;
-        };
-        let inputs = callbacks.tree_inputs();
-        Rc::make_mut(tree).set_visual_viewport_transform(
-            crate::painting::visual_context::node_values::visual_viewport_transform_data(&inputs),
-        );
-        true
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let mut paint_state = arena.paint_state().borrow_mut();
+    let Some(tree) = &mut paint_state.visual_context.tree else {
+        return false;
+    };
+    let inputs = callbacks.tree_inputs();
+    Rc::make_mut(tree).set_visual_viewport_transform(
+        crate::painting::visual_context::node_values::visual_viewport_transform_data(&inputs),
+    );
+    true
 }
 
 /// # Safety
@@ -1701,14 +1586,12 @@ pub unsafe extern "C" fn layout_arena_update_visual_viewport_transform(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_set_needs_to_refresh_scroll_state(arena: *mut c_void, value: bool) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena
-            .paint_state()
-            .borrow_mut()
-            .visual_context
-            .needs_to_refresh_scroll_state = value;
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena
+        .paint_state()
+        .borrow_mut()
+        .visual_context
+        .needs_to_refresh_scroll_state = value;
 }
 
 /// # Safety
@@ -1716,14 +1599,12 @@ pub unsafe extern "C" fn layout_arena_set_needs_to_refresh_scroll_state(arena: *
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_clear_scroll_state(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let state = &mut paint_state.visual_context;
-        state.scroll_state.clear();
-        state.scroll_state_snapshot.clear();
-        state.needs_to_refresh_scroll_state = true;
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let mut paint_state = arena.paint_state().borrow_mut();
+    let state = &mut paint_state.visual_context;
+    state.scroll_state.clear();
+    state.scroll_state_snapshot.clear();
+    state.needs_to_refresh_scroll_state = true;
 }
 
 /// # Safety
@@ -1734,23 +1615,21 @@ pub unsafe extern "C" fn layout_arena_refresh_sticky_constraints(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let state = &mut paint_state.visual_context;
-        let mut any_sticky_payload_changed = false;
-        if let Some(tree) = state.tree.as_mut() {
-            any_sticky_payload_changed = crate::painting::visual_context::refresh::refresh_sticky_constraints(
-                &paintable_rows,
-                &state.scroll_state,
-                tree,
-                &callbacks.tree_inputs(),
-            );
-        }
-        state.needs_to_refresh_scroll_state = true;
-        any_sticky_payload_changed
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let mut paint_state = arena.paint_state().borrow_mut();
+    let state = &mut paint_state.visual_context;
+    let mut any_sticky_payload_changed = false;
+    if let Some(tree) = state.tree.as_mut() {
+        any_sticky_payload_changed = crate::painting::visual_context::refresh::refresh_sticky_constraints(
+            &paintable_rows,
+            &state.scroll_state,
+            tree,
+            &callbacks.tree_inputs(),
+        );
+    }
+    state.needs_to_refresh_scroll_state = true;
+    any_sticky_payload_changed
 }
 
 /// # Safety
@@ -1761,24 +1640,22 @@ pub unsafe extern "C" fn layout_arena_refresh_scroll_state(
     arena: *mut c_void,
     callbacks: FfiVisualContextHostCallbacks,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let mut paint_state = arena.paint_state().borrow_mut();
-        let state = &mut paint_state.visual_context;
-        if !state.needs_to_refresh_scroll_state {
-            return;
-        }
-        state.needs_to_refresh_scroll_state = false;
-        crate::painting::visual_context::refresh::refresh_scroll_state(
-            &paintable_rows,
-            &callbacks,
-            &mut state.scroll_state,
-        );
-        state.scroll_state_snapshot = state
-            .scroll_state
-            .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let mut paint_state = arena.paint_state().borrow_mut();
+    let state = &mut paint_state.visual_context;
+    if !state.needs_to_refresh_scroll_state {
+        return;
+    }
+    state.needs_to_refresh_scroll_state = false;
+    crate::painting::visual_context::refresh::refresh_scroll_state(
+        &paintable_rows,
+        &callbacks,
+        &mut state.scroll_state,
+    );
+    state.scroll_state_snapshot = state
+        .scroll_state
+        .snapshot(callbacks.tree_inputs().device_pixels_per_css_pixel);
 }
 
 /// # Safety
@@ -1793,126 +1670,124 @@ pub unsafe extern "C" fn layout_arena_record_display_list(
     visual_context_callbacks: crate::painting::host::FfiVisualContextHostCallbacks,
     inputs: crate::painting::host::FfiRecordingInputs,
 ) -> u64 {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
+    let arena = unsafe { arena_from_handle(arena) };
+    {
+        let mut paint_state = arena.paint_state().borrow_mut();
+        let has_blocking_wheel_event_region_covering_viewport =
+            inputs.has_blocking_wheel_event_region_covering_viewport;
+        if paint_state.recorded_has_blocking_wheel_event_region_covering_viewport
+            != Some(has_blocking_wheel_event_region_covering_viewport)
         {
-            let mut paint_state = arena.paint_state().borrow_mut();
-            let has_blocking_wheel_event_region_covering_viewport =
-                inputs.has_blocking_wheel_event_region_covering_viewport;
-            if paint_state.recorded_has_blocking_wheel_event_region_covering_viewport
-                != Some(has_blocking_wheel_event_region_covering_viewport)
-            {
-                arena.mark_all_descendant_subtree_caches_dirty();
-                paint_state.recorded_has_blocking_wheel_event_region_covering_viewport =
-                    Some(has_blocking_wheel_event_region_covering_viewport);
-            }
-            if paint_state.recorded_canvas_color != Some(inputs.canvas_color) {
-                arena.mark_all_paint_caches_dirty();
-                paint_state.recorded_canvas_color = Some(inputs.canvas_color);
-            }
+            arena.mark_all_descendant_subtree_caches_dirty();
+            paint_state.recorded_has_blocking_wheel_event_region_covering_viewport =
+                Some(has_blocking_wheel_event_region_covering_viewport);
         }
-        let mut output = {
-            let paint_state = arena.paint_state().borrow();
-            if !arena.paintable_row_is_populated(viewport) || arena.stacking_context_entries(viewport).is_none() {
-                return 0;
-            }
-            let visual_context = &paint_state.visual_context;
-            let inputs = crate::painting::record::RecordingInputs::from_host_and_last_visual_context_update(
-                inputs,
-                visual_context
-                    .last_tree_inputs
-                    .expect("a recording follows a visual context update"),
-                visual_context
-                    .last_root_background_source
-                    .expect("a recording follows a visual context update"),
-            );
-            let command_cache_source = (!inputs.should_show_line_box_borders)
-                .then(|| paint_state.paint_command_cache_source.clone())
-                .flatten();
-            arena.set_paint_recording_in_progress(true);
-            let output = crate::painting::record::traversal::record_display_list(
+        if paint_state.recorded_canvas_color != Some(inputs.canvas_color) {
+            arena.mark_all_paint_caches_dirty();
+            paint_state.recorded_canvas_color = Some(inputs.canvas_color);
+        }
+    }
+    let mut output = {
+        let paint_state = arena.paint_state().borrow();
+        if !arena.paintable_row_is_populated(viewport) || arena.stacking_context_entries(viewport).is_none() {
+            return 0;
+        }
+        let visual_context = &paint_state.visual_context;
+        let inputs = crate::painting::record::RecordingInputs::from_host_and_last_visual_context_update(
+            inputs,
+            visual_context
+                .last_tree_inputs
+                .expect("a recording follows a visual context update"),
+            visual_context
+                .last_root_background_source
+                .expect("a recording follows a visual context update"),
+        );
+        let command_cache_source = (!inputs.should_show_line_box_borders)
+            .then(|| paint_state.paint_command_cache_source.clone())
+            .flatten();
+        arena.set_paint_recording_in_progress(true);
+        let output = crate::painting::record::traversal::record_display_list(
+            arena,
+            &paint_state,
+            viewport,
+            &callbacks,
+            &paint_callbacks,
+            &visual_context_callbacks,
+            inputs,
+            paint_state.hit_test_list_generation + 1,
+            command_cache_source,
+            paint_state.hit_test_item_cache_source.clone(),
+        );
+        if crate::painting::record::verify::enabled_by_environment()
+            && output.recording_stats.spliced_capture_count() > 0
+            && !inputs.should_show_line_box_borders
+        {
+            let mut inputs_for_recording_from_scratch = inputs;
+            inputs_for_recording_from_scratch.paint_command_cache_read_write = false;
+            let recording_from_scratch = crate::painting::record::traversal::record_display_list(
                 arena,
                 &paint_state,
                 viewport,
                 &callbacks,
                 &paint_callbacks,
                 &visual_context_callbacks,
-                inputs,
+                inputs_for_recording_from_scratch,
                 paint_state.hit_test_list_generation + 1,
-                command_cache_source,
-                paint_state.hit_test_item_cache_source.clone(),
+                None,
+                None,
             );
-            if crate::painting::record::verify::enabled_by_environment()
-                && output.recording_stats.spliced_capture_count() > 0
-                && !inputs.should_show_line_box_borders
-            {
-                let mut inputs_for_recording_from_scratch = inputs;
-                inputs_for_recording_from_scratch.paint_command_cache_read_write = false;
-                let recording_from_scratch = crate::painting::record::traversal::record_display_list(
-                    arena,
-                    &paint_state,
-                    viewport,
-                    &callbacks,
-                    &paint_callbacks,
-                    &visual_context_callbacks,
-                    inputs_for_recording_from_scratch,
-                    paint_state.hit_test_list_generation + 1,
-                    None,
-                    None,
-                );
-                crate::painting::record::verify::verify_spliced_recording_matches_fresh(
-                    arena,
-                    &output,
-                    &recording_from_scratch,
-                );
-            }
-            arena.set_paint_recording_in_progress(false);
-            output
-        };
-        let mut paint_state = arena.paint_state().borrow_mut();
-        output.is_identical_to_cache_source = paint_state
-            .paint_command_cache_source
-            .as_ref()
-            .zip(paint_state.hit_test_item_cache_source.as_ref())
-            .is_some_and(|(source, item_source)| {
-                std::rc::Rc::ptr_eq(&output.display_list, &source.display_list)
-                    && std::rc::Rc::ptr_eq(&output.hit_test_list.items, &item_source.items)
-                    && output.recorded_structural_epoch == source.recorded_structural_epoch
-                    && output.wheel_event_listener_state_generation == source.wheel_event_listener_state_generation
-                    && output.has_blocking_wheel_event_listeners == source.has_blocking_wheel_event_listeners
-                    && output.mask_display_lists.is_empty()
-                    && source.mask_display_lists.is_empty()
-            });
-        let list = std::mem::take(&mut output.hit_test_list);
-        let previous_list_is_the_source = paint_state
-            .hit_test_list
-            .as_ref()
-            .zip(paint_state.hit_test_item_cache_source.as_ref())
-            .is_some_and(|(list, source)| std::rc::Rc::ptr_eq(&list.items, &source.items));
-        if output.is_identical_to_cache_source && previous_list_is_the_source {
-            drop(list);
-        } else {
-            paint_state.hit_test_list_generation += 1;
-            debug_assert_eq!(list.generation, paint_state.hit_test_list_generation);
-            if inputs.paint_command_cache_read_write {
-                paint_state.hit_test_item_cache_source = Some(std::rc::Rc::new(
-                    crate::painting::record::cache::HitTestItemCacheSource {
-                        items: list.items.clone(),
-                    },
-                ));
-            }
-            paint_state.hit_test_list = Some(list);
+            crate::painting::record::verify::verify_spliced_recording_matches_fresh(
+                arena,
+                &output,
+                &recording_from_scratch,
+            );
         }
-        let output = std::rc::Rc::new(output);
+        arena.set_paint_recording_in_progress(false);
+        output
+    };
+    let mut paint_state = arena.paint_state().borrow_mut();
+    output.is_identical_to_cache_source = paint_state
+        .paint_command_cache_source
+        .as_ref()
+        .zip(paint_state.hit_test_item_cache_source.as_ref())
+        .is_some_and(|(source, item_source)| {
+            std::rc::Rc::ptr_eq(&output.display_list, &source.display_list)
+                && std::rc::Rc::ptr_eq(&output.hit_test_list.items, &item_source.items)
+                && output.recorded_structural_epoch == source.recorded_structural_epoch
+                && output.wheel_event_listener_state_generation == source.wheel_event_listener_state_generation
+                && output.has_blocking_wheel_event_listeners == source.has_blocking_wheel_event_listeners
+                && output.mask_display_lists.is_empty()
+                && source.mask_display_lists.is_empty()
+        });
+    let list = std::mem::take(&mut output.hit_test_list);
+    let previous_list_is_the_source = paint_state
+        .hit_test_list
+        .as_ref()
+        .zip(paint_state.hit_test_item_cache_source.as_ref())
+        .is_some_and(|(list, source)| std::rc::Rc::ptr_eq(&list.items, &source.items));
+    if output.is_identical_to_cache_source && previous_list_is_the_source {
+        drop(list);
+    } else {
+        paint_state.hit_test_list_generation += 1;
+        debug_assert_eq!(list.generation, paint_state.hit_test_list_generation);
         if inputs.paint_command_cache_read_write {
-            paint_state.paint_command_cache_source = Some(output.clone());
-            // Read-only recordings commit nothing and must not age dirty stamps out.
-            arena.note_paint_record_completed_with_cache_writes();
-            paint_state.visual_context.quarantined_slots_are_releasable = true;
+            paint_state.hit_test_item_cache_source = Some(std::rc::Rc::new(
+                crate::painting::record::cache::HitTestItemCacheSource {
+                    items: list.items.clone(),
+                },
+            ));
         }
-        paint_state.last_recording = Some(output);
-        list_generation_of(&paint_state)
-    })
+        paint_state.hit_test_list = Some(list);
+    }
+    let output = std::rc::Rc::new(output);
+    if inputs.paint_command_cache_read_write {
+        paint_state.paint_command_cache_source = Some(output.clone());
+        // Read-only recordings commit nothing and must not age dirty stamps out.
+        arena.note_paint_record_completed_with_cache_writes();
+        paint_state.visual_context.quarantined_slots_are_releasable = true;
+    }
+    paint_state.last_recording = Some(output);
+    list_generation_of(&paint_state)
 }
 
 /// # Safety
@@ -1926,16 +1801,14 @@ pub unsafe extern "C" fn layout_arena_paint_push_selection_shadow(
     offset_y: CssPixels,
     blur_radius: CssPixels,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: `sink` is the Vec pointer handed out by
-        // FfiPaintHostCallbacks::selection_style_facts.
-        let shadows = unsafe { &mut *sink.cast::<Vec<crate::painting::record::paint::text::ShadowLayer>>() };
-        shadows.push(crate::painting::record::paint::text::ShadowLayer {
-            color: color.0,
-            offset_x,
-            offset_y,
-            blur_radius,
-        });
+    // SAFETY: `sink` is the Vec pointer handed out by
+    // FfiPaintHostCallbacks::selection_style_facts.
+    let shadows = unsafe { &mut *sink.cast::<Vec<crate::painting::record::paint::text::ShadowLayer>>() };
+    shadows.push(crate::painting::record::paint::text::ShadowLayer {
+        color: color.0,
+        offset_x,
+        offset_y,
+        blur_radius,
     });
 }
 
@@ -1948,12 +1821,10 @@ pub unsafe extern "C" fn layout_arena_paint_push_color_stop(
     color: libgfx_rust::Color,
     position: f32,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: `sink` is the ColorStopSink pointer handed out by FfiPaintHostCallbacks::background_layer_image.
-        let sink = unsafe { &mut *sink.cast::<crate::painting::host::ColorStopSink>() };
-        sink.colors.push(color);
-        sink.positions.push(position);
-    });
+    // SAFETY: `sink` is the ColorStopSink pointer handed out by FfiPaintHostCallbacks::background_layer_image.
+    let sink = unsafe { &mut *sink.cast::<crate::painting::host::ColorStopSink>() };
+    sink.colors.push(color);
+    sink.positions.push(position);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2002,67 +1873,61 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
     };
     use crate::painting::visual_context::{TransformData, TransformDataRole, VisualContextTree};
     use libgfx_rust::{CompositingAndBlendingOperator, FloatMatrix4x4, FloatPoint};
-    abort_on_panic(|| {
-        let inputs = unsafe { &*inputs };
-        let tree = VisualContextTree::create(TransformData {
-            matrix: FloatMatrix4x4::identity(),
-            origin: FloatPoint::default(),
-            sorting_context_root_index: None,
-            flattens_inherited_transform: false,
-            role: TransformDataRole::CssTransform,
-            synthetic_plane: false,
-            establishes_sorting_context: false,
-        });
-        let mut recorder = DisplayListRecorder::new();
-        let dest_rect = inputs.dest_rect;
-        match inputs.kind {
-            FfiImagePaintRecordKind::DecodedFrame => recorder.draw_scaled_decoded_image_frame(
-                dest_rect,
-                None,
-                ImageFrameResourceId(inputs.frame_id),
-                inputs.scaling_mode,
-                CompositingAndBlendingOperator::Normal,
-                None,
-            ),
-            FfiImagePaintRecordKind::NestedDisplayList => recorder.paint_nested_display_list(
-                DisplayListResourceId(inputs.nested_display_list_id),
-                dest_rect,
-                inputs.nested_display_list_size,
-            ),
-            FfiImagePaintRecordKind::Gradient => {
-                // SAFETY: the host keeps the gradient style value and its color resolution input
-                // live for the duration of the call.
-                let (gradient_style_value, color_resolution_input) = unsafe {
-                    (
-                        &*inputs
-                            .gradient_style_value
-                            .cast::<crate::css::style_value::StyleValueData>(),
-                        &*inputs
-                            .gradient_stop_color_resolution_input
-                            .cast::<FfiColorResolutionInput>(),
-                    )
-                };
-                let relative_color_channels = relative_color_context_from_ffi(color_resolution_input);
-                // SAFETY: the borrowed input outlives the resolution below.
-                let color_input =
-                    unsafe { resolution_input_from_ffi(color_resolution_input, &relative_color_channels) };
-                let resolved = resolve_gradient_paint_with_input(
-                    gradient_style_value,
-                    inputs.gradient_tile_size.into(),
-                    &color_input,
-                );
-                record_resolved_gradient_fill(
-                    &mut recorder,
-                    DevicePixelConverter::new(inputs.device_pixels_per_css_pixel),
-                    &resolved,
-                    dest_rect,
-                    CompositingAndBlendingOperator::Normal,
-                );
-            }
-        }
-        let recorded = recorder.into_builder().finish();
-        unsafe { consume(context, (&recorded).into(), Rc::into_raw(Rc::new(tree)).cast()) };
+    let inputs = unsafe { &*inputs };
+    let tree = VisualContextTree::create(TransformData {
+        matrix: FloatMatrix4x4::identity(),
+        origin: FloatPoint::default(),
+        sorting_context_root_index: None,
+        flattens_inherited_transform: false,
+        role: TransformDataRole::CssTransform,
+        synthetic_plane: false,
+        establishes_sorting_context: false,
     });
+    let mut recorder = DisplayListRecorder::new();
+    let dest_rect = inputs.dest_rect;
+    match inputs.kind {
+        FfiImagePaintRecordKind::DecodedFrame => recorder.draw_scaled_decoded_image_frame(
+            dest_rect,
+            None,
+            ImageFrameResourceId(inputs.frame_id),
+            inputs.scaling_mode,
+            CompositingAndBlendingOperator::Normal,
+            None,
+        ),
+        FfiImagePaintRecordKind::NestedDisplayList => recorder.paint_nested_display_list(
+            DisplayListResourceId(inputs.nested_display_list_id),
+            dest_rect,
+            inputs.nested_display_list_size,
+        ),
+        FfiImagePaintRecordKind::Gradient => {
+            // SAFETY: the host keeps the gradient style value and its color resolution input
+            // live for the duration of the call.
+            let (gradient_style_value, color_resolution_input) = unsafe {
+                (
+                    &*inputs
+                        .gradient_style_value
+                        .cast::<crate::css::style_value::StyleValueData>(),
+                    &*inputs
+                        .gradient_stop_color_resolution_input
+                        .cast::<FfiColorResolutionInput>(),
+                )
+            };
+            let relative_color_channels = relative_color_context_from_ffi(color_resolution_input);
+            // SAFETY: the borrowed input outlives the resolution below.
+            let color_input = unsafe { resolution_input_from_ffi(color_resolution_input, &relative_color_channels) };
+            let resolved =
+                resolve_gradient_paint_with_input(gradient_style_value, inputs.gradient_tile_size.into(), &color_input);
+            record_resolved_gradient_fill(
+                &mut recorder,
+                DevicePixelConverter::new(inputs.device_pixels_per_css_pixel),
+                &resolved,
+                dest_rect,
+                CompositingAndBlendingOperator::Normal,
+            );
+        }
+    }
+    let recorded = recorder.into_builder().finish();
+    unsafe { consume(context, (&recorded).into(), Rc::into_raw(Rc::new(tree)).cast()) };
 }
 
 /// # Safety
@@ -2072,14 +1937,12 @@ pub unsafe extern "C" fn ladybird_web_record_image_paint_display_list(
 pub unsafe extern "C" fn layout_arena_last_recording_stats(
     arena: *mut c_void,
 ) -> crate::painting::host::FfiPaintRecordingStats {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .last_recording
-            .as_ref()
-            .map_or_else(Default::default, |recording| recording.recording_stats)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state
+        .last_recording
+        .as_ref()
+        .map_or_else(Default::default, |recording| recording.recording_stats)
 }
 
 /// # Safety
@@ -2087,14 +1950,12 @@ pub unsafe extern "C" fn layout_arena_last_recording_stats(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_last_recording_is_identical_to_cache_source(arena: *mut c_void) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .last_recording
-            .as_ref()
-            .is_some_and(|recording| recording.is_identical_to_cache_source)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state
+        .last_recording
+        .as_ref()
+        .is_some_and(|recording| recording.is_identical_to_cache_source)
 }
 
 /// # Safety
@@ -2102,14 +1963,12 @@ pub unsafe extern "C" fn layout_arena_last_recording_is_identical_to_cache_sourc
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_last_recording_has_blocking_wheel_event_listeners(arena: *mut c_void) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .last_recording
-            .as_ref()
-            .is_some_and(|recording| recording.has_blocking_wheel_event_listeners)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state
+        .last_recording
+        .as_ref()
+        .is_some_and(|recording| recording.has_blocking_wheel_event_listeners)
 }
 
 /// # Safety
@@ -2121,14 +1980,12 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
     paintable: NodeSlotId,
     propagated_text_decorations: bool,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if propagated_text_decorations {
-            arena.invalidate_propagated_text_decoration_caches(paintable);
-        } else {
-            arena.invalidate_paint_cache(paintable);
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    if propagated_text_decorations {
+        arena.invalidate_propagated_text_decoration_caches(paintable);
+    } else {
+        arena.invalidate_paint_cache(paintable);
+    }
 }
 
 /// # Safety
@@ -2136,10 +1993,8 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_paint_cache(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paintable_invalidate_for_repaint(arena: *mut c_void, paintable: NodeSlotId) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.invalidate_for_repaint(paintable);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.invalidate_for_repaint(paintable);
 }
 
 /// # Safety
@@ -2150,10 +2005,8 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_subtree_for_repaint(
     arena: *mut c_void,
     paintable: NodeSlotId,
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.invalidate_subtree_for_repaint(paintable);
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.invalidate_subtree_for_repaint(paintable);
 }
 
 /// # Safety
@@ -2161,10 +2014,8 @@ pub unsafe extern "C" fn layout_arena_paintable_invalidate_subtree_for_repaint(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_invalidate_all_paint_caches(arena: *mut c_void) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        arena.mark_all_paint_caches_dirty();
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    arena.mark_all_paint_caches_dirty();
 }
 
 /// # Safety
@@ -2175,15 +2026,13 @@ pub unsafe extern "C" fn layout_arena_paintable_computed_svg_path(
     arena: *mut c_void,
     paintable: NodeSlotId,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(paintable) {
-            return std::ptr::null();
-        }
-        crate::painting::paintable_geometry::committed_svg_path(&paintable_rows, paintable)
-            .map_or(std::ptr::null(), |path| path.as_raw())
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(paintable) {
+        return std::ptr::null();
+    }
+    crate::painting::paintable_geometry::committed_svg_path(&paintable_rows, paintable)
+        .map_or(std::ptr::null(), |path| path.as_raw())
 }
 
 #[repr(C)]
@@ -2207,35 +2056,30 @@ pub unsafe extern "C" fn layout_arena_text_caret_rect_for_position(
     offset: usize,
     affinity_is_downstream: bool,
 ) -> FfiCaretRectResult {
-    abort_on_panic(|| {
-        let mut result = FfiCaretRectResult {
-            found: false,
-            rect: FfiCssPixelRect::default(),
-            style_source: std::ptr::null_mut(),
-            owner_paintable: NodeSlotId::INVALID,
-            nearest_self_painting_inline: NodeSlotId::INVALID,
-        };
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        let Some(answer) = crate::painting::caret::caret_rect_for_position(
-            &paintable_rows,
-            node_slots,
-            offset,
-            affinity_is_downstream,
-        ) else {
-            return result;
-        };
-        result.found = true;
-        result.rect = answer.rect.into();
-        result.style_source = arena.shell_if_live(answer.style_source);
-        result.owner_paintable = answer.owner;
-        result.nearest_self_painting_inline =
-            crate::painting::fragment_ownership::nearest_self_painting_inline_box(&paintable_rows, answer.node)
-                .unwrap_or(NodeSlotId::INVALID);
-        result
-    })
+    let mut result = FfiCaretRectResult {
+        found: false,
+        rect: FfiCssPixelRect::default(),
+        style_source: std::ptr::null_mut(),
+        owner_paintable: NodeSlotId::INVALID,
+        nearest_self_painting_inline: NodeSlotId::INVALID,
+    };
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    let Some(answer) =
+        crate::painting::caret::caret_rect_for_position(&paintable_rows, node_slots, offset, affinity_is_downstream)
+    else {
+        return result;
+    };
+    result.found = true;
+    result.rect = answer.rect.into();
+    result.style_source = arena.shell_if_live(answer.style_source);
+    result.owner_paintable = answer.owner;
+    result.nearest_self_painting_inline =
+        crate::painting::fragment_ownership::nearest_self_painting_inline_box(&paintable_rows, answer.node)
+            .unwrap_or(NodeSlotId::INVALID);
+    result
 }
 
 /// # Safety
@@ -2249,22 +2093,20 @@ pub unsafe extern "C" fn layout_arena_text_caret_rect_in_dom_range(
     node_slot_count: usize,
     offset: usize,
 ) -> FfiOptionalCssPixelRect {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        match crate::painting::caret::caret_rect_in_dom_range(&paintable_rows, node_slots, offset) {
-            Some(rect) => FfiOptionalCssPixelRect {
-                has_value: true,
-                rect: rect.into(),
-            },
-            None => FfiOptionalCssPixelRect {
-                has_value: false,
-                rect: FfiCssPixelRect::default(),
-            },
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    match crate::painting::caret::caret_rect_in_dom_range(&paintable_rows, node_slots, offset) {
+        Some(rect) => FfiOptionalCssPixelRect {
+            has_value: true,
+            rect: rect.into(),
+        },
+        None => FfiOptionalCssPixelRect {
+            has_value: false,
+            rect: FfiCssPixelRect::default(),
+        },
+    }
 }
 
 #[repr(C)]
@@ -2286,39 +2128,37 @@ pub unsafe extern "C" fn layout_arena_paintable_empty_line_caret_rect(
     node_slot_count: usize,
     offset: usize,
 ) -> FfiEmptyLineCaretRect {
-    abort_on_panic(|| {
-        let mut result = FfiEmptyLineCaretRect {
-            has_value: false,
-            rect: FfiCssPixelRect::default(),
-            style_source: std::ptr::null_mut(),
-        };
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(block) {
-            return result;
+    let mut result = FfiEmptyLineCaretRect {
+        has_value: false,
+        rect: FfiCssPixelRect::default(),
+        style_source: std::ptr::null_mut(),
+    };
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(block) {
+        return result;
+    }
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    let side = arena.paintable_side_data(block);
+    let Some(first_fragment) = side.fragments.first() else {
+        return result;
+    };
+    if !node_slots.contains(&first_fragment.layout_node) {
+        return result;
+    }
+    for target in crate::painting::visual_lines::empty_line_caret_targets(&paintable_rows, block) {
+        if target.offset == offset {
+            result.has_value = true;
+            result.rect = target.rect.into();
+            result.style_source = arena.shell_if_live(crate::painting::text_fragment::style_source(
+                &paintable_rows,
+                first_fragment,
+            ));
+            break;
         }
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        let side = arena.paintable_side_data(block);
-        let Some(first_fragment) = side.fragments.first() else {
-            return result;
-        };
-        if !node_slots.contains(&first_fragment.layout_node) {
-            return result;
-        }
-        for target in crate::painting::visual_lines::empty_line_caret_targets(&paintable_rows, block) {
-            if target.offset == offset {
-                result.has_value = true;
-                result.rect = target.rect.into();
-                result.style_source = arena.shell_if_live(crate::painting::text_fragment::style_source(
-                    &paintable_rows,
-                    first_fragment,
-                ));
-                break;
-            }
-        }
-        result
-    })
+    }
+    result
 }
 
 fn with_inline_pieces(
@@ -2349,22 +2189,20 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_piece_border_box_rects(
     context: *mut c_void,
     push_rect: unsafe extern "C" fn(*mut c_void, FfiCssPixelRect),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
-            return;
-        };
-        let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
-        with_inline_pieces(&paintable_rows, inline_paintable, |piece, _| {
-            if piece.is_geometry_only_placeholder {
-                return true;
-            }
-            let rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect).translated_by(root_position);
-            // SAFETY: The consumer copies the plain-data rect synchronously.
-            unsafe { push_rect(context, rect.into()) };
-            true
-        });
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
+        return;
+    };
+    let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
+    with_inline_pieces(&paintable_rows, inline_paintable, |piece, _| {
+        if piece.is_geometry_only_placeholder {
+            return true;
+        }
+        let rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect).translated_by(root_position);
+        // SAFETY: The consumer copies the plain-data rect synchronously.
+        unsafe { push_rect(context, rect.into()) };
+        true
     });
 }
 
@@ -2376,18 +2214,16 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_has_content_pieces(
     arena: *mut c_void,
     inline_paintable: NodeSlotId,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let mut has_content = false;
-        with_inline_pieces(&arena.paintable_rows(), inline_paintable, |piece, _| {
-            if !piece.is_geometry_only_placeholder {
-                has_content = true;
-                return false;
-            }
-            true
-        });
-        has_content
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let mut has_content = false;
+    with_inline_pieces(&arena.paintable_rows(), inline_paintable, |piece, _| {
+        if !piece.is_geometry_only_placeholder {
+            has_content = true;
+            return false;
+        }
+        true
+    });
+    has_content
 }
 
 #[repr(C)]
@@ -2405,35 +2241,33 @@ pub unsafe extern "C" fn layout_arena_inline_paintable_first_piece_position(
     arena: *mut c_void,
     inline_paintable: NodeSlotId,
 ) -> FfiOptionalCssPixelPoint {
-    abort_on_panic(|| {
-        let mut result = FfiOptionalCssPixelPoint {
-            has_value: false,
-            x: CssPixels::from_raw(0),
-            y: CssPixels::from_raw(0),
+    let mut result = FfiOptionalCssPixelPoint {
+        has_value: false,
+        x: CssPixels::from_raw(0),
+        y: CssPixels::from_raw(0),
+    };
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
+        return result;
+    };
+    let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
+    let border_widths = crate::painting::paintable_geometry::committed_border(arena, inline_paintable);
+    let padding_widths = crate::painting::paintable_geometry::committed_padding(arena, inline_paintable);
+    with_inline_pieces(&paintable_rows, inline_paintable, |piece, _data| {
+        let border_rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect);
+        let rect = if piece.is_geometry_only_placeholder {
+            border_rect
+        } else {
+            let padding_rect = piece.shrunken_by_present_edges(border_rect, border_widths);
+            piece.shrunken_by_present_edges(padding_rect, padding_widths)
         };
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        let Some(root) = paintable_rows.inline_pieces_root(inline_paintable) else {
-            return result;
-        };
-        let root_position = crate::painting::paintable_geometry::absolute_position(&paintable_rows, root);
-        let border_widths = crate::painting::paintable_geometry::committed_border(arena, inline_paintable);
-        let padding_widths = crate::painting::paintable_geometry::committed_padding(arena, inline_paintable);
-        with_inline_pieces(&paintable_rows, inline_paintable, |piece, _data| {
-            let border_rect = crate::css::css_pixels::CssPixelRect::from(piece.border_box_rect);
-            let rect = if piece.is_geometry_only_placeholder {
-                border_rect
-            } else {
-                let padding_rect = piece.shrunken_by_present_edges(border_rect, border_widths);
-                piece.shrunken_by_present_edges(padding_rect, padding_widths)
-            };
-            result.has_value = true;
-            result.x = rect.x + root_position.x;
-            result.y = rect.y + root_position.y;
-            false
-        });
-        result
-    })
+        result.has_value = true;
+        result.x = rect.x + root_position.x;
+        result.y = rect.y + root_position.y;
+        false
+    });
+    result
 }
 
 #[repr(C)]
@@ -2458,28 +2292,26 @@ pub unsafe extern "C" fn layout_arena_text_visual_lines(
     context: *mut c_void,
     push: unsafe extern "C" fn(*mut c_void, FfiVisualLine),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        for line in crate::painting::visual_lines::collect_visual_lines(&paintable_rows, node_slots) {
-            // SAFETY: The consumer copies the POD line synchronously.
-            unsafe {
-                push(
-                    context,
-                    FfiVisualLine {
-                        start_offset: line.start_offset,
-                        end_offset: line.end_offset,
-                        end_offset_with_trailing_whitespace: line.end_offset_with_trailing_whitespace,
-                        has_fragments: line.has_fragments,
-                        owner_paintable: line.owner.index,
-                        line_index: line.line_index,
-                    },
-                );
-            }
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    for line in crate::painting::visual_lines::collect_visual_lines(&paintable_rows, node_slots) {
+        // SAFETY: The consumer copies the POD line synchronously.
+        unsafe {
+            push(
+                context,
+                FfiVisualLine {
+                    start_offset: line.start_offset,
+                    end_offset: line.end_offset,
+                    end_offset_with_trailing_whitespace: line.end_offset_with_trailing_whitespace,
+                    has_fragments: line.has_fragments,
+                    owner_paintable: line.owner.index,
+                    line_index: line.line_index,
+                },
+            );
         }
-    });
+    }
 }
 
 fn has_rendered_text_matching(
@@ -2509,13 +2341,11 @@ pub unsafe extern "C" fn layout_arena_text_has_rendered_text_before(
     node_slot_count: usize,
     offset: usize,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
-            fragment.dom_start_offset_in_node < offset
-        })
+    let arena = unsafe { arena_from_handle(arena) };
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
+        fragment.dom_start_offset_in_node < offset
     })
 }
 
@@ -2530,13 +2360,11 @@ pub unsafe extern "C" fn layout_arena_text_has_rendered_text_after(
     node_slot_count: usize,
     offset: usize,
 ) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
-            fragment.dom_end_offset_in_node > offset
-        })
+    let arena = unsafe { arena_from_handle(arena) };
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    has_rendered_text_matching(&arena.paintable_rows(), node_slots, |fragment| {
+        fragment.dom_end_offset_in_node > offset
     })
 }
 
@@ -2559,26 +2387,24 @@ pub unsafe extern "C" fn layout_arena_visual_line_caret_inline_coordinate(
     node_slot_count: usize,
     offset: usize,
 ) -> FfiOptionalCssPixels {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        let coordinate = crate::painting::visual_lines::caret_inline_coordinate(
-            &paintable_rows,
-            owner_paintable,
-            line_index,
-            node_slots,
-            offset,
-        );
-        match coordinate {
-            Some(value) => FfiOptionalCssPixels { has_value: true, value },
-            None => FfiOptionalCssPixels {
-                has_value: false,
-                value: CssPixels::from_raw(0),
-            },
-        }
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    let coordinate = crate::painting::visual_lines::caret_inline_coordinate(
+        &paintable_rows,
+        owner_paintable,
+        line_index,
+        node_slots,
+        offset,
+    );
+    match coordinate {
+        Some(value) => FfiOptionalCssPixels { has_value: true, value },
+        None => FfiOptionalCssPixels {
+            has_value: false,
+            value: CssPixels::from_raw(0),
+        },
+    }
 }
 
 /// # Safety
@@ -2595,20 +2421,18 @@ pub unsafe extern "C" fn layout_arena_visual_line_offset_closest_to_inline_coord
     inline_coordinate: CssPixels,
     fallback_offset: usize,
 ) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        crate::painting::visual_lines::offset_closest_to_inline_coordinate(
-            &paintable_rows,
-            owner_paintable,
-            line_index,
-            node_slots,
-            inline_coordinate,
-        )
-        .unwrap_or(fallback_offset)
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    crate::painting::visual_lines::offset_closest_to_inline_coordinate(
+        &paintable_rows,
+        owner_paintable,
+        line_index,
+        node_slots,
+        inline_coordinate,
+    )
+    .unwrap_or(fallback_offset)
 }
 
 /// # Safety
@@ -2628,35 +2452,29 @@ pub unsafe extern "C" fn layout_arena_text_range_rects(
     context: *mut c_void,
     push_rect: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCssPixelRect),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
 
-        // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
-        let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
-        crate::painting::text_fragment::for_each_fragment_of_nodes(
+    // SAFETY: The caller guarantees the slot span is valid for this synchronous call.
+    let node_slots = unsafe { ffi_slice(node_slots, node_slot_count) };
+    crate::painting::text_fragment::for_each_fragment_of_nodes(&paintable_rows, node_slots, |block, _, fragment| {
+        let fragment_dom_start = fragment.dom_start_offset_in_node;
+        let fragment_dom_end = fragment.dom_end_offset_in_node;
+        if fragment_dom_end <= filter_dom_start || fragment_dom_start >= filter_dom_end {
+            return true;
+        }
+
+        let rect = crate::painting::text_fragment::range_rect(
             &paintable_rows,
-            node_slots,
-            |block, _, fragment| {
-                let fragment_dom_start = fragment.dom_start_offset_in_node;
-                let fragment_dom_end = fragment.dom_end_offset_in_node;
-                if fragment_dom_end <= filter_dom_start || fragment_dom_start >= filter_dom_end {
-                    return true;
-                }
-
-                let rect = crate::painting::text_fragment::range_rect(
-                    &paintable_rows,
-                    fragment,
-                    selection_state,
-                    range_start_offset,
-                    range_end_offset,
-                );
-
-                // SAFETY: The consumer handles a null shell and copies the rect synchronously.
-                unsafe { push_rect(context, arena.shell_if_live(block), rect.into()) };
-                true
-            },
+            fragment,
+            selection_state,
+            range_start_offset,
+            range_end_offset,
         );
+
+        // SAFETY: The consumer handles a null shell and copies the rect synchronously.
+        unsafe { push_rect(context, arena.shell_if_live(block), rect.into()) };
+        true
     });
 }
 
@@ -2675,26 +2493,24 @@ pub unsafe extern "C" fn layout_arena_paintable_first_fragment_rect_for_node(
     block: NodeSlotId,
     node: NodeSlotId,
 ) -> FfiOptionalCssPixelRect {
-    abort_on_panic(|| {
-        let mut result = FfiOptionalCssPixelRect {
-            has_value: false,
-            rect: FfiCssPixelRect::default(),
-        };
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(block) {
-            return result;
+    let mut result = FfiOptionalCssPixelRect {
+        has_value: false,
+        rect: FfiCssPixelRect::default(),
+    };
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(block) {
+        return result;
+    }
+    for fragment in &arena.paintable_side_data(block).fragments {
+        if fragment.layout_node != node {
+            continue;
         }
-        for fragment in &arena.paintable_side_data(block).fragments {
-            if fragment.layout_node != node {
-                continue;
-            }
-            result.has_value = true;
-            result.rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
-            break;
-        }
-        result
-    })
+        result.has_value = true;
+        result.rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
+        break;
+    }
+    result
 }
 
 /// # Safety
@@ -2707,20 +2523,18 @@ pub unsafe extern "C" fn layout_arena_for_each_subtree_fragment_rect(
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiCssPixelRect),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(root) {
-            return;
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(root) {
+        return;
+    }
+    crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, root, |current| {
+        for fragment in &arena.paintable_side_data(current).fragments {
+            let shell = arena.shell_if_live(fragment.layout_node);
+            let rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
+            // SAFETY: The consumer copies its plain-data arguments synchronously.
+            unsafe { consume(context, shell, rect) };
         }
-        crate::painting::paint_order::for_each_in_paint_subtree(&paintable_rows, root, |current| {
-            for fragment in &arena.paintable_side_data(current).fragments {
-                let shell = arena.shell_if_live(fragment.layout_node);
-                let rect = crate::painting::text_fragment::absolute_rect(&paintable_rows, fragment).into();
-                // SAFETY: The consumer copies its plain-data arguments synchronously.
-                unsafe { consume(context, shell, rect) };
-            }
-        });
     });
 }
 
@@ -2735,14 +2549,12 @@ pub unsafe extern "C" fn layout_arena_stacking_context_structure_verification_re
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let report = crate::painting::stacking_context::verify::verification_report(arena, viewport);
-        if !report.is_empty() {
-            // SAFETY: The consumer copies the byte span synchronously.
-            unsafe { consume(context, report.as_ptr(), report.len()) };
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let report = crate::painting::stacking_context::verify::verification_report(arena, viewport);
+    if !report.is_empty() {
+        // SAFETY: The consumer copies the byte span synchronously.
+        unsafe { consume(context, report.as_ptr(), report.len()) };
+    }
 }
 
 /// # Safety
@@ -2757,19 +2569,17 @@ pub unsafe extern "C" fn layout_arena_paintable_dump_block_fragments(
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(paintable) {
-            return;
-        }
-        let mut out = Vec::new();
-        crate::painting::dump::dump_block_fragments(&mut out, &paintable_rows, paintable, indent, interactive);
-        if !out.is_empty() {
-            // SAFETY: The consumer copies the byte span synchronously.
-            unsafe { consume(context, out.as_ptr(), out.len()) };
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(paintable) {
+        return;
+    }
+    let mut out = Vec::new();
+    crate::painting::dump::dump_block_fragments(&mut out, &paintable_rows, paintable, indent, interactive);
+    if !out.is_empty() {
+        // SAFETY: The consumer copies the byte span synchronously.
+        unsafe { consume(context, out.as_ptr(), out.len()) };
+    }
 }
 
 /// # Safety
@@ -2784,25 +2594,23 @@ pub unsafe extern "C" fn layout_arena_paintable_dump_inline_piece_fragments(
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paintable_rows = arena.paintable_rows();
-        if !paintable_rows.paintable_row_is_populated(inline_paintable) {
-            return;
-        }
-        let mut out = Vec::new();
-        crate::painting::dump::dump_inline_piece_fragments(
-            &mut out,
-            &paintable_rows,
-            inline_paintable,
-            indent,
-            interactive,
-        );
-        if !out.is_empty() {
-            // SAFETY: The consumer copies the byte span synchronously.
-            unsafe { consume(context, out.as_ptr(), out.len()) };
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    let paintable_rows = arena.paintable_rows();
+    if !paintable_rows.paintable_row_is_populated(inline_paintable) {
+        return;
+    }
+    let mut out = Vec::new();
+    crate::painting::dump::dump_inline_piece_fragments(
+        &mut out,
+        &paintable_rows,
+        inline_paintable,
+        indent,
+        interactive,
+    );
+    if !out.is_empty() {
+        // SAFETY: The consumer copies the byte span synchronously.
+        unsafe { consume(context, out.as_ptr(), out.len()) };
+    }
 }
 
 /// # Safety
@@ -2816,16 +2624,14 @@ pub unsafe extern "C" fn layout_arena_paintable_grid_layout_json(
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(paintable) {
-            return;
-        }
-        if let Some(data) = crate::painting::paintable_geometry::committed_grid_layout_data(arena, paintable) {
-            let json = crate::painting::devtools_layout::serialize_grid_layout(&data, container_node_id);
-            unsafe { consume(context, json.as_ptr(), json.len()) };
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(paintable) {
+        return;
+    }
+    if let Some(data) = crate::painting::paintable_geometry::committed_grid_layout_data(arena, paintable) {
+        let json = crate::painting::devtools_layout::serialize_grid_layout(&data, container_node_id);
+        unsafe { consume(context, json.as_ptr(), json.len()) };
+    }
 }
 
 /// # Safety
@@ -2839,16 +2645,14 @@ pub unsafe extern "C" fn layout_arena_paintable_flex_layout_json(
     context: *mut c_void,
     consume: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(paintable) {
-            return;
-        }
-        if let Some(data) = crate::painting::paintable_geometry::committed_flex_layout_data(arena, paintable) {
-            let json = crate::painting::devtools_layout::serialize_flex_layout(&data, container_node_id);
-            unsafe { consume(context, json.as_ptr(), json.len()) };
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(paintable) {
+        return;
+    }
+    if let Some(data) = crate::painting::paintable_geometry::committed_flex_layout_data(arena, paintable) {
+        let json = crate::painting::devtools_layout::serialize_flex_layout(&data, container_node_id);
+        unsafe { consume(context, json.as_ptr(), json.len()) };
+    }
 }
 
 /// # Safety
@@ -2865,15 +2669,13 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
         *const grid_formatting_context::FfiUsedGridTrackList,
     ),
 ) {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        if !arena.paintable_row_is_populated(paintable) {
-            return;
-        }
-        if let Some(tracks) = crate::painting::paintable_geometry::committed_used_grid_tracks(arena, paintable) {
-            tracks.with_ffi_views(|columns, rows| unsafe { consume(context, columns, rows) });
-        }
-    });
+    let arena = unsafe { arena_from_handle(arena) };
+    if !arena.paintable_row_is_populated(paintable) {
+        return;
+    }
+    if let Some(tracks) = crate::painting::paintable_geometry::committed_used_grid_tracks(arena, paintable) {
+        tracks.with_ffi_views(|columns, rows| unsafe { consume(context, columns, rows) });
+    }
 }
 
 /// # Safety
@@ -2883,15 +2685,13 @@ pub unsafe extern "C" fn layout_arena_paintable_used_grid_tracks(
 /// `visual_context_tree_release`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_main_visual_context_tree_retain(arena: *mut c_void) -> *const c_void {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .visual_context
-            .tree
-            .as_ref()
-            .map_or(std::ptr::null(), |tree| Rc::into_raw(Rc::clone(tree)).cast())
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state
+        .visual_context
+        .tree
+        .as_ref()
+        .map_or(std::ptr::null(), |tree| Rc::into_raw(Rc::clone(tree)).cast())
 }
 
 /// # Safety
@@ -2899,11 +2699,9 @@ pub unsafe extern "C" fn layout_arena_main_visual_context_tree_retain(arena: *mu
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_has_visual_context_tree(arena: *mut c_void) -> bool {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state.visual_context.tree.is_some()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state.visual_context.tree.is_some()
 }
 
 /// # Safety
@@ -2911,11 +2709,9 @@ pub unsafe extern "C" fn layout_arena_has_visual_context_tree(arena: *mut c_void
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_visual_context_tree_structural_epoch(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state.visual_context.structural_epoch()
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state.visual_context.structural_epoch()
 }
 
 /// # Safety
@@ -2924,11 +2720,9 @@ pub unsafe extern "C" fn layout_arena_visual_context_tree_structural_epoch(arena
 /// a host callback, or an earlier retain), used on the thread that owns it.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_retain(tree: *const c_void) -> *const c_void {
-    abort_on_panic(|| {
-        // SAFETY: The caller guarantees `tree` is a live retained handle, so the strong count is at least one.
-        unsafe { Rc::increment_strong_count(tree.cast::<crate::painting::visual_context::VisualContextTree>()) };
-        tree
-    })
+    // SAFETY: The caller guarantees `tree` is a live retained handle, so the strong count is at least one.
+    unsafe { Rc::increment_strong_count(tree.cast::<crate::painting::visual_context::VisualContextTree>()) };
+    tree
 }
 
 /// # Safety
@@ -2936,13 +2730,11 @@ pub unsafe extern "C" fn visual_context_tree_retain(tree: *const c_void) -> *con
 /// `tree` must be null or a retained tree handle that the caller gives up with this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_release(tree: *const c_void) {
-    abort_on_panic(|| {
-        if tree.is_null() {
-            return;
-        }
-        // SAFETY: The caller gives up the reference it retained, and the strong count is at least one.
-        unsafe { Rc::decrement_strong_count(tree.cast::<crate::painting::visual_context::VisualContextTree>()) };
-    });
+    if tree.is_null() {
+        return;
+    }
+    // SAFETY: The caller gives up the reference it retained, and the strong count is at least one.
+    unsafe { Rc::decrement_strong_count(tree.cast::<crate::painting::visual_context::VisualContextTree>()) };
 }
 
 /// # Safety
@@ -2950,7 +2742,7 @@ pub unsafe extern "C" fn visual_context_tree_release(tree: *const c_void) {
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_structural_epoch(tree: *const c_void) -> u64 {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.structural_epoch)
+    unsafe { tree_from_handle(tree) }.structural_epoch
 }
 
 /// # Safety
@@ -2962,11 +2754,9 @@ pub unsafe extern "C" fn visual_context_tree_serialize(
     sink: *mut c_void,
     append: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let bytes = unsafe { tree_from_handle(tree) }.to_bytes();
-        // SAFETY: The C++ sink copies the bytes synchronously.
-        unsafe { append(sink, bytes.as_ptr(), bytes.len()) };
-    });
+    let bytes = unsafe { tree_from_handle(tree) }.to_bytes();
+    // SAFETY: The C++ sink copies the bytes synchronously.
+    unsafe { append(sink, bytes.as_ptr(), bytes.len()) };
 }
 
 /// # Safety
@@ -2975,14 +2765,12 @@ pub unsafe extern "C" fn visual_context_tree_serialize(
 /// caller owns, or null when the bytes do not describe a valid tree.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_deserialize(bytes: *const u8, length: usize) -> *const c_void {
-    abort_on_panic(|| {
-        // SAFETY: The caller guarantees `bytes` addresses `length` readable bytes.
-        let bytes = unsafe { ffi_slice(bytes, length) };
-        match crate::painting::visual_context::VisualContextTree::from_bytes(bytes) {
-            Some(tree) => Rc::into_raw(Rc::new(tree)).cast(),
-            None => std::ptr::null(),
-        }
-    })
+    // SAFETY: The caller guarantees `bytes` addresses `length` readable bytes.
+    let bytes = unsafe { ffi_slice(bytes, length) };
+    match crate::painting::visual_context::VisualContextTree::from_bytes(bytes) {
+        Some(tree) => Rc::into_raw(Rc::new(tree)).cast(),
+        None => std::ptr::null(),
+    }
 }
 
 /// # Safety
@@ -2990,7 +2778,7 @@ pub unsafe extern "C" fn visual_context_tree_deserialize(bytes: *const u8, lengt
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_spatial_node_count(tree: *const c_void) -> usize {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.spatial_nodes.len())
+    unsafe { tree_from_handle(tree) }.spatial_nodes.len()
 }
 
 /// # Safety
@@ -2998,7 +2786,7 @@ pub unsafe extern "C" fn visual_context_tree_spatial_node_count(tree: *const c_v
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_frame_node_count(tree: *const c_void) -> usize {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.frame_nodes.len())
+    unsafe { tree_from_handle(tree) }.frame_nodes.len()
 }
 
 /// # Safety
@@ -3006,7 +2794,7 @@ pub unsafe extern "C" fn visual_context_tree_frame_node_count(tree: *const c_voi
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_live_spatial_node_count(tree: *const c_void) -> usize {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.live_spatial_node_count as usize)
+    unsafe { tree_from_handle(tree) }.live_spatial_node_count as usize
 }
 
 /// # Safety
@@ -3014,7 +2802,7 @@ pub unsafe extern "C" fn visual_context_tree_live_spatial_node_count(tree: *cons
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_live_frame_node_count(tree: *const c_void) -> usize {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.live_frame_node_count as usize)
+    unsafe { tree_from_handle(tree) }.live_frame_node_count as usize
 }
 
 /// # Safety
@@ -3029,17 +2817,15 @@ pub unsafe extern "C" fn display_list_references_only_live_visual_context_nodes(
     mask_frames: *const FrameNodeIndex,
     mask_frame_count: usize,
 ) -> bool {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the slices address the stated number of values.
-        let (command_runs, mask_frames) = unsafe {
-            (
-                ffi_slice(command_runs, command_run_count),
-                ffi_slice(mask_frames, mask_frame_count),
-            )
-        };
-        tree.display_list_references_only_live_nodes(command_runs, mask_frames)
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the slices address the stated number of values.
+    let (command_runs, mask_frames) = unsafe {
+        (
+            ffi_slice(command_runs, command_run_count),
+            ffi_slice(mask_frames, mask_frame_count),
+        )
+    };
+    tree.display_list_references_only_live_nodes(command_runs, mask_frames)
 }
 
 /// # Safety
@@ -3056,20 +2842,18 @@ pub unsafe extern "C" fn visual_context_tree_transform_point_for_hit_test(
     respect_clip: bool,
     out_local_point: *mut libgfx_rust::FloatPoint,
 ) -> bool {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
-        let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
-        let clip_behavior = crate::painting::visual_context::ClipBehavior::from_respect_clip(respect_clip);
-        match tree.transform_point_for_hit_test(context, screen_point, scroll_offsets, clip_behavior) {
-            Some(local_point) => {
-                // SAFETY: The caller guarantees `out_local_point` is writable.
-                unsafe { *out_local_point = local_point };
-                true
-            }
-            None => false,
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
+    let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
+    let clip_behavior = crate::painting::visual_context::ClipBehavior::from_respect_clip(respect_clip);
+    match tree.transform_point_for_hit_test(context, screen_point, scroll_offsets, clip_behavior) {
+        Some(local_point) => {
+            // SAFETY: The caller guarantees `out_local_point` is writable.
+            unsafe { *out_local_point = local_point };
+            true
         }
-    })
+        None => false,
+    }
 }
 
 /// # Safety
@@ -3081,7 +2865,7 @@ pub unsafe extern "C" fn visual_context_tree_inverse_transform_point(
     spatial: SpatialNodeIndex,
     screen_point: libgfx_rust::FloatPoint,
 ) -> libgfx_rust::FloatPoint {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.inverse_transform_point(spatial, screen_point))
+    unsafe { tree_from_handle(tree) }.inverse_transform_point(spatial, screen_point)
 }
 
 fn include_visual_viewport_transform_from(
@@ -3106,17 +2890,15 @@ pub unsafe extern "C" fn visual_context_tree_transform_rect_to_viewport(
     scroll_offsets_len: usize,
     include_visual_viewport_transform: bool,
 ) -> libgfx_rust::FloatRect {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
-        let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
-        tree.transform_rect_to_viewport(
-            spatial,
-            rect,
-            scroll_offsets,
-            include_visual_viewport_transform_from(include_visual_viewport_transform),
-        )
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
+    let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
+    tree.transform_rect_to_viewport(
+        spatial,
+        rect,
+        scroll_offsets,
+        include_visual_viewport_transform_from(include_visual_viewport_transform),
+    )
 }
 
 /// # Safety
@@ -3129,12 +2911,10 @@ pub unsafe extern "C" fn visual_context_tree_cumulative_scroll_chain_offset(
     scroll_offsets: *const libgfx_rust::FloatPoint,
     scroll_offsets_len: usize,
 ) -> libgfx_rust::FloatPoint {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
-        let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
-        tree.cumulative_scroll_chain_offset(spatial, scroll_offsets)
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
+    let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
+    tree.cumulative_scroll_chain_offset(spatial, scroll_offsets)
 }
 
 /// # Safety
@@ -3148,16 +2928,14 @@ pub unsafe extern "C" fn visual_context_tree_accumulated_matrix(
     scroll_offsets_len: usize,
     include_visual_viewport_transform: bool,
 ) -> libgfx_rust::FloatMatrix4x4 {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
-        let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
-        tree.accumulated_matrix(
-            spatial,
-            scroll_offsets,
-            include_visual_viewport_transform_from(include_visual_viewport_transform),
-        )
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points.
+    let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
+    tree.accumulated_matrix(
+        spatial,
+        scroll_offsets,
+        include_visual_viewport_transform_from(include_visual_viewport_transform),
+    )
 }
 
 /// # Safety
@@ -3172,19 +2950,17 @@ pub unsafe extern "C" fn visual_context_tree_resolve_sticky_offsets(
     sink: *mut c_void,
     push: unsafe extern "C" fn(*mut c_void, SpatialNodeIndex, libgfx_rust::FloatPoint),
 ) {
-    abort_on_panic(|| {
-        let resolved_sticky_entries = {
-            let tree = unsafe { tree_from_handle(tree) };
-            // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points, and the
-            // borrow ends before the sink may grow the same storage.
-            let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
-            tree.resolve_sticky_offsets(scroll_offsets)
-        };
-        for (node_index, offset) in resolved_sticky_entries {
-            // SAFETY: The C++ sink records the entry synchronously.
-            unsafe { push(sink, node_index, offset) };
-        }
-    });
+    let resolved_sticky_entries = {
+        let tree = unsafe { tree_from_handle(tree) };
+        // SAFETY: The caller guarantees the offsets address `scroll_offsets_len` points, and the
+        // borrow ends before the sink may grow the same storage.
+        let scroll_offsets = unsafe { ffi_slice(scroll_offsets, scroll_offsets_len) };
+        tree.resolve_sticky_offsets(scroll_offsets)
+    };
+    for (node_index, offset) in resolved_sticky_entries {
+        // SAFETY: The C++ sink records the entry synchronously.
+        unsafe { push(sink, node_index, offset) };
+    }
 }
 
 /// # Safety
@@ -3194,18 +2970,16 @@ pub unsafe extern "C" fn visual_context_tree_resolve_sticky_offsets(
 pub unsafe extern "C" fn visual_context_tree_visual_viewport_transform(
     tree: *const c_void,
 ) -> crate::painting::host::FfiVisualViewportTransform {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        let crate::painting::visual_context::SpatialData::Transform(transform) =
-            &tree.spatial_nodes[crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX.0 as usize].data
-        else {
-            unreachable!("the visual viewport node is a transform");
-        };
-        crate::painting::host::FfiVisualViewportTransform {
-            matrix: transform.matrix,
-            origin: transform.origin,
-        }
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    let crate::painting::visual_context::SpatialData::Transform(transform) =
+        &tree.spatial_nodes[crate::painting::display_list::commands::VISUAL_VIEWPORT_NODE_INDEX.0 as usize].data
+    else {
+        unreachable!("the visual viewport node is a transform");
+    };
+    crate::painting::host::FfiVisualViewportTransform {
+        matrix: transform.matrix,
+        origin: transform.origin,
+    }
 }
 
 /// # Safety
@@ -3217,11 +2991,9 @@ pub unsafe extern "C" fn visual_context_tree_with_visual_viewport_transform(
     tree: *const c_void,
     transform: crate::painting::host::FfiVisualViewportTransform,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let mut copy = unsafe { tree_from_handle(tree) }.clone();
-        copy.set_visual_viewport_matrix_and_origin(transform.matrix, transform.origin);
-        Rc::into_raw(Rc::new(copy)).cast()
-    })
+    let mut copy = unsafe { tree_from_handle(tree) }.clone();
+    copy.set_visual_viewport_matrix_and_origin(transform.matrix, transform.origin);
+    Rc::into_raw(Rc::new(copy)).cast()
 }
 
 /// # Safety
@@ -3237,26 +3009,24 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     spatial_matrices: *const crate::painting::host::FfiSpatialTransformSample,
     spatial_matrix_count: usize,
 ) -> *const c_void {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the sample arrays address the stated counts.
-        let (frame_opacities, spatial_matrices) = unsafe {
-            (
-                ffi_slice(frame_opacities, frame_opacity_count),
-                ffi_slice(spatial_matrices, spatial_matrix_count),
-            )
-        };
-        let frame_opacities: Vec<(FrameNodeIndex, f32)> = frame_opacities
-            .iter()
-            .map(|sample| (FrameNodeIndex(sample.frame), sample.opacity))
-            .collect();
-        let spatial_matrices: Vec<(SpatialNodeIndex, libgfx_rust::FloatMatrix4x4)> = spatial_matrices
-            .iter()
-            .map(|sample| (SpatialNodeIndex(sample.spatial), sample.matrix))
-            .collect();
-        let sampled = tree.with_sampled_visual_animation_values(&frame_opacities, &spatial_matrices);
-        Rc::into_raw(Rc::new(sampled)).cast()
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the sample arrays address the stated counts.
+    let (frame_opacities, spatial_matrices) = unsafe {
+        (
+            ffi_slice(frame_opacities, frame_opacity_count),
+            ffi_slice(spatial_matrices, spatial_matrix_count),
+        )
+    };
+    let frame_opacities: Vec<(FrameNodeIndex, f32)> = frame_opacities
+        .iter()
+        .map(|sample| (FrameNodeIndex(sample.frame), sample.opacity))
+        .collect();
+    let spatial_matrices: Vec<(SpatialNodeIndex, libgfx_rust::FloatMatrix4x4)> = spatial_matrices
+        .iter()
+        .map(|sample| (SpatialNodeIndex(sample.spatial), sample.matrix))
+        .collect();
+    let sampled = tree.with_sampled_visual_animation_values(&frame_opacities, &spatial_matrices);
+    Rc::into_raw(Rc::new(sampled)).cast()
 }
 
 /// # Safety
@@ -3269,12 +3039,10 @@ pub unsafe extern "C" fn visual_context_tree_visual_animation_targets_are_valid(
     targets: *const u32,
     target_count: usize,
 ) -> bool {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the targets address `target_count` indices.
-        let targets = unsafe { ffi_slice(targets, target_count) };
-        tree.visual_animation_targets_are_valid(targets_are_frames, targets)
-    })
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the targets address `target_count` indices.
+    let targets = unsafe { ffi_slice(targets, target_count) };
+    tree.visual_animation_targets_are_valid(targets_are_frames, targets)
 }
 
 /// # Safety
@@ -3287,14 +3055,14 @@ pub unsafe extern "C" fn visual_context_tree_effects_opacity(
     frame: FrameNodeIndex,
     out_opacity: *mut f32,
 ) -> bool {
-    abort_on_panic(|| match unsafe { tree_from_handle(tree) }.effects_opacity(frame) {
+    match unsafe { tree_from_handle(tree) }.effects_opacity(frame) {
         Some(opacity) => {
             // SAFETY: The caller guarantees `out_opacity` is writable.
             unsafe { *out_opacity = opacity };
             true
         }
         None => false,
-    })
+    }
 }
 
 /// # Safety
@@ -3309,15 +3077,13 @@ pub unsafe extern "C" fn visual_context_tree_mark_spatial_subtrees(
     out_flags: *mut bool,
     flag_count: usize,
 ) {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        // SAFETY: The caller guarantees the roots address `root_count` indices.
-        let roots = unsafe { ffi_slice(roots, root_count) };
-        let in_subtree = tree.spatial_nodes_in_subtrees_of(roots);
-        assert_eq!(in_subtree.len(), flag_count);
-        // SAFETY: The caller guarantees `out_flags` addresses `flag_count` writable flags.
-        unsafe { std::ptr::copy_nonoverlapping(in_subtree.as_ptr(), out_flags, flag_count) };
-    });
+    let tree = unsafe { tree_from_handle(tree) };
+    // SAFETY: The caller guarantees the roots address `root_count` indices.
+    let roots = unsafe { ffi_slice(roots, root_count) };
+    let in_subtree = tree.spatial_nodes_in_subtrees_of(roots);
+    assert_eq!(in_subtree.len(), flag_count);
+    // SAFETY: The caller guarantees `out_flags` addresses `flag_count` writable flags.
+    unsafe { std::ptr::copy_nonoverlapping(in_subtree.as_ptr(), out_flags, flag_count) };
 }
 
 /// # Safety
@@ -3325,7 +3091,7 @@ pub unsafe extern "C" fn visual_context_tree_mark_spatial_subtrees(
 /// `tree` must be a live retained tree handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_has_unisolated_blending_frame(tree: *const c_void) -> bool {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.has_unisolated_blending_frame())
+    unsafe { tree_from_handle(tree) }.has_unisolated_blending_frame()
 }
 
 /// # Safety
@@ -3338,17 +3104,15 @@ pub unsafe extern "C" fn visual_context_tree_for_each_effects_filter_bytes(
     context: *mut c_void,
     visit: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    abort_on_panic(|| {
-        let tree = unsafe { tree_from_handle(tree) };
-        for frame in &tree.frame_nodes {
-            if let crate::painting::visual_context::FrameData::Effects(effects) = &frame.data
-                && let Some(filter_bytes) = &effects.filter
-            {
-                // SAFETY: The C++ visitor reads the bytes synchronously.
-                unsafe { visit(context, filter_bytes.as_ptr(), filter_bytes.len()) };
-            }
+    let tree = unsafe { tree_from_handle(tree) };
+    for frame in &tree.frame_nodes {
+        if let crate::painting::visual_context::FrameData::Effects(effects) = &frame.data
+            && let Some(filter_bytes) = &effects.filter
+        {
+            // SAFETY: The C++ visitor reads the bytes synchronously.
+            unsafe { visit(context, filter_bytes.as_ptr(), filter_bytes.len()) };
         }
-    });
+    }
 }
 
 /// # Safety
@@ -3359,7 +3123,7 @@ pub unsafe extern "C" fn visual_context_tree_frame_is_isolated_by_layer_frame(
     tree: *const c_void,
     frame: FrameNodeIndex,
 ) -> bool {
-    abort_on_panic(|| unsafe { tree_from_handle(tree) }.frame_is_isolated_by_layer_frame(frame))
+    unsafe { tree_from_handle(tree) }.frame_is_isolated_by_layer_frame(frame)
 }
 
 /// # Safety
@@ -3369,20 +3133,17 @@ pub unsafe extern "C" fn visual_context_tree_frame_is_isolated_by_layer_frame(
 /// or `visual_context_tree_test_builder_destroy` consumes it.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_test_builder_create() -> *mut c_void {
-    abort_on_panic(|| {
-        let tree = crate::painting::visual_context::VisualContextTree::create(
-            crate::painting::visual_context::TransformData {
-                matrix: libgfx_rust::FloatMatrix4x4::identity(),
-                origin: libgfx_rust::FloatPoint::default(),
-                sorting_context_root_index: None,
-                flattens_inherited_transform: false,
-                role: crate::painting::visual_context::TransformDataRole::CssTransform,
-                synthetic_plane: false,
-                establishes_sorting_context: false,
-            },
-        );
-        Box::into_raw(Box::new(tree)).cast()
-    })
+    let tree =
+        crate::painting::visual_context::VisualContextTree::create(crate::painting::visual_context::TransformData {
+            matrix: libgfx_rust::FloatMatrix4x4::identity(),
+            origin: libgfx_rust::FloatPoint::default(),
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: crate::painting::visual_context::TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        });
+    Box::into_raw(Box::new(tree)).cast()
 }
 
 /// # Safety
@@ -3403,22 +3164,20 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_transform(
     matrix: libgfx_rust::FloatMatrix4x4,
     origin: libgfx_rust::FloatPoint,
 ) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        tree.append_spatial(
-            crate::painting::visual_context::SpatialData::Transform(crate::painting::visual_context::TransformData {
-                matrix,
-                origin,
-                sorting_context_root_index: None,
-                flattens_inherited_transform: false,
-                role: crate::painting::visual_context::TransformDataRole::CssTransform,
-                synthetic_plane: false,
-                establishes_sorting_context: false,
-            }),
-            SpatialNodeIndex(parent),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.append_spatial(
+        crate::painting::visual_context::SpatialData::Transform(crate::painting::visual_context::TransformData {
+            matrix,
+            origin,
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: crate::painting::visual_context::TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        }),
+        SpatialNodeIndex(parent),
+    )
+    .0
 }
 
 /// # Safety
@@ -3426,18 +3185,16 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_transform(
 /// `builder` must be a live handle from `visual_context_tree_test_builder_create`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_test_builder_append_scroll(builder: *mut c_void, parent: u32) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        tree.append_spatial(
-            crate::painting::visual_context::SpatialData::Scroll(crate::painting::visual_context::ScrollData {
-                state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
-                owner_paintable: NodeSlotId::INVALID,
-                registry_parent_node: SpatialNodeIndex(parent),
-            }),
-            SpatialNodeIndex(parent),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.append_spatial(
+        crate::painting::visual_context::SpatialData::Scroll(crate::painting::visual_context::ScrollData {
+            state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: SpatialNodeIndex(parent),
+        }),
+        SpatialNodeIndex(parent),
+    )
+    .0
 }
 
 /// # Safety
@@ -3449,37 +3206,34 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_sticky(
     parent: u32,
     constraints: crate::painting::host::FfiTestStickyConstraints,
 ) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        let inset =
-            |value: crate::painting::display_list::commands::OptionalF32| value.has_value.then_some(value.value);
-        tree.append_spatial(
-            crate::painting::visual_context::SpatialData::Sticky(crate::painting::visual_context::StickyData {
-                scroller: SpatialNodeIndex(constraints.scroller),
-                parent_sticky: constraints
-                    .has_parent_sticky
-                    .then_some(SpatialNodeIndex(constraints.parent_sticky)),
-                position_relative_to_scroller: constraints.position_relative_to_scroller,
-                border_box_size: constraints.border_box_size,
-                scrollport_size: constraints.scrollport_size,
-                containing_block_region: constraints.containing_block_region,
-                needs_parent_offset_adjustment: constraints.needs_parent_offset_adjustment,
-                inset_top: inset(constraints.inset_top),
-                inset_right: inset(constraints.inset_right),
-                inset_bottom: inset(constraints.inset_bottom),
-                inset_left: inset(constraints.inset_left),
-                state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
-                owner_paintable: NodeSlotId::INVALID,
-                registry_parent_node: if constraints.has_parent_sticky {
-                    SpatialNodeIndex(constraints.parent_sticky)
-                } else {
-                    SpatialNodeIndex(constraints.scroller)
-                },
-            }),
-            SpatialNodeIndex(parent),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    let inset = |value: crate::painting::display_list::commands::OptionalF32| value.has_value.then_some(value.value);
+    tree.append_spatial(
+        crate::painting::visual_context::SpatialData::Sticky(crate::painting::visual_context::StickyData {
+            scroller: SpatialNodeIndex(constraints.scroller),
+            parent_sticky: constraints
+                .has_parent_sticky
+                .then_some(SpatialNodeIndex(constraints.parent_sticky)),
+            position_relative_to_scroller: constraints.position_relative_to_scroller,
+            border_box_size: constraints.border_box_size,
+            scrollport_size: constraints.scrollport_size,
+            containing_block_region: constraints.containing_block_region,
+            needs_parent_offset_adjustment: constraints.needs_parent_offset_adjustment,
+            inset_top: inset(constraints.inset_top),
+            inset_right: inset(constraints.inset_right),
+            inset_bottom: inset(constraints.inset_bottom),
+            inset_left: inset(constraints.inset_left),
+            state_slot: crate::painting::visual_context::scroll_state::NO_SCROLL_STATE_SLOT,
+            owner_paintable: NodeSlotId::INVALID,
+            registry_parent_node: if constraints.has_parent_sticky {
+                SpatialNodeIndex(constraints.parent_sticky)
+            } else {
+                SpatialNodeIndex(constraints.scroller)
+            },
+        }),
+        SpatialNodeIndex(parent),
+    )
+    .0
 }
 
 /// # Safety
@@ -3494,19 +3248,17 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_frame(
     corner_radii: libgfx_rust::CornerRadii,
     mode: crate::painting::visual_context::ClipMode,
 ) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        tree.append_frame(
-            crate::painting::visual_context::FrameData::Clip(crate::painting::visual_context::ClipData {
-                rect,
-                corner_radii,
-                mode,
-            }),
-            FrameNodeIndex(parent_frame),
-            SpatialNodeIndex(spatial),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.append_frame(
+        crate::painting::visual_context::FrameData::Clip(crate::painting::visual_context::ClipData {
+            rect,
+            corner_radii,
+            mode,
+        }),
+        FrameNodeIndex(parent_frame),
+        SpatialNodeIndex(spatial),
+    )
+    .0
 }
 
 /// # Safety
@@ -3523,22 +3275,20 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_path_frame
     bounding_rect: libgfx_rust::IntRect,
     fill_rule: libgfx_rust::WindingRule,
 ) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        // SAFETY: The caller guarantees `path_bytes` addresses `path_bytes_length` readable bytes.
-        let path_bytes = unsafe { ffi_slice(path_bytes, path_bytes_length) };
-        let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(path_bytes);
-        tree.append_frame(
-            crate::painting::visual_context::FrameData::ClipPath(crate::painting::visual_context::ClipPathData {
-                path: Rc::new(path),
-                bounding_rect,
-                fill_rule,
-            }),
-            FrameNodeIndex(parent_frame),
-            SpatialNodeIndex(spatial),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    // SAFETY: The caller guarantees `path_bytes` addresses `path_bytes_length` readable bytes.
+    let path_bytes = unsafe { ffi_slice(path_bytes, path_bytes_length) };
+    let path = libgfx_rust::path::OwnedPath::from_serialized_bytes(path_bytes);
+    tree.append_frame(
+        crate::painting::visual_context::FrameData::ClipPath(crate::painting::visual_context::ClipPathData {
+            path: Rc::new(path),
+            bounding_rect,
+            fill_rule,
+        }),
+        FrameNodeIndex(parent_frame),
+        SpatialNodeIndex(spatial),
+    )
+    .0
 }
 
 /// # Safety
@@ -3552,19 +3302,17 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_effects_frame(
     opacity: f32,
     blend_mode: libgfx_rust::CompositingAndBlendingOperator,
 ) -> u32 {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        tree.append_frame(
-            crate::painting::visual_context::FrameData::Effects(crate::painting::visual_context::EffectsData {
-                opacity,
-                blend_mode,
-                filter: None,
-            }),
-            FrameNodeIndex(parent_frame),
-            SpatialNodeIndex(spatial),
-        )
-        .0
-    })
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.append_frame(
+        crate::painting::visual_context::FrameData::Effects(crate::painting::visual_context::EffectsData {
+            opacity,
+            blend_mode,
+            filter: None,
+        }),
+        FrameNodeIndex(parent_frame),
+        SpatialNodeIndex(spatial),
+    )
+    .0
 }
 
 /// # Safety
@@ -3576,10 +3324,8 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_set_structural_epoch(
     builder: *mut c_void,
     structural_epoch: u64,
 ) {
-    abort_on_panic(|| {
-        let tree = unsafe { test_builder_tree(builder) };
-        tree.structural_epoch = structural_epoch;
-    });
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.structural_epoch = structural_epoch;
 }
 
 /// # Safety
@@ -3588,11 +3334,9 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_set_structural_epoch(
 /// call. Returns a retained tree handle the caller owns.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_test_builder_finish(builder: *mut c_void) -> *const c_void {
-    abort_on_panic(|| {
-        // SAFETY: The caller hands over the boxed tree the create call returned.
-        let tree = unsafe { Box::from_raw(builder.cast::<crate::painting::visual_context::VisualContextTree>()) };
-        Rc::into_raw(Rc::new(*tree)).cast()
-    })
+    // SAFETY: The caller hands over the boxed tree the create call returned.
+    let tree = unsafe { Box::from_raw(builder.cast::<crate::painting::visual_context::VisualContextTree>()) };
+    Rc::into_raw(Rc::new(*tree)).cast()
 }
 
 /// # Safety
@@ -3601,13 +3345,11 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_finish(builder: *mut c
 /// by this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_test_builder_destroy(builder: *mut c_void) {
-    abort_on_panic(|| {
-        if builder.is_null() {
-            return;
-        }
-        // SAFETY: The caller hands over the boxed tree the create call returned.
-        drop(unsafe { Box::from_raw(builder.cast::<crate::painting::visual_context::VisualContextTree>()) });
-    });
+    if builder.is_null() {
+        return;
+    }
+    // SAFETY: The caller hands over the boxed tree the create call returned.
+    drop(unsafe { Box::from_raw(builder.cast::<crate::painting::visual_context::VisualContextTree>()) });
 }
 
 /// # Safety
@@ -3620,22 +3362,20 @@ pub unsafe extern "C" fn layout_arena_scroll_state_snapshot(
     out: *mut libgfx_rust::FloatPoint,
     capacity: usize,
 ) -> usize {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        let snapshot = &paint_state.visual_context.scroll_state_snapshot;
-        let needed = snapshot.len();
-        if !out.is_null() {
-            for (index, offset) in snapshot.iter().enumerate() {
-                if index >= capacity {
-                    break;
-                }
-                // SAFETY: within the caller's capacity.
-                unsafe { *out.add(index) = *offset };
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    let snapshot = &paint_state.visual_context.scroll_state_snapshot;
+    let needed = snapshot.len();
+    if !out.is_null() {
+        for (index, offset) in snapshot.iter().enumerate() {
+            if index >= capacity {
+                break;
             }
+            // SAFETY: within the caller's capacity.
+            unsafe { *out.add(index) = *offset };
         }
-        needed
-    })
+    }
+    needed
 }
 
 /// # Safety
@@ -3648,19 +3388,15 @@ pub unsafe extern "C" fn layout_arena_hit_test_visit_caret_roots_and_chrome_widg
     sink: *mut c_void,
     visit: unsafe extern "C" fn(*mut c_void, NodeSlotId, u8, *mut c_void),
 ) {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, (), |list, arena| {
-            for item in list.items.iter() {
-                let caret_node_shell = arena.shell_if_live(item.caret_node);
-                if item.chrome_widget_kind == crate::painting::hit_test::CHROME_WIDGET_NONE
-                    && caret_node_shell.is_null()
-                {
-                    continue;
-                }
-                // SAFETY: The C++ host consumes the visit synchronously.
-                unsafe { visit(sink, item.paintable, item.chrome_widget_kind, caret_node_shell) };
+    with_hit_test_list_items_only(arena, (), |list, arena| {
+        for item in list.items.iter() {
+            let caret_node_shell = arena.shell_if_live(item.caret_node);
+            if item.chrome_widget_kind == crate::painting::hit_test::CHROME_WIDGET_NONE && caret_node_shell.is_null() {
+                continue;
             }
-        });
+            // SAFETY: The C++ host consumes the visit synchronously.
+            unsafe { visit(sink, item.paintable, item.chrome_widget_kind, caret_node_shell) };
+        }
     });
 }
 
@@ -3673,29 +3409,27 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_facts(
     arena: *mut c_void,
     index: usize,
 ) -> crate::painting::host::FfiHitTestItemExport {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, None, |list, arena| {
-            let item = &list.items[index];
-            assert!(
-                arena.paintable_row_is_populated(item.paintable),
-                "exporting a hit-test item for a non-live paintable"
-            );
-            assert!(
-                arena.paintable_row_is_populated(item.hit_node),
-                "exporting a hit-test item that names a non-live paintable"
-            );
-            Some(crate::painting::host::FfiHitTestItemExport {
-                can_produce_caret_position: item.can_produce_caret_position,
-                paintable: item.paintable,
-                hit_node: item.hit_node,
-                chrome_widget_kind: item.chrome_widget_kind,
-                caret_node_shell: arena.shell_if_live(item.caret_node),
-                caret_rect: item.caret_rect.into(),
-                context: item.context,
-            })
+    with_hit_test_list_items_only(arena, None, |list, arena| {
+        let item = &list.items[index];
+        assert!(
+            arena.paintable_row_is_populated(item.paintable),
+            "exporting a hit-test item for a non-live paintable"
+        );
+        assert!(
+            arena.paintable_row_is_populated(item.hit_node),
+            "exporting a hit-test item that names a non-live paintable"
+        );
+        Some(crate::painting::host::FfiHitTestItemExport {
+            can_produce_caret_position: item.can_produce_caret_position,
+            paintable: item.paintable,
+            hit_node: item.hit_node,
+            chrome_widget_kind: item.chrome_widget_kind,
+            caret_node_shell: arena.shell_if_live(item.caret_node),
+            caret_rect: item.caret_rect.into(),
+            context: item.context,
         })
-        .expect("no hit-test list")
     })
+    .expect("no hit-test list")
 }
 
 /// # Safety
@@ -3704,10 +3438,8 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_facts(
 /// `item_index` must be in range for the current hit-test list.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_hit_test_item_target_shell(arena: *mut c_void, item_index: usize) -> *mut c_void {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, std::ptr::null_mut(), |list, arena| {
-            list.item_target_shell(arena, item_index)
-        })
+    with_hit_test_list_items_only(arena, std::ptr::null_mut(), |list, arena| {
+        list.item_target_shell(arena, item_index)
     })
 }
 
@@ -3722,13 +3454,11 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_dispatch_shell(
     item_index: usize,
     out_allow_pseudo_fallback: *mut bool,
 ) -> *mut c_void {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, std::ptr::null_mut(), |list, arena| {
-            let (shell, allow_pseudo_fallback) = list.item_dispatch_shell(arena, item_index);
-            // SAFETY: The caller provides writable storage for the synchronous result.
-            unsafe { *out_allow_pseudo_fallback = allow_pseudo_fallback };
-            shell
-        })
+    with_hit_test_list_items_only(arena, std::ptr::null_mut(), |list, arena| {
+        let (shell, allow_pseudo_fallback) = list.item_dispatch_shell(arena, item_index);
+        // SAFETY: The caller provides writable storage for the synchronous result.
+        unsafe { *out_allow_pseudo_fallback = allow_pseudo_fallback };
+        shell
     })
 }
 
@@ -3742,10 +3472,8 @@ pub unsafe extern "C" fn layout_arena_hit_test_resolve_hit(
     item_index: usize,
     local_point: FfiCssPixelPoint,
 ) -> crate::painting::host::FfiResolvedHit {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, Default::default(), |list, arena| {
-            list.resolve_hit(arena, item_index, local_point.into())
-        })
+    with_hit_test_list_items_only(arena, Default::default(), |list, arena| {
+        list.resolve_hit(arena, item_index, local_point.into())
     })
 }
 
@@ -3760,15 +3488,13 @@ pub unsafe extern "C" fn layout_arena_hit_test_resolve_caret(
     local_point: FfiCssPixelPoint,
     position_type: u8,
 ) -> crate::painting::host::FfiResolvedCaret {
-    abort_on_panic(|| {
-        with_hit_test_list_items_only(arena, Default::default(), |list, arena| {
-            list.resolve_caret(
-                arena,
-                item_index,
-                local_point.into(),
-                crate::painting::hit_test::caret::CaretPositionType::from_u8(position_type),
-            )
-        })
+    with_hit_test_list_items_only(arena, Default::default(), |list, arena| {
+        list.resolve_caret(
+            arena,
+            item_index,
+            local_point.into(),
+            crate::painting::hit_test::caret::CaretPositionType::from_u8(position_type),
+        )
     })
 }
 
@@ -3783,16 +3509,14 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_line_for_position(
     offset: usize,
     affinity_is_downstream: bool,
 ) -> crate::painting::host::FfiCaretLineForPosition {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures(arena, Default::default(), |list, arena| {
-            match list.caret_line_for_position(arena, &callbacks, offset, affinity_is_downstream) {
-                Some(line_index) => crate::painting::host::FfiCaretLineForPosition {
-                    has_line: true,
-                    line_index,
-                },
-                None => Default::default(),
-            }
-        })
+    with_hit_test_list_and_derived_structures(arena, Default::default(), |list, arena| {
+        match list.caret_line_for_position(arena, &callbacks, offset, affinity_is_downstream) {
+            Some(line_index) => crate::painting::host::FfiCaretLineForPosition {
+                has_line: true,
+                line_index,
+            },
+            None => Default::default(),
+        }
     })
 }
 
@@ -3802,14 +3526,12 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_line_for_position(
 /// `length` readable bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_paint_push_bytes(sink: *mut c_void, bytes: *const u8, length: usize) {
-    abort_on_panic(|| {
-        // SAFETY: `sink` is the Vec pointer handed out by the host callback wrapper; the caller
-        // guarantees the byte range.
-        let vec = unsafe { &mut *sink.cast::<Vec<u8>>() };
-        if length > 0 {
-            vec.extend_from_slice(unsafe { std::slice::from_raw_parts(bytes, length) });
-        }
-    });
+    // SAFETY: `sink` is the Vec pointer handed out by the host callback wrapper; the caller
+    // guarantees the byte range.
+    let vec = unsafe { &mut *sink.cast::<Vec<u8>>() };
+    if length > 0 {
+        vec.extend_from_slice(unsafe { std::slice::from_raw_parts(bytes, length) });
+    }
 }
 
 /// # Safety
@@ -3818,16 +3540,14 @@ pub unsafe extern "C" fn layout_arena_paint_push_bytes(sink: *mut c_void, bytes:
 /// returned pointers borrow the last recording and stay valid until the next one replaces it.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_recorded_display_list(arena: *mut c_void) -> FfiRecordedDisplayList {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        let paint_state = arena.paint_state().borrow();
-        paint_state
-            .last_recording
-            .as_ref()
-            .map_or_else(FfiRecordedDisplayList::empty, |recording| {
-                FfiRecordedDisplayList::with_mask_registrations(&recording.display_list, &recording.mask_display_lists)
-            })
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    let paint_state = arena.paint_state().borrow();
+    paint_state
+        .last_recording
+        .as_ref()
+        .map_or_else(FfiRecordedDisplayList::empty, |recording| {
+            FfiRecordedDisplayList::with_mask_registrations(&recording.display_list, &recording.mask_display_lists)
+        })
 }
 
 /// # Safety
@@ -3838,16 +3558,14 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_line(
     arena: *mut c_void,
     line_index: usize,
 ) -> crate::painting::host::FfiCaretLineExport {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures(arena, Default::default(), |list, _| {
-            let line = &list.caret_lines[line_index];
-            crate::painting::host::FfiCaretLineExport {
-                rect: line.rect.into(),
-                context: line.context,
-                first_caret_item_index: line.first_caret_item_index,
-                last_caret_item_index: line.last_caret_item_index,
-            }
-        })
+    with_hit_test_list_and_derived_structures(arena, Default::default(), |list, _| {
+        let line = &list.caret_lines[line_index];
+        crate::painting::host::FfiCaretLineExport {
+            rect: line.rect.into(),
+            context: line.context,
+            first_caret_item_index: line.first_caret_item_index,
+            last_caret_item_index: line.last_caret_item_index,
+        }
     })
 }
 
@@ -3860,10 +3578,8 @@ fn list_generation_of(paint_state: &crate::painting::paint_state::PaintState) ->
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_hit_test_list_generation(arena: *mut c_void) -> u64 {
-    abort_on_panic(|| {
-        let arena = unsafe { arena_from_handle(arena) };
-        list_generation_of(&arena.paint_state().borrow())
-    })
+    let arena = unsafe { arena_from_handle(arena) };
+    list_generation_of(&arena.paint_state().borrow())
 }
 
 fn with_hit_test_list_items_only<R>(
@@ -3942,12 +3658,8 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_item(
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
     point: FfiCssPixelPoint,
 ) -> crate::painting::host::FfiTopmostItem {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures_and_visual_context_tree(
-            arena,
-            Default::default(),
-            |list, tree, arena| ffi_topmost(list.find_topmost_item(arena, tree, &callbacks, point.into())),
-        )
+    with_hit_test_list_and_derived_structures_and_visual_context_tree(arena, Default::default(), |list, tree, arena| {
+        ffi_topmost(list.find_topmost_item(arena, tree, &callbacks, point.into()))
     })
 }
 
@@ -3960,18 +3672,12 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_topmost_items_for_caret(
     callbacks: crate::painting::host::FfiHitTestQueryCallbacks,
     point: FfiCssPixelPoint,
 ) -> crate::painting::host::FfiTopmostItemsForCaret {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures_and_visual_context_tree(
-            arena,
-            Default::default(),
-            |list, tree, arena| {
-                let (caret_item, hit_item) = list.find_topmost_items_for_caret(arena, tree, &callbacks, point.into());
-                crate::painting::host::FfiTopmostItemsForCaret {
-                    caret_item: ffi_topmost(caret_item),
-                    hit_item: ffi_topmost(hit_item),
-                }
-            },
-        )
+    with_hit_test_list_and_derived_structures_and_visual_context_tree(arena, Default::default(), |list, tree, arena| {
+        let (caret_item, hit_item) = list.find_topmost_items_for_caret(arena, tree, &callbacks, point.into());
+        crate::painting::host::FfiTopmostItemsForCaret {
+            caret_item: ffi_topmost(caret_item),
+            hit_item: ffi_topmost(hit_item),
+        }
     })
 }
 
@@ -3986,17 +3692,14 @@ pub unsafe extern "C" fn layout_arena_hit_test_all(
     push_context: *mut c_void,
     push: unsafe extern "C" fn(*mut c_void, usize),
 ) {
-    abort_on_panic(|| {
-        let indices = with_hit_test_list_and_derived_structures_and_visual_context_tree(
-            arena,
-            Vec::new(),
-            |list, tree, arena| list.hit_test_all(arena, tree, &callbacks, point.into()),
-        );
-        for index in indices {
-            // SAFETY: The C++ sink consumes the index synchronously.
-            unsafe { push(push_context, index) };
-        }
-    });
+    let indices =
+        with_hit_test_list_and_derived_structures_and_visual_context_tree(arena, Vec::new(), |list, tree, arena| {
+            list.hit_test_all(arena, tree, &callbacks, point.into())
+        });
+    for index in indices {
+        // SAFETY: The C++ sink consumes the index synchronously.
+        unsafe { push(push_context, index) };
+    }
 }
 
 /// # Safety
@@ -4008,11 +3711,9 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_at_line_edge(
     line_index: usize,
     position_type: u8,
 ) -> usize {
-    abort_on_panic(|| {
-        let position_type = crate::painting::hit_test::caret::CaretPositionType::from_u8(position_type);
-        with_hit_test_list_and_derived_structures(arena, usize::MAX, |list, _| {
-            list.item_at_line_edge(line_index, position_type)
-        })
+    let position_type = crate::painting::hit_test::caret::CaretPositionType::from_u8(position_type);
+    with_hit_test_list_and_derived_structures(arena, usize::MAX, |list, _| {
+        list.item_at_line_edge(line_index, position_type)
     })
 }
 
@@ -4026,21 +3727,19 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_item_for_line(
     point: FfiCssPixelPoint,
     mode: u8,
 ) -> crate::painting::host::FfiCaretItemForLine {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures(arena, Default::default(), |list, _| {
-            match list.caret_item_for_line(
-                line_index,
-                point.into(),
-                crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
-            ) {
-                Some((item_index, position_type)) => crate::painting::host::FfiCaretItemForLine {
-                    has_item: true,
-                    item_index,
-                    position_type: position_type as u8,
-                },
-                None => Default::default(),
-            }
-        })
+    with_hit_test_list_and_derived_structures(arena, Default::default(), |list, _| {
+        match list.caret_item_for_line(
+            line_index,
+            point.into(),
+            crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
+        ) {
+            Some((item_index, position_type)) => crate::painting::host::FfiCaretItemForLine {
+                has_item: true,
+                item_index,
+                position_type: position_type as u8,
+            },
+            None => Default::default(),
+        }
     })
 }
 
@@ -4049,11 +3748,7 @@ pub unsafe extern "C" fn layout_arena_hit_test_caret_item_for_line(
 /// `arena` must be a live handle from `layout_arena_create`, used on the document thread.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_hit_test_line_block_coordinate(arena: *mut c_void, line_index: usize) -> i32 {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures(arena, 0, |list, _| {
-            list.line_block_coordinate(line_index).raw_value()
-        })
-    })
+    with_hit_test_list_and_derived_structures(arena, 0, |list, _| list.line_block_coordinate(line_index).raw_value())
 }
 
 /// # Safety
@@ -4065,10 +3760,8 @@ pub unsafe extern "C" fn layout_arena_hit_test_item_is_inline_adjacent_to_line(
     item_index: usize,
     line_index: usize,
 ) -> bool {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures(arena, false, |list, _| {
-            list.item_is_inline_adjacent_to_line(item_index, line_index)
-        })
+    with_hit_test_list_and_derived_structures(arena, false, |list, _| {
+        list.item_is_inline_adjacent_to_line(item_index, line_index)
     })
 }
 
@@ -4084,34 +3777,28 @@ pub unsafe extern "C" fn layout_arena_hit_test_find_closest_line(
     scoped: bool,
     respect_clip: bool,
 ) -> crate::painting::host::FfiClosestLine {
-    abort_on_panic(|| {
-        with_hit_test_list_and_derived_structures_and_visual_context_tree(
+    with_hit_test_list_and_derived_structures_and_visual_context_tree(arena, Default::default(), |list, tree, arena| {
+        let closest = list.find_closest_line(
             arena,
-            Default::default(),
-            |list, tree, arena| {
-                let closest = list.find_closest_line(
-                    arena,
-                    tree,
-                    &callbacks,
-                    point.into(),
-                    crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
-                    scoped,
-                    respect_clip,
-                );
-                crate::painting::host::FfiClosestLine {
-                    has_index: closest.index.is_some(),
-                    index: closest.index.unwrap_or(0),
-                    local_x: closest.local_point.x.raw_value(),
-                    local_y: closest.local_point.y.raw_value(),
-                    block_distance: closest.block_distance.raw_value(),
-                    block_start_distance: closest.block_start_distance.raw_value(),
-                    inline_distance: closest.inline_distance.raw_value(),
-                    block_container_margin_rect: closest.block_container_margin_rect.map(Into::into).into(),
-                    is_before_point: closest.is_before_point,
-                    contains_point_in_block_axis: closest.contains_point_in_block_axis,
-                }
-            },
-        )
+            tree,
+            &callbacks,
+            point.into(),
+            crate::painting::hit_test::caret::CaretPositionMode::from_u8(mode),
+            scoped,
+            respect_clip,
+        );
+        crate::painting::host::FfiClosestLine {
+            has_index: closest.index.is_some(),
+            index: closest.index.unwrap_or(0),
+            local_x: closest.local_point.x.raw_value(),
+            local_y: closest.local_point.y.raw_value(),
+            block_distance: closest.block_distance.raw_value(),
+            block_start_distance: closest.block_start_distance.raw_value(),
+            inline_distance: closest.inline_distance.raw_value(),
+            block_container_margin_rect: closest.block_container_margin_rect.map(Into::into).into(),
+            is_before_point: closest.is_before_point,
+            contains_point_in_block_axis: closest.contains_point_in_block_axis,
+        }
     })
 }
 
@@ -4126,29 +3813,27 @@ pub unsafe extern "C" fn layout_arena_hit_test_adjacent_line(
     direction: u8,
     inline_coordinate_raw: i32,
 ) -> crate::painting::host::FfiAdjacentLine {
-    abort_on_panic(|| {
-        let direction = if direction == 1 {
-            crate::painting::hit_test::caret::CaretLineDirection::Next
-        } else {
-            crate::painting::hit_test::caret::CaretLineDirection::Previous
-        };
-        with_hit_test_list_and_derived_structures(arena, Default::default(), |list, arena| {
-            match list.adjacent_line(
-                arena,
-                &callbacks,
-                current_line_index,
-                direction,
-                CssPixels::from_raw(inline_coordinate_raw),
-            ) {
-                Some((line_index, point)) => crate::painting::host::FfiAdjacentLine {
-                    has_line: true,
-                    line_index,
-                    point_x: point.x.raw_value(),
-                    point_y: point.y.raw_value(),
-                },
-                None => Default::default(),
-            }
-        })
+    let direction = if direction == 1 {
+        crate::painting::hit_test::caret::CaretLineDirection::Next
+    } else {
+        crate::painting::hit_test::caret::CaretLineDirection::Previous
+    };
+    with_hit_test_list_and_derived_structures(arena, Default::default(), |list, arena| {
+        match list.adjacent_line(
+            arena,
+            &callbacks,
+            current_line_index,
+            direction,
+            CssPixels::from_raw(inline_coordinate_raw),
+        ) {
+            Some((line_index, point)) => crate::painting::host::FfiAdjacentLine {
+                has_line: true,
+                line_index,
+                point_x: point.x.raw_value(),
+                point_y: point.y.raw_value(),
+            },
+            None => Default::default(),
+        }
     })
 }
 
@@ -4160,9 +3845,7 @@ pub unsafe extern "C" fn layout_arena_hit_test_push_line_break_caret_target(
     sink: *mut c_void,
     target: crate::painting::host::FfiLineBreakCaretTarget,
 ) {
-    abort_on_panic(|| {
-        // SAFETY: `sink` is the Vec pointer handed out by FfiHitTestHostCallbacks::line_break_caret_targets.
-        let targets = unsafe { &mut *sink.cast::<Vec<crate::painting::host::FfiLineBreakCaretTarget>>() };
-        targets.push(target);
-    });
+    // SAFETY: `sink` is the Vec pointer handed out by FfiHitTestHostCallbacks::line_break_caret_targets.
+    let targets = unsafe { &mut *sink.cast::<Vec<crate::painting::host::FfiLineBreakCaretTarget>>() };
+    targets.push(target);
 }

--- a/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_build.rs
@@ -70,8 +70,8 @@ impl<'a> PaintableCommit<'a> {
             let data = self.callbacks.node_data(node);
             (
                 (has_used_values || (facts.is_fragmented_inline() && facts.has_dom_node()))
-                    && node_painting::has_paintable(data.kind),
-                data.kind,
+                    && node_painting::has_paintable(data.kind.get()),
+                data.kind.get(),
             )
         };
         let row_existed_before_this_commit = self.arena().paintable_rows().paintable_row_is_populated(node);
@@ -344,7 +344,7 @@ impl<'a> PaintableCommit<'a> {
         has_trailing_whitespace: bool,
     ) -> (usize, usize, usize, usize) {
         let data = self.callbacks.node_data(layout_node);
-        if !node_facts::kind_is_text(data.kind) {
+        if !node_facts::kind_is_text(data.kind.get()) {
             return (
                 start_offset,
                 start_offset + length_in_code_units,
@@ -396,7 +396,7 @@ impl<'a> PaintableCommit<'a> {
     }
 
     pub(crate) fn stamp_containing_block(&mut self, node: formatting_context::Node) {
-        let containing_block = self.callbacks.node_data(node).containing_block;
+        let containing_block = self.callbacks.node_data(node).containing_block.get();
         let arena = self.arena_mut();
         let mut paintable_rows = arena.paintable_rows_mut();
         if !paintable_rows.paintable_row_is_populated(node) {

--- a/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
+++ b/Libraries/LibWeb/Rust/src/painting/paintable_rows.rs
@@ -470,7 +470,7 @@ impl LayoutNodeArena {
     pub(crate) fn schedule_scrollable_overflow_recalculation(&self, node: NodeSlotId) {
         // SAFETY: The caller supplies a live slot; data() generation-checks every slot the
         // containing-block walk visits.
-        let node_kind = unsafe { (&raw const (*self.data(node)).kind).read() };
+        let node_kind = self.data(node).kind.get();
         if crate::layout::node_facts::kind_is_box(node_kind) {
             let paintable_rows = self.paintable_rows();
             let mut containing_box = node;
@@ -479,7 +479,7 @@ impl LayoutNodeArena {
                     paintable_rows.clear_cached_overflow_data(containing_box);
                 }
                 // SAFETY: As above.
-                let next = unsafe { (&raw const (*self.data(containing_box)).containing_block).read() };
+                let next = self.data(containing_box).containing_block.get();
                 if next.is_invalid() || !self.slot_is_live(next) {
                     break;
                 }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
@@ -48,16 +48,14 @@ pub unsafe extern "C" fn layout_arena_dump_stacking_context_tree(
     viewport: NodeSlotId,
     callbacks: FfiStackingContextDumpCallbacks,
 ) {
-    crate::abort_on_panic(|| {
-        // SAFETY: The caller guarantees a live arena handle borrowed for this call.
-        let arena = unsafe { LayoutNodeArena::from_handle(arena) };
-        if arena.stacking_context_entries(viewport).is_none() {
-            return;
-        }
-        let mut output = String::new();
-        visit(&mut output, arena, viewport, 0, &callbacks);
-        callbacks.append_text(&output);
-    });
+    // SAFETY: The caller guarantees a live arena handle borrowed for this call.
+    let arena = unsafe { LayoutNodeArena::from_handle(arena) };
+    if arena.stacking_context_entries(viewport).is_none() {
+        return;
+    }
+    let mut output = String::new();
+    visit(&mut output, arena, viewport, 0, &callbacks);
+    callbacks.append_text(&output);
 }
 
 fn visit(

--- a/Libraries/LibWeb/Rust/src/svg/attribute_parser.rs
+++ b/Libraries/LibWeb/Rust/src/svg/attribute_parser.rs
@@ -283,13 +283,11 @@ fn with_input<T>(input: FfiSvgInput, parse: impl FnOnce(Input<'_>) -> T) -> Opti
 /// `input` must satisfy [`FfiSvgInput::input`]'s requirements and `value` must be writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_svg_integer(input: FfiSvgInput, value: *mut i32) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(parsed_value) = with_input(input, parse_integer).flatten() else {
-            return false;
-        };
-        unsafe { value.write(parsed_value) };
-        true
-    })
+    let Some(parsed_value) = with_input(input, parse_integer).flatten() else {
+        return false;
+    };
+    unsafe { value.write(parsed_value) };
+    true
 }
 
 /// # Safety
@@ -300,16 +298,14 @@ pub unsafe extern "C" fn rust_parse_svg_number_percentage(
     value: *mut f32,
     is_percentage: *mut bool,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(parsed_value) = with_input(input, parse_number_percentage).flatten() else {
-            return false;
-        };
-        unsafe {
-            value.write(parsed_value.value);
-            is_percentage.write(parsed_value.is_percentage);
-        }
-        true
-    })
+    let Some(parsed_value) = with_input(input, parse_number_percentage).flatten() else {
+        return false;
+    };
+    unsafe {
+        value.write(parsed_value.value);
+        is_percentage.write(parsed_value.is_percentage);
+    }
+    true
 }
 
 /// # Safety
@@ -321,17 +317,15 @@ pub unsafe extern "C" fn rust_parse_svg_points(
     context: *mut c_void,
     set_points: unsafe extern "C" fn(*mut c_void, *const FfiSvgPoint, usize),
 ) {
-    crate::abort_on_panic(|| {
-        let points = with_input(input, parse_points).unwrap_or_default();
-        let points: Vec<_> = points
-            .into_iter()
-            .map(|point| FfiSvgPoint {
-                x: point[0],
-                y: point[1],
-            })
-            .collect();
-        unsafe { set_points(context, points.as_ptr(), points.len()) };
-    });
+    let points = with_input(input, parse_points).unwrap_or_default();
+    let points: Vec<_> = points
+        .into_iter()
+        .map(|point| FfiSvgPoint {
+            x: point[0],
+            y: point[1],
+        })
+        .collect();
+    unsafe { set_points(context, points.as_ptr(), points.len()) };
 }
 
 /// # Safety
@@ -343,20 +337,18 @@ pub unsafe extern "C" fn rust_parse_svg_transform(
     context: *mut c_void,
     set_transforms: unsafe extern "C" fn(*mut c_void, *const FfiSvgTransform, usize),
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(transforms) = with_input(input, parse_transform).flatten() else {
-            return false;
-        };
-        let transforms: Vec<_> = transforms
-            .into_iter()
-            .map(|transform| FfiSvgTransform {
-                kind: transform.kind,
-                values: transform.values,
-            })
-            .collect();
-        unsafe { set_transforms(context, transforms.as_ptr(), transforms.len()) };
-        true
-    })
+    let Some(transforms) = with_input(input, parse_transform).flatten() else {
+        return false;
+    };
+    let transforms: Vec<_> = transforms
+        .into_iter()
+        .map(|transform| FfiSvgTransform {
+            kind: transform.kind,
+            values: transform.values,
+        })
+        .collect();
+    unsafe { set_transforms(context, transforms.as_ptr(), transforms.len()) };
+    true
 }
 
 /// # Safety
@@ -367,43 +359,36 @@ pub unsafe extern "C" fn rust_parse_svg_preserve_aspect_ratio(
     align: *mut u8,
     meet_or_slice: *mut u8,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some((parsed_align, parsed_meet_or_slice)) = with_input(input, parse_preserve_aspect_ratio).flatten()
-        else {
-            return false;
-        };
-        unsafe {
-            align.write(parsed_align);
-            meet_or_slice.write(parsed_meet_or_slice);
-        }
-        true
-    })
+    let Some((parsed_align, parsed_meet_or_slice)) = with_input(input, parse_preserve_aspect_ratio).flatten() else {
+        return false;
+    };
+    unsafe {
+        align.write(parsed_align);
+        meet_or_slice.write(parsed_meet_or_slice);
+    }
+    true
 }
 
 /// # Safety
 /// `input` must satisfy [`FfiSvgInput::input`]'s requirements and `value` must be writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_svg_units(input: FfiSvgInput, value: *mut u8) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(parsed_value) = with_input(input, parse_units).flatten() else {
-            return false;
-        };
-        unsafe { value.write(parsed_value) };
-        true
-    })
+    let Some(parsed_value) = with_input(input, parse_units).flatten() else {
+        return false;
+    };
+    unsafe { value.write(parsed_value) };
+    true
 }
 
 /// # Safety
 /// `input` must satisfy [`FfiSvgInput::input`]'s requirements and `value` must be writable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_svg_spread_method(input: FfiSvgInput, value: *mut u8) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(parsed_value) = with_input(input, parse_spread_method).flatten() else {
-            return false;
-        };
-        unsafe { value.write(parsed_value) };
-        true
-    })
+    let Some(parsed_value) = with_input(input, parse_spread_method).flatten() else {
+        return false;
+    };
+    unsafe { value.write(parsed_value) };
+    true
 }
 
 /// # Safety
@@ -415,10 +400,8 @@ pub unsafe extern "C" fn rust_parse_svg_table_values(
     context: *mut c_void,
     set_values: unsafe extern "C" fn(*mut c_void, *const f32, usize),
 ) {
-    crate::abort_on_panic(|| {
-        let values = with_input(input, parse_table_values).unwrap_or_default();
-        unsafe { set_values(context, values.as_ptr(), values.len()) };
-    });
+    let values = with_input(input, parse_table_values).unwrap_or_default();
+    unsafe { set_values(context, values.as_ptr(), values.len()) };
 }
 
 /// # Safety
@@ -431,18 +414,16 @@ pub unsafe extern "C" fn rust_parse_svg_view_box(
     width: *mut f64,
     height: *mut f64,
 ) -> bool {
-    crate::abort_on_panic(|| {
-        let Some(values) = with_input(input, parse_view_box).flatten() else {
-            return false;
-        };
-        unsafe {
-            min_x.write(values[0]);
-            min_y.write(values[1]);
-            width.write(values[2]);
-            height.write(values[3]);
-        }
-        true
-    })
+    let Some(values) = with_input(input, parse_view_box).flatten() else {
+        return false;
+    };
+    unsafe {
+        min_x.write(values[0]);
+        min_y.write(values[1]);
+        width.write(values[2]);
+        height.write(values[3]);
+    }
+    true
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/svg/path_parser.rs
+++ b/Libraries/LibWeb/Rust/src/svg/path_parser.rs
@@ -728,39 +728,35 @@ impl FfiSvgInput {
 /// - `input` must satisfy [`FfiSvgInput::input`]'s requirements.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_parse_svg_path_data(input: FfiSvgInput) -> *mut c_void {
-    crate::abort_on_panic(|| {
-        let Some(input) = (unsafe { input.input() }) else {
-            return std::ptr::null_mut();
-        };
-        let Some(instructions) = Parser::new(input).parse(true) else {
-            return std::ptr::null_mut();
-        };
-        Box::into_raw(Box::new(ParsedPath { instructions })).cast()
-    })
+    let Some(input) = (unsafe { input.input() }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(instructions) = Parser::new(input).parse(true) else {
+        return std::ptr::null_mut();
+    };
+    Box::into_raw(Box::new(ParsedPath { instructions })).cast()
 }
 
 /// # Safety
 /// `path` must point to a live `ParsedPath`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_svg_path_clone(path: *const c_void) -> *mut c_void {
-    crate::abort_on_panic(|| {
-        let path = unsafe { &*path.cast::<ParsedPath>() };
-        Box::into_raw(Box::new(path.clone())).cast()
-    })
+    let path = unsafe { &*path.cast::<ParsedPath>() };
+    Box::into_raw(Box::new(path.clone())).cast()
 }
 
 /// # Safety
 /// `path` must be a `ParsedPath` allocation returned by this module that has not yet been destroyed.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_svg_path_destroy(path: *mut c_void) {
-    crate::abort_on_panic(|| drop(unsafe { Box::from_raw(path.cast::<ParsedPath>()) }));
+    drop(unsafe { Box::from_raw(path.cast::<ParsedPath>()) });
 }
 
 /// # Safety
 /// `a` and `b` must point to live `ParsedPath` values.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_svg_path_equals(a: *const c_void, b: *const c_void) -> bool {
-    crate::abort_on_panic(|| unsafe { *a.cast::<ParsedPath>() == *b.cast::<ParsedPath>() })
+    unsafe { *a.cast::<ParsedPath>() == *b.cast::<ParsedPath>() }
 }
 
 /// # Safety
@@ -772,17 +768,15 @@ pub unsafe extern "C" fn rust_svg_path_serialize(
     context: *mut c_void,
     append: unsafe extern "C" fn(*mut c_void, *const u8, usize),
 ) {
-    crate::abort_on_panic(|| {
-        let serialized = unsafe { &*path.cast::<ParsedPath>() }.serialize();
-        unsafe { append(context, serialized.as_ptr(), serialized.len()) };
-    });
+    let serialized = unsafe { &*path.cast::<ParsedPath>() }.serialize();
+    unsafe { append(context, serialized.as_ptr(), serialized.len()) };
 }
 
 /// # Safety
 /// `path` must point to a live `ParsedPath`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_svg_path_to_gfx_path(path: *const c_void) -> *mut c_void {
-    crate::abort_on_panic(|| unsafe { &*path.cast::<ParsedPath>() }.to_gfx_path().into_raw())
+    unsafe { &*path.cast::<ParsedPath>() }.to_gfx_path().into_raw()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Every C++ layout node shell kept a raw pointer into the Rust layout node arena and read and wrote its `NodeData` slot directly. Because C++ could write at any moment, the Rust side could never hold a `&NodeData`, so every field access in the arena, the partial relayout walk, the tree builder and the node facts was a raw pointer read or write under a SAFETY comment.

This series removes the aliasing one step at a time:
- Drop the `abort_on_panic` wrappers from the `extern "C"` entry points. The release profile already aborts on panic, and since Rust 1.81 an `extern "C"` function that panics aborts on its own.
- Drop the slot generation that was passed alongside a `NodeSlotId` that already carries it.
- Pass the node kind and the construction-time flags into the arena allocation as one struct instead of stamping them from the shell constructors.
- Route the remaining shell writes (mutable flags, `generated_for`, the style payload pointer) through arena setters.
- Replace the shell's direct reads with a kind payload pointer, and arena getters for links, flags and tags.
- Stop handing the shell a `NodeData` pointer a the generated header and becomes crate-private.
- Make the `NodeData` fields `Cell`s and return arena, which removes about seventy unsafe blocks.

The shell now holds only the arena reference and the slot id. The `unsafe {}` count in `src/layout` 349 to 248, with no raw `NodeData` field access left in the crate. Tree traversal from C++ costs the same as before: one arena call per link ins a shell lookup.

No behavior change intended.