### PR TITLE
LibWeb: Make aspect-ratio-derived block sizes definite

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1675,9 +1675,19 @@ impl BlockFormattingContext {
         let style = self.style(node);
         let box_is_html_element_in_quirks_mode =
             facts.document_in_quirks_mode() && facts.is_html_html_element() && style.height().is_auto();
+        let block_size_is_definite_from_aspect_ratio = self.used(node).has_definite_inline_size()
+            && facts.has_preferred_aspect_ratio()
+            && self.sizing().box_is_sized_as_replaced_element(
+                node,
+                available_space,
+                input.containing_block_constraints,
+            );
 
         // NOTE: In quirks mode, the html element's block size matches the viewport so it can be treated as definite.
-        if self.used(node).has_definite_block_size() || box_is_html_element_in_quirks_mode {
+        if self.used(node).has_definite_block_size()
+            || box_is_html_element_in_quirks_mode
+            || block_size_is_definite_from_aspect_ratio
+        {
             self.resolve_used_block_size_if_treated_as_auto(
                 node,
                 available_space,
@@ -2423,7 +2433,15 @@ impl BlockFormattingContext {
             input.containing_block_constraints,
         );
         self.resolve_used_block_size_if_not_treated_as_auto(node, resolution_space, input.containing_block_constraints);
+        let block_size_is_definite_from_aspect_ratio = self.used(node).has_definite_inline_size()
+            && self.facts(node).has_preferred_aspect_ratio()
+            && self.sizing().box_is_sized_as_replaced_element(
+                node,
+                resolution_space,
+                input.containing_block_constraints,
+            );
         if self.facts(node).has_auto_content_box_size()
+            || block_size_is_definite_from_aspect_ratio
             || (self.style(node).display().is_flex_inside() && !flex_root_resolves_own_auto_block_size)
         {
             self.resolve_used_block_size_if_treated_as_auto(
@@ -2465,7 +2483,15 @@ impl BlockFormattingContext {
             },
         );
         self.resolve_used_block_size_if_not_treated_as_auto(node, available_space, input.containing_block_constraints);
+        let block_size_is_definite_from_aspect_ratio = self.used(node).has_definite_inline_size()
+            && self.facts(node).has_preferred_aspect_ratio()
+            && self.sizing().box_is_sized_as_replaced_element(
+                node,
+                available_space,
+                input.containing_block_constraints,
+            );
         if self.facts(node).has_auto_content_box_size()
+            || block_size_is_definite_from_aspect_ratio
             || (self.style(node).display().is_flex_inside() && !flex_root_resolves_own_auto_block_size)
         {
             self.resolve_used_block_size_if_treated_as_auto(

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1186,7 +1186,12 @@ impl SizingContext {
         }
         let style = self.style(node);
         let facts = self.facts(node);
-        let mut block_size = if self.box_is_sized_as_replaced_element(node, available_space, constraints) {
+        let box_is_sized_as_replaced_element =
+            self.box_is_sized_as_replaced_element(node, available_space, constraints);
+        let block_size_is_definite_from_aspect_ratio = self.used(node).has_definite_inline_size()
+            && facts.has_preferred_aspect_ratio()
+            && box_is_sized_as_replaced_element;
+        let mut block_size = if box_is_sized_as_replaced_element {
             self.compute_block_size_for_replaced_element(node, available_space, constraints)
         } else {
             child_automatic_block_size.unwrap_or_else(automatic_block_size_fallback)
@@ -1236,7 +1241,11 @@ impl SizingContext {
                 block_size = block_size.max(size);
             }
         }
-        self.used(node).set_content_block_size(block_size);
+        let used = self.used(node);
+        used.set_content_block_size(block_size);
+        if block_size_is_definite_from_aspect_ratio {
+            used.has_definite_block_size.set(true);
+        }
     }
 
     pub(crate) fn resolve_box_model_metrics_against_inline_basis(&self, node: Node, containing_inline_size: CssPixels) {

--- a/Tests/LibWeb/Text/expected/css/relative-percentage-inset-through-aspect-ratio.txt
+++ b/Tests/LibWeb/Text/expected/css/relative-percentage-inset-through-aspect-ratio.txt
@@ -1,0 +1,6 @@
+root: y=0, height=100
+aspect-ratio-box: y=0, height=100
+percentage-height-box: y=0, height=100
+centered-box: y=-50, height=100
+float-root: height=100
+float-centered-box: y=-50, height=100

--- a/Tests/LibWeb/Text/expected/css/relative-percentage-inset-through-aspect-ratio.txt
+++ b/Tests/LibWeb/Text/expected/css/relative-percentage-inset-through-aspect-ratio.txt
@@ -1,6 +1,6 @@
 root: y=0, height=100
 aspect-ratio-box: y=0, height=100
 percentage-height-box: y=0, height=100
-centered-box: y=-50, height=100
+centered-box: y=0, height=100
 float-root: height=100
-float-centered-box: y=-50, height=100
+float-centered-box: y=0, height=100

--- a/Tests/LibWeb/Text/input/css/relative-percentage-inset-through-aspect-ratio.html
+++ b/Tests/LibWeb/Text/input/css/relative-percentage-inset-through-aspect-ratio.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #root {
+        width: 100px;
+    }
+
+    #aspect-ratio-box {
+        width: 100%;
+        height: 100%;
+        aspect-ratio: 1;
+    }
+
+    #percentage-height-box {
+        width: 100%;
+        height: 100%;
+    }
+
+    #centered-box {
+        position: relative;
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        aspect-ratio: 1;
+        max-width: 100%;
+        max-height: 100%;
+    }
+
+    #float-root {
+        float: left;
+        width: 100px;
+        height: 100%;
+        aspect-ratio: 1;
+    }
+
+    #float-percentage-height-box {
+        width: 100%;
+        height: 100%;
+    }
+
+    #float-centered-box {
+        position: relative;
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        aspect-ratio: 1;
+        max-width: 100%;
+        max-height: 100%;
+    }
+</style>
+
+<div id="root">
+    <div id="aspect-ratio-box">
+        <div id="percentage-height-box">
+            <div id="centered-box"></div>
+        </div>
+    </div>
+</div>
+
+<div id="float-root">
+    <div id="float-percentage-height-box">
+        <div id="float-centered-box"></div>
+    </div>
+</div>
+
+<script>
+    test(() => {
+        for (const id of ["root", "aspect-ratio-box", "percentage-height-box", "centered-box"]) {
+            const rect = document.getElementById(id).getBoundingClientRect();
+            println(`${id}: y=${rect.y}, height=${rect.height}`);
+        }
+
+        const floatRootRect = document.getElementById("float-root").getBoundingClientRect();
+        const floatCenteredBoxRect = document.getElementById("float-centered-box").getBoundingClientRect();
+        println(`float-root: height=${floatRootRect.height}`);
+        println(`float-centered-box: y=${floatCenteredBoxRect.y - floatRootRect.y}, height=${floatCenteredBoxRect.height}`);
+    });
+</script>


### PR DESCRIPTION
Block sizes produced by transferring a definite inline size through a preferred aspect ratio were not marked definite. As a result, percentage heights and block-axis insets in descendants could resolve without a basis, shifting content outside its container.

Resolve these block sizes before laying out descendants and retain their definiteness for percentage resolution. Add coverage for a relatively positioned descendant centered through a percentage-height intermediary.