### PR TITLE
UI/Qt: Size a background tab’s page before its first layout (and make Reuters.com usable)

### DIFF
--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -19,10 +19,6 @@ target_sources(TestEventLoopImplementation PRIVATE
 )
 set_target_properties(TestEventLoopImplementation PROPERTIES AUTOMOC ON)
 
-if (NOT LINUX)
-    return()
-endif()
-
 find_package(Qt6 QUIET COMPONENTS Gui Widgets)
 if (NOT Qt6_FOUND)
     return()
@@ -33,6 +29,37 @@ add_library(QtTestMain OBJECT
     "${LADYBIRD_SOURCE_DIR}/Libraries/LibTest/AssertionHandler.cpp"
 )
 target_link_libraries(QtTestMain PRIVATE AK LibCore LibTest Qt::Core Qt::Gui Qt::Widgets)
+
+# QtTestMain runs its tests on Qt's offscreen platform plugin, and on Windows nothing deploys that plugin where a test
+# binary can find it: The ladybird target's deploy step copies only the "windows" platform plugin into the bin/platforms
+# directory — and for a binary in a deployed layout, that directory is the whole platform-plugin search path. So a
+# QApplication there finds no platform plugin at all, which is fatal.
+# NB: On Windows, Qt puts up a modal message box before that abort whenever the process has no console window — and a
+# CI test process has none. So the test doesn't fail: It sits in the box until CTest's timeout kills it. Call this for
+# every test that links QtTestMain, so the plugin sits next to the test binary, where Qt looks for it.
+function(deploy_qt_offscreen_platform_plugin target)
+    if (NOT WIN32)
+        return()
+    endif()
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${target}>/platforms"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:Qt6::QOffscreenIntegrationPlugin>"
+            "$<TARGET_FILE_DIR:${target}>/platforms/"
+        VERBATIM
+    )
+endfunction()
+
+ladybird_test("TestHiddenPageSizing.cpp" UI/Qt
+    CUSTOM_MAIN "$<TARGET_OBJECTS:QtTestMain>"
+    LIBS Qt::Core Qt::Gui Qt::Widgets
+)
+target_sources(TestHiddenPageSizing PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/HiddenPageSizing.cpp")
+deploy_qt_offscreen_platform_plugin(TestHiddenPageSizing)
+
+if (NOT LINUX)
+    return()
+endif()
 
 ladybird_test("TestNativeWindowContainerFocus.cpp" UI/Qt LIBS Qt::Core Qt::Gui Qt::Widgets)
 target_sources(TestNativeWindowContainerFocus PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/NativeWindowContainer.cpp")

--- a/Tests/UI/Qt/TestHiddenPageSizing.cpp
+++ b/Tests/UI/Qt/TestHiddenPageSizing.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <UI/Qt/HiddenPageSizing.h>
+
+#include <QApplication>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+namespace {
+
+// The shape of a tab in the browser window: A page in a stacked widget, with a layout that gives one child (the
+// web view) the whole page.
+struct Page {
+    explicit Page(QStackedWidget& stack)
+        : widget(*new QWidget)
+        , child(*new QWidget(&widget))
+    {
+        auto* layout = new QVBoxLayout(&widget);
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->addWidget(&child);
+        stack.addWidget(&widget);
+    }
+
+    QWidget& widget;
+    QWidget& child;
+};
+
+}
+
+// A page that isn't the stacked widget's current page gets no geometry from it, and Qt doesn't lay a hidden page out
+// until it is shown — so its child keeps the default 100x30 after the window is shown and sized. That's the condition
+// the helper exists for — so the test pins it down before exercising the helper.
+TEST_CASE(hidden_page_follows_the_current_page_without_being_shown)
+{
+    QWidget window;
+    auto* stack = new QStackedWidget(&window);
+    auto* window_layout = new QVBoxLayout(&window);
+    window_layout->setContentsMargins(0, 0, 0, 0);
+    window_layout->addWidget(stack);
+
+    Page current(*stack);
+    Page hidden(*stack);
+    stack->setCurrentWidget(&current.widget);
+
+    window.resize(800, 600);
+    window.show();
+    QApplication::processEvents();
+
+    EXPECT_EQ(current.child.size(), QSize(800, 600));
+    EXPECT(!hidden.widget.isVisible());
+    EXPECT_NE(hidden.child.size(), current.child.size());
+
+    Ladybird::size_hidden_page_like(hidden.widget, current.widget);
+
+    EXPECT(!hidden.widget.isVisible());
+    EXPECT_EQ(hidden.widget.size(), current.widget.size());
+    EXPECT_EQ(hidden.child.size(), current.child.size());
+
+    // And the size sticks when the page is finally shown: Qt's deferred layout pass agrees with what was set.
+    stack->setCurrentWidget(&hidden.widget);
+    QApplication::processEvents();
+    EXPECT_EQ(hidden.child.size(), QSize(800, 600));
+}

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(ladybird PRIVATE
     EventLoopImplementationQtEventTarget.cpp
     FindInPageWidget.cpp
     Icon.cpp
+    HiddenPageSizing.cpp
     InputMethodUtils.cpp
     JavaScriptDialog.cpp
     LocationEdit.cpp

--- a/UI/Qt/HiddenPageSizing.cpp
+++ b/UI/Qt/HiddenPageSizing.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Qt/HiddenPageSizing.h>
+
+#include <QLayout>
+
+namespace Ladybird {
+
+void size_hidden_page_like(QWidget& page, QWidget const& current)
+{
+    page.resize(current.size());
+
+    // Resizing a hidden page updates its geometry, but not its children's: The page's layout runs only on its next
+    // activation, which Qt defers until the page is shown. Invalidating first makes activate() lay it out now.
+    if (auto* layout = page.layout()) {
+        layout->invalidate();
+        layout->activate();
+    }
+}
+
+}

--- a/UI/Qt/HiddenPageSizing.h
+++ b/UI/Qt/HiddenPageSizing.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <QWidget>
+
+namespace Ladybird {
+
+// Gives a page that isn't the current one in a stacked widget the current page's geometry, laid out now. The stacked
+// layout sizes only its current page, and Qt holds a hidden page's layout (and its resize event) back until the page
+// is shown. So without this, a hidden page and everything in it keep whatever geometry they last had — or, for a page
+// that's never been shown, Qt's default 100x30 — until the user selects the page.
+void size_hidden_page_like(QWidget& page, QWidget const& current);
+
+}

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -15,6 +15,7 @@
 #if defined(AK_OS_MACOS)
 #    include <UI/Qt/MacWindow.h>
 #endif
+#include <UI/Qt/HiddenPageSizing.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/TabBar.h>
@@ -1613,8 +1614,24 @@ void TabWidget::add_tab(Tab* widget, QString const& label)
     insert_tab(m_tab_bar->count(), widget, label);
 }
 
+// Sizing the hidden page's view alone doesn't hold: The page itself still has its placeholder geometry, and the next
+// pass of the page's own layout pulls the view back to it. So, give the whole page the current page's geometry, laid
+// out now — and only then push the view's viewport.
+static void size_page_like(Tab& page, Tab const& current)
+{
+    size_hidden_page_like(page, current);
+    page.view().push_viewport_size();
+}
+
 void TabWidget::insert_tab(int index, Tab* widget, QString const& label)
 {
+    // A page inserted behind the current one stays at Qt's default geometry until it's selected, and a load can start
+    // into it long before that. Size its view like the current page's view first — as Chrome does for a new background
+    // tab (TabStripModel::AddWebContents) — so the page's first layout sees the real viewport.
+    if (auto* current = as_if<Tab>(m_stacked_widget->currentWidget()); current && current != widget)
+        size_page_like(*widget, *current);
+    widget->view().installEventFilter(this);
+
     m_stacked_widget->insertWidget(index, widget);
     m_tab_bar->insertTab(index, label);
     widget->set_toolbar_container_in_tab_layout(false);
@@ -1640,6 +1657,7 @@ Tab* TabWidget::take_tab(int index)
         return nullptr;
 
     m_stacked_widget->removeWidget(widget);
+    as<Tab>(widget)->view().removeEventFilter(this);
     auto* toolbar = as<Tab>(widget)->toolbar_container();
     if (m_toolbar_container->indexOf(toolbar) != -1)
         m_toolbar_container->removeWidget(toolbar);
@@ -1779,6 +1797,11 @@ bool TabWidget::eventFilter(QObject* watched, QEvent* event)
     if (watched == window() && event->type() == QEvent::Leave)
         defer_update_vertical_tabs_hover_expanded();
 
+    if (event->type() == QEvent::Resize) {
+        if (auto* current = as_if<Tab>(m_stacked_widget->currentWidget()); current && watched == &current->view())
+            size_hidden_pages_like_the_current_one();
+    }
+
     if (watched == m_vertical_tabs_resize_handle) {
         auto reset_resize_handle = [this] {
             m_is_resizing_vertical_tabs = false;
@@ -1886,6 +1909,23 @@ void TabWidget::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
     update_tab_layout();
+}
+
+// The stacked layout sizes only the current page, so the tabs behind it keep stale geometry: Qt's default 100x30 for
+// a tab that was created before the window was first shown — which is every tab but the first on a command line, and
+// every restored one. Their pages may already be loading. So, whenever the current page's view gets its size, then size
+// every hidden page's view the same (Chrome keeps its background tabs at the window's size the same way).
+// NB: This hangs off the view's own resize event, not this widget's: At the window's first show, this widget is laid
+// out before the current page's child layout has run. So at that point the current view still has its placeholder size.
+void TabWidget::size_hidden_pages_like_the_current_one()
+{
+    auto* current = as_if<Tab>(m_stacked_widget->currentWidget());
+    if (!current)
+        return;
+    for (int i = 0; i < m_stacked_widget->count(); ++i) {
+        if (auto* page = as_if<Tab>(m_stacked_widget->widget(i)); page && page != current)
+            size_page_like(*page, *current);
+    }
 }
 
 void TabWidget::accept_tab_drag(QDragMoveEvent* event)

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -221,6 +221,8 @@ private:
     void accept_tab_drop(QDropEvent*, int index);
 
     TabBar* m_tab_bar { nullptr };
+    void size_hidden_pages_like_the_current_one();
+
     QStackedWidget* m_stacked_widget { nullptr };
     QToolButton* m_new_tab_button { nullptr };
     QToolButton* m_minimize_window_button { nullptr };

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -1143,6 +1143,15 @@ void WebContentView::set_viewport_rect(Gfx::IntRect rect)
     handle_resize();
 }
 
+// A view in a tab that isn't the current one gets its geometry, but Qt holds the resize event back until the tab is
+// shown — so the page's first layout would run against whatever the viewport was before, and whatever a script
+// computes from that sticks even after the tab is selected and laid out for real. This pushes the viewport for the
+// geometry the view has now — without waiting for that event.
+void WebContentView::push_viewport_size()
+{
+    update_viewport_size();
+}
+
 void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
 {
     m_device_pixel_ratio = device_pixel_ratio;

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -107,6 +107,7 @@ public:
     virtual bool event(QEvent*) override;
 
     void set_viewport_rect(Gfx::IntRect);
+    void push_viewport_size();
     void set_device_pixel_ratio(double);
     void set_zoom_level(double);
     void set_maximum_frames_per_second(double);


### PR DESCRIPTION
**Problem:** https://reuters.com never finished loading in a tab that wasn’t the one the user was looking at — a restored tab, or any URL after the first on the command line. The tab showed nothing, pinned a core, and kept its WebContent process allocating memory for as long as it stayed open.

**Cause:** A tab that isn’t the tab widget’s current page gets no geometry from Qt’s stacked layout, and Qt holds back a hidden page’s own layout — and its view’s resize event — until the page is shown. So, the page kept Qt’s default 100x30 geometry, `WebContentView` reported that as the viewport, and the document was laid out 100px wide. Reuters’ carousel takes its page step from its container’s `clientWidth` — which came out 0 in a window that narrow. So, its loop pushing page offsets until they reach `scrollWidth` never got anywhere. And nothing corrected the size later: The resize event only arrives once the user selects the tab — and by then, the script has long since run.

**Fix:** Give a hidden page the current page’s geometry, laid out right away. And push its view’s viewport at once: when the page is inserted behind the current one, and again whenever the current page’s view is resized — since on a window’s first show, that’s the moment the real size exists (the tab widget itself is laid out before the current page’s child layout has run). That’s what Chrome does for a new background tab, in `TabStripModel::AddWebContents`: It sizes the new `WebContents` to the active one’s bounds before Blink’s first layout — for exactly this reason. The pure-Qt part lives in `size_hidden_page_like()`.
