### PR TITLE
LibWeb: Share selector query engines within disconnected trees

### DIFF
--- a/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.cpp
@@ -796,9 +796,18 @@ bool StyleEngine::consume_published_match_answer(StyleNodeID node, Vector<RuleMa
 
 void* StyleEngine::compile_selector_query(ReadonlySpan<void const*> selectors)
 {
+    return compile_selector_query(selectors, {});
+}
+
+void* StyleEngine::compile_selector_query(ReadonlySpan<void const*> selectors, Function<void()> const& backfill_attribute_value_texts)
+{
     auto* query = StyleEngineFFI::style_engine_compile_selector_query(m_impl, selectors.data(), selectors.size());
-    if (refresh_attribute_value_text_requirements() && m_style_computer)
-        publish_required_attribute_value_texts(*this, *m_style_computer);
+    if (refresh_attribute_value_text_requirements()) {
+        if (m_style_computer)
+            publish_required_attribute_value_texts(*this, *m_style_computer);
+        else if (backfill_attribute_value_texts)
+            backfill_attribute_value_texts();
+    }
     return query;
 }
 

--- a/Libraries/LibWeb/CSS/StyleEngineBridge.h
+++ b/Libraries/LibWeb/CSS/StyleEngineBridge.h
@@ -256,6 +256,9 @@ public:
     // traversal. False means that transaction did not publish an answer for this node.
     bool consume_published_match_answer(StyleNodeID node, Vector<RuleMatch>&);
     void* compile_selector_query(ReadonlySpan<void const*> selectors);
+    // For an engine with no StyleComputer to reach its elements through: when the new query demands attribute value
+    // text that earlier facts were published without, the callback republishes every attribute value the engine holds.
+    void* compile_selector_query(ReadonlySpan<void const*> selectors, Function<void()> const& backfill_attribute_value_texts);
     static void destroy_selector_query(void*);
     void prepare_selector_query();
     Optional<bool> selector_query_matches(void const* query, StyleNodeID node, StyleNodeID scope_root, StyleNodeID shadow_root);

--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -206,7 +206,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
         }
     }
 
-    document().bump_character_data_version();
+    bump_character_data_version();
 
     if (auto* rare_data = character_data_rare_data()) {
         if (rare_data->grapheme_segmenter)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -840,6 +840,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     m_anchor_name_map.visit_edges(visitor);
     if (m_query_selector_result_cache)
         m_query_selector_result_cache->visit_edges(visitor);
+    if (m_isolated_selector_query_engine_cache)
+        m_isolated_selector_query_engine_cache->visit_edges(visitor);
 
     for (auto& event : m_pending_animation_event_queue) {
         visitor.visit(event.event);
@@ -2543,11 +2545,13 @@ void Document::set_quirks_mode(QuirksMode mode)
         return;
     m_quirks_mode = mode;
 
-    // Quirks mode changes how id and class selectors match, so cached query results must not survive it, not even
-    // those of queries against disconnected trees.
+    // Quirks mode changes how id and class selectors match, so cached query results must not survive it. Nor may
+    // the engines built for queries against disconnected trees, which have it compiled in.
     bump_dom_tree_version();
     if (m_query_selector_result_cache)
         m_query_selector_result_cache->clear();
+    if (m_isolated_selector_query_engine_cache)
+        m_isolated_selector_query_engine_cache->clear();
 
     // It also changes which case a rule cache buckets id and class selectors under, and brings a user
     // agent stylesheet with it, so no scope's rule cache and no element's style survives it either.
@@ -11181,6 +11185,13 @@ QuerySelectorResultCache& Document::query_selector_result_cache()
     if (!m_query_selector_result_cache)
         m_query_selector_result_cache = make<QuerySelectorResultCache>();
     return *m_query_selector_result_cache;
+}
+
+IsolatedSelectorQueryEngineCache& Document::isolated_selector_query_engine_cache()
+{
+    if (!m_isolated_selector_query_engine_cache)
+        m_isolated_selector_query_engine_cache = make<IsolatedSelectorQueryEngineCache>();
+    return *m_isolated_selector_query_engine_cache;
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2543,8 +2543,11 @@ void Document::set_quirks_mode(QuirksMode mode)
         return;
     m_quirks_mode = mode;
 
-    // Quirks mode changes how id and class selectors match, so cached query results must not survive it.
+    // Quirks mode changes how id and class selectors match, so cached query results must not survive it, not even
+    // those of queries against disconnected trees.
     bump_dom_tree_version();
+    if (m_query_selector_result_cache)
+        m_query_selector_result_cache->clear();
 
     // It also changes which case a rule cache buckets id and class selectors under, and brings a user
     // agent stylesheet with it, so no scope's rule cache and no element's style survives it either.
@@ -3982,11 +3985,6 @@ void Document::adopt_node_steps(Node& node)
             for (auto range : ranges_to_transfer)
                 range->update_owner_document({});
         }
-
-        // AD-HOC: A parentless node leaves oldDocument without any mutation observable through oldDocument's
-        //         dom_tree_version. Bump it so that caches keyed on that version can't serve stale results for this
-        //         node if it is later adopted back after being mutated under another document.
-        old_document.bump_dom_tree_version();
     }
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1444,6 +1444,7 @@ public:
 
     RefPtr<SelectorQuery const> selector_query_for(Utf16View) const;
     QuerySelectorResultCache& query_selector_result_cache();
+    IsolatedSelectorQueryEngineCache& isolated_selector_query_engine_cache();
 
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const;
     void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> custom_element_registry) { m_custom_element_registry = custom_element_registry; }
@@ -2038,6 +2039,9 @@ private:
 
     // Cache of querySelectorAll results, validated lazily against the query root's dom_tree_version/character_data_version.
     OwnPtr<QuerySelectorResultCache> m_query_selector_result_cache;
+
+    // Style engines for selector queries against disconnected trees, one per tree root, validated the same way.
+    OwnPtr<IsolatedSelectorQueryEngineCache> m_isolated_selector_query_engine_cache;
 
     // https://fullscreen.spec.whatwg.org/#list-of-pending-fullscreen-events
     Vector<PendingFullscreenEvent> m_pending_fullscreen_events;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -276,11 +276,6 @@ public:
     [[nodiscard]] static GC::Ref<Document> create_for_fragment_parsing(Page&, GC::Ref<EventTarget> relevant_global_event_target);
     virtual ~Document() override;
 
-    // AD-HOC: This number increments whenever a node is added or removed from the document, or an element attribute changes.
-    //         It can be used as a crude invalidation mechanism for caches that depend on the DOM structure.
-    u64 dom_tree_version() const { return m_dom_tree_version; }
-    void bump_dom_tree_version() { ++m_dom_tree_version; }
-
     u64 form_controls_version() const { return m_form_controls_version; }
     void bump_form_controls_version() { ++m_form_controls_version; }
 
@@ -308,10 +303,6 @@ public:
         return identity;
     }
 
-    // AD-HOC: This number increments whenever CharacterData is modified in the document. It is used together with
-    //         dom_tree_version() to understand whether either the DOM tree structure or contents were changed.
-    u64 character_data_version() const { return m_character_data_version; }
-    void bump_character_data_version() { ++m_character_data_version; }
     bool preserve_selection_offsets_during_identical_character_data_replacement() const { return m_preserve_selection_offsets_during_identical_character_data_replacement; }
 
     WebIDL::ExceptionOr<void> populate_with_html_head_and_body();
@@ -1933,14 +1924,12 @@ private:
 
     Optional<AK::UnixDateTime> m_last_modified;
 
-    u64 m_dom_tree_version { 0 };
     u64 m_form_controls_version { 0 };
     u64 m_option_selectedness_version { 0 };
     mutable Array<u64, to_underlying(HTMLCollectionAttributeInvalidationType::Count)> m_html_collection_attribute_invalidation_type_counts {};
     mutable HTMLCollectionAttributeInvalidationTypes m_html_collection_attribute_invalidation_types { 0 };
     u64 m_style_environment_version { 0 };
     u64 m_next_counter_style_environment_identity { 1 };
-    u64 m_character_data_version { 0 };
 
     // https://drafts.csswg.org/css-position-4/#document-top-layer
     // Documents have a top layer, an ordered set containing elements from the document.
@@ -2047,7 +2036,7 @@ private:
     mutable Optional<Utf16String> m_last_selector_query_text;
     mutable RefPtr<SelectorQuery const> m_last_selector_query;
 
-    // Cache of querySelectorAll results, validated lazily against dom_tree_version/character_data_version.
+    // Cache of querySelectorAll results, validated lazily against the query root's dom_tree_version/character_data_version.
     OwnPtr<QuerySelectorResultCache> m_query_selector_result_cache;
 
     // https://fullscreen.spec.whatwg.org/#list-of-pending-fullscreen-events

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1386,7 +1386,7 @@ void Element::run_attribute_change_steps(Utf16FlyString const& local_name, Optio
         auto html_collection_invalidation_types = document().html_collection_attribute_invalidation_types_for_attribute(local_name, namespace_);
         if (html_collection_invalidation_types != 0)
             invalidate_html_collection_caches_in_ancestors_for_attribute_change(html_collection_invalidation_types);
-        document().bump_dom_tree_version();
+        bump_dom_tree_version();
     }
 }
 
@@ -2653,7 +2653,7 @@ void Element::did_update_inline_style()
 
     if (!document().suppresses_attribute_style_invalidation())
         CSS::record_element_declarations_changed(*this, CSS::ElementDeclarationKind::InlineStyle, had_style_attribute, true);
-    document().bump_dom_tree_version();
+    bump_dom_tree_version();
 }
 
 void Element::synchronize_style_attribute() const

--- a/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -58,7 +58,7 @@ void LiveNodeList::update_cache_if_needed() const
     auto& document = m_root->document();
     auto invalidation_version = this->invalidation_version(document);
     if (m_cached_document.ptr().ptr() == &document
-        && m_cached_dom_tree_version == document.dom_tree_version()
+        && m_cached_dom_tree_version == m_root->dom_tree_version()
         && m_cached_invalidation_version == invalidation_version) {
         return;
     }
@@ -79,7 +79,7 @@ void LiveNodeList::update_cache_if_needed() const
     }
 
     m_cached_document = document;
-    m_cached_dom_tree_version = document.dom_tree_version();
+    m_cached_dom_tree_version = m_root->dom_tree_version();
     m_cached_invalidation_version = invalidation_version;
 }
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -405,8 +405,43 @@ WebIDL::ExceptionOr<void> Node::set_text_content(Optional<Utf16String> const& ma
     if (is_connected() && !is_boxless_style_element)
         set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeSetTextContent);
 
-    document().bump_dom_tree_version();
+    bump_dom_tree_version();
     return {};
+}
+
+// The node holding the version counters of the tree a node is in: its document while connected, otherwise its root.
+// A lone node that cannot have children heads a tree nothing can be cached on, so it holds no counters.
+static ParentNode* tree_version_holder(Node const& node)
+{
+    if (node.is_connected())
+        return const_cast<Document*>(&node.document());
+    return const_cast<ParentNode*>(as_if<ParentNode>(node.root()));
+}
+
+static u64 s_last_tree_version = 0;
+
+u64 Node::dom_tree_version() const
+{
+    auto const* holder = tree_version_holder(*this);
+    return holder ? holder->m_dom_tree_version : 0;
+}
+
+u64 Node::character_data_version() const
+{
+    auto const* holder = tree_version_holder(*this);
+    return holder ? holder->m_character_data_version : 0;
+}
+
+void Node::bump_dom_tree_version()
+{
+    if (auto* holder = tree_version_holder(*this))
+        holder->m_dom_tree_version = ++s_last_tree_version;
+}
+
+void Node::bump_character_data_version()
+{
+    if (auto* holder = tree_version_holder(*this))
+        holder->m_character_data_version = ++s_last_tree_version;
 }
 
 // https://dom.spec.whatwg.org/#dom-node-normalize
@@ -1006,7 +1041,7 @@ void Node::insert_nodes_before(Vector<GC::Root<Node>> nodes, GC::Ptr<Node> child
         }
     }
 
-    document().bump_dom_tree_version();
+    bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-pre-insert
@@ -1448,7 +1483,11 @@ void Node::remove(bool suppress_observers)
     parent->children_changed(metadata);
     parent->invalidate_html_collection_caches_in_ancestors(affects_elements);
 
-    document().bump_dom_tree_version();
+    parent->bump_dom_tree_version();
+
+    // The removed node heads a tree of its own again. Anything cached on it from the last time it did must not survive
+    // the changes made under it while it was part of another tree, which were counted against that tree.
+    bump_dom_tree_version();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-replace
@@ -1859,7 +1898,8 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
     old_parent->invalidate_html_collection_caches_in_ancestors(affects_elements);
     new_parent.invalidate_html_collection_caches_in_ancestors(affects_elements);
 
-    document().bump_dom_tree_version();
+    old_parent->bump_dom_tree_version();
+    new_parent.bump_dom_tree_version();
 
     return {};
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -313,6 +313,18 @@ public:
     Document& document() { return *m_document; }
     Document const& document() const { return *m_document; }
 
+    // AD-HOC: Version counters of the tree this node is in, for caches that depend on tree structure or contents.
+    //         The DOM tree version moves whenever a node is inserted into or removed from the tree, or an element
+    //         attribute in it changes; the character data version whenever CharacterData in it is modified.
+    //         A connected node's tree is its document; a disconnected node's is the tree under its root. Counting
+    //         per tree keeps a document's churn from invalidating caches keyed on disconnected trees, and vice versa.
+    //         Every bump takes a stamp no other tree has had, so a version remembered from one tree is never
+    //         mistaken for the version of another.
+    u64 dom_tree_version() const;
+    u64 character_data_version() const;
+    void bump_dom_tree_version();
+    void bump_character_data_version();
+
     GC::Ptr<Document> owner_document() const;
 
     HTML::HTMLHyperlinkElementUtils const* enclosing_link_element() const;

--- a/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Libraries/LibWeb/DOM/ParentNode.h
@@ -47,6 +47,13 @@ protected:
         : Node(document, type)
     {
     }
+
+private:
+    friend class Node;
+
+    // The counters behind Node::dom_tree_version() and Node::character_data_version(), for the tree rooted here.
+    u64 m_dom_tree_version { 0 };
+    u64 m_character_data_version { 0 };
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleEngineBridge.h>
 #include <LibWeb/CSS/StyleEngineInput.h>
+#include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ParentNode.h>
@@ -19,21 +20,17 @@
 
 namespace Web::DOM {
 
+// The style engine of one disconnected tree, populated with every element in it. Each query against the tree is
+// compiled into the engine once, on first use, and matched there from then on.
 class IsolatedSelectorQueryEngine {
 public:
-    IsolatedSelectorQueryEngine(ParentNode& root, CSS::SelectorList const& selectors)
+    explicit IsolatedSelectorQueryEngine(ParentNode& root)
         : m_engine(CSS::StyleEngine::DeviceClass::ForegroundDesktop)
         , m_has_document_root(is<Document>(root))
     {
-        // Attribute-name and default value case behavior are compiled into the query, so publish
-        // the document kind before compiling rather than while facts are populated afterward.
+        // Attribute-name and default value case behavior are compiled into a query, so publish the document kind
+        // before any query is compiled rather than while facts are populated afterward.
         CSS::configure_isolated_selector_query_engine(m_engine, root.document());
-        Vector<void const*> selector_handles;
-        selector_handles.ensure_capacity(selectors.size());
-        for (auto const& selector : selectors)
-            selector_handles.unchecked_append(&selector->rust_selector());
-        m_query = m_engine.compile_selector_query(selector_handles);
-
         CSS::populate_isolated_selector_query_engine(m_engine, root, [&](GC::Ref<Element> element, CSS::StyleNodeID identity) {
             m_identities.set(element, identity);
         });
@@ -41,45 +38,112 @@ public:
 
     ~IsolatedSelectorQueryEngine()
     {
-        CSS::StyleEngine::destroy_selector_query(m_query);
+        destroy_compiled_queries();
     }
 
-    bool matches(Element const& element, ParentNode const& scope)
+    bool matches(SelectorQuery const& query, Element const& element, ParentNode const& scope)
     {
         auto node = m_identities.get(GC::Ptr { element });
         VERIFY(node.has_value());
         CSS::StyleNodeID scope_root;
         if (GC::Ptr<Element const> scope_element = as_if<Element>(scope))
             scope_root = m_identities.get(scope_element).value_or(0);
+        auto const* compiled_query = compiled_query_for(query);
         auto result = m_has_document_root
-            ? m_engine.selector_query_matches(m_query, *node, scope_root, 0)
-            : m_engine.selector_query_matches_without_document_root(m_query, *node, scope_root, 0);
+            ? m_engine.selector_query_matches(compiled_query, *node, scope_root, 0)
+            : m_engine.selector_query_matches_without_document_root(compiled_query, *node, scope_root, 0);
         VERIFY(result.has_value());
         return *result;
     }
 
 private:
+    void const* compiled_query_for(SelectorQuery const& query)
+    {
+        if (auto it = m_compiled_queries.find(&query); it != m_compiled_queries.end())
+            return it->value.handle;
+
+        // A page can manufacture selector strings without end; the engine must not grow with them.
+        static constexpr size_t max_compiled_queries = 256;
+        if (m_compiled_queries.size() >= max_compiled_queries)
+            destroy_compiled_queries();
+
+        Vector<void const*> selector_handles;
+        selector_handles.ensure_capacity(query.selectors().size());
+        for (auto const& selector : query.selectors())
+            selector_handles.unchecked_append(&selector->rust_selector());
+        // Facts were published before this query existed, so any attribute value text it is the first to demand has
+        // to be published now, from the elements the engine was populated with, and the engine prepared against
+        // the facts again before the query matches.
+        auto* handle = m_engine.compile_selector_query(selector_handles, [&] {
+            for (auto const& it : m_identities) {
+                it.key->for_each_attribute([&](Attr const& attribute) {
+                    auto name_atom = m_engine.intern_attribute_name(attribute.local_name(), attribute.namespace_uri());
+                    m_engine.backfill_attribute_value_text_if_required(name_atom, attribute.value());
+                });
+            }
+        });
+        m_engine.prepare_selector_query();
+        m_compiled_queries.set(&query, CompiledQuery { query, handle });
+        return handle;
+    }
+
+    void destroy_compiled_queries()
+    {
+        for (auto& it : m_compiled_queries)
+            CSS::StyleEngine::destroy_selector_query(it.value.handle);
+        m_compiled_queries.clear();
+    }
+
+    struct CompiledQuery {
+        // Keeps the query alive, so its address cannot be taken over by another query while this entry is keyed on it.
+        NonnullRefPtr<SelectorQuery const> query;
+        void* handle { nullptr };
+    };
+
     CSS::StyleEngine m_engine;
     HashMap<GC::Ptr<Element const>, CSS::StyleNodeID> m_identities;
-    void* m_query { nullptr };
+    HashMap<SelectorQuery const*, CompiledQuery> m_compiled_queries;
     bool m_has_document_root { false };
 };
 
-class IsolatedSelectorQueryCacheEntry {
-public:
-    IsolatedSelectorQueryCacheEntry(ParentNode& root, CSS::SelectorList const& selectors)
-        : root(root)
-        , dom_tree_version(root.dom_tree_version())
-        , character_data_version(root.character_data_version())
-        , engine(root, selectors)
-    {
+IsolatedSelectorQueryEngineCache::IsolatedSelectorQueryEngineCache() = default;
+IsolatedSelectorQueryEngineCache::~IsolatedSelectorQueryEngineCache() = default;
+
+IsolatedSelectorQueryEngine& IsolatedSelectorQueryEngineCache::engine_for(ParentNode& root)
+{
+    if (auto it = m_entries.find(&root); it != m_entries.end()) {
+        auto& entry = it->value;
+        if (entry.root.ptr() == GC::Ptr { root }
+            && entry.dom_tree_version == root.dom_tree_version()
+            && entry.character_data_version == root.character_data_version())
+            return *entry.engine;
+        m_entries.remove(it);
     }
 
-    GC::Weak<ParentNode> root;
-    u64 dom_tree_version { 0 };
-    u64 character_data_version { 0 };
-    IsolatedSelectorQueryEngine engine;
-};
+    static constexpr size_t max_entry_count = 64;
+    if (m_entries.size() >= max_entry_count) {
+        m_entries.remove_all_matching([](auto&, auto& entry) { return !entry.root; });
+        if (m_entries.size() >= max_entry_count)
+            m_entries.remove(m_entries.begin());
+    }
+
+    auto engine = make<IsolatedSelectorQueryEngine>(root);
+    auto& engine_reference = *engine;
+    m_entries.set(&root, Entry { root, root.dom_tree_version(), root.character_data_version(), move(engine) });
+    return engine_reference;
+}
+
+void IsolatedSelectorQueryEngineCache::clear()
+{
+    m_entries.clear();
+}
+
+void IsolatedSelectorQueryEngineCache::visit_edges(GC::Cell::Visitor&)
+{
+    // Entries intentionally contain only weak or raw GC pointers, so the cache does not keep disconnected trees
+    // alive.
+    (void)m_entries;
+}
 
 template<typename Matcher>
 static GC::Ptr<Element> first_match(ParentNode& root, Matcher&& matcher)
@@ -280,9 +344,9 @@ bool SelectorQuery::matches(Element const& element, ParentNode const& scope) con
 
     auto& root = as<ParentNode>(const_cast<Node&>(element.root()));
     if (m_is_result_cacheable)
-        return isolated_engine_for(root).matches(element, scope);
-    IsolatedSelectorQueryEngine engine(root, m_selectors);
-    return engine.matches(element, scope);
+        return document.isolated_selector_query_engine_cache().engine_for(root).matches(*this, element, scope);
+    IsolatedSelectorQueryEngine engine(root);
+    return engine.matches(*this, element, scope);
 }
 
 bool SelectorQuery::matches_in_style_engine(Element const& element, ParentNode const& scope) const
@@ -300,35 +364,6 @@ bool SelectorQuery::matches_in_style_engine(Element const& element, ParentNode c
     auto result = const_cast<Document&>(element.document()).style_computer().style_engine().selector_query_matches(m_engine_query, element.style_node_id(), scope_root, shadow_root);
     VERIFY(result.has_value());
     return *result;
-}
-
-IsolatedSelectorQueryEngine& SelectorQuery::isolated_engine_for(ParentNode& root) const
-{
-    auto dom_tree_version = root.dom_tree_version();
-    auto character_data_version = root.character_data_version();
-    for (size_t index = 0; index < m_isolated_engine_cache.size();) {
-        auto& entry = *m_isolated_engine_cache[index];
-        if (!entry.root) {
-            m_isolated_engine_cache.remove(index);
-            continue;
-        }
-        if (entry.root.ptr() != GC::Ptr { root }) {
-            ++index;
-            continue;
-        }
-        if (entry.dom_tree_version == dom_tree_version && entry.character_data_version == character_data_version)
-            return entry.engine;
-        m_isolated_engine_cache.remove(index);
-        break;
-    }
-
-    static constexpr size_t max_isolated_engine_cache_size = 64;
-    if (m_isolated_engine_cache.size() >= max_isolated_engine_cache_size)
-        m_isolated_engine_cache.remove(0);
-    auto entry = make<IsolatedSelectorQueryCacheEntry>(root, m_selectors);
-    auto& engine = entry->engine;
-    m_isolated_engine_cache.append(move(entry));
-    return engine;
 }
 
 GC::Ptr<Element const> SelectorQuery::closest(Element const& element) const
@@ -354,17 +389,17 @@ GC::Ptr<Element const> SelectorQuery::closest(Element const& element) const
 
     auto& root = as<ParentNode>(const_cast<Node&>(element.root()));
     if (m_is_result_cacheable) {
-        auto& engine = isolated_engine_for(root);
+        auto& engine = const_cast<Document&>(element.document()).isolated_selector_query_engine_cache().engine_for(root);
         for (GC::Ptr<Element const> ancestor = &element; ancestor; ancestor = ancestor->parent_element()) {
-            if (engine.matches(*ancestor, element))
+            if (engine.matches(*this, *ancestor, element))
                 return ancestor;
         }
         return nullptr;
     }
 
-    IsolatedSelectorQueryEngine engine(root, m_selectors);
+    IsolatedSelectorQueryEngine engine(root);
     for (GC::Ptr<Element const> ancestor = GC::Ptr { element }; ancestor; ancestor = ancestor->parent_element()) {
-        if (engine.matches(*ancestor, element))
+        if (engine.matches(*this, *ancestor, element))
             return ancestor;
     }
     return nullptr;
@@ -399,11 +434,11 @@ GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
     if (!root.is_connected()) {
         auto& tree_root = as<ParentNode>(root.root());
         if (m_is_result_cacheable) {
-            auto& engine = isolated_engine_for(tree_root);
-            return cache_result(first_match(root, [&](auto& element) { return engine.matches(element, root); }));
+            auto& engine = root.document().isolated_selector_query_engine_cache().engine_for(tree_root);
+            return cache_result(first_match(root, [&](auto& element) { return engine.matches(*this, element, root); }));
         }
-        IsolatedSelectorQueryEngine engine(tree_root, m_selectors);
-        return first_match(root, [&](auto& element) { return engine.matches(element, root); });
+        IsolatedSelectorQueryEngine engine(tree_root);
+        return first_match(root, [&](auto& element) { return engine.matches(*this, element, root); });
     }
 
     auto& document = root.document();
@@ -452,11 +487,11 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
     } else if (!root.is_connected()) {
         auto& tree_root = as<ParentNode>(root.root());
         if (m_is_result_cacheable) {
-            auto& engine = isolated_engine_for(tree_root);
-            collect_matches(root, [&](auto& element) { return engine.matches(element, root); }, elements);
+            auto& engine = document.isolated_selector_query_engine_cache().engine_for(tree_root);
+            collect_matches(root, [&](auto& element) { return engine.matches(*this, element, root); }, elements);
         } else {
-            IsolatedSelectorQueryEngine engine(tree_root, m_selectors);
-            collect_matches(root, [&](auto& element) { return engine.matches(element, root); }, elements);
+            IsolatedSelectorQueryEngine engine(tree_root);
+            collect_matches(root, [&](auto& element) { return engine.matches(*this, element, root); }, elements);
         }
     } else {
         settle_connected_selector_query(document);

--- a/Libraries/LibWeb/DOM/SelectorQuery.cpp
+++ b/Libraries/LibWeb/DOM/SelectorQuery.cpp
@@ -69,8 +69,8 @@ class IsolatedSelectorQueryCacheEntry {
 public:
     IsolatedSelectorQueryCacheEntry(ParentNode& root, CSS::SelectorList const& selectors)
         : root(root)
-        , dom_tree_version(root.document().dom_tree_version())
-        , character_data_version(root.document().character_data_version())
+        , dom_tree_version(root.dom_tree_version())
+        , character_data_version(root.character_data_version())
         , engine(root, selectors)
     {
     }
@@ -304,8 +304,8 @@ bool SelectorQuery::matches_in_style_engine(Element const& element, ParentNode c
 
 IsolatedSelectorQueryEngine& SelectorQuery::isolated_engine_for(ParentNode& root) const
 {
-    auto dom_tree_version = root.document().dom_tree_version();
-    auto character_data_version = root.document().character_data_version();
+    auto dom_tree_version = root.dom_tree_version();
+    auto character_data_version = root.character_data_version();
     for (size_t index = 0; index < m_isolated_engine_cache.size();) {
         auto& entry = *m_isolated_engine_cache[index];
         if (!entry.root) {
@@ -380,14 +380,14 @@ GC::Ptr<Element> SelectorQuery::query_first(ParentNode& root) const
             Vector<GC::RawPtr<Element>> elements;
             if (result)
                 elements.append(*result);
-            root.document().query_selector_result_cache().set(root.document(), root, *this, QuerySelectorResultCache::ResultType::FirstOnly, move(elements));
+            root.document().query_selector_result_cache().set(root, *this, QuerySelectorResultCache::ResultType::FirstOnly, move(elements));
         }
         return result;
     };
 
     if (m_is_result_cacheable) {
         auto& document = root.document();
-        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this, QuerySelectorResultCache::ResultType::FirstOnly))
+        if (auto const* cached_elements = document.query_selector_result_cache().get(root, *this, QuerySelectorResultCache::ResultType::FirstOnly))
             return cached_elements->is_empty() ? nullptr : cached_elements->first().ptr();
     }
 
@@ -440,7 +440,7 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
     auto& document = root.document();
 
     if (m_is_result_cacheable) {
-        if (auto const* cached_elements = document.query_selector_result_cache().get(document, root, *this, QuerySelectorResultCache::ResultType::All))
+        if (auto const* cached_elements = document.query_selector_result_cache().get(root, *this, QuerySelectorResultCache::ResultType::All))
             return create_node_list(*cached_elements);
     }
 
@@ -479,29 +479,20 @@ GC::Ref<NodeList> SelectorQuery::query_all(ParentNode& root) const
 
     auto node_list = create_node_list(elements);
     if (m_is_result_cacheable)
-        document.query_selector_result_cache().set(document, root, *this, QuerySelectorResultCache::ResultType::All, move(elements));
+        document.query_selector_result_cache().set(root, *this, QuerySelectorResultCache::ResultType::All, move(elements));
     return node_list;
 }
 
-void QuerySelectorResultCache::clear_if_dom_tree_changed(Document const& document)
+Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(ParentNode const& root, SelectorQuery const& query, ResultType result_type)
 {
-    if (m_dom_tree_version == document.dom_tree_version())
-        return;
-    m_entries.clear();
-    m_dom_tree_version = document.dom_tree_version();
-}
-
-Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const& document, ParentNode const& root, SelectorQuery const& query, ResultType result_type)
-{
-    clear_if_dom_tree_changed(document);
-
     auto it = m_entries.find(Key { &root, &query });
     if (it == m_entries.end())
         return nullptr;
 
     auto const& entry = it->value;
     if (entry.root.ptr().ptr() != &root
-        || (query.depends_on_character_data() && entry.character_data_version != document.character_data_version())) {
+        || entry.dom_tree_version != root.dom_tree_version()
+        || (query.depends_on_character_data() && entry.character_data_version != root.character_data_version())) {
         m_entries.remove(it);
         return nullptr;
     }
@@ -511,17 +502,15 @@ Vector<GC::RawPtr<Element>> const* QuerySelectorResultCache::get(Document const&
     return &entry.elements;
 }
 
-void QuerySelectorResultCache::set(Document const& document, ParentNode const& root, SelectorQuery const& query, ResultType result_type, Vector<GC::RawPtr<Element>> elements)
+void QuerySelectorResultCache::set(ParentNode const& root, SelectorQuery const& query, ResultType result_type, Vector<GC::RawPtr<Element>> elements)
 {
     static constexpr size_t MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE = 64;
-
-    clear_if_dom_tree_changed(document);
 
     auto key = Key { &root, &query };
     if (!m_entries.contains(key) && m_entries.size() >= MAX_QUERY_SELECTOR_RESULT_CACHE_SIZE)
         m_entries.remove(m_entries.begin());
 
-    m_entries.set(key, Entry { root, query, document.character_data_version(), result_type, move(elements) });
+    m_entries.set(key, Entry { root, query, root.dom_tree_version(), root.character_data_version(), result_type, move(elements) });
 }
 
 void QuerySelectorResultCache::visit_edges(GC::Cell::Visitor&)

--- a/Libraries/LibWeb/DOM/SelectorQuery.h
+++ b/Libraries/LibWeb/DOM/SelectorQuery.h
@@ -57,21 +57,21 @@ private:
     // subtree's elements without matching any of them.
     bool m_matches_every_element { false };
 
-    // Whether matching can only change when the document's dom_tree_version (plus character_data_version, see below)
-    // changes. Queries with selectors that depend on other state (:hover, :checked, :target, etc) are not cacheable.
+    // Whether matching can only change when the dom_tree_version (plus character_data_version, see below) of the
+    // tree the element is in changes. Queries with selectors that depend on other state (:hover, :checked, :target,
+    // etc) are not cacheable.
     bool m_is_result_cacheable { false };
 
     // Whether matching also depends on character data (only :empty), so cached results must additionally be
-    // validated against the document's character_data_version.
+    // validated against the tree's character_data_version.
     bool m_depends_on_character_data { false };
 
     mutable Vector<NonnullOwnPtr<IsolatedSelectorQueryCacheEntry>> m_isolated_engine_cache;
 };
 
 // Caches querySelector first matches and querySelectorAll element lists per (query root, selector query), allowing
-// repeated queries against an unchanged document to skip the subtree walk. Entries are validated lazily against
-// the document's mutation version counters, so no notification on DOM mutation is needed: the whole cache is
-// emptied on first use after dom_tree_version changes.
+// repeated queries against an unchanged tree to skip the subtree walk. Entries are validated lazily against the
+// mutation version counters of the tree the query root is in, so no notification on DOM mutation is needed.
 class QuerySelectorResultCache {
     AK_MAKE_NONCOPYABLE(QuerySelectorResultCache);
     AK_MAKE_NONMOVABLE(QuerySelectorResultCache);
@@ -84,13 +84,12 @@ public:
 
     QuerySelectorResultCache() = default;
 
-    Vector<GC::RawPtr<Element>> const* get(Document const&, ParentNode const& root, SelectorQuery const&, ResultType);
-    void set(Document const&, ParentNode const& root, SelectorQuery const&, ResultType, Vector<GC::RawPtr<Element>>);
+    Vector<GC::RawPtr<Element>> const* get(ParentNode const& root, SelectorQuery const&, ResultType);
+    void set(ParentNode const& root, SelectorQuery const&, ResultType, Vector<GC::RawPtr<Element>>);
+    void clear() { m_entries.clear(); }
     void visit_edges(GC::Cell::Visitor&);
 
 private:
-    void clear_if_dom_tree_changed(Document const&);
-
     struct Key {
         GC::RawPtr<ParentNode const> root;
         SelectorQuery const* query { nullptr };
@@ -109,16 +108,17 @@ private:
         // Keeps the query alive (and its address unique) even if the document's selector query cache evicts it.
         NonnullRefPtr<SelectorQuery const> query;
 
+        u64 dom_tree_version { 0 };
         u64 character_data_version { 0 };
         ResultType result_type { ResultType::FirstOnly };
 
-        // Raw pointers are safe here: the elements were descendants of root when cached, and with dom_tree_version
-        // unchanged no node in this document has been inserted or removed since, so they are still descendants of
-        // root and kept alive by it. Entries are only used after validating the version and that root is alive.
+        // Raw pointers are safe here: the elements were descendants of root when cached, and with the tree's
+        // dom_tree_version unchanged no node has been inserted into or removed from it since, so they are still
+        // descendants of root and kept alive by it. Entries are only used after validating the version and that
+        // root is alive.
         Vector<GC::RawPtr<Element>> elements;
     };
 
-    u64 m_dom_tree_version { 0 };
     HashMap<Key, Entry, KeyTraits> m_entries;
 };
 

--- a/Libraries/LibWeb/DOM/SelectorQuery.h
+++ b/Libraries/LibWeb/DOM/SelectorQuery.h
@@ -18,7 +18,6 @@
 
 namespace Web::DOM {
 
-class IsolatedSelectorQueryCacheEntry;
 class IsolatedSelectorQueryEngine;
 
 // A selectors string parsed for use by querySelector(All), matches() and closest().
@@ -47,7 +46,6 @@ private:
 
     bool matches_simple_selector_in_dom(Element const&) const;
     bool matches_in_style_engine(Element const&, ParentNode const& scope) const;
-    IsolatedSelectorQueryEngine& isolated_engine_for(ParentNode&) const;
 
     CSS::SelectorList m_selectors;
     void* m_engine_query { nullptr };
@@ -65,8 +63,6 @@ private:
     // Whether matching also depends on character data (only :empty), so cached results must additionally be
     // validated against the tree's character_data_version.
     bool m_depends_on_character_data { false };
-
-    mutable Vector<NonnullOwnPtr<IsolatedSelectorQueryCacheEntry>> m_isolated_engine_cache;
 };
 
 // Caches querySelector first matches and querySelectorAll element lists per (query root, selector query), allowing
@@ -120,6 +116,35 @@ private:
     };
 
     HashMap<Key, Entry, KeyTraits> m_entries;
+};
+
+// The document's style engine knows only connected nodes, so a selector query against a disconnected element
+// matches in an engine of its own, populated with the whole tree the element is in. Building one costs a walk of
+// that tree, so this cache keeps one per tree root for every query against the tree to share. Entries are validated
+// lazily against the root's mutation version counters, like query results are.
+class IsolatedSelectorQueryEngineCache {
+    AK_MAKE_NONCOPYABLE(IsolatedSelectorQueryEngineCache);
+    AK_MAKE_NONMOVABLE(IsolatedSelectorQueryEngineCache);
+
+public:
+    IsolatedSelectorQueryEngineCache();
+    ~IsolatedSelectorQueryEngineCache();
+
+    IsolatedSelectorQueryEngine& engine_for(ParentNode& root);
+    void clear();
+    void visit_edges(GC::Cell::Visitor&);
+
+private:
+    struct Entry {
+        // Weak so the cache never keeps a disconnected tree alive, and so that a dead root can never be confused with
+        // a new node allocated at the same address.
+        GC::Weak<ParentNode> root;
+        u64 dom_tree_version { 0 };
+        u64 character_data_version { 0 };
+        NonnullOwnPtr<IsolatedSelectorQueryEngine> engine;
+    };
+
+    HashMap<GC::RawPtr<ParentNode const>, Entry> m_entries;
 };
 
 }

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -279,9 +279,9 @@ ShadowRoot::PartElementMap const& ShadowRoot::part_element_map() const
 {
     // FIXME: dom_tree_version() is crude and invalidates more than necessary.
     //        Come up with a smarter way of invalidating this if it turns out to be slow.
-    if (m_dom_tree_version_when_calculated_part_element_map < document().dom_tree_version()) {
+    if (m_dom_tree_version_when_calculated_part_element_map != dom_tree_version()) {
         const_cast<ShadowRoot*>(this)->calculate_part_element_map();
-        m_dom_tree_version_when_calculated_part_element_map = document().dom_tree_version();
+        m_dom_tree_version_when_calculated_part_element_map = dom_tree_version();
     }
     return m_part_element_map;
 }

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -182,7 +182,7 @@ private:
     CSS::StyleScope m_style_scope;
 
     mutable PartElementMap m_part_element_map;
-    mutable u64 m_dom_tree_version_when_calculated_part_element_map { 0 };
+    mutable Optional<u64> m_dom_tree_version_when_calculated_part_element_map;
 
     // https://dom.spec.whatwg.org/#shadowroot-custom-element-registry
     GC::Ptr<HTML::CustomElementRegistry> m_custom_element_registry;

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -148,11 +148,11 @@ WebIDL::ExceptionOr<bool> Document::exec_command_internal(Utf16FlyString const& 
 
     // AD-HOC: Record the mutations performed by the command action on the editing history, so the user can undo them.
     //         end_recording() is a no-op if the guard below already ended the recording.
+    bool is_cut_or_paste = user_input_type == UIEvents::InputTypes::deleteByCut || user_input_type == UIEvents::InputTypes::insertFromPaste;
     if (affected_editing_host) {
         auto category = Editing::UndoStep::Category::Other;
         // INTEROP: Cut and paste are standalone undo units in Chromium: they never coalesce with typing or deletion
         //          runs, so they categorize as Other even though they run the delete and insertText commands.
-        bool is_cut_or_paste = user_input_type == UIEvents::InputTypes::deleteByCut || user_input_type == UIEvents::InputTypes::insertFromPaste;
         if (!is_cut_or_paste) {
             if (command_definition.command.is_one_of(Editing::CommandNames::insertText, Editing::CommandNames::insertLineBreak, Editing::CommandNames::insertParagraph))
                 category = Editing::UndoStep::Category::Insertion;
@@ -192,8 +192,11 @@ WebIDL::ExceptionOr<bool> Document::exec_command_internal(Utf16FlyString const& 
 
     // NB: Canonicalize the caret the command produced before the ending selection is recorded, but only if the
     //     command actually performed an edit; Chromium leaves the caret alone otherwise.
+    // INTEROP: A user cut or paste counts as an edit whenever its command ran: Chromium fires the input event and
+    //          settles the caret even when the pasted fragment reduces to nothing but transport markers.
     bool tree_was_modified = dom_tree_version() != old_dom_tree_version
-        || character_data_version() != old_character_data_version;
+        || character_data_version() != old_character_data_version
+        || (is_cut_or_paste && command_result);
     if (affected_editing_host && m_selection && tree_was_modified)
         Editing::canonicalize_collapsed_selection_for_editing(*m_selection);
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -592,6 +592,7 @@ class ParentNode;
 class Position;
 class ProcessingInstruction;
 class PseudoElement;
+class IsolatedSelectorQueryEngineCache;
 class QuerySelectorResultCache;
 class Range;
 class RegisteredObserver;

--- a/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -51,8 +51,8 @@ void HTMLHeadingElement::apply_presentational_hints(Vector<CSS::StyleProperty>& 
 WebIDL::UnsignedLong HTMLHeadingElement::heading_level() const
 {
     // h1–h6 elements have a heading level, which is given by getting the element's computed heading level.
-    if (m_dom_tree_version_for_cached_heading_level < document().dom_tree_version()) {
-        m_dom_tree_version_for_cached_heading_level = document().dom_tree_version();
+    if (m_dom_tree_version_for_cached_heading_level != dom_tree_version()) {
+        m_dom_tree_version_for_cached_heading_level = dom_tree_version();
         m_cached_heading_level = computed_heading_level();
     }
     return m_cached_heading_level;

--- a/Libraries/LibWeb/HTML/HTMLHeadingElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHeadingElement.h
@@ -42,7 +42,7 @@ private:
     virtual bool is_html_heading_element() const final { return true; }
 
     mutable WebIDL::UnsignedLong m_cached_heading_level { 0 };
-    mutable u64 m_dom_tree_version_for_cached_heading_level { 0 };
+    mutable Optional<u64> m_dom_tree_version_for_cached_heading_level;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -684,7 +684,7 @@ GC::Ptr<HTMLMapElement> HTMLImageElement::associated_map_element()
         return {};
 
     // OPTIMIZATION: Resolving the map element walks the entire tree, so the result is cached until the DOM changes.
-    if (m_cached_associated_map_element_dom_tree_version == document().dom_tree_version())
+    if (m_cached_associated_map_element_dom_tree_version == dom_tree_version())
         return m_cached_associated_map_element;
 
     // 1. Parse the attribute's value using the rules for parsing a hash-name reference to a map element, with the
@@ -692,7 +692,7 @@ GC::Ptr<HTMLMapElement> HTMLImageElement::associated_map_element()
     // 2. If that returned null, then return. The image is not associated with an image map after all.
     // NB: Step 3 is performed by HTMLMapElement::area_for_point() when a pointing device interacts with the image.
     m_cached_associated_map_element = parse_hash_name_reference_to_map_element(usemap->utf16_view(), *this);
-    m_cached_associated_map_element_dom_tree_version = document().dom_tree_version();
+    m_cached_associated_map_element_dom_tree_version = dom_tree_version();
     return m_cached_associated_map_element;
 }
 

--- a/Tests/LibWeb/Text/expected/DOM/selector-queries-on-disconnected-trees.txt
+++ b/Tests/LibWeb/Text/expected/DOM/selector-queries-on-disconnected-trees.txt
@@ -1,0 +1,21 @@
+initial: partial[one]=true partial[two]=false inner-closest=true second:not(.x)=false first:first-child=true third:last-child=true second:empty=false first:empty=true kind-a-count=3 nth=second root:root=false scope=1
+after partial-name=two: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=false first:first-child=true third:last-child=true second:empty=false first:empty=true kind-a-count=3 nth=second root:root=false scope=1
+after second loses .x: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=true second:empty=false first:empty=true kind-a-count=3 nth=second root:root=false scope=1
+after fourth appended: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=false first:empty=true kind-a-count=4 nth=second root:root=false scope=1
+after first removed: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=false first:empty=true kind-a-count=3 nth=third root:root=false scope=1
+after first reinserted: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=false first:empty=true kind-a-count=4 nth=second root:root=false scope=1
+after second text emptied: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=true first:empty=true kind-a-count=4 nth=second root:root=false scope=1
+after first text filled: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=true first:empty=false kind-a-count=4 nth=second root:root=false scope=1
+after document changes: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=true first:empty=false kind-a-count=4 nth=second root:root=false scope=1
+connected .item count: 4
+connected .item count after disconnected change: 4
+after data-kind=b: partial[one]=false partial[two]=true inner-closest=false second:not(.x)=true first:first-child=true third:last-child=false second:empty=true first:empty=false kind-a-count=0 nth=second root:root=false scope=1
+connected partial[three]=true p count=5
+disconnected again partial[three]=true p count=5 last=fifth
+moved: closest=true in root=0 in other=5
+removed: closest=null p count=6 last=sixth
+adopted away: p count=7 owner=true
+adopted back: p count=7 last=seventh
+live list: 7
+live list after removal: 6
+observer-style queries matched: 1

--- a/Tests/LibWeb/Text/input/DOM/selector-queries-on-disconnected-trees.html
+++ b/Tests/LibWeb/Text/input/DOM/selector-queries-on-disconnected-trees.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="connected"><span class="item"></span></div>
+<script>
+    test(() => {
+        // Selector queries against disconnected trees match in an engine built for the tree, shared by every query
+        // against it and kept until the tree itself changes. Each step below changes one thing and checks that the
+        // next query sees it.
+        const root = document.createElement("div");
+        root.innerHTML = `
+            <section data-kind="a"><p id="first"></p><p id="second" class="x">text</p><p id="third"></p></section>
+            <react-partial partial-name="one"><div class="inner"></div></react-partial>`;
+        const section = root.querySelector("section");
+        const first = root.querySelector("#first");
+        const second = root.querySelector("#second");
+        const third = root.querySelector("#third");
+        const partial = root.querySelector("react-partial");
+        const inner = root.querySelector(".inner");
+
+        const report = (label) => {
+            const facts = [
+                `partial[one]=${partial.matches('react-partial[partial-name="one"]')}`,
+                `partial[two]=${partial.matches('react-partial[partial-name="two"]')}`,
+                `inner-closest=${inner.closest('react-partial[partial-name="one"] .inner') === inner}`,
+                `second:not(.x)=${second.matches("p:not(.x)")}`,
+                `first:first-child=${first.matches("p:first-child")}`,
+                `third:last-child=${third.matches("section > p:last-child")}`,
+                `second:empty=${second.matches(":empty")}`,
+                `first:empty=${first.matches(":empty")}`,
+                `kind-a-count=${root.querySelectorAll('[data-kind="a"] p').length}`,
+                `nth=${root.querySelector("p:nth-child(2)")?.id}`,
+                `root:root=${root.matches(":root")}`,
+                `scope=${root.querySelectorAll(":scope > section").length}`,
+            ];
+            println(`${label}: ${facts.join(" ")}`);
+        };
+
+        report("initial");
+
+        // Attribute changes in the disconnected tree, with nothing else changing.
+        partial.setAttribute("partial-name", "two");
+        report("after partial-name=two");
+        second.classList.remove("x");
+        report("after second loses .x");
+
+        // Structural changes in the disconnected tree.
+        const fourth = document.createElement("p");
+        fourth.id = "fourth";
+        section.appendChild(fourth);
+        report("after fourth appended");
+        section.removeChild(first);
+        report("after first removed");
+        section.insertBefore(first, second);
+        report("after first reinserted");
+
+        // Character data changes in the disconnected tree.
+        second.firstChild.data = "";
+        report("after second text emptied");
+        first.textContent = "filled";
+        report("after first text filled");
+
+        // Changes in the document must not disturb queries against the disconnected tree, and the other way around.
+        const connected = document.getElementById("connected");
+        for (let i = 0; i < 3; ++i) {
+            const item = document.createElement("span");
+            item.className = "item";
+            connected.appendChild(item);
+        }
+        report("after document changes");
+        println(`connected .item count: ${document.querySelectorAll("#connected .item").length}`);
+        section.setAttribute("data-kind", "b");
+        println(`connected .item count after disconnected change: ${document.querySelectorAll("#connected .item").length}`);
+        report("after data-kind=b");
+
+        // A tree that joins the document, changes there, and leaves again must be seen as it is now.
+        connected.appendChild(root);
+        partial.setAttribute("partial-name", "three");
+        section.appendChild(document.createElement("p")).id = "fifth";
+        println(`connected partial[three]=${partial.matches('react-partial[partial-name="three"]')} p count=${root.querySelectorAll("p").length}`);
+        connected.removeChild(root);
+        println(`disconnected again partial[three]=${partial.matches('react-partial[partial-name="three"]')} p count=${root.querySelectorAll("p").length} last=${root.querySelector("section > p:last-child").id}`);
+
+        // A subtree moved between two disconnected trees is seen in its new tree, and again on its own once removed.
+        const other = document.createElement("div");
+        other.className = "other";
+        other.appendChild(section);
+        println(`moved: closest=${first.closest(".other") === other} in root=${root.querySelectorAll("p").length} in other=${other.querySelectorAll("p").length}`);
+        section.appendChild(document.createElement("p")).id = "sixth";
+        other.removeChild(section);
+        println(`removed: closest=${first.closest(".other")} p count=${section.querySelectorAll("p").length} last=${section.querySelector("p:last-child").id}`);
+
+        // A tree adopted into another document, changed there, and adopted back must be seen as it is now.
+        const otherDocument = document.implementation.createHTMLDocument("");
+        otherDocument.adoptNode(section);
+        section.appendChild(otherDocument.createElement("p")).id = "seventh";
+        println(`adopted away: p count=${section.querySelectorAll("p").length} owner=${section.ownerDocument === otherDocument}`);
+        document.adoptNode(section);
+        println(`adopted back: p count=${section.querySelectorAll("p").length} last=${section.querySelector("p:last-child").id}`);
+
+        // Live collections rooted in a disconnected tree follow its changes too.
+        const paragraphs = section.getElementsByTagName("p");
+        println(`live list: ${paragraphs.length}`);
+        section.removeChild(paragraphs[0]);
+        println(`live list after removal: ${paragraphs.length}`);
+
+        // Many different queries against one disconnected tree, as a selector observer makes.
+        let matched = 0;
+        for (let i = 0; i < 200; ++i) {
+            if (partial.matches(`react-partial[partial-name="${i === 3 ? "three" : i}"]`))
+                ++matched;
+        }
+        println(`observer-style queries matched: ${matched}`);
+    });
+</script>


### PR DESCRIPTION
GitHub’s Catalyst selector observer checks roughly 165 selectors against a small detached tree on every mutation batch. Each selector previously built its own isolated style engine, and unrelated document mutations invalidated all of them.

Track mutation versions per DOM tree instead of per document, then share one isolated selector query engine per disconnected tree and compile queries lazily. This keeps connected and detached query caches independent while preserving invalidation across mutations, moves, and adoption.

On a logged-in GitHub PR diff over 20 wheel steps:

| | Before | After |
|---|---:|---:|
| Isolated engine builds | 4,730 | 36 |
| Detached matches()/closest() | ~10 s | 8.3 ms for 11,088 calls |
| Connected selector queries | | 42.7 ms for 22,656 calls |

The connected figure includes style-engine settlement after staged DOM mutations.