### PR TITLE
Speculatively fetch module scripts in CORS mode (and un-break japantimes.co.jp login)

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/preload_scanner.rs
@@ -14,6 +14,7 @@ use crate::token::TokenPayload;
 use crate::token::TokenType;
 use crate::tokenizer::HtmlTokenizer;
 use crate::tokenizer::State;
+use std::borrow::Cow;
 use std::ffi::c_void;
 
 #[repr(C)]
@@ -22,6 +23,7 @@ pub enum RustFfiPreloadScannerAction {
     Base = 0,
     Fetch = 1,
     ModulePreload = 2,
+    ModuleScript = 3,
 }
 
 #[repr(C)]
@@ -265,15 +267,106 @@ fn process_script(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPr
     if src.is_empty() {
         return true;
     }
-
+    let action = match script_type_from_attributes(attributes) {
+        // 'If el has a nomodule content attribute and its type is "classic", then return.' — so the script never runs,
+        // and preparing it doesn't fetch src.
+        Some(ScriptType::Classic) if attribute_value(attributes, attribute_name!("nomodule")).is_some() => return true,
+        Some(ScriptType::Classic) => RustFfiPreloadScannerAction::Fetch,
+        Some(ScriptType::Module) => RustFfiPreloadScannerAction::ModuleScript,
+        // An import map or speculation-rules script with a src attribute only fires an error event, and a script whose
+        // type is null never runs — none of them fetch src.
+        Some(ScriptType::ImportMap) | Some(ScriptType::SpeculationRules) | None => return true,
+    };
     emit_entry(
         callback,
-        RustFfiPreloadScannerAction::Fetch,
+        action,
         src,
         RustFfiPreloadScannerDestination::Script,
         cors_setting_from_attribute(attributes),
         Some(attributes),
     )
+}
+
+/// The type "prepare the script element" gives a script element from its type and language attributes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScriptType {
+    Classic,
+    Module,
+    ImportMap,
+    SpeculationRules,
+}
+
+// https://mimesniff.spec.whatwg.org/#javascript-mime-type
+// A JavaScript MIME type is any MIME type whose essence is one of the following:
+const JAVASCRIPT_MIME_TYPE_ESSENCES: [&[u8]; 16] = [
+    b"application/ecmascript",
+    b"application/javascript",
+    b"application/x-ecmascript",
+    b"application/x-javascript",
+    b"text/ecmascript",
+    b"text/javascript",
+    b"text/javascript1.0",
+    b"text/javascript1.1",
+    b"text/javascript1.2",
+    b"text/javascript1.3",
+    b"text/javascript1.4",
+    b"text/javascript1.5",
+    b"text/jscript",
+    b"text/livescript",
+    b"text/x-ecmascript",
+    b"text/x-javascript",
+];
+
+// https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
+// Steps 8 to 13 of "prepare the script element": the type the element gets from its type and language attributes, or
+// None when "no script is executed, and el's type is left as null".
+fn script_type_from_attributes(attributes: &[Attribute]) -> Option<ScriptType> {
+    let type_attribute = attribute_value(attributes, attribute_name!("type"));
+    let language_attribute = attribute_value(attributes, attribute_name!("language"));
+
+    // 8. If any of the following are true:
+    //    - el has a type attribute whose value is the empty string;
+    //    - el has no type attribute but it has a language attribute and that attribute's value is the empty string; or
+    //    - el has neither a type attribute nor a language attribute,
+    //    then let the script block's type string for this script element be "text/javascript".
+    //    Otherwise, if el has a type attribute, then let the script block's type string be the value of that attribute
+    //    with leading and trailing ASCII whitespace stripped.
+    //    Otherwise, el has a non-empty language attribute; let the script block's type string be the concatenation of
+    //    "text/" and the value of el's language attribute.
+    let type_string: Cow<'_, [u8]> = match (type_attribute, language_attribute) {
+        (Some(""), _) | (None, Some("")) | (None, None) => Cow::Borrowed(b"text/javascript"),
+        (Some(type_attribute), _) => Cow::Borrowed(type_attribute.as_bytes().trim_ascii()),
+        (None, Some(language)) => Cow::Owned([b"text/".as_slice(), language.as_bytes()].concat()),
+    };
+
+    // 9. If the script block's type string is a JavaScript MIME type essence match, then set el's type to "classic".
+    if JAVASCRIPT_MIME_TYPE_ESSENCES
+        .iter()
+        .any(|essence| type_string.eq_ignore_ascii_case(essence))
+    {
+        return Some(ScriptType::Classic);
+    }
+
+    // 10. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string "module", then
+    //     set el's type to "module".
+    if type_string.eq_ignore_ascii_case(b"module") {
+        return Some(ScriptType::Module);
+    }
+
+    // 11. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string "importmap",
+    //     then set el's type to "importmap".
+    if type_string.eq_ignore_ascii_case(b"importmap") {
+        return Some(ScriptType::ImportMap);
+    }
+
+    // 12. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string
+    //     "speculationrules", then set el's type to "speculationrules".
+    if type_string.eq_ignore_ascii_case(b"speculationrules") {
+        return Some(ScriptType::SpeculationRules);
+    }
+
+    // 13. Otherwise, return. (No script is executed, and el's type is left as null.)
+    None
 }
 
 fn process_link(attributes: &[Attribute], callback: &mut impl FnMut(&RustFfiPreloadScannerEntry) -> bool) -> bool {
@@ -782,6 +875,84 @@ mod tests {
                 "high".to_string(),
                 "screen".to_string(),
             ))
+        );
+    }
+
+    #[test]
+    fn classifies_script_elements_by_type() {
+        let entries = collect(
+            r#"
+                <script src="./classic.js"></script>
+                <script type="" src="./empty-type.js"></script>
+                <script type=" Text/JavaScript " src="./javascript-mime-type.js"></script>
+                <script language="javascript1.5" src="./language.js"></script>
+                <script type="module" src="./module.js"></script>
+                <script type=" MODULE " src="./module-uppercase.js"></script>
+                <script type="module" crossorigin src="./module-anonymous.js"></script>
+                <script type="module" crossorigin="use-credentials" src="./module-credentialed.js"></script>
+                <script type="module" nomodule src="./module-nomodule.js"></script>
+                <script nomodule src="./classic-nomodule.js"></script>
+                <script type="importmap" src="./import-map.json"></script>
+                <script type="speculationrules" src="./speculation-rules.json"></script>
+                <script type="text/template" src="./template.html"></script>
+                <script language="" type="text/template" src="./template-language.html"></script>
+            "#,
+        );
+        let script = |action, url: &str, cors_setting| ScannedEntry {
+            action,
+            url: url.to_string(),
+            destination: RustFfiPreloadScannerDestination::Script,
+            cors_setting,
+        };
+        assert_eq!(
+            entries,
+            vec![
+                script(
+                    RustFfiPreloadScannerAction::Fetch,
+                    "./classic.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::Fetch,
+                    "./empty-type.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::Fetch,
+                    "./javascript-mime-type.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::Fetch,
+                    "./language.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::ModuleScript,
+                    "./module.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::ModuleScript,
+                    "./module-uppercase.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+                script(
+                    RustFfiPreloadScannerAction::ModuleScript,
+                    "./module-anonymous.js",
+                    RustFfiPreloadScannerCorsSetting::Anonymous
+                ),
+                script(
+                    RustFfiPreloadScannerAction::ModuleScript,
+                    "./module-credentialed.js",
+                    RustFfiPreloadScannerCorsSetting::UseCredentials
+                ),
+                script(
+                    RustFfiPreloadScannerAction::ModuleScript,
+                    "./module-nomodule.js",
+                    RustFfiPreloadScannerCorsSetting::NoCors
+                ),
+            ]
         );
     }
 }

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
@@ -162,11 +162,14 @@ bool media_attribute_matches_environment(DOM::Document const& document, RustFfiP
     return false;
 }
 
-void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL const& url, RustFfiPreloadScannerEntry const& entry)
+// Speculatively fetches url the way "fetch a single module script" would for a module script element or a modulepreload
+// link (a CORS-mode request carrying the script fetch options the element's attributes give) — so, the response is the
+// one the real fetch later finds in the HTTP cache. A potential-CORS request won't work here; a module script is always
+// fetched in CORS mode, and a server that only sends Access-Control-Allow-Origin in reply to an Origin header answers
+// a no-cors request without it. So the real fetch, served that response from the cache, fails its CORS check.
+// https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
+void issue_speculative_module_fetch(DOM::Document& document, URL::URL const& url, RustFfiPreloadScannerEntry const& entry, Fetch::Infrastructure::Request::Destination destination, Fetch::Infrastructure::Request::ParserMetadata parser_metadata)
 {
-    auto destination = destination_from_preload_scanner(entry.destination);
-    VERIFY(destination.has_value());
-
     auto& settings_object = document.relevant_settings_object();
     auto integrity_metadata = entry.integrity_present
         ? utf16_string_from_preload_scanner(entry.integrity_ptr, entry.integrity_len)
@@ -174,7 +177,7 @@ void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL con
     ScriptFetchOptions options {
         .cryptographic_nonce = utf16_string_from_preload_scanner(entry.nonce_ptr, entry.nonce_len),
         .integrity_metadata = move(integrity_metadata),
-        .parser_metadata = Fetch::Infrastructure::Request::ParserMetadata::NotParserInserted,
+        .parser_metadata = parser_metadata,
         .credentials_mode = cors_settings_attribute_credentials_mode(cors_setting_from_preload_scanner(entry.cors_setting)),
         .referrer_policy = ReferrerPolicy::from_string(utf16_string_from_preload_scanner(entry.referrer_policy_ptr, entry.referrer_policy_len)).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString),
         .fetch_priority = Fetch::Infrastructure::request_priority_from_string(utf16_string_from_preload_scanner(entry.fetch_priority_ptr, entry.fetch_priority_len)).value_or(Fetch::Infrastructure::Request::Priority::Auto),
@@ -188,8 +191,8 @@ void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL con
     request->set_mode(Fetch::Infrastructure::Request::Mode::CORS);
     request->set_referrer(Fetch::Infrastructure::Request::Referrer::Client);
     request->set_client(&settings_object);
-    request->set_destination(*destination);
-    if (first_is_one_of(*destination,
+    request->set_destination(destination);
+    if (first_is_one_of(destination,
             Fetch::Infrastructure::Request::Destination::Worker,
             Fetch::Infrastructure::Request::Destination::SharedWorker,
             Fetch::Infrastructure::Request::Destination::ServiceWorker))
@@ -200,6 +203,25 @@ void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL con
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
     auto algorithms = Fetch::Infrastructure::FetchAlgorithms::create(move(fetch_algorithms_input));
     (void)Fetch::Fetching::fetch(settings_object.realm(), request, algorithms);
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+void issue_speculative_modulepreload_fetch(DOM::Document& document, URL::URL const& url, RustFfiPreloadScannerEntry const& entry)
+{
+    auto destination = destination_from_preload_scanner(entry.destination);
+    VERIFY(destination.has_value());
+
+    // The link's script fetch options have parser metadata "not-parser-inserted".
+    issue_speculative_module_fetch(document, url, entry, *destination, Fetch::Infrastructure::Request::ParserMetadata::NotParserInserted);
+}
+
+// https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
+// A module script element's src is fetched as an external module script graph, whose root request "fetch a single
+// module script" builds with destination "script" — and with parser metadata "parser-inserted", since the parser
+// inserts the element the speculative parser found.
+void issue_speculative_module_script_fetch(DOM::Document& document, URL::URL const& url, RustFfiPreloadScannerEntry const& entry)
+{
+    issue_speculative_module_fetch(document, url, entry, Fetch::Infrastructure::Request::Destination::Script, Fetch::Infrastructure::Request::ParserMetadata::ParserInserted);
 }
 
 }
@@ -221,6 +243,7 @@ void SpeculativeHTMLParser::process_preload_scanner_entry(RustFfiPreloadScannerE
         return;
 
     case RustFfiPreloadScannerAction::Fetch:
+    case RustFfiPreloadScannerAction::ModuleScript:
         break;
     case RustFfiPreloadScannerAction::ModulePreload:
         if (!media_attribute_matches_environment(*m_document, entry))
@@ -250,6 +273,8 @@ void SpeculativeHTMLParser::process_preload_scanner_entry(RustFfiPreloadScannerE
     m_document->add_speculative_fetch_url(*url);
     if (entry.action == RustFfiPreloadScannerAction::ModulePreload)
         issue_speculative_modulepreload_fetch(*m_document, *url, entry);
+    else if (entry.action == RustFfiPreloadScannerAction::ModuleScript)
+        issue_speculative_module_script_fetch(*m_document, *url, entry);
     else
         issue_speculative_fetch(m_document->relevant_settings_object().realm(), *m_document, *url, destination_from_preload_scanner(entry.destination), cors_setting_from_preload_scanner(entry.cors_setting));
 }

--- a/Tests/LibWeb/Text/expected/HTML/speculative-html-parser/module-script-fetch-uses-cors.txt
+++ b/Tests/LibWeb/Text/expected/HTML/speculative-html-parser/module-script-fetch-uses-cors.txt
@@ -1,0 +1,3 @@
+PASS: the speculative fetch of a module script sends an Origin header
+PASS: the speculative fetch of a module script is a CORS-mode request
+PASS: the module script runs once the parser reaches it

--- a/Tests/LibWeb/Text/input/HTML/speculative-html-parser/module-script-fetch-uses-cors.html
+++ b/Tests/LibWeb/Text/input/HTML/speculative-html-parser/module-script-fetch-uses-cors.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    // The speculative HTML parser fetches a module script's src ahead of the parser. That fetch has to be the CORS-mode
+    // request "fetch a single module script" makes — since its response is what the real fetch later finds in the HTTP
+    // cache. And a server that only sends Access-Control-Allow-Origin in reply to an Origin header answers a no-cors
+    // request without it — so the real fetch would fail its CORS check on the cached response.
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+
+        const server = httpTestServer();
+        const run = crypto.randomUUID();
+        const parserGate = `${run}-parser`;
+        const path = name => `/speculative-module-script-${run}-${name}`;
+
+        const parserBlockerURL = await server.createEcho("GET", path("parser-blocker.js"), {
+            status: 200,
+            headers: { "Content-Type": "text/javascript" },
+            body: "",
+            wait_for_unblock: parserGate,
+        });
+        const moduleURL = new URL(await server.createEcho("GET", path("module.js"), {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "text/javascript",
+            },
+            body: `parent.postMessage({ type: "module-ran" }, "*");`,
+        }));
+        // Served from a different host, so the module is cross-origin to the page that embeds it.
+        moduleURL.hostname = uniqueLocalhostHostname("speculative-module-script");
+
+        const scriptStartTag = "<scr" + "ipt";
+        const scriptEndTag = "</scr" + "ipt>";
+        const pageURL = await server.createEcho("GET", path("page.html"), {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: `<!DOCTYPE html>
+                ${scriptStartTag} src="${parserBlockerURL}">${scriptEndTag}
+                ${scriptStartTag} type="module" src="${moduleURL}">${scriptEndTag}`,
+        });
+
+        const recordedHeaders = async url => {
+            // Until the path has been requested, the endpoint answers 404 without CORS headers, so the fetch rejects.
+            let response;
+            try {
+                response = await fetch(`${server.baseURL}/recorded-request-headers${new URL(url).pathname}`);
+            } catch {
+                return null;
+            }
+            if (!response.ok)
+                return null;
+            const headers = await response.json();
+            return Object.fromEntries(Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]));
+        };
+        const waitForRequest = async url => {
+            while (!await recordedHeaders(url)) { }
+        };
+        const moduleRan = new Promise(resolve => {
+            window.addEventListener("message", event => {
+                if (event.data.type === "module-ran")
+                    resolve();
+            });
+        });
+
+        const frame = document.createElement("iframe");
+        frame.src = pageURL;
+        document.body.appendChild(frame);
+
+        // The parser is stuck on the blocking script, so the only request the module can have received is speculative.
+        await waitForRequest(moduleURL);
+        const headers = await recordedHeaders(moduleURL);
+        println(`${headers.origin?.length > 0 ? "PASS" : "FAIL"}: the speculative fetch of a module script sends an Origin header`);
+        println(`${headers["sec-fetch-mode"]?.[0] === "cors" ? "PASS" : "FAIL"}: the speculative fetch of a module script is a CORS-mode request`);
+
+        await fetch(`${server.baseURL}/unblock/${parserGate}`);
+        await moduleRan;
+        println("PASS: the module script runs once the parser reaches it");
+        done();
+    });
+</script>


### PR DESCRIPTION
**Problem:** https://japantimes.co.jp: clicking the login button had no effect.

**Cause:** Our speculative HTML parser’s preload scanner treated every script element with a `src` as a classic script, so its speculative fetch was a potential-CORS request — in no-cors mode whenever the element had no `crossorigin` attribute, a module script element included. Only in reply to a request carrying an `Origin` header does the cdn.piano.io CDN serving the japantimes login scripts send `Access-Control-Allow-Origin`, and its response carries no `Vary` header — so the no-cors speculative response landed in the HTTP cache without the CORS header. The page stylesheets held the parser back long enough for those speculative fetches to complete; the real fetches (which [_“fetch a single module script”_](https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script) always makes in CORS mode) were served the cached responses, failed their CORS check — and came back as null module scripts.

**Fix:** Have the preload scanner classify script elements the way [_“prepare the script element”_ ](https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element)does (steps 8 through 13): The type string from the `type` or `language` attribute decides among classic, module, import map, and speculation-rules scripts — and a null type means no script runs. A module script now gets its own `ModuleScript` entry, and the speculative parser fetches it with the CORS-mode module request it already builds for `modulepreload` links — with destination `script` and parser metadata `parser-inserted`; i.e. the request that fetching an external module script graph makes. Classic scripts with a `nomodule` attribute, import maps, speculation rules, and scripts of an unknown type aren’t fetched speculatively at all — since preparing them fetches nothing either.

> [!NOTE]
> The HTTP cache itself is unaffected by this change; a page that fetches a module’s URL in no-cors mode first (a preload link without `crossorigin`, e.g.) still hands the later module fetch the cached response — as HTTP caching allows for a response without a `Vary` header.
