### PR TITLE
LibMedia+LibRequests+LibWeb: Fix some issues with MSE playback

### DIFF
--- a/Libraries/LibMedia/Containers/ISOBMFF/FragmentSampleIterator.cpp
+++ b/Libraries/LibMedia/Containers/ISOBMFF/FragmentSampleIterator.cpp
@@ -22,12 +22,17 @@ Sample FragmentSampleIterator::peek() const
     auto const& run = m_fragment.track_runs[m_run_index];
     auto decode_time = saturating_add(m_decode_time, run.composition_to_presentation_offset);
     auto presentation_time = saturating_add(decode_time, run.composition_time_offset_of_sample(m_sample_index));
+    auto presentation_end_time = saturating_add(presentation_time, static_cast<i64>(run.duration_of_sample(m_sample_index)));
+
+    auto presentation_timestamp = AK::Duration::from_time_units(presentation_time, 1, run.timescale);
+    auto presentation_end = AK::Duration::from_time_units(presentation_end_time, 1, run.timescale);
+
     return Sample {
         .track_id = run.track_id,
         .sample_description_index = run.defaults.sample_description_index,
         .decode_timestamp = AK::Duration::from_time_units(decode_time, 1, run.timescale),
-        .presentation_timestamp = AK::Duration::from_time_units(presentation_time, 1, run.timescale),
-        .duration = AK::Duration::from_time_units(run.duration_of_sample(m_sample_index), 1, run.timescale),
+        .presentation_timestamp = presentation_timestamp,
+        .duration = presentation_end - presentation_timestamp,
         .is_sync_sample = (run.flags_of_sample(m_sample_index) & SAMPLE_IS_NON_SYNC_SAMPLE) == 0,
         .data_position = m_data_position,
         .data_size = run.size_of_sample(m_sample_index),

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -138,6 +138,7 @@ static DecoderErrorOr<void> initialize_format_context(AVFormatContext*& format_c
         return DecoderError::with_description(DecoderErrorCategory::Memory, "Failed to allocate format context"sv);
     format_context->pb = &io_context;
     format_context->flags |= AVFMT_FLAG_CUSTOM_IO;
+    format_context->flags |= AVFMT_FLAG_DISCARD_CORRUPT;
     format_context->flags |= AVFMT_FLAG_FAST_SEEK;
 
     ArmedScopeGuard close_input = [&] {

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -274,8 +274,7 @@ void DecodedAudioProducer::ThreadData::consume()
 
 void DecodedAudioProducer::ThreadData::enter_halting_state(PipelineStatus status, Optional<DecoderError> error)
 {
-    if (error.has_value() && error->category() == DecoderErrorCategory::Aborted)
-        return;
+    VERIFY(!error.has_value() || error->category() != DecoderErrorCategory::Aborted);
 
     VERIFY(status == PipelineStatus::EndOfStream || status == PipelineStatus::Error);
     m_current_halting_status = status;
@@ -382,8 +381,6 @@ void DecodedAudioProducer::ThreadData::queue_block(AudioBlock const& block)
 
 void DecodedAudioProducer::ThreadData::dispatch_error(DecoderError&& error)
 {
-    if (error.category() == DecoderErrorCategory::Aborted)
-        return;
     if (m_error_handler)
         m_error_handler(move(error));
 }
@@ -442,6 +439,7 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
 
     AK::Duration timestamp;
     bool moved_position = false;
+    AudioBlock last_block;
 
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
@@ -462,28 +460,30 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
         }
 
         auto seek_options = DemuxerSeekOptions::None;
-        if (m_decoder_needs_codec_configuration_next_seek) {
+        if (m_decoder_needs_codec_configuration_next_seek)
             seek_options |= DemuxerSeekOptions::NeedCodecConfiguration;
-            m_decoder_needs_codec_configuration_next_seek = false;
-        }
-        if (m_decoder_needs_keyframe_next_seek) {
+        if (m_decoder_needs_keyframe_next_seek)
             seek_options |= DemuxerSeekOptions::Force;
-            m_decoder_needs_keyframe_next_seek = false;
-        }
         auto demuxer_seek_result_or_error = m_demuxer->seek_to_most_recent_keyframe(m_track, timestamp, seek_options);
         if (demuxer_seek_result_or_error.is_error() && demuxer_seek_result_or_error.error().category() != DecoderErrorCategory::EndOfStream) {
+            if (demuxer_seek_result_or_error.error().category() == DecoderErrorCategory::Aborted)
+                continue;
             handle_error(demuxer_seek_result_or_error.release_error());
             return true;
         }
+
+        m_decoder_needs_codec_configuration_next_seek = false;
+        m_decoder_needs_keyframe_next_seek = false;
+
         auto demuxer_seek_result = demuxer_seek_result_or_error.value_or(DemuxerSeekResult::MovedPosition);
 
         if (demuxer_seek_result == DemuxerSeekResult::MovedPosition) {
             flush_decoder();
             moved_position = true;
+            last_block.clear();
         }
 
         auto new_seek_id = m_seek_id.load();
-        AudioBlock last_block;
 
         while (new_seek_id == seek_id) {
             auto coded_frame_result = m_demuxer->get_next_sample_for_track(m_track);
@@ -495,6 +495,8 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
                         return true;
                     }
                     m_decoder->signal_end_of_stream();
+                } else if (coded_frame_result.error().category() == DecoderErrorCategory::Aborted) {
+                    break;
                 } else {
                     handle_error(coded_frame_result.release_error());
                     return true;
@@ -588,6 +590,8 @@ void DecodedAudioProducer::ThreadData::push_data_and_decode_a_block()
                 return;
             }
             m_decoder->signal_end_of_stream();
+        } else if (sample_result.error().category() == DecoderErrorCategory::Aborted) {
+            return;
         } else {
             set_halting_status_and_wait_for_seek(PipelineStatus::Error, sample_result.release_error());
             return;

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -130,8 +130,7 @@ void DecodedVideoProducer::ThreadData::consume()
 
 void DecodedVideoProducer::ThreadData::enter_halting_state(PipelineStatus status, Optional<DecoderError> error)
 {
-    if (error.has_value() && error->category() == DecoderErrorCategory::Aborted)
-        return;
+    VERIFY(!error.has_value() || error->category() != DecoderErrorCategory::Aborted);
 
     VERIFY(status == PipelineStatus::EndOfStream || status == PipelineStatus::Error);
     m_current_halting_status = status;
@@ -401,8 +400,6 @@ void DecodedVideoProducer::ThreadData::queue_frame(NonnullRefPtr<VideoFrame> con
 
 void DecodedVideoProducer::ThreadData::dispatch_error(DecoderError&& error)
 {
-    if (error.category() == DecoderErrorCategory::Aborted)
-        return;
     if (m_error_handler)
         m_error_handler(move(error));
 }
@@ -424,6 +421,7 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
 
     AK::Duration timestamp;
     bool moved_position = false;
+    RefPtr<VideoFrame> last_frame;
 
     auto handle_error = [&](DecoderError&& error) {
         auto locker = take_lock();
@@ -444,29 +442,31 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
         }
 
         auto seek_options = DemuxerSeekOptions::None;
-        if (m_decoder_needs_codec_configuration_next_seek) {
+        if (m_decoder_needs_codec_configuration_next_seek)
             seek_options |= DemuxerSeekOptions::NeedCodecConfiguration;
-            m_decoder_needs_codec_configuration_next_seek = false;
-        }
-        if (m_decoder_needs_keyframe_next_seek) {
+        if (m_decoder_needs_keyframe_next_seek)
             seek_options |= DemuxerSeekOptions::Force;
-            m_decoder_needs_keyframe_next_seek = false;
-        }
         auto demuxer_seek_result_or_error = m_demuxer->seek_to_most_recent_keyframe(m_track, timestamp, seek_options);
         if (demuxer_seek_result_or_error.is_error() && demuxer_seek_result_or_error.error().category() != DecoderErrorCategory::EndOfStream) {
+            if (demuxer_seek_result_or_error.error().category() == DecoderErrorCategory::Aborted)
+                continue;
             handle_error(demuxer_seek_result_or_error.release_error());
             return true;
         }
+
+        m_decoder_needs_codec_configuration_next_seek = false;
+        m_decoder_needs_keyframe_next_seek = false;
+
         auto demuxer_seek_result = demuxer_seek_result_or_error.value_or(DemuxerSeekResult::MovedPosition);
 
         if (demuxer_seek_result == DemuxerSeekResult::MovedPosition) {
             if (m_decoder != nullptr)
                 m_decoder->flush();
             moved_position = true;
+            last_frame.clear();
         }
 
         auto new_seek_id = m_seek_id.load();
-        RefPtr<VideoFrame> last_frame;
 
         while (new_seek_id == seek_id) {
             auto coded_frame_result = m_demuxer->get_next_sample_for_track(m_track);
@@ -478,6 +478,8 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
                         return true;
                     }
                     m_decoder->signal_end_of_stream();
+                } else if (coded_frame_result.error().category() == DecoderErrorCategory::Aborted) {
+                    break;
                 } else {
                     handle_error(coded_frame_result.release_error());
                     return true;
@@ -651,6 +653,8 @@ void DecodedVideoProducer::ThreadData::push_data_and_decode_some_frames()
                 return;
             }
             m_decoder->signal_end_of_stream();
+        } else if (sample_result.error().category() == DecoderErrorCategory::Aborted) {
+            return;
         } else {
             set_halting_status_and_wait_for_seek(PipelineStatus::Error, sample_result.release_error());
             return;

--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -155,6 +155,11 @@ DisplayingVideoSinkUpdateResult DisplayingVideoSink::update(MonotonicTime now)
         if (m_next_frame->timestamp() > current_time)
             break;
 
+        if (m_current_frame && m_current_frame->timestamp() > m_next_frame->timestamp()) {
+            m_next_frame.clear();
+            continue;
+        }
+
         if (auto frame_size = m_next_frame->size(); frame_size != m_last_dispatched_size) {
             m_last_dispatched_size = frame_size;
             if (m_on_resize)

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -374,6 +374,8 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             m_internal_stream_data->on_data_available(ResponseData::from_bytes(read_bytes));
             if (!m_internal_stream_data || !m_internal_stream_data->read_stream)
                 return;
+            if (m_body_delivery_paused)
+                break;
 
             if (m_internal_stream_data->body_delivery_remaining_byte_count.has_value()) {
                 if (read_bytes.size() >= *m_internal_stream_data->body_delivery_remaining_byte_count) {

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -12,8 +12,8 @@
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
-#include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamOperations.h>
@@ -22,6 +22,8 @@
 namespace Web::Fetch::Fetching {
 
 GC_DEFINE_ALLOCATOR(FetchedDataReceiver);
+
+static constexpr size_t maximum_pending_bytes = 5 * MiB;
 
 FetchedDataReceiver::FetchedDataReceiver(GC::Ref<Streams::ReadableStream> stream)
     : FetchedDataReceiver(nullptr, stream, {})
@@ -73,9 +75,8 @@ void FetchedDataReceiver::handle_network_data(JS::Realm& realm, Requests::Respon
 
         // 2. Otherwise, if the bytes transmission for response’s message body is done normally and stream is readable,
         //    then close stream, and abort these in-parallel steps.
-        Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(GC::Heap::the(), [this, &realm]() {
-            close_stream(realm);
-        }));
+        // NB: The close follows any pending bytes through the same task queue; see deliver_pending_bytes().
+        queue_delivery_task(realm);
         return;
     }
 
@@ -118,10 +119,66 @@ void FetchedDataReceiver::handle_network_data(JS::Realm& realm, Requests::Respon
     }
 
     // 7. Append bytes to buffer.
-    enqueue_into_stream(realm, bytes);
+    m_pending_bytes.append(bytes);
+    queue_delivery_task(realm);
 
-    // FIXME: 8. If the size of buffer is larger than an upper limit chosen by the user agent, ask the user agent
-    //           to suspend the ongoing fetch.
+    // 8. If the size of buffer is larger than an upper limit chosen by the user agent, ask the user agent to suspend
+    //    the ongoing fetch.
+    if (m_pending_bytes.size() >= maximum_pending_bytes && !m_paused_network_delivery) {
+        if (auto request = m_network_request.strong_ref()) {
+            request->set_body_delivery_paused(true);
+            m_paused_network_delivery = true;
+        }
+    }
+}
+
+// AD-HOC: These tasks are queued without a document on purpose. A navigation reads its new document's body through
+//         this receiver while the fetch's task destination is still the previous document's global, and tasks
+//         queued on that document stop running once it is replaced.
+static void queue_networking_task(GC::Ref<GC::Function<void()>> steps)
+{
+    HTML::queue_a_task(HTML::Task::Source::Networking, HTML::main_thread_event_loop(), nullptr, steps);
+}
+
+// This implements the task-queueing half of the pullAlgorithm in HTTP-network-fetch: bytes are handed to the
+// stream from a networking task rather than from the network callback, so consumers see them interleaved with
+// the tasks their own reactions queue.
+// https://fetch.spec.whatwg.org/#ref-for-in-parallel④
+void FetchedDataReceiver::queue_delivery_task(JS::Realm& realm)
+{
+    if (m_delivery_task_queued)
+        return;
+    m_delivery_task_queued = true;
+
+    queue_networking_task(GC::create_function(heap(), [this, &realm]() {
+        deliver_pending_bytes(realm);
+    }));
+}
+
+void FetchedDataReceiver::deliver_pending_bytes(JS::Realm& realm)
+{
+    m_delivery_task_queued = false;
+
+    auto bytes = move(m_pending_bytes);
+    m_pending_bytes = {};
+    if (!bytes.is_empty())
+        enqueue_into_stream(realm, bytes);
+
+    // 1. If the size of buffer is smaller than a lower limit chosen by the user agent and the ongoing fetch is
+    //    suspended, resume the fetch.
+    if (m_paused_network_delivery) {
+        m_paused_network_delivery = false;
+        if (auto request = m_network_request.strong_ref())
+            request->set_body_delivery_paused(false);
+    }
+
+    // The close goes through the queue too, so it lands behind whatever the consumer queued in reaction to the
+    // bytes above, the way it does when a network completion trails the last data.
+    if (m_network_complete) {
+        queue_networking_task(GC::create_function(heap(), [this, &realm]() {
+            close_stream(realm);
+        }));
+    }
 }
 
 void FetchedDataReceiver::set_cached_response_body(Core::ImmutableBytes body)
@@ -138,9 +195,6 @@ void FetchedDataReceiver::set_cached_response_body(Core::ImmutableBytes body)
 // https://fetch.spec.whatwg.org/#ref-for-in-parallel④
 void FetchedDataReceiver::enqueue_into_stream(JS::Realm& realm, ReadonlyBytes bytes)
 {
-    // FIXME: 1. If the size of buffer is smaller than a lower limit chosen by the user agent and the ongoing fetch
-    //           is suspended, resume the fetch.
-
     if (!m_stream->is_readable())
         return;
 

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/ImmutableBytes.h>
 #include <LibGC/CellAllocator.h>
 #include <LibHTTP/Forward.h>
@@ -27,6 +28,7 @@ public:
 
     void set_response(GC::Ref<Fetch::Infrastructure::Response const> response) { m_response = response; }
     void set_body(GC::Ref<Fetch::Infrastructure::Body> body);
+    void set_network_request(RefPtr<Requests::Request> const& request) { m_network_request = request; }
 
     enum class NetworkState {
         Ongoing,
@@ -41,6 +43,8 @@ private:
 
     virtual void visit_edges(Visitor& visitor) override;
 
+    void queue_delivery_task(JS::Realm&);
+    void deliver_pending_bytes(JS::Realm&);
     void enqueue_into_stream(JS::Realm&, ReadonlyBytes);
     void close_stream(JS::Realm&);
 
@@ -62,6 +66,13 @@ private:
     bool m_cache_body_replaces_network_buffer { false };
 
     bool m_network_complete { false };
+
+    // Bytes read off the network but not yet handed to the stream. They are delivered by a queued networking task
+    // so that consumers see them interleaved with other tasks, and reading pauses while too many pile up.
+    WeakPtr<Requests::Request> m_network_request;
+    ByteBuffer m_pending_bytes;
+    bool m_delivery_task_queued { false };
+    bool m_paused_network_delivery { false };
 };
 
 }

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2318,6 +2318,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         ? Requests::RequestClient::TransferLease::Yes
         : Requests::RequestClient::TransferLease::No;
     auto network_request = ResourceLoader::the().load(load_request, on_headers_received, on_data_received, on_cached_body_available, on_complete, transfer_lease);
+    fetched_data_receiver->set_network_request(network_request);
     if (network_request && fetch_params.has_response_body_transfer_lease())
         network_request->set_body_delivery_paused(true);
     fetch_params.controller()->set_pending_request(network_request);

--- a/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.cpp
@@ -433,20 +433,29 @@ void TrackBufferDemuxer::decrement_frames_with_maximum_duration_while_locked(siz
 
 Optional<size_t> TrackBufferDemuxer::find_run_to_play_from_while_locked(AK::Duration timestamp) const
 {
-    Optional<size_t> earliest_run_after_timestamp;
-    for (size_t index = m_runs.size(); index-- > 0;) {
+    if (m_runs.is_empty())
+        return {};
+
+    for (size_t index = 0; index < m_runs.size(); index++) {
         auto const& run = m_runs[index];
-        if (run.presentation_start <= timestamp && timestamp < run.presentation_end)
+
+        if (run.presentation_start > timestamp) {
+            // A hole no wider than the permitted gap size plays from the preceding run first.
+            if (index > 0 && run.presentation_start - m_runs[index - 1].presentation_end <= maximum_time_range_gap())
+                return index - 1;
+            // Resolve seeks to the following run if they are within the permitted gap size.
+            if (run.presentation_start - timestamp <= maximum_time_range_gap())
+                return index;
+            return {};
+        }
+
+        if (timestamp < run.presentation_end)
             return index;
-        if (run.presentation_start >= timestamp)
-            earliest_run_after_timestamp = index;
     }
 
-    if (!earliest_run_after_timestamp.has_value())
-        return {};
-    if (m_runs[*earliest_run_after_timestamp].presentation_start - timestamp > maximum_time_range_gap())
-        return {};
-    return earliest_run_after_timestamp;
+    if (m_reached_end_of_stream)
+        return m_runs.size() - 1;
+    return {};
 }
 
 Optional<ReadonlyBytes> TrackBufferDemuxer::codec_configuration_at_position_while_locked(size_t run_index, size_t frame_index) const

--- a/Meta/Linters/check_libweb_realm_mentions.py
+++ b/Meta/Linters/check_libweb_realm_mentions.py
@@ -47,8 +47,8 @@ ALLOWED_REALM_MENTIONS = {
     "DOMURL": (2, 8, "URLSearchParams iterator objects still materialize JS iterator results in selected realms"),
     "Fetch": (
         22,
-        62,
-        "Fetch bodies, headers, requests, responses, and controllers still materialize JS values/streams",
+        66,
+        "Fetch bodies, headers, requests, responses, and controllers still materialize JS values/streams; the body receiver's delivery and close tasks carry the realm its stream is enqueued and closed in",
     ),
     "FileAPI": (6, 11, "File/Blob/FileReader algorithms still create streams, buffers, and events in selected realms"),
     "Geometry": (8, 8, "geometry constructors and structured clone still materialize JS-facing geometry objects"),

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -24,6 +24,7 @@ Text/input/HTML/media-source-mp4-byte-stream-parser.html
 Text/input/HTML/media-source-mp4-encoder-delay.html
 Text/input/HTML/media-source-mp4-reordered-frames.html
 Text/input/HTML/media-source-remove.html
+Text/input/HTML/media-source-seek-before-run.html
 Text/input/HTML/media-source-setup.html
 Text/input/HTML/media-source-split-ignored-element.html
 Text/input/HTML/HTMLMediaElement-load-overrides-preload-none.html

--- a/Tests/LibWeb/Text/expected/HTML/media-source-adjacent-appends.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-adjacent-appends.txt
@@ -1,4 +1,4 @@
-buffered after the second half: [1.02328125-2.023219954]
-buffered after both halves: [0-2.023219954]
+buffered after the second half: [1.02328125-2.023219955]
+buffered after both halves: [0-2.023219955]
 PASS: seeked into the first group
 PASS: played into the second group

--- a/Tests/LibWeb/Text/expected/HTML/media-source-mp4.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-mp4.txt
@@ -2,10 +2,10 @@ PASS: isTypeSupported
 PASS: addSourceBuffer succeeded
 PASS: loaded media data (28560 bytes)
 buffered after slice 1/5: []
-buffered after slice 2/5: [0-0.510839003]
+buffered after slice 2/5: [0-0.510839002]
 buffered after slice 3/5: [0-1.021678005]
 buffered after slice 4/5: [0-1.323537415]
-buffered after slice 5/5: [0-2.023219954]
+buffered after slice 5/5: [0-2.023219955]
 duration: Infinity
 video track: kind=main, label=VideoHandler, language=""
 audio track: kind=main, label=SoundHandler, language=""

--- a/Tests/LibWeb/Text/expected/HTML/media-source-remove.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-remove.txt
@@ -1,11 +1,11 @@
-buffered after appending: [0-2.023219954]
+buffered after appending: [0-2.023219955]
 remove(-1, 1): TypeError
 remove(duration + 1, duration + 2): TypeError
 remove(1, 1): TypeError
 remove(1, NaN): TypeError
 abort() during range removal: InvalidStateError
 remove() during range removal: InvalidStateError
-buffered after remove(0.6, 0.7): [0-0.603718821, 1.02328125-2.023219954]
+buffered after remove(0.6, 0.7): [0-0.603718821, 1.02328125-2.023219955]
 PASS: the removal left a hole
 PASS: a frame beginning before the removal start was kept
 PASS: the removal continued to the next random access point

--- a/Tests/LibWeb/Text/expected/HTML/media-source-seek-before-run.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-seek-before-run.txt
@@ -1,0 +1,3 @@
+buffered: [5-6.021678005, 16.02328125-17.023219955]
+PASS: seeked to just before the second run
+PASS: seeked to just before the first run

--- a/Tests/LibWeb/Text/input/HTML/media-source-seek-before-run.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-seek-before-run.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        function step(name) {
+            println(`PASS: ${name}`);
+        }
+
+        function fail(name, error) {
+            println(`FAIL: ${name}: ${error}`);
+            done();
+        }
+
+        function topLevelBoxes(bytes) {
+            const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+            const boxes = [];
+            for (let offset = 0; offset + 8 <= bytes.length;) {
+                const size = view.getUint32(offset);
+                boxes.push({ offset, type: String.fromCharCode(...bytes.subarray(offset + 4, offset + 8)) });
+                offset += size;
+            }
+            return boxes;
+        }
+
+        try {
+            const video = document.getElementById("video");
+            const mimeType = 'video/mp4;codecs="av01.0.00M.08,mp4a.40.2"';
+            if (!MediaSource.isTypeSupported(mimeType)) {
+                fail("isTypeSupported", `${mimeType} not supported`);
+                return;
+            }
+
+            const mediaSource = new MediaSource();
+            video.src = URL.createObjectURL(mediaSource);
+
+            mediaSource.addEventListener("sourceopen", async () => {
+                try {
+                    const sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+
+                    const response = await fetch("../../../Assets/av1-aac-fragmented.mp4");
+                    if (!response.ok) {
+                        fail("fetch media", `HTTP ${response.status}`);
+                        return;
+                    }
+                    const data = new Uint8Array(await response.arrayBuffer());
+
+                    const boxes = topLevelBoxes(data);
+                    const movieFragments = boxes.filter(box => box.type === "moof").map(box => box.offset);
+                    const mediaEnd = boxes.find(box => box.type === "mfra")?.offset ?? data.length;
+                    const initializationSegment = data.subarray(0, movieFragments[0]);
+                    const mediaSegments = movieFragments.map((start, index) =>
+                        data.subarray(start, index + 1 < movieFragments.length ? movieFragments[index + 1] : mediaEnd));
+
+                    function formatRanges() {
+                        const buffered = sourceBuffer.buffered;
+                        const ranges = [];
+                        for (let i = 0; i < buffered.length; i++)
+                            ranges.push(`${buffered.start(i)}-${buffered.end(i)}`);
+                        return `[${ranges.join(", ")}]`;
+                    }
+
+                    async function append(bytes) {
+                        await new Promise((resolve, reject) => {
+                            sourceBuffer.addEventListener("updateend", resolve, { once: true });
+                            sourceBuffer.addEventListener("error", () =>
+                                reject(new Error("error event on SourceBuffer")), { once: true });
+                            sourceBuffer.appendBuffer(bytes);
+                        });
+                    }
+
+                    async function seekTo(time) {
+                        await new Promise(resolve => {
+                            video.addEventListener("seeked", resolve, { once: true });
+                            video.currentTime = time;
+                        });
+                    }
+
+                    await append(initializationSegment);
+
+                    // Place the two halves of the media ten seconds apart, so each half is a run of its own with
+                    // a hole between them far wider than any frame.
+                    sourceBuffer.timestampOffset = 5;
+                    for (const segment of mediaSegments.slice(0, 2))
+                        await append(segment);
+                    sourceBuffer.timestampOffset = 15;
+                    for (const segment of mediaSegments.slice(2))
+                        await append(segment);
+                    println(`buffered: ${formatRanges()}`);
+
+                    await new Promise(resolve => {
+                        mediaSource.addEventListener("sourceended", resolve);
+                        mediaSource.endOfStream();
+                    });
+
+                    video.addEventListener("error", () => {
+                        fail("playback", video.error?.message ?? "unknown error");
+                    });
+
+                    // Players seek slightly before a segment they hold and expect the seek to resolve on that
+                    // segment's first frame, as it does in other engines.
+                    const secondRunStart = sourceBuffer.buffered.start(1);
+                    await seekTo(secondRunStart - 0.009);
+                    step("seeked to just before the second run");
+
+                    const firstRunStart = sourceBuffer.buffered.start(0);
+                    await seekTo(firstRunStart - 0.009);
+                    step("seeked to just before the first run");
+
+                    done();
+                } catch (e) {
+                    fail("sourceopen handler", e);
+                }
+            });
+        } catch (e) {
+            fail("setup", e);
+        }
+    });
+</script>


### PR DESCRIPTION
This fixes a few issues that would arise when seeking backwards into unbuffered regions:
- Unnecessary frame erasure when an appended ISOBMFF media segment intersects existing frame runs
- Decoding errors during those backwards seeks
- Occasional flickering of buffered ranges on YouTube accompanied by frozen video

See individual commits for more details.