### PR TITLE
LibWeb: Expand compositor-driven CSS animations and transitions

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1608,7 +1608,12 @@ void Animation::run_pending_play_task()
 
     // 5. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,
     //    and the synchronously notify flag set to false.
-    update_finished_state(DidSeek::No, SynchronouslyNotify::No);
+    // OPTIMIZATION: A new CSS transition can already have a provisional compositor descriptor anchored to its style
+    //               change event time. Keep that descriptor so resolving this task does not restart its visual time.
+    auto should_invalidate = is_css_transition() && m_effect && is<KeyframeEffect>(*m_effect) && static_cast<KeyframeEffect&>(*m_effect).is_compositor_driven()
+        ? ShouldInvalidate::No
+        : ShouldInvalidate::Yes;
+    update_finished_state(DidSeek::No, SynchronouslyNotify::No, should_invalidate);
 }
 
 bool Animation::is_ready_to_run_pending_pause_task() const

--- a/Libraries/LibWeb/Animations/Animation.h
+++ b/Libraries/LibWeb/Animations/Animation.h
@@ -89,6 +89,7 @@ public:
     // https://www.w3.org/TR/web-animations-1/#dom-animation-pending
     bool pending_for_bindings() const;
     bool pending() const { return m_pending_play_task == TaskState::Scheduled || m_pending_pause_task == TaskState::Scheduled; }
+    bool has_pending_play_task() const { return m_pending_play_task == TaskState::Scheduled; }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-ready
     GC::Ref<WebIDL::Promise> ready_for_bindings() const;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1045,6 +1045,7 @@ KeyframeEffect::KeyframeEffect()
 void KeyframeEffect::invalidate_effect()
 {
     m_compositor_opacity_keyframe_value_cache.clear();
+    m_compositor_background_color_keyframe_value_cache.clear();
     m_compositor_transform_keyframe_value_cache.clear();
     m_is_compositor_driven = false;
     m_is_compositor_replaced = false;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -208,9 +208,15 @@ public:
     };
     Optional<CompositorKeyframeValueCache>& compositor_keyframe_value_cache(Compositor::VisualAnimation::TargetKind target_kind)
     {
-        return target_kind == Compositor::VisualAnimation::TargetKind::Opacity
-            ? m_compositor_opacity_keyframe_value_cache
-            : m_compositor_transform_keyframe_value_cache;
+        switch (target_kind) {
+        case Compositor::VisualAnimation::TargetKind::Opacity:
+            return m_compositor_opacity_keyframe_value_cache;
+        case Compositor::VisualAnimation::TargetKind::BackgroundColor:
+            return m_compositor_background_color_keyframe_value_cache;
+        case Compositor::VisualAnimation::TargetKind::Transform:
+            return m_compositor_transform_keyframe_value_cache;
+        }
+        VERIFY_NOT_REACHED();
     }
     virtual void update_computed_properties(AnimationUpdateContext&) override;
     void update_computed_properties_for_style(AnimationUpdateContext&, DOM::AbstractElement);
@@ -244,6 +250,7 @@ private:
     u64 m_animation_preparation_identity { 0 };
     u64 m_animation_preparation_generation { 0 };
     Optional<CompositorKeyframeValueCache> m_compositor_opacity_keyframe_value_cache;
+    Optional<CompositorKeyframeValueCache> m_compositor_background_color_keyframe_value_cache;
     Optional<CompositorKeyframeValueCache> m_compositor_transform_keyframe_value_cache;
     Vector<Compositor::VisualAnimation> m_retained_compositor_animations;
     bool m_is_compositor_driven { false };

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -236,11 +236,34 @@ bool VisualAnimation::has_same_animation_parameters(VisualAnimation const& other
 
 static VisualAnimationValue interpolate_value(VisualAnimationValue const& from, VisualAnimationValue const& to, double progress)
 {
+    auto interpolate_legacy_srgb_color = [](Gfx::Color from, Gfx::Color to, double progress) -> Gfx::Color {
+        auto from_alpha = static_cast<double>(from.alpha()) / 255.0;
+        auto to_alpha = static_cast<double>(to.alpha()) / 255.0;
+        auto alpha = clamp(from_alpha + (to_alpha - from_alpha) * progress, 0.0, 1.0);
+        if (alpha == 0)
+            return Gfx::Color::Transparent;
+        auto interpolate_channel = [&](u8 from_channel, u8 to_channel) {
+            auto from_premultiplied = static_cast<double>(from_channel) * from_alpha;
+            auto to_premultiplied = static_cast<double>(to_channel) * to_alpha;
+            auto channel = (from_premultiplied + (to_premultiplied - from_premultiplied) * progress) / alpha;
+            return round_to<u8>(clamp(channel, 0.0, 255.0));
+        };
+        return Gfx::Color {
+            interpolate_channel(from.red(), to.red()),
+            interpolate_channel(from.green(), to.green()),
+            interpolate_channel(from.blue(), to.blue()),
+            round_to<u8>(alpha * 255.0),
+        };
+    };
+
     VERIFY(from.index() == to.index());
     return from.visit(
         [&](float from_opacity) -> VisualAnimationValue {
             auto to_opacity = to.get<float>();
             return static_cast<float>(from_opacity + (to_opacity - from_opacity) * progress);
+        },
+        [&](Gfx::Color from_color) -> VisualAnimationValue {
+            return interpolate_legacy_srgb_color(from_color, to.get<Gfx::Color>(), progress);
         },
         [&](VisualAnimationTransformList const& from_transforms) -> VisualAnimationValue {
             auto const& to_transforms = to.get<VisualAnimationTransformList>();
@@ -338,6 +361,7 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
     Sample sample;
     value.visit(
         [&](float opacity) { sample.opacity = opacity; },
+        [&](Gfx::Color background_color) { sample.background_color = background_color; },
         [&](VisualAnimationTransformList const& transforms) {
             for (auto const& transform : transforms)
                 sample.transform = sample.transform * transform.to_matrix();
@@ -346,6 +370,11 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
         if (!isfinite(sample.opacity))
             return {};
         sample.opacity = clamp(sample.opacity, 0.0f, 1.0f);
+        return sample;
+    }
+    if (target_kind == TargetKind::BackgroundColor) {
+        if (!sample.background_color.has_value())
+            return {};
         return sample;
     }
     for (size_t row = 0; row < 4; ++row) {
@@ -359,7 +388,7 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
 
 bool VisualAnimation::is_valid() const
 {
-    if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::Transform))
+    if (!first_is_one_of(target_kind, TargetKind::Opacity, TargetKind::BackgroundColor, TargetKind::Transform))
         return false;
     if (visual_context_node_indices.is_empty())
         return false;
@@ -390,6 +419,12 @@ bool VisualAnimation::is_valid() const
         if (target_kind == TargetKind::Opacity) {
             if (!keyframe.value.has<float>() || !isfinite(keyframe.value.get<float>())
                 || keyframe.value.get<float>() < 0 || keyframe.value.get<float>() > 1)
+                return false;
+            continue;
+        }
+
+        if (target_kind == TargetKind::BackgroundColor) {
+            if (!keyframe.value.has<Gfx::Color>())
                 return false;
             continue;
         }

--- a/Libraries/LibWeb/Compositor/VisualAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.cpp
@@ -229,6 +229,7 @@ bool VisualAnimation::has_same_animation_parameters(VisualAnimation const& other
         && iteration_count == other.iteration_count
         && iteration_start == other.iteration_start
         && playback_direction == other.playback_direction
+        && fill_mode == other.fill_mode
         && easing == other.easing
         && keyframes == other.keyframes;
 }
@@ -272,6 +273,12 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
     auto local_time = local_time_at_anchor_ms + elapsed_since_anchor.to_seconds_f64() * 1000.0 * playback_rate;
     if (!isfinite(local_time))
         return {};
+    bool is_in_before_phase = local_time < start_delay_ms;
+    if (is_in_before_phase) {
+        if (fill_mode != VisualAnimationFillMode::Backwards)
+            return {};
+        local_time = start_delay_ms;
+    }
     auto overall_progress = (local_time - start_delay_ms) / iteration_duration_ms + iteration_start;
     if (!isfinite(overall_progress) || overall_progress < 0)
         return {};
@@ -303,7 +310,8 @@ Optional<VisualAnimation::Sample> VisualAnimation::sample(AK::Duration elapsed_s
     }
 
     auto directed_progress = going_forwards ? simple_iteration_progress : 1.0 - simple_iteration_progress;
-    auto transformed_progress = easing.evaluate_at(directed_progress, false);
+    bool before_flag = (is_in_before_phase && going_forwards) || (is_at_or_after_end && !going_forwards);
+    auto transformed_progress = easing.evaluate_at(directed_progress, before_flag);
     if (!isfinite(transformed_progress))
         return {};
 
@@ -360,6 +368,8 @@ bool VisualAnimation::is_valid() const
             VisualAnimationPlaybackDirection::Reverse,
             VisualAnimationPlaybackDirection::Alternate,
             VisualAnimationPlaybackDirection::AlternateReverse))
+        return false;
+    if (!first_is_one_of(fill_mode, VisualAnimationFillMode::None, VisualAnimationFillMode::Backwards))
         return false;
     if (monotonic_time_at_anchor_ns < 0 || !isfinite(local_time_at_anchor_ms) || !isfinite(playback_rate) || playback_rate <= 0
         || !isfinite(start_delay_ms) || !isfinite(iteration_duration_ms) || iteration_duration_ms <= 0
@@ -506,6 +516,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Compositor::VisualAnimation const& a
     TRY(encoder.encode(animation.iteration_count));
     TRY(encoder.encode(animation.iteration_start));
     TRY(encoder.encode(animation.playback_direction));
+    TRY(encoder.encode(animation.fill_mode));
     TRY(encoder.encode(animation.easing));
     TRY(encoder.encode(animation.keyframes));
     return {};
@@ -525,6 +536,7 @@ ErrorOr<Web::Compositor::VisualAnimation> decode(Decoder& decoder)
         .iteration_count = TRY(decoder.decode<double>()),
         .iteration_start = TRY(decoder.decode<double>()),
         .playback_direction = TRY(decoder.decode<Web::Compositor::VisualAnimationPlaybackDirection>()),
+        .fill_mode = TRY(decoder.decode<Web::Compositor::VisualAnimationFillMode>()),
         .easing = TRY(decoder.decode<Web::Compositor::VisualAnimationEasing>()),
         .keyframes = TRY(decoder.decode<Vector<Web::Compositor::VisualAnimationKeyframe>>()),
     };

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -9,6 +9,7 @@
 #include <AK/Time.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
@@ -96,7 +97,7 @@ struct VisualAnimationTransformOperation {
 };
 
 using VisualAnimationTransformList = Vector<VisualAnimationTransformOperation>;
-using VisualAnimationValue = Variant<float, VisualAnimationTransformList>;
+using VisualAnimationValue = Variant<float, Gfx::Color, VisualAnimationTransformList>;
 
 struct VisualAnimationKeyframe {
     double offset { 0 };
@@ -109,11 +110,13 @@ struct VisualAnimationKeyframe {
 struct VisualAnimation {
     struct Sample {
         float opacity { 1 };
+        Optional<Gfx::Color> background_color;
         Gfx::FloatMatrix4x4 transform { Gfx::FloatMatrix4x4::identity() };
     };
 
     enum class TargetKind : u8 {
         Opacity,
+        BackgroundColor,
         Transform,
     };
 

--- a/Libraries/LibWeb/Compositor/VisualAnimation.h
+++ b/Libraries/LibWeb/Compositor/VisualAnimation.h
@@ -59,6 +59,11 @@ enum class VisualAnimationPlaybackDirection : u8 {
     AlternateReverse,
 };
 
+enum class VisualAnimationFillMode : u8 {
+    None,
+    Backwards,
+};
+
 enum class VisualAnimationTransformOperationKind : u8 {
     Translate,
     Translate3d,
@@ -127,6 +132,7 @@ struct VisualAnimation {
     double iteration_count { AK::Infinity<double> };
     double iteration_start { 0 };
     VisualAnimationPlaybackDirection playback_direction { VisualAnimationPlaybackDirection::Normal };
+    VisualAnimationFillMode fill_mode { VisualAnimationFillMode::None };
     VisualAnimationEasing easing;
     Vector<VisualAnimationKeyframe> keyframes;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8015,6 +8015,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 *missing_visual_context_node = true;
             return {};
         }
+
         Compositor::VisualAnimation visual_animation {
             .target_kind = target_kind,
             .visual_context_node_indices = move(visual_context_node_indices),
@@ -8408,6 +8409,49 @@ void Document::update_compositor_animations()
         validate_winner(effects.background_color);
         validate_winner(effects.transform);
     }
+
+    // An opacity of 1 does not otherwise create an effects frame. Give an otherwise publishable opacity
+    // animation a target before the normal handoff loop, and retain that target while the effect remains live.
+    auto can_force_opacity_effects_layer = [](Animations::KeyframeEffect const& effect) {
+        return all_of(effect.target_properties(), [](auto const& property) {
+            return first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor)
+                || is_transform_family_property(property.id());
+        });
+    };
+    bool forced_opacity_effects_layer = false;
+    for (auto& [target, effects] : competing_effects) {
+        auto effect = effects.opacity.winner;
+        if (!effect || opacity_affects_visibility_observation(target.element()) || !can_force_opacity_effects_layer(*effect))
+            continue;
+
+        Optional<bool> only_translates_horizontally;
+        bool missing_visual_context_node = false;
+        (void)build_compositor_animation(*effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::Opacity, only_translates_horizontally, &missing_visual_context_node);
+        auto* layout_node = target.unsafe_layout_node();
+        if (!layout_node)
+            continue;
+        bool already_forced_effects_layer = any_of(layout_nodes_with_stale_forced_effects_layer, [&](auto const& stale_layout_node) {
+            return stale_layout_node.ptr() == layout_node;
+        });
+        if (!missing_visual_context_node && !already_forced_effects_layer)
+            continue;
+
+        if (missing_visual_context_node && !layout_node->needs_compositor_effects_layer()) {
+            layout_node->set_needs_compositor_effects_layer(true);
+            schedule_accumulated_visual_context_update(*layout_node, AccumulatedVisualContextUpdateScope::Structure);
+            CSS::RequiredInvalidationAfterStyleChange invalidation;
+            invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+            Painting::repaint_after_style_change(*layout_node, invalidation);
+            forced_opacity_effects_layer = true;
+        }
+        if (!any_of(m_layout_nodes_with_forced_compositor_effects_layer, [&](auto const& forced_layout_node) { return forced_layout_node.ptr() == layout_node; }))
+            m_layout_nodes_with_forced_compositor_effects_layer.append(*layout_node);
+        layout_nodes_with_stale_forced_effects_layer.remove_first_matching([&](auto const& stale_layout_node) {
+            return stale_layout_node.ptr() == layout_node;
+        });
+    }
+    if (forced_opacity_effects_layer)
+        visual_context_tree = paint_state().visual_context_tree(*this);
 
     bool has_observation_relevant_compositor_animation = false;
     bool requested_withdrawn_effect_sample = false;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7728,10 +7728,17 @@ static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEff
 static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind, Optional<bool>& only_translates_horizontally)
 {
     auto animation = effect.associated_animation();
-    if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running || animation->pending())
+    if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running)
+        return {};
+    bool is_initial_pending_css_transition = animation->pending()
+        && animation->has_pending_play_task()
+        && animation->is_css_transition()
+        && as<CSS::CSSTransition>(*animation).previous_phase() == CSS::CSSTransition::Phase::Idle;
+    if (animation->pending() && !is_initial_pending_css_transition)
         return {};
     auto timeline = animation->timeline();
-    if (!timeline || !timeline->is_monotonically_increasing() || !effect.is_in_the_active_phase())
+    if (!timeline || !timeline->is_monotonically_increasing()
+        || (!effect.is_in_the_before_phase() && !effect.is_in_the_active_phase()))
         return {};
     if ((!isinf(effect.iteration_count()) && effect.iteration_count() != 1) || effect.composite() != Bindings::CompositeOperation::Replace)
         return {};
@@ -7740,6 +7747,8 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     if (effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
         || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
         || effect.iteration_duration().value <= 0)
+        return {};
+    if (effect.is_in_the_before_phase() && effect.before_active_boundary_time() != effect.start_delay())
         return {};
     auto current_time = animation->current_time();
     if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
@@ -7756,10 +7765,30 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
     auto target = effect.target_abstract_element();
     if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
         return {};
-    auto frame_timestamp = target->document().last_animation_frame_timestamp();
-    if (!frame_timestamp.has_value())
+    auto monotonic_time_at_anchor_ms = [&]() -> Optional<double> {
+        if (!is_initial_pending_css_transition) {
+            auto frame_timestamp = target->document().last_animation_frame_timestamp();
+            if (!frame_timestamp.has_value())
+                return {};
+            return *frame_timestamp + target->document().relevant_settings_object().time_origin();
+        }
+
+        // OPTIMIZATION: A new CSS transition is play-pending until the next animation update. Start its compositor
+        //               descriptor at the style change event time without resolving the Animation's pending task.
+        auto const& transition = as<CSS::CSSTransition>(*animation);
+        auto style_change_event_time = Animations::TimeValue {
+            Animations::TimeValue::Type::Milliseconds,
+            transition.transition_start_time() - effect.start_delay().value,
+        };
+        if (!timeline->can_convert_a_timeline_time_to_an_origin_relative_time())
+            return {};
+        auto origin_relative_time = timeline->convert_a_timeline_time_to_an_origin_relative_time(style_change_event_time);
+        if (!origin_relative_time.has_value())
+            return {};
+        return *origin_relative_time + target->document().relevant_settings_object().time_origin();
+    }();
+    if (!monotonic_time_at_anchor_ms.has_value())
         return {};
-    auto monotonic_time_at_anchor_ms = *frame_timestamp + target->document().relevant_settings_object().time_origin();
     auto const* layout_node = target->unsafe_layout_node();
     if (!layout_node)
         return {};
@@ -7945,7 +7974,7 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
         Compositor::VisualAnimation visual_animation {
             .target_kind = target_kind,
             .visual_context_node_indices = move(visual_context_node_indices),
-            .monotonic_time_at_anchor_ns = static_cast<i64>(monotonic_time_at_anchor_ms * 1'000'000.0),
+            .monotonic_time_at_anchor_ns = static_cast<i64>(*monotonic_time_at_anchor_ms * 1'000'000.0),
             .local_time_at_anchor_ms = current_time->value,
             .playback_rate = animation->playback_rate(),
             .start_delay_ms = effect.start_delay().value,
@@ -7953,6 +7982,9 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             .iteration_count = effect.iteration_count(),
             .iteration_start = effect.iteration_start(),
             .playback_direction = static_cast<Compositor::VisualAnimationPlaybackDirection>(to_underlying(effect.playback_direction())),
+            .fill_mode = first_is_one_of(effect.fill_mode(), Bindings::FillMode::Backwards, Bindings::FillMode::Both)
+                ? Compositor::VisualAnimationFillMode::Backwards
+                : Compositor::VisualAnimationFillMode::None,
             .easing = Compositor::VisualAnimationEasing::from_css(effect.timing_function()),
             .keyframes = move(keyframes),
         };
@@ -7980,54 +8012,71 @@ void Document::schedule_compositor_animation_wakeup(double delay_ms)
             document.m_compositor_animation_wakeup_deadline.clear();
             auto timestamp = HighResolutionTime::relative_high_resolution_time(
                 HighResolutionTime::unsafe_shared_current_time(), document.relevant_settings_object().global_object());
-            Optional<double> next_wakeup_delay_ms;
-            bool reached_wakeup = false;
-            for (auto& animation : document.m_associated_animations) {
-                if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
-                    continue;
-                auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
-                auto timeline_time = animation.timeline() ? animation.timeline()->current_time_at_timestamp(timestamp) : Optional<Animations::TimeValue> {};
-                auto current_time = animation.current_time_at(timeline_time);
-                if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
-                    continue;
-                if (!effect.is_compositor_driven()
-                    && !animation.pending()
-                    && animation.playback_rate() > 0
-                    && effect.start_delay().type == Animations::TimeValue::Type::Milliseconds) {
-                    if (current_time->value < effect.start_delay().value) {
-                        auto delay = (effect.start_delay().value - current_time->value) / animation.playback_rate();
-                        if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
-                            next_wakeup_delay_ms = delay;
-                        continue;
-                    }
-                    effect.request_observation_sample();
-                    reached_wakeup = true;
-                    continue;
-                }
-                bool is_compositor_handled = effect.is_compositor_driven()
-                    || effect.is_compositor_replaced()
-                    || !effect.retained_compositor_animations().is_empty();
-                if (!is_compositor_handled || isinf(effect.iteration_count()))
-                    continue;
-                auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
-                if (current_time->value < active_end) {
-                    auto delay = (active_end - current_time->value) / animation.playback_rate();
-                    if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
-                        next_wakeup_delay_ms = delay;
-                    continue;
-                }
-                effect.request_observation_sample();
-                reached_wakeup = true;
-            }
-            if (next_wakeup_delay_ms.has_value())
-                document.schedule_compositor_animation_wakeup(*next_wakeup_delay_ms);
-            if (reached_wakeup) {
-                ++document.m_style_invalidation_counters.animation_frame_pump_requests;
-                document.page().client().request_frame();
-            }
+            document.service_compositor_animation_wakeup(timestamp);
         }));
     }
     m_compositor_animation_wakeup_timer->restart(static_cast<int>(timer_delay_ms));
+}
+
+void Document::service_compositor_animation_wakeup(double timestamp)
+{
+    Optional<double> next_wakeup_delay_ms;
+    bool reached_wakeup = false;
+    bool reached_compositor_active_start = false;
+    for (auto& animation : m_associated_animations) {
+        if (!animation.effect() || !is<Animations::KeyframeEffect>(*animation.effect()))
+            continue;
+        auto& effect = static_cast<Animations::KeyframeEffect&>(*animation.effect());
+        auto timeline_time = animation.timeline() ? animation.timeline()->current_time_at_timestamp(timestamp) : Optional<Animations::TimeValue> {};
+        auto current_time = animation.current_time_at(timeline_time);
+        if (!current_time.has_value() || current_time->type != Animations::TimeValue::Type::Milliseconds)
+            continue;
+        bool is_compositor_handled = effect.is_compositor_driven()
+            || effect.is_compositor_replaced()
+            || !effect.retained_compositor_animations().is_empty();
+        if (!animation.pending()
+            && animation.playback_rate() > 0
+            && effect.start_delay().type == Animations::TimeValue::Type::Milliseconds
+            && effect.is_in_the_before_phase()) {
+            if (current_time->value < effect.start_delay().value) {
+                auto delay = (effect.start_delay().value - current_time->value) / animation.playback_rate();
+                if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                    next_wakeup_delay_ms = delay;
+            } else {
+                effect.request_observation_sample();
+                reached_wakeup = true;
+                if (is_compositor_handled)
+                    reached_compositor_active_start = true;
+            }
+        }
+        if (!is_compositor_handled || isinf(effect.iteration_count()))
+            continue;
+        auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
+        if (current_time->value < active_end) {
+            auto delay = (active_end - current_time->value) / animation.playback_rate();
+            if (!next_wakeup_delay_ms.has_value() || delay < *next_wakeup_delay_ms)
+                next_wakeup_delay_ms = delay;
+            continue;
+        }
+        effect.request_observation_sample();
+        reached_wakeup = true;
+    }
+    if (next_wakeup_delay_ms.has_value())
+        schedule_compositor_animation_wakeup(*next_wakeup_delay_ms);
+    if (reached_wakeup) {
+        if (reached_compositor_active_start)
+            paint_state().republish_visual_animations(*this);
+        ++m_style_invalidation_counters.animation_frame_pump_requests;
+        page().client().request_frame();
+    }
+}
+
+void Document::fire_compositor_animation_wakeup_for_testing(Badge<Internals::Internals>, double frame_time_ms)
+{
+    if (m_compositor_animation_wakeup_timer)
+        m_compositor_animation_wakeup_timer->stop();
+    m_compositor_animation_wakeup_deadline.clear();
+    service_compositor_animation_wakeup(relevant_settings_object().time_origin() + frame_time_ms);
 }
 
 void Document::update_compositor_animations()
@@ -8265,16 +8314,20 @@ void Document::update_compositor_animations()
         effect.set_is_offscreen_throttled(false);
         effect.set_is_observation_relevant_compositor_animation(false);
 
-        if (animation.is_idle() || !effect.is_in_effect())
+        if (animation.is_idle() || (!effect.is_in_effect() && !effect.is_in_the_before_phase()))
             continue;
         auto target = effect.target_abstract_element();
         if (!target.has_value())
             continue;
         auto& effects = competing_effects.ensure(*target);
         auto add_competing_effect = [&](CompetingPropertyEffects& property_effects) {
-            if (effect.composite() != Bindings::CompositeOperation::Replace)
+            bool effect_produces_output = effect.is_in_effect();
+            if (effect_produces_output && effect.composite() != Bindings::CompositeOperation::Replace)
                 property_effects.all_effects_use_replace = false;
-            if (!property_effects.winner || Animations::KeyframeEffect::composite_order(*property_effects.winner, effect) < 0)
+            bool winner_produces_output = property_effects.winner && property_effects.winner->is_in_effect();
+            if (!property_effects.winner
+                || (effect_produces_output && !winner_produces_output)
+                || (effect_produces_output == winner_produces_output && Animations::KeyframeEffect::composite_order(*property_effects.winner, effect) < 0))
                 property_effects.winner = effect;
         };
         if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity)))
@@ -8308,16 +8361,20 @@ void Document::update_compositor_animations()
 
     bool has_observation_relevant_compositor_animation = false;
     bool requested_withdrawn_effect_sample = false;
-    auto schedule_active_end_wakeup = [&](Animations::KeyframeEffect const& effect, Animations::Animation const& animation) {
-        if (isinf(effect.iteration_count())
-            || effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
+    auto schedule_next_phase_wakeup = [&](Animations::KeyframeEffect const& effect, Animations::Animation const& animation) {
+        if (effect.start_delay().type != Animations::TimeValue::Type::Milliseconds
             || effect.iteration_duration().type != Animations::TimeValue::Type::Milliseconds
             || !animation.current_time().has_value()
             || animation.current_time()->type != Animations::TimeValue::Type::Milliseconds
             || animation.playback_rate() <= 0)
             return;
-        auto active_end = effect.start_delay().value + effect.iteration_duration().value * effect.iteration_count();
-        auto delay = (active_end - animation.current_time()->value) / animation.playback_rate();
+        auto next_phase_boundary = effect.start_delay().value;
+        if (animation.current_time()->value >= next_phase_boundary) {
+            if (isinf(effect.iteration_count()))
+                return;
+            next_phase_boundary += effect.iteration_duration().value * effect.iteration_count();
+        }
+        auto delay = (next_phase_boundary - animation.current_time()->value) / animation.playback_rate();
         if (delay > 0 && (!compositor_animation_wakeup_delay_ms.has_value() || delay < *compositor_animation_wakeup_delay_ms))
             compositor_animation_wakeup_delay_ms = delay;
     };
@@ -8342,7 +8399,7 @@ void Document::update_compositor_animations()
         auto abstract_target = effect.target_abstract_element();
         if (!abstract_target.has_value() || effect.target_properties().is_empty())
             continue;
-        if (animation.is_idle() || !effect.is_in_effect())
+        if (animation.is_idle() || (!effect.is_in_effect() && !effect.is_in_the_before_phase()))
             continue;
         auto& target = abstract_target->element();
 
@@ -8370,7 +8427,7 @@ void Document::update_compositor_animations()
                 && effect.iteration_duration().type == Animations::TimeValue::Type::Milliseconds;
             if (all_targeted_properties_have_replace_winners && can_throttle_replaced_effect) {
                 effect.set_is_compositor_replaced(true);
-                schedule_active_end_wakeup(effect, animation);
+                schedule_next_phase_wakeup(effect, animation);
             }
             continue;
         }
@@ -8443,7 +8500,7 @@ void Document::update_compositor_animations()
         if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && transform_was_handed_off)
             effect.set_is_compositor_driven(true);
         effect.set_is_observation_relevant_compositor_animation(transform_affects_observation);
-        schedule_active_end_wakeup(effect, animation);
+        schedule_next_phase_wakeup(effect, animation);
         for (auto const& visual_animation : effect_visual_animations)
             visual_animations.append(visual_animation);
         effect.set_retained_compositor_animations(move(effect_visual_animations));

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -76,6 +76,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ComputationContext.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
@@ -7664,6 +7665,20 @@ static Optional<float> compositor_opacity_animation_value(CSS::StyleValue const&
     return opacity;
 }
 
+static Optional<Gfx::Color> compositor_background_color_animation_value(CSS::StyleValue const& style_value, DOM::AbstractElement target)
+{
+    // Legacy sRGB colors interpolate in gamma-encoded sRGB, which Gfx::Color::mixed_with() matches. Keep modern
+    // color syntaxes on the main thread until compositor values can retain their interpolation color space.
+    if (style_value.to_keyword() == CSS::Keyword::Currentcolor)
+        return {};
+    if (style_value.is_color() && style_value.as_color().color_syntax() != CSS::ColorSyntax::Legacy)
+        return {};
+    auto color = style_value.to_color(CSS::ColorResolutionContext::for_element(target));
+    if (!color.has_value())
+        return {};
+    return color.release_value();
+}
+
 static bool transform_keyframes_only_translate_horizontally(ReadonlySpan<Compositor::VisualAnimationKeyframe> keyframes)
 {
     Vector<float> translate_y_values;
@@ -7725,8 +7740,11 @@ static bool keyframe_effect_only_translates_horizontally(Animations::KeyframeEff
     return transform_keyframes_only_translate_horizontally(keyframes);
 }
 
-static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind, Optional<bool>& only_translates_horizontally)
+static Optional<Compositor::VisualAnimation> build_compositor_animation(Animations::KeyframeEffect& effect, Painting::AccumulatedVisualContextTree const& visual_context_tree, Compositor::VisualAnimation::TargetKind target_kind, Optional<bool>& only_translates_horizontally, bool* missing_visual_context_node = nullptr)
 {
+    if (missing_visual_context_node)
+        *missing_visual_context_node = false;
+
     auto animation = effect.associated_animation();
     if (!animation || animation->play_state() != Bindings::AnimationPlayState::Running)
         return {};
@@ -7757,10 +7775,11 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
         return {};
 
     bool targets_opacity = target_kind == Compositor::VisualAnimation::TargetKind::Opacity && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
+    bool targets_background_color = target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor && effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));
     bool targets_transform = target_kind == Compositor::VisualAnimation::TargetKind::Transform && any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
-    if (!targets_opacity && !targets_transform)
+    if (!targets_opacity && !targets_background_color && !targets_transform)
         return {};
-    if (any_of(effect.target_properties(), [&](auto const& property) { return property.id() != CSS::PropertyID::Opacity && !is_transform_family_property(property.id()); }))
+    if (any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor) && !is_transform_family_property(property.id()); }))
         return {};
     auto target = effect.target_abstract_element();
     if (!target.has_value() || target->element().namespace_uri() == Namespace::SVG)
@@ -7870,6 +7889,18 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                     if (opacity.has_value())
                         value = Compositor::VisualAnimationValue { opacity.release_value() };
                 }
+            } else if (target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor) {
+                auto property = entry.properties.get(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));
+                if (!property.has_value() || !property->has<CSS::RustStyleValueHandle>()) {
+                    new_cache.values.append({});
+                    continue;
+                }
+                auto style_value = resolved_compositor_animation_style_value(CSS::PropertyID::BackgroundColor, property->get<CSS::RustStyleValueHandle>(), *target);
+                if (style_value) {
+                    auto color = compositor_background_color_animation_value(*style_value, *target);
+                    if (color.has_value())
+                        value = Compositor::VisualAnimationValue { color.release_value() };
+                }
             } else {
                 Compositor::VisualAnimationTransformList operations;
                 bool skip_keyframe = false;
@@ -7918,10 +7949,6 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
         return *cached_values;
     };
     auto build_animation_for_target = [&](Compositor::VisualAnimation::TargetKind target_kind) -> Optional<Compositor::VisualAnimation> {
-        auto visual_context_node_indices = Painting::rust_visual_animation_target_node_indices(*layout_node, visual_context_tree, target_kind == Compositor::VisualAnimation::TargetKind::Opacity);
-        if (visual_context_node_indices.is_empty())
-            return {};
-
         Vector<Compositor::VisualAnimationEasing> keyframe_easings;
         keyframe_easings.ensure_capacity(key_frame_set->keyframes_by_key.size());
         for (auto it = key_frame_set->keyframes_by_key.begin(); it != key_frame_set->keyframes_by_key.end(); ++it) {
@@ -7971,6 +7998,23 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                 && transform_keyframes_only_translate_horizontally(keyframes);
         }
 
+        auto ffi_target_kind = [&] {
+            switch (target_kind) {
+            case Compositor::VisualAnimation::TargetKind::Opacity:
+                return Layout::RustFFI::FfiVisualAnimationTargetKind::Opacity;
+            case Compositor::VisualAnimation::TargetKind::BackgroundColor:
+                return Layout::RustFFI::FfiVisualAnimationTargetKind::BackgroundColor;
+            case Compositor::VisualAnimation::TargetKind::Transform:
+                return Layout::RustFFI::FfiVisualAnimationTargetKind::Transform;
+            }
+            VERIFY_NOT_REACHED();
+        }();
+        auto visual_context_node_indices = Painting::rust_visual_animation_target_node_indices(*layout_node, visual_context_tree, ffi_target_kind);
+        if (visual_context_node_indices.is_empty()) {
+            if (missing_visual_context_node)
+                *missing_visual_context_node = true;
+            return {};
+        }
         Compositor::VisualAnimation visual_animation {
             .target_kind = target_kind,
             .visual_context_node_indices = move(visual_context_node_indices),
@@ -8087,6 +8131,7 @@ void Document::update_compositor_animations()
     };
     struct CompetingEffects {
         CompetingPropertyEffects opacity;
+        CompetingPropertyEffects background_color;
         CompetingPropertyEffects transform;
     };
 
@@ -8103,6 +8148,8 @@ void Document::update_compositor_animations()
     HashMap<GC::Ptr<Element>, CSSPixelRect> observation_target_rect_cache;
     GC::RootHashTable<GC::Ref<Element>> elements_with_intersection_observation_descendants;
     GC::RootHashTable<GC::Ref<Element>> elements_with_visibility_observation_descendants;
+    auto layout_nodes_with_stale_forced_effects_layer = move(m_layout_nodes_with_forced_compositor_effects_layer);
+    auto layout_nodes_with_stale_forced_background_color_frame = move(m_layout_nodes_with_forced_compositor_background_color_frame);
     Optional<double> compositor_animation_wakeup_delay_ms;
 
     auto index_shadow_including_element_ancestors = [](Node& node, GC::RootHashTable<GC::Ref<Element>>& index) {
@@ -8332,6 +8379,8 @@ void Document::update_compositor_animations()
         };
         if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity)))
             add_competing_effect(effects.opacity);
+        if (effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor)))
+            add_competing_effect(effects.background_color);
         if (any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); })) {
             add_competing_effect(effects.transform);
             in_effect_transform_effects_by_target.ensure(&target->element()).append(effect);
@@ -8356,6 +8405,7 @@ void Document::update_compositor_animations()
                 property_effects.winner = nullptr;
         };
         validate_winner(effects.opacity);
+        validate_winner(effects.background_color);
         validate_winner(effects.transform);
     }
 
@@ -8404,19 +8454,50 @@ void Document::update_compositor_animations()
         auto& target = abstract_target->element();
 
         bool targets_opacity = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::Opacity));
+        bool targets_background_color = effect.target_properties().contains(CSS::PropertyNameAndID::from_id(CSS::PropertyID::BackgroundColor));
         bool targets_transform = any_of(effect.target_properties(), [](auto const& property) { return is_transform_family_property(property.id()); });
-        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto const& property) { return property.id() != CSS::PropertyID::Opacity && !is_transform_family_property(property.id()); });
+        bool targets_unsupported_property = any_of(effect.target_properties(), [&](auto const& property) { return !first_is_one_of(property.id(), CSS::PropertyID::Opacity, CSS::PropertyID::BackgroundColor) && !is_transform_family_property(property.id()); });
         if (targets_unsupported_property)
             continue;
         auto target_effects = competing_effects.get(*abstract_target);
         VERIFY(target_effects.has_value());
         bool opacity_has_replace_winner = !targets_opacity || target_effects->opacity.winner;
+        bool background_color_has_replace_winner = !targets_background_color || target_effects->background_color.winner;
         bool transform_has_replace_winner = !targets_transform || target_effects->transform.winner;
         bool selected_for_opacity = targets_opacity && target_effects->opacity.winner.ptr() == &effect;
+        bool selected_for_background_color = targets_background_color && target_effects->background_color.winner.ptr() == &effect;
         bool selected_for_transform = targets_transform && target_effects->transform.winner.ptr() == &effect;
-        bool all_targeted_properties_have_replace_winners = opacity_has_replace_winner && transform_has_replace_winner;
+        bool all_targeted_properties_have_replace_winners = opacity_has_replace_winner && background_color_has_replace_winner && transform_has_replace_winner;
 
-        if (!selected_for_opacity && !selected_for_transform) {
+        Optional<bool> only_translates_horizontally;
+
+        // Background colors are display-list content, so associate their fill commands with a dedicated metadata
+        // frame. Validate the descriptor before forcing that frame, which requires one repaint before the animation
+        // can move to the compositor.
+        Layout::Node* background_color_layout_node = nullptr;
+        Optional<Compositor::VisualAnimation> background_color_visual_animation;
+        bool background_color_animation_is_valid = false;
+        if (selected_for_background_color) {
+            if (auto* layout_node = abstract_target->unsafe_layout_node()) {
+                if (Painting::rust_background_color_can_be_compositor_animated(*layout_node)) {
+                    background_color_layout_node = layout_node;
+                    bool missing_visual_context_node = false;
+                    background_color_visual_animation = build_compositor_animation(effect, visual_context_tree, Compositor::VisualAnimation::TargetKind::BackgroundColor, only_translates_horizontally, &missing_visual_context_node);
+                    background_color_animation_is_valid = background_color_visual_animation.has_value() || missing_visual_context_node;
+                    if (!background_color_animation_is_valid) {
+                        background_color_layout_node = nullptr;
+                    } else if (missing_visual_context_node && !layout_node->needs_compositor_background_color_frame()) {
+                        layout_node->set_needs_compositor_background_color_frame(true);
+                        schedule_accumulated_visual_context_update(*layout_node, AccumulatedVisualContextUpdateScope::Structure);
+                        CSS::RequiredInvalidationAfterStyleChange invalidation;
+                        invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+                        Painting::repaint_after_style_change(*layout_node, invalidation);
+                    }
+                }
+            }
+        }
+
+        if (!selected_for_opacity && !selected_for_background_color && !selected_for_transform) {
             bool can_throttle_replaced_effect = animation.play_state() == Bindings::AnimationPlayState::Running
                 && !animation.pending()
                 && animation.playback_rate() > 0
@@ -8432,7 +8513,6 @@ void Document::update_compositor_animations()
             continue;
         }
 
-        Optional<bool> only_translates_horizontally;
         Vector<Compositor::VisualAnimation> effect_visual_animations;
         bool opacity_was_handed_off = !selected_for_opacity;
         if (selected_for_opacity) {
@@ -8441,6 +8521,18 @@ void Document::update_compositor_animations()
                 effect_visual_animations.append(visual_animation.release_value());
                 opacity_was_handed_off = true;
             }
+        }
+        bool background_color_was_handed_off = !selected_for_background_color;
+        if (background_color_visual_animation.has_value()) {
+            effect_visual_animations.append(background_color_visual_animation.release_value());
+            background_color_was_handed_off = true;
+        }
+        if (background_color_layout_node && background_color_animation_is_valid) {
+            if (!any_of(m_layout_nodes_with_forced_compositor_background_color_frame, [&](auto const& forced_layout_node) { return forced_layout_node.ptr() == background_color_layout_node; }))
+                m_layout_nodes_with_forced_compositor_background_color_frame.append(*background_color_layout_node);
+            layout_nodes_with_stale_forced_background_color_frame.remove_first_matching([&](auto const& stale_layout_node) {
+                return stale_layout_node.ptr() == background_color_layout_node;
+            });
         }
         bool transform_was_handed_off = !selected_for_transform;
         if (selected_for_transform) {
@@ -8497,7 +8589,7 @@ void Document::update_compositor_animations()
                 }
             }
         }
-        if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && transform_was_handed_off)
+        if (all_targeted_properties_have_replace_winners && opacity_was_handed_off && background_color_was_handed_off && transform_was_handed_off)
             effect.set_is_compositor_driven(true);
         effect.set_is_observation_relevant_compositor_animation(transform_affects_observation);
         schedule_next_phase_wakeup(effect, animation);
@@ -8507,6 +8599,25 @@ void Document::update_compositor_animations()
         if (auto* layout_node = abstract_target->unsafe_layout_node())
             layout_node->set_retains_compositor_animated_content(true);
         published_compositor_animation = true;
+    }
+
+    for (auto& layout_node : layout_nodes_with_stale_forced_effects_layer) {
+        if (!layout_node)
+            continue;
+        layout_node->set_needs_compositor_effects_layer(false);
+        schedule_accumulated_visual_context_update(*layout_node, AccumulatedVisualContextUpdateScope::Structure);
+        CSS::RequiredInvalidationAfterStyleChange invalidation;
+        invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+        Painting::repaint_after_style_change(*layout_node, invalidation);
+    }
+    for (auto& layout_node : layout_nodes_with_stale_forced_background_color_frame) {
+        if (!layout_node)
+            continue;
+        layout_node->set_needs_compositor_background_color_frame(false);
+        schedule_accumulated_visual_context_update(*layout_node, AccumulatedVisualContextUpdateScope::Structure);
+        CSS::RequiredInvalidationAfterStyleChange invalidation;
+        invalidation.ensure_at_least(CSS::InvalidationLevel::Repaint);
+        Painting::repaint_after_style_change(*layout_node, invalidation);
     }
 
     paint_state().set_visual_animations(*this, move(visual_animations));

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7493,11 +7493,16 @@ static Optional<CSS::Length> compositor_transform_percentage_basis(CSS::Transfor
 
 static Optional<Compositor::VisualAnimationTransformOperation> compositor_transform_operation(CSS::TransformationStyleValue const& transformation, CSSPixelSize reference_size, float device_pixels_per_css_pixel)
 {
-    auto kind = compositor_transform_operation_kind(transformation.transform_function());
+    auto transform_function = transformation.transform_function();
+    Optional<Compositor::VisualAnimationTransformOperationKind> kind;
+    if (transform_function == CSS::TransformFunction::Rotate3d)
+        kind = Compositor::VisualAnimationTransformOperationKind::Rotate;
+    else
+        kind = compositor_transform_operation_kind(transform_function);
     if (!kind.has_value())
         return {};
 
-    auto metadata = CSS::transform_function_metadata(transformation.transform_function());
+    auto metadata = CSS::transform_function_metadata(transform_function);
     auto style_values = transformation.values();
     Vector<float> values;
     values.ensure_capacity(style_values.size());
@@ -7510,7 +7515,7 @@ static Optional<Compositor::VisualAnimationTransformOperation> compositor_transf
             case CSS::TransformFunctionParameterType::Length:
             case CSS::TransformFunctionParameterType::LengthNone:
             case CSS::TransformFunctionParameterType::LengthPercentage:
-                return CSS::Length::from_style_value(style_value, compositor_transform_percentage_basis(transformation.transform_function(), index, reference_size)).absolute_length_to_px().to_float() * device_pixels_per_css_pixel;
+                return CSS::Length::from_style_value(style_value, compositor_transform_percentage_basis(transform_function, index, reference_size)).absolute_length_to_px().to_float() * device_pixels_per_css_pixel;
             case CSS::TransformFunctionParameterType::Number:
             case CSS::TransformFunctionParameterType::NumberPercentage:
                 return CSS::number_from_style_value(style_value, 1);
@@ -7520,6 +7525,26 @@ static Optional<Compositor::VisualAnimationTransformOperation> compositor_transf
         if (!isfinite(value))
             return {};
         values.unchecked_append(value);
+    }
+    if (transform_function == CSS::TransformFunction::Rotate3d) {
+        if (values.size() != 4)
+            return {};
+        float axis;
+        if (values[0] != 0 && values[1] == 0 && values[2] == 0) {
+            *kind = Compositor::VisualAnimationTransformOperationKind::RotateX;
+            axis = values[0];
+        } else if (values[0] == 0 && values[1] != 0 && values[2] == 0) {
+            *kind = Compositor::VisualAnimationTransformOperationKind::RotateY;
+            axis = values[1];
+        } else if (values[0] == 0 && values[1] == 0 && values[2] != 0) {
+            *kind = Compositor::VisualAnimationTransformOperationKind::RotateZ;
+            axis = values[2];
+        } else {
+            return {};
+        }
+        auto angle = axis < 0 ? -values[3] : values[3];
+        values.clear();
+        values.append(angle);
     }
     if (*kind == Compositor::VisualAnimationTransformOperationKind::Translate && values.size() == 1)
         kind = Compositor::VisualAnimationTransformOperationKind::TranslateX;
@@ -7570,8 +7595,43 @@ static bool is_transform_family_property(CSS::PropertyID property_id)
         CSS::PropertyID::Transform);
 }
 
-static Optional<Compositor::VisualAnimationTransformList> compositor_transform_animation_value(CSS::PropertyID property_id, CSS::StyleValue const& style_value, Layout::Node const& layout_node, float device_pixels_per_css_pixel)
+static Optional<Compositor::VisualAnimationTransformList> compositor_transform_animation_value(CSS::PropertyID property_id, CSS::StyleValue const& style_value, Layout::Node const& layout_node, float device_pixels_per_css_pixel, Compositor::VisualAnimationTransformList const* transform_identity_shape = nullptr)
 {
+    if (style_value.is_keyword() && style_value.to_keyword() == CSS::Keyword::None) {
+        Compositor::VisualAnimationTransformList identity;
+        if (transform_identity_shape) {
+            identity.ensure_capacity(transform_identity_shape->size());
+            for (auto const& operation : *transform_identity_shape) {
+                Vector<float> values;
+                values.resize(operation.values.size());
+                if (first_is_one_of(operation.kind,
+                        Compositor::VisualAnimationTransformOperationKind::Scale,
+                        Compositor::VisualAnimationTransformOperationKind::Scale3d,
+                        Compositor::VisualAnimationTransformOperationKind::ScaleX,
+                        Compositor::VisualAnimationTransformOperationKind::ScaleY,
+                        Compositor::VisualAnimationTransformOperationKind::ScaleZ))
+                    values.fill(1);
+                identity.append({ operation.kind, move(values) });
+            }
+            return identity;
+        }
+        switch (property_id) {
+        case CSS::PropertyID::Translate:
+            identity.append({ Compositor::VisualAnimationTransformOperationKind::Translate, { 0, 0 } });
+            return identity;
+        case CSS::PropertyID::Rotate:
+            identity.append({ Compositor::VisualAnimationTransformOperationKind::Rotate, { 0 } });
+            return identity;
+        case CSS::PropertyID::Scale:
+            identity.append({ Compositor::VisualAnimationTransformOperationKind::Scale, { 1, 1 } });
+            return identity;
+        case CSS::PropertyID::Transform:
+            return {};
+        default:
+            return {};
+        }
+    }
+
     Vector<NonnullRefPtr<CSS::TransformationStyleValue const>> transformations;
     if (property_id == CSS::PropertyID::Transform) {
         transformations = CSS::transformations_for_style_value(style_value);
@@ -7746,6 +7806,22 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
             .values = {},
         };
         new_cache.values.ensure_capacity(key_frame_set->keyframes_by_key.size());
+        HashMap<CSS::PropertyID, Optional<Compositor::VisualAnimationTransformList>> transform_identity_shapes;
+        auto resolve_transform_identity_shape = [&](CSS::PropertyID property_id) -> Compositor::VisualAnimationTransformList const* {
+            auto& transform_identity_shape = transform_identity_shapes.ensure(property_id, [&]() -> Optional<Compositor::VisualAnimationTransformList> {
+                for (auto const& candidate_entry : key_frame_set->keyframes_by_key) {
+                    auto candidate = candidate_entry.properties.get(CSS::PropertyNameAndID::from_id(property_id));
+                    if (!candidate.has_value() || !candidate->has<CSS::RustStyleValueHandle>())
+                        continue;
+                    auto candidate_style_value = resolved_compositor_animation_style_value(property_id, candidate->get<CSS::RustStyleValueHandle>(), *target);
+                    if (!candidate_style_value || (candidate_style_value->is_keyword() && candidate_style_value->to_keyword() == CSS::Keyword::None))
+                        continue;
+                    return compositor_transform_animation_value(property_id, *candidate_style_value, *layout_node, device_pixels_per_css_pixel);
+                }
+                return {};
+            });
+            return transform_identity_shape.has_value() ? &*transform_identity_shape : nullptr;
+        };
         size_t transform_property_count = 0;
         for (auto const& property : effect.target_properties()) {
             if (is_transform_family_property(property.id()))
@@ -7785,7 +7861,10 @@ static Optional<Compositor::VisualAnimation> build_compositor_animation(Animatio
                         new_cache.is_valid = false;
                         break;
                     }
-                    auto property_operations = compositor_transform_animation_value(property_id, *style_value, *layout_node, device_pixels_per_css_pixel);
+                    auto const* transform_identity_shape = style_value->is_keyword() && style_value->to_keyword() == CSS::Keyword::None
+                        ? resolve_transform_identity_shape(property_id)
+                        : nullptr;
+                    auto property_operations = compositor_transform_animation_value(property_id, *style_value, *layout_node, device_pixels_per_css_pixel, transform_identity_shape);
                     if (!property_operations.has_value()) {
                         new_cache.is_valid = false;
                         break;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -466,6 +466,7 @@ public:
     void schedule_compositor_animation_wakeup(double delay_ms);
     void stop_compositor_animation_timers();
     void arm_compositor_animation_timers_for_testing(Badge<Internals::Internals>);
+    void fire_compositor_animation_wakeup_for_testing(Badge<Internals::Internals>, double frame_time_ms);
     void request_reentrant_animation_style_flush_for_testing(Badge<Internals::Internals>, Node const&);
     bool run_empty_animation_style_update_for_testing(Badge<Internals::Internals>);
     bool compositor_animation_wakeup_timer_is_active() const;
@@ -1105,6 +1106,7 @@ public:
         u64 animation_timeline_synchronizations { 0 };
         u64 animation_timeline_associated_animation_updates { 0 };
         u64 compositor_visual_animation_updates { 0 };
+        u64 compositor_visual_animation_timing_anchor_updates { 0 };
         u64 compositor_keyframe_value_resolutions { 0 };
         u64 base_style_partial_builds { 0 };
         u64 base_style_full_builds { 0 };
@@ -1468,6 +1470,7 @@ private:
     friend struct AdoptedStyleSheetsAccess;
 
     void finish_animated_style_update();
+    void service_compositor_animation_wakeup(double timestamp);
 
     GC::Ref<WebIDL::ObservableArray> adopted_style_sheets() const;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1845,6 +1845,8 @@ private:
     RefPtr<Core::Timer> m_compositor_animation_wakeup_timer;
     Optional<MonotonicTime> m_compositor_animation_wakeup_deadline;
     RefPtr<Core::Timer> m_compositor_animation_observation_timer;
+    Vector<WeakPtr<Layout::Node>> m_layout_nodes_with_forced_compositor_effects_layer;
+    Vector<WeakPtr<Layout::Node>> m_layout_nodes_with_forced_compositor_background_color_frame;
 
     bool m_temporary_document_for_fragment_parsing { false };
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -224,16 +224,20 @@ u64 Internals::visual_context_tree_node_capacity()
 GC::Ref<JS::Object> Internals::visual_context_node_indices(DOM::Element& element)
 {
     auto& realm = window().principal_realm();
-    window().associated_document().update_paint_and_hit_testing_properties_if_needed();
+    auto& document = window().associated_document();
+    document.update_layout(DOM::UpdateLayoutReason::Debugging);
+    document.update_paint_and_hit_testing_properties_if_needed();
+    auto const* layout_node = element.layout_node();
     auto owned_indices_as_array = [&](Layout::RustFFI::FfiVisualContextBoxNodeList list) -> GC::Ref<JS::Array> {
         Vector<u32> indices;
-        if (auto const* layout_node = element.layout_node())
+        if (layout_node)
             indices = Painting::rust_owned_visual_context_node_indices(*layout_node, list);
         return JS::Array::create_from<u32>(realm, indices.span(), [](u32 index) { return JS::Value { index }; });
     };
     auto object = JS::Object::create(realm, nullptr);
     object->define_direct_property("spatial"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::SpatialNodes), JS::default_attributes);
     object->define_direct_property("frames"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::FrameNodes), JS::default_attributes);
+    object->define_direct_property("needsCompositorBackgroundColorFrame"_utf16_fly_string, JS::Value(layout_node && layout_node->needs_compositor_background_color_frame()), JS::default_attributes);
     return object;
 }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -25,6 +25,7 @@
 #include <LibURL/Parser.h>
 #include <LibWeb/ARIA/AriaData.h>
 #include <LibWeb/ARIA/StateAndProperties.h>
+#include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Bindings/Internals.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -1377,6 +1378,11 @@ void Internals::arm_compositor_animation_timers_for_testing()
     window().associated_document().arm_compositor_animation_timers_for_testing({});
 }
 
+void Internals::fire_compositor_animation_wakeup_for_testing(double frame_time_ms)
+{
+    window().associated_document().fire_compositor_animation_wakeup_for_testing({}, frame_time_ms);
+}
+
 void Internals::request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node> node)
 {
     window().associated_document().request_reentrant_animation_style_flush_for_testing({}, node);
@@ -1980,11 +1986,21 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("animationTimelineAssociatedAnimationUpdates"_utf16_fly_string, JS::Value(counters.animation_timeline_associated_animation_updates), JS::default_attributes);
     object->define_direct_property("associatedAnimations"_utf16_fly_string, JS::Value(document.associated_animation_count()), JS::default_attributes);
     object->define_direct_property("compositorVisualAnimationUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_updates), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationTimingAnchorUpdates"_utf16_fly_string, JS::Value(counters.compositor_visual_animation_timing_anchor_updates), JS::default_attributes);
     object->define_direct_property("compositorKeyframeValueResolutions"_utf16_fly_string, JS::Value(counters.compositor_keyframe_value_resolutions), JS::default_attributes);
-    auto compositor_visual_animation_count = document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()
-        ? document.paint_state().visual_context_tree(document).visual_animations().size()
-        : 0;
+    size_t compositor_visual_animation_count = 0;
+    Optional<double> compositor_visual_animation_local_time_at_anchor;
+    if (document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()) {
+        auto visual_context_tree = document.paint_state().visual_context_tree(document);
+        auto visual_animations = visual_context_tree.visual_animations();
+        compositor_visual_animation_count = visual_animations.size();
+        if (!visual_animations.is_empty())
+            compositor_visual_animation_local_time_at_anchor = visual_animations.first().local_time_at_anchor_ms;
+    }
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationLocalTimeAtAnchor"_utf16_fly_string, compositor_visual_animation_local_time_at_anchor.has_value() ? JS::Value(*compositor_visual_animation_local_time_at_anchor) : JS::js_null(), JS::default_attributes);
+    auto document_timeline_current_time = document.timeline()->current_time();
+    object->define_direct_property("documentTimelineCurrentTime"_utf16_fly_string, document_timeline_current_time.has_value() ? JS::Value(document_timeline_current_time->value) : JS::js_null(), JS::default_attributes);
     object->define_direct_property("compositorAnimationWakeupTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_wakeup_timer_is_active()), JS::default_attributes);
     object->define_direct_property("compositorAnimationObservationTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_observation_timer_is_active()), JS::default_attributes);
     object->define_direct_property("baseStylePartialBuilds"_utf16_fly_string, JS::Value(counters.base_style_partial_builds), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -237,6 +237,7 @@ GC::Ref<JS::Object> Internals::visual_context_node_indices(DOM::Element& element
     auto object = JS::Object::create(realm, nullptr);
     object->define_direct_property("spatial"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::SpatialNodes), JS::default_attributes);
     object->define_direct_property("frames"_utf16_fly_string, owned_indices_as_array(Layout::RustFFI::FfiVisualContextBoxNodeList::FrameNodes), JS::default_attributes);
+    object->define_direct_property("needsCompositorEffectsLayer"_utf16_fly_string, JS::Value(layout_node && layout_node->needs_compositor_effects_layer()), JS::default_attributes);
     object->define_direct_property("needsCompositorBackgroundColorFrame"_utf16_fly_string, JS::Value(layout_node && layout_node->needs_compositor_background_color_frame()), JS::default_attributes);
     return object;
 }
@@ -1994,15 +1995,22 @@ GC::Ref<JS::Object> Internals::style_invalidation_counters_object() const
     object->define_direct_property("compositorKeyframeValueResolutions"_utf16_fly_string, JS::Value(counters.compositor_keyframe_value_resolutions), JS::default_attributes);
     size_t compositor_visual_animation_count = 0;
     Optional<double> compositor_visual_animation_local_time_at_anchor;
+    bool compositor_visual_animations_share_timing_anchor = true;
     if (document.has_committed_viewport_box() && document.paint_state().has_visual_context_tree()) {
         auto visual_context_tree = document.paint_state().visual_context_tree(document);
         auto visual_animations = visual_context_tree.visual_animations();
         compositor_visual_animation_count = visual_animations.size();
-        if (!visual_animations.is_empty())
+        if (!visual_animations.is_empty()) {
             compositor_visual_animation_local_time_at_anchor = visual_animations.first().local_time_at_anchor_ms;
+            compositor_visual_animations_share_timing_anchor = all_of(visual_animations, [&](auto const& animation) {
+                return animation.monotonic_time_at_anchor_ns == visual_animations.first().monotonic_time_at_anchor_ns
+                    && animation.local_time_at_anchor_ms == visual_animations.first().local_time_at_anchor_ms;
+            });
+        }
     }
     object->define_direct_property("compositorVisualAnimations"_utf16_fly_string, JS::Value(compositor_visual_animation_count), JS::default_attributes);
     object->define_direct_property("compositorVisualAnimationLocalTimeAtAnchor"_utf16_fly_string, compositor_visual_animation_local_time_at_anchor.has_value() ? JS::Value(*compositor_visual_animation_local_time_at_anchor) : JS::js_null(), JS::default_attributes);
+    object->define_direct_property("compositorVisualAnimationsShareTimingAnchor"_utf16_fly_string, JS::Value(compositor_visual_animations_share_timing_anchor), JS::default_attributes);
     auto document_timeline_current_time = document.timeline()->current_time();
     object->define_direct_property("documentTimelineCurrentTime"_utf16_fly_string, document_timeline_current_time.has_value() ? JS::Value(document_timeline_current_time->value) : JS::js_null(), JS::default_attributes);
     object->define_direct_property("compositorAnimationWakeupTimerActive"_utf16_fly_string, JS::Value(document.compositor_animation_wakeup_timer_is_active()), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -201,6 +201,7 @@ public:
     void update_compositor_animations();
     bool run_empty_animation_style_update_for_testing();
     void arm_compositor_animation_timers_for_testing();
+    void fire_compositor_animation_wakeup_for_testing(double frame_time_ms);
     void request_reentrant_animation_style_flush_for_testing(GC::Ref<DOM::Node>);
     GC::Ref<JS::Object> layout_tree_build_stats();
     GC::Ref<JS::Object> compare_layout_tree_with_full_rebuild();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -185,6 +185,7 @@ interface Internals {
     undefined updateCompositorAnimations();
     boolean runEmptyAnimationStyleUpdateForTesting();
     undefined armCompositorAnimationTimersForTesting();
+    undefined fireCompositorAnimationWakeupForTesting(double frameTimeMs);
     undefined requestReentrantAnimationStyleFlushForTesting(Node node);
     // Returns the confinement report of the most recent layout tree build for the current
     // document. Keys: builds (cumulative build count), lastBuildRebuiltSubtreeRoots (number of

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -194,6 +194,10 @@ public:
 
     bool needs_layout_update() const { return has_flag(RustFFI::NodeFlag::NeedsLayoutUpdate); }
     void set_retains_compositor_animated_content(bool value) { set_flag(RustFFI::NodeFlag::HasAnimatedOpacityOrTransform, value); }
+    bool needs_compositor_effects_layer() const { return has_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind::Opacity); }
+    void set_needs_compositor_effects_layer(bool value) { set_needs_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind::Opacity, value); }
+    bool needs_compositor_background_color_frame() const { return has_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind::BackgroundColor); }
+    void set_needs_compositor_background_color_frame(bool value) { set_needs_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind::BackgroundColor, value); }
 
     // The arena measures a box that holds a scroll offset eagerly after a full commit, so the box carries that fact
     // as a flag: it is set when a box becomes an element's or a pseudo-element's box, and again whenever the stored
@@ -324,6 +328,16 @@ protected:
     }
 
     bool dom_target_stores_scroll_offset() const;
+
+    bool has_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind kind) const
+    {
+        return RustFFI::layout_arena_node_has_compositor_animation_frame(m_arena->handle(), m_slot, kind);
+    }
+
+    void set_needs_compositor_animation_frame(RustFFI::CompositorAnimationFrameKind kind, bool value)
+    {
+        RustFFI::layout_arena_set_node_needs_compositor_animation_frame(m_arena->handle(), m_slot, kind, value);
+    }
 
     void set_flag(RustFFI::NodeFlag flag, bool value)
     {

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -136,6 +136,7 @@ void AccumulatedVisualContextTree::set_visual_animations(Vector<Compositor::Visu
 AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation_samples(i64 monotonic_time_ns) const
 {
     Vector<Layout::RustFFI::FfiFrameOpacitySample> opacity_samples;
+    Vector<Layout::RustFFI::FfiFrameBackgroundColorSample> background_color_samples;
     Vector<Layout::RustFFI::FfiSpatialTransformSample> transform_samples;
     for (auto const& animation : visual_animations()) {
         auto elapsed_nanoseconds = monotonic_time_ns > animation.monotonic_time_at_anchor_ns
@@ -147,11 +148,16 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
         for (auto node_index : animation.visual_context_node_indices) {
             if (animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity)
                 opacity_samples.append({ .frame = node_index, .opacity = sample->opacity });
+            else if (animation.target_kind == Compositor::VisualAnimation::TargetKind::BackgroundColor)
+                background_color_samples.append({ .frame = node_index, .color = *sample->background_color });
             else
                 transform_samples.append({ .spatial = node_index, .matrix = sample->transform });
         }
     }
-    auto tree = adopt_rust_handle(Layout::RustFFI::visual_context_tree_with_sampled_values(m_rust_tree, opacity_samples.data(), opacity_samples.size(), transform_samples.data(), transform_samples.size()));
+    auto tree = adopt_rust_handle(Layout::RustFFI::visual_context_tree_with_sampled_values(m_rust_tree,
+        opacity_samples.data(), opacity_samples.size(),
+        background_color_samples.data(), background_color_samples.size(),
+        transform_samples.data(), transform_samples.size()));
     tree.m_visual_animations = m_visual_animations;
     return tree;
 }
@@ -159,7 +165,18 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::with_visual_animation
 bool AccumulatedVisualContextTree::visual_animation_targets_are_valid(Compositor::VisualAnimation const& animation) const
 {
     auto const& targets = animation.visual_context_node_indices;
-    return Layout::RustFFI::visual_context_tree_visual_animation_targets_are_valid(m_rust_tree, animation.target_kind == Compositor::VisualAnimation::TargetKind::Opacity, targets.data(), targets.size());
+    auto target_kind = [&] {
+        switch (animation.target_kind) {
+        case Compositor::VisualAnimation::TargetKind::Opacity:
+            return Layout::RustFFI::FfiVisualAnimationTargetKind::Opacity;
+        case Compositor::VisualAnimation::TargetKind::BackgroundColor:
+            return Layout::RustFFI::FfiVisualAnimationTargetKind::BackgroundColor;
+        case Compositor::VisualAnimation::TargetKind::Transform:
+            return Layout::RustFFI::FfiVisualAnimationTargetKind::Transform;
+        }
+        VERIFY_NOT_REACHED();
+    }();
+    return Layout::RustFFI::visual_context_tree_visual_animation_targets_are_valid(m_rust_tree, target_kind, targets.data(), targets.size());
 }
 
 Optional<float> AccumulatedVisualContextTree::effects_opacity(FrameNodeIndex frame) const
@@ -168,6 +185,14 @@ Optional<float> AccumulatedVisualContextTree::effects_opacity(FrameNodeIndex fra
     if (!Layout::RustFFI::visual_context_tree_effects_opacity(m_rust_tree, frame, &opacity))
         return {};
     return opacity;
+}
+
+Optional<Gfx::Color> AccumulatedVisualContextTree::sampled_background_color(FrameNodeIndex frame) const
+{
+    Gfx::Color color;
+    if (!Layout::RustFFI::visual_context_tree_sampled_background_color(m_rust_tree, frame, &color))
+        return {};
+    return color;
 }
 
 Vector<bool> AccumulatedVisualContextTree::spatial_nodes_in_subtrees_of(ReadonlySpan<SpatialNodeIndex> roots) const

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -82,6 +82,7 @@ public:
     WEB_API AccumulatedVisualContextTree with_visual_animation_samples(i64 monotonic_time_ns) const;
     WEB_API bool visual_animation_targets_are_valid(Compositor::VisualAnimation const&) const;
     WEB_API Optional<float> effects_opacity(FrameNodeIndex) const;
+    WEB_API Optional<Gfx::Color> sampled_background_color(FrameNodeIndex) const;
     WEB_API Vector<bool> spatial_nodes_in_subtrees_of(ReadonlySpan<SpatialNodeIndex> roots) const;
 
     WEB_API Optional<Gfx::FloatPoint> transform_point_for_hit_test(ContextRef, Gfx::FloatPoint, ScrollStateSnapshot const&, ClipBehavior = ClipBehavior::Respect) const;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -229,7 +229,10 @@ void DisplayListPlayerSkia::play_command(FillRect const& command)
     auto& canvas = surface().canvas();
     SkPaint paint;
     paint.setAntiAlias(true);
-    paint.setColor(to_skia_color(command.color));
+    auto color = command.background_color_animation_frame == NO_FRAME_NODE
+        ? command.color
+        : active_visual_context_tree().sampled_background_color(command.background_color_animation_frame).value_or(command.color);
+    paint.setColor(to_skia_color(color));
     apply_compositing_and_blending_operator(paint, command.compositing_and_blending_operator);
     canvas.drawRect(to_skia_rect(rect), paint);
 }
@@ -676,7 +679,10 @@ void DisplayListPlayerSkia::play_command(FillRectWithRoundedCorners const& comma
 
     auto& canvas = surface().canvas();
     SkPaint paint;
-    paint.setColor(to_skia_color(command.color));
+    auto color = command.background_color_animation_frame == NO_FRAME_NODE
+        ? command.color
+        : active_visual_context_tree().sampled_background_color(command.background_color_animation_frame).value_or(command.color);
+    paint.setColor(to_skia_color(color));
     paint.setAntiAlias(true);
 
     auto rounded_rect = to_skia_rrect(rect, command.corner_radii);

--- a/Libraries/LibWeb/Painting/DocumentPaintState.cpp
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.cpp
@@ -133,8 +133,12 @@ void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<C
     if (published_animations == animations.span())
         return;
     bool animation_parameters_changed = m_visual_animations.size() != animations.size();
+    bool animation_timing_anchor_changed = false;
     if (!animation_parameters_changed) {
         for (size_t index = 0; index < animations.size(); ++index) {
+            if (m_visual_animations[index].monotonic_time_at_anchor_ns != animations[index].monotonic_time_at_anchor_ns
+                || m_visual_animations[index].local_time_at_anchor_ms != animations[index].local_time_at_anchor_ms)
+                animation_timing_anchor_changed = true;
             if (!m_visual_animations[index].has_same_animation_parameters(animations[index])) {
                 animation_parameters_changed = true;
                 break;
@@ -150,6 +154,16 @@ void DocumentPaintState::set_visual_animations(DOM::Document& document, Vector<C
     m_visual_context_tree_needs_compositor_update = true;
     if (animation_parameters_changed)
         ++document.style_invalidation_counters().compositor_visual_animation_updates;
+    if (animation_timing_anchor_changed)
+        ++document.style_invalidation_counters().compositor_visual_animation_timing_anchor_updates;
+}
+
+void DocumentPaintState::republish_visual_animations(DOM::Document& document)
+{
+    if (!m_visual_context_tree_visual_animations)
+        return;
+    m_visual_context_tree_needs_compositor_update = true;
+    ++document.style_invalidation_counters().compositor_visual_animation_updates;
 }
 
 void DocumentPaintState::append_paint_command_cache_source_resources(DisplayListResourceSet& retained_resources) const

--- a/Libraries/LibWeb/Painting/DocumentPaintState.h
+++ b/Libraries/LibWeb/Painting/DocumentPaintState.h
@@ -37,6 +37,7 @@ public:
     void update_accumulated_visual_contexts(DOM::Document&);
     void update_visual_viewport_accumulated_visual_context(DOM::Document&);
     void set_visual_animations(DOM::Document&, Vector<Compositor::VisualAnimation>);
+    void republish_visual_animations(DOM::Document&);
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     bool has_visual_context_tree() const;

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.cpp
@@ -514,15 +514,23 @@ Vector<u32> rust_owned_visual_context_node_indices(Layout::Node const& layout_no
     return indices;
 }
 
-Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const& layout_node, AccumulatedVisualContextTree const& visual_context_tree, bool targets_are_frames)
+Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const& layout_node, AccumulatedVisualContextTree const& visual_context_tree, Layout::RustFFI::FfiVisualAnimationTargetKind target_kind)
 {
     Vector<u32> indices;
     if (!has_committed_box(layout_node))
         return indices;
     Layout::RustFFI::layout_arena_paintable_visual_animation_target_indices(
-        layout_node.arena_handle(), committed_row_slot(layout_node), visual_context_tree.rust_handle(), targets_are_frames,
+        layout_node.arena_handle(), committed_row_slot(layout_node), visual_context_tree.rust_handle(), target_kind,
         &indices, [](void* context, u32 index) { static_cast<Vector<u32>*>(context)->append(index); });
     return indices;
+}
+
+bool rust_background_color_can_be_compositor_animated(Layout::Node const& layout_node)
+{
+    if (!has_committed_box(layout_node))
+        return false;
+    return Layout::RustFFI::layout_arena_background_color_can_be_compositor_animated(
+        layout_node.arena_handle(), committed_row_slot(layout_node), rust_root_background_source(layout_node.document()));
 }
 
 void const* retain_rust_main_visual_context_tree(DOM::Document const& document)

--- a/Libraries/LibWeb/Painting/PaintingRustBridge.h
+++ b/Libraries/LibWeb/Painting/PaintingRustBridge.h
@@ -27,7 +27,8 @@ WEB_API void dump_stacking_context_tree(StringBuilder&, DOM::Document const&);
 
 WEB_API Layout::RustFFI::FfiVisualContextUpdateOutcome rust_update_accumulated_visual_contexts(DOM::Document&);
 WEB_API Vector<u32> rust_owned_visual_context_node_indices(Layout::Node const&, Layout::RustFFI::FfiVisualContextBoxNodeList);
-WEB_API Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const&, AccumulatedVisualContextTree const&, bool targets_are_frames);
+WEB_API Vector<u32> rust_visual_animation_target_node_indices(Layout::Node const&, AccumulatedVisualContextTree const&, Layout::RustFFI::FfiVisualAnimationTargetKind);
+WEB_API bool rust_background_color_can_be_compositor_animated(Layout::Node const&);
 WEB_API void const* retain_rust_main_visual_context_tree(DOM::Document const&);
 WEB_API CSSPixelRect rust_apply_css_transform_to_rect(Layout::Node const&, CSSPixelRect const&);
 WEB_API Layout::RustFFI::FfiPhysicalOverflowDirections rust_physical_overflow_directions(Layout::Node const&);

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.cpp
@@ -54,6 +54,11 @@ FrameNodeIndex VisualContextTreeTestBuilder::append_clip_frame(FrameNodeIndex pa
     return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_clip_frame(m_builder, parent.value(), spatial.value(), rect, corner_radii, mode) };
 }
 
+FrameNodeIndex VisualContextTreeTestBuilder::append_background_color_animation_frame(FrameNodeIndex parent, SpatialNodeIndex spatial)
+{
+    return FrameNodeIndex { Layout::RustFFI::visual_context_tree_test_builder_append_background_color_animation_frame(m_builder, parent.value(), spatial.value()) };
+}
+
 FrameNodeIndex VisualContextTreeTestBuilder::append_clip_path_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const& path, Gfx::IntRect bounding_rect, Gfx::WindingRule fill_rule)
 {
     auto path_bytes = path.serialize_to_bytes();

--- a/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
+++ b/Libraries/LibWeb/Painting/VisualContextTreeTestBuilder.h
@@ -49,6 +49,7 @@ public:
     SpatialNodeIndex append_transform(SpatialNodeIndex parent, Gfx::FloatMatrix4x4 const&, Gfx::FloatPoint origin = {});
     SpatialNodeIndex append_scroll(SpatialNodeIndex parent);
     SpatialNodeIndex append_sticky(SpatialNodeIndex parent, StickyConstraints const&);
+    FrameNodeIndex append_background_color_animation_frame(FrameNodeIndex parent, SpatialNodeIndex spatial);
     FrameNodeIndex append_clip_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::FloatRect, Gfx::CornerRadii = {}, ClipMode = ClipMode::Intersect);
     FrameNodeIndex append_clip_path_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, Gfx::Path const&, Gfx::IntRect bounding_rect, Gfx::WindingRule);
     FrameNodeIndex append_effects_frame(FrameNodeIndex parent, SpatialNodeIndex spatial, float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal);

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1213,6 +1213,31 @@ impl LayoutNodeArena {
         data.flags.set(updated);
     }
 
+    pub(crate) fn node_has_compositor_animation_frame(
+        &self,
+        id: NodeSlotId,
+        kind: super::node_data::CompositorAnimationFrameKind,
+    ) -> bool {
+        self.data(id).compositor_animation_frame_kinds.get() & kind as u8 != 0
+    }
+
+    pub(crate) fn set_node_needs_compositor_animation_frame(
+        &self,
+        id: NodeSlotId,
+        kind: super::node_data::CompositorAnimationFrameKind,
+        value: bool,
+    ) {
+        self.assert_owner_thread();
+        let frame_kinds = &self.data(id).compositor_animation_frame_kinds;
+        let mut updated = frame_kinds.get();
+        if value {
+            updated |= kind as u8;
+        } else {
+            updated &= !(kind as u8);
+        }
+        frame_kinds.set(updated);
+    }
+
     pub(crate) fn for_each_node_in_layout_subtree_in_pre_order(
         &self,
         root: NodeSlotId,
@@ -2810,6 +2835,16 @@ pub unsafe extern "C" fn layout_arena_node_flags(arena: *mut c_void, id: NodeSlo
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_has_compositor_animation_frame(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    kind: super::node_data::CompositorAnimationFrameKind,
+) -> bool {
+    // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+    unsafe { LayoutNodeArena::from_handle(arena) }.node_has_compositor_animation_frame(id, kind)
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn layout_arena_node_generated_for(arena: *mut c_void, id: NodeSlotId) -> u8 {
     // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
     unsafe { LayoutNodeArena::from_handle(arena) }.node_generated_for(id)
@@ -2886,6 +2921,18 @@ pub unsafe extern "C" fn layout_arena_set_node_flag(arena: *mut c_void, id: Node
     // SAFETY: The C++ wrapper keeps the arena alive for this call and
     // serializes all access on the document thread.
     unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_flag(id, flag, value);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_node_needs_compositor_animation_frame(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    kind: super::node_data::CompositorAnimationFrameKind,
+    value: bool,
+) {
+    assert!(!arena.is_null(), "layout node arena handle is null");
+    // SAFETY: The C++ wrapper keeps the arena alive for this call and serializes all access on the document thread.
+    unsafe { &*arena.cast::<LayoutNodeArena>() }.set_node_needs_compositor_animation_frame(id, kind, value);
 }
 
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -174,6 +174,13 @@ pub enum NodeFlag {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
+pub enum CompositorAnimationFrameKind {
+    Opacity = 1 << 0,
+    BackgroundColor = 1 << 1,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum FfiNodeLink {
     Parent,
     FirstChild,
@@ -219,6 +226,7 @@ pub(crate) struct NodeData {
     /// is unreachable.
     pub fragment_cache_epoch: Cell<u32>,
     pub slot_generation: Cell<u8>,
+    pub compositor_animation_frame_kinds: Cell<u8>,
     pub table_column_span: Cell<u16>,
     pub table_row_span: Cell<u16>,
     pub style: Cell<*const c_void>,
@@ -240,6 +248,7 @@ impl Default for NodeData {
             intrinsic_cache_epoch: Cell::new(0),
             flags: Cell::new(0),
             slot_generation: Cell::new(0),
+            compositor_animation_frame_kinds: Cell::new(0),
             table_column_span: Cell::new(1),
             table_row_span: Cell::new(1),
             fragment_cache_epoch: Cell::new(0),
@@ -266,6 +275,7 @@ mod tests {
         assert_eq!(std::mem::offset_of!(NodeData, flags), 32);
         assert_eq!(std::mem::offset_of!(NodeData, fragment_cache_epoch), 36);
         assert_eq!(std::mem::offset_of!(NodeData, slot_generation), 40);
+        assert_eq!(std::mem::offset_of!(NodeData, compositor_animation_frame_kinds), 41);
         assert_eq!(std::mem::offset_of!(NodeData, table_column_span), 42);
         assert_eq!(std::mem::offset_of!(NodeData, table_row_span), 44);
         assert_eq!(std::mem::offset_of!(NodeData, style), 48);

--- a/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/builder.rs
@@ -306,12 +306,39 @@ impl DisplayListBuilder {
                     let field_offset = offset + std::mem::offset_of!(DisplayListCommandHeader, context);
                     context.write_ffi_bytes(&mut bytes[field_offset..field_offset + std::mem::size_of::<ContextRef>()]);
                 }
+                rewrite_background_color_animation_frame(bytes, offset, &header, rewrite);
             }
             let record_size = HEADER_SIZE + header.payload_size as usize;
             note_command(runs, &header, offset, record_size);
             offset += record_size;
         }
         assert_eq!(offset, bytes.len());
+    }
+}
+
+fn rewrite_background_color_animation_frame(
+    bytes: &mut [u8],
+    record_offset: usize,
+    header: &DisplayListCommandHeader,
+    rewrite: ContextRewrite,
+) {
+    let payload_field_offset = match header.command_type {
+        DisplayListCommandType::FillRect => std::mem::offset_of!(FillRect, background_color_animation_frame),
+        DisplayListCommandType::FillRectWithRoundedCorners => {
+            std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_frame)
+        }
+        _ => return,
+    };
+    let field_offset = record_offset + HEADER_SIZE + payload_field_offset;
+    let field_size = std::mem::size_of::<FrameNodeIndex>();
+    let frame = FrameNodeIndex(u32::from_ne_bytes(
+        bytes[field_offset..field_offset + field_size].try_into().unwrap(),
+    ));
+    if !frame.is_none() && frame == rewrite.recorded_context.frame {
+        rewrite
+            .current_context
+            .frame
+            .write_ffi_bytes(&mut bytes[field_offset..field_offset + field_size]);
     }
 }
 
@@ -438,6 +465,7 @@ mod tests {
             rect: IntRect::new(x, y, width, height),
             color: Color::default(),
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+            background_color_animation_frame: FrameNodeIndex::NONE,
         }
     }
 
@@ -466,6 +494,23 @@ mod tests {
         let mut contexts = Vec::new();
         for_each_command(builder.bytes(), |header, _, _| contexts.push(header.context));
         contexts
+    }
+
+    fn background_color_animation_frames(builder: &DisplayListBuilder) -> Vec<FrameNodeIndex> {
+        let mut frames = Vec::new();
+        for_each_command(builder.bytes(), |header, _, payload| {
+            let field_offset = match header.command_type {
+                DisplayListCommandType::FillRect => {
+                    std::mem::offset_of!(FillRect, background_color_animation_frame)
+                }
+                DisplayListCommandType::FillRectWithRoundedCorners => {
+                    std::mem::offset_of!(FillRectWithRoundedCorners, background_color_animation_frame)
+                }
+                _ => return,
+            };
+            frames.push(FrameNodeIndex(HeaderReader { bytes: payload }.u32_at(field_offset)));
+        });
+        frames
     }
 
     fn assert_runs_cover_tape(builder: &DisplayListBuilder) {
@@ -700,6 +745,54 @@ mod tests {
         );
         assert_runs_cover_tape(&builder);
         assert_eq!(builder.command_runs().len(), 4);
+    }
+
+    #[test]
+    fn a_spliced_capture_rewrites_background_color_animation_frames() {
+        let recorded = context(2, Some(1));
+        let current = context(3, Some(7));
+        let mut source = DisplayListBuilder::new();
+        source.append(
+            &FillRect {
+                background_color_animation_frame: recorded.frame,
+                ..fill_rect(0, 0, 10, 10)
+            },
+            &[],
+            recorded,
+        );
+        source.append(
+            &FillRectWithRoundedCorners {
+                rect: IntRect::new(20, 20, 10, 10),
+                color: Color::default(),
+                corner_radii: CornerRadii::default(),
+                background_color_animation_frame: recorded.frame,
+            },
+            &[],
+            recorded,
+        );
+        source.append(&fill_rect(40, 40, 10, 10), &[], recorded);
+        source.append(
+            &FillRectWithRoundedCorners {
+                rect: IntRect::new(60, 60, 10, 10),
+                color: Color::default(),
+                corner_radii: CornerRadii::default(),
+                background_color_animation_frame: FrameNodeIndex(5),
+            },
+            &[],
+            recorded,
+        );
+
+        let mut builder = DisplayListBuilder::new();
+        builder.append_command_range(
+            &finished(&source),
+            whole_tape(&source),
+            Some(rewrite(recorded, current)),
+        );
+
+        assert_eq!(
+            background_color_animation_frames(&builder),
+            vec![current.frame, current.frame, FrameNodeIndex::NONE, FrameNodeIndex(5)]
+        );
     }
 
     #[test]

--- a/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/commands.rs
@@ -703,11 +703,13 @@ pub struct FillRect {
     pub rect: IntRect,
     pub color: Color,
     pub compositing_and_blending_operator: CompositingAndBlendingOperator,
+    pub background_color_animation_frame: FrameNodeIndex,
 }
 ffi_bytes_fields!(FillRect {
     rect,
     color,
-    compositing_and_blending_operator
+    compositing_and_blending_operator,
+    background_color_animation_frame
 });
 
 impl DisplayListCommand for FillRect {
@@ -1041,11 +1043,13 @@ pub struct FillRectWithRoundedCorners {
     pub rect: IntRect,
     pub color: Color,
     pub corner_radii: CornerRadii,
+    pub background_color_animation_frame: FrameNodeIndex,
 }
 ffi_bytes_fields!(FillRectWithRoundedCorners {
     rect,
     color,
-    corner_radii
+    corner_radii,
+    background_color_animation_frame
 });
 
 impl DisplayListCommand for FillRectWithRoundedCorners {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/damage.rs
@@ -216,6 +216,7 @@ fn spatial_data_is_equal(
 
 fn frame_data_is_equal(a: &FrameData, b: &FrameData) -> bool {
     match (a, b) {
+        (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
         (FrameData::Clip(data), FrameData::Clip(other)) => data == other,
         (FrameData::ClipPath(data), FrameData::ClipPath(other)) => {
             data.bounding_rect == other.bounding_rect
@@ -676,6 +677,7 @@ mod tests {
                 rect,
                 color,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(rect),
             ContextRef::default(),
@@ -825,6 +827,7 @@ mod tests {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(rect),
             context_in(in_order_transform, FrameNodeIndex::NONE),
@@ -834,6 +837,7 @@ mod tests {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(rect),
             context_in(permuted_transform, FrameNodeIndex::NONE),
@@ -910,6 +914,7 @@ mod tests {
                 rect,
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             &[],
             Some(rect),
@@ -967,6 +972,7 @@ mod tests {
                 rect: IntRect::new(0, 0, 10, 10),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             None,
             ContextRef::default(),
@@ -976,6 +982,7 @@ mod tests {
                 rect: IntRect::new(0, 0, 10, 10),
                 color: BLUE,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             None,
             ContextRef::default(),
@@ -1036,6 +1043,7 @@ mod tests {
                 rect: IntRect::new(10, 10, 20, 20),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(IntRect::new(10, 10, 20, 20)),
             context_in(VISUAL_VIEWPORT_NODE_INDEX, old_mask_frame),
@@ -1065,6 +1073,7 @@ mod tests {
                 rect: IntRect::new(10, 10, 20, 20),
                 color: RED,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(IntRect::new(10, 10, 20, 20)),
             context_in(VISUAL_VIEWPORT_NODE_INDEX, old_frame),
@@ -1074,6 +1083,7 @@ mod tests {
                 rect: IntRect::new(30, 30, 20, 20),
                 color: BLUE,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             Some(IntRect::new(30, 30, 20, 20)),
             context_in(VISUAL_VIEWPORT_NODE_INDEX, new_frame),
@@ -1102,6 +1112,7 @@ mod tests {
             rect: IntRect::new(10, 10, 20, 20),
             color: RED,
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+            background_color_animation_frame: FrameNodeIndex::NONE,
         };
         let old_display_list = command_bytes(
             &fill,
@@ -1144,6 +1155,7 @@ mod tests {
             rect: IntRect::new(10, 10, 20, 20),
             color: RED,
             compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+            background_color_animation_frame: FrameNodeIndex::NONE,
         };
         let old_display_list = command_bytes(
             &fill,

--- a/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/dump.rs
@@ -671,6 +671,7 @@ mod tests {
                 rect: IntRect::new(1, 2, 30, 40),
                 color: Color::from_rgba(101, 2, 0, 204),
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Multiply,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             &[],
             ContextRef {

--- a/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/recorder.rs
@@ -368,6 +368,7 @@ impl DisplayListRecorder {
                 rect,
                 color,
                 compositing_and_blending_operator,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             &[],
         );
@@ -397,6 +398,7 @@ impl DisplayListRecorder {
                 rect,
                 color: Color::TRANSPARENT,
                 compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                background_color_animation_frame: FrameNodeIndex::NONE,
             },
             &[],
         );
@@ -866,6 +868,41 @@ impl DisplayListRecorder {
                 rect,
                 color,
                 corner_radii,
+                background_color_animation_frame: FrameNodeIndex::NONE,
+            },
+            &[],
+        );
+    }
+
+    pub fn fill_animated_background_color(
+        &mut self,
+        rect: IntRect,
+        color: Color,
+        corner_radii: CornerRadii,
+        animation_frame: Option<FrameNodeIndex>,
+    ) {
+        if rect.is_empty() || (color.alpha() == 0 && animation_frame.is_none()) {
+            return;
+        }
+        let animation_frame = animation_frame.unwrap_or(FrameNodeIndex::NONE);
+        if !corner_radii.has_any_radius() {
+            self.append_command(
+                &FillRect {
+                    rect,
+                    color,
+                    compositing_and_blending_operator: CompositingAndBlendingOperator::Normal,
+                    background_color_animation_frame: animation_frame,
+                },
+                &[],
+            );
+            return;
+        }
+        self.append_command(
+            &FillRectWithRoundedCorners {
+                rect,
+                color,
+                corner_radii,
+                background_color_animation_frame: animation_frame,
             },
             &[],
         );

--- a/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
+++ b/Libraries/LibWeb/Rust/src/painting/display_list/replay.rs
@@ -103,8 +103,8 @@ struct ReplayDriver<'a, Painter: ReplayPainter> {
     // matrix to its save point, so unwinding applied frames invalidates it. Recorded streams
     // contain no matrix-mutating commands, so playing commands never invalidates the cache.
     current_ctm_space: Option<SpatialNodeIndex>,
-    // Each applied/target frame pushes and pops the canvas state according to its node kind;
-    // a context without a frame targets an empty frame list and takes its coordinates from the palette.
+    // Applied and target frames track the visual-context chain. Semantic frames push and pop canvas state;
+    // metadata-only frames do not. A context without a frame takes its coordinates from the palette.
     applied_frames: Vec<FrameNodeIndex>,
     target_frames: Vec<FrameNodeIndex>,
     applied_context: Option<ContextRef>,
@@ -287,7 +287,7 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
                 self.applied_mask_frame_count -= 1;
                 self.ensure_ctm_space(frame_node.spatial);
                 self.painter.pop_mask(&replay_mask_of(mask), frame_index);
-            } else {
+            } else if !matches!(frame_node.data, FrameData::BackgroundColorAnimation) {
                 self.painter.pop();
             }
             self.current_ctm_space = None;
@@ -335,6 +335,7 @@ impl<Painter: ReplayPainter> ReplayDriver<'_, Painter> {
             }
             self.ensure_ctm_space(frame_node.spatial);
             match &frame_node.data {
+                FrameData::BackgroundColorAnimation => {}
                 FrameData::Clip(clip) => self.painter.push_clip(&replay_clip_of(clip)),
                 FrameData::ClipPath(clip_path) => self.painter.push_clip_path(&clip_path.path, clip_path.fill_rule),
                 FrameData::Effects(effects) => self.painter.push_layer(&replay_layer_of(effects, frame_index)),

--- a/Libraries/LibWeb/Rust/src/painting/ffi.rs
+++ b/Libraries/LibWeb/Rust/src/painting/ffi.rs
@@ -1220,25 +1220,46 @@ pub unsafe extern "C" fn layout_arena_paintable_visual_animation_target_indices(
     arena: *mut c_void,
     slot: NodeSlotId,
     tree: *const c_void,
-    targets_are_frames: bool,
+    target_kind: crate::painting::host::FfiVisualAnimationTargetKind,
     context: *mut c_void,
     append: unsafe extern "C" fn(*mut c_void, u32),
 ) {
     let arena = unsafe { arena_from_handle(arena) };
     let tree = unsafe { tree_from_handle(tree) };
     arena.with_paintable_visual_context_node_handles(slot, |handles| {
-        let owned_indices: Vec<u32> = if targets_are_frames {
-            handles.frame_handles().map(|index| index.0).collect()
-        } else {
-            handles.spatial.iter().map(|index| index.0).collect()
+        let owned_indices: Vec<u32> = match target_kind {
+            crate::painting::host::FfiVisualAnimationTargetKind::Opacity
+            | crate::painting::host::FfiVisualAnimationTargetKind::BackgroundColor => {
+                handles.frame_handles().map(|index| index.0).collect()
+            }
+            crate::painting::host::FfiVisualAnimationTargetKind::Transform => {
+                handles.spatial.iter().map(|index| index.0).collect()
+            }
         };
         for index in owned_indices {
-            if tree.visual_animation_target_is_valid(targets_are_frames, index) {
+            if tree.visual_animation_target_is_valid(target_kind, index) {
                 // SAFETY: the host appends into its own storage synchronously.
                 unsafe { append(context, index) };
             }
         }
     });
+}
+
+/// # Safety
+///
+/// `arena` must be a live layout arena handle used on the document thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_background_color_can_be_compositor_animated(
+    arena: *mut c_void,
+    slot: NodeSlotId,
+    root_background_source: crate::painting::host::FfiRootBackgroundSource,
+) -> bool {
+    let arena = unsafe { arena_from_handle(arena) };
+    crate::painting::record::paint::background_resolution::background_color_can_be_compositor_animated(
+        &arena.paintable_rows(),
+        slot,
+        root_background_source,
+    )
 }
 
 /// # Safety
@@ -3006,14 +3027,17 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
     tree: *const c_void,
     frame_opacities: *const crate::painting::host::FfiFrameOpacitySample,
     frame_opacity_count: usize,
+    frame_background_colors: *const crate::painting::host::FfiFrameBackgroundColorSample,
+    frame_background_color_count: usize,
     spatial_matrices: *const crate::painting::host::FfiSpatialTransformSample,
     spatial_matrix_count: usize,
 ) -> *const c_void {
     let tree = unsafe { tree_from_handle(tree) };
     // SAFETY: The caller guarantees the sample arrays address the stated counts.
-    let (frame_opacities, spatial_matrices) = unsafe {
+    let (frame_opacities, frame_background_colors, spatial_matrices) = unsafe {
         (
             ffi_slice(frame_opacities, frame_opacity_count),
+            ffi_slice(frame_background_colors, frame_background_color_count),
             ffi_slice(spatial_matrices, spatial_matrix_count),
         )
     };
@@ -3021,12 +3045,35 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
         .iter()
         .map(|sample| (FrameNodeIndex(sample.frame), sample.opacity))
         .collect();
+    let frame_background_colors: Vec<(FrameNodeIndex, libgfx_rust::Color)> = frame_background_colors
+        .iter()
+        .map(|sample| (FrameNodeIndex(sample.frame), sample.color))
+        .collect();
     let spatial_matrices: Vec<(SpatialNodeIndex, libgfx_rust::FloatMatrix4x4)> = spatial_matrices
         .iter()
         .map(|sample| (SpatialNodeIndex(sample.spatial), sample.matrix))
         .collect();
-    let sampled = tree.with_sampled_visual_animation_values(&frame_opacities, &spatial_matrices);
+    let sampled =
+        tree.with_sampled_visual_animation_values(&frame_opacities, &frame_background_colors, &spatial_matrices);
     Rc::into_raw(Rc::new(sampled)).cast()
+}
+
+/// # Safety
+///
+/// `tree` must be a live retained tree handle and `color` must point to writable storage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn visual_context_tree_sampled_background_color(
+    tree: *const c_void,
+    frame: FrameNodeIndex,
+    color: *mut libgfx_rust::Color,
+) -> bool {
+    let tree = unsafe { tree_from_handle(tree) };
+    let Some(sampled_color) = tree.sampled_background_color(frame) else {
+        return false;
+    };
+    // SAFETY: The caller guarantees that `color` points to writable storage.
+    unsafe { *color = sampled_color };
+    true
 }
 
 /// # Safety
@@ -3035,14 +3082,14 @@ pub unsafe extern "C" fn visual_context_tree_with_sampled_values(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn visual_context_tree_visual_animation_targets_are_valid(
     tree: *const c_void,
-    targets_are_frames: bool,
+    target_kind: crate::painting::host::FfiVisualAnimationTargetKind,
     targets: *const u32,
     target_count: usize,
 ) -> bool {
     let tree = unsafe { tree_from_handle(tree) };
     // SAFETY: The caller guarantees the targets address `target_count` indices.
     let targets = unsafe { ffi_slice(targets, target_count) };
-    tree.visual_animation_targets_are_valid(targets_are_frames, targets)
+    tree.visual_animation_targets_are_valid(target_kind, targets)
 }
 
 /// # Safety
@@ -3255,6 +3302,24 @@ pub unsafe extern "C" fn visual_context_tree_test_builder_append_clip_frame(
             corner_radii,
             mode,
         }),
+        FrameNodeIndex(parent_frame),
+        SpatialNodeIndex(spatial),
+    )
+    .0
+}
+
+/// # Safety
+///
+/// `builder` must be a live handle from `visual_context_tree_test_builder_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn visual_context_tree_test_builder_append_background_color_animation_frame(
+    builder: *mut c_void,
+    parent_frame: u32,
+    spatial: u32,
+) -> u32 {
+    let tree = unsafe { test_builder_tree(builder) };
+    tree.append_frame(
+        crate::painting::visual_context::FrameData::BackgroundColorAnimation,
         FrameNodeIndex(parent_frame),
         SpatialNodeIndex(spatial),
     )

--- a/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
+++ b/Libraries/LibWeb/Rust/src/painting/host/visual_context.rs
@@ -146,6 +146,21 @@ pub struct FfiFrameOpacitySample {
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
+pub struct FfiFrameBackgroundColorSample {
+    pub frame: u32,
+    pub color: libgfx_rust::Color,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum FfiVisualAnimationTargetKind {
+    Opacity,
+    BackgroundColor,
+    Transform,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
 pub struct FfiSpatialTransformSample {
     pub spatial: u32,
     pub matrix: FloatMatrix4x4,

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background.rs
@@ -112,7 +112,6 @@ pub(crate) fn paint_resolved_background(
     let background_rect = resolved.background_rect;
     let color_box = resolved.color_box;
     let layers = &resolved.layers;
-
     // https://drafts.fxtf.org/compositing/#background-blend-mode
     // Background layers must not blend with the content that is behind the element, instead they
     // must act as if they are rendered into an isolated group.
@@ -218,6 +217,14 @@ fn paint_background_layers(
     let background_rect = resolved.background_rect;
     let color_box = resolved.color_box;
     let layers = &resolved.layers;
+    let background_color_animation_frame = recorder
+        .layout_arena
+        .node_has_compositor_animation_frame(
+            paintable,
+            crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
+        )
+        .then_some(recorder.recorder.accumulated_visual_context().frame)
+        .filter(|frame| !frame.is_none());
 
     let border_box = BackgroundBox {
         rect: background_rect,
@@ -227,14 +234,18 @@ fn paint_background_layers(
     let border = crate::painting::paintable_geometry::committed_border(recorder.layout_arena, paintable);
 
     if is_root_element {
-        recorder
-            .recorder
-            .fill_rect(converter.enclosing_device_rect(color_box.rect), color);
+        recorder.recorder.fill_animated_background_color(
+            converter.enclosing_device_rect(color_box.rect),
+            color,
+            libgfx_rust::CornerRadii::default(),
+            background_color_animation_frame,
+        );
     } else {
-        recorder.recorder.fill_rect_with_rounded_corners(
+        recorder.recorder.fill_animated_background_color(
             converter.rounded_device_rect(color_box.rect),
             color,
             color_box.radii.as_corners(&converter),
+            background_color_animation_frame,
         );
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
+++ b/Libraries/LibWeb/Rust/src/painting/record/paint/background_resolution.rs
@@ -292,6 +292,30 @@ fn computed_background_layers(style: ComputedValuesView<'_>, image_list: FfiLaye
     layers
 }
 
+pub(crate) fn background_color_can_be_compositor_animated(
+    layout_arena: &impl PaintableRowsRead,
+    slot: NodeSlotId,
+    root_background_source: FfiRootBackgroundSource,
+) -> bool {
+    if style_queries::node_is_root_element(layout_arena, slot)
+        || body_background_is_propagated_to_root(layout_arena, slot, root_background_source)
+    {
+        return false;
+    }
+    let Some(source) = background_paint_source_from_style_and_geometry(layout_arena, slot, root_background_source)
+    else {
+        return false;
+    };
+    if source.background_color_clip == css_enums::background_box::TEXT {
+        return false;
+    }
+    !source.layers_style_if_live.is_some_and(|style| {
+        computed_background_layers(style, source.image_list)
+            .iter()
+            .any(|layer| layer.image.is_some() && layer.blend_mode != css_enums::mix_blend_mode::NORMAL)
+    })
+}
+
 fn computed_mask_layers(style: ComputedValuesView<'_>) -> Vec<ComputedLayer<'_>> {
     use css_enums::mix_blend_mode;
     let mask = style.mask();
@@ -680,6 +704,10 @@ pub(crate) fn resolve_background_for_paint<'a>(
     )?;
     if !source.is_root_element
         && source.background_color.alpha() == 0
+        && !recorder.layout_arena.node_has_compositor_animation_frame(
+            paintable,
+            crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
+        )
         && !source
             .layers_style_if_live
             .is_some_and(style_queries::background_layers_have_image)

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/box_build.rs
@@ -466,6 +466,10 @@ pub(crate) fn build_box_visual_context_nodes<Arena: PaintableRowsRead, Sink: Vis
         append_frame_to_own_and_positioned_descendant_contexts!(FrameData::Mask(*mask_layer));
     }
 
+    if facts.needs_compositor_background_color_frame {
+        append_frame_to_own_and_positioned_descendant_contexts!(FrameData::BackgroundColorAnimation);
+    }
+
     assignment.has_accumulated_visual_context = true;
     assignment.accumulated_visual_context = own_state;
     let chain_frames_end = sink.next_frame_node_index().0;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/build.rs
@@ -55,6 +55,7 @@ pub(crate) fn svg_viewport_transform_of(
 }
 
 pub(crate) struct BoxFacts {
+    pub needs_compositor_background_color_frame: bool,
     pub transform: Option<TransformData>,
     pub transform_is_invertible: bool,
     pub perspective: Option<PerspectiveData>,
@@ -88,6 +89,10 @@ impl BoxFacts {
         consults_default_scroll_shift_anchors: bool,
     ) -> Self {
         let mut facts = Self {
+            needs_compositor_background_color_frame: layout_arena.node_has_compositor_animation_frame(
+                slot,
+                crate::layout::node_data::CompositorAnimationFrameKind::BackgroundColor,
+            ),
             transform: None,
             transform_is_invertible: false,
             perspective: None,

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dirty.rs
@@ -75,6 +75,7 @@ pub enum VisualContextGlobalRebuildReason {
     Compaction = 7,
     ForcedForTesting = 8,
     CanonicalDumpRequested = 9,
+    InvalidIncrementalReferences = 10,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -94,9 +95,11 @@ impl VisualContextUpdateScope {
             | Reason::DocumentWideStructuralChange
             | Reason::SvgResourceSubtreeChanged
             | Reason::FilterResourcesChanged => Self::EveryBox,
-            Reason::FirstBuild | Reason::Compaction | Reason::ForcedForTesting | Reason::CanonicalDumpRequested => {
-                Self::FreshTree
-            }
+            Reason::FirstBuild
+            | Reason::Compaction
+            | Reason::ForcedForTesting
+            | Reason::CanonicalDumpRequested
+            | Reason::InvalidIncrementalReferences => Self::FreshTree,
         }
     }
 
@@ -287,6 +290,7 @@ mod tests {
             Reason::Compaction,
             Reason::ForcedForTesting,
             Reason::CanonicalDumpRequested,
+            Reason::InvalidIncrementalReferences,
         ];
         let mut previous_reason = Reason::None;
         let mut previous_scope = VisualContextUpdateScope::DirtyPath;

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/dump.rs
@@ -131,6 +131,7 @@ impl VisualContextTree {
     pub fn dump_frame_node(&self, index: FrameNodeIndex) -> String {
         let mut text = String::new();
         match &self.frame_nodes[index.0 as usize].data {
+            FrameData::BackgroundColorAnimation => text.push_str("background-color-animation"),
             FrameData::Clip(clip) => {
                 let _ = write!(text, "clip={}", format_rect(clip.rect));
                 if clip.corner_radii.has_any_radius() {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -46,6 +46,11 @@ pub(crate) enum IncrementalUpdateResult {
     NeedsFullBuild(VisualContextGlobalRebuildReason),
 }
 
+fn incremental_tree_requires_fresh_build(tree: &VisualContextTree, delta: &VisualContextTreeDelta) -> bool {
+    (!delta.tombstoned_spatial_node_indices.is_empty() || !delta.tombstoned_frame_node_indices.is_empty())
+        && !tree.node_references_are_consistent()
+}
+
 fn box_is_inside_svg_resource_subtree(layout_arena: &impl PaintableRowsRead, slot: NodeSlotId) -> bool {
     let mut node = Some(slot);
     while let Some(current) = node {
@@ -602,6 +607,9 @@ pub(crate) fn update_visual_context_tree<Arena: PaintableRowsRead>(
     }
 
     let tree = Rc::make_mut(state.tree.as_mut().expect("the tree exists throughout the pass"));
+    if incremental_tree_requires_fresh_build(tree, &delta) {
+        return IncrementalUpdateResult::NeedsFullBuild(VisualContextGlobalRebuildReason::InvalidIncrementalReferences);
+    }
     let scroll_state = rebuild_scroll_state_from_tree(layout_arena, tree, &tree_inputs, &mut delta);
     delta.finish();
     tree.debug_assert_slot_accounting();
@@ -675,6 +683,41 @@ pub(crate) fn debug_assert_every_live_node_is_owned(
     _tree: &VisualContextTree,
     _viewport: NodeSlotId,
 ) {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libgfx_rust::{CompositingAndBlendingOperator, FloatMatrix4x4};
+
+    fn effects() -> FrameData {
+        FrameData::Effects(EffectsData {
+            opacity: 0.5,
+            blend_mode: CompositingAndBlendingOperator::Normal,
+            filter: None,
+        })
+    }
+
+    #[test]
+    fn a_tombstoned_parent_of_a_live_frame_requires_a_fresh_tree() {
+        let mut tree = VisualContextTree::create(TransformData {
+            matrix: FloatMatrix4x4::identity(),
+            origin: FloatPoint::default(),
+            sorting_context_root_index: None,
+            flattens_inherited_transform: false,
+            role: TransformDataRole::CssTransform,
+            synthetic_plane: false,
+            establishes_sorting_context: false,
+        });
+        let parent = tree.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
+        tree.append_frame(effects(), parent, VISUAL_VIEWPORT_NODE_INDEX);
+
+        let mut delta = VisualContextTreeDelta::default();
+        assert!(tree.tombstone_frame_slot(parent));
+        delta.note_tombstoned_frame(parent.0);
+
+        assert!(incremental_tree_requires_fresh_build(&tree, &delta));
+    }
 }
 
 fn remap_descendant_contexts(

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/incremental.rs
@@ -243,6 +243,7 @@ pub(crate) fn box_owns_geometry_dependent_nodes(
     let frames_are_geometry_dependent = handles.frame_handles().any(|index| {
         let node = &tree.frame_nodes[index.0 as usize];
         match &node.data {
+            FrameData::BackgroundColorAnimation => false,
             FrameData::Clip(_) | FrameData::ClipPath(_) | FrameData::Mask(_) => true,
             FrameData::Effects(effects) => {
                 effects.filter.is_some() && effects_filter_is_resolved_by_the_host_against_geometry

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/mod.rs
@@ -246,6 +246,7 @@ pub enum SpatialData {
 
 #[derive(Clone)]
 pub enum FrameData {
+    BackgroundColorAnimation,
     Clip(ClipData),
     ClipPath(ClipPathData),
     Effects(EffectsData),
@@ -271,7 +272,7 @@ impl FrameData {
                 let [_, _, width, height] = clip_path.path.bounding_box();
                 width <= 0.0 || height <= 0.0
             }
-            Self::Effects(_) | Self::Dead => false,
+            Self::BackgroundColorAnimation | Self::Effects(_) | Self::Dead => false,
             Self::Mask(mask) => mask.rect.is_empty(),
         }
     }
@@ -494,6 +495,7 @@ pub struct VisualContextTree {
     free_frame_slots: Vec<FrameNodeIndex>,
     quarantined_spatial_slots: Vec<SpatialNodeIndex>,
     quarantined_frame_slots: Vec<FrameNodeIndex>,
+    sampled_background_colors: HashMap<u32, libgfx_rust::Color>,
 }
 
 const COMPACTION_DEAD_NODE_THRESHOLD: usize = 512;
@@ -633,6 +635,7 @@ impl VisualContextTree {
             free_frame_slots: Vec::new(),
             quarantined_spatial_slots: Vec::new(),
             quarantined_frame_slots: Vec::new(),
+            sampled_background_colors: HashMap::new(),
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/node_values.rs
@@ -549,7 +549,13 @@ pub(crate) fn compute_effects_data(
         crate::painting::filter_bytes::serialize_non_url_filter(&effects_values.filter, device_pixels_per_css_pixel)
             .map(std::rc::Rc::new)
     };
-    if filter.is_none() && effects_values.opacity == 1.0 && effects_values.mix_blend_mode == mix_blend_mode::NORMAL {
+    let needs_compositor_effects_layer = layout_arena
+        .node_has_compositor_animation_frame(slot, crate::layout::node_data::CompositorAnimationFrameKind::Opacity);
+    if filter.is_none()
+        && effects_values.opacity == 1.0
+        && effects_values.mix_blend_mode == mix_blend_mode::NORMAL
+        && !needs_compositor_effects_layer
+    {
         return None;
     }
     let effects = EffectsData {
@@ -559,7 +565,8 @@ pub(crate) fn compute_effects_data(
     };
     let needs_layer = effects.opacity < 1.0
         || effects.blend_mode != CompositingAndBlendingOperator::Normal
-        || effects.filter.is_some();
+        || effects.filter.is_some()
+        || needs_compositor_effects_layer;
     needs_layer.then_some(effects)
 }
 

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/queries.rs
@@ -277,6 +277,7 @@ impl VisualContextTree {
             return true;
         }
         match &frame.data {
+            FrameData::BackgroundColorAnimation => true,
             FrameData::Clip(clip) => {
                 // NOTE: The clip rect is in absolute device-pixel coordinates. After inverse-transforming, `point`
                 //       is also in device-pixel coordinates, so we compare them directly.
@@ -637,6 +638,7 @@ impl VisualContextTree {
     pub fn with_sampled_visual_animation_values(
         &self,
         frame_opacities: &[(FrameNodeIndex, f32)],
+        frame_background_colors: &[(FrameNodeIndex, libgfx_rust::Color)],
         spatial_matrices: &[(SpatialNodeIndex, FloatMatrix4x4)],
     ) -> VisualContextTree {
         let mut sampled = self.clone();
@@ -656,27 +658,47 @@ impl VisualContextTree {
                 transform.matrix = *matrix;
             }
         }
+        sampled.sampled_background_colors.clear();
+        for (frame, color) in frame_background_colors {
+            sampled.sampled_background_colors.insert(frame.0, *color);
+        }
         sampled
     }
 
-    pub fn visual_animation_target_is_valid(&self, target_is_frame: bool, target: u32) -> bool {
-        if target_is_frame {
-            matches!(
+    pub fn visual_animation_target_is_valid(
+        &self,
+        target_kind: crate::painting::host::FfiVisualAnimationTargetKind,
+        target: u32,
+    ) -> bool {
+        use crate::painting::host::FfiVisualAnimationTargetKind;
+        match target_kind {
+            FfiVisualAnimationTargetKind::Opacity => matches!(
                 self.frame_nodes.get(target as usize).map(|node| &node.data),
                 Some(FrameData::Effects(_))
-            )
-        } else {
-            matches!(
+            ),
+            FfiVisualAnimationTargetKind::BackgroundColor => matches!(
+                self.frame_nodes.get(target as usize).map(|node| &node.data),
+                Some(FrameData::BackgroundColorAnimation)
+            ),
+            FfiVisualAnimationTargetKind::Transform => matches!(
                 self.spatial_nodes.get(target as usize).map(|node| &node.data),
                 Some(SpatialData::Transform(transform)) if transform.role == TransformDataRole::CssTransform && !transform.synthetic_plane
-            )
+            ),
         }
     }
 
-    pub fn visual_animation_targets_are_valid(&self, targets_are_frames: bool, targets: &[u32]) -> bool {
+    pub fn sampled_background_color(&self, frame: FrameNodeIndex) -> Option<libgfx_rust::Color> {
+        self.sampled_background_colors.get(&frame.0).copied()
+    }
+
+    pub fn visual_animation_targets_are_valid(
+        &self,
+        target_kind: crate::painting::host::FfiVisualAnimationTargetKind,
+        targets: &[u32],
+    ) -> bool {
         targets
             .iter()
-            .all(|&target| self.visual_animation_target_is_valid(targets_are_frames, target))
+            .all(|&target| self.visual_animation_target_is_valid(target_kind, target))
     }
 
     pub fn effects_opacity(&self, frame: FrameNodeIndex) -> Option<f32> {

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -34,6 +34,7 @@ const FRAME_KIND_CLIP_PATH: u8 = 1;
 const FRAME_KIND_EFFECTS: u8 = 2;
 const FRAME_KIND_MASK: u8 = 3;
 const FRAME_KIND_DEAD: u8 = 4;
+const FRAME_KIND_BACKGROUND_COLOR_ANIMATION: u8 = 5;
 
 const MINIMUM_SERIALIZED_SPATIAL_NODE_SIZE: usize = 5;
 const MINIMUM_SERIALIZED_FRAME_NODE_SIZE: usize = 9;
@@ -371,6 +372,7 @@ fn read_spatial_data(reader: &mut TreeByteReader<'_>) -> Option<SpatialData> {
 
 fn write_frame_data(writer: &mut TreeByteWriter, data: &FrameData) {
     match data {
+        FrameData::BackgroundColorAnimation => writer.u8(FRAME_KIND_BACKGROUND_COLOR_ANIMATION),
         FrameData::Clip(clip) => {
             writer.u8(FRAME_KIND_CLIP);
             writer.float_rect(clip.rect);
@@ -402,6 +404,7 @@ fn write_frame_data(writer: &mut TreeByteWriter, data: &FrameData) {
 
 fn read_frame_data(reader: &mut TreeByteReader<'_>) -> Option<FrameData> {
     Some(match reader.u8()? {
+        FRAME_KIND_BACKGROUND_COLOR_ANIMATION => FrameData::BackgroundColorAnimation,
         FRAME_KIND_CLIP => FrameData::Clip(ClipData {
             rect: reader.float_rect()?,
             corner_radii: reader.corner_radii()?,
@@ -576,6 +579,7 @@ impl VisualContextTree {
             free_frame_slots: Vec::new(),
             quarantined_spatial_slots: Vec::new(),
             quarantined_frame_slots: Vec::new(),
+            sampled_background_colors: std::collections::HashMap::new(),
         };
         tree.decoded_references_are_consistent().then_some(tree)
     }
@@ -782,6 +786,7 @@ mod tests {
 
     fn frame_data_matches(a: &FrameData, b: &FrameData) -> bool {
         match (a, b) {
+            (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
             (FrameData::Clip(a), FrameData::Clip(b)) => a == b,
             (FrameData::ClipPath(a), FrameData::ClipPath(b)) => {
                 a.bounding_rect == b.bounding_rect && a.fill_rule == b.fill_rule

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/serialize.rs
@@ -452,7 +452,7 @@ fn spatial_node_has_ancestor(nodes: &[SpatialNode], mut node: usize, ancestor: S
 }
 
 impl VisualContextTree {
-    fn decoded_references_are_consistent(&self) -> bool {
+    pub(super) fn node_references_are_consistent(&self) -> bool {
         let spatial_nodes = &self.spatial_nodes;
         let root = &spatial_nodes[VISUAL_VIEWPORT_NODE_INDEX.0 as usize];
         if root.parent != VISUAL_VIEWPORT_NODE_INDEX || !matches!(root.data, SpatialData::Transform(_)) {
@@ -581,7 +581,7 @@ impl VisualContextTree {
             quarantined_frame_slots: Vec::new(),
             sampled_background_colors: std::collections::HashMap::new(),
         };
-        tree.decoded_references_are_consistent().then_some(tree)
+        tree.node_references_are_consistent().then_some(tree)
     }
 }
 
@@ -930,6 +930,7 @@ mod tests {
             frame_under_tombstone.append_frame(effects(), FrameNodeIndex::NONE, VISUAL_VIEWPORT_NODE_INDEX);
         frame_under_tombstone.append_frame(effects(), parent_frame, VISUAL_VIEWPORT_NODE_INDEX);
         assert!(frame_under_tombstone.tombstone_frame_slot(parent_frame));
+        assert!(!frame_under_tombstone.node_references_are_consistent());
         assert!(VisualContextTree::from_bytes(&encode_tree(&frame_under_tombstone)).is_none());
 
         let mut frame_in_tombstone = VisualContextTree::create(transform(FloatMatrix4x4::identity()));

--- a/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
+++ b/Libraries/LibWeb/Rust/src/painting/visual_context/shape.rs
@@ -44,6 +44,7 @@ pub(crate) enum SpatialNodeShape {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FrameShapeKind {
+    BackgroundColorAnimation,
     Clip { mode: ClipMode },
     ClipPath,
     Effects,
@@ -98,6 +99,7 @@ pub(crate) fn spatial_node_shape(node: &SpatialNode) -> SpatialNodeShape {
 
 pub(crate) fn frame_node_shape(node: &FrameNode) -> FrameNodeShape {
     let kind = match &node.data {
+        FrameData::BackgroundColorAnimation => FrameShapeKind::BackgroundColorAnimation,
         FrameData::Clip(clip) => FrameShapeKind::Clip { mode: clip.mode },
         FrameData::ClipPath(_) => FrameShapeKind::ClipPath,
         FrameData::Effects(_) => FrameShapeKind::Effects,
@@ -134,6 +136,7 @@ pub(crate) fn spatial_payloads_are_equal(a: &SpatialData, b: &SpatialData) -> bo
 
 pub(crate) fn frame_payloads_are_equal(a: &FrameData, b: &FrameData) -> bool {
     match (a, b) {
+        (FrameData::BackgroundColorAnimation, FrameData::BackgroundColorAnimation) => true,
         (FrameData::Clip(a), FrameData::Clip(b)) => a == b,
         (FrameData::ClipPath(a), FrameData::ClipPath(b)) => {
             std::rc::Rc::ptr_eq(&a.path, &b.path) && a.bounding_rect == b.bounding_rect && a.fill_rule == b.fill_rule

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -73,6 +73,35 @@ static bool visual_viewport_transforms_match(Web::Painting::TransformWithOrigin 
         && AK::fabs(a.origin.y() - b.origin.y()) <= translation_epsilon;
 }
 
+static double visual_animation_local_time_at(Web::Compositor::VisualAnimation const& animation, MonotonicTime now)
+{
+    auto elapsed_nanoseconds = now.nanoseconds() > animation.monotonic_time_at_anchor_ns
+        ? now.nanoseconds() - animation.monotonic_time_at_anchor_ns
+        : 0;
+    return animation.local_time_at_anchor_ms
+        + AK::Duration::from_nanoseconds(elapsed_nanoseconds).to_seconds_f64() * 1000.0 * animation.playback_rate;
+}
+
+static bool visual_animation_is_active_at(Web::Compositor::VisualAnimation const& animation, MonotonicTime now)
+{
+    auto local_time = visual_animation_local_time_at(animation, now);
+    if (!isfinite(local_time))
+        return true;
+    if (local_time < animation.start_delay_ms)
+        return false;
+    if (!isfinite(animation.iteration_count))
+        return true;
+    auto active_end = animation.start_delay_ms + animation.iteration_duration_ms * animation.iteration_count;
+    return local_time < active_end;
+}
+
+static bool visual_context_tree_has_active_animation_at(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, MonotonicTime now)
+{
+    return any_of(visual_context_tree.visual_animations(), [&](auto const& animation) {
+        return visual_animation_is_active_at(animation, now);
+    });
+}
+
 static Web::Compositor::AsyncScrollNodeStableID viewport_stable_id_from(Web::Compositor::AsyncScrollNodeID node_id)
 {
     return {
@@ -172,7 +201,7 @@ void ContextState::install_display_list_update(
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
     m_visual_animation_sample_time_ns.clear();
-    m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
+    m_has_active_visual_animations = visual_context_tree_has_active_animation_at(*m_visual_context_tree, MonotonicTime::now());
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     m_scroll_state_snapshot.set_node_count(m_visual_context_tree->spatial_node_count());
     update_caret_blink_timer();
@@ -289,7 +318,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
     apply_display_list_resource_transaction(move(resource_transaction));
     m_visual_context_tree = move(visual_context_tree);
     m_visual_animation_sample_time_ns.clear();
-    m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
+    m_has_active_visual_animations = visual_context_tree_has_active_animation_at(*m_visual_context_tree, MonotonicTime::now());
     // A constraints refresh changes sticky payloads without a new snapshot, and the snapshot that
     // pairs with this tree arrives in a separate message.
     Web::Painting::resolve_sticky_offsets(*m_visual_context_tree, m_scroll_state_snapshot);
@@ -1286,16 +1315,15 @@ bool ContextState::advance_visual_animations(MonotonicTime now)
 
     m_has_active_visual_animations = false;
     for (auto const& animation : m_visual_context_tree->visual_animations()) {
-        if (!isfinite(animation.iteration_count)) {
+        auto local_time = visual_animation_local_time_at(animation, now);
+        if (local_time < animation.start_delay_ms)
+            continue;
+        if (!isfinite(local_time) || !isfinite(animation.iteration_count)) {
             m_has_active_visual_animations = true;
             break;
         }
-        auto elapsed_nanoseconds = now.nanoseconds() > animation.monotonic_time_at_anchor_ns
-            ? now.nanoseconds() - animation.monotonic_time_at_anchor_ns
-            : 0;
-        auto local_time = animation.local_time_at_anchor_ms + AK::Duration::from_nanoseconds(elapsed_nanoseconds).to_seconds_f64() * 1000.0 * animation.playback_rate;
         auto active_end = animation.start_delay_ms + animation.iteration_duration_ms * animation.iteration_count;
-        if (!isfinite(local_time) || local_time < active_end) {
+        if (local_time < active_end) {
             m_has_active_visual_animations = true;
             break;
         }

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -102,6 +102,18 @@ static bool visual_context_tree_has_active_animation_at(Web::Painting::Accumulat
     });
 }
 
+static void update_visual_animation_sampling_state(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<i64>& sample_time_ns, bool& has_active_animations)
+{
+    auto now = MonotonicTime::now();
+    has_active_animations = visual_context_tree_has_active_animation_at(visual_context_tree, now);
+    // A replacement tree can be presented before the next vsync. Keep the most recent sample so that presentation
+    // remains continuous, but sample dormant and completed descriptors at the current boundary when necessary.
+    if (visual_context_tree.visual_animations().is_empty())
+        sample_time_ns.clear();
+    else if (!has_active_animations)
+        sample_time_ns = now.nanoseconds();
+}
+
 static Web::Compositor::AsyncScrollNodeStableID viewport_stable_id_from(Web::Compositor::AsyncScrollNodeID node_id)
 {
     return {
@@ -200,8 +212,7 @@ void ContextState::install_display_list_update(
     invalidate_visual_context_tree_for_compositing();
     m_display_list = move(display_list);
     m_visual_context_tree = move(visual_context_tree);
-    m_visual_animation_sample_time_ns.clear();
-    m_has_active_visual_animations = visual_context_tree_has_active_animation_at(*m_visual_context_tree, MonotonicTime::now());
+    update_visual_animation_sampling_state(*m_visual_context_tree, m_visual_animation_sample_time_ns, m_has_active_visual_animations);
     m_scroll_state_snapshot = move(scroll_state_snapshot);
     m_scroll_state_snapshot.set_node_count(m_visual_context_tree->spatial_node_count());
     update_caret_blink_timer();
@@ -317,8 +328,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
     invalidate_visual_context_tree_for_compositing();
     apply_display_list_resource_transaction(move(resource_transaction));
     m_visual_context_tree = move(visual_context_tree);
-    m_visual_animation_sample_time_ns.clear();
-    m_has_active_visual_animations = visual_context_tree_has_active_animation_at(*m_visual_context_tree, MonotonicTime::now());
+    update_visual_animation_sampling_state(*m_visual_context_tree, m_visual_animation_sample_time_ns, m_has_active_visual_animations);
     // A constraints refresh changes sticky payloads without a new snapshot, and the snapshot that
     // pairs with this tree arrives in a separate message.
     Web::Painting::resolve_sticky_offsets(*m_visual_context_tree, m_scroll_state_snapshot);

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -130,6 +130,7 @@ public:
     bool advance_visual_animations(MonotonicTime now);
     bool has_active_visual_animations() const { return m_has_active_visual_animations; }
     Web::Painting::AccumulatedVisualContextTree const& visual_context_tree_for_testing() const { return current_visual_context_tree(); }
+    Web::Painting::AccumulatedVisualContextTree const& sampled_visual_context_tree_for_testing() { return visual_context_tree_for_compositing(); }
     bool has_sampled_visual_animation_values_for_testing() const { return m_sampled_visual_context_tree.has_value(); }
     u64 visual_context_tree_copy_count_for_testing() const { return m_visual_context_tree_copy_count; }
     Gfx::IntRect caret_damage_rect_for_testing() { return caret_damage_rect(); }

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -362,6 +362,26 @@ TEST_CASE(visual_animations_advance_without_a_web_content_update)
 
     context.update_visual_context_tree(visual_context_tree, {});
     EXPECT(!context.has_sampled_visual_animation_values_for_testing());
+    auto const& updated_tree = context.sampled_visual_context_tree_for_testing();
+    auto updated_translation = updated_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
+    EXPECT_EQ(updated_translation, 4.0f);
+    EXPECT_EQ(updated_tree.effects_opacity(frame), Optional<float> { 0.5f });
+    EXPECT(context.has_sampled_visual_animation_values_for_testing());
+
+    context.install_display_list_update(
+        make_display_list(visual_context_tree, Gfx::Color::Red, Gfx::Color::Transparent, { spatial, frame }),
+        visual_context_tree,
+        {});
+    EXPECT(!context.has_sampled_visual_animation_values_for_testing());
+    auto const& replaced_tree = context.sampled_visual_context_tree_for_testing();
+    auto replaced_translation = replaced_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
+    EXPECT_EQ(replaced_translation, 4.0f);
+    EXPECT_EQ(replaced_tree.effects_opacity(frame), Optional<float> { 0.5f });
+    EXPECT(context.has_sampled_visual_animation_values_for_testing());
+
+    visual_context_tree.set_visual_animations(Vector<Web::Compositor::VisualAnimation> {});
+    context.update_visual_context_tree(visual_context_tree, {});
+    EXPECT(!context.has_sampled_visual_animation_values_for_testing());
     auto const& restored_tree = context.visual_context_tree_for_testing();
     auto restored_translation = restored_tree.accumulated_matrix(spatial, {}, Web::Painting::AccumulatedVisualContextTree::IncludeVisualViewportTransform::Yes)[0, 3];
     EXPECT_EQ(restored_translation, 0.0f);

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -573,6 +573,48 @@ TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
     EXPECT_EQ(bitmap->get_pixel(8, 0), Gfx::Color::Red);
 }
 
+TEST_CASE(delayed_visual_animations_remain_dormant_until_active_start)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto visual_context_tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    Web::Compositor::VisualAnimation animation {
+        .target_kind = Web::Compositor::VisualAnimation::TargetKind::Transform,
+        .visual_context_node_indices = { spatial.value() },
+        .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+        .start_delay_ms = 1000,
+        .iteration_duration_ms = 1000000,
+        .fill_mode = Web::Compositor::VisualAnimationFillMode::Backwards,
+        .easing = {},
+        .keyframes = {
+            { 0, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 0 } } } },
+            { 1, {}, Web::Compositor::VisualAnimationTransformList { { Web::Compositor::VisualAnimationTransformOperationKind::TranslateX, { 20 } } } },
+        },
+    };
+    visual_context_tree.set_visual_animations({ animation });
+
+    context.install_display_list_update(
+        make_display_list(visual_context_tree, Gfx::Color::Red, {}, { spatial, Web::Painting::NO_FRAME_NODE }),
+        visual_context_tree,
+        {});
+
+    EXPECT(!context.has_active_visual_animations());
+    EXPECT(!context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    EXPECT(!context.has_sampled_visual_animation_values_for_testing());
+
+    animation.local_time_at_anchor_ms = 1000;
+    visual_context_tree.set_visual_animations({ animation });
+    context.update_visual_context_tree(visual_context_tree, {});
+
+    EXPECT(context.has_active_visual_animations());
+    EXPECT(context.advance_visual_animations(anchor));
+    EXPECT(context.has_sampled_visual_animation_values_for_testing());
+}
+
 TEST_CASE(oversized_backing_stores_are_rejected)
 {
     Compositor::BackingStoreManager manager;

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -102,7 +102,7 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting
 {
     ByteBuffer command_bytes;
     if (color.has_value()) {
-        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color, Gfx::CompositingAndBlendingOperator::Normal };
+        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
         append_display_list_command(command_bytes, command, command.rect, context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color);
@@ -503,9 +503,9 @@ TEST_CASE(culled_initial_animation_content_becomes_visible)
     });
 
     ByteBuffer command_bytes;
-    auto opacity_command = Web::Painting::FillRect { { 0, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal };
+    auto opacity_command = Web::Painting::FillRect { { 0, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
     append_display_list_command(command_bytes, opacity_command, opacity_command.rect, { opacity_spatial, opacity_frame });
-    auto scale_command = Web::Painting::FillRect { { 8, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal };
+    auto scale_command = Web::Painting::FillRect { { 8, 0, 4, 4 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
     append_display_list_command(command_bytes, scale_command, scale_command.rect, { scale_spatial, Web::Painting::NO_FRAME_NODE });
 
     Gfx::IntRect viewport_rect { 0, 0, 12, 4 };
@@ -525,6 +525,57 @@ TEST_CASE(culled_initial_animation_content_becomes_visible)
     EXPECT_EQ(opacity_pixel.red(), 128);
     EXPECT_EQ(opacity_pixel.alpha(), 128);
     EXPECT_EQ(bitmap->get_pixel(4, 0), Gfx::Color::Red);
+}
+
+TEST_CASE(background_color_animation_replaces_the_recorded_fill_color)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    Web::Painting::VisualContextTreeTestBuilder builder;
+    auto spatial = builder.append_transform(Web::Painting::VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto frame = builder.append_background_color_animation_frame(Web::Painting::NO_FRAME_NODE, spatial);
+    auto visual_context_tree = builder.finish();
+    auto anchor = MonotonicTime::now();
+    visual_context_tree.set_visual_animations({
+        {
+            .target_kind = Web::Compositor::VisualAnimation::TargetKind::BackgroundColor,
+            .visual_context_node_indices = { frame.value() },
+            .monotonic_time_at_anchor_ns = anchor.nanoseconds(),
+            .iteration_duration_ms = 1000,
+            .iteration_count = 1,
+            .easing = {},
+            .keyframes = {
+                { 0, {}, Web::Compositor::VisualAnimationValue { Gfx::Color::Red } },
+                { 1, {}, Web::Compositor::VisualAnimationValue { Gfx::Color::Blue } },
+            },
+        },
+    });
+
+    ByteBuffer command_bytes;
+    auto command = Web::Painting::FillRect {
+        { 0, 0, 4, 4 },
+        Gfx::Color::Green,
+        Gfx::CompositingAndBlendingOperator::Normal,
+        frame,
+    };
+    append_display_list_command(command_bytes, command, command.rect, { spatial, frame });
+
+    Gfx::IntRect viewport_rect { 0, 0, 4, 4 };
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    VERIFY(context.resize_backing_stores_if_needed({}, Compositor::BackingStoreManager::GpuSharing::Disallowed).has_value());
+    context.install_display_list_update(
+        decode_display_list(visual_context_tree, move(command_bytes), Gfx::Color::Transparent),
+        visual_context_tree,
+        {});
+
+    EXPECT(context.advance_visual_animations(anchor + AK::Duration::from_milliseconds(500)));
+    context.queue_present_frame({ viewport_rect, viewport_rect });
+    EXPECT(context.present_synchronously(display_list_player, nullptr));
+
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    EXPECT_EQ(bitmap->get_pixel(0, 0), (Gfx::Color { 128, 0, 128 }));
 }
 
 TEST_CASE(finite_visual_animations_stop_after_their_terminal_sample)
@@ -818,7 +869,7 @@ static NonnullRefPtr<Web::Painting::DisplayList> make_fills_display_list(Web::Pa
 {
     ByteBuffer command_bytes;
     for (auto const& fill : fills) {
-        Web::Painting::FillRect command { fill.rect, fill.color, Gfx::CompositingAndBlendingOperator::Normal };
+        Web::Painting::FillRect command { fill.rect, fill.color, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
         append_display_list_command(command_bytes, command, fill.bounded ? Optional<Gfx::IntRect> { fill.rect } : Optional<Gfx::IntRect> {}, fill.context);
     }
     return decode_display_list(visual_context_tree, move(command_bytes), surface_clear_color, async_scrolling_metadata);
@@ -1260,9 +1311,9 @@ TEST_CASE(async_scroll_presents_report_the_damage_of_the_scrolled_content)
         },
         {},
         in_spatial_node(viewport_scroll_node_index.value()));
-    Web::Painting::FillRect nested_content { { 10, 10, 40, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal };
+    Web::Painting::FillRect nested_content { { 10, 10, 40, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
     append_display_list_command(command_bytes, nested_content, nested_content.rect, in_spatial_node(nested_scroll_node_index.value()));
-    Web::Painting::FillRect viewport_content { { 60, 60, 10, 10 }, Gfx::Color::Green, Gfx::CompositingAndBlendingOperator::Normal };
+    Web::Painting::FillRect viewport_content { { 60, 60, 10, 10 }, Gfx::Color::Green, Gfx::CompositingAndBlendingOperator::Normal, Web::Painting::NO_FRAME_NODE };
     append_display_list_command(command_bytes, viewport_content, viewport_content.rect, in_spatial_node(viewport_scroll_node_index.value()));
     fixture.install(decode_display_list(visual_context_tree, move(command_bytes), {}, Web::Painting::DisplayList::AsyncScrollingMetadata { .viewport_rect = { 0, 0, 100, 100 } }), visual_context_tree);
     fixture.present();

--- a/Tests/LibWeb/TestDisplayListCommandRuns.cpp
+++ b/Tests/LibWeb/TestDisplayListCommandRuns.cpp
@@ -18,7 +18,7 @@ static ContextRef context(u32 spatial, Optional<u32> frame = {})
 
 static void append_fill_rect(ByteBuffer& bytes, ContextRef context, Gfx::IntRect rect)
 {
-    append_display_list_command(bytes, FillRect { rect, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal }, rect, context);
+    append_display_list_command(bytes, FillRect { rect, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, rect, context);
 }
 
 TEST_CASE(runs_split_on_context_changes_and_cover_the_tape)
@@ -63,7 +63,7 @@ TEST_CASE(a_draw_confined_to_its_bounds_contributes_the_confined_bounds)
 {
     ByteBuffer bytes;
     auto root = context(0);
-    append_display_list_command(bytes, FillRect { { 0, 0, 100, 100 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal }, Gfx::IntRect { 10, 10, 20, 20 }, root);
+    append_display_list_command(bytes, FillRect { { 0, 0, 100, 100 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, Gfx::IntRect { 10, 10, 20, 20 }, root);
     append_fill_rect(bytes, root, { 50, 50, 10, 10 });
 
     auto runs = compute_display_list_command_runs(bytes);
@@ -74,7 +74,7 @@ TEST_CASE(a_draw_confined_to_its_bounds_contributes_the_confined_bounds)
 TEST_CASE(a_draw_without_bounds_marks_the_run_unbounded)
 {
     ByteBuffer bytes;
-    append_display_list_command(bytes, FillRect { { 0, 0, 10, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal }, {}, context(0));
+    append_display_list_command(bytes, FillRect { { 0, 0, 10, 10 }, Gfx::Color::Red, Gfx::CompositingAndBlendingOperator::Normal, NO_FRAME_NODE }, {}, context(0));
 
     auto runs = compute_display_list_command_runs(bytes);
     EXPECT(runs[0].has_unbounded_draw);

--- a/Tests/LibWeb/TestVisualAnimation.cpp
+++ b/Tests/LibWeb/TestVisualAnimation.cpp
@@ -153,6 +153,53 @@ TEST_CASE(interpolates_transform_operations_before_composing)
     }
 }
 
+TEST_CASE(interpolates_background_color_in_premultiplied_srgb)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::BackgroundColor,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 500,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), Gfx::Color(255, 0, 0, 0) },
+            { 1, linear_easing(), Gfx::Color(0, 0, 255, 255) },
+        },
+    };
+
+    auto sampled = animation.sample(AK::Duration::zero())->background_color;
+    EXPECT(sampled.has_value());
+    EXPECT_EQ(sampled->red(), 0);
+    EXPECT_EQ(sampled->green(), 0);
+    EXPECT_EQ(sampled->blue(), 255);
+    EXPECT_EQ(sampled->alpha(), 128);
+}
+
+TEST_CASE(extrapolates_overshooting_background_color_easing)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::BackgroundColor,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 750,
+        .iteration_duration_ms = 1000,
+        .easing = {
+            .kind = VisualAnimationEasing::Kind::Linear,
+            .linear_points = { { 0, 0 }, { 1, 2 } },
+        },
+        .keyframes = {
+            { 0, linear_easing(), Gfx::Color(100, 20, 30) },
+            { 1, linear_easing(), Gfx::Color(140, 40, 50) },
+        },
+    };
+
+    auto sampled = animation.sample(AK::Duration::zero())->background_color;
+    EXPECT(sampled.has_value());
+    EXPECT_EQ(sampled->red(), 160);
+    EXPECT_EQ(sampled->green(), 50);
+    EXPECT_EQ(sampled->blue(), 60);
+    EXPECT_EQ(sampled->alpha(), 255);
+}
+
 TEST_CASE(rejects_invalid_timing)
 {
     VisualAnimation animation;

--- a/Tests/LibWeb/TestVisualAnimation.cpp
+++ b/Tests/LibWeb/TestVisualAnimation.cpp
@@ -159,6 +159,56 @@ TEST_CASE(rejects_invalid_timing)
     EXPECT(!animation.sample(AK::Duration::zero()).has_value());
 }
 
+TEST_CASE(applies_backwards_fill_during_start_delay)
+{
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 50,
+        .start_delay_ms = 100,
+        .iteration_duration_ms = 1000,
+        .easing = linear_easing(),
+        .keyframes = {
+            { 0, linear_easing(), 0.25f },
+            { 1, linear_easing(), 0.75f },
+        },
+    };
+
+    EXPECT(!animation.sample(AK::Duration::zero()).has_value());
+    animation.fill_mode = VisualAnimationFillMode::Backwards;
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::zero())->opacity, 0.25f);
+    EXPECT_APPROXIMATE(animation.sample(AK::Duration::from_milliseconds(550))->opacity, 0.5f);
+}
+
+TEST_CASE(applies_before_flag_only_to_effect_easing_during_start_delay)
+{
+    VisualAnimationEasing jump_start {
+        .kind = VisualAnimationEasing::Kind::Steps,
+        .linear_points = {},
+        .interval_count = 4,
+        .step_position = 0,
+    };
+    VisualAnimation animation {
+        .target_kind = VisualAnimation::TargetKind::Opacity,
+        .visual_context_node_indices = { 0 },
+        .local_time_at_anchor_ms = 50,
+        .start_delay_ms = 100,
+        .iteration_duration_ms = 1000,
+        .fill_mode = VisualAnimationFillMode::Backwards,
+        .easing = jump_start,
+        .keyframes = {
+            { 0, linear_easing(), 0.0f },
+            { 1, linear_easing(), 1.0f },
+        },
+    };
+
+    EXPECT_EQ(animation.sample(AK::Duration::zero())->opacity, 0.0f);
+
+    animation.easing = linear_easing();
+    animation.keyframes[0].easing = jump_start;
+    EXPECT_EQ(animation.sample(AK::Duration::zero())->opacity, 0.25f);
+}
+
 TEST_CASE(compares_animation_parameters_independently_of_visual_nodes_and_anchor)
 {
     VisualAnimation animation {

--- a/Tests/LibWeb/Text/expected/css/compositor-animation-start-delay.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-animation-start-delay.txt
@@ -1,0 +1,5 @@
+delayed effects use the compositor before starting: true
+fill modes apply before the active phase: true
+sought negative delay stays off the compositor before zero: true
+delayed effects remain on the compositor while active: true
+effects are withdrawn after their active interval: true

--- a/Tests/LibWeb/Text/expected/css/compositor-background-color-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-background-color-animation.txt
@@ -1,0 +1,12 @@
+background color animations use compositor: true
+background color marker does not create effects layer: true
+transparent background color retains animated fill: true
+root background color stays on main thread: true
+complex and propagated backgrounds stay on main thread: true
+modern color interpolation stays on main thread: true
+modern color creates no compositor marker: true
+currentcolor creates no compositor marker: true
+unsupported timing creates no compositor marker: true
+stable background color builds no overlays: true
+stable background color requests no animation frames: true
+cancel removes background color animation: true

--- a/Tests/LibWeb/Text/expected/css/compositor-transition-none-transform.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-transition-none-transform.txt
@@ -1,0 +1,2 @@
+none transform transitions use the compositor in 2D and 3D: true
+withdrawn mid-transition positions match: true

--- a/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
@@ -12,3 +12,13 @@ resolved start retains compositor anchor: true
 pending current-time seek re-anchors compositor: true
 pending start-time change re-anchors compositor: true
 pending transition retarget replaces descriptor: true
+static opacity transition declarations do not create effects frames: true
+paired opacity and translate transitions start on compositor: true
+paired transitions share their provisional timing anchor: true
+pending fade-out creates an effects frame: true
+withdrawn fade-out removes its forced effects frame: true
+adding an opacity animation creates an effects frame: true
+adding a filter withdraws compositor opacity: true
+adding a filter removes the forced effects frame: true
+retargeted opacity starts with paired translate on compositor: true
+retargeted paired transitions share their provisional timing anchor: true

--- a/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
+++ b/Tests/LibWeb/Text/expected/css/compositor-transition-pending-start.txt
@@ -1,0 +1,14 @@
+new transition remains pending: true
+new transition start time remains unresolved: true
+new transition ready promise remains pending: true
+new transition start event remains pending: true
+new transition starts on compositor: true
+next update resolves pending play: true
+next update resolves start time: true
+next update resolves ready promise: true
+next update dispatches transition events: true
+transition remains on compositor: true
+resolved start retains compositor anchor: true
+pending current-time seek re-anchors compositor: true
+pending start-time change re-anchors compositor: true
+pending transition retarget replaces descriptor: true

--- a/Tests/LibWeb/Text/expected/css/delayed-script-animation-start-wakeup.txt
+++ b/Tests/LibWeb/Text/expected/css/delayed-script-animation-start-wakeup.txt
@@ -1,4 +1,6 @@
-delayed script animation receives its start wake-up: true
-zero-delay animation wakes after rewind: true
-animationstart fires near the active boundary: true
-delayed script animation uses a bounded frame pump: true
+delayed transition uses the compositor before start: true
+delayed compositor effect requests one start frame: true
+delayed compositor effect republishes at active start: true
+seeking reaches the delayed transition's active phase: true
+transitionstart fires after seeking and rendering: true
+active compositor effect retains an end wake-up: true

--- a/Tests/LibWeb/Text/input/css/compositor-animation-start-delay.html
+++ b/Tests/LibWeb/Text/input/css/compositor-animation-start-delay.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="no-fill" style="opacity: 0.75"></div>
+<div id="forwards-fill" style="opacity: 0.75"></div>
+<div id="backwards-fill" style="opacity: 0.75"></div>
+<div id="both-fill" style="opacity: 0.75"></div>
+<div id="sought-negative-delay" style="opacity: 0.75"></div>
+<script>
+    asyncTest(async done => {
+        const noFill = document.getElementById("no-fill");
+        const forwardsFill = document.getElementById("forwards-fill");
+        const backwardsFill = document.getElementById("backwards-fill");
+        const bothFill = document.getElementById("both-fill");
+        const soughtNegativeDelay = document.getElementById("sought-negative-delay");
+        const timeline = internals.createInternalAnimationTimeline();
+        const makeAnimation = (target, fill) => new Animation(new KeyframeEffect(target, [
+            { opacity: 0.25 },
+            { opacity: 0.5 },
+        ], { delay: 100, duration: 100, fill }), timeline);
+        const animations = [
+            makeAnimation(noFill, "none"),
+            makeAnimation(forwardsFill, "forwards"),
+            makeAnimation(backwardsFill, "backwards"),
+            makeAnimation(bothFill, "both"),
+        ];
+        const soughtNegativeDelayAnimation = new Animation(new KeyframeEffect(soughtNegativeDelay, [
+            { opacity: 0.25 },
+            { opacity: 0.5 },
+        ], { delay: -100, duration: 100, fill: "none" }), timeline);
+
+        for (const animation of animations)
+            animation.play();
+        soughtNegativeDelayAnimation.play();
+        timeline.setTime(0);
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+
+        println(`delayed effects use the compositor before starting: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 4}`);
+        timeline.setTimeForObservation(0);
+        const noBackwardsFillUsesUnderlyingValue = getComputedStyle(noFill).opacity === "0.75"
+            && getComputedStyle(forwardsFill).opacity === "0.75";
+        const backwardsFillUsesFirstKeyframe = getComputedStyle(backwardsFill).opacity === "0.25"
+            && getComputedStyle(bothFill).opacity === "0.25";
+        println(`fill modes apply before the active phase: ${noBackwardsFillUsesUnderlyingValue && backwardsFillUsesFirstKeyframe}`);
+
+        soughtNegativeDelayAnimation.currentTime = -50;
+        internals.updateCompositorAnimations();
+        println(`sought negative delay stays off the compositor before zero: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 4}`);
+
+        timeline.setTime(150);
+        internals.updateCompositorAnimations();
+        println(`delayed effects remain on the compositor while active: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 4}`);
+
+        timeline.setTime(250);
+        internals.updateCompositorAnimations();
+        println(`effects are withdrawn after their active interval: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-background-color-animation.html
+++ b/Tests/LibWeb/Text/input/css/compositor-background-color-animation.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @keyframes legacy-color {
+        from { background-color: rgba(255, 0, 0, 0); }
+        to { background-color: blue; }
+    }
+
+    @keyframes modern-color {
+        from { background-color: oklab(40% 0.1 0.1); }
+        to { background-color: oklab(80% -0.1 -0.1); }
+    }
+
+    @keyframes delayed-color {
+        from { background-color: rgba(1, 2, 3, 0); }
+        to { background-color: rgb(4, 5, 6); }
+    }
+
+    @keyframes root-color {
+        from { background-color: red; }
+        to { background-color: transparent; }
+    }
+
+    @keyframes currentcolor-background {
+        from { background-color: currentcolor; }
+        to { background-color: blue; }
+    }
+
+    html {
+        animation: root-color 1s steps(1, start) 100ms infinite both;
+    }
+
+    .target {
+        width: 20px;
+        height: 20px;
+    }
+
+    #legacy {
+        animation: legacy-color 1s linear infinite;
+    }
+
+    #modern {
+        animation: modern-color 1s linear infinite;
+    }
+
+    #unsupported-timing {
+        animation: legacy-color 1s linear 2;
+    }
+
+    #transparent-delay {
+        animation: delayed-color 1s linear 1s 1 both;
+        border-radius: 7px;
+    }
+
+    #currentcolor {
+        color: red;
+        animation: currentcolor-background 1s linear infinite;
+    }
+
+    body,
+    #text-clip,
+    #blended {
+        animation: legacy-color 1s linear infinite;
+    }
+
+    #text-clip {
+        background-clip: text;
+    }
+
+    #blended {
+        background-image: linear-gradient(white, white);
+        background-blend-mode: multiply;
+    }
+</style>
+<div id="legacy" class="target"></div>
+<div id="modern" class="target"></div>
+<div id="unsupported-timing" class="target"></div>
+<div id="transparent-delay" class="target"></div>
+<div id="currentcolor" class="target"></div>
+<div id="text-clip" class="target">text</div>
+<div id="blended" class="target"></div>
+<script>
+    function nextTask() {
+        const { promise, resolve } = Promise.withResolvers();
+        const channel = new MessageChannel();
+        channel.port1.onmessage = resolve;
+        channel.port2.postMessage(null);
+        return promise;
+    }
+
+    asyncTest(async done => {
+        internals.setManualRenderingOpportunities(true);
+        await nextTask();
+        let frameTime = performance.now();
+        async function renderNextFrame() {
+            frameTime += 16;
+            internals.injectRenderingOpportunity(frameTime);
+            await nextTask();
+        }
+        for (let i = 0; i < 4; ++i)
+            await renderNextFrame();
+
+        const initialCounters = internals.getStyleInvalidationCounters();
+        const legacyContext = internals.visualContextNodeIndices(document.querySelector("#legacy"));
+        const displayList = internals.dumpDisplayList();
+        const transparentFillIsRetained = displayList.split("\n").some(line =>
+            line.startsWith("FillRectWithRoundedCorners") && line.includes("color=rgba(0, 0, 0, 0)"));
+        const rootContext = internals.visualContextNodeIndices(document.documentElement);
+        const unsupportedTargets = [document.body, document.querySelector("#text-clip"), document.querySelector("#blended")];
+        const unsupportedTargetsHaveNoMarker = unsupportedTargets.every(target =>
+            !internals.visualContextNodeIndices(target).needsCompositorBackgroundColorFrame);
+        const modernTarget = document.querySelector("#modern");
+        const currentcolorTarget = document.querySelector("#currentcolor");
+        const transparentTarget = document.querySelector("#transparent-delay");
+        const unsupportedTimingTarget = document.querySelector("#unsupported-timing");
+        let modernTargetNeverGetsMarker = true;
+        let currentcolorTargetNeverGetsMarker = true;
+        let unsupportedTimingTargetNeverGetsMarker = true;
+        for (let i = 0; i < 4; ++i) {
+            internals.updateCompositorAnimations();
+            modernTargetNeverGetsMarker &&= !internals.visualContextNodeIndices(modernTarget).needsCompositorBackgroundColorFrame;
+            currentcolorTargetNeverGetsMarker &&= !internals.visualContextNodeIndices(currentcolorTarget).needsCompositorBackgroundColorFrame;
+            unsupportedTimingTargetNeverGetsMarker &&= !internals.visualContextNodeIndices(unsupportedTimingTarget).needsCompositorBackgroundColorFrame;
+        }
+
+        document.documentElement.getAnimations()[0].cancel();
+        modernTarget.getAnimations()[0].cancel();
+        currentcolorTarget.getAnimations()[0].cancel();
+        unsupportedTimingTarget.getAnimations()[0].cancel();
+        for (const target of unsupportedTargets)
+            target.getAnimations()[0].cancel();
+        for (let i = 0; i < 2; ++i)
+            await renderNextFrame();
+
+        internals.resetStyleInvalidationCounters();
+        for (let i = 0; i < 4; ++i)
+            internals.updateCompositorAnimations();
+        const stableCounters = internals.getStyleInvalidationCounters();
+
+        document.querySelector("#legacy").getAnimations()[0].cancel();
+        transparentTarget.getAnimations()[0].cancel();
+        internals.updateCompositorAnimations();
+        const cancellationCounters = internals.getStyleInvalidationCounters();
+
+        println(`background color animations use compositor: ${initialCounters.compositorVisualAnimations === 2}`);
+        println(`background color marker does not create effects layer: ${legacyContext.needsCompositorBackgroundColorFrame && !legacyContext.needsCompositorEffectsLayer}`);
+        println(`transparent background color retains animated fill: ${transparentFillIsRetained}`);
+        println(`root background color stays on main thread: ${!rootContext.needsCompositorBackgroundColorFrame}`);
+        println(`complex and propagated backgrounds stay on main thread: ${unsupportedTargetsHaveNoMarker}`);
+        println(`modern color interpolation stays on main thread: ${initialCounters.animatedStyleOverlayBuilds > 0}`);
+        println(`modern color creates no compositor marker: ${modernTargetNeverGetsMarker}`);
+        println(`currentcolor creates no compositor marker: ${currentcolorTargetNeverGetsMarker}`);
+        println(`unsupported timing creates no compositor marker: ${unsupportedTimingTargetNeverGetsMarker}`);
+        println(`stable background color builds no overlays: ${stableCounters.animatedStyleOverlayBuilds === 0}`);
+        println(`stable background color requests no animation frames: ${stableCounters.animationFramePumpRequests === 0}`);
+        println(`cancel removes background color animation: ${cancellationCounters.compositorVisualAnimations === 0}`);
+        internals.setManualRenderingOpportunities(false);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-transition-none-transform.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transition-none-transform.html
@@ -66,27 +66,50 @@
 <div class="target" id="scale-3d"></div>
 <div class="target" id="rotate-x"></div>
 <script>
+    function nextTask() {
+        const { promise, resolve } = Promise.withResolvers();
+        const channel = new MessageChannel();
+        channel.port1.onmessage = resolve;
+        channel.port2.postMessage(null);
+        return promise;
+    }
+
     asyncTest(async done => {
+        internals.setManualRenderingOpportunities(true);
+        await nextTask();
+
+        const firstFrameTime = performance.now();
+        internals.injectRenderingOpportunity(firstFrameTime);
+        await nextTask();
+
         const initialIndividualTop = individual.getBoundingClientRect().top;
         const initialListTop = list.getBoundingClientRect().top;
         document.body.classList.add("moved");
 
-        await new Promise(requestAnimationFrame);
-        await new Promise(requestAnimationFrame);
+        internals.injectRenderingOpportunity(firstFrameTime + 16);
+        await nextTask();
+        internals.injectRenderingOpportunity(firstFrameTime + 32);
+        await nextTask();
 
         const animations = [...document.querySelectorAll(".target")].flatMap(target => target.getAnimations());
         println(`none transform transitions use the compositor in 2D and 3D: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 5}`);
 
-        for (const animation of animations) {
+        for (const animation of animations)
             animation.pause();
-            await animation.ready;
+
+        internals.injectRenderingOpportunity(firstFrameTime + 48);
+        await nextTask();
+        await Promise.all(animations.map(animation => animation.ready));
+        for (const animation of animations)
             animation.currentTime = 200;
-        }
-        await new Promise(requestAnimationFrame);
+
+        internals.injectRenderingOpportunity(firstFrameTime + 64);
+        await nextTask();
 
         const individualDistance = individual.getBoundingClientRect().top - initialIndividualTop;
         const listDistance = list.getBoundingClientRect().top - initialListTop;
         println(`withdrawn mid-transition positions match: ${Math.abs(individualDistance - 12) < 0.1 && Math.abs(listDistance - 12) < 0.1}`);
+        internals.setManualRenderingOpportunities(false);
         done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/compositor-transition-none-transform.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transition-none-transform.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .target {
+        position: absolute;
+        left: 100px;
+        width: 20px;
+        height: 20px;
+        transition-duration: 400ms;
+        transition-timing-function: linear;
+    }
+
+    #individual {
+        top: 100px;
+        translate: none;
+        transition-property: translate;
+    }
+
+    #list {
+        top: 200px;
+        transform: none;
+        transition-property: transform;
+    }
+
+    #translate-3d {
+        top: 300px;
+        translate: none;
+        transition-property: translate;
+    }
+
+    #scale-3d {
+        top: 400px;
+        scale: none;
+        transition-property: scale;
+    }
+
+    #rotate-x {
+        top: 500px;
+        rotate: none;
+        transition-property: rotate;
+    }
+
+    body.moved #individual {
+        translate: 0 24px;
+    }
+
+    body.moved #list {
+        transform: translateY(24px);
+    }
+
+    body.moved #translate-3d {
+        translate: 0 0 24px;
+    }
+
+    body.moved #scale-3d {
+        scale: 1 1 2;
+    }
+
+    body.moved #rotate-x {
+        rotate: x 45deg;
+    }
+</style>
+<div class="target" id="individual"></div>
+<div class="target" id="list"></div>
+<div class="target" id="translate-3d"></div>
+<div class="target" id="scale-3d"></div>
+<div class="target" id="rotate-x"></div>
+<script>
+    asyncTest(async done => {
+        const initialIndividualTop = individual.getBoundingClientRect().top;
+        const initialListTop = list.getBoundingClientRect().top;
+        document.body.classList.add("moved");
+
+        await new Promise(requestAnimationFrame);
+        await new Promise(requestAnimationFrame);
+
+        const animations = [...document.querySelectorAll(".target")].flatMap(target => target.getAnimations());
+        println(`none transform transitions use the compositor in 2D and 3D: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 5}`);
+
+        for (const animation of animations) {
+            animation.pause();
+            await animation.ready;
+            animation.currentTime = 200;
+        }
+        await new Promise(requestAnimationFrame);
+
+        const individualDistance = individual.getBoundingClientRect().top - initialIndividualTop;
+        const listDistance = list.getBoundingClientRect().top - initialListTop;
+        println(`withdrawn mid-transition positions match: ${Math.abs(individualDistance - 12) < 0.1 && Math.abs(listDistance - 12) < 0.1}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .target {
+        width: 20px;
+        height: 20px;
+        opacity: 0.25;
+        transition: opacity 400ms linear;
+    }
+
+    body.changed #target {
+        opacity: 0.75;
+    }
+
+    #current-time.changed,
+    #start-time.changed,
+    #retarget.first {
+        opacity: 0.5;
+    }
+
+    #retarget.second {
+        opacity: 0.9;
+    }
+</style>
+<div class="target" id="target"></div>
+<div class="target" id="current-time"></div>
+<div class="target" id="start-time"></div>
+<div class="target" id="retarget"></div>
+<script>
+    function nextTask() {
+        const { promise, resolve } = Promise.withResolvers();
+        const channel = new MessageChannel();
+        channel.port1.onmessage = resolve;
+        channel.port2.postMessage(null);
+        return promise;
+    }
+
+    asyncTest(async done => {
+        const currentTimeTarget = document.getElementById("current-time");
+        const startTimeTarget = document.getElementById("start-time");
+        const retargetTarget = document.getElementById("retarget");
+        internals.setManualRenderingOpportunities(true);
+        await nextTask();
+
+        const firstFrameTime = performance.now();
+        internals.injectRenderingOpportunity(firstFrameTime);
+        await nextTask();
+
+        const events = [];
+        target.addEventListener("transitionrun", () => events.push("transitionrun"));
+        target.addEventListener("transitionstart", () => events.push("transitionstart"));
+        document.body.classList.add("changed");
+        internals.resetStyleInvalidationCounters();
+        internals.injectRenderingOpportunity(firstFrameTime + 60);
+        await nextTask();
+
+        const animation = target.getAnimations()[0];
+        internals.updateCompositorAnimations();
+        let readyResolved = false;
+        animation.ready.then(() => readyResolved = true);
+        await Promise.resolve();
+        const firstUpdateCounters = internals.getStyleInvalidationCounters();
+
+        println(`new transition remains pending: ${animation.pending}`);
+        println(`new transition start time remains unresolved: ${animation.startTime === null}`);
+        println(`new transition ready promise remains pending: ${!readyResolved}`);
+        println(`new transition start event remains pending: ${events.length === 0}`);
+        println(`new transition starts on compositor: ${firstUpdateCounters.compositorVisualAnimations === 1}`);
+
+        internals.resetStyleInvalidationCounters();
+        internals.injectRenderingOpportunity(firstFrameTime + 120);
+        await nextTask();
+        await Promise.resolve();
+        internals.updateCompositorAnimations();
+        const secondUpdateCounters = internals.getStyleInvalidationCounters();
+
+        println(`next update resolves pending play: ${!animation.pending}`);
+        println(`next update resolves start time: ${animation.startTime !== null}`);
+        println(`next update resolves ready promise: ${readyResolved}`);
+        println(`next update dispatches transition events: ${events.join(",") === "transitionrun,transitionstart"}`);
+        println(`transition remains on compositor: ${secondUpdateCounters.compositorVisualAnimations === 1}`);
+        println(`resolved start retains compositor anchor: ${secondUpdateCounters.compositorVisualAnimationTimingAnchorUpdates === 0}`);
+
+        animation.cancel();
+        internals.updateCompositorAnimations();
+
+        currentTimeTarget.classList.add("changed");
+        getComputedStyle(currentTimeTarget).opacity;
+        const currentTimeAnimation = currentTimeTarget.getAnimations()[0];
+        internals.updateCompositorAnimations();
+        internals.resetStyleInvalidationCounters();
+        currentTimeAnimation.currentTime = 300;
+        internals.updateCompositorAnimations();
+        const currentTimeCounters = internals.getStyleInvalidationCounters();
+        println(`pending current-time seek re-anchors compositor: ${currentTimeAnimation.pending && currentTimeCounters.compositorVisualAnimationTimingAnchorUpdates === 1 && currentTimeCounters.compositorVisualAnimationLocalTimeAtAnchor === 300}`);
+        currentTimeAnimation.cancel();
+        internals.updateCompositorAnimations();
+
+        startTimeTarget.classList.add("changed");
+        getComputedStyle(startTimeTarget).opacity;
+        const startTimeAnimation = startTimeTarget.getAnimations()[0];
+        internals.updateCompositorAnimations();
+        internals.resetStyleInvalidationCounters();
+        const documentTimelineCurrentTime = internals.getStyleInvalidationCounters().documentTimelineCurrentTime;
+        startTimeAnimation.startTime = documentTimelineCurrentTime - 200;
+        internals.updateCompositorAnimations();
+        const startTimeCounters = internals.getStyleInvalidationCounters();
+        println(`pending start-time change re-anchors compositor: ${!startTimeAnimation.pending && startTimeCounters.compositorVisualAnimationTimingAnchorUpdates === 1 && startTimeCounters.compositorVisualAnimationLocalTimeAtAnchor === 200}`);
+        startTimeAnimation.cancel();
+        internals.updateCompositorAnimations();
+
+        retargetTarget.classList.add("first");
+        getComputedStyle(retargetTarget).opacity;
+        const originalRetargetAnimation = retargetTarget.getAnimations()[0];
+        internals.updateCompositorAnimations();
+        internals.resetStyleInvalidationCounters();
+        retargetTarget.classList.add("second");
+        getComputedStyle(retargetTarget).opacity;
+        const retargetAnimations = retargetTarget.getAnimations();
+        internals.updateCompositorAnimations();
+        const retargetCounters = internals.getStyleInvalidationCounters();
+        println(`pending transition retarget replaces descriptor: ${originalRetargetAnimation.playState === "idle" && retargetAnimations.length === 1 && retargetAnimations[0] !== originalRetargetAnimation && retargetCounters.compositorVisualAnimations === 1 && retargetCounters.compositorVisualAnimationUpdates === 1}`);
+
+        internals.setManualRenderingOpportunities(false);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
+++ b/Tests/LibWeb/Text/input/css/compositor-transition-pending-start.html
@@ -21,11 +21,36 @@
     #retarget.second {
         opacity: 0.9;
     }
+
+    .paired {
+        width: 20px;
+        height: 20px;
+        opacity: 1;
+        translate: none;
+        transition: opacity 400ms linear 100ms, translate 400ms linear 100ms;
+    }
+
+    .paired.changed,
+    #paired-retarget.second {
+        opacity: 0;
+        translate: 0 24px;
+    }
+
+    #paired-retarget.first {
+        opacity: 0.5;
+    }
+
+    .static-opacity-transition {
+        transition: opacity 400ms linear;
+    }
 </style>
 <div class="target" id="target"></div>
 <div class="target" id="current-time"></div>
 <div class="target" id="start-time"></div>
 <div class="target" id="retarget"></div>
+<div class="paired" id="paired"></div>
+<div class="paired" id="paired-retarget"></div>
+<div id="static-opacity-transitions"></div>
 <script>
     function nextTask() {
         const { promise, resolve } = Promise.withResolvers();
@@ -39,6 +64,9 @@
         const currentTimeTarget = document.getElementById("current-time");
         const startTimeTarget = document.getElementById("start-time");
         const retargetTarget = document.getElementById("retarget");
+        const pairedTarget = document.getElementById("paired");
+        const pairedRetargetTarget = document.getElementById("paired-retarget");
+        const staticOpacityTransitions = document.getElementById("static-opacity-transitions");
         internals.setManualRenderingOpportunities(true);
         await nextTask();
 
@@ -105,7 +133,7 @@
         startTimeAnimation.startTime = documentTimelineCurrentTime - 200;
         internals.updateCompositorAnimations();
         const startTimeCounters = internals.getStyleInvalidationCounters();
-        println(`pending start-time change re-anchors compositor: ${!startTimeAnimation.pending && startTimeCounters.compositorVisualAnimationTimingAnchorUpdates === 1 && startTimeCounters.compositorVisualAnimationLocalTimeAtAnchor === 200}`);
+        println(`pending start-time change re-anchors compositor: ${!startTimeAnimation.pending && startTimeCounters.compositorVisualAnimationTimingAnchorUpdates === 1 && Math.abs(startTimeCounters.compositorVisualAnimationLocalTimeAtAnchor - 200) < 1}`);
         startTimeAnimation.cancel();
         internals.updateCompositorAnimations();
 
@@ -120,6 +148,74 @@
         internals.updateCompositorAnimations();
         const retargetCounters = internals.getStyleInvalidationCounters();
         println(`pending transition retarget replaces descriptor: ${originalRetargetAnimation.playState === "idle" && retargetAnimations.length === 1 && retargetAnimations[0] !== originalRetargetAnimation && retargetCounters.compositorVisualAnimations === 1 && retargetCounters.compositorVisualAnimationUpdates === 1}`);
+
+        for (const activeAnimation of document.getAnimations())
+            activeAnimation.cancel();
+        internals.updateCompositorAnimations();
+        document.elementFromPoint(0, 0);
+        for (let i = 0; i < 50; ++i)
+            staticOpacityTransitions.append(document.createElement("div"));
+        for (const child of staticOpacityTransitions.children)
+            child.className = "static-opacity-transition";
+        document.elementFromPoint(0, 0);
+        const staticTransitionEffectsFrameCount = [...staticOpacityTransitions.children]
+            .filter(element => internals.visualContextNodeIndices(element).needsCompositorEffectsLayer).length;
+        println(`static opacity transition declarations do not create effects frames: ${staticTransitionEffectsFrameCount === 0}`);
+
+        const pairedNeedsEffectsFrameBefore = internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer;
+        pairedTarget.classList.add("changed");
+        internals.resetStyleInvalidationCounters();
+        internals.injectRenderingOpportunity(firstFrameTime + 180);
+        await nextTask();
+        internals.updateCompositorAnimations();
+        const pairedAnimations = pairedTarget.getAnimations();
+        const pairedCounters = internals.getStyleInvalidationCounters();
+        const pairedNeedsEffectsFrameAfter = internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer;
+        println(`paired opacity and translate transitions start on compositor: ${pairedAnimations.length === 2 && pairedCounters.compositorVisualAnimations === 2}`);
+        println(`paired transitions share their provisional timing anchor: ${pairedCounters.compositorVisualAnimationsShareTimingAnchor}`);
+        println(`pending fade-out creates an effects frame: ${!pairedNeedsEffectsFrameBefore && pairedNeedsEffectsFrameAfter}`);
+
+        for (const pairedAnimation of pairedAnimations)
+            pairedAnimation.cancel();
+        pairedTarget.style.transition = "none";
+        pairedTarget.classList.remove("changed");
+        document.elementFromPoint(0, 0);
+        internals.updateCompositorAnimations();
+        println(`withdrawn fade-out removes its forced effects frame: ${!internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer}`);
+
+        const mixedAnimation = pairedTarget.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 400, fill: "backwards" });
+        internals.injectRenderingOpportunity(firstFrameTime + 200);
+        await nextTask();
+        internals.updateCompositorAnimations();
+        const mixedOpacityNeedsEffectsFrame = internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer;
+        mixedAnimation.effect.setKeyframes([
+            { opacity: 1, filter: "none" },
+            { opacity: 0, filter: "blur(1px)" },
+        ]);
+        internals.resetStyleInvalidationCounters();
+        internals.updateCompositorAnimations();
+        const mixedEffectCounters = internals.getStyleInvalidationCounters();
+        const mixedEffectNeedsEffectsFrame = internals.visualContextNodeIndices(pairedTarget).needsCompositorEffectsLayer;
+        println(`adding an opacity animation creates an effects frame: ${mixedOpacityNeedsEffectsFrame}`);
+        println(`adding a filter withdraws compositor opacity: ${mixedEffectCounters.compositorVisualAnimations === 0}`);
+        println(`adding a filter removes the forced effects frame: ${!mixedEffectNeedsEffectsFrame}`);
+        mixedAnimation.cancel();
+
+        pairedRetargetTarget.classList.add("first");
+        internals.injectRenderingOpportunity(firstFrameTime + 240);
+        await nextTask();
+        internals.injectRenderingOpportunity(firstFrameTime + 300);
+        await nextTask();
+        const originalPairedRetargetAnimation = pairedRetargetTarget.getAnimations()[0];
+        pairedRetargetTarget.classList.replace("first", "second");
+        internals.resetStyleInvalidationCounters();
+        internals.injectRenderingOpportunity(firstFrameTime + 360);
+        await nextTask();
+        internals.updateCompositorAnimations();
+        const pairedRetargetAnimations = pairedRetargetTarget.getAnimations();
+        const pairedRetargetCounters = internals.getStyleInvalidationCounters();
+        println(`retargeted opacity starts with paired translate on compositor: ${originalPairedRetargetAnimation.playState === "idle" && pairedRetargetAnimations.length === 2 && pairedRetargetCounters.compositorVisualAnimations === 2}`);
+        println(`retargeted paired transitions share their provisional timing anchor: ${pairedRetargetCounters.compositorVisualAnimationsShareTimingAnchor}`);
 
         internals.setManualRenderingOpportunities(false);
         done();

--- a/Tests/LibWeb/Text/input/css/delayed-script-animation-start-wakeup.html
+++ b/Tests/LibWeb/Text/input/css/delayed-script-animation-start-wakeup.html
@@ -1,52 +1,65 @@
 <!doctype html>
 <style>
-    @keyframes delayed-css-start {
-        from { color: rgb(10, 0, 0); }
-        to { color: rgb(20, 0, 0); }
+    #target {
+        width: 20px;
+        height: 20px;
+        transform: translateX(0);
+        transition: transform 100s linear 500ms;
+    }
+
+    #target.changed {
+        transform: translateX(100px);
     }
 </style>
+<div id="target"></div>
 <script src="../include.js"></script>
 <script>
+    function nextTask() {
+        const { promise, resolve } = Promise.withResolvers();
+        const channel = new MessageChannel();
+        channel.port1.onmessage = resolve;
+        channel.port2.postMessage(null);
+        return promise;
+    }
+
+    async function renderAt(frameTime) {
+        internals.injectRenderingOpportunity(frameTime);
+        await nextTask();
+    }
+
     asyncTest(async done => {
-        const target = document.createElement("div");
-        document.body.append(target);
+        internals.setManualRenderingOpportunities(true);
+        await nextTask();
+        const firstFrameTime = performance.now();
+        await renderAt(firstFrameTime);
 
-        const cssTarget = document.createElement("div");
-        let cssAnimationStartTime;
-        cssTarget.addEventListener("animationstart", () => {
-            cssAnimationStartTime = performance.now();
-        });
-        cssTarget.style.animation = "delayed-css-start 100s 500ms";
-        document.body.append(cssTarget);
+        let receivedTransitionStart = false;
+        target.addEventListener("transitionstart", () => receivedTransitionStart = true);
+        target.classList.add("changed");
 
-        const animation = target.animate([
-            { color: "rgb(10, 0, 0)" },
-            { color: "rgb(20, 0, 0)" },
-        ], { delay: 500, duration: 100000, fill: "backwards" });
-        await animation.ready;
+        for (const offset of [16, 32, 48, 64])
+            await renderAt(firstFrameTime + offset);
 
-        const rewoundTarget = document.createElement("div");
-        rewoundTarget.style.visibility = "hidden";
-        document.body.append(rewoundTarget);
-        const rewoundAnimation = rewoundTarget.animate([
-            { transform: "translateX(0px)" },
-            { transform: "translateX(100px)" },
-        ], { duration: 100000, fill: "backwards", iterations: Infinity });
-        await rewoundAnimation.ready;
-        rewoundAnimation.currentTime = -100;
+        const transition = target.getAnimations()[0];
+        await transition.ready;
+        println(`delayed transition uses the compositor before start: ${internals.getStyleInvalidationCounters().compositorVisualAnimations === 1}`);
 
-        const readyTime = performance.now();
+        const activeStartTime = transition.startTime + 501;
         internals.resetStyleInvalidationCounters();
-        await new Promise(resolve => setTimeout(resolve, 625));
+        internals.fireCompositorAnimationWakeupForTesting(activeStartTime);
         const counters = internals.getStyleInvalidationCounters();
 
-        println(`delayed script animation receives its start wake-up: ${animation.currentTime >= 500 && counters.animationFramePumpRequests >= 1}`);
-        println(`zero-delay animation wakes after rewind: ${rewoundAnimation.currentTime >= 0 && counters.animationFramePumpRequests >= 2}`);
-        println(`animationstart fires near the active boundary: ${cssAnimationStartTime !== undefined && cssAnimationStartTime - readyTime <= 625}`);
-        println(`delayed script animation uses a bounded frame pump: ${counters.animationFramePumpRequests >= 2 && counters.animationFramePumpRequests <= 16}`);
+        transition.currentTime = 501;
+        await renderAt(performance.now());
 
-        animation.cancel();
-        rewoundAnimation.cancel();
+        println(`delayed compositor effect requests one start frame: ${counters.animationFramePumpRequests === 1}`);
+        println(`delayed compositor effect republishes at active start: ${counters.compositorVisualAnimationUpdates === 1}`);
+        println(`seeking reaches the delayed transition's active phase: ${transition.currentTime >= 500}`);
+        println(`transitionstart fires after seeking and rendering: ${receivedTransitionStart}`);
+        println(`active compositor effect retains an end wake-up: ${internals.getStyleInvalidationCounters().compositorAnimationWakeupTimerActive}`);
+
+        transition.cancel();
+        internals.setManualRenderingOpportunities(false);
         done();
     });
 </script>


### PR DESCRIPTION
Move more eligible CSS animations and transitions off WebContent, including individual transforms with `none` endpoints, pending and delayed effects, opacity animations without a pre-existing effects layer, and legacy sRGB `background-color` animations. Background colors use non-isolating compositor metadata, while canvas backgrounds, text-clipped fills, blended stacks, and modern color interpolation remain on the main thread.

For an otherwise stable document at 60 Hz, compositor handoff takes eligible background-color animation work from up to 60 WebContent style and paint updates per second to 0 after handoff. Delayed descriptors remain dormant until active start and schedule exactly 1 WebContent wakeup at the phase boundary. New transitions publish during their first style update instead of waiting for another rendering opportunity.

Also validate incremental visual-context trees before serialization and preserve sampled animation values across display-list and tree replacements. This prevents malformed IPC disconnects and one-frame snaps back to base opacity during active animations.

This makes the company logo transitions fluid on https://openai.com/codex even though the page is burning 100% CPU on a goofy ASCII text effect in JS. :)

https://github.com/user-attachments/assets/5f4b3fe7-0075-4f55-b7a1-fcb870e4e406