### PR TITLE
LibWeb: Narrow style routing for shadow tree sheets and element removal

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1731,7 +1731,7 @@ impl StyleEngine {
     pub(super) fn regions_reachable_from_scopes(
         &self,
         scopes: &[TreeScopeID],
-        leaves_scope: bool,
+        subject_leaves_scope: bool,
         host_is_a_subject: bool,
     ) -> Option<Vec<ImpactRegion>> {
         if scopes.is_empty() {
@@ -1754,10 +1754,10 @@ impl StyleEngine {
                 //
                 // A program that leaves its scope reaches the host instead, so it needs the root to
                 // find one, and a scope with no root names no host either.
-                None if !leaves_scope => continue,
+                None if !subject_leaves_scope => continue,
                 None => continue,
             };
-            match leaves_scope {
+            match subject_leaves_scope {
                 // `:host` and `::slotted()` describe the host and what is slotted into it, which are
                 // in the host's own tree and not in the one the sheet is attached to. A rule using
                 // them says nothing about the shadow tree, so naming it would be the widest part of

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -76,7 +76,8 @@ impl StyleEngine {
             specified_values: SpecifiedValues::new(),
             winner_groups: WinnerGroups::new(),
             computed_group_sets: ComputedGroupSets::default(),
-            pending_style_computation_selections: HashMap::default(),
+            pending_element_style_computation_selections: HashMap::default(),
+            pending_pseudo_style_computation_selections: HashMap::default(),
             computed_group_set_memory: MemoryLease::new(MemoryCategory::ComputedGroupSet),
             custom_property_environment_memory: MemoryLease::new(MemoryCategory::CustomPropertyEnvironment),
             computed_fixed_metadata_memory: MemoryLease::new(MemoryCategory::ComputedFixedMetadata),
@@ -1328,8 +1329,8 @@ impl StyleEngine {
             self.winner_groups.remove(node);
             let live_animation_overlays_before = self.computed_group_sets.live_animation_overlay_records();
             self.computed_group_sets.remove(node);
-            self.pending_style_computation_selections
-                .retain(|target, _| target.node() != node);
+            self.pending_element_style_computation_selections.remove(&node);
+            self.pending_pseudo_style_computation_selections.remove(&node);
             let live_animation_overlays_after = self.computed_group_sets.live_animation_overlay_records();
             self.settle_computed_memory();
             self.counters.add(

--- a/Libraries/LibWeb/Rust/src/css/style/inputs.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/inputs.rs
@@ -1814,6 +1814,7 @@ impl StyleEngine {
         compiled: &SelectorProgram,
         entry: usize,
         document_root: StyleNodeID,
+        bounding_scopes: Option<&[TreeScopeID]>,
     ) -> Option<Vec<ImpactRegion>> {
         if compiled.subject_is_only_the_root(entry) {
             return Some(vec![ImpactRegion::Node(document_root)]);
@@ -1845,6 +1846,11 @@ impl StyleEngine {
             match self.facts.postings().lookup(key) {
                 Lookup::Known(posting) => {
                     for relative in posting.candidates() {
+                        if bounding_scopes
+                            .is_some_and(|scopes| scopes.binary_search(&self.tree.tree_scope(relative)).is_err())
+                        {
+                            continue;
+                        }
                         regions.push(region(relative));
                     }
                 }

--- a/Libraries/LibWeb/Rust/src/css/style/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/mod.rs
@@ -823,7 +823,10 @@ pub struct StyleEngine {
     /// computed half of the eventual base style record; custom properties and metadata remain
     /// separate inputs until that record is complete.
     computed_group_sets: ComputedGroupSets,
-    pending_style_computation_selections: HashMap<computed::ComputedStyleTarget, StyleComputationSelection>,
+    /// Pending selections for elements, and separately for the few pseudo-elements that hold one.
+    /// Both are keyed by the element so that retiring it releases every selection by key.
+    pending_element_style_computation_selections: HashMap<StyleNodeID, StyleComputationSelection>,
+    pending_pseudo_style_computation_selections: HashMap<StyleNodeID, Vec<(u8, StyleComputationSelection)>>,
     computed_group_set_memory: MemoryLease,
     custom_property_environment_memory: MemoryLease,
     computed_fixed_metadata_memory: MemoryLease,

--- a/Libraries/LibWeb/Rust/src/css/style/publication.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/publication.rs
@@ -900,13 +900,23 @@ impl StyleEngine {
         });
         self.computed_group_sets
             .set_pending_cascade_state(target, (generation, state));
-        self.pending_style_computation_selections.insert(
-            target,
-            StyleComputationSelection {
-                computed_property_words,
-                computed_property_closure_is_exact,
-            },
-        );
+        let selection = StyleComputationSelection {
+            computed_property_words,
+            computed_property_closure_is_exact,
+        };
+        if target.is_pseudo() {
+            let selections = self
+                .pending_pseudo_style_computation_selections
+                .entry(target.node())
+                .or_default();
+            match selections.iter_mut().find(|(kind, _)| *kind == target.pseudo_kind()) {
+                Some((_, existing)) => *existing = selection,
+                None => selections.push((target.pseudo_kind(), selection)),
+            }
+        } else {
+            self.pending_element_style_computation_selections
+                .insert(target.node(), selection);
+        }
         bridge::FfiExactCascadePublication {
             unchanged,
             computed_group_mask,
@@ -919,7 +929,14 @@ impl StyleEngine {
         pseudo_kind: u8,
     ) -> Option<StyleComputationSelection> {
         let target = computed::ComputedStyleTarget::new(node, pseudo_kind);
-        self.pending_style_computation_selections.get(&target).copied()
+        if !target.is_pseudo() {
+            return self.pending_element_style_computation_selections.get(&node).copied();
+        }
+        self.pending_pseudo_style_computation_selections
+            .get(&node)?
+            .iter()
+            .find(|(kind, _)| *kind == pseudo_kind)
+            .map(|(_, selection)| *selection)
     }
 
     unsafe fn cascade_operator_of_style_value(value: *const StyleValueData) -> CascadeOperator {
@@ -982,7 +999,21 @@ impl StyleEngine {
 
     pub(crate) fn discard_pending_exact_cascade_state(&mut self, target: computed::ComputedStyleTarget) {
         self.computed_group_sets.take_pending_cascade_state(target);
-        self.pending_style_computation_selections.remove(&target);
+        self.remove_pending_style_computation_selection(target);
+    }
+
+    fn remove_pending_style_computation_selection(&mut self, target: computed::ComputedStyleTarget) {
+        if !target.is_pseudo() {
+            self.pending_element_style_computation_selections.remove(&target.node());
+            return;
+        }
+        let Some(selections) = self.pending_pseudo_style_computation_selections.get_mut(&target.node()) else {
+            return;
+        };
+        selections.retain(|(kind, _)| *kind != target.pseudo_kind());
+        if selections.is_empty() {
+            self.pending_pseudo_style_computation_selections.remove(&target.node());
+        }
     }
 
     pub(crate) fn remove_computed_pseudo(
@@ -991,7 +1022,7 @@ impl StyleEngine {
         pseudo_kind: u8,
     ) -> Option<computed::FinalStyleRecordID> {
         let target = computed::ComputedStyleTarget::new(node, pseudo_kind);
-        self.pending_style_computation_selections.remove(&target);
+        self.remove_pending_style_computation_selection(target);
         if let Some(state) = self.computed_group_sets.take_pending_cascade_state(target) {
             self.computed_group_sets
                 .observe_absent_pseudo_cascade_state(target, state);

--- a/Libraries/LibWeb/Rust/src/css/style/record_replay.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/record_replay.rs
@@ -30,7 +30,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 const MAGIC: [u8; 8] = *b"SGREPLAY";
-const FORMAT_VERSION: u64 = 10;
+const FORMAT_VERSION: u64 = 11;
 const EVENT_HEADER_SIZE: usize = 3 * size_of::<u64>();
 const PAYLOAD_ALIGNMENT: usize = 8;
 

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -4127,7 +4127,7 @@ impl StyleEngine {
                         self.counters.bump(Counter::ProgramCandidatesRejectedByCascade);
                         continue;
                     }
-                    let winning_nodes = (!compiled.can_leave_its_scope()
+                    let winning_nodes = (!compiled.subject_can_leave_its_scope()
                         && compiled
                             .entries()
                             .iter()
@@ -4176,7 +4176,8 @@ impl StyleEngine {
                 + first_program_rule;
             let program_rules = &programs[first_program_rule..end_program_rule];
             let can_leave_scope = self.programs.get(selector_program).can_leave_its_scope();
-            let bounded_by_scope = !scopes.is_empty() && !can_leave_scope;
+            let subject_can_leave_scope = self.programs.get(selector_program).subject_can_leave_its_scope();
+            let bounded_by_scope = !scopes.is_empty() && !subject_can_leave_scope;
             // Activation is one input of an active rule match; selector truth is the other. The
             // dispatch posting is only a candidate source, so test the complete selector before
             // admitting one of its nodes. Turning a rule off reads the old side and turning it on
@@ -4427,7 +4428,7 @@ impl StyleEngine {
                         }
                         match self.regions_reachable_from_scopes(
                             &scopes,
-                            compiled.can_leave_its_scope(),
+                            compiled.subject_can_leave_its_scope(),
                             compiled.host_is_a_subject(),
                         ) {
                             Some(reachable) => {

--- a/Libraries/LibWeb/Rust/src/css/style/routing.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/routing.rs
@@ -4419,8 +4419,12 @@ impl StyleEngine {
                     // scope has no bound but the document.
                     Some(Lookup::KnownAbsent) => continue,
                     Some(Lookup::Missing(_)) | None => {
-                        if let Some(narrowed) = self.regions_from_subject_position(compiled, entry_index, document_root)
-                        {
+                        if let Some(narrowed) = self.regions_from_subject_position(
+                            compiled,
+                            entry_index,
+                            document_root,
+                            bounded_by_scope.then_some(scopes.as_slice()),
+                        ) {
                             for region in narrowed {
                                 regions.add_if_not_covered(region, &self.tree, &mut self.counters);
                             }

--- a/Libraries/LibWeb/Rust/src/css/style/selector.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector.rs
@@ -691,6 +691,7 @@ pub struct SelectorProgram {
     /// name); everything else stays out — rather than risking a bit facts never set.
     relation_target_blooms: Box<[u64]>,
     can_leave_scope: bool,
+    subject_can_leave_scope: bool,
 }
 
 impl SelectorProgram {
@@ -878,7 +879,7 @@ impl SelectorProgram {
                     })
                     .sum::<u64>(),
             ];
-            skip [self.can_leave_scope];
+            skip [self.can_leave_scope, self.subject_can_leave_scope];
         }
     }
 }
@@ -1089,6 +1090,11 @@ impl SelectorProgramBuilder {
             .entries
             .iter()
             .any(|entry| self.program.leaves_its_scope(entry.root));
+        self.program.subject_can_leave_scope = self
+            .program
+            .entries
+            .iter()
+            .any(|entry| self.program.subject_leaves_its_scope(entry.root));
         self.program
     }
 }
@@ -2185,10 +2191,61 @@ impl SelectorProgram {
         }
     }
 
+    /// Whether this node's subject itself can lie outside the scope its rule is attached to.
+    ///
+    /// `leaves_its_scope` answers whether the program reads anything outside the scope, and a
+    /// `:host()` under a combinator does: the host's facts decide the rule. Its subject still stays
+    /// inside the tree, because a shadow sheet's combinators never reach the host's light-DOM
+    /// children. So only a `:host`, `::slotted()` or `::part()` in subject position, and the
+    /// implicit scoping root that can be the host, move the subject out; a combinator step, a
+    /// relative selector and an `of` selector all constrain something other than the subject.
+    fn subject_leaves_its_scope(&self, id: SelectorNodeID) -> bool {
+        match self.node(id) {
+            SelectorOp::Host(_) | SelectorOp::Slotted(_) | SelectorOp::ExposedToHost { .. } => true,
+            SelectorOp::Part(_) => true,
+            SelectorOp::IsNode(_) => true,
+            SelectorOp::InScope { root, limit, inner, .. } => {
+                self.subject_leaves_its_scope(inner)
+                    || self.leaves_its_scope(root)
+                    || limit.is_some_and(|limit| self.leaves_its_scope(limit))
+            }
+            SelectorOp::And { first, count } | SelectorOp::Or { first, count } => self
+                .operands(first, count)
+                .iter()
+                .any(|&operand| self.subject_leaves_its_scope(operand)),
+            SelectorOp::Where(inner) | SelectorOp::Not(inner) => self.subject_leaves_its_scope(inner),
+            SelectorOp::Parent(_)
+            | SelectorOp::Ancestor(_)
+            | SelectorOp::PreviousSibling(_)
+            | SelectorOp::PrecedingSibling(_)
+            | SelectorOp::RelativeExists(_)
+            | SelectorOp::NthPosition(_)
+            | SelectorOp::AssignedSlot(_)
+            | SelectorOp::Language { .. }
+            | SelectorOp::ScopeRootInstance
+            | SelectorOp::RelativeAnchorInstance
+            | SelectorOp::Feature(_)
+            | SelectorOp::State(_)
+            | SelectorOp::Root
+            | SelectorOp::Empty
+            | SelectorOp::Scope
+            | SelectorOp::ValueState { .. }
+            | SelectorOp::Heading(_) => false,
+        }
+    }
+
     /// Whether any of this program's entries can decide outside the scope it is attached to.
     #[must_use]
     pub fn can_leave_its_scope(&self) -> bool {
         self.can_leave_scope
+    }
+
+    /// Whether any of this program's entries can have a subject outside the scope it is attached
+    /// to. Narrower than `can_leave_its_scope`: a program whose `:host()` only constrains an
+    /// ancestor reads the host but names subjects inside its own tree.
+    #[must_use]
+    pub fn subject_can_leave_its_scope(&self) -> bool {
+        self.subject_can_leave_scope
     }
 
     /// Whether the host itself is a subject of this program, rather than only a step on the way to
@@ -8045,6 +8102,58 @@ mod tests {
         let part_rule = single_entry(|builder| builder.push(SelectorOp::Part(StyleAtomID(77))));
         assert!(fixture.matches(&part_rule, 2));
         assert!(!fixture.matches(&part_rule, 1));
+    }
+
+    #[test]
+    fn a_host_guard_under_a_combinator_keeps_the_subject_in_its_scope() {
+        // `:host(.theme) > .item` reads the host, so it can leave its scope, but its subject is a
+        // child of the host in the shadow tree and never anything outside it.
+        let host_child = single_entry(|builder| {
+            let theme = builder.push_feature(FeatureTest::Class(CLASS_THEME));
+            let host = builder.push(SelectorOp::Host(theme));
+            let parent = builder.push(SelectorOp::Parent(host));
+            let item = builder.push_feature(FeatureTest::Class(CLASS_ITEM));
+            builder.push_compound(&[item, parent])
+        });
+        assert!(host_child.can_leave_its_scope());
+        assert!(!host_child.subject_can_leave_its_scope());
+
+        // `:host .item`
+        let host_descendant = single_entry(|builder| {
+            let any = builder.push_feature(FeatureTest::AnyElement);
+            let host = builder.push(SelectorOp::Host(any));
+            let ancestor = builder.push(SelectorOp::Ancestor(host));
+            let item = builder.push_feature(FeatureTest::Class(CLASS_ITEM));
+            builder.push_compound(&[item, ancestor])
+        });
+        assert!(host_descendant.can_leave_its_scope());
+        assert!(!host_descendant.subject_can_leave_its_scope());
+
+        // `:host(.theme)` names the host itself.
+        let host = single_entry(|builder| {
+            let theme = builder.push_feature(FeatureTest::Class(CLASS_THEME));
+            builder.push(SelectorOp::Host(theme))
+        });
+        assert!(host.can_leave_its_scope());
+        assert!(host.subject_can_leave_its_scope());
+
+        // `::slotted(.item)` names a light-DOM element of the host.
+        let slotted = single_entry(|builder| {
+            let item = builder.push_feature(FeatureTest::Class(CLASS_ITEM));
+            builder.push(SelectorOp::Slotted(item))
+        });
+        assert!(slotted.can_leave_its_scope());
+        assert!(slotted.subject_can_leave_its_scope());
+
+        // `.theme .item` reads nothing outside its scope.
+        let plain = single_entry(|builder| {
+            let theme = builder.push_feature(FeatureTest::Class(CLASS_THEME));
+            let ancestor = builder.push(SelectorOp::Ancestor(theme));
+            let item = builder.push_feature(FeatureTest::Class(CLASS_ITEM));
+            builder.push_compound(&[item, ancestor])
+        });
+        assert!(!plain.can_leave_its_scope());
+        assert!(!plain.subject_can_leave_its_scope());
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/css/style/selector/replay.rs
+++ b/Libraries/LibWeb/Rust/src/css/style/selector/replay.rs
@@ -62,6 +62,7 @@ pub fn write(program: &SelectorProgram, payload: &mut PayloadWriter) {
         payload.write_u32(*length);
     }
     payload.write_bool(program.can_leave_scope);
+    payload.write_bool(program.subject_can_leave_scope);
 }
 
 pub fn read(payload: &mut PayloadReader) -> Result<SelectorProgram, Error> {
@@ -101,6 +102,7 @@ pub fn read(payload: &mut PayloadReader) -> Result<SelectorProgram, Error> {
         dispatch_metadata: CachedDispatchMetadata::default(),
         relation_target_blooms: Box::default(),
         can_leave_scope: payload.read_bool()?,
+        subject_can_leave_scope: payload.read_bool()?,
     };
     program.cache_dispatch_metadata();
     Ok(program)
@@ -638,6 +640,7 @@ mod tests {
             language_ranges: vec![(0, 2)],
             dispatch_metadata: CachedDispatchMetadata::default(),
             can_leave_scope: true,
+            subject_can_leave_scope: false,
         };
         program.cache_dispatch_metadata();
 

--- a/Tests/LibWeb/Text/expected/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.txt
@@ -1,0 +1,5 @@
+li > div > :focus: 1
+li > div > *: 1
+li :focus: 2
+before focus: rgb(0, 0, 0)
+after focus: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/style-engine/host-child-rule-restyles-shadow-children.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/host-child-rule-restyles-shadow-children.txt
@@ -1,0 +1,4 @@
+light child: rgb(0, 0, 0)
+shadow child: rgb(0, 128, 0)
+shadow last child: rgb(0, 128, 0)
+reactions: 26, recomputes: 26

--- a/Tests/LibWeb/Text/expected/css/style-engine/host-guarded-rule-bounded-to-its-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/host-guarded-rule-bounded-to-its-shadow-tree.txt
@@ -1,0 +1,8 @@
+li: 1
+:host > li: 1
+:host(.a) li: 1
+:host([data-priority]) > li: 1
+:host: 2
+without the host attribute: rgb(0, 0, 0)
+with the host attribute: rgb(1, 2, 3)
+after removing the host attribute: rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/input/css/shadow-root-host-light-dom-trailing-universal-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/shadow-root-host-light-dom-trailing-universal-invalidation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
-<div id="host-child"><span id="direct-child">direct child</span></div>
-<div id="host-descendant"><div><span id="nested-descendant">nested descendant</span></div></div>
+<div id="host-child"><span id="direct-child" class="light">direct child</span></div>
+<div id="host-descendant"><div><span id="nested-descendant" class="light">nested descendant</span></div></div>
 <script>
     function settleAndReset(triggerElement) {
         getComputedStyle(triggerElement).color;
@@ -38,7 +38,7 @@
 
         settleAndReset(directChild);
         const directStyle = document.createElement("style");
-        directStyle.textContent = ":host > * { color: rgb(0, 128, 0); }";
+        directStyle.textContent = ":host > .light { color: rgb(0, 128, 0); }";
         childShadowRoot.appendChild(directStyle);
         const directColor = getComputedStyle(directChild).color;
         // A shadow-scoped selector cannot cascade into the host's light-DOM children. StyleEngine
@@ -47,7 +47,7 @@
 
         settleAndReset(nestedDescendant);
         const descendantStyle = document.createElement("style");
-        descendantStyle.textContent = ":host * { color: rgb(128, 0, 128); }";
+        descendantStyle.textContent = ":host .light { color: rgb(128, 0, 128); }";
         descendantShadowRoot.appendChild(descendantStyle);
         const descendantColor = getComputedStyle(nestedDescendant).color;
         verifyHostSideWorkStayedScoped("host descendant combinator add keeps work scoped", descendantColor);

--- a/Tests/LibWeb/Text/input/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/child-combinator-rule-bounded-to-its-shadow-tree.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<ul id="list"></ul>
+<div id="host"></div>
+<script>
+    test(() => {
+        for (let i = 0; i < 50; ++i) {
+            const bystander = list.appendChild(document.createElement("li"));
+            bystander.appendChild(document.createElement("div"));
+        }
+        const shadow = host.attachShadow({ mode: "open" });
+        const item = shadow.appendChild(document.createElement("li"));
+        const target = item.appendChild(document.createElement("div")).appendChild(document.createElement("button"));
+        internals.updateStyle();
+
+        function recomputationsForSheet(cssText) {
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(cssText);
+            const before = internals.getStyleInvalidationCounters();
+            shadow.adoptedStyleSheets = [sheet];
+            internals.updateStyle();
+            const after = internals.getStyleInvalidationCounters();
+            const count = after.elementStyleRecomputations - before.elementStyleRecomputations;
+            shadow.adoptedStyleSheets = [];
+            internals.updateStyle();
+            return count;
+        }
+
+        println(`li > div > :focus: ${recomputationsForSheet("li > div > :focus { color: red }")}`);
+        println(`li > div > *: ${recomputationsForSheet("li > div > * { color: red }")}`);
+        println(`li :focus: ${recomputationsForSheet("li :focus { color: red }")}`);
+
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync("li > div > :focus { color: rgb(1, 2, 3) }");
+        shadow.adoptedStyleSheets = [sheet];
+        println(`before focus: ${getComputedStyle(target).color}`);
+        target.focus();
+        println(`after focus: ${getComputedStyle(target).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/host-child-rule-restyles-shadow-children.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/host-child-rule-restyles-shadow-children.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<div id="host"><span id="light">light</span></div>
+<script>
+    test(() => {
+        const root = host.attachShadow({ mode: "open" });
+        for (let i = 0; i < 25; ++i) {
+            const span = document.createElement("span");
+            span.textContent = "bystander";
+            root.appendChild(span);
+        }
+        getComputedStyle(light).color;
+        getComputedStyle(root.firstChild).color;
+        internals.resetStyleInvalidationCounters();
+        const style = document.createElement("style");
+        style.textContent = ":host > * { color: rgb(0, 128, 0); }";
+        root.appendChild(style);
+        println(`light child: ${getComputedStyle(light).color}`);
+        println(`shadow child: ${getComputedStyle(root.firstChild).color}`);
+        println(`shadow last child: ${getComputedStyle(root.children[24]).color}`);
+        const counters = internals.getStyleInvalidationCounters();
+        println(`reactions: ${counters.styleEnginePublishedReactions}, recomputes: ${counters.elementStyleRecomputations}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-engine/host-guarded-rule-bounded-to-its-shadow-tree.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/host-guarded-rule-bounded-to-its-shadow-tree.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<ul id="list"></ul>
+<div id="host"></div>
+<script>
+    test(() => {
+        for (let i = 0; i < 50; ++i)
+            list.appendChild(document.createElement("li"));
+        const shadow = host.attachShadow({ mode: "open" });
+        const item = document.createElement("li");
+        shadow.appendChild(item);
+        internals.updateStyle();
+
+        function recomputationsForSheet(cssText) {
+            const sheet = new CSSStyleSheet();
+            sheet.replaceSync(cssText);
+            const before = internals.getStyleInvalidationCounters();
+            shadow.adoptedStyleSheets = [sheet];
+            internals.updateStyle();
+            const after = internals.getStyleInvalidationCounters();
+            const count = after.elementStyleRecomputations - before.elementStyleRecomputations;
+            shadow.adoptedStyleSheets = [];
+            internals.updateStyle();
+            return count;
+        }
+
+        println(`li: ${recomputationsForSheet("li { color: red }")}`);
+        println(`:host > li: ${recomputationsForSheet(":host > li { color: red }")}`);
+        println(`:host(.a) li: ${recomputationsForSheet(":host(.a) li { color: red }")}`);
+        println(`:host([data-priority]) > li: ${recomputationsForSheet(":host([data-priority]) > li { color: red }")}`);
+        println(`:host: ${recomputationsForSheet(":host { color: red }")}`);
+
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(":host([data-priority]) > li { color: rgb(1, 2, 3) }");
+        shadow.adoptedStyleSheets = [sheet];
+        println(`without the host attribute: ${getComputedStyle(item).color}`);
+        host.dataset.priority = "1";
+        println(`with the host attribute: ${getComputedStyle(item).color}`);
+        delete host.dataset.priority;
+        println(`after removing the host attribute: ${getComputedStyle(item).color}`);
+    });
+</script>


### PR DESCRIPTION
This PR keeps the restyle work triggered by a adopting a style sheet into a shadow tree bounded to that tree, where previously it could reach elements across the whole document. This makes removing an element a constant time operation rather than the work being proportional to the page size. Together these roughly halve the cost of adding items in the Lit and ES6 TodoMVC Speedometer3 suites.

See individual commits for details.

Speedometer3 results:

```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      0.929  0.11 ± 0.01           0.12 ± 0.01
Speedometer3  Charts-chartjs                              Draw scatter             1.032  0.14 ± 0.01           0.14 ± 0.00
Speedometer3  Charts-chartjs                              Show tooltip             0.8    0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.075  0.10 ± 0.02           0.10 ± 0.02
Speedometer3  Charts-observable-plot                      Stacked by 20            1.025  0.16 ± 0.01           0.16 ± 0.01
Speedometer3  Charts-observable-plot                      Stacked by 6             1.006  0.10 ± 0.01           0.10 ± 0.00
Speedometer3  Editor-CodeMirror                           Highlight                1.159  0.03 ± 0.01           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     1.044  0.06 ± 0.01           0.06 ± 0.01
Speedometer3  Editor-TipTap                               Highlight                0.763  0.28 ± 0.02           0.36 ± 0.09
Speedometer3  Editor-TipTap                               Long                     0.968  0.22 ± 0.05           0.23 ± 0.06
Speedometer3  NewsSite-Next                               NavigateToPolitics       0.956  0.18 ± 0.01           0.19 ± 0.02
Speedometer3  NewsSite-Next                               NavigateToUS             1.07   0.23 ± 0.02           0.21 ± 0.03
Speedometer3  NewsSite-Next                               NavigateToWorld          1.004  0.18 ± 0.01           0.18 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       1.036  0.17 ± 0.02           0.16 ± 0.02
Speedometer3  NewsSite-Nuxt                               NavigateToUS             1.015  0.16 ± 0.02           0.16 ± 0.02
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          1.015  0.15 ± 0.00           0.15 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   1.003  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingPoints          0.979  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           0.983  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              1.146  0.15 ± 0.03           0.13 ± 0.01
Speedometer3  React-Stockcharts-SVG                       Render                   1.03   0.17 ± 0.03           0.17 ± 0.03
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1.025  0.56 ± 0.04           0.54 ± 0.05
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           0.98   0.13 ± 0.02           0.13 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       0.881  0.10 ± 0.02           0.11 ± 0.03
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         1.2    0.07 ± 0.04           0.06 ± 0.02
Speedometer3  TodoMVC-Backbone                            Adding100Items           1.045  0.10 ± 0.02           0.10 ± 0.02
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       1.096  0.06 ± 0.01           0.06 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         0.985  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.037  0.18 ± 0.05           0.17 ± 0.03
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.251  0.07 ± 0.02           0.06 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         1.09   0.03 ± 0.01           0.03 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.348  0.24 ± 0.02           0.18 ± 0.02
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.101  0.10 ± 0.01           0.09 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         1.066  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.671  0.11 ± 0.02           0.07 ± 0.01
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.022  0.05 ± 0.01           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         1.055  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           0.973  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       0.999  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         1.104  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           1.098  0.11 ± 0.01           0.10 ± 0.01
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.029  0.10 ± 0.01           0.10 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         1.026  0.06 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-React-Redux                         Adding100Items           0.608  0.09 ± 0.00           0.15 ± 0.13
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       0.924  0.12 ± 0.00           0.13 ± 0.02
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         1.031  0.07 ± 0.01           0.07 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.028  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.016  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         1.143  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           1.025  0.06 ± 0.01           0.06 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       1.039  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         0.927  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           1.015  0.07 ± 0.00           0.07 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       0.98   0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         4.014  0.05 ± 0.08           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           0.786  0.23 ± 0.02           0.30 ± 0.09
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       0.97   0.67 ± 0.15           0.69 ± 0.16
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.021  0.21 ± 0.02           0.21 ± 0.03

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  -----------  -----------  -------------------  ---------------------  ---------------------  ---------
Speedometer3  3.85 ± 0.12  3.99 ± 0.19                1.037  6.82 ± 0.21            6.79 ± 0.46                1.004
```
