### PR TITLE
LibWebView: Choose navigation processes by browsing context

### DIFF
--- a/Libraries/LibURL/Site.h
+++ b/Libraries/LibURL/Site.h
@@ -25,6 +25,7 @@ class Site {
 public:
     static Site obtain(Origin const&);
 
+    bool operator==(Site const& other) const { return is_same_site(other); }
     bool is_same_site(Site const& other) const;
 
     String serialize() const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -328,85 +328,13 @@ static size_t retain_registered_property_utf16_fly_string(u16 const* code_units,
 
 GC_DEFINE_ALLOCATOR(Document);
 
-// https://html.spec.whatwg.org/multipage/origin.html#obtain-browsing-context-navigation
-static GC::Ref<HTML::BrowsingContext> obtain_a_browsing_context_to_use_for_a_navigation_response(HTML::NavigationParams const& navigation_params)
-{
-    // 1. Let browsingContext be navigationParams's navigable's active browsing context.
-    auto& browsing_context = *navigation_params.navigable->active_browsing_context();
-
-    // 2. If browsingContext is not a top-level browsing context, return browsingContext.
-    if (!browsing_context.is_top_level())
-        return browsing_context;
-
-    // 3. Let coopEnforcementResult be navigationParams's COOP enforcement result.
-    auto& coop_enforcement_result = navigation_params.coop_enforcement_result;
-
-    // 4. Let swapGroup be coopEnforcementResult's needs a browsing context group switch.
-    auto swap_group = coop_enforcement_result.needs_a_browsing_context_group_switch;
-
-    // 5. Let sourceOrigin be browsingContext's active document's origin.
-    auto& source_origin = browsing_context.active_document()->origin();
-
-    // 6. Let destinationOrigin be navigationParams's origin.
-    auto& destination_origin = navigation_params.origin;
-
-    // 7. If sourceOrigin is not same site with destinationOrigin:
-    if (!source_origin.is_same_site(destination_origin)) {
-        // FIXME: 1. If either of sourceOrigin or destinationOrigin have a scheme that is not an HTTP(S) scheme
-        //    and the user agent considers it necessary for sourceOrigin and destinationOrigin to be
-        //    isolated from each other (for implementation-defined reasons), optionally set swapGroup to true.
-
-        // FIXME: 2. If navigationParams's user involvement is "browser UI", optionally set swapGroup to true.
-    }
-
-    // FIXME: 8. If browsingContext's group's browsing context set's size is 1, optionally set swapGroup to true.
-
-    // 9. If swapGroup is false, then:
-    if (!swap_group) {
-        // 1. If coopEnforcementResult's would need a browsing context group switch due to report-only is true,
-        //    set browsingContext's virtual browsing context group ID to a new unique identifier.
-        if (coop_enforcement_result.would_need_a_browsing_context_group_switch_due_to_report_only) {
-            // FIXME: set browsingContext's virtual browsing context group ID to a new unique identifier.
-        }
-
-        // 2. Return browsingContext.
-        return browsing_context;
-    }
-
-    // 10. Let newBrowsingContext be the first return value of creating a new top-level browsing context and document.
-    auto browsing_context_and_document = HTML::create_a_new_top_level_browsing_context_and_document(browsing_context.page());
-    auto new_browsing_context = browsing_context_and_document.browsing_context;
-
-    // 11. Let navigationCOOP be navigationParams's cross-origin opener policy.
-    auto navigation_coop = navigation_params.opener_policy;
-
-    // FIXME: 12. If navigationCOOP's value is "same-origin-plus-COEP", then set newBrowsingContext's group's cross-origin
-    //     isolation mode to either "logical" or "concrete". The choice of which is implementation-defined.
-
-    // 13. Let sandboxFlags be a clone of navigationParams's final sandboxing flag set.
-    auto sandbox_flags = navigation_params.final_sandboxing_flag_set;
-
-    // 14. If sandboxFlags is not empty, then:
-    if (!is_empty(sandbox_flags)) {
-        // 1. Assert: navigationCOOP's value is "unsafe-none".
-        VERIFY(navigation_coop.value == HTML::OpenerPolicyValue::UnsafeNone);
-
-        // 2. Assert: newBrowsingContext's popup sandboxing flag set is empty.
-        VERIFY(is_empty(new_browsing_context->popup_sandboxing_flag_set()));
-
-        // 3. Set newBrowsingContext's popup sandboxing flag set to sandboxFlags.
-        new_browsing_context->set_popup_sandboxing_flag_set(sandbox_flags);
-    }
-
-    // 15. Return newBrowsingContext.
-    return new_browsing_context;
-}
-
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
 WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type, Utf16FlyString content_type, HTML::NavigationParams const& navigation_params)
 {
     // 1. Let browsingContext be the result of obtaining a browsing context to use for a navigation response given navigationParams.
-    auto browsing_context = obtain_a_browsing_context_to_use_for_a_navigation_response(navigation_params);
+    // NB: The UI process has already performed this algorithm and selected this WebContent process.
+    auto browsing_context = navigation_params.navigable->active_browsing_context();
+    VERIFY(browsing_context);
 
     // FIXME: 2. Let permissionsPolicy be the result of creating a permissions policy from a response given navigationParams's navigable's container, navigationParams's origin, and navigationParams's response.
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -940,6 +940,7 @@ struct DeserializedTransferRecord;
 struct EmbedderPolicy;
 struct Environment;
 struct EnvironmentSettingsObject;
+struct HistoryNavigationPopulation;
 struct NavigationPopulationRequest;
 struct NavigationPopulationResult;
 struct NavigationStartRequest;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2929,7 +2929,7 @@ void LocalNavigable::begin_navigation(PreparedNavigation navigation)
     // 20. If url's scheme is "javascript", then:
     if (url.scheme() == "javascript"sv) {
         if (is_top_level_traversable())
-            active_browsing_context()->page().client().request_navigation_start(*this, active_document.url(), NavigationTarget::TopLevel, url, navigation_id, {});
+            active_browsing_context()->page().client().request_navigation_start(*this, NavigationTarget::TopLevel, url, navigation_id, {});
 
         // 1. Queue a global task on the navigation and traversal task source given navigable's active window to navigate to a javascript: URL given navigable, url, historyHandling, sourceSnapshotParams, initiatorOriginSnapshot, userInvolvement, cspNavigationType, initialInsertion, and navigationId.
         VERIFY(active_window());
@@ -3032,7 +3032,7 @@ void LocalNavigable::begin_navigation(PreparedNavigation navigation)
     park_navigation_for_population(navigation_id, move(navigation), continue_steps);
 
     auto target = is_top_level_traversable() ? NavigationTarget::TopLevel : NavigationTarget::IFrame;
-    active_browsing_context()->page().client().request_navigation_start(*this, active_document.url(), target, url, navigation_id, move(start_request));
+    active_browsing_context()->page().client().request_navigation_start(*this, target, url, navigation_id, move(start_request));
     return;
 }
 
@@ -3108,7 +3108,7 @@ void LocalNavigable::request_population_for_reconstructed_history_entry(Navigati
     });
 
     park_navigation_for_population(navigation_id, {}, continue_steps);
-    page().client().request_navigation_population(*this, active_document()->url(), NavigationTarget::IFrame, move(request));
+    page().client().request_navigation_population(*this, NavigationTarget::IFrame, move(request));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2308,19 +2308,53 @@ void LocalNavigable::populate_session_history_entry_document(
     NavigationParamsVariant navigation_params,
     ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,
     bool allow_POST,
-    GC::Ptr<GC::Function<void(GC::Ptr<PopulateSessionHistoryEntryDocumentOutput>)>> completion_steps)
+    GC::Ptr<GC::Function<void(GC::Ptr<PopulateSessionHistoryEntryDocumentOutput>)>> completion_steps,
+    GC::Ptr<GC::Function<void(NavigationPopulationResult)>> response_steps)
 {
     // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
     if (!active_window()) {
         stop_or_resume_response_body_delivery(navigation_params);
+        if (response_steps) {
+            response_steps->function()({
+                .navigation_params = NavigationParamsNullOrError { "Navigable has no active window"_utf16 },
+                .redirected_url = {},
+                .classic_history_api_state = {},
+                .replacement_document_state = {},
+            });
+        }
         return;
     }
 
     auto navigation_timing_type = reload_pending ? Bindings::NavigationTimingType::Reload : Bindings::NavigationTimingType::BackForward;
-    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, navigation_timing_type, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params](GC::Ref<InternalNavigationResult> result) {
+    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, navigation_timing_type, user_involvement, completion_steps, csp_navigation_type, source_snapshot_params, response_steps](GC::Ref<InternalNavigationResult> result) {
         // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
         if (!active_window()) {
             stop_or_resume_response_body_delivery(result->navigation_params);
+            if (response_steps) {
+                response_steps->function()({
+                    .navigation_params = NavigationParamsNullOrError { "Navigable has no active window"_utf16 },
+                    .redirected_url = {},
+                    .classic_history_api_state = {},
+                    .replacement_document_state = {},
+                });
+            }
+            return;
+        }
+
+        if (response_steps) {
+            auto& realm = active_window()->principal_realm();
+            create_navigation_params_descriptor(realm, result->navigation_params, GC::create_function(heap(), [result, response_steps](NavigationParamsVariantDescriptor params) {
+                Optional<SessionHistoryDocumentStateDescriptor> replacement_document_state;
+                if (result->replacement_document_state)
+                    replacement_document_state = create_session_history_document_state_descriptor(*result->replacement_document_state);
+                response_steps->function()({
+                    .navigation_params = move(params),
+                    .redirected_url = move(result->redirected_url),
+                    .classic_history_api_state = move(result->classic_history_api_state),
+                    .replacement_document_state = move(replacement_document_state),
+                    .resource_cleared = result->resource_cleared,
+                });
+            }));
             return;
         }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1283,7 +1283,7 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
         auto request_new_web_view = [&] {
             TokenizedFeature::Map empty_window_features;
             auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, traversable_navigable()->page());
-            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints, no_opener);
+            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints);
         };
 
         // --> If currentNavigable's active window does not have transient activation and the user agent has been configured to
@@ -1334,30 +1334,23 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
             if (!name.equals_ignoring_ascii_case(u"_blank"sv))
                 target_name = Utf16String::from_utf16(name);
 
-            auto create_new_traversable_closure = [page = new_web_view.page, system_visibility_state = new_web_view.system_visibility_state, window_handle = move(new_web_view.window_handle), target_name](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalTraversableNavigable> {
-                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*page, opener, target_name, {}, system_visibility_state);
-                page->set_top_level_traversable(traversable);
-                traversable->set_window_handle(Utf16String::from_ascii_without_validation(window_handle.bytes()));
-
-                auto initial_history_entry = traversable->active_session_history_entry();
-                VERIFY(initial_history_entry);
-                page->client().page_did_create_top_level_traversable(
-                    traversable->id(),
-                    create_session_history_entry_descriptor(*initial_history_entry));
+            auto create_new_traversable = [&](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalTraversableNavigable> {
+                auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*new_web_view.page, opener, target_name, {}, new_web_view.system_visibility_state);
+                new_web_view.page->set_top_level_traversable(traversable);
+                traversable->set_window_handle(Utf16String::from_ascii_without_validation(new_web_view.window_handle.bytes()));
                 return traversable;
             };
-            auto create_new_traversable = GC::create_function(heap(), move(create_new_traversable_closure));
 
             // 7. If noopener is true, then set chosen to the result of creating a new top-level traversable given null and targetName.
             if (no_opener == TokenizedFeature::NoOpener::Yes) {
-                chosen = create_new_traversable->function()(nullptr);
+                chosen = create_new_traversable(nullptr);
             }
 
             // 8. Otherwise:
             else {
                 // 1. Set chosen to the result of creating a new top-level traversable given currentNavigable's active browsing context, targetName, and currentNavigable.
                 // FIXME: "and currentNavigable", which is the openerNavigableForWebDriver parameter.
-                chosen = create_new_traversable->function()(active_browsing_context());
+                chosen = create_new_traversable(active_browsing_context());
 
                 // 2. If sandboxingFlagSet's sandboxed navigation browsing context flag is set,
                 //    then set chosen's active browsing context's one permitted sandboxed navigator to currentNavigable's active browsing context.

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -177,7 +177,8 @@ public:
         NavigationParamsVariant navigation_params,
         ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,
         bool allow_POST,
-        GC::Ptr<GC::Function<void(GC::Ptr<PopulateSessionHistoryEntryDocumentOutput>)>> completion_steps);
+        GC::Ptr<GC::Function<void(GC::Ptr<PopulateSessionHistoryEntryDocumentOutput>)>> completion_steps,
+        GC::Ptr<GC::Function<void(NavigationPopulationResult)>> response_steps = {});
 
     void queue_navigation_and_traversal_task_for_session_history_entry_population(
         URL::URL url,

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -142,8 +142,12 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_new_top_l
     initial_history_entry->set_step(0);
 
     // 9. Append initialHistoryEntry to traversable's session history entries.
-    // NB: The UI process performs this step in canonical session history.
+    // NB: The UI process keeps the canonical session history, so report the traversable's creation to it.
     traversable->set_has_session_history_entry_and_ready_for_navigation();
+    Optional<CrossProcessId> opener_navigable_id;
+    if (opener)
+        opener_navigable_id = opener->active_document()->navigable()->id();
+    page->client().page_did_create_top_level_traversable(traversable->id(), create_session_history_entry_descriptor(*initial_history_entry), opener_navigable_id);
 
     // 10. If opener is non-null, then legacy-clone a traversable storage shed given opener's top-level traversable and traversable. [STORAGE]
     if (opener) {

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -67,6 +67,8 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
         visitor.visit(operation.value.pre_steps);
         visitor.visit(operation.value.on_apply_complete);
         visitor.visit(operation.value.on_complete);
+        for (auto& population : operation.value.pending_populations)
+            visitor.visit(population.value);
         for (auto& continuation : operation.value.changing_navigable_continuations)
             visitor.visit(continuation.value);
     }
@@ -637,7 +639,7 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
     if (!preserve_ongoing_navigation)
         navigable->set_ongoing_navigation_without_informing_navigation_api(HTML::LocalNavigable::Traversal::Tag);
 
-    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), source_snapshot_params, pending_document, claimed_target_entry = move(claimed_target_entry), navigable, on_complete] {
+    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), source_snapshot_params, pending_document, claimed_target_entry = move(claimed_target_entry), navigable, on_complete]() mutable {
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
@@ -803,6 +805,50 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
                 || target_entry->document_state()->document_id() != navigable->active_document_id()
                 || target_entry->document_state()->reload_pending());
         if (needs_population) {
+            auto continue_population = GC::create_function(heap(), [this, navigable, after_document_populated](HistoryNavigationPopulation population) {
+                if (navigable->has_been_destroyed() || !navigable->active_window()) {
+                    after_document_populated->function()(nullptr);
+                    return;
+                }
+                auto& request = population.request;
+                auto& result = population.result;
+                auto& realm = navigable->active_window()->principal_realm();
+                TemporaryExecutionContext execution_context { realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
+                auto params = create_navigation_params_from_descriptor(realm, *navigable, move(result.navigation_params));
+                if (params.is_error()) {
+                    after_document_populated->function()(nullptr);
+                    return;
+                }
+                auto output = heap().allocate<PopulateSessionHistoryEntryDocumentOutput>();
+                output->redirected_url = move(result.redirected_url);
+                output->classic_history_api_state = move(result.classic_history_api_state);
+                output->resource_cleared = result.resource_cleared;
+                if (result.replacement_document_state.has_value()) {
+                    output->replacement_document_state = DocumentState::create(result.replacement_document_state->id);
+                    apply_session_history_document_state_descriptor_from_ui_process(*output->replacement_document_state, *result.replacement_document_state);
+                }
+                auto fetch_client_origin = request.source_snapshot_params.fetch_client.has_value()
+                    ? Optional<URL::Origin> { request.source_snapshot_params.fetch_client->origin }
+                    : Optional<URL::Origin> {};
+                navigable->queue_navigation_and_traversal_task_for_session_history_entry_population(
+                    request.history_entry.url, request.source_snapshot_params.allows_downloading, move(fetch_client_origin),
+                    request.user_involvement, {}, params.release_value(), request.csp_navigation_type,
+                    request.history_entry.document_state.reload_pending ? Bindings::NavigationTimingType::Reload : Bindings::NavigationTimingType::BackForward,
+                    output, GC::create_function(heap(), [navigable, after_document_populated](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
+                        queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(navigable->heap(), [after_document_populated, output] {
+                            after_document_populated->function()(output);
+                        }));
+                    }));
+            });
+            if (job.population.has_value()) {
+                continue_population->function()(job.population.release_value());
+                return;
+            }
+            auto operation = m_history_operations.find(job.operation_id);
+            if (operation == m_history_operations.end())
+                return;
+            operation->value.pending_populations.set(navigable->id(), continue_population);
+
             // FIXME: 1. Let navTimingType be "back_forward" if targetEntry's document is null; otherwise "reload".
 
             // 2. Let targetSnapshotParams be the result of snapshotting target snapshot params given navigable.
@@ -840,11 +886,23 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
             auto input_navigable_target_name = target_entry->document_state()->navigable_target_name();
             auto input_ever_populated = target_entry->document_state()->ever_populated();
 
+            auto request = NavigationPopulationRequest {
+                .navigable_id = navigable->id(),
+                .history_entry = create_pending_session_history_entry_descriptor(create_session_history_entry_descriptor(*target_entry)),
+                .source_snapshot_params = job.source_snapshot.has_value() ? job.source_snapshot.release_value() : create_navigation_source_snapshot(*potentially_target_specific_source_snapshot_params),
+                .target_snapshot_params = target_snapshot_params,
+                .csp_navigation_type = ContentSecurityPolicy::Directives::Directive::NavigationType::Other,
+                .history_handling = Bindings::NavigationHistoryBehavior::Replace,
+                .user_involvement = job.user_involvement,
+                .navigation_id = {},
+            };
+            request.history_entry.document_state.reload_pending = input_reload_pending;
+
             // 7. In parallel, attempt to populate the history entry's document for targetEntry, given navigable, potentiallyTargetSpecificSourceSnapshotParams,
             //    targetSnapshotParams, userInvolvement, with allowPOST set to allowPOST and completionSteps set to
             //    queue a global task on the navigation and traversal task source given navigable's active window to
             //    run afterDocumentPopulated.
-            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_reload_pending, input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated, user_involvement = job.user_involvement] {
+            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [operation_id = job.operation_id, request = move(request), input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_reload_pending, input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, user_involvement = job.user_involvement] {
                 navigable->populate_session_history_entry_document(
                     move(input_url), move(input_document_resource), move(input_request_referrer),
                     input_request_referrer_policy, move(input_initiator_origin), move(input_origin),
@@ -853,13 +911,8 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
                     *potentially_target_specific_source_snapshot_params, target_snapshot_params,
                     user_involvement, {}, LocalNavigable::NullOrError {},
                     ContentSecurityPolicy::Directives::Directive::NavigationType::Other, allow_POST,
-                    GC::create_function(this->heap(), [this, after_document_populated, navigable](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
-                        VERIFY(active_window());
-                        // AD-HOC: Queue through the apply-history helper so child completion tasks survive frame
-                        //         removal/deactivation. The continuation revalidates the navigable before applying.
-                        queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [after_document_populated, output]() {
-                            after_document_populated->function()(output);
-                        }));
+                    {}, GC::create_function(heap(), [this, operation_id, request](NavigationPopulationResult result) mutable {
+                        page().client().history_navigation_params_creation_finished(operation_id, { move(request), move(result) });
                     }));
             }));
         }
@@ -1389,6 +1442,7 @@ void LocalTraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr
         },
         {
             .source_snapshot_params = source_snapshot_params,
+            .serialized_source_snapshot_params = source_snapshot_params ? Optional<NavigationSourceSnapshot> { create_navigation_source_snapshot(*source_snapshot_params) } : Optional<NavigationSourceSnapshot> {},
         });
 }
 
@@ -1535,7 +1589,19 @@ void LocalTraversableNavigable::queue_navigation_api_state_clear_task(CrossProce
     }));
 }
 
-void LocalTraversableNavigable::run_ui_changing_navigable_history_job(CrossProcessId operation_id, CrossProcessId navigable_id, SessionHistoryEntryDescriptor target_entry, UserNavigationInvolvement user_involvement, Optional<Bindings::NavigationType> navigation_type, bool superseded_by_newer_navigation, GC::Ref<OnChangingNavigableHistoryStepJobComplete> on_complete)
+bool LocalTraversableNavigable::resume_history_navigation_population(CrossProcessId operation_id, HistoryNavigationPopulation&& population)
+{
+    auto operation = m_history_operations.find(operation_id);
+    if (operation == m_history_operations.end())
+        return false;
+    auto continuation = operation->value.pending_populations.take(population.request.navigable_id);
+    if (!continuation.has_value())
+        return false;
+    continuation.value()->function()(move(population));
+    return true;
+}
+
+void LocalTraversableNavigable::run_ui_changing_navigable_history_job(CrossProcessId operation_id, CrossProcessId navigable_id, SessionHistoryEntryDescriptor target_entry, UserNavigationInvolvement user_involvement, Optional<Bindings::NavigationType> navigation_type, bool superseded_by_newer_navigation, GC::Ref<OnChangingNavigableHistoryStepJobComplete> on_complete, Optional<HistoryNavigationPopulation> population)
 {
     auto& operation = m_history_operations.ensure(operation_id);
     auto source_snapshot_params = operation.source_snapshot_params;
@@ -1579,11 +1645,14 @@ void LocalTraversableNavigable::run_ui_changing_navigable_history_job(CrossProce
     }
     auto did_claim_navigable = run_changing_navigable_history_step_job_impl(
         {
+            .operation_id = operation_id,
             .navigable_id = navigable_id,
             .target_entry = local_target_entry.release_nonnull(),
             .user_involvement = user_involvement,
             .navigation_type = navigation_type,
             .superseded_by_newer_navigation = superseded_by_newer_navigation,
+            .source_snapshot = operation.serialized_source_snapshot_params,
+            .population = move(population),
         },
         source_snapshot_params, pending_document,
         GC::create_function(heap(), [this, operation_id, navigable_id, on_complete](LocalChangingNavigableHistoryStepJobResult result) {

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -59,6 +59,7 @@ public:
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable {};
         Optional<Utf16String> expected_ongoing_navigation_id {};
         GC::Ptr<SourceSnapshotParams> source_snapshot_params {};
+        Optional<NavigationSourceSnapshot> serialized_source_snapshot_params {};
         Optional<CrossProcessId> local_target_navigable_id {};
         RefPtr<SessionHistoryEntry> local_target_entry {};
         GC::Ptr<OnHistoryOperationPreSteps> pre_steps {};
@@ -68,6 +69,7 @@ public:
         // State retained between a changing job and its continuation.
         HashTable<CrossProcessId> claimed_navigables_awaiting_continuation {};
         HashMap<CrossProcessId, GC::Ref<ChangingNavigableContinuationState>> changing_navigable_continuations {};
+        HashMap<CrossProcessId, GC::Ref<GC::Function<void(HistoryNavigationPopulation)>>> pending_populations {};
     };
     void request_history_operation(HistoryOperationParameters);
     void request_history_operation(HistoryOperationParameters, HistoryOperationState);
@@ -75,7 +77,8 @@ public:
     void run_ui_history_step_unload_cancelation_job(CrossProcessId operation_id, SessionHistoryEntryDescriptor target_entry, Vector<CrossProcessId> navigables_crossing_documents, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult, UnloadPromptShown)>>);
     void run_ui_history_step_beforeunload_check(Vector<CrossProcessId> navigable_ids, UnloadPromptShown, GC::Ref<GC::Function<void(HistoryStepResult, UnloadPromptShown)>>);
     void queue_navigation_api_state_clear_task(CrossProcessId navigable_id);
-    void run_ui_changing_navigable_history_job(CrossProcessId operation_id, CrossProcessId navigable_id, SessionHistoryEntryDescriptor target_entry, UserNavigationInvolvement, Optional<Bindings::NavigationType>, bool superseded_by_newer_navigation, GC::Ref<OnChangingNavigableHistoryStepJobComplete>);
+    void run_ui_changing_navigable_history_job(CrossProcessId operation_id, CrossProcessId navigable_id, SessionHistoryEntryDescriptor target_entry, UserNavigationInvolvement, Optional<Bindings::NavigationType>, bool superseded_by_newer_navigation, GC::Ref<OnChangingNavigableHistoryStepJobComplete>, Optional<HistoryNavigationPopulation> = {});
+    bool resume_history_navigation_population(CrossProcessId operation_id, HistoryNavigationPopulation&&);
     void prepare_ui_changing_navigable_for_unload(CrossProcessId operation_id, CrossProcessId navigable_id, GC::Ref<GC::Function<void()>> on_complete);
     void apply_ui_changing_navigable_continuation(CrossProcessId operation_id, CrossProcessId navigable_id, HistoryObjectLengthAndIndex, Vector<SessionHistoryEntryDescriptor> entries_for_navigation_api, VisibilityState, UnloadDisplayedDocument, GC::Ref<GC::Function<void(Optional<ReplicatedNavigableState>, Optional<SessionHistoryEntryPersistedState>)>>);
     void run_ui_descendant_unload_task(CrossProcessId navigable_id, GC::Ref<GC::Function<void()>> on_complete);
@@ -140,11 +143,14 @@ private:
 
     // One iteration of "12. For each navigable of changingNavigables, queue a global task ...".
     struct ChangingNavigableHistoryStepJob {
+        CrossProcessId operation_id;
         CrossProcessId navigable_id;
         NonnullRefPtr<SessionHistoryEntry> target_entry;
         UserNavigationInvolvement user_involvement;
         Optional<Bindings::NavigationType> navigation_type;
         bool superseded_by_newer_navigation { false };
+        Optional<NavigationSourceSnapshot> source_snapshot;
+        Optional<HistoryNavigationPopulation> population;
     };
     struct LocalChangingNavigableHistoryStepJobResult {
         ChangingNavigableHistoryStepJobDisposition disposition;

--- a/Libraries/LibWeb/HTML/NavigationPopulationRequest.cpp
+++ b/Libraries/LibWeb/HTML/NavigationPopulationRequest.cpp
@@ -198,4 +198,21 @@ ErrorOr<Web::HTML::NavigationPopulationResult> decode(Decoder& decoder)
     };
 }
 
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::HistoryNavigationPopulation const& population)
+{
+    TRY(encoder.encode(population.request));
+    TRY(encoder.encode(population.result));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::HistoryNavigationPopulation> decode(Decoder& decoder)
+{
+    return Web::HTML::HistoryNavigationPopulation {
+        .request = TRY(decoder.decode<Web::HTML::NavigationPopulationRequest>()),
+        .result = TRY(decoder.decode<Web::HTML::NavigationPopulationResult>()),
+    };
+}
+
 }

--- a/Libraries/LibWeb/HTML/NavigationPopulationRequest.h
+++ b/Libraries/LibWeb/HTML/NavigationPopulationRequest.h
@@ -66,6 +66,11 @@ struct NavigationPopulationResult {
     bool resource_cleared { false };
 };
 
+struct HistoryNavigationPopulation {
+    NavigationPopulationRequest request;
+    NavigationPopulationResult result;
+};
+
 WEB_API NavigationPopulationRequest create_navigation_population_request(NavigationStartRequest, CrossProcessId document_state_id);
 WEB_API void apply_navigation_population_result(NavigationPopulationRequest&, NavigationPopulationResult const&);
 
@@ -90,5 +95,11 @@ WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigationPopulationResult con
 
 template<>
 WEB_API ErrorOr<Web::HTML::NavigationPopulationResult> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::HistoryNavigationPopulation const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::HistoryNavigationPopulation> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -1388,6 +1388,11 @@ void Page::set_viewport_is_fullscreen(ViewportIsFullscreen is_fullscreen)
     process_pending_fullscreen_operations();
 }
 
+void PageClient::history_navigation_params_creation_finished(HTML::CrossProcessId operation_id, HTML::HistoryNavigationPopulation population)
+{
+    page().top_level_traversable()->resume_history_navigation_population(operation_id, move(population));
+}
+
 void PageClient::request_navigation_start(HTML::LocalNavigable& navigable, URL::URL const& current_url, NavigationTarget target, URL::URL const&, Utf16String navigation_id, Optional<HTML::NavigationStartRequest> start_request)
 {
     // A javascript: navigation runs synchronously in this process and never populates an entry; there is nothing

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -1393,24 +1393,24 @@ void PageClient::history_navigation_params_creation_finished(HTML::CrossProcessI
     page().top_level_traversable()->resume_history_navigation_population(operation_id, move(population));
 }
 
-void PageClient::request_navigation_start(HTML::LocalNavigable& navigable, URL::URL const& current_url, NavigationTarget target, URL::URL const&, Utf16String navigation_id, Optional<HTML::NavigationStartRequest> start_request)
+void PageClient::request_navigation_start(HTML::LocalNavigable& navigable, NavigationTarget target, URL::URL const&, Utf16String navigation_id, Optional<HTML::NavigationStartRequest> start_request)
 {
     // A javascript: navigation runs synchronously in this process and never populates an entry; there is nothing
     // for the embedder to retain.
     if (!start_request.has_value())
         return;
 
-    navigable.run_navigation_unload_check(navigation_id, GC::create_function(navigable.heap(), [client = GC::Ref { *this }, navigable = GC::Ref { navigable }, current_url, target, navigation_id, start_request = start_request.release_value()](bool should_continue) mutable {
+    navigable.run_navigation_unload_check(navigation_id, GC::create_function(navigable.heap(), [client = GC::Ref { *this }, navigable = GC::Ref { navigable }, target, navigation_id, start_request = start_request.release_value()](bool should_continue) mutable {
         if (!should_continue) {
             navigable->resume_navigation_params_creation(navigation_id, {});
             return;
         }
         auto population_request = HTML::create_navigation_population_request(move(start_request), client->allocate_cross_process_id());
-        client->request_navigation_population(navigable, current_url, target, move(population_request));
+        client->request_navigation_population(navigable, target, move(population_request));
     }));
 }
 
-void PageClient::request_navigation_population(HTML::LocalNavigable& navigable, URL::URL const&, NavigationTarget, HTML::NavigationPopulationRequest request)
+void PageClient::request_navigation_population(HTML::LocalNavigable& navigable, NavigationTarget, HTML::NavigationPopulationRequest request)
 {
     navigable.resume_navigation_params_creation(request.navigation_id, move(request));
 }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -614,10 +614,10 @@ public:
         HTML::VisibilityState system_visibility_state { HTML::VisibilityState::Hidden };
         String window_handle;
     };
-    virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, HTML::TokenizedFeature::NoOpener) { return {}; }
+    virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints) { return {}; }
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
-    virtual void page_did_create_top_level_traversable([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& initial_history_entry) { }
+    virtual void page_did_create_top_level_traversable([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& initial_history_entry, [[maybe_unused]] Optional<HTML::CrossProcessId> opener_navigable_id) { }
     virtual void page_did_update_session_history_entry_navigation_api_state([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] HTML::StorageSerializationRecord const& navigation_api_state) { }
     virtual void page_did_update_session_history_entry_scroll_restoration_mode([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] HTML::ScrollRestorationMode scroll_restoration_mode) { }
     virtual void page_did_update_session_history_entry_document_state_navigable_target_name([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryIdentity const& entry_identity, [[maybe_unused]] Utf16String const& navigable_target_name) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -488,6 +488,7 @@ public:
     virtual void request_navigation_start(HTML::LocalNavigable&, URL::URL const& current_url, NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<HTML::NavigationStartRequest>);
     virtual void request_navigation_population(HTML::LocalNavigable&, URL::URL const& current_url, NavigationTarget, HTML::NavigationPopulationRequest);
     virtual void navigation_params_creation_finished(HTML::LocalNavigable&, HTML::NavigationPopulationRequest, HTML::NavigationPopulationResult);
+    virtual void history_navigation_params_creation_finished(HTML::CrossProcessId operation_id, HTML::HistoryNavigationPopulation);
     virtual void navigation_population_failed(HTML::CrossProcessId, Utf16String const&) { }
     virtual void page_did_create_child_frame(HTML::CrossProcessId, HTML::CrossProcessId, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_update_child_frame_viewport(HTML::CrossProcessId, CSSPixelRect) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -485,8 +485,8 @@ public:
     virtual bool has_focus() const { return true; }
     virtual void set_has_focus([[maybe_unused]] bool has_focus) { }
     virtual bool has_active_devtools_client() const { return false; }
-    virtual void request_navigation_start(HTML::LocalNavigable&, URL::URL const& current_url, NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<HTML::NavigationStartRequest>);
-    virtual void request_navigation_population(HTML::LocalNavigable&, URL::URL const& current_url, NavigationTarget, HTML::NavigationPopulationRequest);
+    virtual void request_navigation_start(HTML::LocalNavigable&, NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<HTML::NavigationStartRequest>);
+    virtual void request_navigation_population(HTML::LocalNavigable&, NavigationTarget, HTML::NavigationPopulationRequest);
     virtual void navigation_params_creation_finished(HTML::LocalNavigable&, HTML::NavigationPopulationRequest, HTML::NavigationPopulationResult);
     virtual void history_navigation_params_creation_finished(HTML::CrossProcessId operation_id, HTML::HistoryNavigationPopulation);
     virtual void navigation_population_failed(HTML::CrossProcessId, Utf16String const&) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1829,13 +1829,13 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
 
     switch (process.type()) {
     case ProcessType::Compositor:
-        if (auto client = process.client<CompositorClient>(); client.has_value()) {
+        if (auto client = process.client<CompositorClient>()) {
             if (auto on_death = move(client->on_death))
                 on_death();
         }
         break;
     case ProcessType::ImageDecoder:
-        if (auto client = process.client<ImageDecoderClient::Client>(); client.has_value()) {
+        if (auto client = process.client<ImageDecoderClient::Client>()) {
             dbgln_if(WEBVIEW_PROCESS_DEBUG, "Restart ImageDecoder process");
             if (auto on_death = move(client->on_death)) {
                 on_death();
@@ -1843,7 +1843,7 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
         }
         break;
     case ProcessType::RequestServer:
-        if (auto client = process.client<Requests::RequestClient>(); client.has_value()) {
+        if (auto client = process.client<Requests::RequestClient>()) {
             dbgln_if(WEBVIEW_PROCESS_DEBUG, "Restart request server");
             if (auto on_request_server_died = move(client->on_request_server_died))
                 on_request_server_died();
@@ -1851,7 +1851,7 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
         break;
     case ProcessType::WasmCompiler:
 #if defined(HAVE_WASM_COMPILER_SERVICE)
-        if (auto client = process.client<WasmCompilerClient::Client>(); client.has_value()) {
+        if (auto client = process.client<WasmCompilerClient::Client>()) {
             dbgln_if(WEBVIEW_PROCESS_DEBUG, "Restart WebAssembly compiler");
             if (auto on_death = move(client->on_death))
                 on_death();
@@ -1859,7 +1859,7 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
 #endif
         break;
     case ProcessType::WebContent:
-        if (auto client = process.client<WebContentClient>(); client.has_value()) {
+        if (auto client = process.client<WebContentClient>()) {
 #if !defined(AK_OS_WINDOWS)
             if (exit_status.has_value() && WIFEXITED(*exit_status) && WEXITSTATUS(*exit_status) == 0 && !client->has_views())
                 break;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SOURCES
     AutocompleteRanker.cpp
     AutocompleteService.cpp
     BookmarkStore.cpp
+    CanonicalBrowsingContext.cpp
+    CanonicalBrowsingContextGroup.cpp
     CanonicalNavigable.cpp
     CanonicalTraversable.cpp
     BrowserProcess.cpp

--- a/Libraries/LibWebView/CanonicalBrowsingContext.cpp
+++ b/Libraries/LibWebView/CanonicalBrowsingContext.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
+#include <LibWebView/CanonicalTraversable.h>
+#include <LibWebView/WebContentClient.h>
+
+namespace WebView {
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-browsing-context
+NonnullRefPtr<CanonicalBrowsingContext> CanonicalBrowsingContext::create_a_new_browsing_context_and_document(CanonicalBrowsingContextGroup& group, URL::Origin const& document_origin, Optional<WebContentClient&> document_process)
+{
+    // 1. Let browsingContext be a new browsing context.
+    auto browsing_context = adopt_ref(*new CanonicalBrowsingContext);
+
+    // 6. Let sandboxFlags be the result of determining the creation sandboxing flags given browsingContext and embedder.
+    // 7. Let origin be the result of determining the origin given about:blank, sandboxFlags, and creatorOrigin.
+    // NB: The process creating the document determines origin, and replicates it as the document's origin.
+
+    // 9. Let agent be the result of obtaining a similar-origin window agent given origin, group, and false.
+    auto agent = group.obtain_similar_origin_window_agent(document_origin, false);
+
+    // NB: Steps 10 to 24 run in the WebContent process creating the document, so that process hosts agent.
+    if (document_process.has_value())
+        agent->set_hosting_process_if_unset(*document_process);
+
+    // 25. Return browsingContext and document.
+    return browsing_context;
+}
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-browsing-context
+// https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-browsing-context-group-and-document
+NonnullRefPtr<CanonicalBrowsingContext> CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin const& document_origin, Optional<WebContentClient&> document_process)
+{
+    // NB: A group is kept alive by the browsing contexts in its browsing context set, so creating a new browsing context
+    //     group and document is folded in here, where the browsing context holding the group is returned.
+
+    // 1. Let group be a new browsing context group.
+    // 2. Append group to the user agent's browsing context group set.
+    auto group = CanonicalBrowsingContextGroup::create();
+
+    // 3. Let browsingContext and document be the result of creating a new browsing context and document with null, null, and group.
+    auto browsing_context = create_a_new_browsing_context_and_document(*group, document_origin, document_process);
+
+    // 4. Append browsingContext to group.
+    group->append(*browsing_context);
+
+    // 5. Return group and document.
+    // 2. Return group's browsing context set[0] and document.
+    return browsing_context;
+}
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-auxiliary-browsing-context
+NonnullRefPtr<CanonicalBrowsingContext> CanonicalBrowsingContext::create_a_new_auxiliary_browsing_context_and_document(CanonicalNavigable& opener, URL::Origin const& document_origin, Optional<WebContentClient&> document_process)
+{
+    // 1. Let openerTopLevelBrowsingContext be opener's top-level traversable's active browsing context.
+    auto& opener_top_level_browsing_context = opener.top_level_traversable().active_browsing_context();
+
+    // 2. Let group be openerTopLevelBrowsingContext's group.
+    auto group = opener_top_level_browsing_context.group();
+
+    // 3. Assert: group is non-null, as navigating invokes this directly.
+    VERIFY(group);
+
+    // 4. Let browsingContext and document be the result of creating a new browsing context and document with opener's active document, null, and group.
+    auto browsing_context = create_a_new_browsing_context_and_document(*group, document_origin, document_process);
+
+    // FIXME: 5. Set browsingContext's is auxiliary to true.
+
+    // 6. Append browsingContext to group.
+    group->append(*browsing_context);
+
+    // FIXME: 7. Set browsingContext's opener browsing context to opener.
+    // FIXME: 8. Set browsingContext's virtual browsing context group ID to openerTopLevelBrowsingContext's virtual browsing context group ID.
+    // FIXME: 9. Set browsingContext's opener origin at creation to opener's active document's origin.
+
+    // 10. Return browsingContext and document.
+    return browsing_context;
+}
+
+CanonicalBrowsingContext::~CanonicalBrowsingContext()
+{
+    if (m_group)
+        m_group->remove(*this);
+}
+
+RefPtr<CanonicalBrowsingContextGroup> CanonicalBrowsingContext::group() const
+{
+    return m_group;
+}
+
+void CanonicalBrowsingContext::set_group(Badge<CanonicalBrowsingContextGroup>, CanonicalBrowsingContextGroup* group)
+{
+    m_group = group;
+}
+
+}

--- a/Libraries/LibWebView/CanonicalBrowsingContext.h
+++ b/Libraries/LibWebView/CanonicalBrowsingContext.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <LibURL/Origin.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context
+class WEBVIEW_API CanonicalBrowsingContext final : public RefCounted<CanonicalBrowsingContext> {
+public:
+    // A WebContent process creates the document of a new browsing context. The UI process models the browsing context
+    // and the similar-origin window agent of that document, given the document's origin and the process creating it.
+    static NonnullRefPtr<CanonicalBrowsingContext> create_a_new_browsing_context_and_document(CanonicalBrowsingContextGroup&, URL::Origin const& document_origin, Optional<WebContentClient&> document_process);
+    static NonnullRefPtr<CanonicalBrowsingContext> create_a_new_top_level_browsing_context_and_document(URL::Origin const& document_origin, Optional<WebContentClient&> document_process);
+    static NonnullRefPtr<CanonicalBrowsingContext> create_a_new_auxiliary_browsing_context_and_document(CanonicalNavigable& opener, URL::Origin const& document_origin, Optional<WebContentClient&> document_process);
+
+    ~CanonicalBrowsingContext();
+
+    RefPtr<CanonicalBrowsingContextGroup> group() const;
+    void set_group(Badge<CanonicalBrowsingContextGroup>, CanonicalBrowsingContextGroup*);
+
+private:
+    CanonicalBrowsingContext() = default;
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#tlbc-group
+    RefPtr<CanonicalBrowsingContextGroup> m_group;
+};
+
+}

--- a/Libraries/LibWebView/CanonicalBrowsingContextGroup.cpp
+++ b/Libraries/LibWebView/CanonicalBrowsingContextGroup.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
+#include <LibWebView/WebContentClient.h>
+
+namespace WebView {
+
+NonnullRefPtr<CanonicalSimilarOriginWindowAgent> CanonicalSimilarOriginWindowAgent::create()
+{
+    return adopt_ref(*new CanonicalSimilarOriginWindowAgent);
+}
+
+RefPtr<WebContentClient> CanonicalSimilarOriginWindowAgent::hosting_process() const
+{
+    // A process that has exited hosts nothing.
+    auto process = m_hosting_process.strong_ref();
+    if (!process || !process->is_open())
+        return nullptr;
+    return process;
+}
+
+void CanonicalSimilarOriginWindowAgent::set_hosting_process_if_unset(WebContentClient& process)
+{
+    if (hosting_process())
+        return;
+    m_hosting_process = process.make_weak_ptr<WebContentClient>();
+}
+
+NonnullRefPtr<CanonicalBrowsingContextGroup> CanonicalBrowsingContextGroup::create()
+{
+    return adopt_ref(*new CanonicalBrowsingContextGroup);
+}
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#bcg-append
+void CanonicalBrowsingContextGroup::append(CanonicalBrowsingContext& browsing_context)
+{
+    VERIFY(!browsing_context.group());
+
+    // 1. Append browsingContext to group's browsing context set.
+    m_browsing_context_set.set(&browsing_context);
+
+    // 2. Set browsingContext's group to group.
+    browsing_context.set_group({}, this);
+}
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#bcg-remove
+void CanonicalBrowsingContextGroup::remove(CanonicalBrowsingContext& browsing_context)
+{
+    // Keep group alive while step 3 releases browsingContext's reference to it.
+    NonnullRefPtr protected_this = *this;
+
+    // 1. Assert: browsingContext's group is non-null.
+    // 2. Let group be browsingContext's group.
+    VERIFY(browsing_context.group() == this);
+
+    // 3. Set browsingContext's group to null.
+    browsing_context.set_group({}, nullptr);
+
+    // 4. Remove browsingContext from group's browsing context set.
+    m_browsing_context_set.remove(&browsing_context);
+
+    // 5. If group's browsing context set is empty, then remove group from the user agent's browsing context group set.
+    // NB: The group dies with its last reference.
+}
+
+unsigned CanonicalBrowsingContextGroup::AgentClusterKeyTraits::hash(AgentClusterKey const& key)
+{
+    auto value_hash = key.value.visit(
+        [](URL::Site const& site) { return site.serialize().hash(); },
+        [](URL::Origin const& origin) { return Traits<URL::Origin>::hash(origin); });
+    return pair_int_hash(key.value.index(), value_hash);
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#obtain-similar-origin-window-agent
+NonnullRefPtr<CanonicalSimilarOriginWindowAgent> CanonicalBrowsingContextGroup::obtain_similar_origin_window_agent(URL::Origin const& origin, bool requests_oac)
+{
+    // 1. Let site be the result of obtaining a site with origin.
+    auto site = URL::Site::obtain(origin);
+
+    // 2. Let key be site.
+    // NB: A site is an opaque origin or a scheme-and-host. URL::Site wraps both, so normalize an opaque site to its
+    //     origin to preserve which arm of the agent cluster key union it occupies.
+    auto key = origin.is_opaque() ? AgentClusterKey { origin } : AgentClusterKey { move(site) };
+
+    // FIXME: 3. If group's cross-origin isolation mode is not "none", then set key to origin.
+
+    // 4. Otherwise, if group's historical agent cluster key map[origin] exists, then set key to group's historical
+    //    agent cluster key map[origin].
+    if (auto historical_key = m_historical_agent_cluster_key_map.get(origin); historical_key.has_value()) {
+        key = historical_key.release_value();
+    }
+    // 5. Otherwise:
+    else {
+        // 1. If requestsOAC is true, then set key to origin.
+        if (requests_oac)
+            key = AgentClusterKey { origin };
+
+        // 2. Set group's historical agent cluster key map[origin] to key.
+        m_historical_agent_cluster_key_map.set(origin, key);
+    }
+
+    // 6. If group's agent cluster map[key] does not exist:
+    if (!m_agent_cluster_map.contains(key)) {
+        // 1. Let agentCluster be a new agent cluster.
+        // 2. Let agent be a new similar-origin window agent.
+        // 3. Set agentCluster's agents to « agent ».
+        AgentCluster agent_cluster { CanonicalSimilarOriginWindowAgent::create() };
+
+        // 4. Set group's agent cluster map[key] to agentCluster.
+        m_agent_cluster_map.set(key, move(agent_cluster));
+    }
+
+    // 7. Return the single similar-origin window agent contained in group's agent cluster map[key].
+    return m_agent_cluster_map.get(key)->similar_origin_window_agent;
+}
+
+}

--- a/Libraries/LibWebView/CanonicalBrowsingContextGroup.h
+++ b/Libraries/LibWebView/CanonicalBrowsingContextGroup.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/Variant.h>
+#include <AK/WeakPtr.h>
+#include <LibURL/Origin.h>
+#include <LibURL/Site.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#similar-origin-window-agent
+class WEBVIEW_API CanonicalSimilarOriginWindowAgent final : public RefCounted<CanonicalSimilarOriginWindowAgent> {
+public:
+    static NonnullRefPtr<CanonicalSimilarOriginWindowAgent> create();
+
+    RefPtr<WebContentClient> hosting_process() const;
+    void set_hosting_process_if_unset(WebContentClient&);
+
+private:
+    CanonicalSimilarOriginWindowAgent() = default;
+
+    WeakPtr<WebContentClient> m_hosting_process;
+};
+
+// https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-group
+class WEBVIEW_API CanonicalBrowsingContextGroup : public RefCounted<CanonicalBrowsingContextGroup> {
+public:
+    static NonnullRefPtr<CanonicalBrowsingContextGroup> create();
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set
+    OrderedHashTable<CanonicalBrowsingContext*> const& browsing_context_set() const { return m_browsing_context_set; }
+
+    void append(CanonicalBrowsingContext&);
+    void remove(CanonicalBrowsingContext&);
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#obtain-similar-origin-window-agent
+    NonnullRefPtr<CanonicalSimilarOriginWindowAgent> obtain_similar_origin_window_agent(URL::Origin const&, bool requests_oac);
+
+private:
+    CanonicalBrowsingContextGroup() = default;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#agent-cluster-key
+    // An agent cluster key is equivalently a scheme-and-host or an origin. URL::Site wraps both cases, so normalize
+    // an opaque site to its origin to keep the alternatives disjoint.
+    struct AgentClusterKey {
+        bool operator==(AgentClusterKey const&) const = default;
+
+        Variant<URL::Site, URL::Origin> value;
+    };
+
+    struct AgentClusterKeyTraits : public DefaultTraits<AgentClusterKey> {
+        static unsigned hash(AgentClusterKey const&);
+        static bool equals(AgentClusterKey const& a, AgentClusterKey const& b) { return a == b; }
+        static constexpr bool may_have_slow_equality_check() { return true; }
+    };
+
+    struct AgentCluster {
+        NonnullRefPtr<CanonicalSimilarOriginWindowAgent> similar_origin_window_agent;
+    };
+
+    // Browsing contexts own their group, so this inverse membership relation must remain non-owning.
+    OrderedHashTable<CanonicalBrowsingContext*> m_browsing_context_set;
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#agent-cluster-map
+    // FIXME: Make this weak once canonical agent clusters have a lifetime independent of the browsing context group.
+    HashMap<AgentClusterKey, AgentCluster, AgentClusterKeyTraits> m_agent_cluster_map;
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#historical-agent-cluster-key-map
+    HashMap<URL::Origin, AgentClusterKey> m_historical_agent_cluster_key_map;
+};
+
+}

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -8,6 +8,7 @@
 
 #include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/WebContentClient.h>
 
@@ -19,6 +20,19 @@ CanonicalNavigable::CanonicalNavigable(Web::HTML::CrossProcessId id, Optional<We
     , m_reporting_client(move(reporting_client))
     , m_reporting_page_id(reporting_page_id)
 {
+}
+
+CanonicalBrowsingContext& CanonicalNavigable::active_browsing_context() const
+{
+    // A navigable's active browsing context is its active document's browsing context.
+    // NB: Only a top-level browsing context group switch changes it, so it is kept with the navigable.
+    VERIFY(m_active_browsing_context);
+    return *m_active_browsing_context;
+}
+
+void CanonicalNavigable::set_active_browsing_context(NonnullRefPtr<CanonicalBrowsingContext> browsing_context)
+{
+    m_active_browsing_context = move(browsing_context);
 }
 
 CanonicalNavigable::~CanonicalNavigable()

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/WebContentClient.h>
 
@@ -33,6 +34,50 @@ CanonicalBrowsingContext& CanonicalNavigable::active_browsing_context() const
 void CanonicalNavigable::set_active_browsing_context(NonnullRefPtr<CanonicalBrowsingContext> browsing_context)
 {
     m_active_browsing_context = move(browsing_context);
+}
+
+// https://html.spec.whatwg.org/multipage/browsers.html#obtain-browsing-context-navigation
+NonnullRefPtr<CanonicalBrowsingContext> CanonicalNavigable::obtain_a_browsing_context_to_use_for_a_navigation_response(Web::HTML::OpenerPolicyEnforcementResult const& coop_enforcement_result)
+{
+    // 1. Let browsingContext be navigationParams's navigable's active browsing context.
+    NonnullRefPtr browsing_context = active_browsing_context();
+
+    // 2. If browsingContext is not a top-level browsing context, then return browsingContext.
+    if (!is_top_level_traversable())
+        return browsing_context;
+
+    // 3. Let coopEnforcementResult be navigationParams's COOP enforcement result.
+    // 4. Let swapGroup be coopEnforcementResult's needs a browsing context group switch.
+    auto swap_group = coop_enforcement_result.needs_a_browsing_context_group_switch;
+
+    // NB: Steps 5-8 only affect swapGroup through optional choices. This implementation does not take them.
+
+    // 9. If swapGroup is false, then:
+    if (!swap_group) {
+        // FIXME: 1. If coopEnforcementResult's would need a browsing context group switch due to report-only is true,
+        //           set browsingContext's virtual browsing context group ID to a new unique identifier.
+
+        // 2. Return browsingContext.
+        return browsing_context;
+    }
+
+    // 10. Let newBrowsingContext be the first return value of creating a new top-level browsing context and document.
+    // NB: The navigation response's document replaces that document before any process creates it.
+    auto new_browsing_context = CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {});
+
+    // 11. Let navigationCOOP be navigationParams's cross-origin opener policy.
+    // FIXME: 12. If navigationCOOP's value is "same-origin-plus-COEP", then set newBrowsingContext's group's
+    //            cross-origin isolation mode to either "logical" or "concrete". The choice of which is
+    //            implementation-defined.
+
+    // 13. Let sandboxFlags be a clone of navigationParams's final sandboxing flag set.
+    // FIXME: 14. If sandboxFlags is not empty, then:
+    //            1. Assert: navigationCOOP's value is "unsafe-none".
+    //            2. Assert: newBrowsingContext's popup sandboxing flag set is empty.
+    //            3. Set newBrowsingContext's popup sandboxing flag set to sandboxFlags.
+
+    // 15. Return newBrowsingContext.
+    return new_browsing_context;
 }
 
 CanonicalNavigable::~CanonicalNavigable()
@@ -325,7 +370,7 @@ bool CanonicalNavigable::active_document_is(Web::HTML::SessionHistoryEntryDescri
         && m_active_session_history_entry_identity->document_state_id == entry.document_state.id;
 }
 
-void CanonicalNavigable::did_commit_navigation(Web::HTML::ReplicatedNavigableState replicated_state, Optional<Utf16String> const& navigation_id)
+void CanonicalNavigable::did_commit_navigation(Web::HTML::ReplicatedNavigableState replicated_state, Optional<Utf16String> const& navigation_id, RefPtr<CanonicalBrowsingContext> destination_browsing_context)
 {
     auto commits_ongoing_navigation = !m_ongoing_navigation.has_value()
         || !navigation_id.has_value()
@@ -335,7 +380,21 @@ void CanonicalNavigable::did_commit_navigation(Web::HTML::ReplicatedNavigableSta
         ? Optional<Web::HTML::CrossProcessId> { m_active_session_history_entry_identity->document_state_id }
         : Optional<Web::HTML::CrossProcessId> {};
 
+    if (!destination_browsing_context && navigation_id.has_value() && commits_ongoing_navigation && m_ongoing_navigation.has_value())
+        destination_browsing_context = m_ongoing_navigation->destination_browsing_context;
+    if (destination_browsing_context)
+        set_active_browsing_context(destination_browsing_context.release_nonnull());
     set_replicated_state(move(replicated_state));
+
+    auto& traversable = top_level_traversable();
+    auto endpoint = traversable.history_job_endpoint_for(*this);
+    if (endpoint.client) {
+        // FIXME: Pass the document's requestsOAC value once Origin-Agent-Cluster is implemented.
+        auto browsing_context_group = traversable.active_browsing_context().group();
+        VERIFY(browsing_context_group);
+        auto agent = browsing_context_group->obtain_similar_origin_window_agent(m_replicated_state->active_document_origin, false);
+        agent->set_hosting_process_if_unset(*endpoint.client);
+    }
 
     // A navigation can commit while a newer navigation is already in flight. In that case update the replicated
     // state for the committed document without changing the newer navigation's transaction.

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -99,6 +99,10 @@ public:
     CanonicalTraversable& top_level_traversable();
     CanonicalTraversable const& top_level_traversable() const;
 
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-bc
+    CanonicalBrowsingContext& active_browsing_context() const;
+    void set_active_browsing_context(NonnullRefPtr<CanonicalBrowsingContext>);
+
     CanonicalNavigable& append_child(NonnullOwnPtr<CanonicalNavigable>);
     NonnullOwnPtr<CanonicalNavigable> remove_child(CanonicalNavigable&);
     bool is_ancestor_of(CanonicalNavigable const&) const;
@@ -183,6 +187,7 @@ private:
     Vector<NonnullOwnPtr<CanonicalNavigable>> m_children;
 
     Optional<Web::HTML::ReplicatedNavigableState> m_replicated_state;
+    RefPtr<CanonicalBrowsingContext> m_active_browsing_context;
     Optional<Web::HTML::SessionHistoryEntryIdentity> m_current_session_history_entry_identity;
     Optional<Web::HTML::SessionHistoryEntryIdentity> m_active_session_history_entry_identity;
     Vector<PendingSameDocumentSessionHistoryEntry> m_pending_same_document_session_history_entries;

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -21,12 +21,14 @@
 #include <LibRequests/Forward.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/CrossOrigin/OpenerPolicyEnforcementResult.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/NavigationPopulationRequest.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/Export.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/NavigationLoader.h>
@@ -65,6 +67,7 @@ public:
         u64 population_worker_page_id { 0 };
         WeakPtr<WebContentClient> host_client {};
         u64 host_page_id { 0 };
+        RefPtr<CanonicalBrowsingContext> destination_browsing_context {};
     };
 
     // The active document's load, tracked from the document's activation until WebContent reports that
@@ -102,6 +105,8 @@ public:
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-bc
     CanonicalBrowsingContext& active_browsing_context() const;
     void set_active_browsing_context(NonnullRefPtr<CanonicalBrowsingContext>);
+
+    NonnullRefPtr<CanonicalBrowsingContext> obtain_a_browsing_context_to_use_for_a_navigation_response(Web::HTML::OpenerPolicyEnforcementResult const&);
 
     CanonicalNavigable& append_child(NonnullOwnPtr<CanonicalNavigable>);
     NonnullOwnPtr<CanonicalNavigable> remove_child(CanonicalNavigable&);
@@ -153,7 +158,7 @@ public:
     void append_pending_same_document_session_history_entries(Vector<PendingSameDocumentSessionHistoryEntry>);
     Vector<PendingSameDocumentSessionHistoryEntry> const& pending_same_document_session_history_entries() const { return m_pending_same_document_session_history_entries; }
 
-    void did_commit_navigation(Web::HTML::ReplicatedNavigableState, Optional<Utf16String> const& navigation_id);
+    void did_commit_navigation(Web::HTML::ReplicatedNavigableState, Optional<Utf16String> const& navigation_id, RefPtr<CanonicalBrowsingContext> destination_browsing_context = {});
 
     Optional<OngoingNavigation>& ongoing_navigation() { return m_ongoing_navigation; }
     Optional<OngoingNavigation> const& ongoing_navigation() const { return m_ongoing_navigation; }

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -55,8 +55,6 @@ public:
         };
 
         Optional<URL::URL> url {};
-        Optional<URL::URL> current_url {};
-        Optional<Web::NavigationTarget> target {};
         Optional<Utf16String> navigation_id {};
         Optional<Web::HTML::NavigationStartRequest> start_request {};
         u64 sequence_number { 0 };

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/StorageJar.h>
@@ -165,14 +166,53 @@ void CanonicalTraversable::prepare_for_reload()
     session_history_changed();
 }
 
-void CanonicalTraversable::did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+// https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
+void CanonicalTraversable::did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process)
 {
+    // NB: A replacement process creates a traversable of its own for this canonical one, which stays as it is.
     if (!m_session_history.entries().is_empty())
         return;
+
+    // 1. Let document be null.
+    // NB: The reporting process created document, which initialHistoryEntry's document state describes.
+    auto document_origin = initial_history_entry.document_state.origin.value_or(URL::Origin::create_opaque());
+
+    // 2. If opener is null, then set document to the second return value of creating a new top-level browsing context and document.
+    if (!opener.has_value())
+        set_active_browsing_context(CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(document_origin, process));
+
+    // 3. Otherwise, set document to the second return value of creating a new auxiliary browsing context and document given opener.
+    else
+        set_active_browsing_context(CanonicalBrowsingContext::create_a_new_auxiliary_browsing_context_and_document(*opener, document_origin, process));
+
+    // 4. Let documentState be a new document state, with [...]
+    // 5. Let traversable be a new traversable navigable.
+    // 6. Initialize the navigable traversable given documentState.
+    // NB: The initial document is active from the traversable's creation, so replicate its state from initialHistoryEntry.
+    set_replicated_state({
+        .target_name = initial_history_entry.document_state.navigable_target_name,
+        .active_document_url = initial_history_entry.url,
+        .active_document_origin = document_origin,
+        .active_document_is_fully_active = true,
+        .active_session_history_entry_identity = Web::HTML::session_history_entry_identity(initial_history_entry),
+    });
+
+    // 7. Let initialHistoryEntry be traversable's active session history entry.
+    // 8. Set initialHistoryEntry's step to 0.
+    // 9. Append initialHistoryEntry to traversable's session history entries.
     set_current_session_history_entry(initial_history_entry);
     set_active_session_history_entry(initial_history_entry);
     m_session_history.initialize_with_initial_history_entry(move(initial_history_entry));
     session_history_changed();
+
+    // 10. If opener is non-null, then legacy-clone a traversable storage shed given opener's top-level traversable and traversable. [STORAGE]
+    if (opener.has_value())
+        clone_session_storage_from(opener->top_level_traversable());
+
+    // 11. Append traversable to the user agent's top-level traversable set.
+    // NB: The views hold the traversables.
+    // FIXME: 12. Invoke WebDriver BiDi navigable created with traversable and openerNavigableForWebDriver.
+    // 13. Return traversable.
 }
 
 Optional<Web::HTML::CrossProcessId> CanonicalTraversable::nested_history_id_for(CanonicalNavigable const& navigable) const

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -12,6 +12,7 @@
 #include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
+#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/StorageJar.h>
 #include <LibWebView/ViewImplementation.h>
@@ -1265,6 +1266,24 @@ void CanonicalTraversable::continue_history_navigation_population(Web::HTML::Cro
                 endpoint = history_job_endpoint_for(*navigable);
                 operation->changing_job_endpoints.set(navigable_id, *endpoint);
             }
+        } else if (site_isolation_mode() == SiteIsolationMode::IFrame) {
+            auto group = active_browsing_context().group();
+            VERIFY(group);
+            auto agent = group->obtain_similar_origin_window_agent(document->origin, false);
+            auto host = SiteIsolationManager::the().obtain_child_document_host(*navigable, *agent);
+            if (host.is_error()) {
+                did_receive_changing_navigable_history_job_ready(*endpoint->client, endpoint->page_id, operation_id, navigable_id, Web::HTML::ChangingNavigableHistoryStepJobDisposition::Skipped, Web::HTML::UnloadDisplayedDocument::No);
+                return;
+            }
+            endpoint = HistoryJobEndpoint { host.value().client, host.value().page_id };
+            operation->changing_job_endpoints.set(navigable_id, *endpoint);
+            SiteIsolationManager::the().set_child_document_host(*navigable, host.value());
+            operation = find_history_operation(operation_id);
+            if (!operation)
+                return;
+            pending_job = operation->pending_changing_jobs.get(navigable_id);
+            if (!pending_job.has_value())
+                return;
         }
     }
     add_history_operation_completion_endpoint(*operation, *endpoint);

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -8,9 +8,9 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/EventLoop.h>
 #include <LibWeb/Crypto/Crypto.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/StorageJar.h>
@@ -61,7 +61,7 @@ void CanonicalTraversable::set_system_visibility_state(Web::HTML::VisibilityStat
     });
 }
 
-CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state, CanonicalNavigable& fallback_parent)
+CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state, NonnullRefPtr<CanonicalBrowsingContext> browsing_context, CanonicalNavigable& fallback_parent)
 {
     Optional<Web::HTML::SessionHistoryEntryIdentity> current_session_history_entry;
     Vector<CanonicalNavigable::PendingSameDocumentSessionHistoryEntry> pending_same_document_session_history_entries;
@@ -75,6 +75,7 @@ CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_cli
     }
 
     auto navigable = make<CanonicalNavigable>(frame_id, parent_frame_id, &reporting_client, page_id);
+    navigable->set_active_browsing_context(move(browsing_context));
     navigable->set_current_session_history_entry_identity(move(current_session_history_entry));
     navigable->append_pending_same_document_session_history_entries(move(pending_same_document_session_history_entries));
     navigable->set_replicated_state(move(replicated_state));
@@ -471,6 +472,7 @@ struct CanonicalTraversable::HistoryOperation {
     u64 sequence_number;
     bool was_initiated_by_browser { false };
     bool owns_navigation_transaction { false };
+    RefPtr<CanonicalBrowsingContext> destination_browsing_context;
     bool check_for_cancelation { false };
     Function<void()> on_browser_traversal_ready;
     Function<void(Web::HTML::HistoryStepResult)> pending_unload_cancelation;
@@ -515,6 +517,8 @@ struct CanonicalTraversable::HistoryOperation {
         Web::HTML::UnloadDisplayedDocument unload_displayed_document { Web::HTML::UnloadDisplayedDocument::No };
 
         bool unload_preparation_pending { false };
+        OwnPtr<NavigationLoader> population_loader;
+        RefPtr<CanonicalBrowsingContext> browsing_context;
     };
     HashMap<Web::HTML::CrossProcessId, NonnullOwnPtr<PendingChangingJob>> pending_changing_jobs;
     HashMap<Web::HTML::CrossProcessId, HistoryJobEndpoint> changing_job_endpoints;
@@ -542,6 +546,23 @@ struct CanonicalTraversable::HistoryOperation {
 };
 
 CanonicalTraversable::~CanonicalTraversable() = default;
+
+CanonicalBrowsingContext& CanonicalTraversable::browsing_context_for_document_creation(WebContentClient const& client, u64 page_id) const
+{
+    // A response can create child contexts before its top-level document commits. They belong to the destination
+    // group, while the traversable's active browsing context still belongs to the displayed document.
+    if (ongoing_navigation().has_value() && ongoing_navigation()->destination_browsing_context
+        && navigation_host_matches(client, page_id))
+        return *ongoing_navigation()->destination_browsing_context;
+    for (auto const& operation : m_history_operations) {
+        auto job = operation.value->pending_changing_jobs.get(id());
+        auto endpoint = operation.value->changing_job_endpoints.get(id());
+        if (job.has_value() && job.value()->browsing_context && endpoint.has_value()
+            && endpoint->client.ptr() == &client && endpoint->page_id == page_id)
+            return *job.value()->browsing_context;
+    }
+    return active_browsing_context();
+}
 
 Optional<size_t> CanonicalTraversable::effective_current_session_history_step_index() const
 {
@@ -1150,21 +1171,6 @@ bool CanonicalTraversable::select_changing_navigable_history_step_job_endpoint(H
     if (!navigable.has_value())
         return false;
 
-    if (navigable->is_top_level_traversable() && job.navigation_type == Web::Bindings::NavigationType::Traverse) {
-        auto view = ViewImplementation::find_view_for_traversable(*this);
-        if (!view.has_value())
-            return false;
-
-        auto source_url = view->top_level_process_site_url().value_or(URL::about_blank());
-        if (SiteIsolationManager::the().navigation_requires_process_swap(source_url, job.target_entry.url)) {
-            // The replaced process leaves this operation: jobs must not be routed to it, and unload work for the
-            // documents it hosted completes immediately instead of waiting on a process that is going away.
-            if (auto displaced_endpoint = history_job_endpoint_for(*navigable); displaced_endpoint.client)
-                operation.unavailable_job_endpoints.append(move(displaced_endpoint));
-            view->replace_web_content_process_for_history_traversal(job.target_entry.document_state.id, job.target_entry.url);
-        }
-    }
-
     auto endpoint = history_job_endpoint_for(*navigable);
     if (!endpoint.client)
         return false;
@@ -1193,6 +1199,81 @@ bool CanonicalTraversable::select_changing_navigable_history_step_job_endpoint(H
     return true;
 }
 
+void CanonicalTraversable::did_finish_history_navigation_params_creation(WebContentClient& source, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation population)
+{
+    auto navigable_id = population.request.navigable_id;
+    auto* operation = find_history_operation(operation_id);
+    auto discard = [&] { NavigationLoader::discard(source.is_private(), population.result); };
+    if (!operation) {
+        discard();
+        return;
+    }
+    auto endpoint = operation->changing_job_endpoints.get(navigable_id);
+    auto job = operation->pending_changing_jobs.get(navigable_id);
+    if (!endpoint.has_value() || endpoint->client.ptr() != &source || endpoint->page_id != source_page_id
+        || !job.has_value() || job.value()->population_loader
+        || !navigation_transaction_matches(*operation, source, source_page_id, navigable_id)) {
+        discard();
+        return;
+    }
+    auto& loader = job.value()->population_loader;
+    loader = NavigationLoader::create(source.is_private(), move(population.request));
+    loader->did_finish_navigation_params_creation(move(population.result));
+    loader->acquire_response_body([weak_this = make_weak_ptr(), operation_id, navigable_id, source = RefPtr { source }, source_page_id](bool succeeded) {
+        if (!weak_this)
+            return;
+        auto& traversable = static_cast<CanonicalTraversable&>(*weak_this);
+        if (!succeeded) {
+            traversable.did_receive_changing_navigable_history_job_ready(*source, source_page_id, operation_id, navigable_id, Web::HTML::ChangingNavigableHistoryStepJobDisposition::Skipped, Web::HTML::UnloadDisplayedDocument::No);
+            return;
+        }
+        traversable.continue_history_navigation_population(operation_id, navigable_id);
+    });
+}
+
+void CanonicalTraversable::continue_history_navigation_population(Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id)
+{
+    auto* operation = find_history_operation(operation_id);
+    auto navigable = find(navigable_id);
+    if (!operation || !navigable.has_value())
+        return;
+    auto pending_job = operation->pending_changing_jobs.get(navigable_id);
+    auto endpoint = operation->changing_job_endpoints.get(navigable_id).map([](auto const& endpoint) { return endpoint; });
+    if (!pending_job.has_value() || !endpoint.has_value() || !pending_job.value()->population_loader)
+        return;
+    auto loader = move(pending_job.value()->population_loader);
+    auto document = loader->response_document();
+    if (document.has_value()) {
+        auto context = navigable->obtain_a_browsing_context_to_use_for_a_navigation_response(document->coop_enforcement_result);
+        auto group_switch = context.ptr() != &navigable->active_browsing_context();
+        pending_job.value()->browsing_context = context;
+        if (navigable->is_top_level_traversable()) {
+            auto swap_process = group_switch || SiteIsolationManager::the().top_level_navigation_requires_process_swap(active_browsing_context(), replicated_state()->active_document_url, document->url);
+            if (swap_process) {
+                auto view = ViewImplementation::find_view_for_traversable(*this);
+                if (!view.has_value())
+                    return;
+                operation->unavailable_job_endpoints.append(*endpoint);
+                operation->changing_job_endpoints.remove(navigable_id);
+                view->replace_web_content_process_for_history_traversal(pending_job.value()->job.target_entry.document_state.id);
+                operation = find_history_operation(operation_id);
+                if (!operation)
+                    return;
+                pending_job = operation->pending_changing_jobs.get(navigable_id);
+                if (!pending_job.has_value())
+                    return;
+                endpoint = history_job_endpoint_for(*navigable);
+                operation->changing_job_endpoints.set(navigable_id, *endpoint);
+            }
+        }
+    }
+    add_history_operation_completion_endpoint(*operation, *endpoint);
+    auto& job = *pending_job.value();
+    endpoint->client->async_continue_history_navigation_population(endpoint->page_id, operation_id, job.job.target_entry, job.job.navigation_type,
+        Web::HTML::HistoryNavigationPopulation { loader->request(), loader->take_result() });
+    job.population_loader = move(loader);
+}
+
 void CanonicalTraversable::dispatch_changing_navigable_history_step_job(HistoryOperation& operation, Web::HTML::CrossProcessId navigable_id)
 {
     auto endpoint = operation.changing_job_endpoints.get(navigable_id);
@@ -1200,6 +1281,10 @@ void CanonicalTraversable::dispatch_changing_navigable_history_step_job(HistoryO
     auto pending_job = operation.pending_changing_jobs.get(navigable_id);
     VERIFY(pending_job.has_value());
 
+    if (pending_job.value()->population_loader)
+        pending_job.value()->population_loader->reclaim_response_body_after_failed_handoff();
+    pending_job.value()->population_loader = nullptr;
+    pending_job.value()->browsing_context = nullptr;
     auto target_entry = pending_job.value()->job.target_entry;
     endpoint->client->async_run_changing_navigable_history_job(
         endpoint->page_id, operation.operation_id, navigable_id,
@@ -1537,6 +1622,9 @@ void CanonicalTraversable::complete_history_jobs_after_crash(HistoryOperation& o
         operation.changing_job_endpoints.remove(navigable_id);
         if (!pending_job.has_value())
             continue;
+
+        if (pending_job.value()->population_loader)
+            pending_job.value()->population_loader->reclaim_response_body_after_failed_handoff();
 
         switch (pending_job.value()->phase) {
         case HistoryOperation::PendingChangingJob::Phase::Dispatched:
@@ -2249,6 +2337,9 @@ void CanonicalTraversable::finalize_a_cross_document_navigation(HistoryOperation
         return;
     }
 
+    if (navigable->ongoing_navigation().has_value() && navigable->ongoing_navigation()->navigation_id == parameters.navigation_id)
+        operation.destination_browsing_context = navigable->ongoing_navigation()->destination_browsing_context;
+
     auto pending_history_entry = parameters.history_entry;
 
     // 4. If all of the following are true:
@@ -2625,6 +2716,9 @@ void CanonicalTraversable::did_receive_changing_navigable_history_job_ready(WebC
         if (!navigation_transaction_matches(*operation, source_client, source_page_id, navigable_id))
             disposition = Web::HTML::ChangingNavigableHistoryStepJobDisposition::Stale;
 
+        if (disposition != Web::HTML::ChangingNavigableHistoryStepJobDisposition::Ready && pending_job.value()->population_loader)
+            pending_job.value()->population_loader->reclaim_response_body_after_failed_handoff();
+
         if (disposition == Web::HTML::ChangingNavigableHistoryStepJobDisposition::Ready)
             pending_job.value()->unload_displayed_document = unload_displayed_document;
 
@@ -2694,13 +2788,14 @@ void CanonicalTraversable::did_receive_changing_navigable_continuation_applied(W
                     [](Web::FinalizeCrossDocumentNavigationHistoryOperationParameters const& parameters) { return parameters.navigation_id; },
                     [](auto const&) { return Optional<Utf16String> {}; });
                 activated_navigable_state->active_session_history_entry_identity = Web::HTML::session_history_entry_identity(pending_job.value()->job.target_entry);
-                auto active_document_url = activated_navigable_state->active_document_url;
-                navigable->did_commit_navigation(activated_navigable_state.release_value(), navigation_id);
+                auto destination_context = pending_job.value()->browsing_context;
+                if (!destination_context && operation->parameters.has<Web::FinalizeCrossDocumentNavigationHistoryOperationParameters>()
+                    && operation->parameters.get<Web::FinalizeCrossDocumentNavigationHistoryOperationParameters>().navigable_id == navigable_id)
+                    destination_context = operation->destination_browsing_context;
+                navigable->did_commit_navigation(activated_navigable_state.release_value(), navigation_id, move(destination_context));
 
                 if (navigable_id == id()) {
                     if (auto view = ViewImplementation::find_view_for_traversable(*this); view.has_value()) {
-                        if (!Web::HTML::url_matches_about_blank(active_document_url) || !view->m_client_state.site_url.has_value())
-                            view->m_client_state.site_url = move(active_document_url);
                         view->m_client_state.hosts_committed_entry = true;
                         view->m_external_url_request_policy.clear_page_request_allowance();
                         if (view->on_top_level_navigation_commit)

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -44,6 +44,7 @@ public:
     virtual ~CanonicalTraversable() override;
 
     virtual bool is_top_level_traversable() const override { return true; }
+    CanonicalBrowsingContext& browsing_context_for_document_creation(WebContentClient const&, u64 page_id) const;
 
     // Apply-the-history-step coordination. Operations serialize on the traversable's session history traversal
     // queue; the algorithm runs here and dispatches its per-navigable jobs to the processes hosting the documents.
@@ -80,13 +81,14 @@ public:
     void did_receive_history_step_unload_cancelation_result(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult, Web::HTML::UnloadPromptShown);
     void did_receive_history_step_beforeunload_check_result(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult, Web::HTML::UnloadPromptShown);
     void did_receive_changing_navigable_history_job_ready(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::ChangingNavigableHistoryStepJobDisposition, Web::HTML::UnloadDisplayedDocument);
+    void did_finish_history_navigation_params_creation(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation);
     void did_receive_changing_navigable_unload_preparation_complete(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id);
     void did_receive_descendant_unload_task_complete(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId unload_id, Web::HTML::CrossProcessId navigable_id);
     void did_receive_child_navigable_unload_request(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId navigable_id);
     void did_receive_changing_navigable_continuation_applied(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Optional<Web::HTML::ReplicatedNavigableState> activated_navigable_state, Optional<Web::HTML::SessionHistoryEntryPersistedState> previous_entry_persisted_state);
     void did_receive_nonchanging_navigable_history_state_updated(WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id);
 
-    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState, CanonicalNavigable& fallback_parent);
+    CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState, NonnullRefPtr<CanonicalBrowsingContext>, CanonicalNavigable& fallback_parent);
     Optional<CanonicalNavigable&> find(Web::HTML::CrossProcessId navigable_id);
     Optional<CanonicalNavigable const&> find(Web::HTML::CrossProcessId navigable_id) const;
     void remove(CanonicalNavigable&);
@@ -137,6 +139,7 @@ private:
     void add_history_operation_completion_endpoint(HistoryOperation&, HistoryJobEndpoint);
     bool select_changing_navigable_history_step_job_endpoint(HistoryOperation&, ApplyHistoryStepJobs::ChangingNavigableHistoryStepJob&);
     void dispatch_changing_navigable_history_step_job(HistoryOperation&, Web::HTML::CrossProcessId navigable_id);
+    void continue_history_navigation_population(Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id);
     void dispatch_changing_navigable_history_step_continuation(HistoryOperation&, Web::HTML::CrossProcessId navigable_id);
     void send_changing_navigable_continuation_task(HistoryOperation&, Web::HTML::CrossProcessId navigable_id, Web::HTML::UnloadDisplayedDocument);
     void deactivate_a_document_for_cross_document_navigation(HistoryOperation&, Web::HTML::CrossProcessId navigable_id);

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -109,7 +109,7 @@ public:
     ByteString pending_same_document_session_history_entries_for_debug() const;
 
     void prepare_for_reload();
-    void did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry);
+    void did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process);
     bool update_session_history_entry_navigation_api_state(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Web::HTML::StorageSerializationRecord navigation_api_state);
     bool update_session_history_entry_scroll_restoration_mode(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
     bool update_session_history_entry_document_state_navigable_target_name(CanonicalNavigable&, Web::HTML::SessionHistoryEntryIdentity const&, Utf16String navigable_target_name);

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -17,6 +17,8 @@ class Application;
 class Autocomplete;
 class AutocompleteService;
 class BookmarkStore;
+class CanonicalBrowsingContext;
+class CanonicalBrowsingContextGroup;
 class CanonicalNavigable;
 class CanonicalTraversable;
 class CompositorClient;

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -20,6 +20,7 @@ class BookmarkStore;
 class CanonicalBrowsingContext;
 class CanonicalBrowsingContextGroup;
 class CanonicalNavigable;
+class CanonicalSimilarOriginWindowAgent;
 class CanonicalTraversable;
 class CompositorClient;
 class CompositorFontServiceConnection;

--- a/Libraries/LibWebView/NavigationLoader.cpp
+++ b/Libraries/LibWebView/NavigationLoader.cpp
@@ -12,6 +12,57 @@
 
 namespace WebView {
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-populate-the-history-entry's-document
+// The document that the task queued by step 5 creates, if it creates one.
+Optional<NavigationLoader::ResponseDocument> NavigationLoader::response_document() const
+{
+    auto const& navigation_params = result().navigation_params;
+
+    // 3. If navigationParams is a non-fetch scheme navigation params:
+    //    1. Set entry's document state's document to the result of running attempt to create a non-fetch scheme
+    //       document given navigationParams.
+    // NB: That hands the URL off to external software, which creates no document.
+    if (navigation_params.has<Web::HTML::NonFetchSchemeNavigationParamsDescriptor>())
+        return {};
+
+    // 4. Otherwise, if any of the following are true:
+    //    - navigationParams is null;
+    //    [...]
+    //    then:
+    //    1. Set entry's document state's document to the result of creating a document for inline content that
+    //       doesn't have a DOM, given navigable, null, navTimingType, and userInvolvement. The inline content
+    //       should indicate to the user the sort of error that occurred.
+    // NB: That document is created with a new opaque origin, a new opener policy enforcement result, and
+    //     about:error as its URL.
+    if (navigation_params.has<Web::HTML::NavigationParamsNullOrError>()) {
+        auto origin = URL::Origin::create_opaque();
+        return ResponseDocument {
+            .coop_enforcement_result = { .url = URL::about_error(), .origin = origin, .opener_policy = {} },
+            .url = URL::about_error(),
+            .origin = origin,
+        };
+    }
+
+    auto const& fetched_navigation_params = navigation_params.get<Web::HTML::NavigationParamsDescriptor>();
+
+    // FIXME: 5. Otherwise, if navigationParams's response has a `Content-Disposition` header specifying the
+    //           attachment disposition type: [...]
+    //        A download creates no document.
+
+    // 6. Otherwise, if navigationParams's response's status is not 204 and is not 205, then set entry's
+    //    document state's document to the result of loading a document given navigationParams,
+    //    sourceSnapshotParams, and entry's document state's initiator origin.
+    if (fetched_navigation_params.response.status == 204 || fetched_navigation_params.response.status == 205)
+        return {};
+    return ResponseDocument {
+        .coop_enforcement_result = fetched_navigation_params.coop_enforcement_result,
+        // The COOP enforcement result still describes the source document until an opener policy is enforced.
+        // Placement uses the response's final URL, including any redirects.
+        .url = fetched_navigation_params.response.url_list.is_empty() ? m_request.history_entry.url : fetched_navigation_params.response.url_list.last(),
+        .origin = fetched_navigation_params.origin,
+    };
+}
+
 static Web::HTML::NavigationResponseBodyHandle* response_body_handle(Web::HTML::NavigationPopulationResult& result)
 {
     if (!result.navigation_params.has<Web::HTML::NavigationParamsDescriptor>())

--- a/Libraries/LibWebView/NavigationLoader.h
+++ b/Libraries/LibWebView/NavigationLoader.h
@@ -28,6 +28,13 @@ public:
 
     ~NavigationLoader();
 
+    struct ResponseDocument {
+        Web::HTML::OpenerPolicyEnforcementResult coop_enforcement_result;
+        URL::URL url;
+        URL::Origin origin;
+    };
+    Optional<ResponseDocument> response_document() const;
+
     void did_finish_navigation_params_creation(Web::HTML::NavigationPopulationResult);
     void acquire_response_body(Function<void(bool)> completion_steps);
     bool response_body_matches(int request_server_client_id, u64 request_server_request_id) const;

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -36,8 +36,9 @@ Process::Process(ProcessType type, RefPtr<IPC::ConnectionBase> connection, Core:
 
 Process::~Process()
 {
-    if (m_connection)
-        m_connection->shutdown();
+    // shutdown() can release the connection's last owner while dispatching die().
+    if (auto connection = m_connection.strong_ref())
+        connection->shutdown();
 }
 
 ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(Core::ProcessSpawnOptions const& options, bool capture_output)

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <AK/Utf16String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/File.h>
@@ -42,7 +43,7 @@ public:
     void set_title(Optional<Utf16String> title) { m_title = move(title); }
 
     template<typename ConnectionFromClient>
-    Optional<ConnectionFromClient&> client()
+    RefPtr<ConnectionFromClient> client()
     {
         if (auto strong_connection = m_connection.strong_ref())
             return as<ConnectionFromClient>(*strong_connection);

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -9,6 +9,7 @@
 #include <AK/StringBuilder.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
@@ -26,23 +27,15 @@ SiteIsolationManager& SiteIsolationManager::the()
 
 bool SiteIsolationManager::top_level_navigation_requires_process_swap(CanonicalBrowsingContext const& browsing_context, URL::URL const& current_url, URL::URL const& target_url) const
 {
+    if (site_isolation_mode() == SiteIsolationMode::Disabled)
+        return false;
+
     // Obtaining a browsing context to use for a navigation response only lets an implementation-defined browsing
     // context group switch happen when the group holds a single browsing context (step 8). Ladybird cannot retain
     // WindowProxy relationships across a process swap either, so related top-level browsing contexts share a process.
     auto group = browsing_context.group();
     VERIFY(group);
     if (group->browsing_context_set().size() > 1)
-        return false;
-
-    return navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::TopLevel);
-}
-
-bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const
-{
-    if (site_isolation_mode() == SiteIsolationMode::Disabled)
-        return false;
-
-    if (target == Web::NavigationTarget::IFrame && site_isolation_mode() != SiteIsolationMode::IFrame)
         return false;
 
     // Allow navigating from about:blank to any site.
@@ -53,36 +46,13 @@ bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& curr
     if (target_url.scheme() == "javascript"sv)
         return false;
 
-    // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(s) navigation.
+    // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(S) navigation.
     auto current_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(current_url.scheme());
     auto target_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme());
-
     if (!current_url_is_http || !target_url_is_http)
         return current_url_is_http || target_url_is_http;
 
-    // Disallow cross-site HTTP(S) navigation.
     return !current_url.origin().is_same_site(target_url.origin());
-}
-
-bool SiteIsolationManager::child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const
-{
-    if (site_isolation_mode() != SiteIsolationMode::IFrame)
-        return false;
-
-    // A remote child can keep its current process when navigating within the same site.
-    if (child_frame.has_remote_host()
-        && !navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::IFrame)) {
-        return false;
-    }
-
-    // Use origin-based same-site checks for HTTP(S). about:blank, srcdoc, and data: need the initiator origin, so fall
-    // back to using a URL decision for now.
-    if (Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme())) {
-        if (auto const* parent_frame = child_frame.parent(); parent_frame && parent_frame->replicated_state().has_value())
-            return !parent_frame->replicated_state()->active_document_origin.is_same_site(target_url.origin());
-    }
-
-    return navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::IFrame);
 }
 
 Optional<SiteIsolationManager::RemoteChildFrameInputTarget> SiteIsolationManager::remote_child_frame_input_target_at(WebContentClient& client, u64 page_id, Web::DevicePixelPoint position) const
@@ -195,6 +165,49 @@ HashMap<pid_t, pid_t> SiteIsolationManager::remote_frame_process_embedders() con
     });
 
     return embedders;
+}
+
+ErrorOr<SiteIsolationManager::DocumentHost> SiteIsolationManager::obtain_child_document_host(CanonicalNavigable& navigable, CanonicalSimilarOriginWindowAgent& agent)
+{
+    auto host = agent.hosting_process();
+    if (host && host.ptr() == navigable.reporting_client_if_any())
+        return DocumentHost { *host, navigable.reporting_page_id() };
+    if (host && navigable.has_remote_host() && host.ptr() == &navigable.remote_host_client())
+        return DocumentHost { *host, navigable.remote_host_page_id() };
+
+    auto& traversable = navigable.top_level_traversable();
+    auto current_step = traversable.session_history().current_step();
+    VERIFY(current_step.has_value());
+    auto const* current_entry = traversable.session_history().get_the_target_history_entry(navigable, *current_step);
+    VERIFY(current_entry);
+
+    u64 page_id;
+    if (host) {
+        page_id = Application::the().allocate_page_id();
+        host->async_create_embedded_page(page_id, navigable.id(), current_entry->document_state.id, traversable.system_visibility_state());
+    } else {
+        auto process = TRY(Application::the().launch_child_frame_web_content_process(navigable.reporting_client().is_private(), navigable.id(), current_entry->document_state.id));
+        host = move(process.client);
+        page_id = process.page_id;
+        agent.set_hosting_process_if_unset(*host);
+    }
+
+    host->register_embedded_page(page_id, navigable);
+    host->async_set_page_parent_context(page_id, Web::Compositor::compositor_context_id_for_page(navigable.reporting_page_id()));
+    if (navigable.viewport_rect().has_value())
+        host->async_set_viewport(page_id, navigable.viewport_rect()->size(), navigable.device_pixel_ratio(), Web::ViewportIsFullscreen::No);
+    host->async_update_visibility_state(page_id, navigable.id(), traversable.system_visibility_state());
+    return DocumentHost { host.release_nonnull(), page_id };
+}
+
+void SiteIsolationManager::set_child_document_host(CanonicalNavigable& navigable, DocumentHost const& host)
+{
+    if (host.client.ptr() == navigable.reporting_client_if_any() && host.page_id == navigable.reporting_page_id()) {
+        if (navigable.has_remote_host())
+            transition_child_frame_to_local(navigable);
+    } else if (!navigable.has_remote_host() || &navigable.remote_host_client() != host.client.ptr() || navigable.remote_host_page_id() != host.page_id) {
+        transition_child_frame_to_remote(navigable.reporting_client(), navigable.reporting_page_id(), navigable.id(), host.client, host.page_id);
+    }
 }
 
 void SiteIsolationManager::transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::CrossProcessId frame_id, NonnullRefPtr<WebContentClient> remote_client, u64 remote_page_id)

--- a/Libraries/LibWebView/SiteIsolationManager.cpp
+++ b/Libraries/LibWebView/SiteIsolationManager.cpp
@@ -9,6 +9,8 @@
 #include <AK/StringBuilder.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/SiteIsolation.h>
 #include <LibWebView/ViewImplementation.h>
@@ -20,6 +22,19 @@ SiteIsolationManager& SiteIsolationManager::the()
 {
     static auto& manager = *new SiteIsolationManager;
     return manager;
+}
+
+bool SiteIsolationManager::top_level_navigation_requires_process_swap(CanonicalBrowsingContext const& browsing_context, URL::URL const& current_url, URL::URL const& target_url) const
+{
+    // Obtaining a browsing context to use for a navigation response only lets an implementation-defined browsing
+    // context group switch happen when the group holds a single browsing context (step 8). Ladybird cannot retain
+    // WindowProxy relationships across a process swap either, so related top-level browsing contexts share a process.
+    auto group = browsing_context.group();
+    VERIFY(group);
+    if (group->browsing_context_set().size() > 1)
+        return false;
+
+    return navigation_requires_process_swap(current_url, target_url, Web::NavigationTarget::TopLevel);
 }
 
 bool SiteIsolationManager::navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget target) const

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -29,6 +29,7 @@ public:
         Web::DevicePixelRect viewport_rect;
     };
 
+    [[nodiscard]] bool top_level_navigation_requires_process_swap(CanonicalBrowsingContext const&, URL::URL const& current_url, URL::URL const& target_url) const;
     [[nodiscard]] bool navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel) const;
     [[nodiscard]] bool child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const;
 

--- a/Libraries/LibWebView/SiteIsolationManager.h
+++ b/Libraries/LibWebView/SiteIsolationManager.h
@@ -12,7 +12,6 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
-#include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/CanonicalNavigable.h>
 #include <LibWebView/Forward.h>
@@ -30,8 +29,13 @@ public:
     };
 
     [[nodiscard]] bool top_level_navigation_requires_process_swap(CanonicalBrowsingContext const&, URL::URL const& current_url, URL::URL const& target_url) const;
-    [[nodiscard]] bool navigation_requires_process_swap(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget = Web::NavigationTarget::TopLevel) const;
-    [[nodiscard]] bool child_frame_navigation_requires_process_swap(CanonicalNavigable const& child_frame, URL::URL const& current_url, URL::URL const& target_url) const;
+
+    struct DocumentHost {
+        NonnullRefPtr<WebContentClient> client;
+        u64 page_id;
+    };
+    ErrorOr<DocumentHost> obtain_child_document_host(CanonicalNavigable&, CanonicalSimilarOriginWindowAgent&);
+    void set_child_document_host(CanonicalNavigable&, DocumentHost const&);
 
     void transition_child_frame_to_remote(WebContentClient& parent_client, u64 page_id, Web::HTML::CrossProcessId frame_id, NonnullRefPtr<WebContentClient>, u64 remote_page_id);
     void transition_child_frame_to_local(CanonicalNavigable&);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -251,7 +251,6 @@ bool ViewImplementation::create_new_process_for_cross_site_navigation(Utf16Strin
     if (auto const* current_entry = m_top_level_traversable.session_history().current_entry())
         initial_document_state_id = current_entry->document_state.id;
     initialize_client(CreateNewClient::Yes, initial_document_state_id);
-    m_client_state.site_url = url;
     VERIFY(m_client_state.client);
 
     if (on_web_content_process_change_for_cross_site_navigation)
@@ -291,7 +290,7 @@ bool ViewImplementation::create_new_process_for_cross_site_navigation(Utf16Strin
     return true;
 }
 
-void ViewImplementation::replace_web_content_process_for_history_traversal(Web::HTML::CrossProcessId target_document_state_id, URL::URL const& target_url)
+void ViewImplementation::replace_web_content_process_for_history_traversal(Web::HTML::CrossProcessId target_document_state_id)
 {
     auto pending_webdriver_command_ids = move(m_pending_webdriver_command_ids);
     auto pending_webdriver_crash_command_ids = move(m_pending_webdriver_crash_command_ids);
@@ -310,7 +309,6 @@ void ViewImplementation::replace_web_content_process_for_history_traversal(Web::
     // NB: Preserve the in-flight traversal operations so crash recovery can redispatch them to the
     //     replacement process.
     initialize_client(CreateNewClient::Yes, target_document_state_id);
-    m_client_state.site_url = target_url;
     VERIFY(m_client_state.client);
 
     if (on_web_content_process_change_for_cross_site_navigation)
@@ -3065,19 +3063,13 @@ void ViewImplementation::respawn_web_content_process_after_crash()
 {
     // NB: In-flight operations are preserved: crash recovery redispatches them onto the replacement process.
     Optional<Web::HTML::CrossProcessId> initial_document_state_id;
-    Optional<URL::URL> process_site_url;
-    if (auto const* target_entry = m_top_level_traversable.ongoing_browser_history_traversal_target_entry()) {
+    if (auto const* target_entry = m_top_level_traversable.ongoing_browser_history_traversal_target_entry())
         initial_document_state_id = target_entry->document_state.id;
-        process_site_url = target_entry->url;
-    }
     if (!initial_document_state_id.has_value()) {
-        if (auto const* current_entry = m_top_level_traversable.session_history().current_entry()) {
+        if (auto const* current_entry = m_top_level_traversable.session_history().current_entry())
             initial_document_state_id = current_entry->document_state.id;
-            process_site_url = current_entry->url;
-        }
     }
     initialize_client(CreateNewClient::Yes, initial_document_state_id);
-    m_client_state.site_url = move(process_site_url);
     VERIFY(m_client_state.client);
 
     // Don't keep a stale backup bitmap around.

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2011,9 +2011,9 @@ void ViewImplementation::did_change_screen_wake_lock_state(Badge<WebContentClien
         on_screen_wake_lock_state_changed(m_screen_wake_lock_state);
 }
 
-void ViewImplementation::did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+void ViewImplementation::did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process)
 {
-    m_top_level_traversable.did_create_top_level_traversable(move(initial_history_entry));
+    m_top_level_traversable.did_create_top_level_traversable(move(initial_history_entry), opener, process);
     update_navigation_action_state();
     dump_session_history("created-top-level-traversable"sv);
 }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -104,10 +104,9 @@ public:
     Optional<String> const& favicon_hash() const { return m_favicon_hash; }
 
     String const& handle() const { return m_client_state.client_handle; }
-    Optional<URL::URL> const& top_level_process_site_url() const { return m_client_state.site_url; }
 
     bool create_new_process_for_cross_site_navigation(Utf16String const& navigation_id);
-    void replace_web_content_process_for_history_traversal(Web::HTML::CrossProcessId target_document_state_id, URL::URL const& target_url);
+    void replace_web_content_process_for_history_traversal(Web::HTML::CrossProcessId target_document_state_id);
 
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size, Gfx::IntRect damage_rect);
 
@@ -619,7 +618,6 @@ protected:
         String client_handle;
         SharedBitmap front_bitmap;
         Vector<SharedBitmap> other_bitmaps;
-        Optional<URL::URL> site_url;
         u64 page_index { 0 };
         bool has_usable_bitmap { false };
         // Whether this process hosts the document of the canonical current session history entry. A

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -329,7 +329,7 @@ public:
     void did_change_screen_wake_lock_state(Badge<WebContentClient>, Web::ScreenWakeLockState);
     Web::ScreenWakeLockState screen_wake_lock_state() const { return m_screen_wake_lock_state; }
 
-    void did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry);
+    void did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<CanonicalNavigable&> opener, WebContentClient& process);
     void request_history_operation(Badge<WebContentClient>, WebContentClient&, u64 requesting_page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationParameters);
     void did_receive_history_operation_ready(Badge<WebContentClient>, WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HistoryOperationReadyResult);
     void did_receive_history_step_unload_cancelation_result(Badge<WebContentClient>, WebContentClient&, u64 source_page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryStepResult, Web::HTML::UnloadPromptShown);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -928,41 +928,27 @@ bool WebContentClient::continue_navigation_population_in_selected_process(u64 pa
         return view->create_new_process_for_cross_site_navigation(navigation_id);
     }
 
-    auto const& current_url = *ongoing_navigation->current_url;
-    auto const& target_url = *ongoing_navigation->url;
-    if (!SiteIsolationManager::the().child_frame_navigation_requires_process_swap(*navigable, current_url, target_url))
+    // A child navigable's document is created in the process hosting the agent cluster of the document's origin
+    // within the browsing context group. Without iframe isolation, every agent cluster of a child's document is
+    // hosted by its container document's process.
+    auto browsing_context_group = navigable->top_level_traversable().active_browsing_context().group();
+    VERIFY(browsing_context_group);
+    if (site_isolation_mode() != SiteIsolationMode::IFrame)
         return populate_in(*this, page_id);
 
-    auto current_step = navigable->top_level_traversable().session_history().current_step();
-    VERIFY(current_step.has_value());
-    auto const* current_entry = navigable->top_level_traversable().session_history().get_the_target_history_entry(*navigable, *current_step);
-    VERIFY(current_entry);
+    // FIXME: Pass the document's requestsOAC value once Origin-Agent-Cluster is implemented.
+    auto agent = browsing_context_group->obtain_similar_origin_window_agent(document->origin, false);
 
-    auto remote_process_or_error = Application::the().launch_child_frame_web_content_process(m_is_private, navigable_id, current_entry->document_state.id);
-    if (remote_process_or_error.is_error()) {
-        warnln("Unable to create WebContent process for child frame navigation: {}", remote_process_or_error.error());
+    auto host_or_error = SiteIsolationManager::the().obtain_child_document_host(*navigable, *agent);
+    if (host_or_error.is_error()) {
+        warnln("Unable to create WebContent page for child frame navigation: {}", host_or_error.error());
         navigable->clear_ongoing_navigation();
         return false;
     }
-
-    auto remote_process = remote_process_or_error.release_value();
-    auto remote_page_id = remote_process.page_id;
-    auto remote_client = move(remote_process.client);
-    navigable->set_navigation_host(*remote_client, remote_page_id);
-    remote_client->register_embedded_page(remote_page_id, *navigable);
-    remote_client->async_set_page_parent_context(remote_page_id, Web::Compositor::compositor_context_id_for_page(navigable->reporting_page_id()));
-    if (navigable->viewport_rect().has_value()) {
-        remote_client->async_set_viewport(
-            remote_page_id,
-            navigable->viewport_rect()->size(),
-            navigable->device_pixel_ratio(),
-            Web::ViewportIsFullscreen::No);
-    }
-    remote_client->async_update_visibility_state(remote_page_id, navigable->id(), navigable->top_level_traversable().system_visibility_state());
-    remote_client->async_populate_navigation(remote_page_id, loader.request(), loader.take_result());
-
-    SiteIsolationManager::the().transition_child_frame_to_remote(navigable->reporting_client(), navigable->reporting_page_id(), navigable_id, move(remote_client), remote_page_id);
-    return true;
+    auto host = host_or_error.release_value();
+    navigable->set_navigation_host(*host.client, host.page_id);
+    SiteIsolationManager::the().set_child_document_host(*navigable, host);
+    return populate_in(*host.client, host.page_id);
 }
 
 void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -602,7 +602,7 @@ void WebContentClient::cancel_navigation_transactions()
     });
 }
 
-void WebContentClient::did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request)
+void WebContentClient::did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request)
 {
     auto* target_navigable = navigable_for_page(page_id);
     if (target == Web::NavigationTarget::IFrame) {
@@ -638,8 +638,6 @@ void WebContentClient::did_request_navigation_start(u64 page_id, Web::HTML::Cros
     if (!start_request.has_value()) {
         target_navigable->set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
             .url = url,
-            .current_url = move(current_url),
-            .target = target,
             .navigation_id = navigation_id,
             .sequence_number = sequence_number,
         });
@@ -653,8 +651,6 @@ void WebContentClient::did_request_navigation_start(u64 page_id, Web::HTML::Cros
 
     target_navigable->set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
         .url = move(url),
-        .current_url = move(current_url),
-        .target = target,
         .navigation_id = navigation_id,
         .start_request = move(start_request),
         .sequence_number = sequence_number,
@@ -695,7 +691,7 @@ void WebContentClient::did_complete_navigation_unload_check(u64 page_id, Web::HT
     }
 }
 
-void WebContentClient::did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request)
+void WebContentClient::did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request)
 {
     auto const& target_url = request.history_entry.url;
 
@@ -735,15 +731,11 @@ void WebContentClient::did_request_navigation_population(u64 page_id, Web::HTML:
     if (continues_reconstructed_child_navigation) {
         auto& ongoing_navigation = *target_navigable->ongoing_navigation();
         ongoing_navigation.url = target_url;
-        ongoing_navigation.current_url = move(current_url);
-        ongoing_navigation.target = target;
         ongoing_navigation.phase = CanonicalNavigable::OngoingNavigation::Phase::Populating;
         ongoing_navigation.loader = NavigationLoader::create(m_is_private, move(request));
     } else {
         target_navigable->set_ongoing_navigation(CanonicalNavigable::OngoingNavigation {
             .url = target_url,
-            .current_url = move(current_url),
-            .target = target,
             .navigation_id = request.navigation_id,
             .sequence_number = target_navigable->top_level_traversable().next_sequence_number(),
             .phase = CanonicalNavigable::OngoingNavigation::Phase::Populating,
@@ -795,9 +787,7 @@ void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::H
     }
 
     auto& ongoing_navigation = navigable->ongoing_navigation();
-    if (!ongoing_navigation.has_value()
-        || !ongoing_navigation->loader
-        || !ongoing_navigation->current_url.has_value()) {
+    if (!ongoing_navigation.has_value() || !ongoing_navigation->loader) {
         NavigationLoader::discard(m_is_private, *result);
         end_recorded_load_for_canceled_navigation();
         navigable->clear_ongoing_navigation();

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -21,6 +21,8 @@
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/WebDriver/Error.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/FontService.h>
@@ -28,6 +30,7 @@
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/NavigationLoader.h>
+#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/SiteIsolationManager.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/ViewImplementation.h>
@@ -831,6 +834,16 @@ void WebContentClient::did_finish_navigation_params_creation(u64 page_id, Web::H
     });
 }
 
+void WebContentClient::did_finish_history_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation population)
+{
+    auto* host = navigable_for_page(page_id);
+    if (!host) {
+        NavigationLoader::discard(m_is_private, population.result);
+        return;
+    }
+    host->top_level_traversable().did_finish_history_navigation_params_creation(*this, page_id, operation_id, move(population));
+}
+
 void WebContentClient::did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id)
 {
     auto navigable = population_worker_navigable_for_page(page_id, navigable_id);
@@ -862,7 +875,8 @@ void WebContentClient::did_fail_navigation_population(u64 page_id, Web::HTML::Cr
 
 bool WebContentClient::continue_navigation_population_in_selected_process(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id)
 {
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    // The population steps up to the response ran in the population worker, which delivered the result here.
+    auto navigable = population_worker_navigable_for_page(page_id, navigable_id);
     if (!navigable.has_value())
         return false;
 
@@ -874,43 +888,50 @@ bool WebContentClient::continue_navigation_population_in_selected_process(u64 pa
         return false;
     }
 
-    auto const& result = ongoing_navigation->loader->result();
-    auto const& current_url = *ongoing_navigation->current_url;
-    auto const& target_url = *ongoing_navigation->url;
-
-    // Step 6 of https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-response
-    // A 204 or 205 response does not load a document, so keep the active document's process as the host.
-    auto creates_a_document = true;
-    if (result.navigation_params.has<Web::HTML::NavigationParamsDescriptor>()) {
-        auto status = result.navigation_params.get<Web::HTML::NavigationParamsDescriptor>().response.status;
-        creates_a_document = status != 204 && status != 205;
-    }
-
-    auto requires_process_swap = false;
-    if (creates_a_document) {
-        if (navigable->is_top_level_traversable()) {
-            requires_process_swap = SiteIsolationManager::the().navigation_requires_process_swap(current_url, target_url, ongoing_navigation->target.value_or(Web::NavigationTarget::TopLevel));
-        } else {
-            requires_process_swap = SiteIsolationManager::the().child_frame_navigation_requires_process_swap(*navigable, current_url, target_url);
-        }
-    }
-
+    auto& loader = *ongoing_navigation->loader;
     ongoing_navigation->phase = CanonicalNavigable::OngoingNavigation::Phase::Populating;
 
-    if (!requires_process_swap) {
-        navigable->set_navigation_host(*this, page_id);
-        async_populate_navigation(page_id, ongoing_navigation->loader->request(), ongoing_navigation->loader->take_result());
+    auto populate_in = [&](WebContentClient& host, u64 host_page_id) {
+        navigable->set_navigation_host(host, host_page_id);
+        host.async_populate_navigation(host_page_id, loader.request(), loader.take_result());
         return true;
-    }
+    };
+
+    // The task queued by step 5 of attempting to populate the history entry's document runs in the process hosting
+    // the browsing context that the document it creates belongs to. A response that creates no document is finished
+    // by the process that fetched it.
+    auto document = loader.response_document();
+    if (!document.has_value())
+        return populate_in(*this, page_id);
+
+    // https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object
+    // 1. Let browsingContext be the result of obtaining a browsing context to use for a navigation response given navigationParams.
+    auto browsing_context = navigable->obtain_a_browsing_context_to_use_for_a_navigation_response(document->coop_enforcement_result);
+    auto browsing_context_group_switch = browsing_context.ptr() != &navigable->active_browsing_context();
 
     if (navigable->is_top_level_traversable()) {
-        if (auto view = view_for_page_id(page_id); view.has_value()) {
-            return view->create_new_process_for_cross_site_navigation(navigation_id);
-        } else {
+        auto& traversable = navigable->top_level_traversable();
+        auto site_isolation_process_swap = SiteIsolationManager::the().top_level_navigation_requires_process_swap(
+            traversable.active_browsing_context(),
+            traversable.replicated_state()->active_document_url,
+            document->url);
+        if (!browsing_context_group_switch && !site_isolation_process_swap)
+            return populate_in(*this, page_id);
+
+        auto view = view_for_page_id(page_id);
+        if (!view.has_value()) {
             navigable->clear_ongoing_navigation();
             return false;
         }
+        if (browsing_context_group_switch)
+            ongoing_navigation->destination_browsing_context = move(browsing_context);
+        return view->create_new_process_for_cross_site_navigation(navigation_id);
     }
+
+    auto const& current_url = *ongoing_navigation->current_url;
+    auto const& target_url = *ongoing_navigation->url;
+    if (!SiteIsolationManager::the().child_frame_navigation_requires_process_swap(*navigable, current_url, target_url))
+        return populate_in(*this, page_id);
 
     auto current_step = navigable->top_level_traversable().session_history().current_step();
     VERIFY(current_step.has_value());
@@ -938,7 +959,7 @@ bool WebContentClient::continue_navigation_population_in_selected_process(u64 pa
             Web::ViewportIsFullscreen::No);
     }
     remote_client->async_update_visibility_state(remote_page_id, navigable->id(), navigable->top_level_traversable().system_visibility_state());
-    remote_client->async_populate_navigation(remote_page_id, ongoing_navigation->loader->request(), ongoing_navigation->loader->take_result());
+    remote_client->async_populate_navigation(remote_page_id, loader.request(), loader.take_result());
 
     SiteIsolationManager::the().transition_child_frame_to_remote(navigable->reporting_client(), navigable->reporting_page_id(), navigable_id, move(remote_client), remote_page_id);
     return true;
@@ -949,8 +970,27 @@ void WebContentClient::did_create_child_frame(u64 page_id, Web::HTML::CrossProce
     auto* host = navigable_for_page(page_id);
     if (!host)
         return;
+    auto& traversable = host->top_level_traversable();
 
-    host->top_level_traversable().insert(*this, page_id, move(parent_frame_id), move(frame_id), move(replicated_state), *host);
+    // A process materializing a frame that exists re-hosts its document. The canonical navigable's browsing context
+    // stays as it is.
+    if (auto existing_navigable = traversable.find(frame_id); existing_navigable.has_value()) {
+        traversable.insert(*this, page_id, move(parent_frame_id), move(frame_id), move(replicated_state), existing_navigable->active_browsing_context(), *host);
+        return;
+    }
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#create-a-new-child-navigable
+    // 2. Let group be element's node document's browsing context's top-level browsing context's group.
+    auto group = traversable.browsing_context_for_document_creation(*this, page_id).group();
+    VERIFY(group);
+
+    // 3. Let browsingContext and document be the result of creating a new browsing context and document given element's node document, element, and group.
+    auto browsing_context = CanonicalBrowsingContext::create_a_new_browsing_context_and_document(*group, replicated_state.active_document_origin, *this);
+
+    // 6. Let documentState be a new document state, with [...]
+    // 7. Let navigable be a new navigable.
+    // 8. Initialize the navigable navigable given documentState and parentNavigable.
+    traversable.insert(*this, page_id, move(parent_frame_id), move(frame_id), move(replicated_state), move(browsing_context), *host);
 }
 
 void WebContentClient::did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -214,7 +214,7 @@ void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
     m_views.set(m_initial_page_id, view);
 
     if (m_initial_top_level_history_entry_awaiting_view.has_value())
-        view.did_create_top_level_traversable({}, m_initial_top_level_history_entry_awaiting_view.release_value());
+        view.did_create_top_level_traversable({}, m_initial_top_level_history_entry_awaiting_view.release_value(), {}, *this);
 }
 
 void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 compositor_connection_id)
@@ -330,6 +330,19 @@ CanonicalNavigable* WebContentClient::navigable_for_page(u64 page_id)
         return &view->traversable();
 
     return nullptr;
+}
+
+Optional<CanonicalNavigable&> WebContentClient::hosted_navigable(Web::HTML::CrossProcessId navigable_id)
+{
+    for (auto const& view : m_views) {
+        if (auto navigable = hosted_navigable_for_page(view.key, navigable_id); navigable.has_value())
+            return navigable;
+    }
+    for (auto const& embedded_page : m_embedded_pages) {
+        if (auto navigable = hosted_navigable_for_page(embedded_page.key, navigable_id); navigable.has_value())
+            return navigable;
+    }
+    return {};
 }
 
 Optional<CanonicalNavigable&> WebContentClient::hosted_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id)
@@ -1967,7 +1980,7 @@ void WebContentClient::did_post_broadcast_channel_message(u64, Web::HTML::Broadc
     WorkerProcessManager::the().broadcast_channel_message_from_web_content(message, m_is_private);
 }
 
-Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, bool clone_session_storage)
+Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)
 {
     auto new_page_id = Application::the().allocate_page_id();
     String handle;
@@ -1980,11 +1993,6 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
     auto view = view_for_page_id(new_page_id);
     if (!view.has_value())
         return { {}, {}, Web::HTML::VisibilityState::Hidden, move(handle) };
-
-    // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-top-level-traversable
-    // 10. If opener is non-null, then legacy-clone a traversable storage shed given opener's top-level traversable and traversable. [STORAGE]
-    if (clone_session_storage && opener_view.has_value())
-        view->traversable().clone_session_storage_from(opener_view->traversable());
 
     auto root_navigable_id = Application::the().allocate_ui_process_cross_process_id();
     view->traversable().set_id(root_navigable_id);
@@ -2240,7 +2248,7 @@ void WebContentClient::did_change_screen_wake_lock_state(u64 page_id, Web::Scree
         view->did_change_screen_wake_lock_state({}, wake_lock_state);
 }
 
-void WebContentClient::did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+void WebContentClient::did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id)
 {
     if (page_id == m_initial_page_id && navigable_id == m_root_navigable_id) {
         if (m_did_create_initial_top_level_traversable)
@@ -2260,7 +2268,11 @@ void WebContentClient::did_create_top_level_traversable(u64 page_id, Web::HTML::
     auto view = ViewImplementation::find_view_for_traversable(navigable->top_level_traversable());
     if (!view.has_value())
         return;
-    view->did_create_top_level_traversable({}, move(initial_history_entry));
+
+    Optional<CanonicalNavigable&> opener;
+    if (opener_navigable_id.has_value())
+        opener = hosted_navigable(*opener_navigable_id);
+    view->did_create_top_level_traversable({}, move(initial_history_entry), opener, *this);
 }
 
 void WebContentClient::did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -103,6 +103,7 @@ public:
     // False once the page can no longer host work: the page is unregistered or the process is gone. A page
     // awaiting a detached close remains open; it still coordinates its own close.
     bool is_page_open(u64 page_id) const;
+    Optional<CanonicalNavigable&> hosted_navigable(Web::HTML::CrossProcessId navigable_id);
     Optional<CanonicalNavigable&> hosted_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id);
     Optional<CanonicalNavigable&> population_worker_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id);
 
@@ -246,7 +247,7 @@ private:
     virtual void did_change_storage_item(u64 page_id, Web::StorageAPI::StorageEndpointType storage_endpoint, String url, Optional<Utf16String> key, Optional<Utf16String> old_value, Optional<Utf16String> new_value) override;
     virtual void did_update_indexed_database(u64 page_id, String update) override;
     virtual void did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) override;
-    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints, bool clone_session_storage) override;
+    virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;
     virtual void did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) override;
@@ -283,7 +284,7 @@ private:
     virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState) override;
-    virtual void did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry) override;
+    virtual void did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) override;
     virtual void did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state) override;
     virtual void did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual void did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -152,6 +152,7 @@ private:
     virtual void did_complete_navigation_unload_check(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) override;
     virtual void did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest) override;
     virtual void did_finish_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id, Optional<Web::HTML::NavigationPopulationResult>) override;
+    virtual void did_finish_history_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation) override;
     virtual void did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) override;
     virtual void did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -148,9 +148,9 @@ private:
 
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
-    virtual void did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request) override;
+    virtual void did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request) override;
     virtual void did_complete_navigation_unload_check(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) override;
-    virtual void did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest) override;
+    virtual void did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest) override;
     virtual void did_finish_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id, Optional<Web::HTML::NavigationPopulationResult>) override;
     virtual void did_finish_history_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation) override;
     virtual void did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -490,6 +490,25 @@ void ConnectionFromClient::queue_navigation_api_state_clear_task(u64 page_id, We
         page->page().top_level_traversable()->queue_navigation_api_state_clear_task(navigable_id);
 }
 
+void ConnectionFromClient::continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType> navigation_type, Web::HTML::HistoryNavigationPopulation population)
+{
+    auto page = this->page(page_id);
+    auto navigable_id = population.request.navigable_id;
+    if (!page.has_value()) {
+        async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, Web::HTML::ChangingNavigableHistoryStepJobDisposition::Skipped, Web::HTML::UnloadDisplayedDocument::No);
+        return;
+    }
+    auto traversable = page->page().top_level_traversable();
+    if (traversable->resume_history_navigation_population(operation_id, move(population)))
+        return;
+    auto user_involvement = population.request.user_involvement;
+    traversable->run_ui_changing_navigable_history_job(operation_id, navigable_id, move(target_entry), user_involvement, navigation_type, false,
+        GC::create_function(Web::HTML::main_thread_event_loop().heap(), [this, page_id, operation_id, navigable_id](Web::HTML::ChangingNavigableHistoryStepJobDisposition disposition, Web::HTML::UnloadDisplayedDocument unload_displayed_document) {
+            async_changing_navigable_history_job_ready(page_id, operation_id, navigable_id, disposition, unload_displayed_document);
+        }),
+        move(population));
+}
+
 void ConnectionFromClient::run_changing_navigable_history_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Web::HTML::UserNavigationInvolvement user_involvement, Optional<Web::Bindings::NavigationType> navigation_type, bool superseded_by_newer_navigation)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -199,6 +199,12 @@ void ConnectionFromClient::initialize(u64 initial_page_id, Web::HTML::CrossProce
     m_page_host->initialize(initial_page_id, root_navigable_id, cross_process_id_allocator, initial_document_state_id, system_visibility_state);
 }
 
+void ConnectionFromClient::create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state)
+{
+    auto& page = m_page_host->create_page(page_id, root_navigable_id);
+    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
+}
+
 void ConnectionFromClient::set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -85,6 +85,7 @@ private:
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
+    virtual void continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType>, Web::HTML::HistoryNavigationPopulation) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String handle) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -85,6 +85,7 @@ private:
     virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void set_font_catalog(IPC::File, u64 size, u64 generation) override;
     virtual void initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
+    virtual void create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) override;
     virtual void continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType>, Web::HTML::HistoryNavigationPopulation) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -238,14 +238,14 @@ Web::HTML::CrossProcessId PageClient::allocate_navigable_id()
     return allocate_cross_process_id();
 }
 
-void PageClient::request_navigation_start(Web::HTML::LocalNavigable& navigable, URL::URL const& current_url, Web::NavigationTarget target, URL::URL const& url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request)
+void PageClient::request_navigation_start(Web::HTML::LocalNavigable& navigable, Web::NavigationTarget target, URL::URL const& url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request)
 {
-    client().async_did_request_navigation_start(m_id, navigable.id(), current_url, target, url, move(navigation_id), move(start_request));
+    client().async_did_request_navigation_start(m_id, navigable.id(), target, url, move(navigation_id), move(start_request));
 }
 
-void PageClient::request_navigation_population(Web::HTML::LocalNavigable& navigable, URL::URL const& current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request)
+void PageClient::request_navigation_population(Web::HTML::LocalNavigable& navigable, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request)
 {
-    client().async_did_request_navigation_population(m_id, navigable.id(), current_url, target, move(request));
+    client().async_did_request_navigation_population(m_id, navigable.id(), target, move(request));
 }
 
 void PageClient::navigation_params_creation_finished(Web::HTML::LocalNavigable& navigable, Web::HTML::NavigationPopulationRequest request, Web::HTML::NavigationPopulationResult result)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1359,16 +1359,13 @@ void PageClient::page_did_update_resource_count(i32 count_waiting)
     client().async_did_update_resource_count(m_id, count_waiting);
 }
 
-PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Web::HTML::TokenizedFeature::NoOpener no_opener)
+PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints)
 {
-    if (no_opener == Web::HTML::TokenizedFeature::NoOpener::Yes) {
-        // FIXME: Create an abstraction to let this WebContent process know about a new process we create?
-        // FIXME: For now, just create a new page in the same process anyway
-        // FIXME: Proper agent-cluster separation must also cover same-process
-        // COOP/noopener popups before they receive distinct main-world cells.
-    }
-
-    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints, no_opener == Web::HTML::TokenizedFeature::NoOpener::No);
+    // FIXME: Create an abstraction to let this WebContent process know about a new process we create?
+    // FIXME: For now, just create a new page in the same process anyway
+    // FIXME: Proper agent-cluster separation must also cover same-process
+    // COOP/noopener popups before they receive distinct main-world cells.
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints);
     if (!response) {
         dbgln("WebContent client disconnected during DidRequestNewWebView. Exiting peacefully.");
         Core::Process::terminate_immediately(0);
@@ -1399,9 +1396,9 @@ void PageClient::page_did_close_top_level_traversable()
     m_owner.remove_page({}, m_id);
 }
 
-void PageClient::page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry)
+void PageClient::page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id)
 {
-    client().async_did_create_top_level_traversable(m_id, navigable_id, initial_history_entry);
+    client().async_did_create_top_level_traversable(m_id, navigable_id, initial_history_entry, opener_navigable_id);
 }
 
 void PageClient::page_did_change_needs_beforeunload_check(bool needs_beforeunload_check)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -253,6 +253,11 @@ void PageClient::navigation_params_creation_finished(Web::HTML::LocalNavigable& 
     client().async_did_finish_navigation_params_creation(m_id, navigable.id(), request.navigation_id, move(result));
 }
 
+void PageClient::history_navigation_params_creation_finished(Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation population)
+{
+    client().async_did_finish_history_navigation_params_creation(m_id, operation_id, move(population));
+}
+
 void PageClient::navigation_population_failed(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_id)
 {
     client().async_did_fail_navigation_population(m_id, navigable_id, navigation_id);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -176,6 +176,7 @@ private:
     virtual void request_navigation_start(Web::HTML::LocalNavigable&, URL::URL const& current_url, Web::NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest>) override;
     virtual void request_navigation_population(Web::HTML::LocalNavigable&, URL::URL const& current_url, Web::NavigationTarget, Web::HTML::NavigationPopulationRequest) override;
     virtual void navigation_params_creation_finished(Web::HTML::LocalNavigable&, Web::HTML::NavigationPopulationRequest, Web::HTML::NavigationPopulationResult) override;
+    virtual void history_navigation_params_creation_finished(Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation) override;
     virtual void navigation_population_failed(Web::HTML::CrossProcessId, Utf16String const&) override;
     virtual void page_did_create_child_frame(Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_update_child_frame_viewport(Web::HTML::CrossProcessId frame_id, Web::CSSPixelRect) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -264,10 +264,10 @@ private:
     virtual void page_did_broadcast_storage_change(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& url, Optional<Utf16String> const& key, Optional<Utf16String> const& old_value, Optional<Utf16String> const& new_value) override;
     virtual void page_did_update_indexed_database(String const& url, Web::IndexedDB::TransactionChanges const&) override;
     virtual void page_did_update_resource_count(i32) override;
-    virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
+    virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints) override;
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
-    virtual void page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry) override;
+    virtual void page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) override;
     virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
     virtual void page_did_update_session_history_entry_navigation_api_state(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Web::HTML::StorageSerializationRecord const& navigation_api_state) override;
     virtual void page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity const& entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -173,8 +173,8 @@ private:
 
     // ^PageClient
     virtual bool is_connection_open() const override;
-    virtual void request_navigation_start(Web::HTML::LocalNavigable&, URL::URL const& current_url, Web::NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest>) override;
-    virtual void request_navigation_population(Web::HTML::LocalNavigable&, URL::URL const& current_url, Web::NavigationTarget, Web::HTML::NavigationPopulationRequest) override;
+    virtual void request_navigation_start(Web::HTML::LocalNavigable&, Web::NavigationTarget, URL::URL const& url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest>) override;
+    virtual void request_navigation_population(Web::HTML::LocalNavigable&, Web::NavigationTarget, Web::HTML::NavigationPopulationRequest) override;
     virtual void navigation_params_creation_finished(Web::HTML::LocalNavigable&, Web::HTML::NavigationPopulationRequest, Web::HTML::NavigationPopulationResult) override;
     virtual void history_navigation_params_creation_finished(Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation) override;
     virtual void navigation_population_failed(Web::HTML::CrossProcessId, Utf16String const&) override;

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -27,10 +27,7 @@ void PageHost::initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_na
     VERIFY(m_pages.is_empty());
     m_cross_process_id_allocator = cross_process_id_allocator;
     auto& first_page = create_page(initial_page_id, root_navigable_id);
-    auto traversable = Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
-    auto initial_history_entry = traversable->active_session_history_entry();
-    VERIFY(initial_history_entry);
-    first_page.page().client().page_did_create_top_level_traversable(traversable->id(), Web::HTML::create_session_history_entry_descriptor(*initial_history_entry));
+    Web::HTML::LocalTraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank(), Empty {}, initial_document_state_id, system_visibility_state);
 }
 
 PageClient& PageHost::create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id)

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -67,9 +67,9 @@ endpoint WebContentClient
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
-    did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request) =|
+    did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request) =|
     did_complete_navigation_unload_check(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) =|
-    did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request) =|
+    did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request) =|
     did_finish_history_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation population) =|
     did_finish_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id, Optional<Web::HTML::NavigationPopulationResult> result) =|
     did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -172,7 +172,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, bool clone_session_storage) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Web::HTML::VisibilityState system_visibility_state, String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, Web::HTML::VisibilityState system_visibility_state, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|
@@ -203,7 +203,7 @@ endpoint WebContentClient
     did_request_primary_paste(u64 page_id) =|
     did_update_primary_selection(u64 page_id, String text) =|
 
-    did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry) =|
+    did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry, Optional<Web::HTML::CrossProcessId> opener_navigable_id) =|
     did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::StorageSerializationRecord navigation_api_state) =|
     did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Web::HTML::ScrollRestorationMode scroll_restoration_mode) =|
     did_update_session_history_entry_document_state_navigable_target_name(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryIdentity entry_identity, Utf16String navigable_target_name) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -70,6 +70,7 @@ endpoint WebContentClient
     did_request_navigation_start(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, URL::URL url, Utf16String navigation_id, Optional<Web::HTML::NavigationStartRequest> start_request) =|
     did_complete_navigation_unload_check(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) =|
     did_request_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, URL::URL current_url, Web::NavigationTarget target, Web::HTML::NavigationPopulationRequest request) =|
+    did_finish_history_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::HistoryNavigationPopulation population) =|
     did_finish_navigation_params_creation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id, Optional<Web::HTML::NavigationPopulationResult> result) =|
     did_fail_navigation_population(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_id) =|
     did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -87,6 +87,7 @@ endpoint WebContentServer
     run_history_step_beforeunload_check(u64 page_id, Web::HTML::CrossProcessId operation_id, Vector<Web::HTML::CrossProcessId> navigable_ids, Web::HTML::UnloadPromptShown unload_prompt_shown) =|
     discard_embedded_page(u64 page_id) =|
     queue_navigation_api_state_clear_task(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id) =|
+    continue_history_navigation_population(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Web::Bindings::NavigationType> navigation_type, Web::HTML::HistoryNavigationPopulation population) =|
     run_changing_navigable_history_job(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Web::HTML::UserNavigationInvolvement user_involvement, Optional<Web::Bindings::NavigationType> navigation_type, bool superseded_by_newer_navigation) =|
     prepare_changing_navigable_for_unload(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id) =|
     apply_changing_navigable_continuation(u64 page_id, Web::HTML::CrossProcessId operation_id, Web::HTML::CrossProcessId navigable_id, u64 script_history_length, u64 script_history_index, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries_for_navigation_api, Web::HTML::VisibilityState system_visibility_state, Web::HTML::UnloadDisplayedDocument unload_displayed_document) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -51,6 +51,7 @@ endpoint WebContentServer
     init_transport(int peer_pid) => (int peer_pid)
     set_font_catalog(IPC::File file, u64 size, u64 generation) =|
     initialize(u64 initial_page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessIdAllocator cross_process_id_allocator, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
+    create_embedded_page(u64 page_id, Web::HTML::CrossProcessId root_navigable_id, Web::HTML::CrossProcessId initial_document_state_id, Web::HTML::VisibilityState system_visibility_state) =|
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)

--- a/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-popup-keeps-opener.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-popup-keeps-opener.txt
@@ -1,0 +1,2 @@
+message: hello from <cross-site host>
+popup.closed: false

--- a/Tests/LibWeb/Text/expected/SiteIsolation/iframe/parent-renavigates-remote-iframe-to-local.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/iframe/parent-renavigates-remote-iframe-to-local.txt
@@ -1,0 +1,3 @@
+iframe became local: true
+WebContent#0
+  iframe#0: local

--- a/Tests/LibWeb/Text/expected/SiteIsolation/iframe/parent-renavigates-remote-iframe-within-site.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/iframe/parent-renavigates-remote-iframe-within-site.txt
@@ -1,0 +1,3 @@
+second document ran: true
+WebContent#0
+  iframe#0: remote WebContent#1

--- a/Tests/LibWeb/Text/expected/SiteIsolation/iframe/same-site-siblings-share-process.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/iframe/same-site-siblings-share-process.txt
@@ -1,0 +1,9 @@
+child 0 ran: true
+child 1 ran: true
+WebContent#0
+  iframe#0: remote WebContent#1
+  iframe#1: remote WebContent#1
+after removing first child:
+child 2 ran: true
+WebContent#0
+  iframe#0: remote WebContent#1

--- a/Tests/LibWeb/Text/input/SiteIsolation/cross-site-popup-keeps-opener.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/cross-site-popup-keeps-opener.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // A popup with an opener stays in its opener's browsing context group when it navigates cross-site: the group
+    // has two browsing contexts, so obtaining a browsing context to use for the navigation response makes no browsing
+    // context group switch, and the opener keeps its handle on the popup.
+    promiseTest(async () => {
+        const httpServer = httpTestServer();
+        const runId = crypto.randomUUID();
+
+        const crossSiteUrl = new URL(
+            await httpServer.createEcho("GET", `/popup-cross-site-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: `<!DOCTYPE html><script>opener.postMessage("hello from " + location.hostname, "*");<\/script>`,
+            })
+        );
+        crossSiteUrl.hostname = uniqueLocalhostHostname("popup-cross-site");
+
+        const popupUrl = await httpServer.createEcho("GET", `/popup-same-site-${runId}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: `<!DOCTYPE html><script>location.href = ${JSON.stringify(crossSiteUrl.href)};<\/script>`,
+        });
+
+        const messageReceived = new Promise(resolve => {
+            addEventListener("message", event => resolve(event.data), { once: true });
+        });
+        const popup = window.open(popupUrl);
+        const message = await messageReceived;
+        println(`message: ${message.replace(crossSiteUrl.hostname, "<cross-site host>")}`);
+        println(`popup.closed: ${popup.closed}`);
+        popup.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SiteIsolation/iframe/parent-renavigates-remote-iframe-to-local.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/iframe/parent-renavigates-remote-iframe-to-local.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const httpServer = httpTestServer();
+        const runId = crypto.randomUUID();
+
+        const remoteUrl = new URL(
+            await httpServer.createEcho("GET", `/oop-iframe-return-local-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: "<!DOCTYPE html>remote",
+            })
+        );
+        remoteUrl.hostname = uniqueLocalhostHostname("oop-iframe-return-local");
+
+        const iframe = document.createElement("iframe");
+        iframe.src = remoteUrl;
+        document.body.appendChild(iframe);
+
+        if (!(await waitForCondition(() => internals.dumpSiteIsolationProcessTree().includes("remote")))) {
+            println("iframe did not become remote");
+            return;
+        }
+
+        iframe.src = "about:blank";
+        const becameLocal = await waitForCondition(() => internals.dumpSiteIsolationProcessTree().includes("local"));
+        println(`iframe became local: ${becameLocal}`);
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SiteIsolation/iframe/parent-renavigates-remote-iframe-within-site.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/iframe/parent-renavigates-remote-iframe-within-site.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    // A parent navigating its out-of-process iframe to another page of the site the frame displays keeps the frame in
+    // the process hosting that site: the new document's agent cluster is already hosted there. The navigation is
+    // fetched by the parent's process, so the document must be handed to the frame's process to be created.
+    promiseTest(async () => {
+        const httpServer = httpTestServer();
+        const runId = crypto.randomUUID();
+        const childHostname = uniqueLocalhostHostname("oop-iframe-renavigate");
+
+        const firstChildUrl = new URL(
+            await httpServer.createEcho("GET", `/oop-iframe-renavigate-first-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: "<!DOCTYPE html>first",
+            })
+        );
+        firstChildUrl.hostname = childHostname;
+
+        const markerUrl = new URL(
+            await httpServer.createEcho("GET", `/oop-iframe-renavigate-marker-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/plain" },
+                body: "marker",
+            })
+        );
+        markerUrl.hostname = childHostname;
+
+        const secondChildUrl = new URL(
+            await httpServer.createEcho("GET", `/oop-iframe-renavigate-second-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: `<!DOCTYPE html>second<script>fetch(${JSON.stringify(markerUrl.href)});<\/script>`,
+            })
+        );
+        secondChildUrl.hostname = childHostname;
+
+        const iframe = document.createElement("iframe");
+        iframe.src = firstChildUrl;
+        document.body.appendChild(iframe);
+        if (!(await waitForCondition(() => internals.dumpSiteIsolationProcessTree().includes("remote")))) {
+            println("iframe did not become remote");
+            return;
+        }
+
+        iframe.src = secondChildUrl;
+
+        // The second document's script fetches the marker; the echo server records the request when it is made.
+        const recordedUrl = `${httpServer.baseURL}/recorded-request-headers/echo/oop-iframe-renavigate-marker-${runId}`;
+        let secondDocumentRan = false;
+        for (let attempt = 0; attempt < 600 && !secondDocumentRan; ++attempt) {
+            try {
+                secondDocumentRan = (await fetch(recordedUrl)).ok;
+            } catch {}
+            if (!secondDocumentRan) await timeout(25);
+        }
+        println(`second document ran: ${secondDocumentRan}`);
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SiteIsolation/iframe/same-site-siblings-share-process.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/iframe/same-site-siblings-share-process.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const runId = crypto.randomUUID();
+        const hostname = uniqueLocalhostHostname("oop-siblings");
+        const frames = [];
+        const loadChild = async (frame, index) => {
+            const markerPath = `/oop-sibling-marker-${runId}-${index}`;
+            const marker = new URL(await server.createEcho("GET", markerPath, {
+                status: 200,
+                body: "marker",
+            }));
+            marker.hostname = hostname;
+            const url = new URL(await server.createEcho("GET", `/oop-sibling-${runId}-${index}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: `<!doctype html><script>fetch(${JSON.stringify(marker.href)});<\/script>`,
+            }));
+            url.hostname = hostname;
+            frame.src = url;
+            if (!frame.isConnected) document.body.appendChild(frame);
+            let documentRan = false;
+            for (let attempt = 0; attempt < 600 && !documentRan; ++attempt) {
+                try {
+                    documentRan = (await fetch(`${server.baseURL}/recorded-request-headers/echo${markerPath}`)).ok;
+                } catch {}
+                if (!documentRan) await timeout(25);
+            }
+            println(`child ${index} ran: ${documentRan}`);
+        };
+        for (let index = 0; index < 2; ++index) {
+            const frame = document.createElement("iframe");
+            frames.push(frame);
+            await loadChild(frame, index);
+        }
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+
+        // Closing one embedded page must leave the other page in the shared process alive.
+        frames[0].remove();
+        await waitForCondition(() => !internals.dumpSiteIsolationProcessTree().includes("iframe#1"));
+        println("after removing first child:");
+        await loadChild(frames[1], 2);
+        println(internals.dumpSiteIsolationProcessTree().trimEnd());
+    });
+</script>

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestApplyHistoryStep.cpp
     TestAutocompleteMuxer.cpp
     TestAutocompleteRanker.cpp
+    TestCanonicalBrowsingContextGroup.cpp
     TestCookieJar.cpp
     TestDownloadSegmentation.cpp
     TestDownloadStore.cpp

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES
     TestFaviconStore.cpp
     TestHistoryStore.cpp
     TestHSTSStore.cpp
+    TestNavigationLoader.cpp
     TestOmnibox.cpp
     TestPausedDebuggerOverlay.cpp
     TestProfile.cpp
@@ -29,6 +30,9 @@ foreach(source IN LISTS TEST_SOURCES)
     endif()
     ladybird_test("${source}" LibWebView LIBS ${test_libraries})
 endforeach()
+
+target_sources(TestNavigationLoader PRIVATE ${LADYBIRD_SOURCE_DIR}/Libraries/LibWebView/NavigationLoader.cpp)
+target_link_libraries(TestNavigationLoader PRIVATE LibRequests LibWeb)
 
 if (NOT WIN32)
     add_executable(TestAutocomplete TestAutocomplete.cpp)

--- a/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
+++ b/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/CanonicalBrowsingContext.h>
+#include <LibWebView/CanonicalBrowsingContextGroup.h>
+#include <LibWebView/CanonicalTraversable.h>
+
+static URL::Origin origin_for(StringView url)
+{
+    return URL::Parser::basic_parse(url).value().origin();
+}
+
+TEST_CASE(top_level_browsing_context_is_alone_in_a_new_group)
+{
+    auto browsing_context = WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {});
+    auto group = browsing_context->group();
+    VERIFY(group);
+
+    EXPECT_EQ(group->browsing_context_set().size(), 1u);
+    EXPECT(group->browsing_context_set().contains(browsing_context.ptr()));
+}
+
+TEST_CASE(auxiliary_browsing_context_joins_the_openers_group)
+{
+    WebView::CanonicalTraversable opener;
+    opener.set_active_browsing_context(WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(origin_for("https://a.ladybird.org"sv), {}));
+
+    auto popup_browsing_context = WebView::CanonicalBrowsingContext::create_a_new_auxiliary_browsing_context_and_document(opener, origin_for("https://a.ladybird.org"sv), {});
+
+    EXPECT_EQ(popup_browsing_context->group(), opener.active_browsing_context().group());
+    EXPECT_EQ(popup_browsing_context->group()->browsing_context_set().size(), 2u);
+}
+
+TEST_CASE(child_browsing_context_is_not_in_the_group)
+{
+    auto top_level_browsing_context = WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(origin_for("https://a.ladybird.org"sv), {});
+    auto group = top_level_browsing_context->group();
+    VERIFY(group);
+
+    auto child_browsing_context = WebView::CanonicalBrowsingContext::create_a_new_browsing_context_and_document(*group, origin_for("https://a.ladybird.org"sv), {});
+
+    EXPECT_EQ(child_browsing_context->group(), nullptr);
+    EXPECT_EQ(group->browsing_context_set().size(), 1u);
+}
+
+TEST_CASE(replacing_a_traversables_browsing_context_leaves_its_group)
+{
+    WebView::CanonicalTraversable traversable;
+    traversable.set_active_browsing_context(WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {}));
+    auto* initial_browsing_context = &traversable.active_browsing_context();
+    VERIFY(initial_browsing_context->group());
+    NonnullRefPtr initial_group = *initial_browsing_context->group();
+
+    auto replacement_browsing_context = WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {});
+    traversable.set_active_browsing_context(replacement_browsing_context);
+
+    EXPECT_EQ(&traversable.active_browsing_context(), replacement_browsing_context.ptr());
+    EXPECT(initial_group->browsing_context_set().is_empty());
+}
+
+TEST_CASE(removing_a_browsing_context_clears_its_group)
+{
+    auto browsing_context = WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {});
+    VERIFY(browsing_context->group());
+    NonnullRefPtr group = *browsing_context->group();
+
+    group->remove(*browsing_context);
+
+    EXPECT_EQ(browsing_context->group(), nullptr);
+    EXPECT(!group->browsing_context_set().contains(browsing_context.ptr()));
+}
+
+TEST_CASE(site_keyed_agent_clusters)
+{
+    auto group = WebView::CanonicalBrowsingContextGroup::create();
+    auto first_origin = origin_for("https://a.ladybird.org"sv);
+    auto second_origin = origin_for("https://b.ladybird.org"sv);
+
+    auto first_agent = group->obtain_similar_origin_window_agent(first_origin, false);
+    auto second_agent = group->obtain_similar_origin_window_agent(second_origin, false);
+
+    EXPECT_EQ(first_agent.ptr(), second_agent.ptr());
+}
+
+TEST_CASE(origin_keyed_agent_clusters)
+{
+    auto group = WebView::CanonicalBrowsingContextGroup::create();
+    auto first_origin = origin_for("https://a.ladybird.org"sv);
+    auto second_origin = origin_for("https://b.ladybird.org"sv);
+
+    auto origin_keyed_agent = group->obtain_similar_origin_window_agent(first_origin, true);
+    auto site_keyed_agent = group->obtain_similar_origin_window_agent(second_origin, false);
+
+    EXPECT_NE(origin_keyed_agent.ptr(), site_keyed_agent.ptr());
+
+    // The first decision for an origin is permanent within a browsing context group.
+    auto first_origin_again = group->obtain_similar_origin_window_agent(first_origin, false);
+    EXPECT_EQ(origin_keyed_agent.ptr(), first_origin_again.ptr());
+}
+
+TEST_CASE(historical_site_key_cannot_be_changed_by_a_later_oac_request)
+{
+    auto group = WebView::CanonicalBrowsingContextGroup::create();
+    auto origin = origin_for("https://a.ladybird.org"sv);
+
+    auto site_keyed_agent = group->obtain_similar_origin_window_agent(origin, false);
+    auto agent_after_oac_request = group->obtain_similar_origin_window_agent(origin, true);
+
+    EXPECT_EQ(site_keyed_agent.ptr(), agent_after_oac_request.ptr());
+}
+
+TEST_CASE(opaque_origins_have_distinct_agent_clusters)
+{
+    auto group = WebView::CanonicalBrowsingContextGroup::create();
+    auto first_origin = URL::Origin::create_opaque();
+    auto second_origin = URL::Origin::create_opaque();
+
+    auto first_agent = group->obtain_similar_origin_window_agent(first_origin, false);
+    auto first_agent_again = group->obtain_similar_origin_window_agent(first_origin, false);
+    auto second_agent = group->obtain_similar_origin_window_agent(second_origin, false);
+
+    EXPECT_EQ(first_agent.ptr(), first_agent_again.ptr());
+    EXPECT_NE(first_agent.ptr(), second_agent.ptr());
+}

--- a/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
+++ b/Tests/LibWebView/TestCanonicalBrowsingContextGroup.cpp
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
 #include <LibWebView/CanonicalBrowsingContext.h>
 #include <LibWebView/CanonicalBrowsingContextGroup.h>
 #include <LibWebView/CanonicalTraversable.h>
+#include <LibWebView/SiteIsolation.h>
+#include <LibWebView/SiteIsolationManager.h>
 
 static URL::Origin origin_for(StringView url)
 {
@@ -75,6 +78,45 @@ TEST_CASE(removing_a_browsing_context_clears_its_group)
     EXPECT(!group->browsing_context_set().contains(browsing_context.ptr()));
 }
 
+TEST_CASE(response_browsing_context_is_activated_only_at_commit)
+{
+    WebView::CanonicalTraversable traversable;
+    traversable.set_active_browsing_context(WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {}));
+    auto* initial_context = &traversable.active_browsing_context();
+    auto initial_group = initial_context->group();
+    auto destination_url = URL::Parser::basic_parse("https://ladybird.org/"sv).release_value();
+    auto destination_context = traversable.obtain_a_browsing_context_to_use_for_a_navigation_response({
+        .needs_a_browsing_context_group_switch = true,
+        .url = destination_url,
+        .origin = destination_url.origin(),
+        .opener_policy = {},
+    });
+    auto navigation_id = Utf16String::from_utf8("navigation"sv);
+    traversable.ensure_ongoing_navigation().navigation_id = navigation_id;
+    traversable.ongoing_navigation()->destination_browsing_context = destination_context;
+
+    EXPECT_EQ(&traversable.active_browsing_context(), initial_context);
+    EXPECT(initial_group->browsing_context_set().contains(initial_context));
+
+    traversable.clear_ongoing_navigation();
+    EXPECT_EQ(&traversable.active_browsing_context(), initial_context);
+    EXPECT(initial_group->browsing_context_set().contains(initial_context));
+
+    traversable.ensure_ongoing_navigation().navigation_id = navigation_id;
+    traversable.ongoing_navigation()->destination_browsing_context = destination_context;
+    traversable.did_commit_navigation({
+                                          .target_name = {},
+                                          .active_document_url = destination_url,
+                                          .active_document_origin = destination_url.origin(),
+                                          .active_document_is_fully_active = true,
+                                          .active_session_history_entry_identity = {},
+                                      },
+        navigation_id);
+    EXPECT_EQ(&traversable.active_browsing_context(), destination_context.ptr());
+    EXPECT(initial_group->browsing_context_set().is_empty());
+    EXPECT(!traversable.ongoing_navigation().has_value());
+}
+
 TEST_CASE(site_keyed_agent_clusters)
 {
     auto group = WebView::CanonicalBrowsingContextGroup::create();
@@ -126,4 +168,27 @@ TEST_CASE(opaque_origins_have_distinct_agent_clusters)
 
     EXPECT_EQ(first_agent.ptr(), first_agent_again.ptr());
     EXPECT_NE(first_agent.ptr(), second_agent.ptr());
+}
+
+TEST_CASE(top_level_site_isolation_process_swaps)
+{
+    auto restore_site_isolation_mode = ScopeGuard([mode = WebView::site_isolation_mode()] {
+        WebView::set_site_isolation_mode(mode);
+    });
+    WebView::set_site_isolation_mode(WebView::SiteIsolationMode::TopLevel);
+
+    auto browsing_context = WebView::CanonicalBrowsingContext::create_a_new_top_level_browsing_context_and_document(URL::Origin::create_opaque(), {});
+    auto current_url = URL::Parser::basic_parse("https://a.example/path"sv).release_value();
+    auto same_site_url = URL::Parser::basic_parse("https://sub.a.example/other"sv).release_value();
+    auto cross_site_url = URL::Parser::basic_parse("https://b.example/path"sv).release_value();
+
+    EXPECT(!WebView::SiteIsolationManager::the().top_level_navigation_requires_process_swap(*browsing_context, URL::about_blank(), cross_site_url));
+    EXPECT(!WebView::SiteIsolationManager::the().top_level_navigation_requires_process_swap(*browsing_context, current_url, same_site_url));
+    EXPECT(WebView::SiteIsolationManager::the().top_level_navigation_requires_process_swap(*browsing_context, current_url, cross_site_url));
+
+    WebView::CanonicalTraversable opener;
+    opener.set_active_browsing_context(browsing_context);
+    auto related_browsing_context = WebView::CanonicalBrowsingContext::create_a_new_auxiliary_browsing_context_and_document(opener, URL::Origin::create_opaque(), {});
+    EXPECT(browsing_context->group()->browsing_context_set().contains(related_browsing_context.ptr()));
+    EXPECT(!WebView::SiteIsolationManager::the().top_level_navigation_requires_process_swap(*browsing_context, current_url, cross_site_url));
 }

--- a/Tests/LibWebView/TestNavigationLoader.cpp
+++ b/Tests/LibWebView/TestNavigationLoader.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/NavigationLoader.h>
+
+static Web::HTML::NavigationParamsDescriptor navigation_params_for(URL::URL const& url)
+{
+    return {
+        .id = {},
+        .navigable_id = {},
+        .request = {},
+        .response = {},
+        .coop_enforcement_result = { .url = url, .origin = url.origin(), .opener_policy = {} },
+        .reserved_environment = {},
+        .origin = url.origin(),
+        .policy_container = {},
+        .opener_policy = {},
+        .about_base_url = {},
+    };
+}
+
+TEST_CASE(response_document_uses_history_entry_url_when_response_url_list_is_empty)
+{
+    auto url = URL::Parser::basic_parse("https://ladybird.org/"sv).release_value();
+    Web::HTML::NavigationPopulationRequest request {};
+    request.history_entry.url = url;
+    auto loader = WebView::NavigationLoader::create(WebView::IsPrivate::No, move(request));
+    loader->did_finish_navigation_params_creation({
+        .navigation_params = navigation_params_for(url),
+        .redirected_url = {},
+        .classic_history_api_state = {},
+        .replacement_document_state = {},
+    });
+
+    auto document = loader->response_document();
+    EXPECT(document.has_value());
+    if (document.has_value())
+        EXPECT_EQ(document->url, url);
+}
+
+TEST_CASE(response_document_uses_last_response_url_after_redirects)
+{
+    auto initial_url = URL::Parser::basic_parse("https://ladybird.org/"sv).release_value();
+    auto final_url = URL::Parser::basic_parse("https://example.com/"sv).release_value();
+    Web::HTML::NavigationPopulationRequest request {};
+    request.history_entry.url = initial_url;
+    auto loader = WebView::NavigationLoader::create(WebView::IsPrivate::No, move(request));
+    auto params = navigation_params_for(initial_url);
+    params.response.url_list = { initial_url, final_url };
+    loader->did_finish_navigation_params_creation({
+        .navigation_params = move(params),
+        .redirected_url = {},
+        .classic_history_api_state = {},
+        .replacement_document_state = {},
+    });
+
+    auto document = loader->response_document();
+    EXPECT(document.has_value());
+    if (document.has_value())
+        EXPECT_EQ(document->url, final_url);
+}

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -74,6 +74,9 @@ class TestPageServer(http.server.ThreadingHTTPServer):
         self.same_site_post_result_document_ran = threading.Event()
         self.same_url_post_result_document_ran = threading.Event()
         self.reload_blocked_document_ran = threading.Event()
+        self.history_response_redirect = None
+        self.history_response_request_count = 0
+        self.history_response_destination_count = 0
 
     def handle_error(self, request, client_address):
         if isinstance(sys.exc_info()[1], BrokenPipeError):
@@ -85,6 +88,25 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         server = cast(TestPageServer, self.server)
         server_port = server.server_port
+
+        if self.path == "/history-response":
+            server.history_response_request_count += 1
+            self.send_response(302 if server.history_response_redirect else 200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Cache-Control", "no-store")
+            if server.history_response_redirect:
+                self.send_header("Location", server.history_response_redirect)
+            self.end_headers()
+            self.wfile.write(b"<!doctype html><title>History response source</title>")
+            return
+
+        if self.path == "/history-response-destination":
+            server.history_response_destination_count += 1
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<!doctype html><title>History response destination</title>")
+            return
 
         if self.path == "/a":
             with server.a_request_lock:
@@ -2459,6 +2481,89 @@ def expect_post_crash_recovery_waits_for_load(webdriver_port, session_id, page_s
     expect_current_entry_resource(webdriver_port, session_id, "after POST crash recovery", "post", log)
 
 
+def run_navigation_response_process_selection_test(webdriver_port, url_a, url_b, url_d, url_redirect_to_b):
+    for label, target_url, expected_url, should_swap in [
+        ("same-site navigation", url_d, url_d, False),
+        ("cross-site navigation", url_b, url_b, True),
+        ("same-site URL redirecting cross-site", url_redirect_to_b, url_b, True),
+    ]:
+        session_id = create_session(webdriver_port)
+        log = []
+        try:
+            load_url_from_ui(webdriver_port, session_id, url_a)
+            expect_url(webdriver_port, session_id, "process selection source", url_a, log)
+            source_process_id = session_history(webdriver_port, session_id)["ui"]["webContentProcessID"]
+
+            execute_script(webdriver_port, session_id, f"location.href = {json.dumps(target_url)}; return null;")
+            wait_for_script_result(
+                webdriver_port,
+                session_id,
+                label,
+                "return location.href;",
+                lambda url, expected_url=expected_url: url == expected_url,
+                log,
+            )
+            destination_process_id = session_history(webdriver_port, session_id)["ui"]["webContentProcessID"]
+            did_swap = source_process_id != destination_process_id
+            if did_swap != should_swap:
+                raise AssertionError(
+                    f"Expected process swap={should_swap} for {label}, "
+                    f"got WebContent PID {source_process_id} -> {destination_process_id}"
+                )
+        finally:
+            request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
+def run_history_response_process_selection_tests(webdriver_port, page_server):
+    local_base = f"http://localhost:{page_server.server_port}"
+    remote_base = f"http://127.0.0.1:{page_server.server_port}"
+    for operation, stored_base, destination_base, should_swap in [
+        ("back", local_base, remote_base, True),
+        ("back", remote_base, local_base, False),
+        ("forward", local_base, remote_base, True),
+        ("reload", local_base, remote_base, True),
+        ("reload", local_base, local_base, False),
+    ]:
+        session_id = create_session(webdriver_port)
+        log = []
+        page_server.history_response_redirect = None
+        try:
+            if operation == "forward":
+                load_url_from_ui(webdriver_port, session_id, local_base + "/a")
+            load_url_from_ui(webdriver_port, session_id, stored_base + "/history-response")
+            if operation == "back":
+                load_url_from_ui(webdriver_port, session_id, local_base + "/d")
+            elif operation == "forward":
+                traverse_history_from_ui(webdriver_port, session_id, -1)
+
+            before = session_history(webdriver_port, session_id)["ui"]
+            requests_before = page_server.history_response_request_count
+            destinations_before = page_server.history_response_destination_count
+            destination = destination_base + "/history-response-destination"
+            page_server.history_response_redirect = destination
+            if operation == "reload":
+                refresh(webdriver_port, session_id)
+            else:
+                traverse_history_from_ui(webdriver_port, session_id, -1 if operation == "back" else 1)
+            label = f"{operation} redirect from {stored_base} to {destination_base}"
+            expect_url(webdriver_port, session_id, label, destination, log)
+            after = session_history(webdriver_port, session_id)["ui"]
+            did_swap = before["webContentProcessID"] != after["webContentProcessID"]
+            if did_swap != should_swap:
+                raise AssertionError(f"Expected process swap={should_swap} for {label}: {before} -> {after}")
+            if page_server.history_response_request_count != requests_before + 1:
+                raise AssertionError(f"Refetched the history entry during {label}")
+            if page_server.history_response_destination_count != destinations_before + 1:
+                raise AssertionError(f"Refetched the redirect destination during {label}")
+            expected_index = before["currentUsedStepIndex"] + {"back": -1, "forward": 1, "reload": 0}[operation]
+            if after["currentUsedStepIndex"] != expected_index or len(after["entries"]) != len(before["entries"]):
+                raise AssertionError(f"Changed the history operation during {label}: {before} -> {after}")
+            expect_session_history_idle(webdriver_port, session_id, label, log)
+        finally:
+            page_server.history_response_redirect = None
+            request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
 def run_test(webdriver_binary):
     page_server = TestPageServer(("0.0.0.0", 0), TestPageHandler)
     page_server_thread = threading.Thread(target=page_server.serve_forever, daemon=True)
@@ -2532,6 +2637,9 @@ def run_test(webdriver_binary):
             url_iframe_deferred_fragment_first,
             url_iframe_deferred_fragment_second,
         )
+
+        run_navigation_response_process_selection_test(webdriver_port, url_a, url_b, url_d, url_redirect_to_b)
+        run_history_response_process_selection_tests(webdriver_port, page_server)
 
         run_uncommitted_navigation_browser_ui_back_tests(
             webdriver_port,


### PR DESCRIPTION
Model browsing context groups and window agents in the UI process, then use
navigation response metadata to select the WebContent process that creates the
document.

This replaces URL-based process selection and correctly routes popup and
cross-process iframe navigations.