### PR TITLE
LibWeb: Skip measuring grid items that span only fixed tracks

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -2313,21 +2313,50 @@ impl GridFormattingContext {
         content
     }
 
+    fn item_contributes_to_track_sizing(&self, item: GridItem, axis: Axis) -> bool {
+        let available = self.axis_available(axis);
+        let tracks = self.axis_tracks(axis);
+        let start = item.position(axis).max(0) as usize;
+        let end = start.saturating_add(item.span(axis)).min(tracks.len());
+        if start >= end {
+            return false;
+        }
+        tracks[start..end].iter().any(|track| {
+            track.min_sizing.is_intrinsic(available)
+                || track.max_sizing.is_intrinsic(available)
+                || (track.max_sizing.flex_factor().is_some() && !matches!(available, AvailableSize::Definite(_)))
+        })
+    }
+
     fn item_contribution(&self, item: GridItem, axis: Axis, combined_track_count: usize) -> ItemContribution {
+        let spanned_tracks = Self::spanned_interleaved_indices(item, axis, combined_track_count);
+        let is_scroll_container = self.facts(item.box_).is_scroll_container();
+        if !self.item_contributes_to_track_sizing(item, axis) {
+            return ItemContribution {
+                spanned_tracks,
+                span: item.span(axis),
+                minimum: CssPixels::default(),
+                min_content: CssPixels::default(),
+                limited_min_content: CssPixels::default(),
+                max_content: CssPixels::default(),
+                limited_max_content: CssPixels::default(),
+                is_scroll_container,
+            };
+        }
         let minimum = self.minimum_contribution(item, axis);
         let min_content = self.min_content_contribution(item, axis);
         let max_content = self.max_content_contribution(item, axis);
         let limited_min = self.limited_content_contribution(min_content, minimum, item, axis);
         let limited_max = self.limited_content_contribution(max_content, minimum, item, axis);
         ItemContribution {
-            spanned_tracks: Self::spanned_interleaved_indices(item, axis, combined_track_count),
+            spanned_tracks,
             span: item.span(axis),
             minimum,
             min_content,
             limited_min_content: limited_min,
             max_content,
             limited_max_content: limited_max,
-            is_scroll_container: self.facts(item.box_).is_scroll_container(),
+            is_scroll_container,
         }
     }
 


### PR DESCRIPTION
Track sizing only consults an item's size contributions when the item spans an intrinsic track, or a flexible track sized against an indefinite available space. Every item was nevertheless measured for its minimum, min-content and max-content contributions. Each measurement laid out the item's whole subtree under intrinsic constraints without affecting any track size.

We now skip those measurements for items that span nothing but fixed tracks.

This improves multiple `CompletingAllItems` tests in Speedometer3.

Full Speedometer3 results:
```
Benchmark     Suite                                       Test                   Speedup  Old (Mean ± Range)    New (Mean ± Range)
------------  ------------------------------------------  -------------------  ---------  --------------------  --------------------
Speedometer3  Charts-chartjs                              Draw opaque scatter      0.994  0.10 ± 0.00           0.10 ± 0.00
Speedometer3  Charts-chartjs                              Draw scatter             0.972  0.14 ± 0.00           0.14 ± 0.00
Speedometer3  Charts-chartjs                              Show tooltip             0.926  0.00 ± 0.00           0.00 ± 0.00
Speedometer3  Charts-observable-plot                      Dotted                   1.059  0.09 ± 0.02           0.09 ± 0.00
Speedometer3  Charts-observable-plot                      Stacked by 20            1.027  0.17 ± 0.02           0.16 ± 0.01
Speedometer3  Charts-observable-plot                      Stacked by 6             0.968  0.10 ± 0.00           0.10 ± 0.00
Speedometer3  Editor-CodeMirror                           Highlight                0.976  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  Editor-CodeMirror                           Long                     0.957  0.06 ± 0.01           0.06 ± 0.01
Speedometer3  Editor-TipTap                               Highlight                1.135  0.28 ± 0.10           0.25 ± 0.02
Speedometer3  Editor-TipTap                               Long                     1.163  0.18 ± 0.06           0.16 ± 0.02
Speedometer3  NewsSite-Next                               NavigateToPolitics       0.986  0.18 ± 0.01           0.18 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToUS             1.023  0.21 ± 0.02           0.20 ± 0.01
Speedometer3  NewsSite-Next                               NavigateToWorld          0.976  0.18 ± 0.01           0.18 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToPolitics       1.038  0.17 ± 0.03           0.16 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToUS             0.968  0.15 ± 0.01           0.15 ± 0.01
Speedometer3  NewsSite-Nuxt                               NavigateToWorld          1.004  0.16 ± 0.02           0.16 ± 0.01
Speedometer3  Perf-Dashboard                              Render                   1.124  0.09 ± 0.05           0.08 ± 0.04
Speedometer3  Perf-Dashboard                              SelectingPoints          0.986  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  Perf-Dashboard                              SelectingRange           0.97   0.06 ± 0.00           0.06 ± 0.00
Speedometer3  React-Stockcharts-SVG                       PanTheChart              0.987  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  React-Stockcharts-SVG                       Render                   1.078  0.16 ± 0.03           0.14 ± 0.01
Speedometer3  React-Stockcharts-SVG                       ZoomTheChart             1      0.50 ± 0.06           0.50 ± 0.04
Speedometer3  TodoMVC-Angular-Complex-DOM                 Adding100Items           0.967  0.12 ± 0.02           0.13 ± 0.02
Speedometer3  TodoMVC-Angular-Complex-DOM                 CompletingAllItems       1.017  0.08 ± 0.01           0.08 ± 0.01
Speedometer3  TodoMVC-Angular-Complex-DOM                 DeletingAllItems         0.988  0.06 ± 0.02           0.06 ± 0.02
Speedometer3  TodoMVC-Backbone                            Adding100Items           0.913  0.09 ± 0.00           0.09 ± 0.01
Speedometer3  TodoMVC-Backbone                            CompletingAllItems       0.937  0.05 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Backbone                            DeletingAllItems         0.968  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      Adding100Items           1.024  0.16 ± 0.01           0.16 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES5                      CompletingAllItems       1.224  0.07 ± 0.02           0.06 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES5                      DeletingAllItems         0.975  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  Adding100Items           1.092  0.17 ± 0.03           0.15 ± 0.01
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  CompletingAllItems       1.053  0.09 ± 0.00           0.08 ± 0.00
Speedometer3  TodoMVC-JavaScript-ES6-Webpack-Complex-DOM  DeletingAllItems         0.986  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     Adding100Items           1.023  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     CompletingAllItems       1.087  0.05 ± 0.00           0.05 ± 0.00
Speedometer3  TodoMVC-Lit-Complex-DOM                     DeletingAllItems         0.998  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  Adding100Items           1.044  0.04 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  CompletingAllItems       1.078  0.03 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Preact-Complex-DOM                  DeletingAllItems         1.02   0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   Adding100Items           0.997  0.09 ± 0.00           0.09 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   CompletingAllItems       1.002  0.10 ± 0.00           0.10 ± 0.00
Speedometer3  TodoMVC-React-Complex-DOM                   DeletingAllItems         0.476  0.05 ± 0.00           0.11 ± 0.13
Speedometer3  TodoMVC-React-Redux                         Adding100Items           1.051  0.10 ± 0.02           0.09 ± 0.01
Speedometer3  TodoMVC-React-Redux                         CompletingAllItems       0.965  0.12 ± 0.00           0.12 ± 0.00
Speedometer3  TodoMVC-React-Redux                         DeletingAllItems         0.964  0.06 ± 0.00           0.07 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  Adding100Items           1.085  0.04 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  CompletingAllItems       1.658  0.05 ± 0.04           0.03 ± 0.00
Speedometer3  TodoMVC-Svelte-Complex-DOM                  DeletingAllItems         0.974  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-Vue                                 Adding100Items           0.984  0.06 ± 0.00           0.06 ± 0.00
Speedometer3  TodoMVC-Vue                                 CompletingAllItems       0.948  0.04 ± 0.00           0.04 ± 0.00
Speedometer3  TodoMVC-Vue                                 DeletingAllItems         1.031  0.02 ± 0.00           0.02 ± 0.00
Speedometer3  TodoMVC-WebComponents                       Adding100Items           0.993  0.07 ± 0.01           0.07 ± 0.00
Speedometer3  TodoMVC-WebComponents                       CompletingAllItems       0.952  0.02 ± 0.00           0.03 ± 0.00
Speedometer3  TodoMVC-WebComponents                       DeletingAllItems         0.998  0.01 ± 0.00           0.01 ± 0.00
Speedometer3  TodoMVC-jQuery                              Adding100Items           1.072  0.25 ± 0.06           0.23 ± 0.02
Speedometer3  TodoMVC-jQuery                              CompletingAllItems       1.006  0.65 ± 0.13           0.65 ± 0.15
Speedometer3  TodoMVC-jQuery                              DeletingAllItems         1.003  0.20 ± 0.01           0.20 ± 0.01

Benchmark     Old Score    New Score      Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  -----------  -----------  -------------------  ---------------------  ---------------------  ---------
Speedometer3  4.19 ± 0.25  4.23 ± 0.18                 1.01  6.34 ± 0.49            6.26 ± 0.33                1.013
```