### PR TITLE
LibWeb: Make time coarsening idempotent

### DIFF
--- a/Libraries/LibWeb/HighResolutionTime/TimeOrigin.cpp
+++ b/Libraries/LibWeb/HighResolutionTime/TimeOrigin.cpp
@@ -48,14 +48,19 @@ DOMHighResTimeStamp get_time_origin_timestamp(JS::Object const& global)
 DOMHighResTimeStamp coarsen_time(DOMHighResTimeStamp timestamp, HTML::CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability)
 {
     // 1. Let time resolution be 100 microseconds, or a higher implementation-defined value.
-    auto time_resolution_milliseconds = 0.1;
+    i64 coarsening_factor = 10;
 
     // 2. If crossOriginIsolatedCapability is true, set time resolution to be 5 microseconds, or a higher implementation-defined value.
     if (cross_origin_isolated_capability == HTML::CanUseCrossOriginIsolatedAPIs::Yes)
-        time_resolution_milliseconds = 0.005;
+        coarsening_factor = 200;
 
     // 3. In an implementation-defined manner, coarsen and potentially jitter timestamp such that its resolution will not exceed time resolution
-    timestamp = floor(timestamp / time_resolution_milliseconds) * time_resolution_milliseconds;
+    auto bucket = static_cast<i64>(floor(timestamp * static_cast<double>(coarsening_factor)));
+    timestamp = static_cast<double>(bucket) / static_cast<double>(coarsening_factor);
+    // NB: Division can represent the exact bucket boundary slightly below its intended value. Move such a result up
+    //     by one representable value so that coarsening it again does not select the previous bucket.
+    if (floor(timestamp * static_cast<double>(coarsening_factor)) < static_cast<double>(bucket))
+        timestamp = nextafter(timestamp, AK::Infinity<double>);
 
     // FIXME: Applying jitter to the coarsened timestamp here may decrease our susceptibility to timing attacks.
 

--- a/Libraries/LibWeb/HighResolutionTime/TimeOrigin.h
+++ b/Libraries/LibWeb/HighResolutionTime/TimeOrigin.h
@@ -16,7 +16,7 @@ namespace Web::HighResolutionTime {
 
 DOMHighResTimeStamp estimated_monotonic_time_of_the_unix_epoch();
 DOMHighResTimeStamp get_time_origin_timestamp(JS::Object const&);
-DOMHighResTimeStamp coarsen_time(DOMHighResTimeStamp timestamp, HTML::CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability = HTML::CanUseCrossOriginIsolatedAPIs::No);
+WEB_API DOMHighResTimeStamp coarsen_time(DOMHighResTimeStamp timestamp, HTML::CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability = HTML::CanUseCrossOriginIsolatedAPIs::No);
 DOMHighResTimeStamp current_high_resolution_time(JS::Object const&);
 DOMHighResTimeStamp relative_high_resolution_time(DOMHighResTimeStamp, JS::Object const&);
 DOMHighResTimeStamp relative_high_resolution_coarsen_time(DOMHighResTimeStamp, JS::Object const&);

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SOURCES
     TestFetchResponse.cpp
     TestFetchURL.cpp
     TestHTMLTokenizer.cpp
+    TestHighResolutionTime.cpp
     TestImageData.cpp
     TestLengthAbsolutizeParity.cpp
     TestMicrosyntax.cpp

--- a/Tests/LibWeb/TestHighResolutionTime.cpp
+++ b/Tests/LibWeb/TestHighResolutionTime.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
+
+TEST_CASE(coarsening_time_is_idempotent)
+{
+    auto coarsened_time = Web::HighResolutionTime::coarsen_time(4'320'001'000.2001);
+    EXPECT_EQ(coarsened_time, 4'320'001'000.2);
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(coarsened_time), coarsened_time);
+
+    auto finely_coarsened_time = Web::HighResolutionTime::coarsen_time(4'320'001'000.0251, Web::HTML::CanUseCrossOriginIsolatedAPIs::Yes);
+    EXPECT_EQ(finely_coarsened_time, nextafter(4'320'001'000.025, AK::Infinity<double>));
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(finely_coarsened_time, Web::HTML::CanUseCrossOriginIsolatedAPIs::Yes), finely_coarsened_time);
+}
+
+TEST_CASE(coarsening_negative_time_rounds_down)
+{
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(-1.234), -1.3);
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(-1.234, Web::HTML::CanUseCrossOriginIsolatedAPIs::Yes), nextafter(-1.235, AK::Infinity<double>));
+}
+
+TEST_CASE(coarsening_time_does_not_cross_bucket_boundaries)
+{
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(0.1), 0.1);
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(nextafter(0.1, -AK::Infinity<double>)), 0.0);
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(-0.1), -0.1);
+    EXPECT_EQ(Web::HighResolutionTime::coarsen_time(nextafter(-0.1, -AK::Infinity<double>)), -0.2);
+}


### PR DESCRIPTION
Coarsening an already-coarsened timestamp could move it into the previous bucket when floating-point division rounded just below an integer. This made rAF timestamps depend on system uptime and caused `rendering-opportunity-raf-timestamp.html` to flake.

Select resolution buckets using integer identifiers, then canonicalize the resulting `DOMHighResTimeStamp` so values already on bucket boundaries remain stable without changing which bucket an input belongs to. Add coverage for the 100 µs and 5 µs resolutions, including positive and negative boundary behavior.