### PR TITLE
LibWeb: Rematerialize cleared style reaction gaps

### DIFF
--- a/Libraries/LibWeb/CSS/UpdateStyle.cpp
+++ b/Libraries/LibWeb/CSS/UpdateStyle.cpp
@@ -280,6 +280,11 @@ static RequiredInvalidationAfterStyleChange apply_style_engine_reactions(DOM::Do
 
             if (reaction.gap != StyleEngineFFI::FfiStyleDeltaGap::Materialize && !element->has_style())
                 continue;
+            // An earlier display:none reaction in this batch can clear the style of a materialization gap after the
+            // inheritance closure was built. The gap must then rematerialize rather than letting its descendants
+            // compute against a missing inheritance parent.
+            if (reaction.gap == StyleEngineFFI::FfiStyleDeltaGap::Materialize && reaction.reaction == 0 && !element->has_style())
+                reaction.reaction = StyleEngine::RecomputeStyle;
 
             bool const has_published_style_reaction = reaction.reaction & StyleEngine::PublishedStyle;
             if (has_published_style_reaction) {

--- a/Tests/LibWeb/Text/expected/css/display-none-reveal-details-inheritance.txt
+++ b/Tests/LibWeb/Text/expected/css/display-none-reveal-details-inheritance.txt
@@ -1,0 +1,4 @@
+item before: sans-serif
+label before: sans-serif
+item after: sans-serif
+label after: sans-serif

--- a/Tests/LibWeb/Text/input/css/display-none-reveal-details-inheritance.html
+++ b/Tests/LibWeb/Text/input/css/display-none-reveal-details-inheritance.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    promiseTest(async () => {
+        const iframe = document.createElement("iframe");
+        iframe.style.width = "500px";
+        iframe.style.height = "200px";
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                body { font-family: sans-serif; }
+                #sidebar { display: none; }
+                @media (min-width: 401px) {
+                    #sidebar { display: block; }
+                    /* Keep a descendant in the same media-query reaction batch as the sidebar. */
+                    x-item { width: 10px; }
+                }
+            </style>
+            <script>
+                customElements.define("x-outer", class extends HTMLElement {
+                    constructor() {
+                        super();
+                        this.attachShadow({ mode: "open" }).innerHTML = '<slot></slot>';
+                    }
+                });
+                customElements.define("x-middle", class extends HTMLElement {
+                    constructor() {
+                        super();
+                        this.attachShadow({ mode: "open" }).innerHTML = '<slot></slot>';
+                    }
+                });
+                customElements.define("x-item", class extends HTMLElement {
+                    constructor() {
+                        super();
+                        this.attachShadow({ mode: "open" }).innerHTML = '<span id="label">Wordspire</span>';
+                    }
+                });
+            <\/script>
+            <x-outer id="sidebar">
+                <div style="contain: layout">
+                    <x-middle>
+                        <details open>
+                            <x-item id="item"></x-item>
+                        </details>
+                    </x-middle>
+                </div>
+            </x-outer>
+            `;
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const item = child.document.getElementById("item");
+        const label = item.shadowRoot.getElementById("label");
+        child.document.body.offsetHeight;
+        println(`item before: ${child.getComputedStyle(item).fontFamily}`);
+        println(`label before: ${child.getComputedStyle(label).fontFamily}`);
+
+        iframe.style.width = "300px";
+        document.body.offsetHeight;
+        await animationFrame();
+        child.document.body.offsetHeight;
+
+        iframe.style.width = "500px";
+        document.body.offsetHeight;
+        await animationFrame();
+        child.document.body.offsetHeight;
+
+        println(`item after: ${child.getComputedStyle(item).fontFamily}`);
+        println(`label after: ${child.getComputedStyle(label).fontFamily}`);
+    });
+</script>


### PR DESCRIPTION
A `display:none` reaction can clear descendant styles after a zero-bit materialization gap has already been scheduled in the same batch. Applying that gap as a no-op lets descendants compute against a missing inheritance parent, leaving initial values in place until a targeted restyle.

Promote cleared materialization gaps to full style recomputations. Add regression coverage for inheritance across a display-none shadow host, nested slots, and the `<details>` user-agent shadow tree.