### PR TITLE
Let the layout node arena own node lifetime and anonymous boxes

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -787,6 +787,7 @@ set(SOURCES
     Internals/XRTest.cpp
     IntersectionObserver/IntersectionObserver.cpp
     IntersectionObserver/IntersectionObserverEntry.cpp
+    Layout/AnonymousBoxStyle.cpp
     Layout/Box.cpp
     Layout/ImageProvider.cpp
     Layout/LayoutRustBridge.cpp

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -2157,22 +2157,13 @@ public:
     {
     }
 
-    static LayoutStyle adopting_pinned_style_record(StyleRecordID style_record_identity)
-    {
-        LayoutStyle style { style_record_identity };
-        style.m_adopts_style_record_pin = true;
-        return style;
-    }
-
     explicit operator bool() const { return !!m_style_record_identity || m_values; }
     [[nodiscard]] StyleRecordID style_record_identity() const { return m_style_record_identity; }
-    [[nodiscard]] bool adopts_style_record_pin() const { return m_adopts_style_record_pin; }
     [[nodiscard]] RefPtr<ComputedValues const> const& values() const { return m_values; }
 
 private:
     RefPtr<ComputedValues const> m_values;
     StyleRecordID m_style_record_identity;
-    bool m_adopts_style_record_pin { false };
 };
 
 class ComputedValues::Mutator final {

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1266,9 +1266,11 @@ private:
 
 public:
     ReadonlySpan<Utf16FlyString> anchor_names() const { return m_noninherited.anchor->anchor_names_span(); }
+    PositionAnchor position_anchor_value() const { return m_noninherited.anchor->position_anchor_value(); }
     Vector<ComputedAnimationName> animation_names() const { return m_noninherited.animation->animation_names_value(); }
 
     Float float_() const { return static_cast<Float>(m_noninherited.box->float_); }
+    Clear clear() const { return static_cast<Clear>(m_noninherited.box->clear); }
     Color caret_color() const { return m_inherited.ui->caret_color_value(); }
     Clip clip() const { return m_noninherited.effects->clip_value(); }
     ColorInterpolation color_interpolation() const { return m_inherited.svg->color_interpolation_value(); }
@@ -1306,6 +1308,7 @@ public:
     WhiteSpaceCollapse white_space_collapse() const { return m_inherited.text->white_space_collapse_value(); }
     FlexDirection flex_direction() const { return static_cast<FlexDirection>(m_noninherited.alignment->flex_direction); }
     AlignSelf align_self() const { return static_cast<AlignSelf>(m_noninherited.alignment->align_self); }
+    int order() const { return m_noninherited.alignment->order; }
     Appearance appearance() const { return static_cast<Appearance>(m_noninherited.misc->appearance); }
     float opacity() const { return m_noninherited.effects->opacity; }
     Visibility visibility() const { return static_cast<Visibility>(m_inherited.box->visibility); }
@@ -2154,13 +2157,22 @@ public:
     {
     }
 
+    static LayoutStyle adopting_pinned_style_record(StyleRecordID style_record_identity)
+    {
+        LayoutStyle style { style_record_identity };
+        style.m_adopts_style_record_pin = true;
+        return style;
+    }
+
     explicit operator bool() const { return !!m_style_record_identity || m_values; }
     [[nodiscard]] StyleRecordID style_record_identity() const { return m_style_record_identity; }
+    [[nodiscard]] bool adopts_style_record_pin() const { return m_adopts_style_record_pin; }
     [[nodiscard]] RefPtr<ComputedValues const> const& values() const { return m_values; }
 
 private:
     RefPtr<ComputedValues const> m_values;
     StyleRecordID m_style_record_identity;
+    bool m_adopts_style_record_pin { false };
 };
 
 class ComputedValues::Mutator final {

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -119,29 +119,25 @@ Optional<AbstractElement> AbstractElement::element_to_inherit_style_from() const
 Optional<AbstractElement> AbstractElement::walk_layout_tree(WalkMethod walk_method)
 {
     // NB: Called during style recalculation.
-    Layout::Node* node = unsafe_layout_node();
-    if (!node)
+    Layout::Node* start_node = unsafe_layout_node();
+    if (!start_node)
         return OptionalNone {};
 
+    auto* arena_handle = start_node->arena_handle();
+    auto slot = Layout::Node::slot_id(start_node);
     while (true) {
-        switch (walk_method) {
-        case WalkMethod::Previous:
-            node = node->previous_in_pre_order();
-            break;
-        case WalkMethod::PreviousSibling:
-            node = node->previous_sibling();
-            break;
-        }
-        if (!node)
+        slot = Layout::RustFFI::layout_arena_previous_dom_backed_or_generated_node(arena_handle, slot, walk_method == WalkMethod::PreviousSibling);
+        if (slot.index == Layout::RustFFI::INVALID_NODE_SLOT_INDEX)
             return OptionalNone {};
 
-        if (auto* previous_element = as_if<Element>(node->dom_node()))
+        if (auto* previous_element = as_if<Element>(static_cast<Node*>(Layout::RustFFI::layout_arena_node_dom_node(arena_handle, slot))))
             return AbstractElement { *previous_element };
 
-        if (node->is_generated_for_pseudo_element()) {
-            auto pseudo_element = node->generated_for_pseudo_element();
+        auto* generated_node = static_cast<Layout::Node*>(Layout::RustFFI::layout_arena_node_shell_if_live(arena_handle, slot));
+        if (generated_node && generated_node->is_generated_for_pseudo_element()) {
+            auto pseudo_element = generated_node->generated_for_pseudo_element();
             if (pseudo_element.has_value() && CSS::is_tree_abiding_pseudo_element(*pseudo_element))
-                return AbstractElement { *node->pseudo_element_generator(), pseudo_element };
+                return AbstractElement { *generated_node->pseudo_element_generator(), pseudo_element };
         }
     }
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -10247,20 +10247,20 @@ void Document::register_scroll_snap_container(Layout::Node const& snap_container
     m_scroll_snap_containers.append(snap_container.make_weak_ptr());
 }
 
-Vector<NonnullRefPtr<Layout::Node const>> Document::collect_scroll_snap_containers()
+Vector<WeakPtr<Layout::Node const>> Document::collect_scroll_snap_containers()
 {
     // A registered box whose layout node a style or layout update dropped is no longer a box of this document.
     m_scroll_snap_containers.remove_all_matching([](auto const& registered) {
         return !registered;
     });
 
-    Vector<NonnullRefPtr<Layout::Node const>> snap_containers;
+    Vector<WeakPtr<Layout::Node const>> snap_containers;
     snap_containers.ensure_capacity(m_scroll_snap_containers.size());
     for (auto const& registered : m_scroll_snap_containers) {
         // The scroll snap properties of a registered box can stop making it a snap container without its layout node
         // being rebuilt, and a registered box the latest commit left out has no committed box to snap with.
         if (Painting::has_committed_box(*registered) && Painting::is_scroll_snap_container(*registered))
-            snap_containers.unchecked_append(*registered);
+            snap_containers.unchecked_append(registered);
     }
     return snap_containers;
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -668,7 +668,11 @@ Document::Document(Page& page, GC::Ref<EventTarget> relevant_global_event_target
     HTML::main_thread_event_loop().register_document({}, *this);
 }
 
-Document::~Document() = default;
+Document::~Document()
+{
+    if (m_layout_root)
+        m_layout_node_arena->free_subtree(Layout::Node::slot_id(m_layout_root));
+}
 
 void Document::synchronize_dirty_style_attributes()
 {
@@ -1474,9 +1478,13 @@ WebIDL::ExceptionOr<void> Document::set_title(Utf16View title)
 
 void Document::set_layout_root(Layout::Viewport& viewport)
 {
-    if (m_layout_root.ptr() == &viewport)
+    if (m_layout_root == &viewport)
         return;
-    m_layout_root = viewport;
+    if (auto* replaced_layout_root = exchange(m_layout_root, nullptr)) {
+        replaced_layout_root->prepare_subtree_for_detach_from_layout_tree();
+        layout_node_arena().free_subtree(Layout::Node::slot_id(replaced_layout_root));
+    }
+    m_layout_root = &viewport;
     m_paint_state = make<Painting::DocumentPaintState>(layout_node_arena());
 }
 
@@ -1486,7 +1494,8 @@ void Document::tear_down_layout_tree()
         m_layout_root->prepare_subtree_for_detach_from_layout_tree();
     m_hit_test_display_list = nullptr;
     m_chrome_widget_registry->clear();
-    m_layout_root = nullptr;
+    if (auto* layout_root = exchange(m_layout_root, nullptr))
+        layout_node_arena().free_subtree(Layout::Node::slot_id(layout_root));
     m_paint_state = nullptr;
     if (m_layout_node_arena)
         Layout::RustFFI::layout_arena_clear_scrollable_overflow_contained_boxes(m_layout_node_arena->handle());
@@ -1902,7 +1911,7 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed, Layout
     // contained-boxes index; refresh it before overflow measurement follows them. A pending full
     // recalculation rebuilds the index inside its own measurement traversal instead.
     if (layout_tree_changed == LayoutTreeChanged::Yes && !Layout::RustFFI::layout_arena_needs_full_scrollable_overflow_recalculation(layout_node_arena().handle()))
-        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root.ptr()));
+        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
     if (layout_commit_scope == LayoutCommitScope::Full)
         update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::HandledByFullLayoutCommit);
     else
@@ -2249,7 +2258,7 @@ Document::PartialRelayoutResult Document::try_partial_relayout(Vector<Layout::Ru
     if (needs_layout_tree_rebuild) {
         auto tree_build_timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
         auto tree_build_result = Layout::build_layout_tree(*this);
-        set_layout_root(as<Layout::Viewport>(*tree_build_result.root));
+        set_layout_root(*tree_build_result.root);
         record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
         needs_layout_tree_rebuild = false;
         if (reconcile_stale_list_item_counters_after_tree_build(tree_build_result.rebuilt_subtree_roots) || tree_build_result.needs_another_build_pass)
@@ -2402,7 +2411,7 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
 
         if (needs_layout_tree_rebuild) {
             auto tree_build_result = Layout::build_layout_tree(*this);
-            set_layout_root(as<Layout::Viewport>(*tree_build_result.root));
+            set_layout_root(*tree_build_result.root);
             record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
 
             // NB: Called during layout update.
@@ -2445,7 +2454,7 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
             viewport_rect.width(),
             viewport_rect.height(),
             should_collect_devtools_layout_data);
-        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root.ptr()));
+        Layout::RustFFI::layout_arena_rebuild_scrollable_overflow_contained_boxes(layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
 
         style_invalidation_counters().relayouts_performed++;
 
@@ -2456,7 +2465,7 @@ void Document::update_layout(UpdateLayoutReason reason, ThrottledAnimationSampli
         after_layout_commit(LayoutTreeChanged::Yes, LayoutCommitScope::Full);
 
         Layout::RustFFI::layout_arena_reset_layout_update_flags_in_subtree(
-            layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root.ptr()));
+            layout_node_arena().handle(), Layout::Node::slot_id(m_layout_root));
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("LAYOUT {} {} µs", to_string(reason), timer.elapsed_time().to_microseconds());

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -884,6 +884,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_previously_repainted_cursor_position);
     if (m_hit_test_display_list)
         m_hit_test_display_list->visit_edges(visitor);
+    if (m_layout_node_arena)
+        m_layout_node_arena->visit_dom_nodes(visitor);
     visitor.visit(m_editing_host_manager);
     visitor.visit(m_editing_history);
     visitor.visit(m_local_storage_holder);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -693,6 +693,7 @@ Layout::NodeArena& Document::layout_node_arena()
     // fragment-parsing documents) skip the Rust arena round-trip entirely.
     if (!m_layout_node_arena) {
         m_layout_node_arena = make_ref_counted<Layout::NodeArena>();
+        m_layout_node_arena->set_document({}, this);
         Layout::RustFFI::layout_arena_set_chrome_state_callback(
             m_layout_node_arena->handle(), this,
             [](void* context, Layout::RustFFI::NodeSlotId slot, Layout::RustFFI::PaintableRowResetKind kind) {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -203,7 +203,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 #include <LibWeb/Layout/AnonymousBoxStyle.h>
-#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -711,6 +711,23 @@ Layout::NodeArena& Document::layout_node_arena()
             .shell_style_changed = [](void*, void* shell) { as<Layout::NodeWithStyle>(*static_cast<Layout::Node*>(shell)).refresh_style_from_arena(); },
         };
         Layout::RustFFI::layout_arena_set_style_record_host_callbacks(m_layout_node_arena->handle(), style_record_host_callbacks);
+        Layout::RustFFI::layout_arena_set_shell_factory(m_layout_node_arena->handle(), this, [](void* context, Layout::RustFFI::NodeSlotId slot, Layout::RustFFI::NodeKind kind) {
+            auto& document = *static_cast<Document*>(context);
+            switch (kind) {
+            case Layout::RustFFI::NodeKind::BlockContainer:
+            case Layout::RustFFI::NodeKind::TableWrapper:
+                Layout::allocate_layout_node<Layout::BlockContainer>(document, Layout::BindToPreparedArenaSlot::Yes, slot, kind);
+                return;
+            case Layout::RustFFI::NodeKind::Box:
+                Layout::allocate_layout_node<Layout::Box>(document, Layout::BindToPreparedArenaSlot::Yes, slot, kind);
+                return;
+            case Layout::RustFFI::NodeKind::InlineNode:
+                Layout::allocate_layout_node<Layout::NodeWithStyle>(document, Layout::BindToPreparedArenaSlot::Yes, slot, kind).attach_style_resources();
+                return;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        });
         Layout::RustFFI::layout_arena_set_chrome_state_callback(
             m_layout_node_arena->handle(), this,
             [](void* context, Layout::RustFFI::NodeSlotId slot, Layout::RustFFI::PaintableRowResetKind kind) {
@@ -743,6 +760,7 @@ void Document::finalize()
     if (m_layout_node_arena) {
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
         Layout::RustFFI::layout_arena_clear_style_record_host_callbacks(m_layout_node_arena->handle());
+        Layout::RustFFI::layout_arena_clear_shell_factory(m_layout_node_arena->handle());
         VERIFY(Layout::RustFFI::layout_arena_live_slot_count(m_layout_node_arena->handle()) == 0);
         m_layout_node_arena->set_document({}, nullptr);
     }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -704,6 +704,11 @@ Layout::NodeArena& Document::layout_node_arena()
                 return { .record = reinherited_style_record.value(), .payloads = style_computer.style_record_payloads(reinherited_style_record) };
             },
             .unpin_style_record = [](void* context, u64 style_record) { static_cast<Document*>(context)->style_computer().unpin_style_record(CSS::StyleRecordID { style_record }); },
+            .reinherit_owned_anonymous_box_style = [](void*, void* shell, u64 parent_style_record) -> bool {
+                return as<Layout::NodeWithStyle>(*static_cast<Layout::Node*>(shell)).reinherit_owned_computed_values_from(CSS::StyleRecordID { parent_style_record });
+            },
+            .reset_table_box_style_used_by_wrapper = [](void*, void* table_box_shell) { as<Layout::Box>(*static_cast<Layout::Node*>(table_box_shell)).reset_table_box_computed_values_used_by_wrapper_to_init_values(); },
+            .shell_style_changed = [](void*, void* shell) { as<Layout::NodeWithStyle>(*static_cast<Layout::Node*>(shell)).refresh_style_from_arena(); },
         };
         Layout::RustFFI::layout_arena_set_style_record_host_callbacks(m_layout_node_arena->handle(), style_record_host_callbacks);
         Layout::RustFFI::layout_arena_set_chrome_state_callback(

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -668,11 +668,7 @@ Document::Document(Page& page, GC::Ref<EventTarget> relevant_global_event_target
     HTML::main_thread_event_loop().register_document({}, *this);
 }
 
-Document::~Document()
-{
-    if (m_layout_root)
-        m_layout_node_arena->free_subtree(Layout::Node::slot_id(m_layout_root));
-}
+Document::~Document() = default;
 
 void Document::synchronize_dirty_style_attributes()
 {
@@ -722,8 +718,12 @@ void Document::record_layout_tree_build(u64 rebuilt_subtree_root_count, bool esc
 void Document::finalize()
 {
     stop_compositor_animation_timers();
-    if (m_layout_node_arena)
+    tear_down_layout_tree();
+    if (m_layout_node_arena) {
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
+        VERIFY(Layout::RustFFI::layout_arena_live_slot_count(m_layout_node_arena->handle()) == 0);
+        m_layout_node_arena->set_document({}, nullptr);
+    }
     CSS::ComputedValuesFFI::rust_custom_property_registry_destroy(m_rust_custom_property_registry);
     Base::finalize();
     HTML::main_thread_event_loop().unregister_document({}, *this);
@@ -5912,9 +5912,8 @@ void Document::destroy()
     // 6. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
     run_unloading_cleanup_steps();
 
-    // AD-HOC: Destruction does not go through did_stop_being_active_document_in_navigable(),
-    //         but stale per-node and root layout pointers can still keep the old
-    //         layout tree alive until GC runs.
+    // AD-HOC: Destruction does not go through did_stop_being_active_document_in_navigable().
+    //         Tear the layout tree down now instead of holding it until finalization.
     clear_layout_nodes_for_inactive_document();
     tear_down_layout_tree();
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -202,6 +202,7 @@
 #include <LibWeb/Infra/SerializedURL.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
+#include <LibWeb/Layout/AnonymousBoxStyle.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
@@ -690,6 +691,21 @@ Layout::NodeArena& Document::layout_node_arena()
     if (!m_layout_node_arena) {
         m_layout_node_arena = make_ref_counted<Layout::NodeArena>();
         m_layout_node_arena->set_document({}, this);
+        Layout::RustFFI::FfiStyleRecordHostCallbacks style_record_host_callbacks {
+            .context = this,
+            .derive_anonymous_style_record = [](void* context, u64 parent_style_record, Layout::RustFFI::FfiAnonymousStyleKind kind, Layout::RustFFI::FfiAnonymousStyleOverrides overrides) -> Layout::RustFFI::FfiDerivedStyleRecord {
+                auto& style_computer = static_cast<Document*>(context)->style_computer();
+                auto style_record = Layout::derive_pinned_anonymous_box_style_record(style_computer, CSS::StyleRecordID { parent_style_record }, kind, overrides);
+                return { .record = style_record.value(), .payloads = style_computer.style_record_payloads(style_record) };
+            },
+            .reinherit_anonymous_style_record = [](void* context, u64 style_record, u64 parent_style_record) -> Layout::RustFFI::FfiDerivedStyleRecord {
+                auto& style_computer = static_cast<Document*>(context)->style_computer();
+                auto reinherited_style_record = Layout::reinherit_pinned_anonymous_box_style_record(style_computer, CSS::StyleRecordID { style_record }, CSS::StyleRecordID { parent_style_record });
+                return { .record = reinherited_style_record.value(), .payloads = style_computer.style_record_payloads(reinherited_style_record) };
+            },
+            .unpin_style_record = [](void* context, u64 style_record) { static_cast<Document*>(context)->style_computer().unpin_style_record(CSS::StyleRecordID { style_record }); },
+        };
+        Layout::RustFFI::layout_arena_set_style_record_host_callbacks(m_layout_node_arena->handle(), style_record_host_callbacks);
         Layout::RustFFI::layout_arena_set_chrome_state_callback(
             m_layout_node_arena->handle(), this,
             [](void* context, Layout::RustFFI::NodeSlotId slot, Layout::RustFFI::PaintableRowResetKind kind) {
@@ -721,6 +737,7 @@ void Document::finalize()
     tear_down_layout_tree();
     if (m_layout_node_arena) {
         Layout::RustFFI::layout_arena_clear_chrome_state_callback(m_layout_node_arena->handle());
+        Layout::RustFFI::layout_arena_clear_style_record_host_callbacks(m_layout_node_arena->handle());
         VERIFY(Layout::RustFFI::layout_arena_live_slot_count(m_layout_node_arena->handle()) == 0);
         m_layout_node_arena->set_document({}, nullptr);
     }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1188,7 +1188,7 @@ public:
     [[nodiscard]] bool may_have_scroll_snap_areas() const { return m_may_have_scroll_snap_areas; }
 
     void register_scroll_snap_container(Layout::Node const&);
-    [[nodiscard]] Vector<NonnullRefPtr<Layout::Node const>> collect_scroll_snap_containers();
+    [[nodiscard]] Vector<WeakPtr<Layout::Node const>> collect_scroll_snap_containers();
 
     virtual Vector<Utf16FlyString> supported_property_names() const override;
     Vector<GC::Ref<DOM::Element>> const& potentially_named_elements() const { return m_potentially_named_elements; }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1566,7 +1566,7 @@ private:
     RefPtr<Layout::NodeArena> m_layout_node_arena;
     OwnPtr<Painting::DocumentPaintState> m_paint_state;
     NonnullRefPtr<Painting::ChromeWidgetRegistry> m_chrome_widget_registry;
-    RefPtr<Layout::Viewport> m_layout_root;
+    Layout::Viewport* m_layout_root { nullptr };
     bool m_may_have_content_visibility_auto_style { false };
 
     GC::Ptr<Node> m_hovered_node;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1235,7 +1235,7 @@ Optional<GC::RootVector<GC::Ref<DOM::Element>>> Element::get_the_attribute_assoc
     return elements;
 }
 
-RefPtr<Layout::Node> Element::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* Element::create_layout_node(CSS::LayoutStyle style)
 {
     if (local_name() == u"noscript"sv && document().is_scripting_enabled())
         return nullptr;
@@ -1246,26 +1246,26 @@ RefPtr<Layout::Node> Element::create_layout_node(CSS::LayoutStyle style)
     return create_layout_node_for_display_type(document(), display, style, this);
 }
 
-RefPtr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, CSS::LayoutStyle style, Element* element)
+Layout::NodeWithStyle* Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, CSS::LayoutStyle style, Element* element)
 {
     if (display.is_none())
-        return {};
+        return nullptr;
 
     if (display.is_contents())
-        return {};
+        return nullptr;
 
     if (display.is_table_inside() || display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group() || display.is_table_row())
-        return make_ref_counted<Layout::Box>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::Box>(document, element, style);
 
     if (display.is_list_item())
-        return make_ref_counted<Layout::BlockContainer>(document, element, style, Layout::RustFFI::NodeKind::ListItemBox);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style, Layout::RustFFI::NodeKind::ListItemBox);
 
     if (display.is_table_cell())
-        return make_ref_counted<Layout::BlockContainer>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
 
     if (display.is_table_column() || display.is_table_column_group() || display.is_table_caption()) {
         // FIXME: This is just an incorrect placeholder until we improve table layout support.
-        return make_ref_counted<Layout::BlockContainer>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
     }
 
     if (display.is_math_inside()) {
@@ -1273,35 +1273,35 @@ RefPtr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM::
         // MathML elements with a computed display value equal to block math or inline math control box generation
         // and layout according to their tag name, as described in the relevant sections.
         // FIXME: Figure out what kind of node we should make for them. For now, we'll stick with a generic Box.
-        return make_ref_counted<Layout::BlockContainer>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
     }
 
     if (display.is_inline_outside()) {
         if (display.is_flow_root_inside())
-            return make_ref_counted<Layout::BlockContainer>(document, element, style);
+            return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
         if (display.is_flow_inside())
-            return make_ref_counted<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
+            return &Layout::allocate_layout_node<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
         if (display.is_flex_inside())
-            return make_ref_counted<Layout::Box>(document, element, style);
+            return &Layout::allocate_layout_node<Layout::Box>(document, element, style);
         if (display.is_grid_inside())
-            return make_ref_counted<Layout::Box>(document, element, style);
+            return &Layout::allocate_layout_node<Layout::Box>(document, element, style);
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Support display: {}", display.to_string());
-        return make_ref_counted<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
+        return &Layout::allocate_layout_node<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
     }
 
     if (display.is_flex_inside() || display.is_grid_inside())
-        return make_ref_counted<Layout::Box>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::Box>(document, element, style);
 
     if (display.is_flow_inside() || display.is_flow_root_inside())
-        return make_ref_counted<Layout::BlockContainer>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
 
     dbgln("FIXME: CSS display '{}' not implemented yet.", display.to_string());
 
     // FIXME: We don't actually support `display: block ruby`, this is just a hack to prevent a crash
     if (display.is_ruby_inside())
-        return make_ref_counted<Layout::BlockContainer>(document, element, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document, element, style);
 
-    return make_ref_counted<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
+    return &Layout::allocate_layout_node<Layout::NodeWithStyle>(document, element, style, Layout::RustFFI::NodeKind::InlineNode);
 }
 
 void Element::apply_presentational_hints(Vector<CSS::StyleProperty>& properties) const
@@ -3235,7 +3235,7 @@ void Element::clear_synthetic_pseudo_element_layout_nodes()
                 return TraversalDecision::Continue;
             });
             layout_node->prepare_subtree_for_detach_from_layout_tree();
-            Layout::detach_layout_node_for_destruction(*layout_node);
+            Layout::destroy_layout_subtree(*layout_node);
         }
         pseudo_element.set_layout_node(nullptr);
     });

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -578,14 +578,14 @@ public:
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean() const;
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean(Painting::AccumulatedVisualContextTree const&) const;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle);
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle);
 
     virtual void did_receive_focus() { }
     virtual void did_lose_focus() { }
     bool should_indicate_focus() const;
     virtual bool is_focusable() const override;
 
-    static RefPtr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, CSS::LayoutStyle, Element*);
+    static Layout::NodeWithStyle* create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, CSS::LayoutStyle, Element*);
 
     void set_synthetic_pseudo_element_node(Badge<Layout::LayoutTreeBuilderAccess>, CSS::PseudoElement, Layout::NodeWithStyle*);
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1184,8 +1184,8 @@ static bool can_detach_layout_subtree_for_removal(Node const& node, Node const& 
         // content directly in the parent instead.
         bool an_anonymous_inline_wrapper_remains = false;
         bool an_in_flow_block_level_sibling_remains = false;
-        for (auto sibling = parent_layout_node->first_child(); sibling; sibling = sibling->next_sibling()) {
-            if (sibling.ptr() == layout_node)
+        for (auto const* sibling = parent_layout_node->first_child(); sibling; sibling = sibling->next_sibling()) {
+            if (sibling == layout_node)
                 continue;
             if (auto const* sibling_with_style = as_if<Layout::NodeWithStyle>(*sibling); sibling_with_style && sibling_with_style->is_out_of_flow())
                 continue;
@@ -1350,7 +1350,7 @@ void Node::remove(bool suppress_observers)
             if (auto* first_letter_owner = first_letter_owner_for_layout_subtree_from(*parent)) {
                 first_letter_owner->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::NodeRemove);
             } else if (can_detach_layout_subtree_for_removal(*this, *parent)) {
-                RefPtr<Layout::Node> layout_node = unsafe_layout_node();
+                auto* layout_node = unsafe_layout_node();
                 layout_node->for_each_in_inclusive_subtree([](Layout::Node& node) {
                     node.clear_committed_box();
                     return TraversalDecision::Continue;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1356,7 +1356,7 @@ void Node::remove(bool suppress_observers)
                     return TraversalDecision::Continue;
                 });
                 layout_node->prepare_subtree_for_detach_from_layout_tree();
-                VERIFY(Layout::detach_layout_node_for_destruction(*layout_node));
+                VERIFY(Layout::destroy_layout_subtree(*layout_node));
                 if (auto* parent_layout_node = parent->unsafe_layout_node(); !parent_layout_node->has_children())
                     parent_layout_node->set_children_are_inline(false);
                 parent->set_needs_layout_update(SetNeedsLayoutReason::LayoutTreeUpdate);
@@ -2428,7 +2428,7 @@ void Node::removed_from(IsSubtreeRoot, Node* old_parent, Node&)
     if (m_layout_node) {
         if (auto* top_layer_placement = m_layout_node->topmost_layout_node_of_top_layer_placement()) {
             top_layer_placement->prepare_subtree_for_detach_from_layout_tree();
-            VERIFY(Layout::detach_layout_node_for_destruction(*top_layer_placement));
+            VERIFY(Layout::destroy_layout_subtree(*top_layer_placement));
         }
     }
     m_layout_node = nullptr;

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -22,11 +22,11 @@ HTMLAudioElement::HTMLAudioElement(DOM::Document& document, DOM::QualifiedName q
 
 HTMLAudioElement::~HTMLAudioElement() = default;
 
-RefPtr<Layout::Node> HTMLAudioElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLAudioElement::create_layout_node(CSS::LayoutStyle style)
 {
-    auto audio_box = make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::AudioBox);
-    audio_box->set_replaced_box_can_have_children(shadow_root() != nullptr);
-    return audio_box;
+    auto& audio_box = Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::AudioBox);
+    audio_box.set_replaced_box_can_have_children(shadow_root() != nullptr);
+    return &audio_box;
 }
 
 bool HTMLAudioElement::should_paint() const

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -21,7 +21,7 @@ public:
 
 private:
     HTMLAudioElement(DOM::Document&, DOM::QualifiedName);
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -25,9 +25,9 @@ HTMLBRElement::HTMLBRElement(DOM::Document& document, DOM::QualifiedName qualifi
 
 HTMLBRElement::~HTMLBRElement() = default;
 
-RefPtr<Layout::Node> HTMLBRElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLBRElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::NodeWithStyle>(document(), *this, style, Layout::RustFFI::NodeKind::BreakNode);
+    return &Layout::allocate_layout_node<Layout::NodeWithStyle>(document(), *this, style, Layout::RustFFI::NodeKind::BreakNode);
 }
 
 bool HTMLBRElement::is_presentational_hint(Utf16FlyString const& name) const

--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -17,7 +17,7 @@ class HTMLBRElement final : public HTMLElement {
 public:
     virtual ~HTMLBRElement() override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
     // Whether this <br> renders an empty line, i.e. nothing else renders between the start of its line and the <br>

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -248,9 +248,9 @@ void HTMLCanvasElement::attribute_changed(Utf16FlyString const& local_name, Opti
     }
 }
 
-RefPtr<Layout::Node> HTMLCanvasElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLCanvasElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::CanvasBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::CanvasBox);
 }
 
 HTMLCanvasElement::HasOrCreatedContext HTMLCanvasElement::create_2d_context(CanvasRenderingContext2DSettings context_attributes)

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -86,7 +86,7 @@ private:
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     template<typename ContextType>
     JS::ThrowCompletionOr<HasOrCreatedContext> create_webgl_context(JS::Value options);

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -81,18 +81,18 @@ GC::Ptr<DOM::HTMLCollection> const& HTMLFieldSetElement::elements()
     return m_elements;
 }
 
-RefPtr<Layout::Node> HTMLFieldSetElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLFieldSetElement::create_layout_node(CSS::LayoutStyle style)
 {
-    auto fieldset_box = make_ref_counted<Layout::BlockContainer>(document(), this, style, Layout::RustFFI::NodeKind::FieldSetBox);
+    auto& fieldset_box = Layout::allocate_layout_node<Layout::BlockContainer>(document(), this, style, Layout::RustFFI::NodeKind::FieldSetBox);
     // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
     // If the computed outer display type is inline, the fieldset is expected to behave as inline-block. Otherwise, it
     // is expected to behave as flow-root. This does not change the computed value.
-    if (fieldset_box->display().is_flow_inside()) {
-        fieldset_box->modify_computed_values([&](auto& values) {
-            values.set_display(CSS::Display { fieldset_box->display().outside(), CSS::DisplayInside::FlowRoot });
+    if (fieldset_box.display().is_flow_inside()) {
+        fieldset_box.modify_computed_values([&](auto& values) {
+            values.set_display(CSS::Display { fieldset_box.display().outside(), CSS::DisplayInside::FlowRoot });
         });
     }
-    return fieldset_box;
+    return &fieldset_box;
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -42,7 +42,7 @@ public:
 
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::group; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     HTMLFieldSetElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -40,9 +40,9 @@ HTMLIFrameElement::HTMLIFrameElement(DOM::Document& document, DOM::QualifiedName
 
 HTMLIFrameElement::~HTMLIFrameElement() = default;
 
-RefPtr<Layout::Node> HTMLIFrameElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLIFrameElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::NavigableContainerViewport);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::NavigableContainerViewport);
 }
 
 void HTMLIFrameElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -25,7 +25,7 @@ class WEB_API HTMLIFrameElement final
 public:
     virtual ~HTMLIFrameElement() override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     // ^EventTarget
     virtual bool is_focusable() const override

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -307,14 +307,14 @@ void HTMLImageElement::form_associated_element_attribute_changed(Utf16FlyString 
     }
 }
 
-RefPtr<Layout::Node> HTMLImageElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLImageElement::create_layout_node(CSS::LayoutStyle style)
 {
     if (renders_as_alt_text() && !alt().is_empty()) {
         auto computed_style = this->computed_style();
         VERIFY(computed_style);
         return Element::create_layout_node_for_display_type(document(), computed_style->display(), style, this);
     }
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
 }
 
 void HTMLImageElement::create_alt_text_shadow_tree()

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -137,7 +137,7 @@ private:
     // https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     virtual void did_set_viewport_rect(CSSPixelRect const&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -154,7 +154,7 @@ void HTMLInputElement::set_being_activated(bool activated)
         set_needs_repaint();
 }
 
-RefPtr<Layout::Node> HTMLInputElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLInputElement::create_layout_node(CSS::LayoutStyle style)
 {
     if (type_state() == TypeAttributeState::Hidden)
         return nullptr;
@@ -167,7 +167,7 @@ RefPtr<Layout::Node> HTMLInputElement::create_layout_node(CSS::LayoutStyle style
             VERIFY(computed_style);
             return Element::create_layout_node_for_display_type(document(), computed_style->display(), style, this);
         }
-        return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
+        return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
     }
 
     // https://drafts.csswg.org/css-ui/#appearance-switching
@@ -185,18 +185,18 @@ RefPtr<Layout::Node> HTMLInputElement::create_layout_node(CSS::LayoutStyle style
     case TypeAttributeState::SubmitButton:
     case TypeAttributeState::Button:
     case TypeAttributeState::ResetButton:
-        return make_ref_counted<Layout::BlockContainer>(document(), this, style);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), this, style);
     case TypeAttributeState::Checkbox:
-        return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::CheckBox);
+        return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::CheckBox);
     case TypeAttributeState::RadioButton:
-        return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::RadioButton);
+        return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::RadioButton);
     case TypeAttributeState::Range:
-        return make_ref_counted<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::RangeInputBox);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::RangeInputBox);
     case TypeAttributeState::Color:
     case TypeAttributeState::FileUpload:
         return Element::create_layout_node_for_display_type(document(), computed_style->display(), style, this);
     default:
-        return make_ref_counted<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::TextInputBox);
+        return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::TextInputBox);
     }
 }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -72,7 +72,7 @@ class WEB_API HTMLInputElement final
 public:
     virtual ~HTMLInputElement() override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
     virtual void set_being_activated(bool) override;
 
     enum class TypeAttributeState {

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.cpp
@@ -33,9 +33,9 @@ HTMLFormElement* HTMLLegendElement::form()
     return nullptr;
 }
 
-RefPtr<Layout::Node> HTMLLegendElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLLegendElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::LegendBox);
+    return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::LegendBox);
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLLegendElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLegendElement.h
@@ -19,7 +19,7 @@ public:
 
     HTMLFormElement* form();
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     HTMLLegendElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -206,16 +206,16 @@ void HTMLObjectElement::set_data(Utf16View data)
     set_attribute_value(HTML::AttributeNames::data, data);
 }
 
-RefPtr<Layout::Node> HTMLObjectElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLObjectElement::create_layout_node(CSS::LayoutStyle style)
 {
     switch (m_representation) {
     case Representation::Children:
         return NavigableContainer::create_layout_node(style);
     case Representation::ContentNavigable:
-        return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::NavigableContainerViewport);
+        return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::NavigableContainerViewport);
     case Representation::Image:
         if (image_data())
-            return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
+            return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::ImageBox);
         break;
     default:
         break;

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -64,7 +64,7 @@ private:
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     bool has_ancestor_media_element_or_object_element_not_showing_fallback_content() const;
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -533,9 +533,9 @@ Optional<Utf16String> HTMLTextAreaElement::placeholder_value() const
     return get_attribute_value(HTML::AttributeNames::placeholder);
 }
 
-RefPtr<Layout::Node> HTMLTextAreaElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLTextAreaElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::TextAreaBox);
+    return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::TextAreaBox);
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -150,7 +150,7 @@ private:
 
     virtual bool is_html_textarea_element() const final { return true; }
     virtual void visit_edges(Cell::Visitor&) override;
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     void set_raw_value(Utf16String);
 

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -70,11 +70,11 @@ void HTMLVideoElement::attribute_changed(Utf16FlyString const& name, Optional<Ut
     }
 }
 
-RefPtr<Layout::Node> HTMLVideoElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* HTMLVideoElement::create_layout_node(CSS::LayoutStyle style)
 {
-    auto video_box = make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::VideoBox);
-    video_box->set_replaced_box_can_have_children(shadow_root() != nullptr);
-    return video_box;
+    auto& video_box = Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::VideoBox);
+    video_box.set_replaced_box_can_have_children(shadow_root() != nullptr);
+    return &video_box;
 }
 
 void HTMLVideoElement::set_intrinsic_video_dimensions(Optional<Gfx::Size<u32>> dimensions)

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -71,7 +71,7 @@ private:
 
     virtual bool is_html_video_element() const override { return true; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     WebIDL::ExceptionOr<void> determine_element_poster_frame(Optional<Utf16String> const& poster);
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4263,8 +4263,11 @@ void LocalNavigable::re_snap_scroll_containers_after_layout_change()
     auto snap_containers = document->collect_scroll_snap_containers();
 
     bool any_snap_container_deferred = false;
-    for (auto const& snap_container : snap_containers) {
-        auto stable_node_id = Painting::async_scroll_node_stable_id(snap_container);
+    for (auto const& registered_snap_container : snap_containers) {
+        auto const* snap_container = registered_snap_container.ptr();
+        if (!snap_container)
+            continue;
+        auto stable_node_id = Painting::async_scroll_node_stable_id(*snap_container);
         if (!stable_node_id.has_value())
             continue;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1485,6 +1485,20 @@ u64 Internals::layout_node_identity(DOM::Node& node)
     return layout_node ? static_cast<u64>(layout_node->arena_slot_index()) + 1 : 0;
 }
 
+u64 Internals::layout_arena_live_slot_count()
+{
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::Debugging);
+    return Layout::RustFFI::layout_arena_live_slot_count(document.layout_node_arena().handle());
+}
+
+u64 Internals::layout_arena_shell_count()
+{
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::Debugging);
+    return Layout::RustFFI::layout_arena_shell_count(document.layout_node_arena().handle());
+}
+
 GC::Ref<JS::Object> Internals::style_engine_transaction_reactions()
 {
     auto& realm = HTML::relevant_realm(window());

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -212,6 +212,8 @@ public:
     u64 before_layout_style_record_identity(DOM::Element&);
     u64 paint_style_record_identity(DOM::Element&);
     u64 layout_node_identity(DOM::Node&);
+    u64 layout_arena_live_slot_count();
+    u64 layout_arena_shell_count();
     double style_engine_match_document();
     Utf16String style_engine_matched_rules();
     GC::Ref<JS::Object> style_engine_transaction_reactions();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -210,6 +210,8 @@ interface Internals {
     // Stable for the lifetime of a layout node, and zero when the DOM node has no principal
     // layout node. Useful for asserting that incremental tree builds preserve unaffected nodes.
     unsigned long long layoutNodeIdentity(Node node);
+    unsigned long long layoutArenaLiveSlotCount();
+    unsigned long long layoutArenaShellCount();
     double styleEngineMatchDocument();
     // Reports a snapshot of StyleEngine's matched rules for the whole document.
     DOMString styleEngineMatchedRules();

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/Layout/AnonymousBoxStyle.h>
+
+namespace Web::Layout {
+
+static void transfer_table_box_style_to_wrapper(CSS::ComputedValues const& table_box_values, CSS::ComputedValues::Builder& wrapper)
+{
+    // The computed values of properties 'position', 'float', 'margin-*', 'top', 'right', 'bottom', and 'left' on the table element are used on the table wrapper box and not the table box;
+    // all other values of non-inheritable properties are used on the table box and not the table wrapper box.
+    // (Where the table element's values are not used on the table and table wrapper boxes, the initial values are used instead.)
+    if (table_box_values.display().is_inline_outside())
+        wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::InlineBlock));
+    else
+        wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+    wrapper->set_position(table_box_values.position());
+    wrapper->set_position_anchor(table_box_values.position_anchor_value());
+    wrapper->set_inset(table_box_values.inset());
+    wrapper->set_float(table_box_values.float_());
+    wrapper->set_clear(table_box_values.clear());
+    // CSS 2 moves table-root positioning and margins to the wrapper. The wrapper is also the grid item for
+    // display:table, so grid placement, self-alignment, and order need to move there as well.
+    wrapper->copy_grid_placements_from(table_box_values);
+    wrapper->set_align_self(table_box_values.align_self());
+    wrapper->set_justify_self(table_box_values.justify_self());
+    wrapper->set_order(table_box_values.order());
+    wrapper->set_margin(table_box_values.margin());
+    // AD-HOC:
+    // To match other browsers, z-index needs to be moved to the wrapper box as well,
+    // even if the spec does not mention that: https://github.com/w3c/csswg-drafts/issues/11689
+    // Note that there may be more properties that need to be added to this list.
+    wrapper->set_z_index(table_box_values.z_index());
+    // "clip" only takes effect on absolutely-positioned elements; the table box isn't one — the wrapper is.
+    wrapper->set_clip(table_box_values.clip());
+    // AD-HOC: The wrapper box participates in inline layout in place of the table box, so vertical-align
+    //         must be moved to the wrapper to have any effect.
+    wrapper->set_vertical_align(table_box_values.vertical_align());
+}
+
+static CSS::StyleRecordID intern_and_pin_anonymous_box_style(CSS::StyleComputer const& style_computer, CSS::ComputedValues::Builder&& builder)
+{
+    auto style_record = style_computer.intern_anonymous_layout_style(*move(builder).build());
+    style_computer.pin_style_record(style_record);
+    return style_record;
+}
+
+CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const& style_computer, CSS::StyleRecordID parent_style_record, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides)
+{
+    auto parent_values = style_computer.computed_style_record_view(parent_style_record);
+    VERIFY(parent_values);
+    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*parent_values);
+    auto block_flow_or_inline_block = overrides.inline_block_wrapper
+        ? CSS::Display::from_short(CSS::Display::Short::InlineBlock)
+        : CSS::Display(CSS::DisplayOutside::Block, CSS::DisplayInside::Flow);
+    switch (kind) {
+    case AnonymousBoxStyleKind::Wrapper:
+        builder->set_display(block_flow_or_inline_block);
+        break;
+    case AnonymousBoxStyleKind::TableRow:
+        builder->set_display(CSS::Display { CSS::DisplayInternal::TableRow });
+        break;
+    case AnonymousBoxStyleKind::TableCell:
+        builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
+        break;
+    case AnonymousBoxStyleKind::Table:
+        builder->set_display(CSS::Display::from_short(CSS::Display::Short::Table));
+        break;
+    case AnonymousBoxStyleKind::InlineTable:
+        builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineTable));
+        break;
+    case AnonymousBoxStyleKind::MissingTableCell:
+        builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
+        // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
+        builder->set_vertical_align(CSS::VerticalAlign::Middle);
+        break;
+    case AnonymousBoxStyleKind::TableWrapper:
+        transfer_table_box_style_to_wrapper(*parent_values, builder);
+        break;
+    case AnonymousBoxStyleKind::ButtonFlexWrapper:
+        // A full-height flex column that centers the button contents vertically.
+        builder->set_display(CSS::Display { CSS::DisplayOutside::Block, CSS::DisplayInside::Flex });
+        builder->set_justify_content(CSS::JustifyContent::Center);
+        builder->set_flex_direction(CSS::FlexDirection::Column);
+        builder->set_height(CSS::Size::make_percentage(CSS::Percentage(100)));
+        break;
+    case AnonymousBoxStyleKind::ButtonContentBox:
+        // Let percentage-sized descendants shrink to fixed-height buttons instead of the flex
+        // item's automatic minimum size.
+        builder->set_display(block_flow_or_inline_block);
+        builder->set_min_height(CSS::Size::make_px(CSSPixels(0)));
+        break;
+    case AnonymousBoxStyleKind::FieldsetContentWrapper:
+        builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+        builder->set_overflow_x(overrides.overflow_x);
+        builder->set_overflow_y(overrides.overflow_y);
+        break;
+    }
+    return intern_and_pin_anonymous_box_style(style_computer, move(builder));
+}
+
+CSS::StyleRecordID reinherit_pinned_anonymous_box_style_record(CSS::StyleComputer const& style_computer, CSS::StyleRecordID style_record, CSS::StyleRecordID parent_style_record)
+{
+    auto values = style_computer.computed_style_record_view(style_record);
+    VERIFY(values);
+    auto parent_values = style_computer.computed_style_record_view(parent_style_record);
+    VERIFY(parent_values);
+    CSS::ComputedValues::Builder builder { *values };
+    builder->inherit_from(*parent_values);
+    return intern_and_pin_anonymous_box_style(style_computer, move(builder));
+}
+
+}

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
@@ -54,7 +54,9 @@ CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer c
 {
     auto parent_values = style_computer.computed_style_record_view(parent_style_record);
     VERIFY(parent_values);
-    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*parent_values);
+    auto builder = kind == RustFFI::FfiAnonymousStyleKind::InlineStyleWrapper
+        ? CSS::ComputedValues::Builder { *parent_values }
+        : CSS::ComputedValues::Builder::create_inheriting_from(*parent_values);
     auto block_flow_or_inline_block = overrides.inline_block_wrapper
         ? CSS::Display::from_short(CSS::Display::Short::InlineBlock)
         : CSS::Display(CSS::DisplayOutside::Block, CSS::DisplayInside::Flow);
@@ -99,6 +101,9 @@ CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer c
         builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
         builder->set_overflow_x(static_cast<CSS::Overflow>(overrides.overflow_x));
         builder->set_overflow_y(static_cast<CSS::Overflow>(overrides.overflow_y));
+        break;
+    case RustFFI::FfiAnonymousStyleKind::InlineStyleWrapper:
+        builder->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
         break;
     }
     return intern_and_pin_anonymous_box_style(style_computer, move(builder));

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.cpp
@@ -50,7 +50,7 @@ static CSS::StyleRecordID intern_and_pin_anonymous_box_style(CSS::StyleComputer 
     return style_record;
 }
 
-CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const& style_computer, CSS::StyleRecordID parent_style_record, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides)
+CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const& style_computer, CSS::StyleRecordID parent_style_record, RustFFI::FfiAnonymousStyleKind kind, RustFFI::FfiAnonymousStyleOverrides const& overrides)
 {
     auto parent_values = style_computer.computed_style_record_view(parent_style_record);
     VERIFY(parent_values);
@@ -59,46 +59,46 @@ CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer c
         ? CSS::Display::from_short(CSS::Display::Short::InlineBlock)
         : CSS::Display(CSS::DisplayOutside::Block, CSS::DisplayInside::Flow);
     switch (kind) {
-    case AnonymousBoxStyleKind::Wrapper:
+    case RustFFI::FfiAnonymousStyleKind::Wrapper:
         builder->set_display(block_flow_or_inline_block);
         break;
-    case AnonymousBoxStyleKind::TableRow:
+    case RustFFI::FfiAnonymousStyleKind::TableRow:
         builder->set_display(CSS::Display { CSS::DisplayInternal::TableRow });
         break;
-    case AnonymousBoxStyleKind::TableCell:
+    case RustFFI::FfiAnonymousStyleKind::TableCell:
         builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
         break;
-    case AnonymousBoxStyleKind::Table:
+    case RustFFI::FfiAnonymousStyleKind::Table:
         builder->set_display(CSS::Display::from_short(CSS::Display::Short::Table));
         break;
-    case AnonymousBoxStyleKind::InlineTable:
+    case RustFFI::FfiAnonymousStyleKind::InlineTable:
         builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineTable));
         break;
-    case AnonymousBoxStyleKind::MissingTableCell:
+    case RustFFI::FfiAnonymousStyleKind::MissingTableCell:
         builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
         // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
         builder->set_vertical_align(CSS::VerticalAlign::Middle);
         break;
-    case AnonymousBoxStyleKind::TableWrapper:
+    case RustFFI::FfiAnonymousStyleKind::TableWrapper:
         transfer_table_box_style_to_wrapper(*parent_values, builder);
         break;
-    case AnonymousBoxStyleKind::ButtonFlexWrapper:
+    case RustFFI::FfiAnonymousStyleKind::ButtonFlexWrapper:
         // A full-height flex column that centers the button contents vertically.
         builder->set_display(CSS::Display { CSS::DisplayOutside::Block, CSS::DisplayInside::Flex });
         builder->set_justify_content(CSS::JustifyContent::Center);
         builder->set_flex_direction(CSS::FlexDirection::Column);
         builder->set_height(CSS::Size::make_percentage(CSS::Percentage(100)));
         break;
-    case AnonymousBoxStyleKind::ButtonContentBox:
+    case RustFFI::FfiAnonymousStyleKind::ButtonContentBox:
         // Let percentage-sized descendants shrink to fixed-height buttons instead of the flex
         // item's automatic minimum size.
         builder->set_display(block_flow_or_inline_block);
         builder->set_min_height(CSS::Size::make_px(CSSPixels(0)));
         break;
-    case AnonymousBoxStyleKind::FieldsetContentWrapper:
+    case RustFFI::FfiAnonymousStyleKind::FieldsetContentWrapper:
         builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
-        builder->set_overflow_x(overrides.overflow_x);
-        builder->set_overflow_y(overrides.overflow_y);
+        builder->set_overflow_x(static_cast<CSS::Overflow>(overrides.overflow_x));
+        builder->set_overflow_y(static_cast<CSS::Overflow>(overrides.overflow_y));
         break;
     }
     return intern_and_pin_anonymous_box_style(style_computer, move(builder));

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.h
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.h
@@ -6,32 +6,13 @@
 
 #pragma once
 
-#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/StyleRecordID.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Layout/LayoutRustFFI.h>
 
 namespace Web::Layout {
 
-enum class AnonymousBoxStyleKind : u8 {
-    Wrapper,
-    TableRow,
-    TableCell,
-    Table,
-    InlineTable,
-    MissingTableCell,
-    TableWrapper,
-    ButtonFlexWrapper,
-    ButtonContentBox,
-    FieldsetContentWrapper,
-};
-
-struct AnonymousBoxStyleOverrides {
-    bool inline_block_wrapper { false };
-    CSS::Overflow overflow_x { CSS::Overflow::Visible };
-    CSS::Overflow overflow_y { CSS::Overflow::Visible };
-};
-
-[[nodiscard]] CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const&, CSS::StyleRecordID parent_style_record, AnonymousBoxStyleKind, AnonymousBoxStyleOverrides const& = {});
+[[nodiscard]] CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const&, CSS::StyleRecordID parent_style_record, RustFFI::FfiAnonymousStyleKind, RustFFI::FfiAnonymousStyleOverrides const&);
 [[nodiscard]] CSS::StyleRecordID reinherit_pinned_anonymous_box_style_record(CSS::StyleComputer const&, CSS::StyleRecordID style_record, CSS::StyleRecordID parent_style_record);
 
 }

--- a/Libraries/LibWeb/Layout/AnonymousBoxStyle.h
+++ b/Libraries/LibWeb/Layout/AnonymousBoxStyle.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Enums.h>
+#include <LibWeb/CSS/StyleRecordID.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Layout {
+
+enum class AnonymousBoxStyleKind : u8 {
+    Wrapper,
+    TableRow,
+    TableCell,
+    Table,
+    InlineTable,
+    MissingTableCell,
+    TableWrapper,
+    ButtonFlexWrapper,
+    ButtonContentBox,
+    FieldsetContentWrapper,
+};
+
+struct AnonymousBoxStyleOverrides {
+    bool inline_block_wrapper { false };
+    CSS::Overflow overflow_x { CSS::Overflow::Visible };
+    CSS::Overflow overflow_y { CSS::Overflow::Visible };
+};
+
+[[nodiscard]] CSS::StyleRecordID derive_pinned_anonymous_box_style_record(CSS::StyleComputer const&, CSS::StyleRecordID parent_style_record, AnonymousBoxStyleKind, AnonymousBoxStyleOverrides const& = {});
+[[nodiscard]] CSS::StyleRecordID reinherit_pinned_anonymous_box_style_record(CSS::StyleComputer const&, CSS::StyleRecordID style_record, CSS::StyleRecordID parent_style_record);
+
+}

--- a/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Libraries/LibWeb/Layout/BlockContainer.h
@@ -17,6 +17,10 @@ public:
         : Box(document, node, move(style), kind)
     {
     }
+    BlockContainer(DOM::Document& document, BindToPreparedArenaSlot bind, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind)
+        : Box(document, bind, slot, kind)
+    {
+    }
     virtual ~BlockContainer() override = default;
 
 private:

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -31,6 +31,11 @@ Box::Box(DOM::Document& document, GC::Ptr<DOM::Node> node, CSS::LayoutStyle styl
 {
 }
 
+Box::Box(DOM::Document& document, BindToPreparedArenaSlot bind, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind)
+    : NodeWithStyle(document, bind, slot, kind)
+{
+}
+
 Box::~Box()
 {
 }

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -57,6 +57,7 @@ public:
     bool compensates_for_vertical_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll); }
 
     Box(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::Box);
+    Box(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);
 
 private:
     CSS::SizeWithAspectRatio compute_auto_content_box_size() const;

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -681,3 +681,8 @@ extern "C" WEB_API void ladybird_layout_node_shell_release(void* shell)
 {
     static_cast<Web::Layout::Node*>(shell)->unref();
 }
+
+extern "C" WEB_API void ladybird_layout_node_shell_destroy(void* shell)
+{
+    delete static_cast<Web::Layout::Node*>(shell);
+}

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -677,12 +677,7 @@ extern "C" WEB_API size_t ladybird_layout_text_node_rendered_text_offset_for_dom
     return text_node.rendered_text_offset_for_dom_offset(offset, boundary);
 }
 
-extern "C" WEB_API void ladybird_layout_node_shell_release(void* shell)
-{
-    static_cast<Web::Layout::Node*>(shell)->unref();
-}
-
 extern "C" WEB_API void ladybird_layout_node_shell_destroy(void* shell)
 {
-    delete static_cast<Web::Layout::Node*>(shell);
+    Web::Layout::Node::delete_arena_owned_shell(*static_cast<Web::Layout::Node*>(shell));
 }

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -75,3 +75,4 @@ extern "C" WEB_API size_t ladybird_layout_text_node_dom_offset_for_rendered_text
 extern "C" WEB_API size_t ladybird_layout_text_node_rendered_text_offset_for_dom_offset(void*, size_t, bool use_end_boundary);
 
 extern "C" WEB_API void ladybird_layout_node_shell_release(void*);
+extern "C" WEB_API void ladybird_layout_node_shell_destroy(void*);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -74,5 +74,4 @@ extern "C" WEB_API bool ladybird_layout_code_point_has_emoji_property(u32);
 extern "C" WEB_API size_t ladybird_layout_text_node_dom_offset_for_rendered_text_offset(void*, size_t, bool use_end_boundary);
 extern "C" WEB_API size_t ladybird_layout_text_node_rendered_text_offset_for_dom_offset(void*, size_t, bool use_end_boundary);
 
-extern "C" WEB_API void ladybird_layout_node_shell_release(void*);
 extern "C" WEB_API void ladybird_layout_node_shell_destroy(void*);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -23,7 +23,6 @@
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
-#include <LibWeb/Layout/AnonymousBoxStyle.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/Node.h>
@@ -495,7 +494,7 @@ void NodeWithStyle::apply_style(CSS::StyleRecordID style_record_identity)
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     // A style change can introduce the properties that make a node carry replaced-content facts,
     // such as size containment arriving on a kept layout node.
-    propagate_style_to_anonymous_wrappers();
+    RustFFI::layout_arena_reinherit_anonymous_descendants(arena_handle(), slot_id(this));
     attach_style_resources();
     // A pseudo layout node can outlive replacement of the DOM pseudo's record until the layout
     // tree is rebuilt. Root its record across that gap, including metadata-only style changes that
@@ -553,74 +552,37 @@ CSS::StyleScope const& NodeWithStyle::style_scope() const
     return document().style_scope();
 }
 
-void NodeWithStyle::propagate_style_to_anonymous_wrappers()
+void NodeWithStyle::refresh_style_from_arena()
 {
-    // Update the style of any anonymous wrappers that inherit from this node.
-    // FIXME: This is pretty hackish. It would be nicer if they shared the inherited style
-    //        data structure somehow, so this wasn't necessary.
-
-    // If this is a `display:table` box with an anonymous wrapper parent,
-    // the parent inherits style from *this* node, not the other way around.
-    if (auto* table_wrapper = parent() && parent()->is_table_wrapper() ? parent() : nullptr; table_wrapper && display().is_table_inside()) {
-        table_wrapper->adopt_pinned_anonymous_style_record(derive_pinned_anonymous_box_style_record(document().style_computer(), m_style_record_identity, RustFFI::FfiAnonymousStyleKind::TableWrapper, {}));
-        reset_table_box_computed_values_used_by_wrapper_to_init_values();
-    }
-
-    // Propagate style to all anonymous children (except table wrappers!)
-    for_each_child_of_type<NodeWithStyle>([&](NodeWithStyle& child) {
-        if (child.is_anonymous() && !child.is_table_wrapper()) {
-            // NB: The principal box of a pseudo-element (::before, ::after, ::marker, etc) has its own computed
-            //     style, which is applied to it separately. Don't clobber that style with inherited values from
-            //     this node.
-            if (child.is_pseudo_element_principal_box())
-                return IterationDecision::Continue;
-            if (child.m_owned_computed_values) {
-                CSS::ComputedValues::Builder builder(child.owned_computed_values());
-                auto values = copy_computed_values();
-                builder->inherit_from(*values);
-                child.set_computed_values(move(builder).build());
-            } else {
-                child.adopt_pinned_anonymous_style_record(reinherit_pinned_anonymous_box_style_record(document().style_computer(), child.m_style_record_identity, m_style_record_identity));
-            }
-            child.propagate_style_to_anonymous_wrappers();
-        }
-        return IterationDecision::Continue;
-    });
-}
-
-void NodeWithStyle::adopt_pinned_anonymous_style_record(CSS::StyleRecordID style_record_identity)
-{
-    VERIFY(is_anonymous());
-    VERIFY(!m_owned_computed_values);
-    auto new_record_view = document().style_computer().computed_style_record_view(style_record_identity);
-    VERIFY(new_record_view);
-    auto old_record_view = computed_style_record_view();
-    bool changes_layout_affecting_style = !old_record_view
-        || CSS::ComputedValues::either_carries_animated_overlay(*old_record_view, *new_record_view)
-        || new_record_view->differs_in_any_layout_affecting_group_payload_from(*old_record_view);
-
+    m_style_record_identity = CSS::StyleRecordID { RustFFI::layout_arena_node_style_record(arena_handle(), slot_id(this)) };
+    VERIFY(m_style_record_identity);
     m_background_layers.clear();
     m_mask_layers.clear();
     m_border_image.clear();
     m_list_style_type.clear();
     m_list_style_image.clear();
-    RustFFI::layout_arena_replace_arena_pinned_style_record(arena_handle(), slot_id(this), style_record_identity.value(), document().style_computer().style_record_payloads(style_record_identity));
-    m_style_record_identity = style_record_identity;
-    set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());
-    set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, new_record_view->inset_properties_contain_anchor_functions());
+    auto record_view = computed_style_record_view();
+    VERIFY(record_view);
+    set_flag(RustFFI::NodeFlag::HasAnchorNames, !record_view->anchor_names().is_empty());
+    set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, record_view->inset_properties_contain_anchor_functions());
     set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
+}
 
-    if (changes_layout_affecting_style) {
-        bump_fragment_cache_epoch_of_self_and_ancestors();
-        RustFFI::layout_arena_reset_cached_intrinsic_sizes_of_self_and_ancestors(arena_handle(), slot_id(this));
-    }
-
-    for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-        if (auto* text_child = as_if<TextNode>(*child))
-            text_child->enroll_for_arena_text_content_sync();
-    }
+bool NodeWithStyle::reinherit_owned_computed_values_from(CSS::StyleRecordID parent_style_record_identity)
+{
+    // NB: The principal box of a pseudo-element (::before, ::after, ::marker, etc) has its own computed
+    //     style, which is applied to it separately. Don't clobber that style with inherited values from
+    //     the parent.
+    if (is_pseudo_element_principal_box())
+        return false;
+    auto parent_record_view = document().style_computer().computed_style_record_view(parent_style_record_identity);
+    VERIFY(parent_record_view);
+    CSS::ComputedValues::Builder builder(owned_computed_values());
+    builder->inherit_from(*parent_record_view);
+    set_computed_values(move(builder).build());
+    return true;
 }
 
 bool Node::is_root_element() const

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -77,7 +77,6 @@ Node::Node(DOM::Document& document, BindToPreparedArenaSlot, RustFFI::NodeSlotId
 {
     VERIFY(RustFFI::layout_arena_node_dom_node(m_arena->handle(), m_slot) == nullptr);
     RustFFI::layout_arena_attach_shell(m_arena->handle(), m_slot, this);
-    update_has_scroll_offset_flag();
 }
 
 Node::~Node()
@@ -348,7 +347,8 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, BindToPreparedArenaSlot bi
 {
     m_style_record_identity = CSS::StyleRecordID { RustFFI::layout_arena_node_style_record(arena_handle(), slot) };
     VERIFY(m_style_record_identity);
-    initialize_from_style_record();
+    m_style_payloads = RustFFI::layout_arena_node_style_payloads(arena_handle(), slot);
+    VERIFY(m_style_payloads);
 }
 
 void NodeWithStyle::initialize_from_style_record()
@@ -710,10 +710,7 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
         RustFFI::layout_arena_reset_cached_intrinsic_sizes_of_self_and_ancestors(arena_handle(), slot_id(this));
     }
 
-    for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
-        if (auto* text_child = as_if<TextNode>(*child))
-            text_child->enroll_for_arena_text_content_sync();
-    }
+    RustFFI::layout_arena_enroll_text_children_for_content_sync(arena_handle(), slot_id(this));
 }
 
 void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_identity)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -60,9 +60,10 @@ static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Docu
 Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, AttachToDOMNode attach_to_dom_node)
     : m_arena(document.layout_node_arena())
     , m_slot(m_arena->allocate(build_node_construction_facts(document, node, kind, this)))
-    , m_dom_node(node ? *node : document)
+    , m_dom_node(node)
     , m_kind(kind)
 {
+    VERIFY(RustFFI::layout_arena_node_dom_node(m_arena->handle(), m_slot) == m_dom_node.ptr());
     update_has_scroll_offset_flag();
 
     if (node && attach_to_dom_node == AttachToDOMNode::Yes)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -716,7 +716,7 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
         return;
     }
 
-    bool should_repin_style_record = m_style_record_owner;
+    bool should_repin_style_record = m_style_record_pinned;
     auto new_record_view = document().style_computer().computed_style_record_view(style_record_identity);
     VERIFY(new_record_view);
     auto old_record_view = computed_style_record_view();
@@ -748,21 +748,20 @@ void NodeWithStyle::set_style_record_identity(CSS::StyleRecordID style_record_id
 
 void NodeWithStyle::pin_style_record_for_cxx_consumers()
 {
-    if (m_style_record_owner)
+    if (m_style_record_pinned)
         return;
 
     VERIFY(m_style_record_identity);
-    auto& owner = document();
-    owner.style_computer().pin_style_record(m_style_record_identity);
-    m_style_record_owner = owner;
+    document().style_computer().pin_style_record(m_style_record_identity);
+    m_style_record_pinned = true;
 }
 
 void NodeWithStyle::release_pinned_style_record()
 {
-    if (!m_style_record_owner)
+    if (!m_style_record_pinned)
         return;
-    m_style_record_owner->style_computer().unpin_style_record(m_style_record_identity);
-    m_style_record_owner = {};
+    document().style_computer().unpin_style_record(m_style_record_identity);
+    m_style_record_pinned = false;
 }
 
 void NodeWithStyle::bind_generated_style_record(CSS::StyleRecordID target_style_record_identity)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -45,6 +45,7 @@ static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Docu
     return {
         .kind = kind,
         .shell = shell,
+        .dom_node = node.ptr(),
         .is_anonymous = node == nullptr,
         .is_html_input_element = node && is<HTML::HTMLInputElement>(*node),
         .is_html_html_element = node && node->is_html_html_element(),

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/Layout/AnonymousBoxStyle.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/Node.h>
@@ -321,6 +322,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     VERIFY(style);
     if (!!style.style_record_identity()) {
         m_style_record_identity = style.style_record_identity();
+        m_style_record_pinned = style.adopts_style_record_pin();
     } else if (auto* element = as_if<DOM::Element>(node.ptr())) {
         m_owned_computed_values = style.values();
         m_style_record_identity = document.style_computer().intern_computed_style_inputs({ *element }, *style.values());
@@ -538,11 +540,8 @@ void NodeWithStyle::propagate_style_to_anonymous_wrappers()
     // If this is a `display:table` box with an anonymous wrapper parent,
     // the parent inherits style from *this* node, not the other way around.
     if (auto* table_wrapper = parent() && parent()->is_table_wrapper() ? parent() : nullptr; table_wrapper && display().is_table_inside()) {
-        CSS::ComputedValues::Builder builder(table_wrapper->owned_computed_values());
-        auto values = copy_computed_values();
-        builder->inherit_from(*values);
-        transfer_table_box_computed_values_to_wrapper_computed_values(builder);
-        table_wrapper->set_computed_values(move(builder).build());
+        table_wrapper->adopt_pinned_anonymous_style_record(derive_pinned_anonymous_box_style_record(document().style_computer(), m_style_record_identity, AnonymousBoxStyleKind::TableWrapper));
+        reset_table_box_computed_values_used_by_wrapper_to_init_values();
     }
 
     // Propagate style to all anonymous children (except table wrappers!)
@@ -553,14 +552,54 @@ void NodeWithStyle::propagate_style_to_anonymous_wrappers()
             //     this node.
             if (child.is_pseudo_element_principal_box())
                 return IterationDecision::Continue;
-            CSS::ComputedValues::Builder builder(child.owned_computed_values());
-            auto values = copy_computed_values();
-            builder->inherit_from(*values);
-            child.set_computed_values(move(builder).build());
+            if (child.m_owned_computed_values) {
+                CSS::ComputedValues::Builder builder(child.owned_computed_values());
+                auto values = copy_computed_values();
+                builder->inherit_from(*values);
+                child.set_computed_values(move(builder).build());
+            } else {
+                child.adopt_pinned_anonymous_style_record(reinherit_pinned_anonymous_box_style_record(document().style_computer(), child.m_style_record_identity, m_style_record_identity));
+            }
             child.propagate_style_to_anonymous_wrappers();
         }
         return IterationDecision::Continue;
     });
+}
+
+void NodeWithStyle::adopt_pinned_anonymous_style_record(CSS::StyleRecordID style_record_identity)
+{
+    VERIFY(is_anonymous());
+    VERIFY(!m_owned_computed_values);
+    auto new_record_view = document().style_computer().computed_style_record_view(style_record_identity);
+    VERIFY(new_record_view);
+    auto old_record_view = computed_style_record_view();
+    bool changes_layout_affecting_style = !old_record_view
+        || CSS::ComputedValues::either_carries_animated_overlay(*old_record_view, *new_record_view)
+        || new_record_view->differs_in_any_layout_affecting_group_payload_from(*old_record_view);
+
+    release_pinned_style_record();
+    m_background_layers.clear();
+    m_mask_layers.clear();
+    m_border_image.clear();
+    m_list_style_type.clear();
+    m_list_style_image.clear();
+    m_style_record_identity = style_record_identity;
+    m_style_record_pinned = true;
+    set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());
+    set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, new_record_view->inset_properties_contain_anchor_functions());
+    set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
+    publish_style_record_to_node_data();
+    set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
+
+    if (changes_layout_affecting_style) {
+        bump_fragment_cache_epoch_of_self_and_ancestors();
+        RustFFI::layout_arena_reset_cached_intrinsic_sizes_of_self_and_ancestors(arena_handle(), slot_id(this));
+    }
+
+    for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
+        if (auto* text_child = as_if<TextNode>(*child))
+            text_child->enroll_for_arena_text_content_sync();
+    }
 }
 
 bool Node::is_root_element() const
@@ -626,18 +665,6 @@ Gfx::AffineTransform NodeWithStyle::used_svg_element_transform() const
     if (auto const* graphics_element = as_if<SVG::SVGGraphicsElement>(dom_node()))
         transform.multiply(graphics_element->additional_element_transform());
     return transform;
-}
-
-NodeWithStyle& NodeWithStyle::create_anonymous_wrapper() const
-{
-    auto values = copy_computed_values();
-    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*values);
-    builder->set_display(CSS::Display(CSS::DisplayOutside::Block, CSS::DisplayInside::Flow));
-    // CSS 2.2 9.2.1.1 creates anonymous block boxes, but 9.4.1 states inline-block creates a BFC.
-    // Set wrapper to inline-block to participate correctly in the IFC within the parent inline-block.
-    if (display().is_inline_block() && !has_children())
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineBlock));
-    return allocate_layout_node<BlockContainer>(const_cast<DOM::Document&>(document()), nullptr, move(builder).build());
 }
 
 void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const> computed_values)
@@ -881,41 +908,6 @@ void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_valu
         values.set_clip(CSS::InitialValues::clip());
         values.set_vertical_align(CSS::InitialValues::vertical_align());
     });
-}
-
-void NodeWithStyle::transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues::Builder& builder)
-{
-    // The computed values of properties 'position', 'float', 'margin-*', 'top', 'right', 'bottom', and 'left' on the table element are used on the table wrapper box and not the table box;
-    // all other values of non-inheritable properties are used on the table box and not the table wrapper box.
-    // (Where the table element's values are not used on the table and table wrapper boxes, the initial values are used instead.)
-    if (display().is_inline_outside())
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineBlock));
-    else
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
-    builder->set_position(position());
-    builder->set_position_anchor(position_anchor_value());
-    builder->set_inset(inset());
-    builder->set_float(float_());
-    builder->set_clear(clear());
-    // CSS 2 moves table-root positioning and margins to the wrapper. The wrapper is also the grid item for
-    // display:table, so grid placement, self-alignment, and order need to move there as well.
-    builder->copy_grid_placements_from(style_group<CSS::ComputedValues::GridValues>());
-    builder->set_align_self(align_self());
-    builder->set_justify_self(justify_self());
-    builder->set_order(order());
-    builder->set_margin(margin());
-    // AD-HOC:
-    // To match other browsers, z-index needs to be moved to the wrapper box as well,
-    // even if the spec does not mention that: https://github.com/w3c/csswg-drafts/issues/11689
-    // Note that there may be more properties that need to be added to this list.
-    builder->set_z_index(z_index());
-    // "clip" only takes effect on absolutely-positioned elements; the table box isn't one — the wrapper is.
-    builder->set_clip(clip());
-    // AD-HOC: The wrapper box participates in inline layout in place of the table box, so vertical-align
-    //         must be moved to the wrapper to have any effect.
-    builder->set_vertical_align(vertical_align());
-
-    reset_table_box_computed_values_used_by_wrapper_to_init_values();
 }
 
 bool overflow_value_makes_box_a_scroll_container(CSS::Overflow overflow)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -46,11 +46,6 @@ NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document, RustFFI::FfiNo
     m_slot = m_arena->allocate(construction_facts);
 }
 
-NodeArenaAllocation::~NodeArenaAllocation()
-{
-    m_arena->free(m_slot);
-}
-
 static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, void* shell)
 {
     return {
@@ -80,7 +75,13 @@ Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind k
 
 Node::~Node()
 {
-    VERIFY(!parent_ptr());
+    VERIFY(m_arena_is_destroying_shell);
+}
+
+void Node::delete_arena_owned_shell(Node& node)
+{
+    node.m_arena_is_destroying_shell = true;
+    delete &node;
 }
 
 RustFFI::NodeSlotId Node::slot_id(Node const* node)
@@ -630,7 +631,7 @@ Gfx::AffineTransform NodeWithStyle::used_svg_element_transform() const
     return transform;
 }
 
-NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
+NodeWithStyle& NodeWithStyle::create_anonymous_wrapper() const
 {
     auto values = copy_computed_values();
     auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*values);
@@ -639,8 +640,7 @@ NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
     // Set wrapper to inline-block to participate correctly in the IFC within the parent inline-block.
     if (display().is_inline_block() && !has_children())
         builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineBlock));
-    auto wrapper = adopt_ref(*new BlockContainer(const_cast<DOM::Document&>(document()), nullptr, move(builder).build()));
-    return *wrapper;
+    return allocate_layout_node<BlockContainer>(const_cast<DOM::Document&>(document()), nullptr, move(builder).build());
 }
 
 void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const> computed_values)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -40,12 +40,6 @@
 
 namespace Web::Layout {
 
-NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document, RustFFI::FfiNodeConstructionFacts const& construction_facts)
-    : m_arena(document.layout_node_arena())
-{
-    m_slot = m_arena->allocate(construction_facts);
-}
-
 static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, void* shell)
 {
     return {
@@ -63,7 +57,8 @@ static RustFFI::FfiNodeConstructionFacts build_node_construction_facts(DOM::Docu
 }
 
 Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind kind, AttachToDOMNode attach_to_dom_node)
-    : NodeArenaAllocation(document, build_node_construction_facts(document, node, kind, this))
+    : m_arena(document.layout_node_arena())
+    , m_slot(m_arena->allocate(build_node_construction_facts(document, node, kind, this)))
     , m_dom_node(node ? *node : document)
     , m_kind(kind)
 {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1015,14 +1015,14 @@ void Node::verify_has_scroll_offset_flag() const
 
 DOM::Document& Node::document()
 {
-    VERIFY(m_dom_node);
-    return m_dom_node->document();
+    VERIFY(m_arena->document());
+    return *m_arena->document();
 }
 
 DOM::Document const& Node::document() const
 {
-    VERIFY(m_dom_node);
-    return m_dom_node->document();
+    VERIFY(m_arena->document());
+    return *m_arena->document();
 }
 
 // https://drafts.csswg.org/css-ui/#propdef-user-select

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -71,6 +71,16 @@ Node::Node(DOM::Document& document, GC::Ptr<DOM::Node> node, RustFFI::NodeKind k
         node->set_layout_node({}, *this);
 }
 
+Node::Node(DOM::Document& document, BindToPreparedArenaSlot, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind)
+    : m_arena(document.layout_node_arena())
+    , m_slot(slot)
+    , m_kind(kind)
+{
+    VERIFY(RustFFI::layout_arena_node_dom_node(m_arena->handle(), m_slot) == nullptr);
+    RustFFI::layout_arena_attach_shell(m_arena->handle(), m_slot, this);
+    update_has_scroll_offset_flag();
+}
+
 Node::~Node()
 {
     VERIFY(m_arena_is_destroying_shell);
@@ -322,7 +332,6 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     VERIFY(style);
     if (!!style.style_record_identity()) {
         m_style_record_identity = style.style_record_identity();
-        m_style_record_pinned = style.adopts_style_record_pin();
     } else if (auto* element = as_if<DOM::Element>(node.ptr())) {
         m_owned_computed_values = style.values();
         m_style_record_identity = document.style_computer().intern_computed_style_inputs({ *element }, *style.values());
@@ -330,6 +339,21 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
         m_owned_computed_values = style.values();
         m_style_record_identity = document.style_computer().intern_anonymous_layout_style(*style.values());
     }
+    initialize_from_style_record();
+    if (m_owned_computed_values)
+        pin_style_record_for_cxx_consumers();
+}
+
+NodeWithStyle::NodeWithStyle(DOM::Document& document, BindToPreparedArenaSlot bind, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind)
+    : Node(document, bind, slot, kind)
+{
+    m_style_record_identity = CSS::StyleRecordID { RustFFI::layout_arena_node_style_record(arena_handle(), slot) };
+    VERIFY(m_style_record_identity);
+    initialize_from_style_record();
+}
+
+void NodeWithStyle::initialize_from_style_record()
+{
     // NB: Nodes constructed from an interned style record own no ComputedValues; read anchor names through the record view there.
     bool has_anchor_names = false;
     bool insets_use_anchor_functions = false;
@@ -346,8 +370,6 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, GC::Ptr<DOM::Node> node, C
     publish_style_record_to_node_data();
     set_flag(RustFFI::NodeFlag::HasPreserve3dTransformStyle, transform_style() == CSS::TransformStyle::Preserve3d);
     synchronize_table_span_data();
-    if (m_owned_computed_values)
-        pin_style_record_for_cxx_consumers();
 }
 
 CSS::ComputedValues const& NodeWithStyle::owned_computed_values() const
@@ -540,7 +562,7 @@ void NodeWithStyle::propagate_style_to_anonymous_wrappers()
     // If this is a `display:table` box with an anonymous wrapper parent,
     // the parent inherits style from *this* node, not the other way around.
     if (auto* table_wrapper = parent() && parent()->is_table_wrapper() ? parent() : nullptr; table_wrapper && display().is_table_inside()) {
-        table_wrapper->adopt_pinned_anonymous_style_record(derive_pinned_anonymous_box_style_record(document().style_computer(), m_style_record_identity, AnonymousBoxStyleKind::TableWrapper));
+        table_wrapper->adopt_pinned_anonymous_style_record(derive_pinned_anonymous_box_style_record(document().style_computer(), m_style_record_identity, RustFFI::FfiAnonymousStyleKind::TableWrapper, {}));
         reset_table_box_computed_values_used_by_wrapper_to_init_values();
     }
 
@@ -577,14 +599,13 @@ void NodeWithStyle::adopt_pinned_anonymous_style_record(CSS::StyleRecordID style
         || CSS::ComputedValues::either_carries_animated_overlay(*old_record_view, *new_record_view)
         || new_record_view->differs_in_any_layout_affecting_group_payload_from(*old_record_view);
 
-    release_pinned_style_record();
     m_background_layers.clear();
     m_mask_layers.clear();
     m_border_image.clear();
     m_list_style_type.clear();
     m_list_style_image.clear();
+    RustFFI::layout_arena_replace_arena_pinned_style_record(arena_handle(), slot_id(this), style_record_identity.value(), document().style_computer().style_record_payloads(style_record_identity));
     m_style_record_identity = style_record_identity;
-    m_style_record_pinned = true;
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !new_record_view->anchor_names().is_empty());
     set_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions, new_record_view->inset_properties_contain_anchor_functions());
     set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, false);
@@ -820,7 +841,7 @@ void NodeWithStyle::publish_style_record_to_node_data()
     auto const* payloads = document().style_computer().style_engine().style_record_payloads(m_style_record_identity);
     VERIFY(payloads);
     m_style_payloads = payloads;
-    RustFFI::layout_arena_set_node_style_payloads(arena_handle(), slot_id(this), payloads);
+    RustFFI::layout_arena_set_node_style(arena_handle(), slot_id(this), m_style_record_identity.value(), payloads);
     if (content_visibility() == CSS::ContentVisibility::Auto)
         document().note_content_visibility_auto_style();
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -57,6 +57,8 @@ public:
     void* arena_handle() const;
     NodeArena& node_arena() const { return *m_arena; }
 
+    RustFFI::NodeSlotId linked_slot(RustFFI::FfiNodeLink link) const { return RustFFI::layout_arena_node_link_slot(m_arena->handle(), m_slot, link); }
+    bool has_parent() const { return linked_slot(RustFFI::FfiNodeLink::Parent).index != RustFFI::INVALID_NODE_SLOT_INDEX; }
     Node* parent_ptr() { return linked_node(RustFFI::FfiNodeLink::Parent); }
     Node const* parent_ptr() const { return linked_node(RustFFI::FfiNodeLink::Parent); }
     Node* first_child_ptr() { return linked_node(RustFFI::FfiNodeLink::FirstChild); }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -347,9 +347,9 @@ private:
 
     NonnullRefPtr<NodeArena> m_arena;
     RustFFI::NodeSlotId m_slot;
-    // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
-    // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
-    GC::Root<DOM::Node> m_dom_node;
+    // A DOM mutation can disconnect a node before the next layout-tree update. The arena roots the DOM node
+    // through Document::visit_edges while this slot is live, so detach hooks never observe a collected element.
+    GC::RawPtr<DOM::Node> m_dom_node;
     GC::Weak<DOM::Element> m_pseudo_element_generator;
     RustFFI::NodeKind m_kind { RustFFI::NodeKind::Unset };
     bool m_arena_is_destroying_shell { false };

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -641,15 +641,14 @@ public:
     Gfx::Font const& first_available_font() const;
     CSS::StyleScope const& style_scope() const;
 
-    NodeWithStyle& create_anonymous_wrapper() const;
-
-    void transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues::Builder& wrapper_computed_values);
+    void reset_table_box_computed_values_used_by_wrapper_to_init_values();
 
     bool is_body() const { return has_flag(RustFFI::NodeFlag::IsBody); }
     bool is_scroll_container() const;
 
     void set_computed_values(NonnullRefPtr<CSS::ComputedValues const>);
     void set_style_record_identity(CSS::StyleRecordID);
+    void adopt_pinned_anonymous_style_record(CSS::StyleRecordID);
     void pin_style_record_for_cxx_consumers();
     void release_pinned_style_record();
     void bind_generated_style_record(CSS::StyleRecordID);
@@ -663,7 +662,6 @@ private:
 
     virtual bool is_node_with_style() const final { return true; }
 
-    void reset_table_box_computed_values_used_by_wrapper_to_init_values();
     void propagate_style_to_anonymous_wrappers();
     void publish_style_record_to_node_data();
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -39,18 +39,7 @@ enum class LayoutUpdatePropagation : u8 {
     BoundarySelfOnly,
 };
 
-class NodeArenaAllocation {
-protected:
-    NodeArenaAllocation(DOM::Document&, RustFFI::FfiNodeConstructionFacts const&);
-
-    NonnullRefPtr<NodeArena> m_arena;
-    RustFFI::NodeSlotId m_slot {};
-};
-
-class WEB_API Node
-    : public Weakable<Node>
-    , private NodeArenaAllocation {
-
+class WEB_API Node : public Weakable<Node> {
 public:
     AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
 
@@ -84,13 +73,13 @@ public:
     template<typename Callback>
     TraversalDecision for_each_in_inclusive_subtree(Callback callback) const
     {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, callback);
+        return traverse_preorder(*this, IncludeTraversalRoot::Yes, callback);
     }
 
     template<typename Callback>
     TraversalDecision for_each_in_inclusive_subtree(Callback callback)
     {
-        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, callback);
+        return traverse_preorder(*this, IncludeTraversalRoot::Yes, callback);
     }
 
     template<typename U, typename Callback>
@@ -356,8 +345,8 @@ private:
 
     u8 generated_for() const { return RustFFI::layout_arena_node_generated_for(m_arena->handle(), m_slot); }
 
-protected:
-private:
+    NonnullRefPtr<NodeArena> m_arena;
+    RustFFI::NodeSlotId m_slot;
     // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
     GC::Root<DOM::Node> m_dom_node;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -42,21 +42,20 @@ enum class LayoutUpdatePropagation : u8 {
 class NodeArenaAllocation {
 protected:
     NodeArenaAllocation(DOM::Document&, RustFFI::FfiNodeConstructionFacts const&);
-    ~NodeArenaAllocation();
 
     NonnullRefPtr<NodeArena> m_arena;
     RustFFI::NodeSlotId m_slot {};
 };
 
 class WEB_API Node
-    : public RefCounted<Node>
-    , public Weakable<Node>
+    : public Weakable<Node>
     , private NodeArenaAllocation {
 
 public:
     AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
 
     virtual ~Node();
+    static void delete_arena_owned_shell(Node&);
     StringView class_name() const;
 
     static RustFFI::NodeSlotId slot_id(Node const*);
@@ -364,7 +363,14 @@ private:
     GC::Root<DOM::Node> m_dom_node;
     GC::Weak<DOM::Element> m_pseudo_element_generator;
     RustFFI::NodeKind m_kind { RustFFI::NodeKind::Unset };
+    bool m_arena_is_destroying_shell { false };
 };
+
+template<typename T, typename... Args>
+T& allocate_layout_node(Args&&... args)
+{
+    return *new T(forward<Args>(args)...);
+}
 
 class WEB_API NodeWithStyle : public Node {
 public:
@@ -646,7 +652,7 @@ public:
     Gfx::Font const& first_available_font() const;
     CSS::StyleScope const& style_scope() const;
 
-    NonnullRefPtr<NodeWithStyle> create_anonymous_wrapper() const;
+    NodeWithStyle& create_anonymous_wrapper() const;
 
     void transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues::Builder& wrapper_computed_values);
 
@@ -677,8 +683,8 @@ private:
     void const* m_style_payloads { nullptr };
     RefPtr<CSS::ComputedValues const> m_owned_computed_values;
     CSS::StyleRecordID m_style_record_identity;
-    // Layout nodes are ref-counted rather than GC cells, so this owner cannot be a traced GC::Ptr.
-    // Document::tear_down_layout_tree() must drop the layout root, which destroys these nodes and
+    // Layout nodes are not GC cells, so this owner cannot be a traced GC::Ptr.
+    // Document::tear_down_layout_tree() must free the layout root, which destroys these nodes and
     // unpins their records before this root is cleared. Every document destruction path goes
     // through that teardown.
     GC::Root<DOM::Document> m_style_record_owner;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -75,12 +75,12 @@ public:
     Node* previous_sibling_ptr() { return linked_node(RustFFI::FfiNodeLink::PreviousSibling); }
     bool has_children() const { return first_child_ptr() != nullptr; }
 
-    RefPtr<Node> first_child() { return first_child_ptr(); }
-    RefPtr<Node const> first_child() const { return first_child_ptr(); }
-    RefPtr<Node> next_sibling() { return next_sibling_ptr(); }
-    RefPtr<Node const> next_sibling() const { return next_sibling_ptr(); }
-    RefPtr<Node> previous_sibling() { return previous_sibling_ptr(); }
-    RefPtr<Node const> previous_sibling() const { return const_cast<Node*>(this)->previous_sibling_ptr(); }
+    Node* first_child() { return first_child_ptr(); }
+    Node const* first_child() const { return first_child_ptr(); }
+    Node* next_sibling() { return next_sibling_ptr(); }
+    Node const* next_sibling() const { return next_sibling_ptr(); }
+    Node* previous_sibling() { return previous_sibling_ptr(); }
+    Node const* previous_sibling() const { return const_cast<Node*>(this)->previous_sibling_ptr(); }
 
     template<typename Callback>
     TraversalDecision for_each_in_inclusive_subtree(Callback callback) const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -672,11 +672,10 @@ private:
     void const* m_style_payloads { nullptr };
     RefPtr<CSS::ComputedValues const> m_owned_computed_values;
     CSS::StyleRecordID m_style_record_identity;
-    // Layout nodes are not GC cells, so this owner cannot be a traced GC::Ptr.
-    // Document::tear_down_layout_tree() must free the layout root, which destroys these nodes and
-    // unpins their records before this root is cleared. Every document destruction path goes
-    // through that teardown.
-    GC::Root<DOM::Document> m_style_record_owner;
+    // The pin is released through the arena's document, so Document::tear_down_layout_tree()
+    // must free the layout root before the document's style computer goes away. Every document
+    // destruction path goes through that teardown.
+    bool m_style_record_pinned { false };
     struct ImageObserverSlots {
         Vector<OwnPtr<ImageObserver>> background_layers;
         Vector<OwnPtr<ImageObserver>> mask_layers;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -654,7 +654,8 @@ public:
 
     void set_computed_values(NonnullRefPtr<CSS::ComputedValues const>);
     void set_style_record_identity(CSS::StyleRecordID);
-    void adopt_pinned_anonymous_style_record(CSS::StyleRecordID);
+    void refresh_style_from_arena();
+    bool reinherit_owned_computed_values_from(CSS::StyleRecordID parent_style_record_identity);
     void pin_style_record_for_cxx_consumers();
     void release_pinned_style_record();
     void bind_generated_style_record(CSS::StyleRecordID);
@@ -668,7 +669,6 @@ private:
 
     virtual bool is_node_with_style() const final { return true; }
 
-    void propagate_style_to_anonymous_wrappers();
     void initialize_from_style_record();
     void publish_style_record_to_node_data();
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -39,6 +39,10 @@ enum class LayoutUpdatePropagation : u8 {
     BoundarySelfOnly,
 };
 
+enum class BindToPreparedArenaSlot {
+    Yes,
+};
+
 class WEB_API Node : public Weakable<Node> {
 public:
     AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
@@ -310,6 +314,7 @@ public:
 
 protected:
     Node(DOM::Document&, GC::Ptr<DOM::Node>, RustFFI::NodeKind, AttachToDOMNode = AttachToDOMNode::Yes);
+    Node(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);
 
     bool has_flag(RustFFI::NodeFlag flag) const
     {
@@ -364,6 +369,7 @@ T& allocate_layout_node(Args&&... args)
 class WEB_API NodeWithStyle : public Node {
 public:
     NodeWithStyle(DOM::Document&, GC::Ptr<DOM::Node>, CSS::LayoutStyle, RustFFI::NodeKind = RustFFI::NodeKind::NodeWithStyle);
+    NodeWithStyle(DOM::Document&, BindToPreparedArenaSlot, RustFFI::NodeSlotId, RustFFI::NodeKind);
 
     virtual ~NodeWithStyle() override;
 
@@ -663,6 +669,7 @@ private:
     virtual bool is_node_with_style() const final { return true; }
 
     void propagate_style_to_anonymous_wrappers();
+    void initialize_from_style_record();
     void publish_style_record_to_node_data();
 
     void rebuild_image_observers();

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -28,9 +28,9 @@ RustFFI::NodeSlotId NodeArena::allocate(RustFFI::FfiNodeConstructionFacts const&
     return RustFFI::layout_arena_allocate(m_handle, construction_facts);
 }
 
-void NodeArena::free(RustFFI::NodeSlotId slot)
+void NodeArena::free_subtree(RustFFI::NodeSlotId root)
 {
-    RustFFI::layout_arena_free(m_handle, slot);
+    RustFFI::layout_arena_free_subtree(m_handle, root);
 }
 
 u64 NodeArena::formatting_context_run_cache_hit_count() const
@@ -48,9 +48,9 @@ u64 NodeArena::intrinsic_measurement_count() const
     return RustFFI::layout_arena_intrinsic_measurement_count(m_handle);
 }
 
-bool detach_layout_node_for_destruction(Node& node)
+bool destroy_layout_subtree(Node& node)
 {
-    return RustFFI::layout_arena_detach_node_for_destruction(node.arena_handle(), Node::slot_id(&node));
+    return RustFFI::layout_arena_detach_and_free_subtree(node.arena_handle(), Node::slot_id(&node));
 }
 
 void NodeArena::sync_enrolled_content_for_layout()

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
@@ -46,6 +47,13 @@ u64 NodeArena::table_cell_measurement_cache_miss_count() const
 u64 NodeArena::intrinsic_measurement_count() const
 {
     return RustFFI::layout_arena_intrinsic_measurement_count(m_handle);
+}
+
+void NodeArena::visit_dom_nodes(GC::Cell::Visitor& visitor) const
+{
+    RustFFI::layout_arena_visit_dom_nodes(m_handle, &visitor, [](void* visitor_pointer, void* dom_node_pointer) {
+        static_cast<GC::Cell::Visitor*>(visitor_pointer)->visit(static_cast<DOM::Node*>(dom_node_pointer));
+    });
 }
 
 bool destroy_layout_subtree(Node& node)

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -11,6 +11,7 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
+#include <LibGC/Cell.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Layout/LayoutRustFFI.h>
 
@@ -35,6 +36,7 @@ public:
     u64 intrinsic_measurement_count() const;
 
     void sync_enrolled_content_for_layout();
+    void visit_dom_nodes(GC::Cell::Visitor&) const;
 
 private:
     void* m_handle { nullptr };

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -28,7 +28,7 @@ public:
     ~NodeArena();
 
     RustFFI::NodeSlotId allocate(RustFFI::FfiNodeConstructionFacts const&);
-    void free(RustFFI::NodeSlotId);
+    void free_subtree(RustFFI::NodeSlotId);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
     u64 table_cell_measurement_cache_miss_count() const;
@@ -40,6 +40,6 @@ private:
     void* m_handle { nullptr };
 };
 
-WEB_API bool detach_layout_node_for_destruction(Node&);
+WEB_API bool destroy_layout_subtree(Node&);
 
 }

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -6,13 +6,16 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <LibGC/Cell.h>
+#include <LibGC/Ptr.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Layout/LayoutRustFFI.h>
 
 namespace Web::Layout {
@@ -38,8 +41,12 @@ public:
     void sync_enrolled_content_for_layout();
     void visit_dom_nodes(GC::Cell::Visitor&) const;
 
+    DOM::Document* document() const { return m_document.ptr(); }
+    void set_document(Badge<DOM::Document>, DOM::Document* document) { m_document = document; }
+
 private:
     void* m_handle { nullptr };
+    GC::RawPtr<DOM::Document> m_document;
 };
 
 WEB_API bool destroy_layout_subtree(Node&);

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -423,9 +423,18 @@ TextNode::TextForRendering TextNode::apply_text_transform(Utf16String const& str
     VERIFY_NOT_REACHED();
 }
 
+static CSS::ComputedValues::InheritedTextValues const& inherited_text_values_of_parent(TextNode const& text_node)
+{
+    auto parent_slot = text_node.linked_slot(RustFFI::FfiNodeLink::Parent);
+    auto const* payloads = static_cast<void const* const*>(RustFFI::layout_arena_node_style_payloads(text_node.arena_handle(), parent_slot));
+    VERIFY(payloads);
+    return *static_cast<CSS::ComputedValues::InheritedTextValues const*>(payloads[CSS::ComputedValues::InheritedTextValues::style_group_index]);
+}
+
 TextNode::TextForRenderingCacheKey TextNode::create_text_for_rendering_cache_key() const
 {
-    auto text_transform = parent()->text_transform();
+    auto const& parent_inherited_text_values = inherited_text_values_of_parent(*this);
+    auto text_transform = parent_inherited_text_values.text_transform_value();
     Optional<Utf16String> lang;
     if (first_is_one_of(text_transform, CSS::TextTransform::Uppercase, CSS::TextTransform::Lowercase, CSS::TextTransform::Capitalize)) {
         if (auto parent_element = parent_element_for_text_transform())
@@ -434,7 +443,7 @@ TextNode::TextForRenderingCacheKey TextNode::create_text_for_rendering_cache_key
 
     return {
         .text_transform = text_transform,
-        .white_space_collapse = parent()->white_space_collapse(),
+        .white_space_collapse = parent_inherited_text_values.white_space_collapse_value(),
         .lang = move(lang),
         .is_password_input = is_password_input(),
         .dom_start_offset = dom_start_offset(),

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -69,10 +69,10 @@ private:
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
     RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks();
 
-    static NonnullRefPtr<BlockContainer> create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style);
+    static BlockContainer& create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style);
     static RustFFI::FfiFirstLetterNodes create_first_letter_nodes(DOM::Element&, RustFFI::FfiFirstLetterTarget);
 
-    RefPtr<Layout::Node> m_layout_root;
+    Layout::Viewport* m_layout_root { nullptr };
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
     OwnPtr<PseudoElementFrameStorage> m_pseudo_element_frames;
     OwnPtr<FirstLetterTextContext> m_first_letter_text_context;
@@ -433,29 +433,15 @@ private:
     mutable OwnPtr<ImageClient> m_image_client;
 };
 
-static NonnullRefPtr<Box> create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::LayoutStyle style, CSS::AbstractImageStyleValue& image)
+static Box& create_content_image_box(DOM::Document& document, GC::Ptr<DOM::Element> element, CSS::LayoutStyle style, CSS::AbstractImageStyleValue& image)
 {
     image.load_any_resources(document);
     auto image_provider = GeneratedContentImageProvider::create(document, image);
     auto& image_provider_ref = *image_provider;
-    auto image_box = make_ref_counted<Box>(document, element, style, RustFFI::NodeKind::ImageBox);
-    image_box->set_owned_image_provider(move(image_provider));
-    image_provider_ref.set_layout_node(*image_box);
+    auto& image_box = allocate_layout_node<Box>(document, element, style, RustFFI::NodeKind::ImageBox);
+    image_box.set_owned_image_provider(move(image_provider));
+    image_provider_ref.set_layout_node(image_box);
     return image_box;
-}
-
-static RustFFI::NodeSlotId release_to_rust(NonnullRefPtr<Node> node)
-{
-    return Node::slot_id(&node.leak_ref());
-}
-
-template<typename T>
-static RustFFI::NodeSlotId retain_for_rust(RefPtr<T> const& node)
-{
-    if (!node)
-        return RustFFI::NodeSlotId_INVALID;
-    node->ref();
-    return Node::slot_id(node.ptr());
 }
 
 static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::ComputedContentData const& content)
@@ -470,8 +456,8 @@ static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::Comput
 }
 
 struct FirstLetterTextSlices {
-    NonnullRefPtr<TextNode> first_letter_slice;
-    NonnullRefPtr<TextNode> remainder_slice;
+    TextNode* first_letter_slice;
+    TextNode* remainder_slice;
 };
 
 static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& document, TextNode& text_node, size_t letter_end)
@@ -482,16 +468,16 @@ static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& docu
     // (from a content property) has no DOM node and gets plain generated slices of its text instead.
     if (auto* dom_text = text_node.dom_text()) {
         auto& mutable_dom_text = const_cast<DOM::Text&>(*dom_text);
-        auto remainder_slice = make_ref_counted<TextSliceNode>(document, mutable_dom_text, Node::AttachToDOMNode::Yes, letter_end, full_length - letter_end);
-        auto first_letter_slice = make_ref_counted<TextSliceNode>(document, mutable_dom_text, Node::AttachToDOMNode::No, 0, letter_end);
-        remainder_slice->set_first_letter_slice(*first_letter_slice);
-        return { move(first_letter_slice), move(remainder_slice) };
+        auto& remainder_slice = allocate_layout_node<TextSliceNode>(document, mutable_dom_text, Node::AttachToDOMNode::Yes, letter_end, full_length - letter_end);
+        auto& first_letter_slice = allocate_layout_node<TextSliceNode>(document, mutable_dom_text, Node::AttachToDOMNode::No, 0, letter_end);
+        remainder_slice.set_first_letter_slice(first_letter_slice);
+        return { &first_letter_slice, &remainder_slice };
     }
 
     auto text = text_node.text();
     return {
-        make_ref_counted<GeneratedTextNode>(document, Utf16String::from_utf16(text.utf16_view().substring_view(0, letter_end))),
-        make_ref_counted<GeneratedTextNode>(document, Utf16String::from_utf16(text.utf16_view().substring_view(letter_end, full_length - letter_end))),
+        &allocate_layout_node<GeneratedTextNode>(document, Utf16String::from_utf16(text.utf16_view().substring_view(0, letter_end))),
+        &allocate_layout_node<GeneratedTextNode>(document, Utf16String::from_utf16(text.utf16_view().substring_view(letter_end, full_length - letter_end))),
     };
 }
 
@@ -513,16 +499,16 @@ RustFFI::FfiFirstLetterNodes LayoutTreeBuildBridge::create_first_letter_nodes(DO
         LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::FirstLetter, first_letter_wrapper);
     }
     return {
-        .wrapper = retain_for_rust(first_letter_wrapper),
-        .first_letter_slice = release_to_rust(move(first_letter_slice)),
-        .remainder_slice = release_to_rust(move(remainder_slice)),
+        .wrapper = Node::slot_id(first_letter_wrapper),
+        .first_letter_slice = Node::slot_id(first_letter_slice),
+        .remainder_slice = Node::slot_id(remainder_slice),
     };
 }
 
-NonnullRefPtr<BlockContainer> LayoutTreeBuildBridge::create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style)
+BlockContainer& LayoutTreeBuildBridge::create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style)
 {
-    auto list_item_marker = make_ref_counted<BlockContainer>(list_box.document(), nullptr, move(marker_style), RustFFI::NodeKind::ListItemMarkerBox);
-    list_item_marker->set_list_marker_is_inside(list_box.list_style_position() == CSS::ListStylePosition::Inside);
+    auto& list_item_marker = allocate_layout_node<BlockContainer>(list_box.document(), nullptr, move(marker_style), RustFFI::NodeKind::ListItemMarkerBox);
+    list_item_marker.set_list_marker_is_inside(list_box.list_style_position() == CSS::ListStylePosition::Inside);
     return list_item_marker;
 }
 
@@ -612,9 +598,9 @@ struct PseudoElementFrame {
     CSS::Display display;
     RefPtr<CSS::AbstractImageStyleValue const> replacement_image;
     BlockContainer* originating_list_box { nullptr };
-    RefPtr<NodeWithStyle> layout_node;
+    NodeWithStyle* layout_node { nullptr };
     CSS::ContentData resolved_content;
-    RefPtr<Layout::Node> content_item;
+    Layout::Node* content_item { nullptr };
 };
 
 struct LayoutTreeBuildBridge::PseudoElementFrameStorage {
@@ -728,21 +714,21 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 VERIFY_NOT_REACHED();
             case RustFFI::FfiPseudoElementDecision::ContentReplacement:
                 VERIFY(frame.replacement_image);
-                frame.layout_node = create_content_image_box(document, nullptr, style, const_cast<CSS::AbstractImageStyleValue&>(*frame.replacement_image));
+                frame.layout_node = &create_content_image_box(document, nullptr, style, const_cast<CSS::AbstractImageStyleValue&>(*frame.replacement_image));
                 break;
             case RustFFI::FfiPseudoElementDecision::Contents:
-                frame.layout_node = make_ref_counted<NodeWithStyle>(document, nullptr, style, RustFFI::NodeKind::InlineNode);
+                frame.layout_node = &allocate_layout_node<NodeWithStyle>(document, nullptr, style, RustFFI::NodeKind::InlineNode);
                 frame.layout_node->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
                 break;
             case RustFFI::FfiPseudoElementDecision::Box:
                 if (frame.originating_list_box) {
-                    frame.layout_node = create_list_item_marker(*frame.originating_list_box, style);
+                    frame.layout_node = &create_list_item_marker(*frame.originating_list_box, style);
                     break;
                 }
                 frame.layout_node = DOM::Element::create_layout_node_for_display_type(document, frame.display, style, nullptr);
                 break;
             }
-            return retain_for_rust(frame.layout_node); },
+            return Node::slot_id(frame.layout_node); },
         .attach_style_resources = [](void* frame_pointer) {
             VERIFY(frame_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
@@ -765,11 +751,11 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             VERIFY(frame.layout_node);
             auto marker_style = element.document().style_computer().materialize_style_record({ element, CSS::PseudoElement::Marker });
-            auto list_item_marker = create_list_item_marker(as<BlockContainer>(*frame.layout_node), move(marker_style));
-            list_item_marker->attach_style_resources();
-            list_item_marker->set_generated_for(CSS::PseudoElement::Marker, element);
-            LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::Marker, list_item_marker);
-            return release_to_rust(move(list_item_marker)); },
+            auto& list_item_marker = create_list_item_marker(as<BlockContainer>(*frame.layout_node), move(marker_style));
+            list_item_marker.attach_style_resources();
+            list_item_marker.set_generated_for(CSS::PseudoElement::Marker, element);
+            LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::Marker, &list_item_marker);
+            return Node::slot_id(&list_item_marker); },
         .create_nested_list_marker_content = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement originating_pseudo, void* marker_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -780,21 +766,21 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             auto& list_item_marker = as<BlockContainer>(*static_cast<Node*>(marker_pointer));
             DOM::AbstractElement element_reference { element, css_pseudo_element(originating_pseudo) };
             auto content = resolve_normal_marker_content(element_reference, list_box, list_item_marker);
-            auto content_node = [&]() -> NonnullRefPtr<Node> {
+            auto& content_node = [&]() -> Node& {
                 if (auto const* text = content.data.first().get_pointer<Utf16String>()) {
-                    auto text_node = make_ref_counted<GeneratedTextNode>(list_box.document(), *text);
-                    text_node->set_generated_for(CSS::PseudoElement::Marker, element);
+                    auto& text_node = allocate_layout_node<GeneratedTextNode>(list_box.document(), *text);
+                    text_node.set_generated_for(CSS::PseudoElement::Marker, element);
                     return text_node;
                 }
                 auto& image = *content.data.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
-                auto image_box = create_content_image_box(list_box.document(), nullptr, list_item_marker.copy_computed_values(), image);
-                image_box->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-                image_box->attach_style_resources();
-                image_box->set_generated_for(CSS::PseudoElement::Marker, element);
+                auto& image_box = create_content_image_box(list_box.document(), nullptr, list_item_marker.copy_computed_values(), image);
+                image_box.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+                image_box.attach_style_resources();
+                image_box.set_generated_for(CSS::PseudoElement::Marker, element);
                 return image_box;
             }();
             list_item_marker.set_content(content);
-            return release_to_rust(move(content_node)); },
+            return Node::slot_id(&content_node); },
         .configure_layout_node = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -812,7 +798,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer), css_pseudo_element(ffi_pseudo) };
             auto computed_values = element_reference.computed_style();
             VERIFY(computed_values);
-            if (auto* marker = frame.layout_node->is_list_item_marker_box() ? static_cast<BlockContainer*>(frame.layout_node.ptr()) : nullptr;
+            if (auto* marker = frame.layout_node->is_list_item_marker_box() ? static_cast<BlockContainer*>(frame.layout_node) : nullptr;
                 marker && computed_values->computed_content().type == CSS::ComputedContentData::Type::Normal) {
                 VERIFY(frame.originating_list_box);
                 frame.resolved_content = resolve_normal_marker_content(element_reference, *frame.originating_list_box, *marker);
@@ -845,18 +831,18 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 // zero-length child that would force layout to measure an otherwise empty box.
                 if (string->is_empty() && !(frame.display.is_inline_outside() && frame.display.is_flow_inside()))
                     return Node::slot_id(nullptr);
-                frame.content_item = make_ref_counted<GeneratedTextNode>(element.document(), *string);
+                frame.content_item = &allocate_layout_node<GeneratedTextNode>(element.document(), *string);
             } else {
                 auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
-                auto image_box = create_content_image_box(element.document(), nullptr, frame.layout_node->copy_computed_values(), image);
+                auto& image_box = create_content_image_box(element.document(), nullptr, frame.layout_node->copy_computed_values(), image);
                 // https://drafts.csswg.org/css-content-3/#content-property
                 // For <image>, this is an inline anonymous replaced element.
-                image_box->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-                image_box->attach_style_resources();
-                frame.content_item = move(image_box);
+                image_box.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+                image_box.attach_style_resources();
+                frame.content_item = &image_box;
             }
             frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
-            return retain_for_rust(frame.content_item); },
+            return Node::slot_id(frame.content_item); },
     };
 }
 
@@ -908,7 +894,7 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node
         // The parent may keep its subtree (a child lost its box in place); an emptied container
         // reads as having block-level children, like a freshly built one.
         auto* parent = layout_node->parent();
-        detach_layout_node_for_destruction(*layout_node);
+        destroy_layout_subtree(*layout_node);
         if (!parent->has_children())
             parent->set_children_are_inline(false);
     }
@@ -946,7 +932,7 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
 }
 
 struct PrincipalNodeFrame {
-    RefPtr<Layout::Node> layout_node;
+    Layout::Node* layout_node { nullptr };
     RefPtr<CSS::ComputedValues const> anonymous_computed_values;
     CSS::StyleRecordID style_record_identity;
     GC::Ptr<CSS::StyleComputer> style_record_owner;
@@ -1242,31 +1228,31 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 auto computed_content = computed_values->computed_content();
                 auto const* replacement_image = content_replacement_image(computed_content);
                 VERIFY(replacement_image);
-                frame.layout_node = create_content_image_box(element.document(), element, style, const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
+                frame.layout_node = &create_content_image_box(element.document(), element, style, const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
                 break;
             }
             case RustFFI::FfiElementLayoutKind::SvgMask:
-                frame.layout_node = make_ref_counted<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGMaskBox);
+                frame.layout_node = &allocate_layout_node<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGMaskBox);
                 break;
             case RustFFI::FfiElementLayoutKind::SvgClipPath:
-                frame.layout_node = make_ref_counted<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGClipBox);
+                frame.layout_node = &allocate_layout_node<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGClipBox);
                 break;
             case RustFFI::FfiElementLayoutKind::SvgPattern:
-                frame.layout_node = make_ref_counted<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGPatternBox);
+                frame.layout_node = &allocate_layout_node<Layout::Box>(element.document(), element, style, RustFFI::NodeKind::SVGPatternBox);
                 break;
             case RustFFI::FfiElementLayoutKind::Normal:
                 frame.layout_node = element.create_layout_node(style);
                 break;
             }
-            return retain_for_rust(frame.layout_node); },
+            return Node::slot_id(frame.layout_node); },
         .create_principal_document_layout = [](void* frame_pointer, void* document_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(document_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& document = *static_cast<DOM::Document*>(document_pointer);
             frame.anonymous_computed_values = document.style_computer().create_document_style();
-            frame.layout_node = make_ref_counted<Layout::Viewport>(document, frame.anonymous_computed_values.release_nonnull());
-            return retain_for_rust(frame.layout_node); },
+            frame.layout_node = &allocate_layout_node<Layout::Viewport>(document, frame.anonymous_computed_values.release_nonnull());
+            return Node::slot_id(frame.layout_node); },
         .principal_text_layout_facts = [](void* text_pointer) -> RustFFI::FfiTextLayoutFacts {
             VERIFY(text_pointer);
             auto& text = *static_cast<DOM::Text*>(text_pointer);
@@ -1289,7 +1275,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node = static_cast<DOM::Node*>(node_pointer)->unsafe_layout_node(); },
         .principal_layout_node = [](void* frame_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
-            return Node::slot_id(static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node.ptr()); },
+            return Node::slot_id(static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node); },
         .attach_principal_style_resources = [](void* frame_pointer) {
             VERIFY(frame_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
@@ -1311,7 +1297,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
-            builder.m_layout_root = frame.layout_node; },
+            builder.m_layout_root = &as<Layout::Viewport>(*frame.layout_node); },
         .document_layout_node = [](void* document_pointer) -> RustFFI::NodeSlotId {
             VERIFY(document_pointer);
             // NB: Called during layout tree construction.
@@ -1342,11 +1328,11 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
 static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(PrincipalNodeFrame& frame, DOM::Text& text_node, bool needs_style_wrapper)
 {
     auto& document = text_node.document();
-    auto layout_node = make_ref_counted<Layout::TextNode>(document, text_node);
+    auto& layout_node = allocate_layout_node<Layout::TextNode>(document, text_node);
     if (!needs_style_wrapper) {
-        frame.layout_node = layout_node;
+        frame.layout_node = &layout_node;
         return {
-            .layout_node = retain_for_rust(frame.layout_node),
+            .layout_node = Node::slot_id(frame.layout_node),
             .wrapped_text = RustFFI::NodeSlotId_INVALID,
         };
     }
@@ -1354,21 +1340,21 @@ static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(Principa
     auto style_parent_values = style_parent.computed_style();
     VERIFY(style_parent_values);
     auto wrapper_values = CSS::ComputedValues::Builder { *style_parent_values }.build();
-    auto wrapper = make_ref_counted<Layout::NodeWithStyle>(document, nullptr, move(wrapper_values), RustFFI::NodeKind::InlineNode);
-    wrapper->attach_style_resources();
-    wrapper->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-    frame.layout_node = wrapper;
+    auto& wrapper = allocate_layout_node<Layout::NodeWithStyle>(document, nullptr, move(wrapper_values), RustFFI::NodeKind::InlineNode);
+    wrapper.attach_style_resources();
+    wrapper.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+    frame.layout_node = &wrapper;
     return {
-        .layout_node = retain_for_rust(frame.layout_node),
-        .wrapped_text = release_to_rust(move(layout_node)),
+        .layout_node = Node::slot_id(frame.layout_node),
+        .wrapped_text = Node::slot_id(&layout_node),
     };
 }
 
 // A full-height flex column that centers the button contents vertically.
-static NonnullRefPtr<NodeWithStyle> create_button_flex_wrapper(NodeWithStyle& parent)
+static NodeWithStyle& create_button_flex_wrapper(NodeWithStyle& parent)
 {
-    auto flex_wrapper = parent.create_anonymous_wrapper();
-    flex_wrapper->modify_computed_values([](auto& values) {
+    auto& flex_wrapper = parent.create_anonymous_wrapper();
+    flex_wrapper.modify_computed_values([](auto& values) {
         values.set_display(CSS::Display { CSS::DisplayOutside::Block, CSS::DisplayInside::Flex });
         values.set_justify_content(CSS::JustifyContent::Center);
         values.set_flex_direction(CSS::FlexDirection::Column);
@@ -1379,10 +1365,10 @@ static NonnullRefPtr<NodeWithStyle> create_button_flex_wrapper(NodeWithStyle& pa
 
 // Let percentage-sized descendants shrink to fixed-height buttons instead of the flex
 // item's automatic minimum size.
-static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithStyle& parent)
+static NodeWithStyle& create_button_content_box_wrapper(NodeWithStyle& parent)
 {
-    auto content_box_wrapper = parent.create_anonymous_wrapper();
-    content_box_wrapper->modify_computed_values([](auto& values) {
+    auto& content_box_wrapper = parent.create_anonymous_wrapper();
+    content_box_wrapper.modify_computed_values([](auto& values) {
         values.set_min_height(CSS::Size::make_px(CSSPixels(0)));
     });
     return content_box_wrapper;
@@ -1393,7 +1379,7 @@ LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
     RustFFI::rust_build_layout_tree(&callbacks, dom_node.document().layout_node_arena().handle(), &dom_node);
     return {
-        .root = move(m_layout_root),
+        .root = m_layout_root,
         .rebuilt_subtree_roots = move(m_rebuilt_subtree_roots),
         .layout_tree_update_escaped_rebuild_roots = m_layout_tree_update_escaped_rebuild_roots,
         .needs_another_build_pass = m_needs_another_build_pass,
@@ -1470,8 +1456,8 @@ static RustFFI::NodeSlotId ffi_create_anonymous_table_box(void*, void* parent_po
     }
 
     if (kind == RustFFI::FfiAnonymousTableBoxKind::TableCell)
-        return release_to_rust(make_ref_counted<BlockContainer>(parent.document(), nullptr, move(builder).build()));
-    return release_to_rust(make_ref_counted<Box>(parent.document(), nullptr, move(builder).build()));
+        return Node::slot_id(&allocate_layout_node<BlockContainer>(parent.document(), nullptr, move(builder).build()));
+    return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, move(builder).build()));
 }
 
 static NonnullRefPtr<CSS::ComputedValues const> table_wrapper_computed_values(Box& table_box)
@@ -1486,7 +1472,7 @@ static RustFFI::NodeSlotId ffi_create_table_wrapper(void*, void* table_root_poin
 {
     VERIFY(table_root_pointer);
     auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
-    return release_to_rust(make_ref_counted<BlockContainer>(table_box.document(), nullptr, table_wrapper_computed_values(table_box), RustFFI::NodeKind::TableWrapper));
+    return Node::slot_id(&allocate_layout_node<BlockContainer>(table_box.document(), nullptr, table_wrapper_computed_values(table_box), RustFFI::NodeKind::TableWrapper));
 }
 
 static RustFFI::NodeSlotId ffi_create_missing_table_cell(void*, void* row_pointer)
@@ -1498,14 +1484,14 @@ static RustFFI::NodeSlotId ffi_create_missing_table_cell(void*, void* row_pointe
     builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
     // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
     builder->set_vertical_align(CSS::VerticalAlign::Middle);
-    return release_to_rust(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
+    return Node::slot_id(&allocate_layout_node<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
 }
 
 static RustFFI::NodeSlotId ffi_create_anonymous_wrapper(void*, void* parent_pointer)
 {
     VERIFY(parent_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    return release_to_rust(parent.create_anonymous_wrapper());
+    return Node::slot_id(&parent.create_anonymous_wrapper());
 }
 
 static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void*, void* layout_node_pointer)
@@ -1515,11 +1501,11 @@ static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void
 
     // If the box does not overflow in the vertical axis, then it is centered vertically.
     // FIXME: Only apply alignment when box overflows
-    auto flex_wrapper = create_button_flex_wrapper(parent);
-    auto content_box_wrapper = create_button_content_box_wrapper(parent);
+    auto& flex_wrapper = create_button_flex_wrapper(parent);
+    auto& content_box_wrapper = create_button_content_box_wrapper(parent);
     return {
-        .flex_wrapper = release_to_rust(move(flex_wrapper)),
-        .content_box = release_to_rust(move(content_box_wrapper)),
+        .flex_wrapper = Node::slot_id(&flex_wrapper),
+        .content_box = Node::slot_id(&content_box_wrapper),
     };
 }
 
@@ -1527,8 +1513,8 @@ static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layo
 {
     VERIFY(layout_node_pointer);
     auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(layout_node_pointer));
-    auto wrapper = fieldset_box.create_anonymous_wrapper();
-    wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+    auto& wrapper = fieldset_box.create_anonymous_wrapper();
+    wrapper.set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
 
     // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
     // The following properties are expected to inherit from the fieldset element:
@@ -1537,9 +1523,9 @@ static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layo
     //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
     //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
     // FIXME: Transfer all of these properties, not just overflow.
-    wrapper->set_overflow(fieldset_box.overflow_x(), fieldset_box.overflow_y());
+    wrapper.set_overflow(fieldset_box.overflow_x(), fieldset_box.overflow_y());
     fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
-    return release_to_rust(move(wrapper));
+    return Node::slot_id(&wrapper);
 }
 
 RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_callbacks()

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -106,7 +106,7 @@ void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& el
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
 struct PrincipalNodeFrame;
-static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(PrincipalNodeFrame&, DOM::Text&, bool needs_style_wrapper);
+static RustFFI::NodeSlotId create_layout_node_for_text(PrincipalNodeFrame&, DOM::Text&);
 
 static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node)
 {
@@ -1264,11 +1264,19 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .parent_display_is_contents = style_parent_values && style_parent_values->display().is_contents(),
                 .text_is_ascii_whitespace = text.data().is_ascii_whitespace(),
                 .parent_collapses_whitespace = style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse),
+                .style_parent_style_record = style_parent ? style_parent->style_record_identity().value() : 0,
             }; },
-        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) -> RustFFI::FfiPrincipalTextLayoutNodes {
+        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(text_pointer);
-            return create_layout_node_for_text(*static_cast<PrincipalNodeFrame*>(frame_pointer), *static_cast<DOM::Text*>(text_pointer), needs_style_wrapper); },
+            return create_layout_node_for_text(*static_cast<PrincipalNodeFrame*>(frame_pointer), *static_cast<DOM::Text*>(text_pointer)); },
+        .set_principal_layout_node = [](void* builder_pointer, void* frame_pointer, RustFFI::NodeSlotId slot) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            frame.layout_node = static_cast<Node*>(RustFFI::layout_arena_node_shell_if_live(builder.m_document->layout_node_arena().handle(), slot));
+            VERIFY(frame.layout_node); },
         .reuse_principal_layout = [](void* frame_pointer, void* node_pointer) {
             VERIFY(frame_pointer);
             VERIFY(node_pointer);
@@ -1326,29 +1334,10 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
         element.document().update_style_for_element({ element });
 }
 
-static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(PrincipalNodeFrame& frame, DOM::Text& text_node, bool needs_style_wrapper)
+static RustFFI::NodeSlotId create_layout_node_for_text(PrincipalNodeFrame& frame, DOM::Text& text_node)
 {
-    auto& document = text_node.document();
-    auto& layout_node = allocate_layout_node<Layout::TextNode>(document, text_node);
-    if (!needs_style_wrapper) {
-        frame.layout_node = &layout_node;
-        return {
-            .layout_node = Node::slot_id(frame.layout_node),
-            .wrapped_text = RustFFI::NodeSlotId_INVALID,
-        };
-    }
-    auto& style_parent = as<DOM::Element>(*text_node.flat_tree_parent());
-    auto style_parent_values = style_parent.computed_style();
-    VERIFY(style_parent_values);
-    auto wrapper_values = CSS::ComputedValues::Builder { *style_parent_values }.build();
-    auto& wrapper = allocate_layout_node<Layout::NodeWithStyle>(document, nullptr, move(wrapper_values), RustFFI::NodeKind::InlineNode);
-    wrapper.attach_style_resources();
-    wrapper.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-    frame.layout_node = &wrapper;
-    return {
-        .layout_node = Node::slot_id(frame.layout_node),
-        .wrapped_text = Node::slot_id(&layout_node),
-    };
+    frame.layout_node = &allocate_layout_node<Layout::TextNode>(text_node.document(), text_node);
+    return Node::slot_id(frame.layout_node);
 }
 
 LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
@@ -1427,12 +1416,12 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
             case RustFFI::NodeKind::Box:
                 allocate_layout_node<Box>(document, BindToPreparedArenaSlot::Yes, slot, kind);
                 return;
+            case RustFFI::NodeKind::InlineNode:
+                allocate_layout_node<NodeWithStyle>(document, BindToPreparedArenaSlot::Yes, slot, kind).attach_style_resources();
+                return;
             default:
                 VERIFY_NOT_REACHED();
             } },
-        .reset_table_box_style_used_by_wrapper = [](void*, void* table_box_pointer) {
-            VERIFY(table_box_pointer);
-            as<Box>(*static_cast<Node*>(table_box_pointer)).reset_table_box_computed_values_used_by_wrapper_to_init_values(); },
         .take_fieldset_overflow_for_content_wrapper = [](void*, void* fieldset_box_pointer) -> RustFFI::FfiAnonymousStyleOverrides {
             VERIFY(fieldset_box_pointer);
             auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(fieldset_box_pointer));

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -34,6 +34,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
+#include <LibWeb/Layout/AnonymousBoxStyle.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/NodeArena.h>
@@ -1350,28 +1351,21 @@ static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(Principa
     };
 }
 
-// A full-height flex column that centers the button contents vertically.
-static NodeWithStyle& create_button_flex_wrapper(NodeWithStyle& parent)
+static CSS::LayoutStyle derived_anonymous_box_style(NodeWithStyle const& parent, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides = {})
 {
-    auto& flex_wrapper = parent.create_anonymous_wrapper();
-    flex_wrapper.modify_computed_values([](auto& values) {
-        values.set_display(CSS::Display { CSS::DisplayOutside::Block, CSS::DisplayInside::Flex });
-        values.set_justify_content(CSS::JustifyContent::Center);
-        values.set_flex_direction(CSS::FlexDirection::Column);
-        values.set_height(CSS::Size::make_percentage(CSS::Percentage(100)));
-    });
-    return flex_wrapper;
+    return CSS::LayoutStyle::adopting_pinned_style_record(derive_pinned_anonymous_box_style_record(parent.document().style_computer(), parent.style_record_identity(), kind, overrides));
 }
 
-// Let percentage-sized descendants shrink to fixed-height buttons instead of the flex
-// item's automatic minimum size.
-static NodeWithStyle& create_button_content_box_wrapper(NodeWithStyle& parent)
+static AnonymousBoxStyleOverrides anonymous_wrapper_overrides_for(NodeWithStyle const& parent)
 {
-    auto& content_box_wrapper = parent.create_anonymous_wrapper();
-    content_box_wrapper.modify_computed_values([](auto& values) {
-        values.set_min_height(CSS::Size::make_px(CSSPixels(0)));
-    });
-    return content_box_wrapper;
+    // CSS 2.2 9.2.1.1 creates anonymous block boxes, but 9.4.1 states inline-block creates a BFC.
+    // Set wrapper to inline-block to participate correctly in the IFC within the parent inline-block.
+    return { .inline_block_wrapper = parent.display().is_inline_block() && !parent.has_children() };
+}
+
+static BlockContainer& create_anonymous_block_container(NodeWithStyle& parent, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides = {}, RustFFI::NodeKind node_kind = RustFFI::NodeKind::BlockContainer)
+{
+    return allocate_layout_node<BlockContainer>(parent.document(), nullptr, derived_anonymous_box_style(parent, kind, overrides), node_kind);
 }
 
 LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
@@ -1438,60 +1432,40 @@ static RustFFI::NodeSlotId ffi_create_anonymous_table_box(void*, void* parent_po
 {
     VERIFY(parent_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    auto parent_values = parent.copy_computed_values();
-    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*parent_values);
     switch (kind) {
     case RustFFI::FfiAnonymousTableBoxKind::TableRow:
-        builder->set_display(CSS::Display { CSS::DisplayInternal::TableRow });
-        break;
+        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::TableRow)));
     case RustFFI::FfiAnonymousTableBoxKind::TableCell:
-        builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
-        break;
+        return Node::slot_id(&create_anonymous_block_container(parent, AnonymousBoxStyleKind::TableCell));
     case RustFFI::FfiAnonymousTableBoxKind::Table:
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::Table));
-        break;
+        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::Table)));
     case RustFFI::FfiAnonymousTableBoxKind::InlineTable:
-        builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineTable));
-        break;
+        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::InlineTable)));
     }
-
-    if (kind == RustFFI::FfiAnonymousTableBoxKind::TableCell)
-        return Node::slot_id(&allocate_layout_node<BlockContainer>(parent.document(), nullptr, move(builder).build()));
-    return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, move(builder).build()));
-}
-
-static NonnullRefPtr<CSS::ComputedValues const> table_wrapper_computed_values(Box& table_box)
-{
-    auto table_values = table_box.copy_computed_values();
-    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*table_values);
-    table_box.transfer_table_box_computed_values_to_wrapper_computed_values(builder);
-    return move(builder).build();
+    VERIFY_NOT_REACHED();
 }
 
 static RustFFI::NodeSlotId ffi_create_table_wrapper(void*, void* table_root_pointer)
 {
     VERIFY(table_root_pointer);
     auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
-    return Node::slot_id(&allocate_layout_node<BlockContainer>(table_box.document(), nullptr, table_wrapper_computed_values(table_box), RustFFI::NodeKind::TableWrapper));
+    auto& wrapper = create_anonymous_block_container(table_box, AnonymousBoxStyleKind::TableWrapper, {}, RustFFI::NodeKind::TableWrapper);
+    table_box.reset_table_box_computed_values_used_by_wrapper_to_init_values();
+    return Node::slot_id(&wrapper);
 }
 
 static RustFFI::NodeSlotId ffi_create_missing_table_cell(void*, void* row_pointer)
 {
     VERIFY(row_pointer);
     auto& row_box = as<Box>(*static_cast<Node*>(row_pointer));
-    auto row_values = row_box.copy_computed_values();
-    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(*row_values);
-    builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
-    // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
-    builder->set_vertical_align(CSS::VerticalAlign::Middle);
-    return Node::slot_id(&allocate_layout_node<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
+    return Node::slot_id(&create_anonymous_block_container(row_box, AnonymousBoxStyleKind::MissingTableCell));
 }
 
 static RustFFI::NodeSlotId ffi_create_anonymous_wrapper(void*, void* parent_pointer)
 {
     VERIFY(parent_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    return Node::slot_id(&parent.create_anonymous_wrapper());
+    return Node::slot_id(&create_anonymous_block_container(parent, AnonymousBoxStyleKind::Wrapper, anonymous_wrapper_overrides_for(parent)));
 }
 
 static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void*, void* layout_node_pointer)
@@ -1501,8 +1475,8 @@ static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void
 
     // If the box does not overflow in the vertical axis, then it is centered vertically.
     // FIXME: Only apply alignment when box overflows
-    auto& flex_wrapper = create_button_flex_wrapper(parent);
-    auto& content_box_wrapper = create_button_content_box_wrapper(parent);
+    auto& flex_wrapper = create_anonymous_block_container(parent, AnonymousBoxStyleKind::ButtonFlexWrapper);
+    auto& content_box_wrapper = create_anonymous_block_container(parent, AnonymousBoxStyleKind::ButtonContentBox, anonymous_wrapper_overrides_for(parent));
     return {
         .flex_wrapper = Node::slot_id(&flex_wrapper),
         .content_box = Node::slot_id(&content_box_wrapper),
@@ -1513,8 +1487,6 @@ static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layo
 {
     VERIFY(layout_node_pointer);
     auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(layout_node_pointer));
-    auto& wrapper = fieldset_box.create_anonymous_wrapper();
-    wrapper.set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
 
     // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
     // The following properties are expected to inherit from the fieldset element:
@@ -1523,7 +1495,7 @@ static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layo
     //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
     //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
     // FIXME: Transfer all of these properties, not just overflow.
-    wrapper.set_overflow(fieldset_box.overflow_x(), fieldset_box.overflow_y());
+    auto& wrapper = create_anonymous_block_container(fieldset_box, AnonymousBoxStyleKind::FieldsetContentWrapper, { .overflow_x = fieldset_box.overflow_x(), .overflow_y = fieldset_box.overflow_y() });
     fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
     return Node::slot_id(&wrapper);
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1127,7 +1127,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .is_element = element != nullptr,
                 .is_text = is<DOM::Text>(node),
                 .rendered_in_top_layer = element && element->rendered_in_top_layer(),
-                .layout_node_is_attached = existing_layout_node && existing_layout_node->parent(),
+                .layout_node_is_attached = existing_layout_node && existing_layout_node->has_parent(),
                 .is_svg_container = node.is_svg_container(),
                 .requires_svg_container = node.requires_svg_container(),
                 .is_svg_foreign_object = node.is_svg_foreign_object_element(),
@@ -1405,23 +1405,6 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
 {
     return {
         .context = this,
-        .create_anonymous_shell = [](void* context, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind) {
-            VERIFY(context);
-            auto& document = *static_cast<LayoutTreeBuildBridge*>(context)->m_document;
-            switch (kind) {
-            case RustFFI::NodeKind::BlockContainer:
-            case RustFFI::NodeKind::TableWrapper:
-                allocate_layout_node<BlockContainer>(document, BindToPreparedArenaSlot::Yes, slot, kind);
-                return;
-            case RustFFI::NodeKind::Box:
-                allocate_layout_node<Box>(document, BindToPreparedArenaSlot::Yes, slot, kind);
-                return;
-            case RustFFI::NodeKind::InlineNode:
-                allocate_layout_node<NodeWithStyle>(document, BindToPreparedArenaSlot::Yes, slot, kind).attach_style_resources();
-                return;
-            default:
-                VERIFY_NOT_REACHED();
-            } },
         .take_fieldset_overflow_for_content_wrapper = [](void*, void* fieldset_box_pointer) -> RustFFI::FfiAnonymousStyleOverrides {
             VERIFY(fieldset_box_pointer);
             auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(fieldset_box_pointer));

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -124,8 +124,8 @@ static bool may_reuse_layout_node_for_child_list_insertion(DOM::Node const& node
         };
 
         Node const* last_layout_child = nullptr;
-        for (auto layout_child = layout_node->first_child(); layout_child; layout_child = layout_child->next_sibling())
-            last_layout_child = layout_child.ptr();
+        for (auto* layout_child = layout_node->first_child(); layout_child; layout_child = layout_child->next_sibling())
+            last_layout_child = layout_child;
         auto const* trailing_inline_wrapper = last_layout_child && last_layout_child->is_anonymous() && last_layout_child->children_are_inline()
                 && !last_layout_child->is_generated_for_pseudo_element()
             ? last_layout_child
@@ -881,7 +881,7 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node
     node.set_child_needs_layout_tree_update(false);
 
     // NB: Called during layout tree construction.
-    RefPtr<Layout::Node> layout_node = node.unsafe_layout_node();
+    auto* layout_node = node.unsafe_layout_node();
     // SVGPatternBox, SVGMaskBox, and SVGClipBox are created on behalf of a referencing
     // element and attached to that element's layout subtree. Skip them so they survive
     // cleanup of their DOM ancestor, unless their layout attachment is inside the
@@ -897,7 +897,7 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_node(DOM::Node& node
                 return static_cast<DOM::Node*>(node_pointer)->is_shadow_including_inclusive_descendant_of(*static_cast<DOM::Node*>(root_pointer)); },
         };
         if (RustFFI::rust_should_preserve_svg_resource_layout_node(
-                &callbacks, layout_node->arena_handle(), Node::slot_id(layout_node.ptr()), const_cast<DOM::Node*>(cleared_subtree_root)))
+                &callbacks, layout_node->arena_handle(), Node::slot_id(layout_node), const_cast<DOM::Node*>(cleared_subtree_root)))
             return TraversalDecision::SkipChildrenAndContinue;
     }
 
@@ -946,7 +946,6 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
 }
 
 struct PrincipalNodeFrame {
-    RefPtr<Layout::Node> old_layout_node;
     RefPtr<Layout::Node> layout_node;
     RefPtr<CSS::ComputedValues const> anonymous_computed_values;
     CSS::StyleRecordID style_record_identity;
@@ -1170,15 +1169,14 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 storage.frames.append(make<PrincipalNodeFrame>());
             auto& frame = *storage.frames[storage.active_frame_count++];
             auto& node = *static_cast<DOM::Node*>(node_pointer);
-            // NB: Called during layout tree construction.
-            frame.old_layout_node = node.unsafe_layout_node();
             frame.layout_node = nullptr;
             frame.anonymous_computed_values = nullptr;
             VERIFY(!frame.style_record_owner);
             frame.style_record_identity = 0;
+            // NB: Called during layout tree construction.
             return {
                 .frame = &frame,
-                .old_layout_node = Node::slot_id(frame.old_layout_node.ptr()),
+                .old_layout_node = Node::slot_id(node.unsafe_layout_node()),
             }; },
         .pop_principal_frame = [](void* builder_pointer, void* frame_pointer) {
             VERIFY(builder_pointer);
@@ -1194,7 +1192,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 frame.style_record_owner->unpin_style_record(frame.style_record_identity);
                 frame.style_record_owner = nullptr;
             }
-            frame.old_layout_node = nullptr;
             frame.layout_node = nullptr;
             frame.anonymous_computed_values = nullptr;
             frame.style_record_identity = 0;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -34,7 +34,6 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
-#include <LibWeb/Layout/AnonymousBoxStyle.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/NodeArena.h>
@@ -73,6 +72,7 @@ private:
     static BlockContainer& create_list_item_marker(BlockContainer& list_box, CSS::LayoutStyle marker_style);
     static RustFFI::FfiFirstLetterNodes create_first_letter_nodes(DOM::Element&, RustFFI::FfiFirstLetterTarget);
 
+    GC::Ptr<DOM::Document> m_document;
     Layout::Viewport* m_layout_root { nullptr };
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
     OwnPtr<PseudoElementFrameStorage> m_pseudo_element_frames;
@@ -1351,25 +1351,9 @@ static RustFFI::FfiPrincipalTextLayoutNodes create_layout_node_for_text(Principa
     };
 }
 
-static CSS::LayoutStyle derived_anonymous_box_style(NodeWithStyle const& parent, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides = {})
-{
-    return CSS::LayoutStyle::adopting_pinned_style_record(derive_pinned_anonymous_box_style_record(parent.document().style_computer(), parent.style_record_identity(), kind, overrides));
-}
-
-static AnonymousBoxStyleOverrides anonymous_wrapper_overrides_for(NodeWithStyle const& parent)
-{
-    // CSS 2.2 9.2.1.1 creates anonymous block boxes, but 9.4.1 states inline-block creates a BFC.
-    // Set wrapper to inline-block to participate correctly in the IFC within the parent inline-block.
-    return { .inline_block_wrapper = parent.display().is_inline_block() && !parent.has_children() };
-}
-
-static BlockContainer& create_anonymous_block_container(NodeWithStyle& parent, AnonymousBoxStyleKind kind, AnonymousBoxStyleOverrides const& overrides = {}, RustFFI::NodeKind node_kind = RustFFI::NodeKind::BlockContainer)
-{
-    return allocate_layout_node<BlockContainer>(parent.document(), nullptr, derived_anonymous_box_style(parent, kind, overrides), node_kind);
-}
-
 LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
 {
+    m_document = &dom_node.document();
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
     RustFFI::rust_build_layout_tree(&callbacks, dom_node.document().layout_node_arena().handle(), &dom_node);
     return {
@@ -1428,86 +1412,44 @@ static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(v
     };
 }
 
-static RustFFI::NodeSlotId ffi_create_anonymous_table_box(void*, void* parent_pointer, RustFFI::FfiAnonymousTableBoxKind kind)
-{
-    VERIFY(parent_pointer);
-    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    switch (kind) {
-    case RustFFI::FfiAnonymousTableBoxKind::TableRow:
-        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::TableRow)));
-    case RustFFI::FfiAnonymousTableBoxKind::TableCell:
-        return Node::slot_id(&create_anonymous_block_container(parent, AnonymousBoxStyleKind::TableCell));
-    case RustFFI::FfiAnonymousTableBoxKind::Table:
-        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::Table)));
-    case RustFFI::FfiAnonymousTableBoxKind::InlineTable:
-        return Node::slot_id(&allocate_layout_node<Box>(parent.document(), nullptr, derived_anonymous_box_style(parent, AnonymousBoxStyleKind::InlineTable)));
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static RustFFI::NodeSlotId ffi_create_table_wrapper(void*, void* table_root_pointer)
-{
-    VERIFY(table_root_pointer);
-    auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
-    auto& wrapper = create_anonymous_block_container(table_box, AnonymousBoxStyleKind::TableWrapper, {}, RustFFI::NodeKind::TableWrapper);
-    table_box.reset_table_box_computed_values_used_by_wrapper_to_init_values();
-    return Node::slot_id(&wrapper);
-}
-
-static RustFFI::NodeSlotId ffi_create_missing_table_cell(void*, void* row_pointer)
-{
-    VERIFY(row_pointer);
-    auto& row_box = as<Box>(*static_cast<Node*>(row_pointer));
-    return Node::slot_id(&create_anonymous_block_container(row_box, AnonymousBoxStyleKind::MissingTableCell));
-}
-
-static RustFFI::NodeSlotId ffi_create_anonymous_wrapper(void*, void* parent_pointer)
-{
-    VERIFY(parent_pointer);
-    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
-    return Node::slot_id(&create_anonymous_block_container(parent, AnonymousBoxStyleKind::Wrapper, anonymous_wrapper_overrides_for(parent)));
-}
-
-static RustFFI::FfiButtonContentWrappers ffi_create_button_content_wrappers(void*, void* layout_node_pointer)
-{
-    VERIFY(layout_node_pointer);
-    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(layout_node_pointer));
-
-    // If the box does not overflow in the vertical axis, then it is centered vertically.
-    // FIXME: Only apply alignment when box overflows
-    auto& flex_wrapper = create_anonymous_block_container(parent, AnonymousBoxStyleKind::ButtonFlexWrapper);
-    auto& content_box_wrapper = create_anonymous_block_container(parent, AnonymousBoxStyleKind::ButtonContentBox, anonymous_wrapper_overrides_for(parent));
-    return {
-        .flex_wrapper = Node::slot_id(&flex_wrapper),
-        .content_box = Node::slot_id(&content_box_wrapper),
-    };
-}
-
-static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointer)
-{
-    VERIFY(layout_node_pointer);
-    auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(layout_node_pointer));
-
-    // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-    // The following properties are expected to inherit from the fieldset element:
-    //     align-content, align-items, border-radius, column-count, column-fill, column-gap, column-rule,
-    //     column-width, flex-direction, flex-wrap, grid (grid-auto-columns, grid-auto-flow, grid-auto-rows,
-    //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
-    //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
-    // FIXME: Transfer all of these properties, not just overflow.
-    auto& wrapper = create_anonymous_block_container(fieldset_box, AnonymousBoxStyleKind::FieldsetContentWrapper, { .overflow_x = fieldset_box.overflow_x(), .overflow_y = fieldset_box.overflow_y() });
-    fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
-    return Node::slot_id(&wrapper);
-}
-
 RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_callbacks()
 {
     return {
         .context = this,
-        .create_anonymous_wrapper = ffi_create_anonymous_wrapper,
-        .create_anonymous_table_box = ffi_create_anonymous_table_box,
-        .create_table_wrapper = ffi_create_table_wrapper,
-        .create_missing_table_cell = ffi_create_missing_table_cell,
+        .create_anonymous_shell = [](void* context, RustFFI::NodeSlotId slot, RustFFI::NodeKind kind) {
+            VERIFY(context);
+            auto& document = *static_cast<LayoutTreeBuildBridge*>(context)->m_document;
+            switch (kind) {
+            case RustFFI::NodeKind::BlockContainer:
+            case RustFFI::NodeKind::TableWrapper:
+                allocate_layout_node<BlockContainer>(document, BindToPreparedArenaSlot::Yes, slot, kind);
+                return;
+            case RustFFI::NodeKind::Box:
+                allocate_layout_node<Box>(document, BindToPreparedArenaSlot::Yes, slot, kind);
+                return;
+            default:
+                VERIFY_NOT_REACHED();
+            } },
+        .reset_table_box_style_used_by_wrapper = [](void*, void* table_box_pointer) {
+            VERIFY(table_box_pointer);
+            as<Box>(*static_cast<Node*>(table_box_pointer)).reset_table_box_computed_values_used_by_wrapper_to_init_values(); },
+        .take_fieldset_overflow_for_content_wrapper = [](void*, void* fieldset_box_pointer) -> RustFFI::FfiAnonymousStyleOverrides {
+            VERIFY(fieldset_box_pointer);
+            auto& fieldset_box = as<BlockContainer>(*static_cast<Node*>(fieldset_box_pointer));
+            // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+            // The following properties are expected to inherit from the fieldset element:
+            //     align-content, align-items, border-radius, column-count, column-fill, column-gap, column-rule,
+            //     column-width, flex-direction, flex-wrap, grid (grid-auto-columns, grid-auto-flow, grid-auto-rows,
+            //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
+            //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
+            // FIXME: Transfer all of these properties, not just overflow.
+            RustFFI::FfiAnonymousStyleOverrides overrides {
+                .inline_block_wrapper = false,
+                .overflow_x = to_underlying(fieldset_box.overflow_x()),
+                .overflow_y = to_underlying(fieldset_box.overflow_y()),
+            };
+            fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
+            return overrides; },
         .prepare_subtree_for_detach = [](void*, void* layout_node_pointer) {
             VERIFY(layout_node_pointer);
             static_cast<Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
@@ -1535,8 +1477,6 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
             auto const white_space_collapse = text_node.parent()->white_space_collapse();
             return first_is_one_of(white_space_collapse,
                 CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces); },
-        .create_button_content_wrappers = ffi_create_button_content_wrappers,
-        .create_fieldset_content_wrapper = ffi_create_fieldset_content_wrapper,
     };
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -13,7 +13,7 @@
 namespace Web::Layout {
 
 struct LayoutTreeBuildResult {
-    RefPtr<Layout::Node> root;
+    Layout::Viewport* root { nullptr };
     Vector<Layout::Node*> rebuilt_subtree_roots;
     bool layout_tree_update_escaped_rebuild_roots { false };
     bool needs_another_build_pass { false };

--- a/Libraries/LibWeb/Painting/SVGMasking.cpp
+++ b/Libraries/LibWeb/Painting/SVGMasking.cpp
@@ -20,9 +20,9 @@ static Layout::Box const* first_child_layout_box_of_kind(SVG::SVGGraphicsElement
     // NB: Called during painting.
     if (!graphics_element.unsafe_layout_node())
         return nullptr;
-    for (auto child = graphics_element.unsafe_layout_node()->first_child(); child; child = child->next_sibling()) {
+    for (auto const* child = graphics_element.unsafe_layout_node()->first_child(); child; child = child->next_sibling()) {
         if (child->kind() == kind)
-            return static_cast<Layout::Box const*>(child.ptr());
+            return static_cast<Layout::Box const*>(child);
     }
     return nullptr;
 }

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -3038,6 +3038,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "NodeSlotId".to_string(),
     ];
     tree_builder_config.export.exclude = vec![
+        "ladybird_layout_node_shell_destroy".to_string(),
         "ladybird_layout_node_shell_release".to_string(),
         "ladybird_layout_text_node_dom_offset_for_rendered_text_offset".to_string(),
         "ladybird_layout_text_node_rendered_text_offset_for_dom_offset".to_string(),

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -3039,7 +3039,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     ];
     tree_builder_config.export.exclude = vec![
         "ladybird_layout_node_shell_destroy".to_string(),
-        "ladybird_layout_node_shell_release".to_string(),
         "ladybird_layout_text_node_dom_offset_for_rendered_text_offset".to_string(),
         "ladybird_layout_text_node_rendered_text_offset_for_dom_offset".to_string(),
         "rust_calc_node_create_numeric_dimension".to_string(),

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -1296,6 +1296,13 @@ unsafe fn payloads_equal(table: &StyleGroupVTable, a: *const c_void, b: *const c
     }
 }
 
+pub(crate) fn style_group_affects_layout(group_index: usize) -> bool {
+    !matches!(
+        vtable(group_index).lifecycle,
+        StyleGroupLifecycle::Mask | StyleGroupLifecycle::TextReset | StyleGroupLifecycle::Background
+    )
+}
+
 pub(crate) fn style_group_payloads_equal(group_index: usize, a: *const c_void, b: *const c_void) -> bool {
     assert!(!a.is_null());
     assert!(!b.is_null());

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -987,7 +987,7 @@ impl FfiLayoutFcCallbacks {
     }
 
     pub(crate) fn shell(&self, node: Node) -> *mut c_void {
-        let shell = self.node_data(node).shell.get();
+        let shell = self.arena().node_shell(node);
         assert!(!shell.is_null());
         shell
     }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -435,6 +435,28 @@ pub(crate) struct FreedSlot {
     pub(crate) detached_children: DetachedShells,
 }
 
+#[must_use]
+pub(crate) struct FreedSubtree {
+    shells: Vec<*mut c_void>,
+    paintable_row_resets: Vec<crate::painting::paintable_rows::PaintableRowReset>,
+}
+
+impl FreedSubtree {
+    #[cfg(test)]
+    pub(crate) fn shell_count(&self) -> usize {
+        self.shells.len()
+    }
+
+    pub(crate) fn destroy_shells_and_invoke_callbacks(self) {
+        for shell in self.shells {
+            crate::layout::tree_mutation::destroy_shell(shell);
+        }
+        for reset in self.paintable_row_resets {
+            reset.invoke_callback();
+        }
+    }
+}
+
 const MAXIMUM_PRE_ORDER_LABEL_STRIDE: u64 = 1 << 32;
 
 pub(crate) struct LayoutNodeArena {
@@ -649,10 +671,63 @@ impl LayoutNodeArena {
         self.assert_owner_thread();
 
         assert!(!id.is_invalid(), "invalid layout node arena slot ID");
-        let index = id.slot_index();
-        let id_generation = id.generation();
         self.mark_descendant_subtree_caches_dirty_from_layout_node(id);
         let detached_children = self.unlink_children_for_free(id);
+        let paintable_row_reset = self.free_unlinked_slot(id);
+        FreedSlot {
+            paintable_row_reset,
+            detached_children,
+        }
+    }
+
+    pub(crate) fn free_subtree(&mut self, root: NodeSlotId) -> FreedSubtree {
+        self.assert_owner_thread();
+
+        assert!(!root.is_invalid(), "invalid layout node arena slot ID");
+        self.assert_node_is_unlinked_from_parent(root);
+        let mut slots_in_pre_order = Vec::new();
+        self.for_each_node_in_layout_subtree_in_pre_order(root, |slot| slots_in_pre_order.push(slot));
+
+        let mut shells = Vec::with_capacity(slots_in_pre_order.len());
+        let mut paintable_row_resets = Vec::new();
+        for slot in slots_in_pre_order {
+            self.mark_descendant_subtree_caches_dirty_from_layout_node(slot);
+            shells.push(self.node_shell(slot));
+            self.unlink_children_of_node_being_freed(slot);
+            if let Some(reset) = self.free_unlinked_slot(slot) {
+                paintable_row_resets.push(reset);
+            }
+        }
+        FreedSubtree {
+            shells,
+            paintable_row_resets,
+        }
+    }
+
+    fn assert_node_is_unlinked_from_parent(&self, id: NodeSlotId) {
+        let data = self.data(id);
+        assert!(
+            data.parent.get().is_invalid()
+                && data.previous_sibling.get().is_invalid()
+                && data.next_sibling.get().is_invalid(),
+            "layout node arena freed a slot that is still linked under a parent"
+        );
+    }
+
+    fn unlink_children_of_node_being_freed(&self, id: NodeSlotId) {
+        let data = self.data(id);
+        loop {
+            let child = data.first_child.get();
+            if child.is_invalid() {
+                break;
+            }
+            self.unlink_child(id, child);
+        }
+    }
+
+    fn free_unlinked_slot(&mut self, id: NodeSlotId) -> Option<crate::painting::paintable_rows::PaintableRowReset> {
+        let index = id.slot_index();
+        let id_generation = id.generation();
         let should_reuse = {
             let metadata = self.metadata_mut(index);
             assert!(metadata.occupied, "layout node arena freed an unused slot");
@@ -718,20 +793,12 @@ impl LayoutNodeArena {
         if should_reuse {
             self.free_list.push(index);
         }
-        FreedSlot {
-            paintable_row_reset,
-            detached_children,
-        }
+        paintable_row_reset
     }
 
     fn unlink_children_for_free(&self, id: NodeSlotId) -> DetachedShells {
+        self.assert_node_is_unlinked_from_parent(id);
         let data = self.data(id);
-        let (parent, previous_sibling, next_sibling) =
-            { (data.parent.get(), data.previous_sibling.get(), data.next_sibling.get()) };
-        assert!(
-            parent.is_invalid() && previous_sibling.is_invalid() && next_sibling.is_invalid(),
-            "layout node arena freed a slot that is still linked under a parent"
-        );
         let mut detached_children = DetachedShells::default();
         loop {
             let child = data.first_child.get();
@@ -2108,6 +2175,46 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId) {
     if let Some(reset) = freed.paintable_row_reset {
         reset.invoke_callback();
     }
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `root` must name a live node
+/// in this arena that has no parent. Every C++-side detach preparation that walks the subtree
+/// must already have run. Every shell in the subtree is destroyed before this returns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_free_subtree(arena: *mut c_void, root: NodeSlotId) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all access on
+    // the document thread; the borrow ends before the shells are destroyed.
+    let freed = {
+        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
+        arena.free_subtree(root)
+    };
+    freed.destroy_shells_and_invoke_callbacks();
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `node` must name a live node
+/// in this arena. Every C++-side detach preparation that walks the subtree must already have
+/// run. The node and every shell in its subtree are destroyed before this returns.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_detach_and_free_subtree(arena: *mut c_void, node: NodeSlotId) -> bool {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all access on
+    // the document thread; the borrow ends before the shells are destroyed.
+    let (was_attached, freed) = {
+        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
+        let parent = arena.data(node).parent.get();
+        let was_attached = !parent.is_invalid();
+        if was_attached {
+            arena.remove_child(parent, node);
+        }
+        (was_attached, arena.free_subtree(node))
+    };
+    freed.destroy_shells_and_invoke_callbacks();
+    was_attached
 }
 
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -18,7 +18,6 @@ use crate::layout::node_data::{
     FfiNodeConstructionFacts, FfiNodeLink, FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeKind,
     NodeSlotId,
 };
-use crate::layout::tree_mutation::{DetachedShell, DetachedShells};
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::ffi::c_void;
@@ -430,12 +429,6 @@ enum AncestorInvalidation {
 }
 
 #[must_use]
-pub(crate) struct FreedSlot {
-    pub(crate) paintable_row_reset: Option<crate::painting::paintable_rows::PaintableRowReset>,
-    pub(crate) detached_children: DetachedShells,
-}
-
-#[must_use]
 pub(crate) struct FreedSubtree {
     shells: Vec<*mut c_void>,
     paintable_row_resets: Vec<crate::painting::paintable_rows::PaintableRowReset>,
@@ -667,19 +660,6 @@ impl LayoutNodeArena {
         NodeSlotId::new(index, generation)
     }
 
-    pub(crate) fn free(&mut self, id: NodeSlotId) -> FreedSlot {
-        self.assert_owner_thread();
-
-        assert!(!id.is_invalid(), "invalid layout node arena slot ID");
-        self.mark_descendant_subtree_caches_dirty_from_layout_node(id);
-        let detached_children = self.unlink_children_for_free(id);
-        let paintable_row_reset = self.free_unlinked_slot(id);
-        FreedSlot {
-            paintable_row_reset,
-            detached_children,
-        }
-    }
-
     pub(crate) fn free_subtree(&mut self, root: NodeSlotId) -> FreedSubtree {
         self.assert_owner_thread();
 
@@ -794,22 +774,6 @@ impl LayoutNodeArena {
             self.free_list.push(index);
         }
         paintable_row_reset
-    }
-
-    fn unlink_children_for_free(&self, id: NodeSlotId) -> DetachedShells {
-        self.assert_node_is_unlinked_from_parent(id);
-        let data = self.data(id);
-        let mut detached_children = DetachedShells::default();
-        loop {
-            let child = data.first_child.get();
-            if child.is_invalid() {
-                break;
-            }
-            let shell = self.node_shell(child);
-            self.unlink_child(id, child);
-            detached_children.push(DetachedShell::from_tree_reference(shell));
-        }
-        detached_children
     }
 
     pub(crate) fn data(&self, id: NodeSlotId) -> &NodeData {
@@ -2162,21 +2126,6 @@ pub unsafe extern "C" fn layout_arena_allocate(
     unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate(construction_facts)
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId) {
-    assert!(!arena.is_null(), "layout node arena handle is null");
-    // SAFETY: The C++ wrapper keeps the arena alive for this call and
-    // serializes all access on the document thread.
-    let freed = {
-        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-        arena.free(id)
-    };
-    freed.detached_children.release_all();
-    if let Some(reset) = freed.paintable_row_reset {
-        reset.invoke_callback();
-    }
-}
-
 /// # Safety
 ///
 /// The arena must remain valid for the duration of the call, and `root` must name a live node
@@ -2186,12 +2135,8 @@ pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId) {
 pub unsafe extern "C" fn layout_arena_free_subtree(arena: *mut c_void, root: NodeSlotId) {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all access on
-    // the document thread; the borrow ends before the shells are destroyed.
-    let freed = {
-        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-        arena.free_subtree(root)
-    };
-    freed.destroy_shells_and_invoke_callbacks();
+    // the document thread.
+    crate::layout::tree_mutation::free_subtree_and_destroy_shells(arena.cast::<LayoutNodeArena>(), root);
 }
 
 /// # Safety
@@ -2202,18 +2147,11 @@ pub unsafe extern "C" fn layout_arena_free_subtree(arena: *mut c_void, root: Nod
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_detach_and_free_subtree(arena: *mut c_void, node: NodeSlotId) -> bool {
     assert!(!arena.is_null(), "layout node arena handle is null");
+    let arena = arena.cast::<LayoutNodeArena>();
     // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all access on
-    // the document thread; the borrow ends before the shells are destroyed.
-    let (was_attached, freed) = {
-        let arena = unsafe { &mut *arena.cast::<LayoutNodeArena>() };
-        let parent = arena.data(node).parent.get();
-        let was_attached = !parent.is_invalid();
-        if was_attached {
-            arena.remove_child(parent, node);
-        }
-        (was_attached, arena.free_subtree(node))
-    };
-    freed.destroy_shells_and_invoke_callbacks();
+    // the document thread; the shared borrow ends before the subtree is freed.
+    let was_attached = unsafe { &*arena }.detach_from_parent(node);
+    crate::layout::tree_mutation::free_subtree_and_destroy_shells(arena, node);
     was_attached
 }
 
@@ -2348,25 +2286,6 @@ pub unsafe extern "C" fn layout_arena_node_flags(arena: *mut c_void, id: NodeSlo
 pub unsafe extern "C" fn layout_arena_node_generated_for(arena: *mut c_void, id: NodeSlotId) -> u8 {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     unsafe { LayoutNodeArena::from_handle(arena) }.node_generated_for(id)
-}
-
-/// # Safety
-///
-/// The arena must remain valid for the duration of the call, and `node` must name a live node
-/// in this arena. Every C++-side detach preparation that walks the tree must already have run.
-/// Unless the caller holds its own reference, the node may be destroyed before this returns.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_detach_node_for_destruction(arena: *mut c_void, node: NodeSlotId) -> bool {
-    // SAFETY: The C++ caller keeps the arena alive for this synchronous call; the borrow
-    // ends before the release below re-enters the arena.
-    let detached = unsafe { LayoutNodeArena::from_handle(arena) }.detach_from_parent(node);
-    match detached {
-        Some(detached) => {
-            detached.release();
-            true
-        }
-        None => false,
-    }
 }
 
 /// # Safety
@@ -2649,9 +2568,11 @@ mod tests {
         assert_eq!(first_data_address, std::ptr::from_ref(arena.data(first.slot)) as usize);
         arena.data(first.slot).table_column_span.set(42);
         assert_eq!(arena.data(first.slot).table_column_span.get(), 42);
-        arena.free(first.slot).detached_children.release_all();
+        arena.free_subtree(first.slot).destroy_shells_and_invoke_callbacks();
         for allocation in allocations {
-            arena.free(allocation.slot).detached_children.release_all();
+            arena
+                .free_subtree(allocation.slot)
+                .destroy_shells_and_invoke_callbacks();
         }
     }
 
@@ -2661,20 +2582,22 @@ mod tests {
         let mut arena = LayoutNodeArena::new();
         let allocation = arena.allocate_for_test();
         assert_eq!(std::ptr::from_ref(arena.data(allocation.slot)) as usize % 64, 0);
-        arena.free(allocation.slot).detached_children.release_all();
+        arena
+            .free_subtree(allocation.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
     fn freed_slots_are_reused_with_a_new_generation() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate_for_test();
-        arena.free(first.slot).detached_children.release_all();
+        arena.free_subtree(first.slot).destroy_shells_and_invoke_callbacks();
 
         let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         assert_ne!(second.slot, first.slot);
         assert_ne!(second.slot.generation(), first.slot.generation());
-        arena.free(second.slot).detached_children.release_all();
+        arena.free_subtree(second.slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -2690,7 +2613,7 @@ mod tests {
         assert_ne!(flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
-        arena.free(anchor.slot).detached_children.release_all();
+        arena.free_subtree(anchor.slot).destroy_shells_and_invoke_callbacks();
         assert!(arena.default_scroll_shift_anchor(positioned.slot).is_invalid());
 
         let anchor_slot_reoccupant = arena.allocate_for_test();
@@ -2708,7 +2631,9 @@ mod tests {
         assert_eq!(cleared_flags & NodeFlag::CompensatesForHorizontalScroll as u32, 0);
         assert_eq!(cleared_flags & NodeFlag::CompensatesForVerticalScroll as u32, 0);
 
-        arena.free(positioned.slot).detached_children.release_all();
+        arena
+            .free_subtree(positioned.slot)
+            .destroy_shells_and_invoke_callbacks();
         let positioned_slot_reoccupant = arena.allocate_for_test();
         assert_eq!(
             positioned_slot_reoccupant.slot.slot_index(),
@@ -2716,14 +2641,17 @@ mod tests {
         );
         arena.set_default_scroll_shift(positioned_slot_reoccupant.slot, anchor_slot_reoccupant.slot, true, true);
         arena
-            .free(positioned_slot_reoccupant.slot)
-            .detached_children
-            .release_all();
+            .free_subtree(positioned_slot_reoccupant.slot)
+            .destroy_shells_and_invoke_callbacks();
         let next_reoccupant = arena.allocate_for_test();
         assert!(arena.default_scroll_shift_anchor(next_reoccupant.slot).is_invalid());
 
-        arena.free(next_reoccupant.slot).detached_children.release_all();
-        arena.free(anchor_slot_reoccupant.slot).detached_children.release_all();
+        arena
+            .free_subtree(next_reoccupant.slot)
+            .destroy_shells_and_invoke_callbacks();
+        arena
+            .free_subtree(anchor_slot_reoccupant.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -2753,21 +2681,21 @@ mod tests {
         assert_eq!(arena.data(child.slot).flags.get() & update_flags, 0);
         assert_eq!(arena.data(detached.slot).flags.get() & update_flags, update_flags);
         arena.remove_child(root.slot, child.slot);
-        arena.free(root.slot).detached_children.release_all();
-        arena.free(child.slot).detached_children.release_all();
-        arena.free(detached.slot).detached_children.release_all();
+        arena.free_subtree(root.slot).destroy_shells_and_invoke_callbacks();
+        arena.free_subtree(child.slot).destroy_shells_and_invoke_callbacks();
+        arena.free_subtree(detached.slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
     fn stale_slot_ids_do_not_resolve_to_a_new_occupant() {
         let mut arena = LayoutNodeArena::new();
         let first = arena.allocate_for_test();
-        arena.free(first.slot).detached_children.release_all();
+        arena.free_subtree(first.slot).destroy_shells_and_invoke_callbacks();
         let second = arena.allocate_for_test();
 
         let stale_read = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| arena.data(first.slot)));
         assert!(stale_read.is_err());
-        arena.free(second.slot).detached_children.release_all();
+        arena.free_subtree(second.slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -2787,7 +2715,9 @@ mod tests {
         }
 
         assert!(arena.committed_fragment_link(arena.data(allocation.slot)).is_none());
-        arena.free(allocation.slot).detached_children.release_all();
+        arena
+            .free_subtree(allocation.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -2810,8 +2740,8 @@ mod tests {
             .committed_fragment_link(arena.data(new.slot))
             .expect("new slot must receive the committed fragment");
         assert!(std::rc::Rc::ptr_eq(&moved.fragment, &retained_fragment));
-        arena.free(old.slot).detached_children.release_all();
-        arena.free(new.slot).detached_children.release_all();
+        arena.free_subtree(old.slot).destroy_shells_and_invoke_callbacks();
+        arena.free_subtree(new.slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -2891,7 +2821,7 @@ mod tests {
             false
         }));
         assert_eq!(dependency_computations.get(), 2);
-        arena.free(first.slot).detached_children.release_all();
+        arena.free_subtree(first.slot).destroy_shells_and_invoke_callbacks();
 
         let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
@@ -2909,7 +2839,7 @@ mod tests {
             ),
             None
         );
-        arena.free(second.slot).detached_children.release_all();
+        arena.free_subtree(second.slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -3008,7 +2938,9 @@ mod tests {
             arena.intrinsic_block_size_cache_get(data, max_content, key_at_another_inline_size_with_inline_basis(400)),
             None
         );
-        arena.free(allocation.slot).detached_children.release_all();
+        arena
+            .free_subtree(allocation.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -3057,12 +2989,12 @@ mod tests {
             .intrinsic_cache_epoch
             .set(first_data.intrinsic_cache_epoch.get() + 1);
         assert_eq!(arena.table_cell_measurement_cache_get(first_data, key), None);
-        arena.free(first.slot).detached_children.release_all();
+        arena.free_subtree(first.slot).destroy_shells_and_invoke_callbacks();
 
         let second = arena.allocate_for_test();
         assert_eq!(second.slot.slot_index(), first.slot.slot_index());
         let second_data = &*arena.data(second.slot);
         assert_eq!(arena.table_cell_measurement_cache_get(second_data, key), None);
-        arena.free(second.slot).detached_children.release_all();
+        arena.free_subtree(second.slot).destroy_shells_and_invoke_callbacks();
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -456,7 +456,7 @@ pub(crate) struct LayoutNodeArena {
     chunks: Vec<Box<Chunk>>,
     chunks_by_address: Vec<ChunkAddress>,
     slot_metadata: Vec<SlotMetadata>,
-    dom_nodes: Vec<*mut c_void>,
+    dom_nodes: Vec<Cell<*mut c_void>>,
     pre_order_labels: Vec<Cell<u64>>,
     pre_order_relabel_count: Cell<u64>,
     free_list: Vec<u32>,
@@ -584,15 +584,33 @@ impl LayoutNodeArena {
     // Freshly created chunks are default-initialized and free() resets slots on release, so
     // allocate() always hands out clean NodeData without writing it again.
     pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeSlotId {
+        let slot = self.allocate_unbound(construction_facts.dom_node);
+        self.bind_shell(slot, construction_facts);
+        slot
+    }
+
+    pub(crate) fn allocate_unbound(&mut self, dom_node: *mut c_void) -> NodeSlotId {
         let slot = self.allocate_slot();
-        self.dom_nodes[slot.slot_index() as usize] = construction_facts.dom_node;
-        let data = self.data_mut(slot.slot_index());
+        self.dom_nodes[slot.slot_index() as usize].set(dom_node);
+        slot
+    }
+
+    pub(crate) fn bind_shell(&self, slot: NodeSlotId, construction_facts: FfiNodeConstructionFacts) {
+        assert!(
+            self.slot_is_live(slot),
+            "layout node arena bound a shell to a dead slot"
+        );
+        let data = self.data(slot);
+        assert!(
+            data.shell.get().is_null(),
+            "layout node arena bound a second shell to a slot"
+        );
+        self.dom_nodes[slot.slot_index() as usize].set(construction_facts.dom_node);
         data.kind.set(construction_facts.kind);
         data.shell.set(construction_facts.shell);
         data.flags
             .set(super::node_facts::construction_flags(&construction_facts));
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
-        slot
     }
 
     #[cfg(test)]
@@ -634,7 +652,7 @@ impl LayoutNodeArena {
                 self.chunks.push(chunk);
             }
             self.slot_metadata.push(SlotMetadata::default());
-            self.dom_nodes.push(std::ptr::null_mut());
+            self.dom_nodes.push(Cell::new(std::ptr::null_mut()));
             self.pre_order_labels.push(Cell::new(0));
             // Grown with the slot space up front: nearly every slot gets a run
             // record each layout pass, so register() never has to resize.
@@ -728,7 +746,7 @@ impl LayoutNodeArena {
         }
         self.pre_order_labels[index as usize].set(0);
         self.metadata_mut(index).occupied = false;
-        self.dom_nodes[index as usize] = std::ptr::null_mut();
+        self.dom_nodes[index as usize].set(std::ptr::null_mut());
 
         if let Some(slot) = self.intrinsic_size_caches.get_mut().get_mut(index as usize) {
             *slot = IntrinsicSizeCacheSlot::default();
@@ -1973,8 +1991,9 @@ impl LayoutNodeArena {
 
     pub(crate) fn visit_dom_nodes(&self, mut visit: impl FnMut(*mut c_void)) {
         for (metadata, dom_node) in self.slot_metadata.iter().zip(&self.dom_nodes) {
+            let dom_node = dom_node.get();
             if metadata.occupied && !dom_node.is_null() {
-                visit(*dom_node);
+                visit(dom_node);
             }
         }
     }
@@ -1983,7 +2002,7 @@ impl LayoutNodeArena {
         if !self.slot_is_live(id) {
             return std::ptr::null_mut();
         }
-        self.dom_nodes[id.slot_index() as usize]
+        self.dom_nodes[id.slot_index() as usize].get()
     }
 
     pub(crate) fn live_slot_count(&self) -> u32 {
@@ -2586,6 +2605,29 @@ mod tests {
             is_editing_host: false,
             is_body: false,
         }
+    }
+
+    #[test]
+    fn an_unbound_slot_has_no_shell_until_a_shell_is_bound() {
+        let mut arena = LayoutNodeArena::new();
+        let mut dom_node_storage = 0u8;
+        let dom_node = std::ptr::from_mut(&mut dom_node_storage).cast::<c_void>();
+        let slot = arena.allocate_unbound(dom_node);
+        assert!(arena.slot_is_live(slot));
+        assert!(arena.node_shell(slot).is_null());
+        assert_eq!(arena.data(slot).kind.get(), NodeKind::Unset);
+        assert_eq!(arena.node_dom_node(slot), dom_node);
+
+        let unbound_freed = arena.free_subtree(slot);
+        assert_eq!(unbound_freed.shell_count(), 1);
+        unbound_freed.destroy_shells_and_invoke_callbacks();
+        assert!(!arena.slot_is_live(slot));
+
+        let slot = arena.allocate_unbound(dom_node);
+        arena.bind_shell(slot, test_construction_facts(dom_node));
+        assert_eq!(arena.data(slot).kind.get(), NodeKind::Box);
+        assert!(arena.data(slot).flags.get() & NodeFlag::HasStyle as u32 != 0);
+        arena.free_subtree(slot).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -456,6 +456,7 @@ pub(crate) struct LayoutNodeArena {
     chunks: Vec<Box<Chunk>>,
     chunks_by_address: Vec<ChunkAddress>,
     slot_metadata: Vec<SlotMetadata>,
+    dom_nodes: Vec<*mut c_void>,
     pre_order_labels: Vec<Cell<u64>>,
     pre_order_relabel_count: Cell<u64>,
     free_list: Vec<u32>,
@@ -491,6 +492,7 @@ impl LayoutNodeArena {
             chunks: Vec::new(),
             chunks_by_address: Vec::new(),
             slot_metadata: Vec::new(),
+            dom_nodes: Vec::new(),
             pre_order_labels: Vec::new(),
             pre_order_relabel_count: Cell::new(0),
             free_list: Vec::new(),
@@ -583,6 +585,7 @@ impl LayoutNodeArena {
     // allocate() always hands out clean NodeData without writing it again.
     pub(crate) fn allocate(&mut self, construction_facts: FfiNodeConstructionFacts) -> NodeSlotId {
         let slot = self.allocate_slot();
+        self.dom_nodes[slot.slot_index() as usize] = construction_facts.dom_node;
         let data = self.data_mut(slot.slot_index());
         data.kind.set(construction_facts.kind);
         data.shell.set(construction_facts.shell);
@@ -631,6 +634,7 @@ impl LayoutNodeArena {
                 self.chunks.push(chunk);
             }
             self.slot_metadata.push(SlotMetadata::default());
+            self.dom_nodes.push(std::ptr::null_mut());
             self.pre_order_labels.push(Cell::new(0));
             // Grown with the slot space up front: nearly every slot gets a run
             // record each layout pass, so register() never has to resize.
@@ -724,6 +728,7 @@ impl LayoutNodeArena {
         }
         self.pre_order_labels[index as usize].set(0);
         self.metadata_mut(index).occupied = false;
+        self.dom_nodes[index as usize] = std::ptr::null_mut();
 
         if let Some(slot) = self.intrinsic_size_caches.get_mut().get_mut(index as usize) {
             *slot = IntrinsicSizeCacheSlot::default();
@@ -1966,6 +1971,25 @@ impl LayoutNodeArena {
             .is_some_and(|metadata| metadata.occupied && metadata.generation == id.generation())
     }
 
+    pub(crate) fn visit_dom_nodes(&self, mut visit: impl FnMut(*mut c_void)) {
+        for (metadata, dom_node) in self.slot_metadata.iter().zip(&self.dom_nodes) {
+            if metadata.occupied && !dom_node.is_null() {
+                visit(*dom_node);
+            }
+        }
+    }
+
+    pub(crate) fn node_dom_node(&self, id: NodeSlotId) -> *mut c_void {
+        if !self.slot_is_live(id) {
+            return std::ptr::null_mut();
+        }
+        self.dom_nodes[id.slot_index() as usize]
+    }
+
+    pub(crate) fn live_slot_count(&self) -> u32 {
+        self.live_count
+    }
+
     pub(crate) fn shell_if_live(&self, id: NodeSlotId) -> *mut c_void {
         if !self.slot_is_live(id) {
             return std::ptr::null_mut();
@@ -2153,6 +2177,41 @@ pub unsafe extern "C" fn layout_arena_detach_and_free_subtree(arena: *mut c_void
     let was_attached = unsafe { &*arena }.detach_from_parent(node);
     crate::layout::tree_mutation::free_subtree_and_destroy_shells(arena, node);
     was_attached
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and the visitor must not
+/// re-enter the arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_visit_dom_nodes(
+    arena: *mut c_void,
+    context: *mut c_void,
+    visit: unsafe extern "C" fn(*mut c_void, *mut c_void),
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.visit_dom_nodes(|dom_node| {
+        // SAFETY: Guaranteed by the entry point's contract.
+        unsafe { visit(context, dom_node) }
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_dom_node(arena: *mut c_void, node: NodeSlotId) -> *mut c_void {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.node_dom_node(node)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_live_slot_count(arena: *mut c_void) -> u32 {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.live_slot_count()
 }
 
 #[unsafe(no_mangle)]
@@ -2509,8 +2568,56 @@ mod tests {
         Chunk, IntrinsicBlockSizeMeasurement, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey,
         IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
     };
-    use crate::layout::node_data::{NodeFlag, NodeSlotId};
+    use crate::layout::node_data::{FfiNodeConstructionFacts, NodeFlag, NodeKind, NodeSlotId};
     use crate::layout::{CssPixels, fragment_tree, used_values};
+    use std::ffi::c_void;
+
+    fn test_construction_facts(dom_node: *mut c_void) -> FfiNodeConstructionFacts {
+        FfiNodeConstructionFacts {
+            kind: NodeKind::Box,
+            shell: std::ptr::null_mut(),
+            dom_node,
+            is_anonymous: dom_node.is_null(),
+            is_html_input_element: false,
+            is_html_html_element: false,
+            is_document_element: false,
+            is_in_user_agent_shadow_tree: false,
+            uses_button_layout: false,
+            is_editing_host: false,
+            is_body: false,
+        }
+    }
+
+    #[test]
+    fn dom_nodes_are_reported_only_while_their_slot_is_live() {
+        let mut arena = LayoutNodeArena::new();
+        let mut dom_node_storage = 0u8;
+        let dom_node = std::ptr::from_mut(&mut dom_node_storage).cast::<c_void>();
+        let anonymous = arena.allocate(test_construction_facts(std::ptr::null_mut()));
+        let element = arena.allocate(test_construction_facts(dom_node));
+        assert!(arena.node_dom_node(anonymous).is_null());
+        assert_eq!(arena.node_dom_node(element), dom_node);
+        let mut visited = Vec::new();
+        arena.visit_dom_nodes(|node| visited.push(node));
+        assert_eq!(visited, vec![dom_node]);
+        assert_eq!(arena.live_slot_count(), 2);
+
+        arena.free_subtree(element).destroy_shells_and_invoke_callbacks();
+        assert!(arena.node_dom_node(element).is_null());
+        let reoccupant = arena.allocate_for_test();
+        assert_eq!(reoccupant.slot.slot_index(), element.slot_index());
+        assert!(arena.node_dom_node(element).is_null());
+        assert!(arena.node_dom_node(reoccupant.slot).is_null());
+        visited.clear();
+        arena.visit_dom_nodes(|node| visited.push(node));
+        assert!(visited.is_empty());
+
+        arena.free_subtree(anonymous).destroy_shells_and_invoke_callbacks();
+        arena
+            .free_subtree(reoccupant.slot)
+            .destroy_shells_and_invoke_callbacks();
+        assert_eq!(arena.live_slot_count(), 0);
+    }
 
     fn test_fragment_link(node: NodeSlotId) -> fragment_tree::FragmentLink {
         fragment_tree::FragmentLink {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -614,7 +614,7 @@ impl LayoutNodeArena {
 
     pub(crate) fn register_svg_pattern_referencing_node(&self, node: NodeSlotId) {
         let mut nodes = self.svg_pattern_referencing_nodes.borrow_mut();
-        nodes.retain(|candidate| !self.shell_if_live(*candidate).is_null());
+        nodes.retain(|candidate| self.slot_is_live(*candidate));
         if nodes.contains(&node) {
             return;
         }
@@ -623,7 +623,7 @@ impl LayoutNodeArena {
 
     pub(crate) fn svg_pattern_referencing_nodes(&self) -> Vec<NodeSlotId> {
         let mut nodes = self.svg_pattern_referencing_nodes.borrow_mut();
-        nodes.retain(|candidate| !self.shell_if_live(*candidate).is_null());
+        nodes.retain(|candidate| self.slot_is_live(*candidate));
         nodes.clone()
     }
 
@@ -2206,28 +2206,28 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_flags_if_live(&self, id: NodeSlotId) -> u32 {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return 0;
         }
         self.data(id).flags.get()
     }
 
     pub(crate) fn node_is_generated_for_pseudo_element(&self, id: NodeSlotId) -> bool {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return false;
         }
         self.data(id).generated_for.get() != 0
     }
 
     pub(crate) fn node_kind_if_live(&self, id: NodeSlotId) -> Option<NodeKind> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         Some(self.data(id).kind.get())
     }
 
     pub(crate) fn node_parent_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         let parent = self.data(id).parent.get();
@@ -2235,7 +2235,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_first_child_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         let child = self.data(id).first_child.get();
@@ -2243,7 +2243,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_next_sibling_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         let sibling = self.data(id).next_sibling.get();
@@ -2251,7 +2251,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_data_if_live(&self, id: NodeSlotId) -> Option<&NodeData> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         Some(self.data(id))
@@ -2263,7 +2263,7 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_containing_block_if_live(&self, id: NodeSlotId) -> Option<NodeSlotId> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         let block = self.data(id).containing_block.get();
@@ -2274,7 +2274,7 @@ impl LayoutNodeArena {
         &self,
         id: NodeSlotId,
     ) -> Option<crate::css::computed_value_views::ComputedValuesView<'_>> {
-        if self.shell_if_live(id).is_null() {
+        if !self.slot_is_live(id) {
             return None;
         }
         let payloads = self.style_payloads(id)?;

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -428,10 +428,56 @@ enum AncestorInvalidation {
     ContentChange,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiAnonymousStyleKind {
+    Wrapper,
+    TableRow,
+    TableCell,
+    Table,
+    InlineTable,
+    MissingTableCell,
+    TableWrapper,
+    ButtonFlexWrapper,
+    ButtonContentBox,
+    FieldsetContentWrapper,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiAnonymousStyleOverrides {
+    pub inline_block_wrapper: bool,
+    pub overflow_x: u8,
+    pub overflow_y: u8,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiDerivedStyleRecord {
+    pub record: u64,
+    pub payloads: *const c_void,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiStyleRecordHostCallbacks {
+    pub context: *mut c_void,
+    pub derive_anonymous_style_record: unsafe extern "C" fn(
+        *mut c_void,
+        u64,
+        FfiAnonymousStyleKind,
+        FfiAnonymousStyleOverrides,
+    ) -> FfiDerivedStyleRecord,
+    pub reinherit_anonymous_style_record: unsafe extern "C" fn(*mut c_void, u64, u64) -> FfiDerivedStyleRecord,
+    pub unpin_style_record: unsafe extern "C" fn(*mut c_void, u64),
+}
+
 #[must_use]
 pub(crate) struct FreedSubtree {
     shells: Vec<*mut c_void>,
     paintable_row_resets: Vec<crate::painting::paintable_rows::PaintableRowReset>,
+    arena_pinned_style_records: Vec<u64>,
+    style_record_host: Option<FfiStyleRecordHostCallbacks>,
 }
 
 impl FreedSubtree {
@@ -440,12 +486,23 @@ impl FreedSubtree {
         self.shells.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn arena_pinned_style_record_count(&self) -> usize {
+        self.arena_pinned_style_records.len()
+    }
+
     pub(crate) fn destroy_shells_and_invoke_callbacks(self) {
         for shell in self.shells {
             crate::layout::tree_mutation::destroy_shell(shell);
         }
         for reset in self.paintable_row_resets {
             reset.invoke_callback();
+        }
+        if let Some(host) = self.style_record_host {
+            for style_record in self.arena_pinned_style_records {
+                // SAFETY: Registration and unregistration keep the host context live.
+                unsafe { (host.unpin_style_record)(host.context, style_record) };
+            }
         }
     }
 }
@@ -457,6 +514,9 @@ pub(crate) struct LayoutNodeArena {
     chunks_by_address: Vec<ChunkAddress>,
     slot_metadata: Vec<SlotMetadata>,
     dom_nodes: Vec<Cell<*mut c_void>>,
+    style_records: Vec<Cell<u64>>,
+    style_records_pinned_by_arena: Vec<Cell<bool>>,
+    style_record_host: Cell<Option<FfiStyleRecordHostCallbacks>>,
     pre_order_labels: Vec<Cell<u64>>,
     pre_order_relabel_count: Cell<u64>,
     free_list: Vec<u32>,
@@ -493,6 +553,9 @@ impl LayoutNodeArena {
             chunks_by_address: Vec::new(),
             slot_metadata: Vec::new(),
             dom_nodes: Vec::new(),
+            style_records: Vec::new(),
+            style_records_pinned_by_arena: Vec::new(),
+            style_record_host: Cell::new(None),
             pre_order_labels: Vec::new(),
             pre_order_relabel_count: Cell::new(0),
             free_list: Vec::new(),
@@ -653,6 +716,8 @@ impl LayoutNodeArena {
             }
             self.slot_metadata.push(SlotMetadata::default());
             self.dom_nodes.push(Cell::new(std::ptr::null_mut()));
+            self.style_records.push(Cell::new(0));
+            self.style_records_pinned_by_arena.push(Cell::new(false));
             self.pre_order_labels.push(Cell::new(0));
             // Grown with the slot space up front: nearly every slot gets a run
             // record each layout pass, so register() never has to resize.
@@ -692,9 +757,13 @@ impl LayoutNodeArena {
 
         let mut shells = Vec::with_capacity(slots_in_pre_order.len());
         let mut paintable_row_resets = Vec::new();
+        let mut arena_pinned_style_records = Vec::new();
         for slot in slots_in_pre_order {
             self.mark_descendant_subtree_caches_dirty_from_layout_node(slot);
             shells.push(self.node_shell(slot));
+            if self.style_records_pinned_by_arena[slot.slot_index() as usize].get() {
+                arena_pinned_style_records.push(self.style_records[slot.slot_index() as usize].get());
+            }
             self.unlink_children_of_node_being_freed(slot);
             if let Some(reset) = self.free_unlinked_slot(slot) {
                 paintable_row_resets.push(reset);
@@ -703,6 +772,8 @@ impl LayoutNodeArena {
         FreedSubtree {
             shells,
             paintable_row_resets,
+            arena_pinned_style_records,
+            style_record_host: self.style_record_host.get(),
         }
     }
 
@@ -747,6 +818,8 @@ impl LayoutNodeArena {
         self.pre_order_labels[index as usize].set(0);
         self.metadata_mut(index).occupied = false;
         self.dom_nodes[index as usize].set(std::ptr::null_mut());
+        self.style_records[index as usize].set(0);
+        self.style_records_pinned_by_arena[index as usize].set(false);
 
         if let Some(slot) = self.intrinsic_size_caches.get_mut().get_mut(index as usize) {
             *slot = IntrinsicSizeCacheSlot::default();
@@ -821,11 +894,112 @@ impl LayoutNodeArena {
         data.generated_for.set(generated_for);
     }
 
-    pub(crate) fn set_node_style_payloads(&self, id: NodeSlotId, payloads: *const c_void) {
+    pub(crate) fn set_node_style(&self, id: NodeSlotId, style_record: u64, payloads: *const c_void) {
         self.assert_owner_thread();
         let data = self.data(id);
         data.style.set(payloads);
+        self.style_records[id.slot_index() as usize].set(style_record);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(id);
+    }
+
+    pub(crate) fn node_style_record(&self, id: NodeSlotId) -> u64 {
+        assert!(
+            self.slot_is_live(id),
+            "layout node arena read the style record of a dead slot"
+        );
+        self.style_records[id.slot_index() as usize].get()
+    }
+
+    pub(crate) fn node_style_record_is_pinned_by_arena(&self, id: NodeSlotId) -> bool {
+        assert!(
+            self.slot_is_live(id),
+            "layout node arena read the style pin of a dead slot"
+        );
+        self.style_records_pinned_by_arena[id.slot_index() as usize].get()
+    }
+
+    pub(crate) fn set_style_record_host(&self, host: Option<FfiStyleRecordHostCallbacks>) {
+        self.style_record_host.set(host);
+    }
+
+    fn style_record_host(&self) -> FfiStyleRecordHostCallbacks {
+        self.style_record_host
+            .get()
+            .expect("layout node arena has no style record host")
+    }
+
+    pub(crate) fn derive_anonymous_style_record(
+        &self,
+        parent_style_record: u64,
+        kind: FfiAnonymousStyleKind,
+        overrides: FfiAnonymousStyleOverrides,
+    ) -> FfiDerivedStyleRecord {
+        assert!(parent_style_record != 0, "anonymous box parent has no style record");
+        let host = self.style_record_host();
+        // SAFETY: Registration and unregistration keep the host context live.
+        unsafe { (host.derive_anonymous_style_record)(host.context, parent_style_record, kind, overrides) }
+    }
+
+    pub(crate) fn stamp_anonymous_box(&self, slot: NodeSlotId, kind: NodeKind, derived: FfiDerivedStyleRecord) {
+        self.assert_owner_thread();
+        let data = self.data(slot);
+        assert_eq!(
+            data.kind.get(),
+            NodeKind::Unset,
+            "stamped an anonymous box onto a bound slot"
+        );
+        assert!(derived.record != 0 && !derived.payloads.is_null());
+        data.kind.set(kind);
+        data.flags
+            .set(super::node_facts::construction_flags(&FfiNodeConstructionFacts {
+                kind,
+                shell: std::ptr::null_mut(),
+                dom_node: std::ptr::null_mut(),
+                is_anonymous: true,
+                is_html_input_element: false,
+                is_html_html_element: false,
+                is_document_element: false,
+                is_in_user_agent_shadow_tree: false,
+                uses_button_layout: false,
+                is_editing_host: false,
+                is_body: false,
+            }));
+        self.style_records[slot.slot_index() as usize].set(derived.record);
+        self.style_records_pinned_by_arena[slot.slot_index() as usize].set(true);
+        data.style.set(derived.payloads);
+        self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
+    }
+
+    pub(crate) fn replace_arena_pinned_style_record(&self, slot: NodeSlotId, derived: FfiDerivedStyleRecord) {
+        self.assert_owner_thread();
+        assert!(
+            self.node_style_record_is_pinned_by_arena(slot),
+            "replaced a style record the arena does not pin"
+        );
+        assert!(derived.record != 0 && !derived.payloads.is_null());
+        let previous_style_record = self.style_records[slot.slot_index() as usize].replace(derived.record);
+        self.data(slot).style.set(derived.payloads);
+        self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
+        if previous_style_record != derived.record {
+            let host = self.style_record_host();
+            // SAFETY: Registration and unregistration keep the host context live.
+            unsafe { (host.unpin_style_record)(host.context, previous_style_record) };
+        } else {
+            let host = self.style_record_host();
+            // SAFETY: As above; the derivation pinned the record a second time.
+            unsafe { (host.unpin_style_record)(host.context, derived.record) };
+        }
+    }
+
+    pub(crate) fn attach_shell(&self, slot: NodeSlotId, shell: *mut c_void) {
+        self.assert_owner_thread();
+        assert!(!shell.is_null());
+        let data = self.data(slot);
+        assert!(
+            data.shell.get().is_null(),
+            "layout node arena attached a second shell to a slot"
+        );
+        data.shell.set(shell);
     }
 
     pub(crate) fn set_node_flag(&self, id: NodeSlotId, flag: NodeFlag, value: bool) {
@@ -2447,14 +2621,71 @@ pub unsafe extern "C" fn layout_arena_set_node_generated_for(arena: *mut c_void,
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_set_node_style_payloads(
+pub unsafe extern "C" fn layout_arena_set_node_style(
     arena: *mut c_void,
     id: NodeSlotId,
+    style_record: u64,
     payloads: *const c_void,
 ) {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: As above.
-    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_style_payloads(id, payloads);
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_style(id, style_record, payloads);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_style_record(arena: *mut c_void, id: NodeSlotId) -> u64 {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.node_style_record(id)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_style_record_is_pinned_by_arena(arena: *mut c_void, id: NodeSlotId) -> bool {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.node_style_record_is_pinned_by_arena(id)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_replace_arena_pinned_style_record(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    style_record: u64,
+    payloads: *const c_void,
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.replace_arena_pinned_style_record(
+        id,
+        FfiDerivedStyleRecord {
+            record: style_record,
+            payloads,
+        },
+    );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_attach_shell(arena: *mut c_void, id: NodeSlotId, shell: *mut c_void) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.attach_shell(id, shell);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_style_record_host_callbacks(
+    arena: *mut c_void,
+    callbacks: FfiStyleRecordHostCallbacks,
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_style_record_host(Some(callbacks));
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_clear_style_record_host_callbacks(arena: *mut c_void) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_style_record_host(None);
 }
 
 #[unsafe(no_mangle)]
@@ -2584,16 +2815,21 @@ mod tests {
     use std::cell::Cell;
 
     use crate::layout::layout_node_arena::{
-        Chunk, IntrinsicBlockSizeMeasurement, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey,
-        IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement, TableCellMeasurementKey,
+        Chunk, FfiDerivedStyleRecord, IntrinsicBlockSizeMeasurement, IntrinsicInlineSizeMeasurement,
+        IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK, TableCellMeasurement,
+        TableCellMeasurementKey,
     };
     use crate::layout::node_data::{FfiNodeConstructionFacts, NodeFlag, NodeKind, NodeSlotId};
     use crate::layout::{CssPixels, fragment_tree, used_values};
     use std::ffi::c_void;
 
     fn test_construction_facts(dom_node: *mut c_void) -> FfiNodeConstructionFacts {
+        test_construction_facts_with_kind(dom_node, NodeKind::Box)
+    }
+
+    fn test_construction_facts_with_kind(dom_node: *mut c_void, kind: NodeKind) -> FfiNodeConstructionFacts {
         FfiNodeConstructionFacts {
-            kind: NodeKind::Box,
+            kind,
             shell: std::ptr::null_mut(),
             dom_node,
             is_anonymous: dom_node.is_null(),
@@ -2628,6 +2864,41 @@ mod tests {
         assert_eq!(arena.data(slot).kind.get(), NodeKind::Box);
         assert!(arena.data(slot).flags.get() & NodeFlag::HasStyle as u32 != 0);
         arena.free_subtree(slot).destroy_shells_and_invoke_callbacks();
+    }
+
+    #[test]
+    fn an_anonymous_box_stamped_by_the_arena_keeps_its_style_record_until_freed() {
+        let mut arena = LayoutNodeArena::new();
+        let payloads = [std::ptr::null::<c_void>(); 1];
+        let slot = arena.allocate_unbound(std::ptr::null_mut());
+        arena.stamp_anonymous_box(
+            slot,
+            NodeKind::InlineNode,
+            FfiDerivedStyleRecord {
+                record: 7,
+                payloads: payloads.as_ptr().cast(),
+            },
+        );
+        assert_eq!(arena.data(slot).kind.get(), NodeKind::InlineNode);
+        assert!(arena.data(slot).flags.get() & NodeFlag::Anonymous as u32 != 0);
+        assert!(arena.data(slot).flags.get() & NodeFlag::HasStyle as u32 != 0);
+        assert_eq!(arena.node_style_record(slot), 7);
+        assert!(arena.node_style_record_is_pinned_by_arena(slot));
+
+        let element = arena.allocate(test_construction_facts_with_kind(
+            std::ptr::null_mut(),
+            NodeKind::InlineNode,
+        ));
+        arena.set_node_style(element, 9, payloads.as_ptr().cast());
+        assert_eq!(arena.node_style_record(element), 9);
+        assert!(!arena.node_style_record_is_pinned_by_arena(element));
+
+        let freed = arena.free_subtree(slot);
+        assert_eq!(freed.arena_pinned_style_record_count(), 1);
+        freed.destroy_shells_and_invoke_callbacks();
+        let freed = arena.free_subtree(element);
+        assert_eq!(freed.arena_pinned_style_record_count(), 0);
+        freed.destroy_shells_and_invoke_callbacks();
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -12,6 +12,7 @@ use super::geometry::AvailableSpace;
 use super::used_values::SizeConstraint;
 use super::used_values::UsedValues;
 use crate::css::style::fast_hash::FastMap as HashMap;
+use crate::layout::ComputedValuesView;
 use crate::layout::CssPixels;
 use crate::layout::FfiReplacedContentFacts;
 use crate::layout::node_data::{
@@ -441,6 +442,7 @@ pub enum FfiAnonymousStyleKind {
     ButtonFlexWrapper,
     ButtonContentBox,
     FieldsetContentWrapper,
+    InlineStyleWrapper,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -470,6 +472,30 @@ pub struct FfiStyleRecordHostCallbacks {
     ) -> FfiDerivedStyleRecord,
     pub reinherit_anonymous_style_record: unsafe extern "C" fn(*mut c_void, u64, u64) -> FfiDerivedStyleRecord,
     pub unpin_style_record: unsafe extern "C" fn(*mut c_void, u64),
+    pub reinherit_owned_anonymous_box_style: unsafe extern "C" fn(*mut c_void, *mut c_void, u64) -> bool,
+    pub reset_table_box_style_used_by_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub shell_style_changed: unsafe extern "C" fn(*mut c_void, *mut c_void),
+}
+
+fn style_payloads_equal_in_layout_affecting_groups(a: *const c_void, b: *const c_void) -> bool {
+    if a == b {
+        return true;
+    }
+    if a.is_null() || b.is_null() {
+        return false;
+    }
+    // SAFETY: A non-null style pointer addresses the engine's group pointer array, which
+    // FfiStylePayloads mirrors exactly.
+    let (a, b) = unsafe { (&*a.cast::<FfiStylePayloads>(), &*b.cast::<FfiStylePayloads>()) };
+    (0..a.groups.len()).all(|group_index| {
+        !crate::css::computed_values::style_group_affects_layout(group_index)
+            || a.groups[group_index] == b.groups[group_index]
+            || crate::css::computed_values::style_group_payloads_equal(
+                group_index,
+                a.groups[group_index],
+                b.groups[group_index],
+            )
+    })
 }
 
 #[must_use]
@@ -938,6 +964,109 @@ impl LayoutNodeArena {
         let host = self.style_record_host();
         // SAFETY: Registration and unregistration keep the host context live.
         unsafe { (host.derive_anonymous_style_record)(host.context, parent_style_record, kind, overrides) }
+    }
+
+    pub(crate) fn reinherit_anonymous_style_record(
+        &self,
+        style_record: u64,
+        parent_style_record: u64,
+    ) -> FfiDerivedStyleRecord {
+        assert!(style_record != 0 && parent_style_record != 0);
+        let host = self.style_record_host();
+        // SAFETY: Registration and unregistration keep the host context live.
+        unsafe { (host.reinherit_anonymous_style_record)(host.context, style_record, parent_style_record) }
+    }
+
+    pub(crate) fn reset_table_box_style_used_by_wrapper(&self, table_box: NodeSlotId) {
+        let shell = self.node_shell(table_box);
+        assert!(
+            !shell.is_null(),
+            "table box without a shell cannot reset the properties its wrapper took"
+        );
+        let host = self.style_record_host();
+        // SAFETY: Registration and unregistration keep the host context live, and the shell is live.
+        unsafe { (host.reset_table_box_style_used_by_wrapper)(host.context, shell) };
+    }
+
+    pub(crate) fn reinherit_anonymous_descendants(&self, node: NodeSlotId) {
+        self.assert_owner_thread();
+        if self.node_style_record(node) == 0 {
+            return;
+        }
+        let parent = self.data(node).parent.get();
+        let parent_is_table_wrapper_of_this_table_box = !parent.is_invalid()
+            && self.data(parent).kind.get() == NodeKind::TableWrapper
+            && self
+                .style_payloads(node)
+                .is_some_and(|payloads| ComputedValuesView::new(&payloads.groups).display().is_table_inside());
+        if parent_is_table_wrapper_of_this_table_box {
+            let derived = self.derive_anonymous_style_record(
+                self.node_style_record(node),
+                FfiAnonymousStyleKind::TableWrapper,
+                FfiAnonymousStyleOverrides::default(),
+            );
+            self.apply_reinherited_style_record(parent, derived);
+            self.reset_table_box_style_used_by_wrapper(node);
+        }
+        self.reinherit_anonymous_children(node, self.node_style_record(node));
+    }
+
+    fn reinherit_anonymous_children(&self, parent: NodeSlotId, parent_style_record: u64) {
+        let mut child = self.data(parent).first_child.get();
+        while !child.is_invalid() {
+            let next_sibling = self.data(child).next_sibling.get();
+            let data = self.data(child);
+            let flags = data.flags.get();
+            let is_anonymous_styled_child = flags & NodeFlag::Anonymous as u32 != 0
+                && flags & NodeFlag::HasStyle as u32 != 0
+                && data.kind.get() != NodeKind::TableWrapper;
+            if is_anonymous_styled_child {
+                if self.style_records_pinned_by_arena[child.slot_index() as usize].get() {
+                    let derived =
+                        self.reinherit_anonymous_style_record(self.node_style_record(child), parent_style_record);
+                    self.apply_reinherited_style_record(child, derived);
+                    self.reinherit_anonymous_children(child, derived.record);
+                } else if !data.shell.get().is_null() {
+                    let host = self.style_record_host();
+                    // SAFETY: Registration and unregistration keep the host context live, and the shell is live.
+                    let descendants_follow = unsafe {
+                        (host.reinherit_owned_anonymous_box_style)(host.context, data.shell.get(), parent_style_record)
+                    };
+                    if descendants_follow {
+                        self.reinherit_anonymous_children(child, self.node_style_record(child));
+                    }
+                }
+            }
+            child = next_sibling;
+        }
+    }
+
+    fn apply_reinherited_style_record(&self, slot: NodeSlotId, derived: FfiDerivedStyleRecord) {
+        let previous_payloads = self.data(slot).style.get();
+        let changes_layout_affecting_style =
+            !style_payloads_equal_in_layout_affecting_groups(previous_payloads, derived.payloads);
+        self.replace_arena_pinned_style_record(slot, derived);
+        if changes_layout_affecting_style {
+            self.bump_fragment_cache_epoch_of_self_and_ancestors(slot);
+            self.reset_cached_intrinsic_sizes_of_self_and_ancestors(slot);
+        }
+        let mut child = self.data(slot).first_child.get();
+        while !child.is_invalid() {
+            if super::node_facts::kind_is_text(self.data(child).kind.get()) {
+                self.enroll_text_node_for_content_sync(child);
+            }
+            child = self.data(child).next_sibling.get();
+        }
+        let shell = self.node_shell(slot);
+        if !shell.is_null() {
+            let host = self.style_record_host();
+            // SAFETY: Registration and unregistration keep the host context live, and the shell is live.
+            unsafe { (host.shell_style_changed)(host.context, shell) };
+        }
+    }
+
+    pub(crate) fn enroll_text_node_for_content_sync(&self, node: NodeSlotId) {
+        self.text_nodes_enrolled_for_content_sync.borrow_mut().push(node);
     }
 
     pub(crate) fn stamp_anonymous_box(&self, slot: NodeSlotId, kind: NodeKind, derived: FfiDerivedStyleRecord) {
@@ -2662,6 +2791,13 @@ pub unsafe extern "C" fn layout_arena_replace_arena_pinned_style_record(
             payloads,
         },
     );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_reinherit_anonymous_descendants(arena: *mut c_void, node: NodeSlotId) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.reinherit_anonymous_descendants(node);
 }
 
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -460,6 +460,31 @@ pub struct FfiDerivedStyleRecord {
     pub payloads: *const c_void,
 }
 
+type ShellFactory = (*mut c_void, unsafe extern "C" fn(*mut c_void, NodeSlotId, NodeKind));
+
+fn style_insets_use_anchor_functions(style: ComputedValuesView<'_>) -> bool {
+    let surround = style.surround();
+    [
+        &surround.top_anchor_inset,
+        &surround.right_anchor_inset,
+        &surround.bottom_anchor_inset,
+        &surround.left_anchor_inset,
+    ]
+    .iter()
+    .any(|handle| !handle.pointer.is_null())
+        || [
+            &surround.inset.top,
+            &surround.inset.right,
+            &surround.inset.bottom,
+            &surround.inset.left,
+        ]
+        .iter()
+        .any(|side| {
+            side.length_percentage()
+                .is_some_and(|value| value.contains_anchor_function())
+        })
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiStyleRecordHostCallbacks {
@@ -543,6 +568,7 @@ pub(crate) struct LayoutNodeArena {
     style_records: Vec<Cell<u64>>,
     style_records_pinned_by_arena: Vec<Cell<bool>>,
     style_record_host: Cell<Option<FfiStyleRecordHostCallbacks>>,
+    shell_factory: Cell<Option<ShellFactory>>,
     pre_order_labels: Vec<Cell<u64>>,
     pre_order_relabel_count: Cell<u64>,
     free_list: Vec<u32>,
@@ -582,6 +608,7 @@ impl LayoutNodeArena {
             style_records: Vec::new(),
             style_records_pinned_by_arena: Vec::new(),
             style_record_host: Cell::new(None),
+            shell_factory: Cell::new(None),
             pre_order_labels: Vec::new(),
             pre_order_relabel_count: Cell::new(0),
             free_list: Vec::new(),
@@ -786,7 +813,7 @@ impl LayoutNodeArena {
         let mut arena_pinned_style_records = Vec::new();
         for slot in slots_in_pre_order {
             self.mark_descendant_subtree_caches_dirty_from_layout_node(slot);
-            shells.push(self.node_shell(slot));
+            shells.push(self.data(slot).shell.get());
             if self.style_records_pinned_by_arena[slot.slot_index() as usize].get() {
                 arena_pinned_style_records.push(self.style_records[slot.slot_index() as usize].get());
             }
@@ -1057,11 +1084,13 @@ impl LayoutNodeArena {
             }
             child = self.data(child).next_sibling.get();
         }
-        let shell = self.node_shell(slot);
+        let shell = self.data(slot).shell.get();
         if !shell.is_null() {
             let host = self.style_record_host();
             // SAFETY: Registration and unregistration keep the host context live, and the shell is live.
             unsafe { (host.shell_style_changed)(host.context, shell) };
+        } else {
+            self.refresh_insets_use_anchor_functions_flag(slot);
         }
     }
 
@@ -1097,6 +1126,47 @@ impl LayoutNodeArena {
         self.style_records_pinned_by_arena[slot.slot_index() as usize].set(true);
         data.style.set(derived.payloads);
         self.enroll_node_for_replaced_content_facts_sync_if_eligible(slot);
+    }
+
+    pub(crate) fn refresh_insets_use_anchor_functions_flag(&self, slot: NodeSlotId) {
+        let insets_use_anchor_functions = self
+            .style_payloads(slot)
+            .is_some_and(|payloads| style_insets_use_anchor_functions(ComputedValuesView::new(&payloads.groups)));
+        self.set_node_flag(slot, NodeFlag::InsetsUseAnchorFunctions, insets_use_anchor_functions);
+    }
+
+    pub(crate) fn set_shell_factory(&self, factory: Option<ShellFactory>) {
+        self.shell_factory.set(factory);
+    }
+
+    fn materialize_shell(&self, id: NodeSlotId) -> *mut c_void {
+        let Some((context, factory)) = self.shell_factory.get() else {
+            return std::ptr::null_mut();
+        };
+        let data = self.data(id);
+        if data.kind.get() == NodeKind::Unset || data.flags.get() & NodeFlag::Anonymous as u32 == 0 {
+            return std::ptr::null_mut();
+        }
+        // SAFETY: Registration and unregistration keep the factory context live; the factory binds a
+        // shell to this live slot and writes nothing but the slot's shell cell.
+        unsafe { factory(context, id, data.kind.get()) };
+        data.shell.get()
+    }
+
+    pub(crate) fn shell_count(&self) -> u32 {
+        let mut count = 0;
+        for (index, metadata) in self.slot_metadata.iter().enumerate() {
+            if metadata.occupied
+                && !self
+                    .data(NodeSlotId::new(index as u32, metadata.generation))
+                    .shell
+                    .get()
+                    .is_null()
+            {
+                count += 1;
+            }
+        }
+        count
     }
 
     pub(crate) fn replace_arena_pinned_style_record(&self, slot: NodeSlotId, derived: FfiDerivedStyleRecord) {
@@ -1242,8 +1312,8 @@ impl LayoutNodeArena {
                 // SAFETY: Both slots are live; the callback only reads DOM ancestry
                 // and per-node facts through the shells and does not mutate the tree.
                 let inline_containing_block = unsafe {
-                    let node_shell = data.shell.get();
-                    let ancestor_shell = self.data(ancestor).shell.get();
+                    let node_shell = self.node_shell(node);
+                    let ancestor_shell = self.node_shell(ancestor);
                     inline_cb_lookup(node_shell, ancestor_shell)
                 };
                 data.inline_containing_block.set(inline_containing_block);
@@ -2308,6 +2378,50 @@ impl LayoutNodeArena {
         self.dom_nodes[id.slot_index() as usize].get()
     }
 
+    pub(crate) fn previous_dom_backed_or_generated_node(
+        &self,
+        start: NodeSlotId,
+        previous_sibling_only: bool,
+    ) -> NodeSlotId {
+        let mut current = start;
+        loop {
+            let data = self.data(current);
+            current = if previous_sibling_only {
+                data.previous_sibling.get()
+            } else if data.previous_sibling.get().is_invalid() {
+                data.parent.get()
+            } else {
+                let mut deepest_last_descendant = data.previous_sibling.get();
+                loop {
+                    let last_child = self.data(deepest_last_descendant).last_child.get();
+                    if last_child.is_invalid() {
+                        break;
+                    }
+                    deepest_last_descendant = last_child;
+                }
+                deepest_last_descendant
+            };
+            if current.is_invalid() {
+                return NodeSlotId::INVALID;
+            }
+            let has_dom_node = !self.dom_nodes[current.slot_index() as usize].get().is_null();
+            if has_dom_node || self.data(current).generated_for.get() != 0 {
+                return current;
+            }
+        }
+    }
+
+    pub(crate) fn enroll_text_children_for_content_sync(&self, parent: NodeSlotId) {
+        let mut child = self.data(parent).first_child.get();
+        while !child.is_invalid() {
+            let data = self.data(child);
+            if crate::layout::node_facts::kind_is_text(data.kind.get()) {
+                self.enroll_text_node_for_content_sync(child);
+            }
+            child = data.next_sibling.get();
+        }
+    }
+
     pub(crate) fn live_slot_count(&self) -> u32 {
         self.live_count
     }
@@ -2316,20 +2430,22 @@ impl LayoutNodeArena {
         if !self.slot_is_live(id) {
             return std::ptr::null_mut();
         }
-        self.data(id).shell.get()
+        self.node_shell(id)
+    }
+
+    pub(crate) fn node_link_slot(&self, id: NodeSlotId, link: FfiNodeLink) -> NodeSlotId {
+        let data = self.data(id);
+        match link {
+            FfiNodeLink::Parent => data.parent.get(),
+            FfiNodeLink::FirstChild => data.first_child.get(),
+            FfiNodeLink::LastChild => data.last_child.get(),
+            FfiNodeLink::PreviousSibling => data.previous_sibling.get(),
+            FfiNodeLink::NextSibling => data.next_sibling.get(),
+        }
     }
 
     pub(crate) fn node_link_shell(&self, id: NodeSlotId, link: FfiNodeLink) -> *mut c_void {
-        let data = self.data(id);
-        let linked = {
-            match link {
-                FfiNodeLink::Parent => data.parent.get(),
-                FfiNodeLink::FirstChild => data.first_child.get(),
-                FfiNodeLink::LastChild => data.last_child.get(),
-                FfiNodeLink::PreviousSibling => data.previous_sibling.get(),
-                FfiNodeLink::NextSibling => data.next_sibling.get(),
-            }
-        };
+        let linked = self.node_link_slot(id, link);
         if linked.is_invalid() {
             return std::ptr::null_mut();
         }
@@ -2350,7 +2466,11 @@ impl LayoutNodeArena {
     }
 
     pub(crate) fn node_shell(&self, id: NodeSlotId) -> *mut c_void {
-        self.data(id).shell.get()
+        let shell = self.data(id).shell.get();
+        if !shell.is_null() {
+            return shell;
+        }
+        self.materialize_shell(id)
     }
 
     pub(crate) fn dom_offset_for_rendered_text_offset(
@@ -2520,6 +2640,22 @@ pub unsafe extern "C" fn layout_arena_visit_dom_nodes(
     });
 }
 
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `start` must name a live node
+/// in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_previous_dom_backed_or_generated_node(
+    arena: *mut c_void,
+    start: NodeSlotId,
+    previous_sibling_only: bool,
+) -> NodeSlotId {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.previous_dom_backed_or_generated_node(start, previous_sibling_only)
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_dom_node(arena: *mut c_void, node: NodeSlotId) -> *mut c_void {
     assert!(!arena.is_null(), "layout node arena handle is null");
@@ -2646,6 +2782,16 @@ pub unsafe extern "C" fn layout_arena_node_link_shell(
 ) -> *mut c_void {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     unsafe { LayoutNodeArena::from_handle(arena) }.node_link_shell(id, link)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_link_slot(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    link: FfiNodeLink,
+) -> NodeSlotId {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_link_slot(id, link)
 }
 
 #[unsafe(no_mangle)]
@@ -2801,6 +2947,38 @@ pub unsafe extern "C" fn layout_arena_reinherit_anonymous_descendants(arena: *mu
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_style_payloads(arena: *mut c_void, id: NodeSlotId) -> *const c_void {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.data(id).style.get()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_shell_count(arena: *mut c_void) -> u32 {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.shell_count()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_shell_factory(
+    arena: *mut c_void,
+    context: *mut c_void,
+    factory: unsafe extern "C" fn(*mut c_void, NodeSlotId, NodeKind),
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_shell_factory(Some((context, factory)));
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_clear_shell_factory(arena: *mut c_void) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: As above.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_shell_factory(None);
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_attach_shell(arena: *mut c_void, id: NodeSlotId, shell: *mut c_void) {
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: As above.
@@ -2822,6 +3000,18 @@ pub unsafe extern "C" fn layout_arena_clear_style_record_host_callbacks(arena: *
     assert!(!arena.is_null(), "layout node arena handle is null");
     // SAFETY: As above.
     unsafe { &*arena.cast::<LayoutNodeArena>() }.set_style_record_host(None);
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `parent` must name a live node
+/// in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_enroll_text_children_for_content_sync(arena: *mut c_void, parent: NodeSlotId) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and
+    // serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.enroll_text_children_for_content_sync(parent);
 }
 
 #[unsafe(no_mangle)]
@@ -3035,6 +3225,34 @@ mod tests {
         let freed = arena.free_subtree(element);
         assert_eq!(freed.arena_pinned_style_record_count(), 0);
         freed.destroy_shells_and_invoke_callbacks();
+    }
+
+    #[test]
+    fn previous_dom_backed_or_generated_node_skips_anonymous_slots() {
+        let mut arena = LayoutNodeArena::new();
+        let mut root_dom_node_storage = 0u8;
+        let mut element_dom_node_storage = 0u8;
+        let root_dom_node = std::ptr::from_mut(&mut root_dom_node_storage).cast::<c_void>();
+        let element_dom_node = std::ptr::from_mut(&mut element_dom_node_storage).cast::<c_void>();
+        let root = arena.allocate(test_construction_facts(root_dom_node));
+        let anonymous_wrapper = arena.allocate(test_construction_facts(std::ptr::null_mut()));
+        let nested_anonymous = arena.allocate(test_construction_facts(std::ptr::null_mut()));
+        let element = arena.allocate(test_construction_facts(element_dom_node));
+        arena.insert_child(root, anonymous_wrapper, NodeSlotId::INVALID);
+        arena.insert_child(anonymous_wrapper, nested_anonymous, NodeSlotId::INVALID);
+        arena.insert_child(root, element, NodeSlotId::INVALID);
+
+        assert_eq!(arena.previous_dom_backed_or_generated_node(element, false), root);
+        assert!(arena.previous_dom_backed_or_generated_node(element, true).is_invalid());
+        assert!(arena.previous_dom_backed_or_generated_node(root, false).is_invalid());
+
+        arena.data(nested_anonymous).generated_for.set(1);
+        assert_eq!(
+            arena.previous_dom_backed_or_generated_node(element, false),
+            nested_anonymous
+        );
+
+        arena.free_subtree(root).destroy_shells_and_invoke_callbacks();
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -187,6 +187,7 @@ pub enum FfiNodeLink {
 pub struct FfiNodeConstructionFacts {
     pub kind: NodeKind,
     pub shell: *mut c_void,
+    pub dom_node: *mut c_void,
     pub is_anonymous: bool,
     pub is_html_input_element: bool,
     pub is_html_html_element: bool,

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -551,7 +551,9 @@ mod tests {
     }
 
     fn free_node(arena: &mut LayoutNodeArena, allocation: &NodeAllocation) {
-        arena.free(allocation.slot).detached_children.release_all();
+        arena
+            .free_subtree(allocation.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
+++ b/Libraries/LibWeb/Rust/src/layout/partial_relayout.rs
@@ -150,7 +150,7 @@ impl LayoutNodeArena {
         let kind = self.data(node).kind.get();
         assert!(node_facts::kind_is_box(kind));
         let mut roots = self.partial_relayout_boundary_roots.borrow_mut();
-        roots.retain(|candidate| !self.shell_if_live(*candidate).is_null());
+        roots.retain(|candidate| self.slot_is_live(*candidate));
         if roots.contains(&node) {
             return;
         }
@@ -229,8 +229,8 @@ impl LayoutNodeArena {
             // through the rebuilt subtree roots below) or removed together with the dirt
             // inside it (the removal dirtied its parent, whose own marking covers the
             // mutation). Slot generations make the stale slot ids of such boundaries
-            // resolve to no shell.
-            if self.shell_if_live(slot).is_null() {
+            // resolve to no live slot.
+            if !self.slot_is_live(slot) {
                 continue;
             }
             let parent = self.data(slot).parent.get();
@@ -588,8 +588,8 @@ mod tests {
         let reused = allocate_box_with_a_dummy_shell(&mut arena);
         let drained = arena.take_partial_relayout_boundary_roots();
         assert_eq!(drained, vec![allocation.slot]);
-        assert!(arena.shell_if_live(allocation.slot).is_null());
-        assert!(!arena.shell_if_live(reused.slot).is_null());
+        assert!(!arena.slot_is_live(allocation.slot));
+        assert!(arena.slot_is_live(reused.slot));
         free_node(&mut arena, &reused);
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -7,7 +7,7 @@
 use super::*;
 
 use crate::abort_on_panic;
-use crate::layout::layout_node_arena::LayoutNodeArena;
+use crate::layout::layout_node_arena::{FfiAnonymousStyleKind, FfiAnonymousStyleOverrides, LayoutNodeArena};
 use crate::layout::node_data::{GENERATED_FOR_AFTER, GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
 use crate::layout::tree_mutation::{UnplacedLayoutNode, free_subtree_and_destroy_shells};
 use crate::layout::{ComputedValuesView, FfiDisplay};
@@ -1077,13 +1077,7 @@ unsafe fn update_principal_node_descendants(
                     // anonymous BlockContainer so that a BFC handles their layout.
                     let first_child = layout_host.first_child(layout_node);
                     if first_child.is_invalid() || !node_has_flag(layout_host.data(first_child), NodeFlag::Anonymous) {
-                        // SAFETY: `layout_node` is a live NodeWithStyle.
-                        let wrapper = layout_host.created(unsafe {
-                            (layout_host.callbacks.create_anonymous_wrapper)(
-                                layout_host.callbacks.context,
-                                layout_host.shell(layout_node),
-                            )
-                        });
+                        let wrapper = layout_host.create_anonymous_wrapper_box(layout_node);
                         layout_host.attach_child(state.current_parent(), wrapper, NodeSlotId::INVALID);
                     }
                     let wrapper = layout_host.first_child(layout_node);
@@ -2254,25 +2248,16 @@ pub(crate) enum FfiInsertionMode {
 }
 
 #[repr(C)]
-pub struct FfiButtonContentWrappers {
-    pub flex_wrapper: NodeSlotId,
-    pub content_box: NodeSlotId,
-}
-
-#[repr(C)]
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
-    pub create_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-    pub create_anonymous_table_box:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiAnonymousTableBoxKind) -> NodeSlotId,
-    pub create_table_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
-    pub create_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_anonymous_shell: unsafe extern "C" fn(*mut c_void, NodeSlotId, NodeKind),
+    pub reset_table_box_style_used_by_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub take_fieldset_overflow_for_content_wrapper:
+        unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAnonymousStyleOverrides,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub text_is_ascii_whitespace: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub prepare_first_letter_text:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiFirstLetterTextCallbacks) -> bool,
-    pub create_button_content_wrappers: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiButtonContentWrappers,
-    pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2488,6 +2473,41 @@ impl TreeBuilderHost<'_> {
         UnplacedLayoutNode::new(slot)
     }
 
+    fn create_anonymous_box(
+        &self,
+        parent: LayoutNode,
+        style_kind: FfiAnonymousStyleKind,
+        overrides: FfiAnonymousStyleOverrides,
+        node_kind: NodeKind,
+    ) -> UnplacedLayoutNode {
+        let derived =
+            self.arena()
+                .derive_anonymous_style_record(self.arena().node_style_record(parent), style_kind, overrides);
+        // SAFETY: Entry points guarantee that the arena remains live, and callers hold no reference derived from
+        // it across the allocation.
+        let slot = unsafe { &mut *self.arena }.allocate_unbound(std::ptr::null_mut());
+        self.arena().stamp_anonymous_box(slot, node_kind, derived);
+        // SAFETY: `slot` is a live anonymous box that only the builder knows.
+        unsafe { (self.callbacks.create_anonymous_shell)(self.callbacks.context, slot, node_kind) };
+        UnplacedLayoutNode::new(slot)
+    }
+
+    fn anonymous_wrapper_overrides(&self, parent: LayoutNode) -> FfiAnonymousStyleOverrides {
+        FfiAnonymousStyleOverrides {
+            inline_block_wrapper: self.display(parent).is_inline_block() && self.first_child(parent).is_invalid(),
+            ..FfiAnonymousStyleOverrides::default()
+        }
+    }
+
+    fn create_anonymous_wrapper_box(&self, parent: LayoutNode) -> UnplacedLayoutNode {
+        self.create_anonymous_box(
+            parent,
+            FfiAnonymousStyleKind::Wrapper,
+            self.anonymous_wrapper_overrides(parent),
+            NodeKind::BlockContainer,
+        )
+    }
+
     fn attach_child(&self, parent: LayoutNode, child: UnplacedLayoutNode, before: LayoutNode) {
         self.arena().attach_child(parent, child, before);
     }
@@ -2579,10 +2599,13 @@ impl TreeBuilderHost<'_> {
         assert!(!nodes.is_empty());
         let parent = self.parent(nodes[0]);
         assert!(!parent.is_invalid());
-        // SAFETY: `parent` is a live NodeWithStyle.
-        let wrapper = self.created(unsafe {
-            (self.callbacks.create_anonymous_table_box)(self.callbacks.context, self.shell(parent), kind)
-        });
+        let (style_kind, node_kind) = match kind {
+            FfiAnonymousTableBoxKind::TableRow => (FfiAnonymousStyleKind::TableRow, NodeKind::Box),
+            FfiAnonymousTableBoxKind::TableCell => (FfiAnonymousStyleKind::TableCell, NodeKind::BlockContainer),
+            FfiAnonymousTableBoxKind::Table => (FfiAnonymousStyleKind::Table, NodeKind::Box),
+            FfiAnonymousTableBoxKind::InlineTable => (FfiAnonymousStyleKind::InlineTable, NodeKind::Box),
+        };
+        let wrapper = self.create_anonymous_box(parent, style_kind, FfiAnonymousStyleOverrides::default(), node_kind);
         let wrapper_slot = wrapper.slot();
         for &node in nodes {
             self.move_child(node, wrapper_slot, NodeSlotId::INVALID);
@@ -2673,9 +2696,7 @@ fn is_out_of_flow_table_internal_child_of_table_root(
 }
 
 fn create_anonymous_wrapper(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
-    // SAFETY: `parent` is a live NodeWithStyle.
-    let wrapper =
-        host.created(unsafe { (host.callbacks.create_anonymous_wrapper)(host.callbacks.context, host.shell(parent)) });
+    let wrapper = host.create_anonymous_wrapper_box(parent);
     let wrapper_slot = wrapper.slot();
     host.attach_child(parent, wrapper, NodeSlotId::INVALID);
     wrapper_slot
@@ -2833,10 +2854,7 @@ fn insertion_parent_for_block_node(
         }
         child = layout.next_sibling(child);
     }
-    // SAFETY: `new_parent` is a live NodeWithStyle.
-    let wrapper = layout.created(unsafe {
-        (layout.callbacks.create_anonymous_wrapper)(layout.callbacks.context, layout.shell(new_parent))
-    });
+    let wrapper = layout.create_anonymous_wrapper_box(new_parent);
     let wrapper_slot = wrapper.slot();
     layout.set_children_are_inline(wrapper_slot, true);
     for child in children_to_wrap {
@@ -3225,11 +3243,18 @@ fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Layou
             child = host.next_sibling(child);
         }
 
-        // SAFETY: `layout_node` is a live NodeWithStyle.
-        let wrappers =
-            unsafe { (host.callbacks.create_button_content_wrappers)(host.callbacks.context, host.shell(layout_node)) };
-        let flex_wrapper = host.created(wrappers.flex_wrapper);
-        let content_box = host.created(wrappers.content_box);
+        let flex_wrapper = host.create_anonymous_box(
+            layout_node,
+            FfiAnonymousStyleKind::ButtonFlexWrapper,
+            FfiAnonymousStyleOverrides::default(),
+            NodeKind::BlockContainer,
+        );
+        let content_box = host.create_anonymous_box(
+            layout_node,
+            FfiAnonymousStyleKind::ButtonContentBox,
+            host.anonymous_wrapper_overrides(layout_node),
+            NodeKind::BlockContainer,
+        );
         let flex_wrapper_slot = flex_wrapper.slot();
         let content_box_slot = content_box.slot();
         host.attach_child(flex_wrapper_slot, content_box, NodeSlotId::INVALID);
@@ -3279,9 +3304,15 @@ fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Lay
         }
 
         // SAFETY: `layout_node` is a live fieldset box.
-        let wrapper = host.created(unsafe {
-            (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, host.shell(layout_node))
-        });
+        let overrides = unsafe {
+            (host.callbacks.take_fieldset_overflow_for_content_wrapper)(host.callbacks.context, host.shell(layout_node))
+        };
+        let wrapper = host.create_anonymous_box(
+            layout_node,
+            FfiAnonymousStyleKind::FieldsetContentWrapper,
+            overrides,
+            NodeKind::BlockContainer,
+        );
         let wrapper_slot = wrapper.slot();
         host.attach_child(layout_node, wrapper, NodeSlotId::INVALID);
         for child in children {
@@ -3632,10 +3663,16 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         let parent = host.parent(table_root);
         assert!(!parent.is_invalid());
         if host.data(parent).kind.get() != NodeKind::TableWrapper {
+            let wrapper = host.create_anonymous_box(
+                table_root,
+                FfiAnonymousStyleKind::TableWrapper,
+                FfiAnonymousStyleOverrides::default(),
+                NodeKind::TableWrapper,
+            );
             // SAFETY: `table_root` is a live table box.
-            let wrapper = host.created(unsafe {
-                (host.callbacks.create_table_wrapper)(host.callbacks.context, host.shell(table_root))
-            });
+            unsafe {
+                (host.callbacks.reset_table_box_style_used_by_wrapper)(host.callbacks.context, host.shell(table_root));
+            }
             let wrapper_slot = wrapper.slot();
             host.move_child(table_root, wrapper_slot, NodeSlotId::INVALID);
             host.attach_child(parent, wrapper, nearest_sibling);
@@ -3654,9 +3691,12 @@ fn fixup_row(
         if table_grid.occupancy.contains(&(column_index, row_index)) {
             continue;
         }
-        // SAFETY: `row` is a live table-row box.
-        let cell = host
-            .created(unsafe { (host.callbacks.create_missing_table_cell)(host.callbacks.context, host.shell(row)) });
+        let cell = host.create_anonymous_box(
+            row,
+            FfiAnonymousStyleKind::MissingTableCell,
+            FfiAnonymousStyleOverrides::default(),
+            NodeKind::BlockContainer,
+        );
         host.arena()
             .set_node_flag(cell.slot(), NodeFlag::IsMissingTableCell, true);
         host.attach_child(row, cell, NodeSlotId::INVALID);

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -351,11 +351,14 @@ pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
     // SAFETY: The arena and layout node remain live throughout the ancestor walk.
     let mut ancestor = unsafe { &*arena }.data(layout_node).parent.get();
     while !ancestor.is_invalid() {
-        // SAFETY: `ancestor` is a live layout node with a live shell.
+        // SAFETY: `ancestor` is a live layout node, and a non-anonymous one has a shell.
         let data = unsafe { &*arena }.data(ancestor);
-        let shell = data.shell.get();
         let parent = data.parent.get();
-        let dom_node = unsafe { (callbacks.layout_dom_node)(shell) };
+        if data.flags.get() & NodeFlag::Anonymous as u32 != 0 {
+            ancestor = parent;
+            continue;
+        }
+        let dom_node = unsafe { (callbacks.layout_dom_node)(data.shell.get()) };
         // SAFETY: Both DOM pointers remain live throughout cleanup.
         if !dom_node.is_null()
             && unsafe { (callbacks.dom_is_shadow_including_inclusive_descendant)(dom_node, cleared_subtree_root) }
@@ -427,7 +430,7 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
         } else {
             topmost
         };
-        let shell = unsafe { &*arena }.data(layout_node_to_detach).shell.get();
+        let shell = unsafe { &*arena }.node_shell(layout_node_to_detach);
         // SAFETY: The C++ detach preparation walks the still-linked subtree; the shared arena
         // borrow ends before the subtree is freed.
         unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
@@ -2250,7 +2253,6 @@ pub(crate) enum FfiInsertionMode {
 #[repr(C)]
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
-    pub create_anonymous_shell: unsafe extern "C" fn(*mut c_void, NodeSlotId, NodeKind),
     pub take_fieldset_overflow_for_content_wrapper:
         unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAnonymousStyleOverrides,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -2453,7 +2455,7 @@ impl TreeBuilderHost<'_> {
     }
 
     fn shell(&self, node: LayoutNode) -> *mut c_void {
-        let shell = self.data(node).shell.get();
+        let shell = self.arena().node_shell(node);
         assert!(!shell.is_null());
         shell
     }
@@ -2501,8 +2503,10 @@ impl TreeBuilderHost<'_> {
         // it across the allocation.
         let slot = unsafe { &mut *self.arena }.allocate_unbound(std::ptr::null_mut());
         self.arena().stamp_anonymous_box(slot, node_kind, derived);
-        // SAFETY: `slot` is a live anonymous box that only the builder knows.
-        unsafe { (self.callbacks.create_anonymous_shell)(self.callbacks.context, slot, node_kind) };
+        self.arena().refresh_insets_use_anchor_functions_flag(slot);
+        if node_kind == NodeKind::InlineNode {
+            assert!(!self.arena().node_shell(slot).is_null());
+        }
         UnplacedLayoutNode::new(slot)
     }
 
@@ -3222,7 +3226,7 @@ fn find_first_letter_in_block(host: &DomTreeBuilderHost<'_>, block: LayoutNode) 
         // Stop descending if this child block defines its own ::first-letter: the child will style the first letter
         // inside it, so the ancestor's ::first-letter must not also claim the same letter.
         // SAFETY: The child shell and its associated DOM node remain live throughout the walk.
-        if unsafe { (host.callbacks.layout_node_has_first_letter_style)(layout_host.shell(child)) } {
+        if !is_anonymous && unsafe { (host.callbacks.layout_node_has_first_letter_style)(layout_host.shell(child)) } {
             break;
         }
         let target = find_first_letter_in_block(host, child);

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -116,8 +116,8 @@ pub struct FfiDomTreeBuilderCallbacks {
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind) -> NodeSlotId,
     pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub principal_text_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiTextLayoutFacts,
-    pub create_principal_text_layout:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> FfiPrincipalTextLayoutNodes,
+    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub set_principal_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, NodeSlotId),
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
@@ -136,13 +136,6 @@ pub struct FfiDomTreeBuilderCallbacks {
 pub struct FfiPrincipalNodeFrame {
     pub frame: *mut c_void,
     pub old_layout_node: NodeSlotId,
-}
-
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiPrincipalTextLayoutNodes {
-    pub layout_node: NodeSlotId,
-    pub wrapped_text: NodeSlotId,
 }
 
 #[derive(Clone, Copy)]
@@ -170,6 +163,7 @@ pub struct FfiTextLayoutFacts {
     pub parent_display_is_contents: bool,
     pub text_is_ascii_whitespace: bool,
     pub parent_collapses_whitespace: bool,
+    pub style_parent_style_record: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -1431,18 +1425,24 @@ fn construct_principal_layout_node(
                 facts.parent_collapses_whitespace,
             );
             // SAFETY: The frame and DOM text node remain live throughout construction.
-            let created =
-                unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node, needs_style_wrapper) };
+            let text_layout_node = unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node) };
             let layout_host = host.layout();
-            if !created.wrapped_text.is_invalid() {
-                layout_host.set_children_are_inline(created.layout_node, true);
-                layout_host.attach_child(
-                    created.layout_node,
-                    layout_host.created(created.wrapped_text),
-                    NodeSlotId::INVALID,
+            if needs_style_wrapper {
+                let wrapper = layout_host.create_anonymous_box_from_style_record(
+                    facts.style_parent_style_record,
+                    FfiAnonymousStyleKind::InlineStyleWrapper,
+                    FfiAnonymousStyleOverrides::default(),
+                    NodeKind::InlineNode,
                 );
+                let wrapper_slot = wrapper.slot();
+                layout_host.set_children_are_inline(wrapper_slot, true);
+                layout_host.attach_child(wrapper_slot, layout_host.created(text_layout_node), NodeSlotId::INVALID);
+                // SAFETY: The builder and frame remain live, and the wrapper is a live node the builder owns.
+                unsafe { (host.callbacks.set_principal_layout_node)(host.callbacks.builder, frame, wrapper_slot) };
+                created_box = Some(wrapper);
+            } else {
+                created_box = Some(layout_host.created(text_layout_node));
             }
-            created_box = Some(layout_host.created(created.layout_node));
         }
     } else {
         // SAFETY: The frame and DOM node remain live throughout the call.
@@ -2251,7 +2251,6 @@ pub(crate) enum FfiInsertionMode {
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
     pub create_anonymous_shell: unsafe extern "C" fn(*mut c_void, NodeSlotId, NodeKind),
-    pub reset_table_box_style_used_by_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub take_fieldset_overflow_for_content_wrapper:
         unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiAnonymousStyleOverrides,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -2480,9 +2479,24 @@ impl TreeBuilderHost<'_> {
         overrides: FfiAnonymousStyleOverrides,
         node_kind: NodeKind,
     ) -> UnplacedLayoutNode {
-        let derived =
-            self.arena()
-                .derive_anonymous_style_record(self.arena().node_style_record(parent), style_kind, overrides);
+        self.create_anonymous_box_from_style_record(
+            self.arena().node_style_record(parent),
+            style_kind,
+            overrides,
+            node_kind,
+        )
+    }
+
+    fn create_anonymous_box_from_style_record(
+        &self,
+        parent_style_record: u64,
+        style_kind: FfiAnonymousStyleKind,
+        overrides: FfiAnonymousStyleOverrides,
+        node_kind: NodeKind,
+    ) -> UnplacedLayoutNode {
+        let derived = self
+            .arena()
+            .derive_anonymous_style_record(parent_style_record, style_kind, overrides);
         // SAFETY: Entry points guarantee that the arena remains live, and callers hold no reference derived from
         // it across the allocation.
         let slot = unsafe { &mut *self.arena }.allocate_unbound(std::ptr::null_mut());
@@ -3669,10 +3683,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
                 FfiAnonymousStyleOverrides::default(),
                 NodeKind::TableWrapper,
             );
-            // SAFETY: `table_root` is a live table box.
-            unsafe {
-                (host.callbacks.reset_table_box_style_used_by_wrapper)(host.callbacks.context, host.shell(table_root));
-            }
+            host.arena().reset_table_box_style_used_by_wrapper(table_root);
             let wrapper_slot = wrapper.slot();
             host.move_child(table_root, wrapper_slot, NodeSlotId::INVALID);
             host.attach_child(parent, wrapper, nearest_sibling);

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -9,7 +9,7 @@ use super::*;
 use crate::abort_on_panic;
 use crate::layout::layout_node_arena::LayoutNodeArena;
 use crate::layout::node_data::{GENERATED_FOR_AFTER, GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
-use crate::layout::tree_mutation::OwnedLayoutNode;
+use crate::layout::tree_mutation::{UnplacedLayoutNode, free_subtree_and_destroy_shells};
 use crate::layout::{ComputedValuesView, FfiDisplay};
 use std::ffi::c_void;
 
@@ -434,12 +434,11 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
             topmost
         };
         let shell = unsafe { &*arena }.data(layout_node_to_detach).shell.get();
-        // SAFETY: The C++ detach preparation walks the still-linked subtree; the arena borrow
-        // ends before the release below re-enters it.
+        // SAFETY: The C++ detach preparation walks the still-linked subtree; the shared arena
+        // borrow ends before the subtree is freed.
         unsafe { (callbacks.prepare_subtree_for_detach)(shell) };
-        let detached = unsafe { &*arena }.detach_from_parent(layout_node_to_detach);
-        if let Some(detached) = detached {
-            detached.release();
+        if unsafe { &*arena }.detach_from_parent(layout_node_to_detach) {
+            free_subtree_and_destroy_shells(arena, layout_node_to_detach);
         }
     }
 
@@ -1317,7 +1316,7 @@ struct PrincipalNodeUpdate<'host, 'callbacks, 'state, 'context> {
 
 struct PrincipalBoxConstruction {
     layout_node: LayoutNode,
-    created_box: Option<OwnedLayoutNode>,
+    created_box: Option<UnplacedLayoutNode>,
     handled_display_contents: bool,
 }
 
@@ -1356,10 +1355,8 @@ fn construct_principal_layout_node(
                 let layout_host = host.layout();
                 let backdrop_parent = layout_host.parent(old_backdrop);
                 assert!(!backdrop_parent.is_invalid());
-                layout_host
-                    .arena()
-                    .detach_child(backdrop_parent, old_backdrop)
-                    .release();
+                layout_host.arena().detach_child(backdrop_parent, old_backdrop);
+                layout_host.free_subtree(old_backdrop);
             }
         }
         // SAFETY: The frame, builder, and DOM element remain live throughout the call.
@@ -1657,18 +1654,18 @@ fn update_principal_node_after_entry(
                 }
                 let old_parent = layout_host.parent(old_layout_node);
                 assert!(!old_parent.is_invalid());
-                let detached_old_box = arena.replace_child(
+                let replaced_old_box = arena.replace_child(
                     old_parent,
                     old_layout_node,
                     created_box.take().expect("a principal box to place"),
                 );
-                detached_old_box.release();
+                layout_host.free_subtree(replaced_old_box);
             }
             FfiPrincipalBoxPlacement::DocumentRoot => {
                 // SAFETY: The builder and frame remain live; the frame retains the viewport.
                 unsafe { (host.callbacks.set_layout_root)(host.callbacks.builder, frame) };
                 if let Some(viewport) = created_box.take() {
-                    host.layout().release_owned(viewport);
+                    viewport.placed_as_layout_root();
                 }
             }
             FfiPrincipalBoxPlacement::None => assert!(created_box.is_none()),
@@ -2007,7 +2004,7 @@ fn create_pseudo_element(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> Option<OwnedLayoutNode> {
+) -> Option<UnplacedLayoutNode> {
     assert!(!element.is_null());
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The builder owns frame storage that remains live throughout the build.
@@ -2026,7 +2023,7 @@ fn create_pseudo_element_with_frame(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> Option<OwnedLayoutNode> {
+) -> Option<UnplacedLayoutNode> {
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The frame and element remain live throughout initialization.
     let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
@@ -2487,12 +2484,11 @@ impl TreeBuilderHost<'_> {
         unsafe { &*self.arena }
     }
 
-    fn created(&self, slot: NodeSlotId) -> OwnedLayoutNode {
-        // SAFETY: Create callbacks return a live node carrying one reference for the caller.
-        unsafe { OwnedLayoutNode::adopt_created(slot) }
+    fn created(&self, slot: NodeSlotId) -> UnplacedLayoutNode {
+        UnplacedLayoutNode::new(slot)
     }
 
-    fn attach_child(&self, parent: LayoutNode, child: OwnedLayoutNode, before: LayoutNode) {
+    fn attach_child(&self, parent: LayoutNode, child: UnplacedLayoutNode, before: LayoutNode) {
         self.arena().attach_child(parent, child, before);
     }
 
@@ -2500,8 +2496,12 @@ impl TreeBuilderHost<'_> {
         self.arena().move_child(child, new_parent, before);
     }
 
-    fn release_owned(&self, node: OwnedLayoutNode) {
-        node.into_detached_shell(self.arena()).release();
+    fn free_unplaced(&self, node: UnplacedLayoutNode) {
+        self.free_subtree(node.into_slot());
+    }
+
+    fn free_subtree(&self, node: LayoutNode) {
+        free_subtree_and_destroy_shells(self.arena, node);
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
@@ -2565,14 +2565,13 @@ impl TreeBuilderHost<'_> {
     }
 
     fn remove_nodes(&self, nodes: &[LayoutNode]) {
-        let mut detached_shells = Vec::with_capacity(nodes.len());
         for &node in nodes {
             let parent = self.parent(node);
             assert!(!parent.is_invalid());
-            detached_shells.push(self.arena().detach_child(parent, node));
+            self.arena().detach_child(parent, node);
         }
-        for detached_shell in detached_shells {
-            detached_shell.release();
+        for &node in nodes {
+            self.free_subtree(node);
         }
     }
 
@@ -2853,7 +2852,7 @@ fn insertion_parent_for_block_node(
 fn insert_child_in_dom_order(
     host: &DomTreeBuilderHost<'_>,
     parent: LayoutNode,
-    child: OwnedLayoutNode,
+    child: UnplacedLayoutNode,
     dom_node: *mut c_void,
 ) {
     assert!(!dom_node.is_null());
@@ -2926,7 +2925,7 @@ fn insert_node_into_inline_or_block_ancestor(
     host: &DomTreeBuilderHost<'_>,
     state: &mut TreeBuilderState,
     nearest_insertion_ancestor: LayoutNode,
-    node: OwnedLayoutNode,
+    node: UnplacedLayoutNode,
     is_inline_outside: bool,
     mode: FfiInsertionMode,
     dom_node: *mut c_void,
@@ -3121,8 +3120,8 @@ fn create_first_letter_boxes(host: &DomTreeBuilderHost<'_>, element: *mut c_void
     let first_letter_slice = layout_host.created(nodes.first_letter_slice);
     let remainder_slice = layout_host.created(nodes.remainder_slice);
     if nodes.wrapper.is_invalid() {
-        layout_host.release_owned(first_letter_slice);
-        layout_host.release_owned(remainder_slice);
+        layout_host.free_unplaced(first_letter_slice);
+        layout_host.free_unplaced(remainder_slice);
         return;
     }
     let wrapper = layout_host.created(nodes.wrapper);
@@ -3134,7 +3133,8 @@ fn create_first_letter_boxes(host: &DomTreeBuilderHost<'_>, element: *mut c_void
     layout_host.attach_child(wrapper_slot, first_letter_slice, NodeSlotId::INVALID);
     layout_host.attach_child(parent, wrapper, text_node);
     layout_host.attach_child(parent, remainder_slice, text_node);
-    layout_host.arena().detach_child(parent, text_node).release();
+    layout_host.arena().detach_child(parent, text_node);
+    layout_host.free_subtree(text_node);
 }
 
 fn is_marker_content(data: &NodeData) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1469,7 +1469,7 @@ fn transfer_fragments_to_replacement_box(
     let Some(containing_block) = arena.node_containing_block_if_live(old_layout_node) else {
         return;
     };
-    if arena.shell_if_live(containing_block).is_null() {
+    if !arena.slot_is_live(containing_block) {
         return;
     }
     let paintable_rows = arena.paintable_rows();

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -10,6 +10,16 @@ use std::ffi::c_void;
 
 unsafe extern "C" {
     fn ladybird_layout_node_shell_release(shell: *mut c_void);
+    fn ladybird_layout_node_shell_destroy(shell: *mut c_void);
+}
+
+pub(crate) fn destroy_shell(shell: *mut c_void) {
+    if shell.is_null() {
+        return;
+    }
+    // SAFETY: The arena has already freed the shell's slot, and destroying a shell never
+    // re-enters the arena.
+    unsafe { ladybird_layout_node_shell_destroy(shell) };
 }
 
 fn release_shell(shell: *mut c_void) {
@@ -170,6 +180,9 @@ impl LayoutNodeArena {
 mod ffi_test_stubs {
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_layout_node_shell_release(_shell: *mut std::ffi::c_void) {}
+
+    #[unsafe(no_mangle)]
+    extern "C" fn ladybird_layout_node_shell_destroy(_shell: *mut std::ffi::c_void) {}
 }
 
 #[cfg(test)]
@@ -319,6 +332,36 @@ mod tests {
 
         free(&mut arena, a);
         free(&mut arena, b);
+    }
+
+    #[test]
+    fn freeing_a_subtree_frees_every_descendant_in_one_call() {
+        let mut arena = LayoutNodeArena::new();
+        let root = arena.allocate_for_test();
+        let a = arena.allocate_for_test();
+        let b = arena.allocate_for_test();
+        let c = arena.allocate_for_test();
+        arena.attach_child(root.slot, owned(a.slot), NodeSlotId::INVALID);
+        arena.attach_child(a.slot, owned(b.slot), NodeSlotId::INVALID);
+        arena.attach_child(root.slot, owned(c.slot), NodeSlotId::INVALID);
+
+        let freed = arena.free_subtree(root.slot);
+
+        assert_eq!(freed.shell_count(), 4);
+        for slot in [root.slot, a.slot, b.slot, c.slot] {
+            assert!(!arena.slot_is_live(slot));
+        }
+        freed.destroy_shells_and_invoke_callbacks();
+    }
+
+    #[test]
+    #[should_panic(expected = "still linked under a parent")]
+    fn freeing_a_subtree_whose_root_is_still_attached_panics() {
+        let mut arena = LayoutNodeArena::new();
+        let parent = arena.allocate_for_test();
+        let child = arena.allocate_for_test();
+        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
+        let _ = arena.free_subtree(child.slot);
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_mutation.rs
@@ -9,7 +9,6 @@ use crate::layout::node_data::NodeSlotId;
 use std::ffi::c_void;
 
 unsafe extern "C" {
-    fn ladybird_layout_node_shell_release(shell: *mut c_void);
     fn ladybird_layout_node_shell_destroy(shell: *mut c_void);
 }
 
@@ -22,85 +21,19 @@ pub(crate) fn destroy_shell(shell: *mut c_void) {
     unsafe { ladybird_layout_node_shell_destroy(shell) };
 }
 
-fn release_shell(shell: *mut c_void) {
-    if shell.is_null() {
-        #[cfg(not(test))]
-        debug_assert!(!shell.is_null(), "layout node has no C++ shell");
-        return;
-    }
-    // SAFETY: Node::unref() may destroy the shell and re-enter layout_arena_free; every caller
-    // releases with no arena borrow live.
-    unsafe { ladybird_layout_node_shell_release(shell) };
+pub(crate) fn free_subtree_and_destroy_shells(arena: *mut LayoutNodeArena, root: NodeSlotId) {
+    // SAFETY: Callers hold no reference derived from the arena across this call, and the
+    // mutable borrow ends before the shells are destroyed.
+    let freed = unsafe { &mut *arena }.free_subtree(root);
+    freed.destroy_shells_and_invoke_callbacks();
 }
 
-#[must_use = "the tree's reference to the detached layout node must be released"]
-pub(crate) struct DetachedShell(*mut c_void);
+#[must_use = "an unplaced layout node must be attached or freed"]
+pub(crate) struct UnplacedLayoutNode(NodeSlotId);
 
-impl DetachedShell {
-    pub(crate) fn from_tree_reference(shell: *mut c_void) -> Self {
-        Self(shell)
-    }
-
-    pub(crate) fn release(self) {
-        let shell = self.0;
-        std::mem::forget(self);
-        release_shell(shell);
-    }
-}
-
-impl Drop for DetachedShell {
-    fn drop(&mut self) {
-        debug_assert!(
-            std::thread::panicking(),
-            "detached layout node shell dropped without being released"
-        );
-    }
-}
-
-#[must_use = "the tree's references to the detached layout nodes must be released"]
-#[derive(Default)]
-pub(crate) struct DetachedShells(Vec<*mut c_void>);
-
-impl DetachedShells {
-    pub(crate) fn push(&mut self, detached: DetachedShell) {
-        let shell = detached.0;
-        std::mem::forget(detached);
-        self.0.push(shell);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub(crate) fn release_all(mut self) {
-        let shells = std::mem::take(&mut self.0);
-        std::mem::forget(self);
-        for shell in shells {
-            release_shell(shell);
-        }
-    }
-}
-
-impl Drop for DetachedShells {
-    fn drop(&mut self) {
-        debug_assert!(
-            self.0.is_empty() || std::thread::panicking(),
-            "detached layout node shells dropped without being released"
-        );
-    }
-}
-
-#[must_use = "an owned layout node must be attached or released"]
-pub(crate) struct OwnedLayoutNode(NodeSlotId);
-
-impl OwnedLayoutNode {
-    /// # Safety
-    ///
-    /// `slot` must name a live node whose shell carries exactly one reference that was handed
-    /// to the caller.
-    pub(crate) unsafe fn adopt_created(slot: NodeSlotId) -> Self {
-        assert!(!slot.is_invalid(), "adopted an invalid layout node slot");
+impl UnplacedLayoutNode {
+    pub(crate) fn new(slot: NodeSlotId) -> Self {
+        assert!(!slot.is_invalid(), "an unplaced layout node needs a live slot");
         Self(slot)
     }
 
@@ -108,22 +41,22 @@ impl OwnedLayoutNode {
         self.0
     }
 
-    fn into_slot(self) -> NodeSlotId {
+    pub(crate) fn into_slot(self) -> NodeSlotId {
         let slot = self.0;
         std::mem::forget(self);
         slot
     }
 
-    pub(crate) fn into_detached_shell(self, arena: &LayoutNodeArena) -> DetachedShell {
-        DetachedShell(arena.node_shell(self.into_slot()))
+    pub(crate) fn placed_as_layout_root(self) {
+        self.into_slot();
     }
 }
 
-impl Drop for OwnedLayoutNode {
+impl Drop for UnplacedLayoutNode {
     fn drop(&mut self) {
         debug_assert!(
             std::thread::panicking(),
-            "owned layout node {:?} leaked without being attached or released",
+            "unplaced layout node {:?} leaked without being attached or freed",
             self.0
         );
     }
@@ -138,21 +71,23 @@ fn next_sibling_of(arena: &LayoutNodeArena, node: NodeSlotId) -> NodeSlotId {
 }
 
 impl LayoutNodeArena {
-    pub(crate) fn attach_child(&self, parent: NodeSlotId, child: OwnedLayoutNode, before: NodeSlotId) {
+    pub(crate) fn attach_child(&self, parent: NodeSlotId, child: UnplacedLayoutNode, before: NodeSlotId) {
         self.assert_owner_thread();
         self.insert_child(parent, child.into_slot(), before);
     }
 
-    pub(crate) fn detach_child(&self, parent: NodeSlotId, child: NodeSlotId) -> DetachedShell {
+    pub(crate) fn detach_child(&self, parent: NodeSlotId, child: NodeSlotId) {
         self.assert_owner_thread();
-        let shell = self.node_shell(child);
         self.remove_child(parent, child);
-        DetachedShell(shell)
     }
 
-    pub(crate) fn detach_from_parent(&self, node: NodeSlotId) -> Option<DetachedShell> {
+    pub(crate) fn detach_from_parent(&self, node: NodeSlotId) -> bool {
         let parent = parent_of(self, node);
-        (!parent.is_invalid()).then(|| self.detach_child(parent, node))
+        if parent.is_invalid() {
+            return false;
+        }
+        self.detach_child(parent, node);
+        true
     }
 
     pub(crate) fn move_child(&self, child: NodeSlotId, new_parent: NodeSlotId, before: NodeSlotId) {
@@ -167,27 +102,24 @@ impl LayoutNodeArena {
         &self,
         parent: NodeSlotId,
         old_child: NodeSlotId,
-        new_child: OwnedLayoutNode,
-    ) -> DetachedShell {
+        new_child: UnplacedLayoutNode,
+    ) -> NodeSlotId {
         let successor = next_sibling_of(self, old_child);
-        let detached = self.detach_child(parent, old_child);
+        self.detach_child(parent, old_child);
         self.attach_child(parent, new_child, successor);
-        detached
+        old_child
     }
 }
 
 #[cfg(test)]
 mod ffi_test_stubs {
     #[unsafe(no_mangle)]
-    extern "C" fn ladybird_layout_node_shell_release(_shell: *mut std::ffi::c_void) {}
-
-    #[unsafe(no_mangle)]
     extern "C" fn ladybird_layout_node_shell_destroy(_shell: *mut std::ffi::c_void) {}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::OwnedLayoutNode;
+    use super::UnplacedLayoutNode;
     use crate::layout::LayoutNodeArena;
     use crate::layout::layout_node_arena::NodeAllocation;
     use crate::layout::node_data::{NodeKind, NodeSlotId};
@@ -215,13 +147,14 @@ mod tests {
         arena.data(node).fragment_cache_epoch.get()
     }
 
-    fn owned(slot: NodeSlotId) -> OwnedLayoutNode {
-        // SAFETY: Test nodes have no shell, and the release hook skips null shells.
-        unsafe { OwnedLayoutNode::adopt_created(slot) }
+    fn owned(slot: NodeSlotId) -> UnplacedLayoutNode {
+        UnplacedLayoutNode::new(slot)
     }
 
     fn free(arena: &mut LayoutNodeArena, allocation: NodeAllocation) {
-        arena.free(allocation.slot).detached_children.release_all();
+        arena
+            .free_subtree(allocation.slot)
+            .destroy_shells_and_invoke_callbacks();
     }
 
     #[test]
@@ -235,7 +168,7 @@ mod tests {
         assert_eq!(links(&arena, parent.slot).last_child, child.slot);
         assert_eq!(links(&arena, child.slot).parent, parent.slot);
 
-        arena.detach_child(parent.slot, child.slot).release();
+        arena.detach_child(parent.slot, child.slot);
         assert!(links(&arena, parent.slot).first_child.is_invalid());
         assert!(links(&arena, child.slot).parent.is_invalid());
 
@@ -250,9 +183,9 @@ mod tests {
         let child = arena.allocate_for_test();
         arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
 
-        arena.detach_from_parent(child.slot).expect("attached child").release();
+        assert!(arena.detach_from_parent(child.slot));
         assert!(links(&arena, parent.slot).first_child.is_invalid());
-        assert!(arena.detach_from_parent(parent.slot).is_none());
+        assert!(!arena.detach_from_parent(parent.slot));
 
         free(&mut arena, parent);
         free(&mut arena, child);
@@ -270,7 +203,7 @@ mod tests {
             arena.attach_child(parent.slot, owned(child), NodeSlotId::INVALID);
         }
 
-        arena.replace_child(parent.slot, b.slot, owned(d.slot)).release();
+        assert_eq!(arena.replace_child(parent.slot, b.slot, owned(d.slot)), b.slot);
 
         assert_eq!(links(&arena, parent.slot).first_child, a.slot);
         assert_eq!(links(&arena, a.slot).next_sibling, d.slot);
@@ -282,9 +215,6 @@ mod tests {
 
         free(&mut arena, b);
         free(&mut arena, parent);
-        for orphan in [a, d, c] {
-            free(&mut arena, orphan);
-        }
     }
 
     #[test]
@@ -309,29 +239,6 @@ mod tests {
 
         free(&mut arena, first_parent);
         free(&mut arena, second_parent);
-        for orphan in [a, b, c] {
-            free(&mut arena, orphan);
-        }
-    }
-
-    #[test]
-    fn freeing_a_node_unlinks_its_children_and_hands_back_their_references() {
-        let mut arena = LayoutNodeArena::new();
-        let root = arena.allocate_for_test();
-        let a = arena.allocate_for_test();
-        let b = arena.allocate_for_test();
-        arena.attach_child(root.slot, owned(a.slot), NodeSlotId::INVALID);
-        arena.attach_child(root.slot, owned(b.slot), NodeSlotId::INVALID);
-
-        let freed = arena.free(root.slot);
-        assert_eq!(freed.detached_children.len(), 2);
-        assert!(links(&arena, a.slot).parent.is_invalid());
-        assert!(links(&arena, b.slot).parent.is_invalid());
-        assert!(links(&arena, a.slot).next_sibling.is_invalid());
-        freed.detached_children.release_all();
-
-        free(&mut arena, a);
-        free(&mut arena, b);
     }
 
     #[test]
@@ -365,16 +272,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "still linked under a parent")]
-    fn freeing_a_node_still_linked_under_a_parent_panics() {
-        let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate_for_test();
-        let child = arena.allocate_for_test();
-        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
-        let _ = arena.free(child.slot);
-    }
-
-    #[test]
     fn a_structural_change_bumps_the_fragment_cache_epoch_of_every_ancestor() {
         if super::super::fc_run_cache::fc_run_cache_mode_from_environment()
             == super::super::fc_run_cache::FcRunCacheMode::Disabled
@@ -400,9 +297,6 @@ mod tests {
         assert_eq!(fragment_cache_epoch(&arena, child.slot), 0);
 
         free(&mut arena, grandparent);
-        for orphan in [parent, sibling, child] {
-            free(&mut arena, orphan);
-        }
     }
 
     #[test]
@@ -438,28 +332,14 @@ mod tests {
         );
 
         free(&mut arena, grandparent);
-        free(&mut arena, parent);
-        free(&mut arena, child);
     }
 
     #[cfg(debug_assertions)]
     #[test]
-    #[should_panic(expected = "without being released")]
-    fn dropping_a_detached_shell_without_releasing_it_panics() {
-        let mut arena = LayoutNodeArena::new();
-        let parent = arena.allocate_for_test();
-        let child = arena.allocate_for_test();
-        arena.attach_child(parent.slot, owned(child.slot), NodeSlotId::INVALID);
-        let _ = arena.detach_child(parent.slot, child.slot);
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "leaked without being attached or released")]
-    fn dropping_an_owned_layout_node_without_placing_it_panics() {
+    #[should_panic(expected = "leaked without being attached or freed")]
+    fn dropping_an_unplaced_layout_node_panics() {
         let mut arena = LayoutNodeArena::new();
         let node = arena.allocate_for_test();
-        // SAFETY: Test nodes have no shell, and the hooks skip null shells.
-        let _ = unsafe { OwnedLayoutNode::adopt_created(node.slot) };
+        let _ = UnplacedLayoutNode::new(node.slot);
     }
 }

--- a/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/stacking_context/dump.rs
@@ -65,14 +65,13 @@ fn visit(
     depth: usize,
     callbacks: &FfiStackingContextDumpCallbacks,
 ) {
-    let layout_node_shell = arena.shell_if_live(root);
     output.extend(std::iter::repeat_n(' ', depth));
-    if layout_node_shell.is_null() {
+    if !arena.slot_is_live(root) {
         output.push_str("SC for (gone)\n");
     } else {
         push_line(
             output,
-            &callbacks.debug_description(layout_node_shell),
+            &callbacks.debug_description(arena.node_shell(root)),
             paintable_geometry::absolute_rect_or_default(&arena.paintable_rows(), root),
             effective_z_index(arena, root),
             has_css_transform(arena, root),

--- a/Libraries/LibWeb/SVG/SVGAElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGAElement.cpp
@@ -67,9 +67,9 @@ GC::Ref<DOM::DOMTokenList> SVGAElement::rel_list()
     return *m_rel_list;
 }
 
-RefPtr<Layout::Node> SVGAElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGAElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
 }
 
 void SVGAElement::activation_behavior(DOM::Event const& event)

--- a/Libraries/LibWeb/SVG/SVGAElement.h
+++ b/Libraries/LibWeb/SVG/SVGAElement.h
@@ -25,7 +25,7 @@ public:
 
     GC::Ref<DOM::DOMTokenList> rel_list();
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     SVGAElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -29,7 +29,7 @@ void SVGClipPathElement::attribute_changed(Utf16FlyString const& name, Optional<
         m_clip_path_units = parse_units(value.value_or({}));
 }
 
-RefPtr<Layout::Node> SVGClipPathElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGClipPathElement::create_layout_node(CSS::LayoutStyle)
 {
     // Clip paths are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -34,7 +34,7 @@ public:
         return m_clip_path_units.value_or(ClipPathUnits::UserSpaceOnUse);
     }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     SVGClipPathElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGDefsElement.h
+++ b/Libraries/LibWeb/SVG/SVGDefsElement.h
@@ -18,7 +18,7 @@ class SVGDefsElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGDefsElement();
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override
     {
         return nullptr;
     }

--- a/Libraries/LibWeb/SVG/SVGDescElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGDescElement.cpp
@@ -18,7 +18,7 @@ SVGDescElement::SVGDescElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-RefPtr<Layout::Node> SVGDescElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGDescElement::create_layout_node(CSS::LayoutStyle)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGDescElement.h
+++ b/Libraries/LibWeb/SVG/SVGDescElement.h
@@ -16,7 +16,7 @@ class SVGDescElement final : public SVGElement {
 
 private:
     SVGDescElement(DOM::Document&, DOM::QualifiedName);
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -35,7 +35,7 @@ SVGElement::SVGElement(DOM::Document& document, DOM::QualifiedName qualified_nam
 {
 }
 
-RefPtr<Layout::Node> SVGElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGElement::create_layout_node(CSS::LayoutStyle)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -33,7 +33,7 @@ class WEB_API SVGElement
 public:
     virtual bool requires_svg_container() const override { return true; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     GC::Ref<SVGAnimatedString> class_name();
     GC::Ptr<SVGSVGElement> owner_svg_element();

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -27,9 +27,9 @@ void SVGForeignObjectElement::initialize_element()
 {
 }
 
-RefPtr<Layout::Node> SVGForeignObjectElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGForeignObjectElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::SVGForeignObjectBox);
+    return &Layout::allocate_layout_node<Layout::BlockContainer>(document(), *this, style, Layout::RustFFI::NodeKind::SVGForeignObjectBox);
 }
 
 void SVGForeignObjectElement::visit_edges(GC::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
@@ -18,7 +18,7 @@ class SVGForeignObjectElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGForeignObjectElement() override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     // AD-HOC: The spec states that the x, y, width and height IDL attributes reflect the respective computed values and their
     //         corresponding presentation attributes but other browsers reflect the attribute values instead - see

--- a/Libraries/LibWeb/SVG/SVGGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGElement.cpp
@@ -19,9 +19,9 @@ SVGGElement::SVGGElement(DOM::Document& document, DOM::QualifiedName qualified_n
 {
 }
 
-RefPtr<Layout::Node> SVGGElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGGElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGGElement.h
+++ b/Libraries/LibWeb/SVG/SVGGElement.h
@@ -17,7 +17,7 @@ class SVGGElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGGElement() override = default;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     virtual bool is_svg_g_element() const final { return true; }

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -23,9 +23,9 @@ void SVGGeometryElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_path_length);
 }
 
-RefPtr<Layout::Node> SVGGeometryElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGGeometryElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGeometryBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGeometryBox);
 }
 
 // https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.h
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.h
@@ -16,7 +16,7 @@ class SVGGeometryElement : public SVGGraphicsElement {
     WEB_WRAPPABLE(SVGGeometryElement, SVGGraphicsElement);
 
 public:
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size, CSS::ComputedValues const&) = 0;
 

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -148,9 +148,9 @@ void SVGImageElement::fetch_the_document(URL::URL const& url)
     }
 }
 
-RefPtr<Layout::Node> SVGImageElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGImageElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGImageBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGImageBox);
 }
 
 GC::Ptr<HTML::DecodedImageData> SVGImageElement::decoded_image_data() const

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -63,7 +63,7 @@ private:
 
     virtual bool is_svg_image_element() const override { return true; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
     virtual void decoded_image_data_did_update() override { set_needs_repaint(); }
 
     Optional<URL::URL> m_href;

--- a/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -22,7 +22,7 @@ SVGMaskElement::SVGMaskElement(DOM::Document& document, DOM::QualifiedName tag_n
 
 SVGMaskElement::~SVGMaskElement() = default;
 
-RefPtr<Layout::Node> SVGMaskElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGMaskElement::create_layout_node(CSS::LayoutStyle)
 {
     // Masks are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -33,7 +33,7 @@ public:
 
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     CSSPixelRect resolve_masking_area(CSSPixelRect const& target_object_bounding_box, Gfx::FloatSize const& viewport_size, Gfx::AffineTransform const& user_space_to_css_pixels) const;
 

--- a/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
@@ -18,7 +18,7 @@ SVGMetadataElement::SVGMetadataElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-RefPtr<Layout::Node> SVGMetadataElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGMetadataElement::create_layout_node(CSS::LayoutStyle)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGMetadataElement.h
+++ b/Libraries/LibWeb/SVG/SVGMetadataElement.h
@@ -17,7 +17,7 @@ class SVGMetadataElement final : public SVGElement {
 
 private:
     SVGMetadataElement(DOM::Document&, DOM::QualifiedName);
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -62,7 +62,7 @@ public:
     };
     Optional<PaintGeometry> resolve_paint_geometry(SVGPaintContext const&, double device_pixels_per_css_pixel, Layout::Node const& target_layout_node) const;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override { return nullptr; }
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override { return nullptr; }
 
 protected:
     SVGPatternElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -45,9 +45,9 @@ void SVGSVGElement::visit_edges(Visitor& visitor)
     visitor.visit(m_active_view_element);
 }
 
-RefPtr<Layout::Node> SVGSVGElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGSVGElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGSVGBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGSVGBox);
 }
 
 Optional<CSS::Length> SVGSVGElement::width_attribute_length() const

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -25,7 +25,7 @@ class SVGSVGElement final : public SVGGraphicsElement
     GC_DECLARE_ALLOCATOR(SVGSVGElement);
 
 public:
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     virtual bool requires_svg_container() const override { return false; }
     virtual bool is_svg_container() const override { return true; }

--- a/Libraries/LibWeb/SVG/SVGSwitchElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSwitchElement.cpp
@@ -20,9 +20,9 @@ SVGSwitchElement::SVGSwitchElement(DOM::Document& document, DOM::QualifiedName q
 
 SVGSwitchElement::~SVGSwitchElement() = default;
 
-RefPtr<Layout::Node> SVGSwitchElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGSwitchElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGSwitchElement.h
+++ b/Libraries/LibWeb/SVG/SVGSwitchElement.h
@@ -18,7 +18,7 @@ class SVGSwitchElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGSwitchElement() override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 private:
     SVGSwitchElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -48,14 +48,14 @@ bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const
     return is<SVGUseElement>(host);
 }
 
-RefPtr<Layout::Node> SVGSymbolElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGSymbolElement::create_layout_node(CSS::LayoutStyle style)
 {
     // https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement
     // [..] it also includes a ‘symbol’ element that is not the instance root of a use-element shadow tree.
     if (!is_direct_child_of_use_shadow_tree())
-        return {};
+        return nullptr;
 
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -27,7 +27,7 @@ private:
     virtual void initialize_element() override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     bool is_direct_child_of_use_shadow_tree() const;
 

--- a/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
@@ -18,12 +18,12 @@ SVGTSpanElement::SVGTSpanElement(DOM::Document& document, DOM::QualifiedName qua
 {
 }
 
-RefPtr<Layout::Node> SVGTSpanElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGTSpanElement::create_layout_node(CSS::LayoutStyle style)
 {
     // Text must be within an SVG <text> element.
     if (first_flat_tree_ancestor_of_type<SVGTextElement>())
-        return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextBox);
-    return {};
+        return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextBox);
+    return nullptr;
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGTSpanElement.h
+++ b/Libraries/LibWeb/SVG/SVGTSpanElement.h
@@ -17,7 +17,7 @@ class SVGTSpanElement : public SVGTextPositioningElement {
     GC_DECLARE_ALLOCATOR(SVGTSpanElement);
 
 public:
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 protected:
     SVGTSpanElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGTextElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextElement.cpp
@@ -17,9 +17,9 @@ SVGTextElement::SVGTextElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-RefPtr<Layout::Node> SVGTextElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGTextElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextBox);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGTextElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextElement.h
@@ -17,7 +17,7 @@ class SVGTextElement : public SVGTextPositioningElement {
     GC_DECLARE_ALLOCATOR(SVGTextElement);
 
 public:
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
 protected:
     SVGTextElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -49,9 +49,9 @@ void SVGTextPathElement::visit_edges(Cell::Visitor& visitor)
     SVGURIReferenceMixin::visit_edges(visitor);
 }
 
-RefPtr<Layout::Node> SVGTextPathElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGTextPathElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextPathBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGTextPathBox);
 }
 
 };

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.h
@@ -21,7 +21,7 @@ class SVGTextPathElement
     GC_DECLARE_ALLOCATOR(SVGTextPathElement);
 
 public:
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     GC::Ptr<SVGGeometryElement const> path_or_shape() const;
 

--- a/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -18,7 +18,7 @@ SVGTitleElement::SVGTitleElement(DOM::Document& document, DOM::QualifiedName qua
 {
 }
 
-RefPtr<Layout::Node> SVGTitleElement::create_layout_node(CSS::LayoutStyle)
+Layout::Node* SVGTitleElement::create_layout_node(CSS::LayoutStyle)
 {
     return nullptr;
 }

--- a/Libraries/LibWeb/SVG/SVGTitleElement.h
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.h
@@ -16,7 +16,7 @@ class SVGTitleElement final : public SVGElement {
 
 private:
     SVGTitleElement(DOM::Document&, DOM::QualifiedName);
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
 };
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -395,9 +395,9 @@ GC::Ptr<SVGElement> SVGUseElement::instance_root() const
     return const_cast<DOM::ShadowRoot&>(*shadow_root()).first_child_of_type<SVGElement>();
 }
 
-RefPtr<Layout::Node> SVGUseElement::create_layout_node(CSS::LayoutStyle style)
+Layout::Node* SVGUseElement::create_layout_node(CSS::LayoutStyle style)
 {
-    return make_ref_counted<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
+    return &Layout::allocate_layout_node<Layout::Box>(document(), *this, style, Layout::RustFFI::NodeKind::SVGGraphicsBox);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -65,7 +65,7 @@ private:
 
     virtual bool is_svg_use_element() const override { return true; }
 
-    virtual RefPtr<Layout::Node> create_layout_node(CSS::LayoutStyle) override;
+    virtual Layout::Node* create_layout_node(CSS::LayoutStyle) override;
 
     void process_the_url(Optional<Utf16String> const& href);
     Optional<Utf16String> href_value() const;

--- a/Libraries/LibWeb/TreeTraversal.h
+++ b/Libraries/LibWeb/TreeTraversal.h
@@ -10,15 +10,15 @@
 
 namespace Web {
 
-enum class IncludeRefCountedTreeRoot {
+enum class IncludeTraversalRoot {
     No,
     Yes,
 };
 
 template<typename T, typename Callback>
-TraversalDecision traverse_ref_counted_preorder(T& root, IncludeRefCountedTreeRoot include_root, Callback callback)
+TraversalDecision traverse_preorder(T& root, IncludeTraversalRoot include_root, Callback callback)
 {
-    auto* current = include_root == IncludeRefCountedTreeRoot::Yes ? &root : root.first_child_ptr();
+    auto* current = include_root == IncludeTraversalRoot::Yes ? &root : root.first_child_ptr();
     while (current) {
         TraversalDecision decision = callback(*current);
         if (decision == TraversalDecision::Break)

--- a/Tests/LibWeb/Text/expected/HTML/iframe-document-collected-after-removal-with-layout-tree.txt
+++ b/Tests/LibWeb/Text/expected/HTML/iframe-document-collected-after-removal-with-layout-tree.txt
@@ -1,0 +1,3 @@
+document collected: true
+window collected: true
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/expected/layout-tree-update/anonymous-shells-are-materialized-on-demand.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/anonymous-shells-are-materialized-on-demand.txt
@@ -1,0 +1,3 @@
+anonymous boxes exist without shells: true
+walking the layout tree materializes shells: true
+shells never exceed live slots: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/remove-deep-subtree-via-display-none.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/remove-deep-subtree-via-display-none.txt
@@ -1,0 +1,4 @@
+container preserved after hiding: true
+sibling preserved after hiding: true
+incremental tree matches full rebuild after hiding: true
+incremental tree matches full rebuild after showing: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/remove-deep-subtree.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/remove-deep-subtree.txt
@@ -1,0 +1,3 @@
+container preserved: true
+sibling preserved: true
+incremental tree matches full rebuild: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/remove-top-layer-element-with-backdrop.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/remove-top-layer-element-with-backdrop.txt
@@ -1,0 +1,3 @@
+modal is rendered in the top layer: true
+incremental tree matches full rebuild: true
+sibling still laid out: true

--- a/Tests/LibWeb/Text/expected/layout-tree-update/removed-subtree-layout-nodes-survive-gc.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/removed-subtree-layout-nodes-survive-gc.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/iframe-document-collected-after-removal-with-layout-tree.html
+++ b/Tests/LibWeb/Text/input/HTML/iframe-document-collected-after-removal-with-layout-tree.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `<div style="display: flex"><img alt="x" src="data:,"><span>text</span><ul><li>marker</li></ul></div>`;
+        iframe.onload = async () => {
+            iframe.contentDocument.body.offsetHeight;
+            const weakDocument = new WeakRef(iframe.contentDocument);
+            const weakWindow = new WeakRef(iframe.contentWindow);
+            iframe.remove();
+            const maximumGcRoundsWhileNavigableTeardownTasksDrain = 100;
+            const eitherTargetIsStillAlive = () => weakDocument.deref() !== undefined || weakWindow.deref() !== undefined;
+            for (let round = 0; round < maximumGcRoundsWhileNavigableTeardownTasksDrain && eitherTargetIsStillAlive(); ++round) {
+                await new Promise(resolve => setTimeout(resolve, 0));
+                await internals.gcAsync();
+            }
+            println(`document collected: ${weakDocument.deref() === undefined}`);
+            println(`window collected: ${weakWindow.deref() === undefined}`);
+            println("PASS (didn't crash)");
+            done();
+        };
+        document.body.append(iframe);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/anonymous-shells-are-materialized-on-demand.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/anonymous-shells-are-materialized-on-demand.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<script src="../include.js"></script>
+<table id="table"><td id="cell">a</td><td>b</td></table>
+<button id="button">x</button>
+<script>
+    test(() => {
+        const liveSlots = internals.layoutArenaLiveSlotCount();
+        const shellsBeforeAccess = internals.layoutArenaShellCount();
+        println(`anonymous boxes exist without shells: ${liveSlots > shellsBeforeAccess}`);
+
+        internals.dumpLayoutTree(document);
+        const shellsAfterAccess = internals.layoutArenaShellCount();
+        println(`walking the layout tree materializes shells: ${shellsAfterAccess > shellsBeforeAccess}`);
+        println(`shells never exceed live slots: ${shellsAfterAccess <= internals.layoutArenaLiveSlotCount()}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/remove-deep-subtree-via-display-none.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/remove-deep-subtree-via-display-none.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    .with-generated-content::before {
+        content: "x";
+    }
+</style>
+<div id="container"><div id="sibling">sibling</div></div>
+<script>
+    test(() => {
+        const chainRoot = document.createElement("div");
+        let deepest = chainRoot;
+        for (let depth = 1; depth < 1000; ++depth) {
+            const level = document.createElement("div");
+            if (depth % 100 === 0)
+                level.className = "with-generated-content";
+            deepest.appendChild(level);
+            deepest = level;
+        }
+        deepest.appendChild(document.createElement("span")).textContent = "leaf";
+        container.appendChild(chainRoot);
+        document.body.offsetHeight;
+
+        const containerIdentity = internals.layoutNodeIdentity(container);
+        const siblingIdentity = internals.layoutNodeIdentity(sibling);
+
+        chainRoot.style.display = "none";
+        document.body.offsetHeight;
+
+        println(`container preserved after hiding: ${internals.layoutNodeIdentity(container) === containerIdentity}`);
+        println(`sibling preserved after hiding: ${internals.layoutNodeIdentity(sibling) === siblingIdentity}`);
+        println(`incremental tree matches full rebuild after hiding: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+
+        chainRoot.style.display = "";
+        document.body.offsetHeight;
+
+        println(`incremental tree matches full rebuild after showing: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/remove-deep-subtree.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/remove-deep-subtree.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    .with-generated-content::before {
+        content: "x";
+    }
+</style>
+<div id="container"><div id="sibling">sibling</div></div>
+<script>
+    test(() => {
+        const chainRoot = document.createElement("div");
+        let deepest = chainRoot;
+        for (let depth = 1; depth < 4000; ++depth) {
+            const level = document.createElement("div");
+            if (depth % 100 === 0)
+                level.className = "with-generated-content";
+            deepest.appendChild(level);
+            deepest = level;
+        }
+        deepest.appendChild(document.createElement("span")).textContent = "leaf";
+        container.appendChild(chainRoot);
+        document.body.offsetHeight;
+
+        const containerIdentity = internals.layoutNodeIdentity(container);
+        const siblingIdentity = internals.layoutNodeIdentity(sibling);
+
+        chainRoot.remove();
+        document.body.offsetHeight;
+
+        println(`container preserved: ${internals.layoutNodeIdentity(container) === containerIdentity}`);
+        println(`sibling preserved: ${internals.layoutNodeIdentity(sibling) === siblingIdentity}`);
+        println(`incremental tree matches full rebuild: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/remove-top-layer-element-with-backdrop.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/remove-top-layer-element-with-backdrop.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    dialog::backdrop {
+        background: rgba(0, 0, 0, 0.5);
+    }
+</style>
+<div id="container"><dialog id="modal"><div>modal content</div></dialog><div id="sibling">sibling</div></div>
+<script>
+    test(() => {
+        modal.showModal();
+        document.body.offsetHeight;
+        println(`modal is rendered in the top layer: ${getComputedStyle(modal).display !== "none"}`);
+
+        modal.remove();
+        document.body.offsetHeight;
+
+        println(`incremental tree matches full rebuild: ${internals.compareLayoutTreeWithFullRebuild().matches}`);
+        println(`sibling still laid out: ${sibling.offsetHeight > 0}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/removed-subtree-layout-nodes-survive-gc.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/removed-subtree-layout-nodes-survive-gc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host"><div id="positioned" style="position: absolute"><img id="img" src="data:,"></div></div>
+<script>
+    asyncTest(done => {
+        document.body.offsetHeight;
+        setTimeout(() => {
+            positioned.remove();
+            internals.gc();
+            document.body.offsetHeight;
+            internals.gc();
+            println("PASS (didn't crash)");
+            done();
+        }, 0);
+    });
+</script>


### PR DESCRIPTION
The arena already decides which layout nodes exist, but each node's lifetime still belonged to its C++ shell: `Layout::Node` was `RefCounted`, allocated its own slot, and the arena held a reference per child link. Teardown ping-ponged between Rust and C++, every shell carried one or two `GC::Root`s, and a document with a layout tree could never be collected.

This series inverts that. The slot owns the shell, the document roots layout DOM nodes through the arena, Rust allocates a slot before any shell exists, and the tree builder creates anonymous boxes itself from the parent's style record. Anonymous boxes get a C++ shell only when some C++ code asks for one.

The direction is that the C++ layout node becomes a view over arena state that is materialized on demand. Anonymous boxes are the first kind to get there; text nodes, element boxes and pseudo-element boxes still hold state that would have to move into the arena first.