### PR TITLE
Meta: Resolve frames placed directly under a tagged-backtrace

### DIFF
--- a/Meta/analyze-xctrace-time-profile.py
+++ b/Meta/analyze-xctrace-time-profile.py
@@ -59,8 +59,10 @@ def inclusive_weights(path):
                 if reference := column.get("ref"):
                     names = tagged_backtraces[reference]
                     continue
+                # xctrace 16.0 (Xcode 26) nests a backtrace element inside each tagged-backtrace, and xctrace 27.0
+                # (Xcode 27) puts the frame elements directly under it — so resolve whichever element holds the frames.
                 backtrace = column.find("backtrace")
-                names = [] if backtrace is None else _resolve_backtrace(backtrace, frames, backtraces)
+                names = _resolve_backtrace(column if backtrace is None else backtrace, frames, backtraces)
                 if identity := column.get("id"):
                     tagged_backtraces[identity] = names
 

--- a/Tests/Meta/test-xctrace-time-profile.py
+++ b/Tests/Meta/test-xctrace-time-profile.py
@@ -35,6 +35,26 @@ class TestXctraceTimeProfile(unittest.TestCase):
         self.assertEqual(sample_count, 3)
         self.assertEqual(weights, {"leaf": 4_000_000, "caller": 2_000_000, "outer": 2_000_000})
 
+    def test_resolves_frames_placed_directly_under_tagged_backtrace(self):
+        exported_table = """<?xml version="1.0"?>
+<trace-query-result><node>
+<row><weight id="1">1000000</weight><tagged-backtrace id="2">
+<frame id="3" name="leaf"/><frame id="4" name="caller"/>
+</tagged-backtrace></row>
+<row><weight ref="1"/><tagged-backtrace ref="2"/></row>
+<row><weight id="5">2000000</weight><tagged-backtrace id="6">
+<frame ref="3"/><frame id="7" name="outer"/>
+</tagged-backtrace></row>
+</node></trace-query-result>
+"""
+        with tempfile.NamedTemporaryFile("w", suffix=".xml") as export:
+            export.write(exported_table)
+            export.flush()
+            sample_count, weights = MODULE["inclusive_weights"](export.name)
+
+        self.assertEqual(sample_count, 3)
+        self.assertEqual(weights, {"leaf": 4_000_000, "caller": 2_000_000, "outer": 2_000_000})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Problem:** `analyze-xctrace-time-profile.py`, when run with the xctrace in Xcode 27 beta, printed the sample count, and then an empty table for every export — so a WebContent profile couldn’t be summarized at all.

**Cause:** `inclusive_weights()` only looked for a `backtrace` element nested inside each `tagged-backtrace` column — which is where Xcode 26 xctrace puts the frames. But xctrace 27.0 emits the frame elements directly under `tagged-backtrace` — so the column’s search for a nested backtrace came back empty on every row. Every sample resolved to no frames — and no weight was attributed anywhere.

**Fix:** Resolve the frames from whichever element holds them: the nested `backtrace` when there is one — and otherwise, the `tagged-backtrace` column itself. No behavior change; exports still summarize the same way.
